### PR TITLE
Remove an allocation importing symmetric keys

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptImportKey.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptImportKey.cs
@@ -25,6 +25,10 @@ internal static partial class Interop
             {
                 blob = new byte[blobSize];
             }
+            else
+            {
+                blob.Clear();
+            }
 
             fixed (byte* pbBlob = blob)
             {

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptImportKey.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptImportKey.cs
@@ -16,24 +16,34 @@ internal static partial class Interop
             const string BCRYPT_KEY_DATA_BLOB = "KeyDataBlob";
             int keySize = key.Length;
             int blobSize = sizeof(BCRYPT_KEY_DATA_BLOB_HEADER) + keySize;
-            byte[] blob = new byte[blobSize];
+
+            // 64 is large enough to hold a BCRYPT_KEY_DATA_BLOB_HEADER and an AES-256 key with room to spare.
+            int MaxStackKeyBlob = 64;
+            Span<byte> blob = stackalloc byte[MaxStackKeyBlob];
+
+            if (blobSize > MaxStackKeyBlob)
+            {
+                blob = new byte[blobSize];
+            }
+
             fixed (byte* pbBlob = blob)
             {
                 BCRYPT_KEY_DATA_BLOB_HEADER* pBlob = (BCRYPT_KEY_DATA_BLOB_HEADER*)pbBlob;
                 pBlob->dwMagic = BCRYPT_KEY_DATA_BLOB_HEADER.BCRYPT_KEY_DATA_BLOB_MAGIC;
                 pBlob->dwVersion = BCRYPT_KEY_DATA_BLOB_HEADER.BCRYPT_KEY_DATA_BLOB_VERSION1;
                 pBlob->cbKeyData = (uint)keySize;
-            }
 
-            key.CopyTo(blob.AsSpan(sizeof(BCRYPT_KEY_DATA_BLOB_HEADER)));
-            SafeKeyHandle hKey;
-            NTSTATUS ntStatus = BCryptImportKey(hAlg, IntPtr.Zero, BCRYPT_KEY_DATA_BLOB, out hKey, IntPtr.Zero, 0, blob, blobSize, 0);
-            if (ntStatus != NTSTATUS.STATUS_SUCCESS)
-            {
-                throw CreateCryptographicException(ntStatus);
-            }
 
-            return hKey;
+                key.CopyTo(blob.Slice(sizeof(BCRYPT_KEY_DATA_BLOB_HEADER)));
+                SafeKeyHandle hKey;
+                NTSTATUS ntStatus = BCryptImportKey(hAlg, IntPtr.Zero, BCRYPT_KEY_DATA_BLOB, out hKey, IntPtr.Zero, 0, pbBlob, blobSize, 0);
+                if (ntStatus != NTSTATUS.STATUS_SUCCESS)
+                {
+                    throw CreateCryptographicException(ntStatus);
+                }
+
+                return hKey;
+            }
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -48,6 +58,6 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        private static partial NTSTATUS BCryptImportKey(SafeAlgorithmHandle hAlgorithm, IntPtr hImportKey, string pszBlobType, out SafeKeyHandle hKey, IntPtr pbKeyObject, int cbKeyObject, byte[] pbInput, int cbInput, int dwFlags);
+        private static unsafe partial NTSTATUS BCryptImportKey(SafeAlgorithmHandle hAlgorithm, IntPtr hImportKey, string pszBlobType, out SafeKeyHandle hKey, IntPtr pbKeyObject, int cbKeyObject, byte* pbInput, int cbInput, int dwFlags);
     }
 }


### PR DESCRIPTION
This makes a small improvement to importing symmetric encryption keys.

|             Method |        Job | Toolchain | DataSize | Mode |                               Algorithm |     Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |----------- |---------- |--------- |----- |---------------------------------------- |---------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
| Encrypt_Cbc_ToSpan | Job-LHKAOV |    branch |       16 | None | Internal.Cryptography.AesImplementation | 631.5 ns | 12.63 ns | 11.20 ns |  0.98 |    0.04 | 0.0439 |     - |     - |     184 B |
| Encrypt_Cbc_ToSpan | Job-TGELHQ |      main |       16 | None | Internal.Cryptography.AesImplementation | 639.1 ns | 12.67 ns | 18.17 ns |  1.00 |    0.00 | 0.0610 |     - |     - |     256 B |


