### PR TITLE
Optimize new DateTime(const, const, const)

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5197,7 +5197,7 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
         {
             int             length;
             const char16_t* str = info.compCompHnd->getStringLiteral(asIndex->Arr()->AsStrCon()->gtScpHnd,
-                                                                    asIndex->Arr()->AsStrCon()->gtSconCPX, &length);
+                                                                     asIndex->Arr()->AsStrCon()->gtSconCPX, &length);
             if ((cnsIndex < length) && (str != nullptr))
             {
                 GenTree* cnsCharNode = gtNewIconNode(str[cnsIndex], TYP_INT);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5183,20 +5183,26 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
 
     noway_assert(elemTyp != TYP_STRUCT || elemStructType != nullptr);
 
-    // Fold "cns_str"[cns_index] to ushort constant
-    if (opts.OptimizationEnabled() && asIndex->Arr()->OperIs(GT_CNS_STR) && asIndex->Index()->IsIntCnsFitsInI32())
+    if (opts.OptimizationEnabled())
     {
-        const int cnsIndex = static_cast<int>(asIndex->Index()->AsIntConCommon()->IconValue());
-        if (cnsIndex >= 0)
+        // Fold potential constant expressions, e.g. "ADD(CNS, CNS)"
+        asIndex->Index() = gtFoldExpr(asIndex->Index());
+
+        // Fold "cns_str"[cns_index] to ushort constant
+        if (asIndex->Arr()->OperIs(GT_CNS_STR) && asIndex->Index()->IsIntCnsFitsInI32())
         {
-            int             length;
-            const char16_t* str = info.compCompHnd->getStringLiteral(asIndex->Arr()->AsStrCon()->gtScpHnd,
-                                                                     asIndex->Arr()->AsStrCon()->gtSconCPX, &length);
-            if ((cnsIndex < length) && (str != nullptr))
+            const int cnsIndex = static_cast<int>(asIndex->Index()->AsIntConCommon()->IconValue());
+            if (cnsIndex >= 0)
             {
-                GenTree* cnsCharNode = gtNewIconNode(str[cnsIndex], TYP_INT);
-                INDEBUG(cnsCharNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);
-                return cnsCharNode;
+                int             length;
+                const char16_t* str = info.compCompHnd->getStringLiteral(asIndex->Arr()->AsStrCon()->gtScpHnd,
+                                                                        asIndex->Arr()->AsStrCon()->gtSconCPX, &length);
+                if ((cnsIndex < length) && (str != nullptr))
+                {
+                    GenTree* cnsCharNode = gtNewIconNode(str[cnsIndex], TYP_INT);
+                    INDEBUG(cnsCharNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);
+                    return cnsCharNode;
+                }
             }
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -585,14 +585,24 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRange_BadYearMonthDay();
             }
 
-            uint[] days = IsLeapYear(year) ? s_daysToMonth366 : s_daysToMonth365;
-            if ((uint)day > days[month] - days[month - 1])
+            const string DaysToMonth365Str = "\u0000\u001f\u003b\u005a\u0078\u0097\u00b5\u00d4\u00f3\u00111\u00130\u0014e\u0016d";
+            const string DaysToMonth366Str = "\u0000\u001f\u003c\u005b\u0079\u0098\u00b6\u00d5\u00f4\u00112\u00131\u0014f\u0016e";
+
+            if (IsLeapYear(year))
+            {
+                return DateToTicks(year, month, day, DaysToMonth366Str);
+            }
+            return DateToTicks(year, month, day, DaysToMonth365Str);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong DateToTicks(int year, int month, int day, string daysToMonthMap)
+        {
+            if ((uint)day > daysToMonthMap[month] - daysToMonthMap[month - 1])
             {
                 ThrowHelper.ThrowArgumentOutOfRange_BadYearMonthDay();
             }
-
-            uint n = DaysToYear((uint)year) + days[month - 1] + (uint)day - 1;
-            return n * (ulong)TicksPerDay;
+            return (DaysToYear((uint)year) + daysToMonthMap[month - 1] + (uint)day - 1) * (ulong)TicksPerDay;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -585,6 +585,10 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRange_BadYearMonthDay();
             }
 
+            // These constants are s_daysToMonth365/s_daysToMonth366 encoded as strings
+            // Unfortunately, it's the only way for JIT to fold RVA[const] at the moment,
+            // Once C# gets ROS<anything>=RVA we'll change s_daysToMonth365 to ReadOnlySpan<uint> and implement
+            // constant folding in JIT for it (for constant indices) and remove this
             const string DaysToMonth365Str = "\u0000\u001f\u003b\u005a\u0078\u0097\u00b5\u00d4\u00f3\u00111\u00130\u0014e\u0016d";
             const string DaysToMonth366Str = "\u0000\u001f\u003c\u005b\u0079\u0098\u00b6\u00d5\u00f4\u00112\u00131\u0014f\u0016e";
 


### PR DESCRIPTION
This PR optimizes `new DateTime(const, const, const)` case, e.g.:
```csharp
[Benchmark]
public DateTime ConstDate() => new (2022, 12, 10);
```
Currently emits:
```asm
; Method Test:ConstDate():System.DateTime:this
G_M10442_IG01:              ;; offset=0000H
       4883EC28             sub      rsp, 40
G_M10442_IG02:              ;; offset=0004H
       48B9104AD1CEF87F0000 mov      rcx, 0x7FF8CED14A10
       BAF9000000           mov      edx, 249
       E808639F5F           call     CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE
       48B8201280B98B020000 mov      rax, 0x28BB9801220
       488B00               mov      rax, gword ptr [rax]
       8B5008               mov      edx, dword ptr [rax+8]
       83FA0C               cmp      edx, 12
       762B                 jbe      SHORT G_M10442_IG05
       8B5040               mov      edx, dword ptr [rax+64]
       8B403C               mov      eax, dword ptr [rax+60]
       2BD0                 sub      edx, eax
       83FA0A               cmp      edx, 10
       7218                 jb       SHORT G_M10442_IG04
       0574430B00           add      eax, 0xB4374
       48BA00C0692AC9000000 mov      rdx, 0xC92A69C000
       480FAFC2             imul     rax, rdx
G_M10442_IG03:              ;; offset=004DH
       4883C428             add      rsp, 40
       C3                   ret      
G_M10442_IG04:              ;; offset=0052H
       E8B183FFFF           call     System.ThrowHelper:ThrowArgumentOutOfRange_BadYearMonthDay()
       CC                   int3     
G_M10442_IG05:              ;; offset=0058H
       E803AD685F           call     CORINFO_HELP_RNGCHKFAIL
       CC                   int3     
; Total bytes of code: 94
```
New codegen:
```asm
; Method Test:ConstDate():System.DateTime:this
G_M10442_IG01:              ;; offset=0000H
G_M10442_IG02:              ;; offset=0000H
       48B80040044BBAE2D908 mov      rax, 0x8D9E2BA4B044000
G_M10442_IG03:              ;; offset=000AH
       C3                   ret      
; Total bytes of code: 11
```
Benchmarks

|     Method |                   Toolchain |    y | d | m |      Mean |
|----------- |---------------------------- |----- |-- |-- |----------:|
|  ConstDate | \Core_Root_base\corerun.exe |    ? | ? | ? | 0.4368 ns |
|  ConstDate |      \Core_Root\corerun.exe |    ? | ? | ? | 0.0266 ns |
|            |                             |      |   |   |           |
| ConstMonth | \Core_Root_base\corerun.exe | 2022 | 1 | ? | 1.2839 ns |
| ConstMonth |      \Core_Root\corerun.exe | 2022 | 1 | ? | 0.7184 ns |
|            |                             |      |   |   |           |
|    VarDate | \Core_Root_base\corerun.exe | 2022 | 1 | 2 | 1.6864 ns |
|    VarDate |      \Core_Root\corerun.exe | 2022 | 1 | 2 | 1.6519 ns |

Feel free to reject it 🙂, eventually we should be able to get constant case codegen even with the current code, for that we need:
1) Wait till C# gets `ReadOnlySpan<any primitive>` for RVA data
2) Make `s_daysToMonth365` and `s_daysToMonth366` `ReadOnlySpan<uint>`
3) Implement `RVA[const index]` folding in JIT - unfortunately it's a bit tricky but should be doable
4) Forward Substitution (probably a bit more advanced than what Andy's currently doing)