### PR TITLE
Make sure that StressLogAnalyzer works with filtering 64 bit addresses

### DIFF
--- a/src/coreclr/tools/StressLogAnalyzer/StressLogPlugin.cpp
+++ b/src/coreclr/tools/StressLogAnalyzer/StressLogPlugin.cpp
@@ -609,12 +609,14 @@ void Usage()
     printf("     e.g. '-tid:2bc8,GC3,BG14' would print messages from thread 2bc8, the gc thread\n");
     printf("     associated with heap 3, and the background GC thread for heap 14\n");
     printf("\n");
-    printf(" -e: printf earliest messages from all threads\n");
+    printf(" -e: print earliest messages from all threads\n");
     printf(" -e:<thread id1>,<thread id2>,...: print earliest messages from the listed\n");
     printf("     threads. Thread ids are in hex, given as GC<decimal heap number>,\n");
     printf("     or BG<decimal heap number>\n");
     printf("     e.g. '-e:2bc8,GC3,BG14' would print the earliest messages from thread 2bc8,\n");
     printf("     the gc thread associated with heap 3, and the background GC thread for heap 14\n");
+    printf("\n");
+    printf(" -a: print all messages from all threads\n");
     printf("\n");
 }
 

--- a/src/coreclr/tools/StressLogAnalyzer/StressLogPlugin.cpp
+++ b/src/coreclr/tools/StressLogAnalyzer/StressLogPlugin.cpp
@@ -752,7 +752,7 @@ bool ParseOptions(int argc, char* argv[])
                         else
                         {
                             int i = s_threadFilterCount++;
-                            s_threadFilter[i] = strtoul(arg, &end, 16);
+                            s_threadFilter[i] = strtoull(arg, &end, 16);
                         }
                         if (*end == ',')
                         {
@@ -968,7 +968,7 @@ bool ParseOptions(int argc, char* argv[])
                         else
                         {
                             int i = s_printEarliestMessageFromThreadCount++;
-                            s_printEarliestMessageFromThread[i] = strtoul(arg, &end, 16);
+                            s_printEarliestMessageFromThread[i] = strtoull(arg, &end, 16);
                         }
                         if (*end == ',')
                         {

--- a/src/coreclr/tools/StressLogAnalyzer/StressLogPlugin.cpp
+++ b/src/coreclr/tools/StressLogAnalyzer/StressLogPlugin.cpp
@@ -50,6 +50,7 @@ bool IsInCantAllocStressLogRegion()
 size_t StressLog::writing_base_address;
 size_t StressLog::reading_base_address;
 
+bool s_showAllMessages = false;
 BOOL g_bDacBroken;
 WCHAR g_mdName[1];
 SYMBOLS* g_ExtSymbols;
@@ -665,14 +666,14 @@ bool ParseOptions(int argc, char* argv[])
                 {
                     int i = s_valueFilterCount++;
                     char* end = nullptr;
-                    s_valueFilter[i].start = strtoul(&arg[3], &end, 16);
+                    s_valueFilter[i].start = strtoull(&arg[3], &end, 16);
                     if (*end == '-')
                     {
-                        s_valueFilter[i].end = strtoul(end + 1, &end, 16);
+                        s_valueFilter[i].end = strtoull(end + 1, &end, 16);
                     }
                     else if (*end == '+')
                     {
-                        s_valueFilter[i].end = s_valueFilter[i].start + strtoul(end + 1, &end, 16);
+                        s_valueFilter[i].end = s_valueFilter[i].start + strtoull(end + 1, &end, 16);
                     }
                     else if (*end != '\0')
                     {
@@ -848,6 +849,10 @@ bool ParseOptions(int argc, char* argv[])
                 }
                 break;
 
+            case 'a':
+            case 'A':
+                s_showAllMessages = true;
+                break;
             case 'f':
             case 'F':
                 if (arg[2] == '\0')
@@ -1106,7 +1111,7 @@ DWORD WINAPI ProcessStresslogWorker(LPVOID)
                 int numberOfArgs = (msg->numberOfArgsX << 3) + msg->numberOfArgs;
                 if (!fIgnoreMessage)
                 {
-                    bool fIncludeMessage = FilterMessage(hdr, tsl, msg->facility, format, deltaTime, numberOfArgs, msg->args);
+                    bool fIncludeMessage = s_showAllMessages || FilterMessage(hdr, tsl, msg->facility, format, deltaTime, numberOfArgs, msg->args);
                     if (!fIncludeMessage && s_valueFilterCount > 0)
                     {
                         for (int i = 0; i < numberOfArgs; i++)
@@ -1218,6 +1223,7 @@ int ProcessStressLog(void* baseAddress, int argc, char* argv[])
     s_timeFilterEnd = 0;
     s_outputFileName = nullptr;
     s_fPrintFormatStrings = false;
+    s_showAllMessages = false;
     memset(&mapImageToStringId, 0, sizeof(mapImageToStringId));
 
     if (!ParseOptions(argc, argv))


### PR DESCRIPTION
The bug was a typo, I should have used [`strtoull`](https://www.cplusplus.com/reference/cstdlib/strtoull/) instead of [`strtoul`](https://www.cplusplus.com/reference/cstdlib/strtoul/). The latter only works with 32-bit integers.

In this change, I added a `-a` mode for dumping all messages, just in case we need to debug similar situations again.