### PR TITLE
superpmi: Catch errors while printing the unicode string 

### DIFF
--- a/src/coreclr/scripts/jitutil.py
+++ b/src/coreclr/scripts/jitutil.py
@@ -92,23 +92,22 @@ def set_pipeline_variable(name, value):
 ##
 ################################################################################
 
-def decode_string(str_to_decode):
+def decode_and_print(str_to_decode):
     """Decode a UTF-8 encoded bytes to string.
 
     Args:
         str_to_decode (byte stream): Byte stream to decode
 
     Returns:
-        String output. If there any encoding/decoding errors, it will replace it with
-        UnicodeEncodeError.
+        String output. If there any encoding/decoding errors, it will not print anything
+        and return an empty string.
     """
+    output = ''
     try:
         output = str_to_decode.decode("utf-8", errors='replace')
-    except UnicodeEncodeError:
-        output = "UnicodeEncodeError"
-    except UnicodeDecodeError:
-        output = "UnicodeDecodeError"
-    return output
+        print(output)
+    finally:
+        return output
 
 def run_command(command_to_run, _cwd=None, _exit_on_fail=False, _output_file=None):
     """ Runs the command.
@@ -138,15 +137,14 @@ def run_command(command_to_run, _cwd=None, _exit_on_fail=False, _output_file=Non
                     if proc.poll() is not None:
                         break
                     if output:
-                        output_str = decode_string(output.strip())
-                        print(output_str)
+                        output_str = decode_and_print(output.strip())
                         of.write(output_str + "\n")
         else:
             command_stdout, command_stderr = proc.communicate()
             if len(command_stdout) > 0:
-                print(decode_string(command_stdout))
+                decode_and_print(command_stdout)
             if len(command_stderr) > 0:
-                print(decode_string(command_stderr))
+                decode_and_print(command_stderr)
 
         return_code = proc.returncode
         if _exit_on_fail and return_code != 0:


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/64251, I made a fix to catch decoding issues, but seems that the problem also occurs when printing those characters. On quick search reveals [this problem and proposals to fix them](https://stackoverflow.com/questions/27092833/unicodeencodeerror-charmap-codec-cant-encode-characters), but the simplest thing to do in our situation would be to just return empty string if such errors occur. So, I converted the `decode_string` method to `decode_and_print` which will catch the printing errors as well.

Fixes: #64575 

