### PR TITLE
[mono] Remove OP_FCONV_TO_U opcode

### DIFF
--- a/src/mono/mono/mini/cpu-amd64.md
+++ b/src/mono/mono/mini/cpu-amd64.md
@@ -284,7 +284,6 @@ float_cgt_membase: dest:i src1:f src2:b len:35
 float_cgt_un_membase: dest:i src1:f src2:b len:48
 float_clt_membase: dest:i src1:f src2:b len:35
 float_clt_un_membase: dest:i src1:f src2:b len:42
-float_conv_to_u: dest:i src1:f len:46
 
 # R4 opcodes
 r4_conv_to_i1: dest:i src1:f len:32

--- a/src/mono/mono/mini/cpu-arm.md
+++ b/src/mono/mono/mini/cpu-arm.md
@@ -220,7 +220,6 @@ float_clt_un: dest:i src1:f src2:f len:20
 float_cneq: dest:y src1:f src2:f len:20
 float_cge: dest:y src1:f src2:f len:20
 float_cle: dest:y src1:f src2:f len:20
-float_conv_to_u: dest:i src1:f len:36
 
 # R4 opcodes
 rmove: dest:f src1:f len:4

--- a/src/mono/mono/mini/cpu-arm64.md
+++ b/src/mono/mono/mini/cpu-arm64.md
@@ -218,7 +218,6 @@ float_clt_un: dest:i src1:f src2:f len:20
 float_cneq: dest:i src1:f src2:f len:20
 float_cge: dest:i src1:f src2:f len:20
 float_cle: dest:i src1:f src2:f len:20
-float_conv_to_u: dest:i src1:f len:36
 setfret: src1:f len:12
 
 # R4 opcodes

--- a/src/mono/mono/mini/cpu-mips.md
+++ b/src/mono/mono/mini/cpu-mips.md
@@ -383,7 +383,6 @@ float_cgt: dest:i src1:f src2:f len:20
 float_cgt_un: dest:i src1:f src2:f len:20
 float_clt: dest:i src1:f src2:f len:20
 float_clt_un: dest:i src1:f src2:f len:20
-float_conv_to_u: dest:i src1:f len:36
 call_handler: len:20 clob:c
 endfilter: src1:i len:16
 aotconst: dest:i len:8

--- a/src/mono/mono/mini/cpu-ppc.md
+++ b/src/mono/mono/mini/cpu-ppc.md
@@ -200,7 +200,6 @@ float_cgt: dest:i src1:f src2:f len:16
 float_cgt_un: dest:i src1:f src2:f len:20
 float_clt: dest:i src1:f src2:f len:16
 float_clt_un: dest:i src1:f src2:f len:20
-float_conv_to_u: dest:i src1:f len:36
 float_cneq: dest:i src1:f src2:f len:16
 float_cge: dest:i src1:f src2:f len:16
 float_cle: dest:i src1:f src2:f len:16

--- a/src/mono/mono/mini/cpu-ppc64.md
+++ b/src/mono/mono/mini/cpu-ppc64.md
@@ -204,7 +204,6 @@ float_cgt: dest:i src1:f src2:f len:16
 float_cgt_un: dest:i src1:f src2:f len:20
 float_clt: dest:i src1:f src2:f len:16
 float_clt_un: dest:i src1:f src2:f len:20
-float_conv_to_u: dest:i src1:f len:36
 float_cneq: dest:i src1:f src2:f len:16
 float_cge: dest:i src1:f src2:f len:16
 float_cle: dest:i src1:f src2:f len:16

--- a/src/mono/mono/mini/cpu-s390x.md
+++ b/src/mono/mono/mini/cpu-s390x.md
@@ -128,7 +128,6 @@ float_conv_to_u1: dest:i src1:f len:72
 float_conv_to_u2: dest:i src1:f len:72
 float_conv_to_u4: dest:i src1:f len:72
 float_conv_to_u8: dest:i src1:f len:72
-float_conv_to_u: dest:i src1:f len:36
 float_div: dest:f src1:f src2:f len:24
 float_div_un: dest:f src1:f src2:f len:30
 float_mul: dest:f src1:f src2:f len:8

--- a/src/mono/mono/mini/cpu-sparc.md
+++ b/src/mono/mono/mini/cpu-sparc.md
@@ -180,7 +180,6 @@ float_cgt: dest:i src1:f src2:f len:64
 float_cgt_un: dest:i src1:f src2:f len:64
 float_clt: dest:i src1:f src2:f len:64
 float_clt_un: dest:i src1:f src2:f len:64
-float_conv_to_u: dest:i src1:f len:64
 call_handler: len:64 clob:c
 aotconst: dest:i len:64
 adc: dest:i src1:i src2:i len:4

--- a/src/mono/mono/mini/cpu-x86.md
+++ b/src/mono/mono/mini/cpu-x86.md
@@ -266,7 +266,6 @@ float_clt_un: dest:y src1:f src2:f len:32
 float_cneq: dest:y src1:f src2:f len:25
 float_cge: dest:y src1:f src2:f len:37
 float_cle: dest:y src1:f src2:f len:37
-float_conv_to_u: dest:i src1:f len:36
 call_handler: len:11 clob:c
 aotconst: dest:i len:5
 load_gotaddr: dest:i len:64

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -5169,7 +5169,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_U4_R8)
 #ifdef MONO_ARCH_EMULATE_FCONV_TO_U4
-			LOCAL_VAR (ip [1], gint32) = mono_fconv_u4_2 (LOCAL_VAR (ip [2], double));
+			LOCAL_VAR (ip [1], gint32) = mono_fconv_u4 (LOCAL_VAR (ip [2], double));
 #else
 			LOCAL_VAR (ip [1], gint32) = (guint32) LOCAL_VAR (ip [2], double);
 #endif
@@ -5225,7 +5225,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_U8_R8)
 #ifdef MONO_ARCH_EMULATE_FCONV_TO_U8
-			LOCAL_VAR (ip [1], gint64) = mono_fconv_u8_2 (LOCAL_VAR (ip [2], double));
+			LOCAL_VAR (ip [1], gint64) = mono_fconv_u8 (LOCAL_VAR (ip [2], double));
 #else
 			LOCAL_VAR (ip [1], gint64) = (guint64) LOCAL_VAR (ip [2], double);
 #endif

--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -918,6 +918,7 @@ mono_ldtoken_wrapper_generic_shared (MonoImage *image, int token, MonoMethod *me
 	return mono_ldtoken_wrapper (image, token, generic_context);
 }
 
+#ifdef MONO_ARCH_EMULATE_FCONV_TO_U8
 guint64
 mono_fconv_u8 (double v)
 {
@@ -933,18 +934,6 @@ mono_fconv_u8 (double v)
 		return 0;
 	return (guint64)v;
 #endif
-}
-
-#ifdef MONO_ARCH_EMULATE_FCONV_TO_U8
-guint64
-mono_fconv_u8_2 (double v)
-{
-	// Separate from mono_fconv_u8 to avoid duplicate JIT icall.
-	//
-	// When there are duplicates, there is single instancing
-	// against function address that breaks stuff. For example,
-	// wrappers are only produced for one of them, breaking FullAOT.
-	return mono_fconv_u8 (v);
 }
 
 guint64
@@ -973,6 +962,7 @@ mono_fconv_i8 (double v)
 }
 #endif
 
+#ifdef MONO_ARCH_EMULATE_FCONV_TO_U4
 guint32
 mono_fconv_u4 (double v)
 {
@@ -980,18 +970,6 @@ mono_fconv_u4 (double v)
 	if (mono_isinf (v) || mono_isnan (v))
 		return 0;
 	return (guint32)v;
-}
-
-#ifdef MONO_ARCH_EMULATE_FCONV_TO_U4
-guint32
-mono_fconv_u4_2 (double v)
-{
-	// Separate from mono_fconv_u4 to avoid duplicate JIT icall.
-	//
-	// When there are duplicates, there is single instancing
-	// against function address that breaks stuff. For example,
-	// wrappers are only produced for one of them, breaking FullAOT.
-	return mono_fconv_u4 (v);
 }
 
 guint32

--- a/src/mono/mono/mini/jit-icalls.h
+++ b/src/mono/mono/mini/jit-icalls.h
@@ -77,14 +77,12 @@ ICALL_EXPORT gpointer mono_ldtoken_wrapper (MonoImage *image, int token, MonoGen
 ICALL_EXPORT gpointer mono_ldtoken_wrapper_generic_shared (MonoImage *image, int token, MonoMethod *method);
 
 ICALL_EXPORT guint64 mono_fconv_u8 (double v);
-ICALL_EXPORT guint64 mono_fconv_u8_2 (double v);
 
 ICALL_EXPORT guint64 mono_rconv_u8 (float v);
 
 ICALL_EXPORT gint64 mono_fconv_i8 (double v);
 
 ICALL_EXPORT guint32 mono_fconv_u4 (double v);
-ICALL_EXPORT guint32 mono_fconv_u4_2 (double v);
 
 ICALL_EXPORT guint32 mono_rconv_u4 (float v);
 

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -1133,7 +1133,10 @@ type_from_op (MonoCompile *cfg, MonoInst *ins, MonoInst *src1, MonoInst *src2)
 			ins->opcode = OP_LCONV_TO_U;
 			break;
 		case STACK_R8:
-			ins->opcode = OP_FCONV_TO_U;
+			if (TARGET_SIZEOF_VOID_P == 8)
+				ins->opcode = OP_FCONV_TO_U8;
+			else
+				ins->opcode = OP_FCONV_TO_U4;
 			break;
 		case STACK_R4:
 			if (TARGET_SIZEOF_VOID_P == 8)

--- a/src/mono/mono/mini/mini-arm.c
+++ b/src/mono/mono/mini/mini-arm.c
@@ -5686,7 +5686,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			code = emit_float_to_int (cfg, code, ins->dreg, ins->sreg1, 4, TRUE);
 			break;
 		case OP_FCONV_TO_U4:
-		case OP_FCONV_TO_U:
 			code = emit_float_to_int (cfg, code, ins->dreg, ins->sreg1, 4, FALSE);
 			break;
 		case OP_FCONV_TO_I8:

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -981,7 +981,6 @@ op_to_llvm_type (int opcode)
 	case OP_RCONV_TO_U8:
 		return LLVMInt64Type ();
 	case OP_FCONV_TO_I:
-	case OP_FCONV_TO_U:
 		return TARGET_SIZEOF_VOID_P == 8 ? LLVMInt64Type () : LLVMInt32Type ();
 	case OP_IADD_OVF:
 	case OP_IADD_OVF_UN:

--- a/src/mono/mono/mini/mini-mips.c
+++ b/src/mono/mono/mini/mini-mips.c
@@ -4270,7 +4270,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			code = emit_float_to_int (cfg, code, ins->dreg, ins->sreg1, 4, TRUE);
 			break;
 		case OP_FCONV_TO_U4:
-		case OP_FCONV_TO_U:
 			code = emit_float_to_int (cfg, code, ins->dreg, ins->sreg1, 4, FALSE);
 			break;
 		case OP_SQRT:

--- a/src/mono/mono/mini/mini-ops.h
+++ b/src/mono/mono/mini/mini-ops.h
@@ -586,7 +586,6 @@ MINI_OP(OP_FCGT_UN_MEMBASE,"float_cgt_un_membase", IREG, FREG, IREG)
 MINI_OP(OP_FCLT_MEMBASE,   "float_clt_membase", IREG, FREG, IREG)
 MINI_OP(OP_FCLT_UN_MEMBASE,"float_clt_un_membase", IREG, FREG, IREG)
 
-MINI_OP(OP_FCONV_TO_U,	"float_conv_to_u", IREG, FREG, NONE)
 MINI_OP(OP_CKFINITE, "ckfinite", FREG, FREG, NONE)
 
 /* r4 opcodes: must be in the same order as the matching CEE_ opcodes: ovfops_op_map */

--- a/src/mono/mono/mini/mini-ppc.c
+++ b/src/mono/mono/mini/mini-ppc.c
@@ -4163,7 +4163,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			code = emit_float_to_int (cfg, code, ins->dreg, ins->sreg1, 4, TRUE);
 			break;
 		case OP_FCONV_TO_U4:
-		case OP_FCONV_TO_U:
 			code = emit_float_to_int (cfg, code, ins->dreg, ins->sreg1, 4, FALSE);
 			break;
 		case OP_LCONV_TO_R_UN:

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4760,11 +4760,11 @@ register_icalls (void)
 #endif
 
 #ifdef MONO_ARCH_EMULATE_FCONV_TO_U8
-	register_opcode_emulation (OP_FCONV_TO_U8, __emul_fconv_to_u8, mono_icall_sig_ulong_double, mono_fconv_u8_2, FALSE);
+	register_opcode_emulation (OP_FCONV_TO_U8, __emul_fconv_to_u8, mono_icall_sig_ulong_double, mono_fconv_u8, FALSE);
 	register_opcode_emulation (OP_RCONV_TO_U8, __emul_rconv_to_u8, mono_icall_sig_ulong_float, mono_rconv_u8, FALSE);
 #endif
 #ifdef MONO_ARCH_EMULATE_FCONV_TO_U4
-	register_opcode_emulation (OP_FCONV_TO_U4, __emul_fconv_to_u4, mono_icall_sig_uint32_double, mono_fconv_u4_2, FALSE);
+	register_opcode_emulation (OP_FCONV_TO_U4, __emul_fconv_to_u4, mono_icall_sig_uint32_double, mono_fconv_u4, FALSE);
 	register_opcode_emulation (OP_RCONV_TO_U4, __emul_rconv_to_u4, mono_icall_sig_uint32_float, mono_rconv_u4, FALSE);
 #endif
 	register_opcode_emulation (OP_FCONV_TO_OVF_I8, __emul_fconv_to_ovf_i8, mono_icall_sig_long_double, mono_fconv_ovf_i8, FALSE);
@@ -4840,13 +4840,6 @@ register_icalls (void)
 
 #ifdef COMPRESSED_INTERFACE_BITMAP
 	register_icall (mono_class_interface_match, mono_icall_sig_uint32_ptr_int32, TRUE);
-#endif
-
-	// FIXME Elsewhere these are registered with no_wrapper = FALSE
-#if SIZEOF_REGISTER == 4
-	register_opcode_emulation (OP_FCONV_TO_U, __emul_fconv_to_u, mono_icall_sig_uint32_double, mono_fconv_u4, TRUE);
-#else
-	register_opcode_emulation (OP_FCONV_TO_U, __emul_fconv_to_u, mono_icall_sig_ulong_double, mono_fconv_u8, TRUE);
 #endif
 
 	/* other jit icalls */

--- a/src/mono/mono/mini/mini-s390x.c
+++ b/src/mono/mono/mini/mini-s390x.c
@@ -4290,7 +4290,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			s390_cfdbr (code, ins->dreg, 5, ins->sreg1);
 			break;
 		case OP_FCONV_TO_U4:
-		case OP_FCONV_TO_U:
 			if (mono_hwcap_s390x_has_fpe) {
 				s390_clgdbr (code, ins->dreg, 5, ins->sreg1, 0);
 			} else {

--- a/src/mono/mono/mini/mini-sparc.c
+++ b/src/mono/mono/mini/mini-sparc.c
@@ -3395,7 +3395,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_FCONV_TO_U2:
 #ifndef SPARCV9
 		case OP_FCONV_TO_I:
-		case OP_FCONV_TO_U:
 #endif
 		case OP_FCONV_TO_I4:
 		case OP_FCONV_TO_U4: {


### PR DESCRIPTION
* Emit OP_FCONV_TO_U8/U4 instead of OP_FCONV_TO_U.

* Remove OP_FCONV_TO_U implementations across all back ends.

* Remove duplicated mono_fconv_u8/u4 icall wrappers.

* Fixes https://github.com/dotnet/runtime/issues/64570

CC @lambdageek 