### PR TITLE
Improve perf of Enumerable.Sum/Average/Max/Min for arrays and lists

### DIFF
--- a/src/libraries/System.Linq/src/System.Linq.csproj
+++ b/src/libraries/System.Linq/src/System.Linq.csproj
@@ -100,6 +100,8 @@
     <Reference Include="System.Memory" />
     <Reference Include="System.Numerics.Vectors" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.Extensions" />
+    <Reference Include="System.Runtime.InteropServices" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Linq/src/System/Linq/Average.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Average.cs
@@ -47,12 +47,18 @@ namespace System.Linq
             long sum = 0;
             int i = 0;
 
-            if (Vector.IsHardwareAccelerated)
+            if (Vector.IsHardwareAccelerated && span.Length >= Vector<int>.Count)
             {
-                for (; i <= span.Length - Vector<int>.Count; i += Vector<int>.Count)
+                Vector<long> sums = default;
+                do
                 {
-                    sum += Vector.Sum(new Vector<int>(span.Slice(i)));
+                    Vector.Widen(new Vector<int>(span.Slice(i)), out Vector<long> low, out Vector<long> high);
+                    sums += low;
+                    sums += high;
+                    i += Vector<int>.Count;
                 }
+                while (i <= span.Length - Vector<int>.Count);
+                sum += Vector.Sum(sums);
             }
 
             for (; (uint)i < (uint)span.Length; i++)

--- a/src/libraries/System.Linq/src/System/Linq/Average.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Average.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace System.Linq
 {
@@ -9,9 +10,9 @@ namespace System.Linq
     {
         public static double Average(this IEnumerable<int> source)
         {
-            if (source == null)
+            if (source.TryGetSpan(out ReadOnlySpan<int> span))
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                return Average(span);
             }
 
             using (IEnumerator<int> e = source.GetEnumerator())
@@ -34,6 +35,32 @@ namespace System.Linq
 
                 return (double)sum / count;
             }
+        }
+
+        private static double Average(ReadOnlySpan<int> span)
+        {
+            if (span.IsEmpty)
+            {
+                ThrowHelper.ThrowNoElementsException();
+            }
+
+            long sum = 0;
+            int i = 0;
+
+            if (Vector.IsHardwareAccelerated)
+            {
+                for (; i <= span.Length - Vector<int>.Count; i += Vector<int>.Count)
+                {
+                    sum += Vector.Sum(new Vector<int>(span.Slice(i)));
+                }
+            }
+
+            for (; (uint)i < (uint)span.Length; i++)
+            {
+                sum += span[i];
+            }
+
+            return (double)sum / span.Length;
         }
 
         public static double? Average(this IEnumerable<int?> source)
@@ -75,9 +102,9 @@ namespace System.Linq
 
         public static double Average(this IEnumerable<long> source)
         {
-            if (source == null)
+            if (source.TryGetSpan(out ReadOnlySpan<long> span))
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                return Average(span);
             }
 
             using (IEnumerator<long> e = source.GetEnumerator())
@@ -100,6 +127,22 @@ namespace System.Linq
 
                 return (double)sum / count;
             }
+        }
+
+        private static double Average(ReadOnlySpan<long> span)
+        {
+            if (span.IsEmpty)
+            {
+                ThrowHelper.ThrowNoElementsException();
+            }
+
+            long sum = span[0];
+            for (int i = 1; i < span.Length; i++)
+            {
+                checked { sum += span[i]; }
+            }
+
+            return (double)sum / span.Length;
         }
 
         public static double? Average(this IEnumerable<long?> source)
@@ -141,9 +184,14 @@ namespace System.Linq
 
         public static float Average(this IEnumerable<float> source)
         {
-            if (source == null)
+            if (source.TryGetSpan(out ReadOnlySpan<float> span))
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                if (span.IsEmpty)
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                return (float)(Sum(span) / span.Length);
             }
 
             using (IEnumerator<float> e = source.GetEnumerator())
@@ -204,9 +252,14 @@ namespace System.Linq
 
         public static double Average(this IEnumerable<double> source)
         {
-            if (source == null)
+            if (source.TryGetSpan(out ReadOnlySpan<double> span))
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                if (span.IsEmpty)
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                return Sum(span) / span.Length;
             }
 
             using (IEnumerator<double> e = source.GetEnumerator())
@@ -270,9 +323,14 @@ namespace System.Linq
 
         public static decimal Average(this IEnumerable<decimal> source)
         {
-            if (source == null)
+            if (source.TryGetSpan(out ReadOnlySpan<decimal> span))
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                if (span.IsEmpty)
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                return Sum(span) / span.Length;
             }
 
             using (IEnumerator<decimal> e = source.GetEnumerator())

--- a/src/libraries/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Enumerable.cs
@@ -2,11 +2,52 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Linq
 {
     public static partial class Enumerable
     {
         public static IEnumerable<TSource> AsEnumerable<TSource>(this IEnumerable<TSource> source) => source;
+
+        /// <summary>Validates that source is not null and then tries to extract a span from the source.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // fast type checks that don't add a lot of overhead
+        private static bool TryGetSpan<TSource>(this IEnumerable<TSource> source, out ReadOnlySpan<TSource> span)
+            // This constraint isn't required, but the overheads involved here can be more substantial when TSource
+            // is a reference type and generic implementations are shared.  So for now we're protecting ourselves
+            // and forcing a conscious choice to remove this in the future, at which point it should be paired with
+            // sufficient performance testing.
+            where TSource : struct
+        {
+            if (source is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            // Use `GetType() == typeof(...)` rather than `is` to avoid cast helpers.  This is measurably cheaper
+            // but does mean we could end up missing some rare cases where we could get a span but don't (e.g. a uint[]
+            // masquerading as an int[]).  That's an acceptable tradeoff.  The Unsafe usage is only after we've
+            // validated the exact type; this could be changed to a cast in the future if the JIT starts to recognize it.
+            // We only pay the comparison/branching costs here for super common types we expect to be used frequently
+            // with LINQ methods.
+
+            bool result = true;
+            if (source.GetType() == typeof(TSource[]))
+            {
+                span = Unsafe.As<TSource[]>(source);
+            }
+            else if (source.GetType() == typeof(List<TSource>))
+            {
+                span = CollectionsMarshal.AsSpan(Unsafe.As<List<TSource>>(source));
+            }
+            else
+            {
+                span = default;
+                result = false;
+            }
+
+            return result;
+        }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Max.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Max.cs
@@ -10,14 +10,9 @@ namespace System.Linq
     {
         public static int Max(this IEnumerable<int> source)
         {
-            if (source == null)
+            if (source.TryGetSpan(out ReadOnlySpan<int> span))
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
-            }
-
-            if (source.GetType() == typeof(int[]))
-            {
-                return Max((int[])source);
+                return Max(span);
             }
 
             int value;
@@ -42,29 +37,29 @@ namespace System.Linq
             return value;
         }
 
-        private static int Max(int[] array)
+        private static int Max(ReadOnlySpan<int> span)
         {
-            if (array.Length == 0)
+            if (span.IsEmpty)
             {
                 ThrowHelper.ThrowNoElementsException();
             }
 
             // Vectorize the search if possible.
             int index, value;
-            if (Vector.IsHardwareAccelerated && array.Length >= Vector<int>.Count * 2)
+            if (Vector.IsHardwareAccelerated && span.Length >= Vector<int>.Count * 2)
             {
-                // The array is at least two vectors long. Create a vector from the first N elements,
-                // and then repeatedly compare that against the next vector from the array.  At the end,
+                // The span is at least two vectors long. Create a vector from the first N elements,
+                // and then repeatedly compare that against the next vector from the span.  At the end,
                 // the resulting vector will contain the maximum values found, and we then need only
                 // to find the max of those.
-                var maxes = new Vector<int>(array);
+                var maxes = new Vector<int>(span);
                 index = Vector<int>.Count;
                 do
                 {
-                    maxes = Vector.Max(maxes, new Vector<int>(array, index));
+                    maxes = Vector.Max(maxes, new Vector<int>(span.Slice(index)));
                     index += Vector<int>.Count;
                 }
-                while (index + Vector<int>.Count <= array.Length);
+                while (index + Vector<int>.Count <= span.Length);
 
                 value = maxes[0];
                 for (int i = 1; i < Vector<int>.Count; i++)
@@ -77,16 +72,16 @@ namespace System.Linq
             }
             else
             {
-                value = array[0];
+                value = span[0];
                 index = 1;
             }
 
             // Iterate through the remaining elements, comparing against the max.
-            for (int i = index; (uint)i < (uint)array.Length; i++)
+            for (int i = index; (uint)i < (uint)span.Length; i++)
             {
-                if (array[i] > value)
+                if (span[i] > value)
                 {
-                    value = array[i];
+                    value = span[i];
                 }
             }
 
@@ -157,14 +152,9 @@ namespace System.Linq
 
         public static long Max(this IEnumerable<long> source)
         {
-            if (source == null)
+            if (source.TryGetSpan(out ReadOnlySpan<long> span))
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
-            }
-
-            if (source.GetType() == typeof(long[]))
-            {
-                return Max((long[])source);
+                return Max(span);
             }
 
             long value;
@@ -189,9 +179,9 @@ namespace System.Linq
             return value;
         }
 
-        private static long Max(long[] array)
+        private static long Max(ReadOnlySpan<long> span)
         {
-            if (array.Length == 0)
+            if (span.IsEmpty)
             {
                 ThrowHelper.ThrowNoElementsException();
             }
@@ -199,20 +189,20 @@ namespace System.Linq
             // Vectorize the search if possible.
             int index;
             long value;
-            if (Vector.IsHardwareAccelerated && array.Length >= Vector<long>.Count * 2)
+            if (Vector.IsHardwareAccelerated && span.Length >= Vector<long>.Count * 2)
             {
-                // The array is at least two vectors long. Create a vector from the first N elements,
-                // and then repeatedly compare that against the next vector from the array.  At the end,
+                // The span is at least two vectors long. Create a vector from the first N elements,
+                // and then repeatedly compare that against the next vector from the span.  At the end,
                 // the resulting vector will contain the maximum values found, and we then need only
                 // to find the max of those.
-                var maxes = new Vector<long>(array);
+                var maxes = new Vector<long>(span);
                 index = Vector<long>.Count;
                 do
                 {
-                    maxes = Vector.Max(maxes, new Vector<long>(array, index));
+                    maxes = Vector.Max(maxes, new Vector<long>(span.Slice(index)));
                     index += Vector<long>.Count;
                 }
-                while (index + Vector<long>.Count <= array.Length);
+                while (index + Vector<long>.Count <= span.Length);
 
                 value = maxes[0];
                 for (int i = 1; i < Vector<long>.Count; i++)
@@ -225,16 +215,16 @@ namespace System.Linq
             }
             else
             {
-                value = array[0];
+                value = span[0];
                 index = 1;
             }
 
             // Iterate through the remaining elements, comparing against the max.
-            for (int i = index; (uint)i < (uint)array.Length; i++)
+            for (int i = index; (uint)i < (uint)span.Length; i++)
             {
-                if (array[i] > value)
+                if (span[i] > value)
                 {
-                    value = array[i];
+                    value = span[i];
                 }
             }
 
@@ -299,9 +289,9 @@ namespace System.Linq
 
         public static double Max(this IEnumerable<double> source)
         {
-            if (source == null)
+            if (source.TryGetSpan(out ReadOnlySpan<double> span))
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                return Max(span);
             }
 
             double value;
@@ -335,6 +325,33 @@ namespace System.Linq
                     {
                         value = x;
                     }
+                }
+            }
+
+            return value;
+        }
+
+        private static double Max(ReadOnlySpan<double> span)
+        {
+            if (span.IsEmpty)
+            {
+                ThrowHelper.ThrowNoElementsException();
+            }
+
+            int i;
+            for (i = 0; i < span.Length && double.IsNaN(span[i]); i++);
+
+            if (i == span.Length)
+            {
+                return span[^1];
+            }
+
+            double value;
+            for (value = span[i]; (uint)i < (uint)span.Length; i++)
+            {
+                if (span[i] > value)
+                {
+                    value = span[i];
                 }
             }
 
@@ -397,9 +414,9 @@ namespace System.Linq
 
         public static float Max(this IEnumerable<float> source)
         {
-            if (source == null)
+            if (source.TryGetSpan(out ReadOnlySpan<float> span))
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                return Max(span);
             }
 
             float value;
@@ -428,6 +445,33 @@ namespace System.Linq
                     {
                         value = x;
                     }
+                }
+            }
+
+            return value;
+        }
+
+        private static float Max(ReadOnlySpan<float> span)
+        {
+            if (span.IsEmpty)
+            {
+                ThrowHelper.ThrowNoElementsException();
+            }
+
+            int i;
+            for (i = 0; i < span.Length && float.IsNaN(span[i]); i++);
+
+            if (i == span.Length)
+            {
+                return span[^1];
+            }
+
+            float value;
+            for (value = span[i]; (uint)i < (uint)span.Length; i++)
+            {
+                if (span[i] > value)
+                {
+                    value = span[i];
                 }
             }
 
@@ -490,9 +534,9 @@ namespace System.Linq
 
         public static decimal Max(this IEnumerable<decimal> source)
         {
-            if (source == null)
+            if (source.TryGetSpan(out ReadOnlySpan<decimal> span))
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                return Max(span);
             }
 
             decimal value;
@@ -511,6 +555,25 @@ namespace System.Linq
                     {
                         value = x;
                     }
+                }
+            }
+
+            return value;
+        }
+
+        private static decimal Max(ReadOnlySpan<decimal> span)
+        {
+            if (span.IsEmpty)
+            {
+                ThrowHelper.ThrowNoElementsException();
+            }
+
+            decimal value = span[0];
+            for (int i = 1; (uint)i < (uint)span.Length; i++)
+            {
+                if (span[i] > value)
+                {
+                    value = span[i];
                 }
             }
 

--- a/src/libraries/System.Linq/src/System/Linq/Sum.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Sum.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace System.Linq
 {
@@ -9,17 +10,19 @@ namespace System.Linq
     {
         public static int Sum(this IEnumerable<int> source)
         {
-            if (source == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
-            }
-
             int sum = 0;
-            checked
+            if (source.TryGetSpan(out ReadOnlySpan<int> span))
+            {
+                foreach (int v in span)
+                {
+                    checked { sum += v; }
+                }
+            }
+            else
             {
                 foreach (int v in source)
                 {
-                    sum += v;
+                    checked { sum += v; }
                 }
             }
 
@@ -50,17 +53,19 @@ namespace System.Linq
 
         public static long Sum(this IEnumerable<long> source)
         {
-            if (source == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
-            }
-
             long sum = 0;
-            checked
+            if (source.TryGetSpan(out ReadOnlySpan<long> span))
+            {
+                foreach (long v in span)
+                {
+                    checked { sum += v; }
+                }
+            }
+            else
             {
                 foreach (long v in source)
                 {
-                    sum += v;
+                    checked { sum += v; }
                 }
             }
 
@@ -91,9 +96,9 @@ namespace System.Linq
 
         public static float Sum(this IEnumerable<float> source)
         {
-            if (source == null)
+            if (source.TryGetSpan(out ReadOnlySpan<float> span))
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                return (float)Sum(span);
             }
 
             double sum = 0;
@@ -103,6 +108,27 @@ namespace System.Linq
             }
 
             return (float)sum;
+        }
+
+        private static double Sum(ReadOnlySpan<float> span)
+        {
+            double sum = 0;
+            int i = 0;
+
+            if (Vector.IsHardwareAccelerated)
+            {
+                for (; i <= span.Length - Vector<float>.Count; i += Vector<float>.Count)
+                {
+                    sum += Vector.Sum(new Vector<float>(span.Slice(i)));
+                }
+            }
+
+            for (; (uint)i < (uint)span.Length; i++)
+            {
+                sum += span[i];
+            }
+
+            return sum;
         }
 
         public static float? Sum(this IEnumerable<float?> source)
@@ -126,15 +152,36 @@ namespace System.Linq
 
         public static double Sum(this IEnumerable<double> source)
         {
-            if (source == null)
+            if (source.TryGetSpan(out ReadOnlySpan<double> span))
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                return Sum(span);
             }
 
             double sum = 0;
-            foreach (double v in source)
+            foreach (double d in source)
             {
-                sum += v;
+                sum += d;
+            }
+
+            return sum;
+        }
+
+        private static double Sum(ReadOnlySpan<double> span)
+        {
+            double sum = 0;
+            int i = 0;
+
+            if (Vector.IsHardwareAccelerated)
+            {
+                for (; i <= span.Length - Vector<double>.Count; i += Vector<double>.Count)
+                {
+                    sum += Vector.Sum(new Vector<double>(span.Slice(i)));
+                }
+            }
+
+            for (; (uint)i < (uint)span.Length; i++)
+            {
+                sum += span[i];
             }
 
             return sum;
@@ -161,17 +208,27 @@ namespace System.Linq
 
         public static decimal Sum(this IEnumerable<decimal> source)
         {
-            if (source == null)
+            if (source.TryGetSpan(out ReadOnlySpan<decimal> span))
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                return Sum(span);
             }
 
             decimal sum = 0;
-            foreach (decimal v in source)
+            foreach (decimal d in source)
             {
-                sum += v;
+                sum += d;
             }
 
+            return sum;
+        }
+
+        private static decimal Sum(ReadOnlySpan<decimal> span)
+        {
+            decimal sum = 0;
+            foreach (decimal d in span)
+            {
+                sum += d;
+            }
             return sum;
         }
 

--- a/src/libraries/System.Linq/src/System/Linq/Sum.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Sum.cs
@@ -113,17 +113,8 @@ namespace System.Linq
         private static double Sum(ReadOnlySpan<float> span)
         {
             double sum = 0;
-            int i = 0;
 
-            if (Vector.IsHardwareAccelerated)
-            {
-                for (; i <= span.Length - Vector<float>.Count; i += Vector<float>.Count)
-                {
-                    sum += Vector.Sum(new Vector<float>(span.Slice(i)));
-                }
-            }
-
-            for (; (uint)i < (uint)span.Length; i++)
+            for (int i = 0; i < span.Length; i++)
             {
                 sum += span[i];
             }
@@ -169,17 +160,8 @@ namespace System.Linq
         private static double Sum(ReadOnlySpan<double> span)
         {
             double sum = 0;
-            int i = 0;
 
-            if (Vector.IsHardwareAccelerated)
-            {
-                for (; i <= span.Length - Vector<double>.Count; i += Vector<double>.Count)
-                {
-                    sum += Vector.Sum(new Vector<double>(span.Slice(i)));
-                }
-            }
-
-            for (; (uint)i < (uint)span.Length; i++)
+            for (int i = 0; i < span.Length; i++)
             {
                 sum += span[i];
             }

--- a/src/libraries/System.Linq/tests/AverageTests.cs
+++ b/src/libraries/System.Linq/tests/AverageTests.cs
@@ -85,10 +85,17 @@ namespace System.Linq.Tests
         [Fact]
         public void Int_EmptySource_ThrowsInvalidOperationException()
         {
-            int[] source = new int[0];
-
-            Assert.Throws<InvalidOperationException>(() => source.Average());
-            Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
+            foreach (IEnumerable<int> source in new IEnumerable<int>[]
+            {
+                Array.Empty<int>(),
+                new List<int>(),
+                Enumerable.Empty<int>(),
+                new TestEnumerable<int>(Array.Empty<int>())
+            })
+            {
+                Assert.Throws<InvalidOperationException>(() => source.Average());
+                Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
+            }
         }
 
         [Fact]
@@ -110,18 +117,28 @@ namespace System.Linq.Tests
             yield return new object[] { new int[] { 5 }, 5 };
             yield return new object[] { new int[] { 0, 0, 0, 0, 0 }, 0 };
             yield return new object[] { new int[] { 5, -10, 15, 40, 28 }, 15.6 };
+
+            for (int i = 1; i <= 33; i++)
+            {
+                int sum = 0;
+                for (int c = 1; c <= i; c++) sum += c;
+                double expected = (double)sum / i;
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(1, i)), expected };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(1, i).ToArray()), expected };
+            }
         }
 
         [Theory]
         [MemberData(nameof(Int_TestData))]
-        public void Int(int[] source, double expected)
+        public void Int(IEnumerable<int> source, double expected)
         {
             Assert.Equal(expected, source.Average());
             Assert.Equal(expected, source.Average(x => x));
         }
 
         [Theory, MemberData(nameof(Int_TestData))]
-        public void IntRunOnce(int[] source, double expected)
+        public void IntRunOnce(IEnumerable<int> source, double expected)
         {
             Assert.Equal(expected, source.RunOnce().Average());
             Assert.Equal(expected, source.RunOnce().Average(x => x));
@@ -190,10 +207,17 @@ namespace System.Linq.Tests
         [Fact]
         public void Long_EmptySource_ThrowsInvalidOperationException()
         {
-            long[] source = new long[0];
-
-            Assert.Throws<InvalidOperationException>(() => source.Average());
-            Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
+            foreach (IEnumerable<long> source in new IEnumerable<long>[]
+            {
+                Array.Empty<long>(),
+                new List<long>(),
+                Enumerable.Empty<long>(),
+                new TestEnumerable<long>(Array.Empty<long>())
+            })
+            {
+                Assert.Throws<InvalidOperationException>(() => source.Average());
+                Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
+            }
         }
 
         [Fact]
@@ -215,11 +239,21 @@ namespace System.Linq.Tests
             yield return new object[] { new long[] { long.MaxValue }, long.MaxValue };
             yield return new object[] { new long[] { 0, 0, 0, 0, 0 }, 0 };
             yield return new object[] { new long[] { 5, -10, 15, 40, 28 }, 15.6 };
+
+            for (int i = 1; i <= 33; i++)
+            {
+                int sum = 0;
+                for (int c = 1; c <= i; c++) sum += c;
+                double expected = (double)sum / i;
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(1, i).Select(i => (long)i)), expected };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(1, i).Select(i => (long)i).ToArray()), expected };
+            }
         }
 
         [Theory]
         [MemberData(nameof(Long_TestData))]
-        public void Long(long[] source, double expected)
+        public void Long(IEnumerable<long> source, double expected)
         {
             Assert.Equal(expected, source.Average());
             Assert.Equal(expected, source.Average(x => x));
@@ -296,10 +330,17 @@ namespace System.Linq.Tests
         [Fact]
         public void Double_EmptySource_ThrowsInvalidOperationException()
         {
-            double[] source = new double[0];
-
-            Assert.Throws<InvalidOperationException>(() => source.Average());
-            Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
+            foreach (IEnumerable<double> source in new IEnumerable<double>[]
+            {
+                Array.Empty<double>(),
+                new List<double>(),
+                Enumerable.Empty<double>(),
+                new TestEnumerable<double>(Array.Empty<double>())
+            })
+            {
+                Assert.Throws<InvalidOperationException>(() => source.Average());
+                Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
+            }
         }
 
         [Fact]
@@ -322,11 +363,21 @@ namespace System.Linq.Tests
             yield return new object[] { new double[] { 0.0, 0.0, 0.0, 0.0, 0.0 }, 0 };
             yield return new object[] { new double[] { 5.5, -10, 15.5, 40.5, 28.5 }, 16 };
             yield return new object[] { new double[] { 5.58, double.NaN, 30, 4.55, 19.38 }, double.NaN };
+
+            for (int i = 1; i <= 33; i++)
+            {
+                int sum = 0;
+                for (int c = 1; c <= i; c++) sum += c;
+                double expected = (double)sum / i;
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(1, i).Select(i => (double)i)), expected };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(1, i).Select(i => (double)i).ToArray()), expected };
+            }
         }
 
         [Theory]
         [MemberData(nameof(Double_TestData))]
-        public void Average_Double(double[] source, double expected)
+        public void Average_Double(IEnumerable<double> source, double expected)
         {
             Assert.Equal(expected, source.Average());
             Assert.Equal(expected, source.Average(x => x));
@@ -396,10 +447,17 @@ namespace System.Linq.Tests
         [Fact]
         public void Decimal_EmptySource_ThrowsInvalidOperationException()
         {
-            decimal[] source = new decimal[0];
-
-            Assert.Throws<InvalidOperationException>(() => source.Average());
-            Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
+            foreach (IEnumerable<decimal> source in new IEnumerable<decimal>[]
+            {
+                Array.Empty<decimal>(),
+                new List<decimal>(),
+                Enumerable.Empty<decimal>(),
+                new TestEnumerable<decimal>(Array.Empty<decimal>())
+            })
+            {
+                Assert.Throws<InvalidOperationException>(() => source.Average());
+                Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
+            }
         }
 
         [Fact]
@@ -421,11 +479,21 @@ namespace System.Linq.Tests
             yield return new object[] { new decimal[] { decimal.MaxValue }, decimal.MaxValue };
             yield return new object[] { new decimal[] { 0.0m, 0.0m, 0.0m, 0.0m, 0.0m }, 0 };
             yield return new object[] { new decimal[] { 5.5m, -10m, 15.5m, 40.5m, 28.5m }, 16 };
+
+            for (int i = 1; i <= 33; i++)
+            {
+                int sum = 0;
+                for (int c = 1; c <= i; c++) sum += c;
+                decimal expected = (decimal)sum / i;
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(1, i).Select(i => (decimal)i)), expected };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(1, i).Select(i => (decimal)i).ToArray()), expected };
+            }
         }
 
         [Theory]
         [MemberData(nameof(Decimal_TestData))]
-        public void Decimal(decimal[] source, decimal expected)
+        public void Decimal(IEnumerable<decimal> source, decimal expected)
         {
             Assert.Equal(expected, source.Average());
             Assert.Equal(expected, source.Average(x => x));
@@ -502,10 +570,17 @@ namespace System.Linq.Tests
         [Fact]
         public void Float_EmptySource_ThrowsInvalidOperationException()
         {
-            float[] source = new float[0];
-
-            Assert.Throws<InvalidOperationException>(() => source.Average());
-            Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
+            foreach (IEnumerable<float> source in new IEnumerable<float>[]
+            {
+                Array.Empty<float>(),
+                new List<float>(),
+                Enumerable.Empty<float>(),
+                new TestEnumerable<float>(Array.Empty<float>())
+            })
+            {
+                Assert.Throws<InvalidOperationException>(() => source.Average());
+                Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
+            }
         }
 
         [Fact]
@@ -527,11 +602,21 @@ namespace System.Linq.Tests
             yield return new object[] { new float[] { float.MaxValue }, float.MaxValue };
             yield return new object[] { new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, 0f };
             yield return new object[] { new float[] { 5.5f, -10f, 15.5f, 40.5f, 28.5f }, 16f };
+
+            for (int i = 1; i <= 33; i++)
+            {
+                int sum = 0;
+                for (int c = 1; c <= i; c++) sum += c;
+                float expected = (float)sum / i;
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(1, i).Select(i => (float)i)), expected };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(1, i).Select(i => (float)i).ToArray()), expected };
+            }
         }
 
         [Theory]
         [MemberData(nameof(Float_TestData))]
-        public void Float(float[] source, float expected)
+        public void Float(IEnumerable<float> source, float expected)
         {
             Assert.Equal(expected, source.Average());
             Assert.Equal(expected, source.Average(x => x));

--- a/src/libraries/System.Linq/tests/MaxTests.cs
+++ b/src/libraries/System.Linq/tests/MaxTests.cs
@@ -46,17 +46,24 @@ namespace System.Linq.Tests
 
         public static IEnumerable<object[]> Max_Int_TestData()
         {
-            yield return new object[] { Enumerable.Repeat(42, 1), 42 };
-            yield return new object[] { Enumerable.Range(1, 10).ToArray(), 10 };
-            yield return new object[] { new int[] { -100, -15, -50, -10 }, -10 };
-            yield return new object[] { new int[] { -16, 0, 50, 100, 1000 }, 1000 };
-            yield return new object[] { new int[] { -16, 0, 50, 100, 1000 }.Concat(Enumerable.Repeat(int.MaxValue, 1)), int.MaxValue };
+            foreach ((int[] array, long expected) in new[]
+            {
+                (new[] { 42 }, 42),
+                (Enumerable.Range(1, 10).ToArray(), 10),
+                (new int[] { -100, -15, -50, -10 }, -10),
+                (new int[] { -16, 0, 50, 100, 1000 }, 1000),
+                (new int[] { -16, 0, 50, 100, 1000 }.Concat(Enumerable.Repeat(int.MaxValue, 1)).ToArray(), int.MaxValue),
 
-            yield return new object[] { Enumerable.Repeat(20, 1), 20 };
-            yield return new object[] { Enumerable.Repeat(-2, 5), -2 };
-            yield return new object[] { new int[] { 16, 9, 10, 7, 8 }, 16 };
-            yield return new object[] { new int[] { 6, 9, 10, 0, 50 }, 50 };
-            yield return new object[] { new int[] { -6, 0, -9, 0, -10, 0 }, 0 };
+                (new[] { 20 }, 20),
+                (Enumerable.Repeat(-2, 5).ToArray(), -2),
+                (new int[] { 16, 9, 10, 7, 8 }, 16),
+                (new int[] { 6, 9, 10, 0, 50 }, 50),
+                (new int[] { -6, 0, -9, 0, -10, 0 }, 0),
+            })
+            {
+                yield return new object[] { new TestEnumerable<int>(array), expected };
+                yield return new object[] { array, expected };
+            }
 
             for (int length = 2; length < 33; length++)
             {
@@ -75,17 +82,24 @@ namespace System.Linq.Tests
 
         public static IEnumerable<object[]> Max_Long_TestData()
         {
-            yield return new object[] { Enumerable.Repeat(42L, 1), 42L };
-            yield return new object[] { Enumerable.Range(1, 10).Select(i => (long)i).ToArray(), 10L };
-            yield return new object[] { new long[] { -100, -15, -50, -10 }, -10L };
-            yield return new object[] { new long[] { -16, 0, 50, 100, 1000 }, 1000L };
-            yield return new object[] { new long[] { -16, 0, 50, 100, 1000 }.Concat(Enumerable.Repeat(long.MaxValue, 1)), long.MaxValue };
+            foreach ((long[] array, long expected) in new[]
+            {
+                (new[] { 42L }, 42L),
+                (Enumerable.Range(1, 10).Select(i => (long)i).ToArray(), 10L),
+                (new long[] { -100, -15, -50, -10 }, -10L),
+                (new long[] { -16, 0, 50, 100, 1000 }, 1000L),
+                (new long[] { -16, 0, 50, 100, 1000 }.Concat(Enumerable.Repeat(long.MaxValue, 1)).ToArray(), long.MaxValue),
 
-            yield return new object[] { Enumerable.Repeat(int.MaxValue + 10L, 1), int.MaxValue + 10L };
-            yield return new object[] { Enumerable.Repeat(500L, 5), 500L };
-            yield return new object[] { new long[] { 250, 49, 130, 47, 28 }, 250L };
-            yield return new object[] { new long[] { 6, 9, 10, 0, int.MaxValue + 50L }, int.MaxValue + 50L };
-            yield return new object[] { new long[] { 6, 50, 9, 50, 10, 50 }, 50L };
+                (new[] { int.MaxValue + 10L }, int.MaxValue + 10L),
+                (Enumerable.Repeat(500L, 5).ToArray(), 500L),
+                (new long[] { 250, 49, 130, 47, 28 }, 250L),
+                (new long[] { 6, 9, 10, 0, int.MaxValue + 50L }, int.MaxValue + 50L),
+                (new long[] { 6, 50, 9, 50, 10, 50 }, 50L),
+            })
+            {
+                yield return new object[] { new TestEnumerable<long>(array), expected };
+                yield return new object[] { array, expected };
+            }
 
             for (int length = 2; length < 33; length++)
             {
@@ -120,32 +134,45 @@ namespace System.Linq.Tests
 
         public static IEnumerable<object[]> Max_Float_TestData()
         {
-            yield return new object[] { Enumerable.Repeat(42f, 1), 42f };
-            yield return new object[] { Enumerable.Range(1, 10).Select(i => (float)i).ToArray(), 10f };
-            yield return new object[] { new float[] { -100, -15, -50, -10 }, -10f };
-            yield return new object[] { new float[] { -16, 0, 50, 100, 1000 }, 1000f };
-            yield return new object[] { new float[] { -16, 0, 50, 100, 1000 }.Concat(Enumerable.Repeat(float.MaxValue, 1)), float.MaxValue };
+            foreach ((float[] array, float expected) in new[]
+            {
+                (new[] { 42f }, 42f),
+                (Enumerable.Range(1, 10).Select(i => (float)i).ToArray(), 10f),
+                (new float[] { -100, -15, -50, -10 }, -10f),
+                (new float[] { -16, 0, 50, 100, 1000 }, 1000f),
+                (new float[] { -16, 0, 50, 100, 1000 }.Concat(Enumerable.Repeat(float.MaxValue, 1)).ToArray(), float.MaxValue),
 
-            yield return new object[] { Enumerable.Repeat(5.5f, 1), 5.5f };
-            yield return new object[] { new float[] { 112.5f, 4.9f, 30f, 4.7f, 28f }, 112.5f };
-            yield return new object[] { new float[] { 6.8f, 9.4f, -10f, 0f, float.NaN, 53.6f }, 53.6f };
-            yield return new object[] { new float[] { -5.5f, float.PositiveInfinity, 9.9f, float.PositiveInfinity }, float.PositiveInfinity };
+                (new[] { 5.5f }, 5.5f),
+                (new float[] { 112.5f, 4.9f, 30f, 4.7f, 28f }, 112.5f),
+                (new float[] { 6.8f, 9.4f, -10f, 0f, float.NaN, 53.6f }, 53.6f),
+                (new float[] { -5.5f, float.PositiveInfinity, 9.9f, float.PositiveInfinity }, float.PositiveInfinity),
 
-            yield return new object[] { Enumerable.Repeat(float.NaN, 5), float.NaN };
-            yield return new object[] { new float[] { float.NaN, 6.8f, 9.4f, 10f, 0, -5.6f }, 10f };
-            yield return new object[] { new float[] { 6.8f, 9.4f, 10f, 0, -5.6f, float.NaN }, 10f };
-            yield return new object[] { new float[] { float.NaN, float.NegativeInfinity }, float.NegativeInfinity };
-            yield return new object[] { new float[] { float.NegativeInfinity, float.NaN }, float.NegativeInfinity };
+                (Enumerable.Repeat(float.NaN, 5).ToArray(), float.NaN),
+                (new float[] { float.NaN, 6.8f, 9.4f, 10f, 0, -5.6f }, 10f),
+                (new float[] { 6.8f, 9.4f, 10f, 0, -5.6f, float.NaN }, 10f),
+                (new float[] { float.NaN, float.NegativeInfinity }, float.NegativeInfinity),
+                (new float[] { float.NegativeInfinity, float.NaN }, float.NegativeInfinity),
+                
+                // Normally NaN < anything and anything < NaN returns false
+                // However, this leads to some irksome outcomes in Min and Max.
+                // If we use those semantics then Min(NaN, 5.0) is NaN, but
+                // Min(5.0, NaN) is 5.0!  To fix this, we impose a total
+                // ordering where NaN is smaller than every value, including
+                // negative infinity.
+                (Enumerable.Range(1, 10).Select(i => (float)i).Concat(Enumerable.Repeat(float.NaN, 1)).ToArray(), 10f),
+                (new float[] { -1f, -10, float.NaN, 10, 200, 1000 }, 1000f),
+                (new float[] { float.MinValue, 3000f, 100, 200, float.NaN, 1000 }, 3000f),
+            })
+            {
+                yield return new object[] { new TestEnumerable<float>(array), expected };
+                yield return new object[] { array, expected };
+            }
 
-            // Normally NaN < anything and anything < NaN returns false
-            // However, this leads to some irksome outcomes in Min and Max.
-            // If we use those semantics then Min(NaN, 5.0) is NaN, but
-            // Min(5.0, NaN) is 5.0!  To fix this, we impose a total
-            // ordering where NaN is smaller than every value, including
-            // negative infinity.
-            yield return new object[] { Enumerable.Range(1, 10).Select(i => (float)i).Concat(Enumerable.Repeat(float.NaN, 1)).ToArray(), 10f };
-            yield return new object[] { new float[] { -1f, -10, float.NaN, 10, 200, 1000 }, 1000f };
-            yield return new object[] { new float[] { float.MinValue, 3000f, 100, 200, float.NaN, 1000 }, 3000f };
+            for (int length = 2; length < 33; length++)
+            {
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (float)i)), (float)(length + length - 1) };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (float)i).ToArray()), (float)(length + length - 1) };
+            }
         }
 
         [Theory]
@@ -192,31 +219,44 @@ namespace System.Linq.Tests
 
         public static IEnumerable<object[]> Max_Double_TestData()
         {
-            yield return new object[] { Enumerable.Repeat(42.0, 1), 42.0 };
-            yield return new object[] { Enumerable.Range(1, 10).Select(i => (double)i).ToArray(), 10.0 };
-            yield return new object[] { new double[] { -100, -15, -50, -10 }, -10.0 };
-            yield return new object[] { new double[] { -16, 0, 50, 100, 1000 }, 1000.0 };
-            yield return new object[] { new double[] { -16, 0, 50, 100, 1000 }.Concat(Enumerable.Repeat(double.MaxValue, 1)), double.MaxValue };
+            foreach ((double[] array, double expected) in new[]
+            {
+                (new[] { 42.0 }, 42.0),
+                (Enumerable.Range(1, 10).Select(i => (double)i).ToArray(), 10.0),
+                (new double[] { -100, -15, -50, -10 }, -10.0),
+                (new double[] { -16, 0, 50, 100, 1000 }, 1000.0),
+                (new double[] { -16, 0, 50, 100, 1000 }.Concat(Enumerable.Repeat(double.MaxValue, 1)).ToArray(), double.MaxValue),
 
-            yield return new object[] { Enumerable.Repeat(5.5, 1), 5.5 };
-            yield return new object[] { Enumerable.Repeat(double.NaN, 5), double.NaN };
-            yield return new object[] { new double[] { 112.5, 4.9, 30, 4.7, 28 }, 112.5 };
-            yield return new object[] { new double[] { 6.8, 9.4, -10, 0, double.NaN, 53.6 }, 53.6 };
-            yield return new object[] { new double[] { -5.5, double.PositiveInfinity, 9.9, double.PositiveInfinity }, double.PositiveInfinity };
-            yield return new object[] { new double[] { double.NaN, 6.8, 9.4, 10.5, 0, -5.6 }, 10.5 };
-            yield return new object[] { new double[] { 6.8, 9.4, 10.5, 0, -5.6, double.NaN }, 10.5 };
-            yield return new object[] { new double[] { double.NaN, double.NegativeInfinity }, double.NegativeInfinity };
-            yield return new object[] { new double[] { double.NegativeInfinity, double.NaN }, double.NegativeInfinity };
+                (Enumerable.Repeat(5.5, 1).ToArray(), 5.5),
+                (Enumerable.Repeat(double.NaN, 5).ToArray(), double.NaN),
+                (new double[] { 112.5, 4.9, 30, 4.7, 28 }, 112.5),
+                (new double[] { 6.8, 9.4, -10, 0, double.NaN, 53.6 }, 53.6),
+                (new double[] { -5.5, double.PositiveInfinity, 9.9, double.PositiveInfinity }, double.PositiveInfinity),
+                (new double[] { double.NaN, 6.8, 9.4, 10.5, 0, -5.6 }, 10.5),
+                (new double[] { 6.8, 9.4, 10.5, 0, -5.6, double.NaN }, 10.5),
+                (new double[] { double.NaN, double.NegativeInfinity }, double.NegativeInfinity),
+                (new double[] { double.NegativeInfinity, double.NaN }, double.NegativeInfinity),
 
-            // Normally NaN < anything and anything < NaN returns false
-            // However, this leads to some irksome outcomes in Min and Max.
-            // If we use those semantics then Min(NaN, 5.0) is NaN, but
-            // Min(5.0, NaN) is 5.0!  To fix this, we impose a total
-            // ordering where NaN is smaller than every value, including
-            // negative infinity.
-            yield return new object[] { Enumerable.Range(1, 10).Select(i => (double)i).Concat(Enumerable.Repeat(double.NaN, 1)).ToArray(), 10.0 };
-            yield return new object[] { new double[] { -1F, -10, double.NaN, 10, 200, 1000 }, 1000.0 };
-            yield return new object[] { new double[] { double.MinValue, 3000F, 100, 200, double.NaN, 1000 }, 3000.0 };
+                // Normally NaN < anything and anything < NaN returns false
+                // However, this leads to some irksome outcomes in Min and Max.
+                // If we use those semantics then Min(NaN, 5.0) is NaN, but
+                // Min(5.0, NaN) is 5.0!  To fix this, we impose a total
+                // ordering where NaN is smaller than every value, including
+                // negative infinity.
+                (Enumerable.Range(1, 10).Select(i => (double)i).Concat(Enumerable.Repeat(double.NaN, 1)).ToArray(), 10.0),
+                (new double[] { -1F, -10, double.NaN, 10, 200, 1000 }, 1000.0),
+                (new double[] { double.MinValue, 3000F, 100, 200, double.NaN, 1000 }, 3000.0),
+            })
+            {
+                yield return new object[] { new TestEnumerable<double>(array), expected };
+                yield return new object[] { array, expected };
+            }
+
+            for (int length = 2; length < 33; length++)
+            {
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (double)i)), (double)(length + length - 1) };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (double)i).ToArray()), (double)(length + length - 1) };
+            }
         }
 
         [Theory]
@@ -263,17 +303,30 @@ namespace System.Linq.Tests
 
         public static IEnumerable<object[]> Max_Decimal_TestData()
         {
-            yield return new object[] { Enumerable.Repeat(42m, 1), 42m };
-            yield return new object[] { Enumerable.Range(1, 10).Select(i => (decimal)i).ToArray(), 10m };
-            yield return new object[] { new decimal[] { -100, -15, -50, -10 }, -10m };
-            yield return new object[] { new decimal[] { -16, 0, 50, 100, 1000 }, 1000m };
-            yield return new object[] { new decimal[] { -16, 0, 50, 100, 1000 }.Concat(Enumerable.Repeat(decimal.MaxValue, 1)), decimal.MaxValue };
+            foreach ((decimal[] array, decimal expected) in new[]
+            {
+                (new[] { 42m }, 42m),
+                (Enumerable.Range(1, 10).Select(i => (decimal)i).ToArray(), 10m),
+                (new decimal[] { -100, -15, -50, -10 }, -10m),
+                (new decimal[] { -16, 0, 50, 100, 1000 }, 1000m),
+                (new decimal[] { -16, 0, 50, 100, 1000 }.Concat(Enumerable.Repeat(decimal.MaxValue, 1)).ToArray(), decimal.MaxValue),
 
-            yield return new object[] { new decimal[] { 5.5m }, 5.5m };
-            yield return new object[] { Enumerable.Repeat(-3.4m, 5), -3.4m };
-            yield return new object[] { new decimal[] { 122.5m, 4.9m, 10m, 4.7m, 28m }, 122.5m };
-            yield return new object[] { new decimal[] { 6.8m, 9.4m, 10m, 0m, 0m, decimal.MaxValue }, decimal.MaxValue };
-            yield return new object[] { new decimal[] { -5.5m, 0m, 9.9m, -5.5m, 9.9m }, 9.9m };
+                (new decimal[] { 5.5m }, 5.5m),
+                (Enumerable.Repeat(-3.4m, 5).ToArray(), -3.4m),
+                (new decimal[] { 122.5m, 4.9m, 10m, 4.7m, 28m }, 122.5m),
+                (new decimal[] { 6.8m, 9.4m, 10m, 0m, 0m, decimal.MaxValue }, decimal.MaxValue),
+                (new decimal[] { -5.5m, 0m, 9.9m, -5.5m, 9.9m }, 9.9m),
+            })
+            {
+                yield return new object[] { new TestEnumerable<decimal>(array), expected };
+                yield return new object[] { array, expected };
+            }
+
+            for (int length = 2; length < 33; length++)
+            {
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (decimal)i)), (decimal)(length + length - 1) };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (decimal)i).ToArray()), (decimal)(length + length - 1) };
+            }
         }
 
         [Theory]
@@ -296,6 +349,8 @@ namespace System.Linq.Tests
         {
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<decimal>().Max());
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<decimal>().Max(x => x));
+            Assert.Throws<InvalidOperationException>(() => Array.Empty<decimal>().Max());
+            Assert.Throws<InvalidOperationException>(() => new List<decimal>().Max(x => x));
         }
 
         public static IEnumerable<object[]> Max_NullableInt_TestData()

--- a/src/libraries/System.Linq/tests/MinTests.cs
+++ b/src/libraries/System.Linq/tests/MinTests.cs
@@ -30,18 +30,25 @@ namespace System.Linq.Tests
 
         public static IEnumerable<object[]> Min_Int_TestData()
         {
-            yield return new object[] { Enumerable.Repeat(42, 1), 42 };
-            yield return new object[] { Enumerable.Range(1, 10).ToArray(), 1 };
-            yield return new object[] { new int[] { -1, -10, 10, 200, 1000 }, -10 };
-            yield return new object[] { new int[] { 3000, 100, 200, 1000 }, 100 };
-            yield return new object[] { new int[] { 3000, 100, 200, 1000 }.Concat(Enumerable.Repeat(int.MinValue, 1)), int.MinValue };
+            foreach ((int[] array, long expected) in new[]
+            {
+                (new[] { 42 }, 42),
+                (Enumerable.Range(1, 10).ToArray(), 1),
+                (new int[] { -1, -10, 10, 200, 1000 }, -10),
+                (new int[] { 3000, 100, 200, 1000 }, 100),
+                (new int[] { 3000, 100, 200, 1000 }.Concat(Enumerable.Repeat(int.MinValue, 1)).ToArray(), int.MinValue),
 
-            yield return new object[] { Enumerable.Repeat(20, 1), 20 };
-            yield return new object[] { Enumerable.Repeat(-2, 5), -2 };
-            yield return new object[] { Enumerable.Range(1, 10).ToArray(), 1 };
-            yield return new object[] { new int[] { 6, 9, 10, 7, 8 }, 6 };
-            yield return new object[] { new int[] { 6, 9, 10, 0, -5 }, -5 };
-            yield return new object[] { new int[] { 6, 0, 9, 0, 10, 0 }, 0 };
+                (new[] { 20 }, 20),
+                (Enumerable.Repeat(-2, 5).ToArray(), -2),
+                (Enumerable.Range(1, 10).ToArray(), 1),
+                (new int[] { 6, 9, 10, 7, 8 }, 6),
+                (new int[] { 6, 9, 10, 0, -5 }, -5),
+                (new int[] { 6, 0, 9, 0, 10, 0 }, 0),
+            })
+            {
+                yield return new object[] { new TestEnumerable<int>(array), expected };
+                yield return new object[] { array, expected };
+            }
 
             for (int length = 2; length < 33; length++)
             {
@@ -76,17 +83,24 @@ namespace System.Linq.Tests
 
         public static IEnumerable<object[]> Min_Long_TestData()
         {
-            yield return new object[] { Enumerable.Repeat(42L, 1), 42L };
-            yield return new object[] { Enumerable.Range(1, 10).Select(i => (long)i).ToArray(), 1L };
-            yield return new object[] { new long[] { -1, -10, 10, 200, 1000 }, -10L };
-            yield return new object[] { new long[] { 3000, 100, 200, 1000 }, 100L };
-            yield return new object[] { new long[] { 3000, 100, 200, 1000 }.Concat(Enumerable.Repeat(long.MinValue, 1)), long.MinValue };
+            foreach ((long[] array, long expected) in new[]
+            {
+                (new[] { 42L }, 42L),
+                (Enumerable.Range(1, 10).Select(i => (long)i).ToArray(), 1L),
+                (new long[] { -1, -10, 10, 200, 1000 }, -10L),
+                (new long[] { 3000, 100, 200, 1000 }, 100L),
+                (new long[] { 3000, 100, 200, 1000 }.Concat(Enumerable.Repeat(long.MinValue, 1)).ToArray(), long.MinValue),
 
-            yield return new object[] { Enumerable.Repeat(int.MaxValue + 10L, 1), int.MaxValue + 10L };
-            yield return new object[] { Enumerable.Repeat(500L, 5), 500L };
-            yield return new object[] { new long[] { -250, 49, 130, 47, 28 }, -250L };
-            yield return new object[] { new long[] { 6, 9, 10, 0, -int.MaxValue - 50L }, -int.MaxValue - 50L };
-            yield return new object[] { new long[] { 6, -5, 9, -5, 10, -5 }, -5 };
+                (new[] { int.MaxValue + 10L }, int.MaxValue + 10L),
+                (Enumerable.Repeat(500L, 5).ToArray(), 500L),
+                (new long[] { -250, 49, 130, 47, 28 }, -250L),
+                (new long[] { 6, 9, 10, 0, -int.MaxValue - 50L }, -int.MaxValue - 50L),
+                (new long[] { 6, -5, 9, -5, 10, -5 }, -5),
+            })
+            {
+                yield return new object[] { new TestEnumerable<long>(array), expected };
+                yield return new object[] { array, expected };
+            }
 
             for (int length = 2; length < 33; length++)
             {
@@ -121,39 +135,52 @@ namespace System.Linq.Tests
 
         public static IEnumerable<object[]> Min_Float_TestData()
         {
-            yield return new object[] { Enumerable.Repeat(42f, 1), 42f };
-            yield return new object[] { Enumerable.Range(1, 10).Select(i => (float)i).ToArray(), 1f };
-            yield return new object[] { new float[] { -1, -10, 10, 200, 1000 }, -10f };
-            yield return new object[] { new float[] { 3000, 100, 200, 1000 }, 100 };
-            yield return new object[] { new float[] { 3000, 100, 200, 1000 }.Concat(Enumerable.Repeat(float.MinValue, 1)), float.MinValue };
+            foreach ((float[] array, float expected) in new[]
+            {
+                (new[] { 42f }, 42f),
+                (Enumerable.Range(1, 10).Select(i => (float)i).ToArray(), 1f),
+                (new float[] { -1, -10, 10, 200, 1000 }, -10f),
+                (new float[] { 3000, 100, 200, 1000 }, 100),
+                (new float[] { 3000, 100, 200, 1000 }.Concat(Enumerable.Repeat(float.MinValue, 1)).ToArray(), float.MinValue),
 
-            yield return new object[] { Enumerable.Repeat(5.5f, 1), 5.5f };
-            yield return new object[] { Enumerable.Repeat(float.NaN, 5), float.NaN };
-            yield return new object[] { new float[] { -2.5f, 4.9f, 130f, 4.7f, 28f }, -2.5f};
-            yield return new object[] { new float[] { 6.8f, 9.4f, 10f, 0, -5.6f }, -5.6f };
-            yield return new object[] { new float[] { -5.5f, float.NegativeInfinity, 9.9f, float.NegativeInfinity }, float.NegativeInfinity };
+                (new[] { 5.5f }, 5.5f),
+                (Enumerable.Repeat(float.NaN, 5).ToArray(), float.NaN),
+                (new float[] { -2.5f, 4.9f, 130f, 4.7f, 28f }, -2.5f),
+                (new float[] { 6.8f, 9.4f, 10f, 0, -5.6f }, -5.6f),
+                (new float[] { -5.5f, float.NegativeInfinity, 9.9f, float.NegativeInfinity }, float.NegativeInfinity),
 
-            yield return new object[] { new float[] { float.NaN, 6.8f, 9.4f, 10f, 0, -5.6f }, float.NaN };
-            yield return new object[] { new float[] { 6.8f, 9.4f, 10f, 0, -5.6f, float.NaN }, float.NaN };
-            yield return new object[] { new float[] { float.NaN, float.NegativeInfinity }, float.NaN };
-            yield return new object[] { new float[] { float.NegativeInfinity, float.NaN }, float.NaN };
+                (new float[] { float.NaN, 6.8f, 9.4f, 10f, 0, -5.6f }, float.NaN),
+                (new float[] { 6.8f, 9.4f, 10f, 0, -5.6f, float.NaN }, float.NaN),
+                (new float[] { float.NaN, float.NegativeInfinity }, float.NaN),
+                (new float[] { float.NegativeInfinity, float.NaN }, float.NaN),
+
+                // Normally NaN < anything is false, as is anything < NaN
+                // However, this leads to some irksome outcomes in Min and Max.
+                // If we use those semantics then Min(NaN, 5.0) is NaN, but
+                // Min(5.0, NaN) is 5.0!  To fix this, we impose a total
+                // ordering where NaN is smaller than every value, including
+                // negative infinity.
+                (Enumerable.Range(1, 10).Select(i => (float)i).Concat(Enumerable.Repeat(float.NaN, 1)).ToArray(), float.NaN),
+                (new float[] { -1F, -10, float.NaN, 10, 200, 1000 }, float.NaN),
+                (new float[] { float.MinValue, 3000F, 100, 200, float.NaN, 1000 }, float.NaN),
+            })
+            {
+                yield return new object[] { new TestEnumerable<float>(array), expected };
+                yield return new object[] { array, expected };
+            }
 
             // In .NET Core, Enumerable.Min shortcircuits if it finds any float.NaN in the array,
             // as nothing can be less than float.NaN. See https://github.com/dotnet/corefx/pull/2426.
             // Without this optimization, we would iterate through int.MaxValue elements, which takes
             // a long time.
             yield return new object[] { Enumerable.Repeat(float.NaN, int.MaxValue), float.NaN };
-            yield return new object[] { Enumerable.Repeat(float.NaN, 3), float.NaN };
+            yield return new object[] { Enumerable.Repeat(float.NaN, 3).ToArray(), float.NaN };
 
-            // Normally NaN < anything is false, as is anything < NaN
-            // However, this leads to some irksome outcomes in Min and Max.
-            // If we use those semantics then Min(NaN, 5.0) is NaN, but
-            // Min(5.0, NaN) is 5.0!  To fix this, we impose a total
-            // ordering where NaN is smaller than every value, including
-            // negative infinity.
-            yield return new object[] { Enumerable.Range(1, 10).Select(i => (float)i).Concat(Enumerable.Repeat(float.NaN, 1)).ToArray(), float.NaN };
-            yield return new object[] { new float[] { -1F, -10, float.NaN, 10, 200, 1000 }, float.NaN };
-            yield return new object[] { new float[] { float.MinValue, 3000F, 100, 200, float.NaN, 1000 }, float.NaN };
+            for (int length = 2; length < 33; length++)
+            {
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (float)i)), (float)length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (float)i).ToArray()), (float)length };
+            }
         }
 
         [Theory]
@@ -182,38 +209,50 @@ namespace System.Linq.Tests
 
         public static IEnumerable<object[]> Min_Double_TestData()
         {
-            yield return new object[] { Enumerable.Repeat(42.0, 1), 42.0 };
-            yield return new object[] { Enumerable.Range(1, 10).Select(i => (double)i).ToArray(), 1.0 };
-            yield return new object[] { new double[] { -1, -10, 10, 200, 1000 }, -10.0 };
-            yield return new object[] { new double[] { 3000, 100, 200, 1000 }, 100.0 };
-            yield return new object[] { new double[] { 3000, 100, 200, 1000 }.Concat(Enumerable.Repeat(double.MinValue, 1)), double.MinValue };
+            foreach ((double[] array, double expected) in new[]
+            {
+                (new[] { 42.0 }, 42.0),
+                (Enumerable.Range(1, 10).Select(i => (double)i).ToArray(), 1.0 ),
+                (new double[] { -1, -10, 10, 200, 1000 }, -10.0),
+                (new double[] { 3000, 100, 200, 1000 }, 100.0),
+                (new double[] { 3000, 100, 200, 1000 }.Concat(Enumerable.Repeat(double.MinValue, 1)).ToArray(), double.MinValue),
 
-            yield return new object[] { Enumerable.Repeat(5.5, 1), 5.5 };
-            yield return new object[] { new double[] { -2.5, 4.9, 130, 4.7, 28 }, -2.5 };
-            yield return new object[] { new double[] { 6.8, 9.4, 10, 0, -5.6 }, -5.6 };
-            yield return new object[] { new double[] { -5.5, double.NegativeInfinity, 9.9, double.NegativeInfinity }, double.NegativeInfinity };
+                (new[] { 5.5 }, 5.5),
+                (new double[] { -2.5, 4.9, 130, 4.7, 28 }, -2.5),
+                (new double[] { 6.8, 9.4, 10, 0, -5.6 }, -5.6),
+                (new double[] { -5.5, double.NegativeInfinity, 9.9, double.NegativeInfinity }, double.NegativeInfinity),
+
+                (new double[] { double.NaN, 6.8, 9.4, 10, 0, -5.6 }, double.NaN),
+                (new double[] { 6.8, 9.4, 10, 0, -5.6, double.NaN }, double.NaN),
+                (new double[] { double.NaN, double.NegativeInfinity }, double.NaN),
+                (new double[] { double.NegativeInfinity, double.NaN }, double.NaN),
+
+                // Normally NaN < anything is false, as is anything < NaN
+                // However, this leads to some irksome outcomes in Min and Max.
+                // If we use those semantics then Min(NaN, 5.0) is NaN, but
+                // Min(5.0, NaN) is 5.0!  To fix this, we impose a total
+                // ordering where NaN is smaller than every value, including
+                // negative infinity.
+                (Enumerable.Range(1, 10).Select(i => (double)i).Concat(Enumerable.Repeat(double.NaN, 1)).ToArray(), double.NaN),
+                (new double[] { -1, -10, double.NaN, 10, 200, 1000 }, double.NaN),
+                (new double[] { double.MinValue, 3000F, 100, 200, double.NaN, 1000 }, double.NaN),
+            })
+            {
+                yield return new object[] { new TestEnumerable<double>(array), expected };
+                yield return new object[] { array, expected };
+            }
 
             // In .NET Core, Enumerable.Min shortcircuits if it finds any double.NaN in the array,
             // as nothing can be less than double.NaN. See https://github.com/dotnet/corefx/pull/2426.
             // Without this optimization, we would iterate through int.MaxValue elements, which takes
             // a long time.
             yield return new object[] { Enumerable.Repeat(double.NaN, int.MaxValue), double.NaN };
-            yield return new object[] { Enumerable.Repeat(double.NaN, 3), double.NaN };
 
-            yield return new object[] { new double[] { double.NaN, 6.8, 9.4, 10, 0, -5.6 }, double.NaN };
-            yield return new object[] { new double[] { 6.8, 9.4, 10, 0, -5.6, double.NaN }, double.NaN };
-            yield return new object[] { new double[] { double.NaN, double.NegativeInfinity }, double.NaN };
-            yield return new object[] { new double[] { double.NegativeInfinity, double.NaN }, double.NaN };
-
-            // Normally NaN < anything is false, as is anything < NaN
-            // However, this leads to some irksome outcomes in Min and Max.
-            // If we use those semantics then Min(NaN, 5.0) is NaN, but
-            // Min(5.0, NaN) is 5.0!  To fix this, we impose a total
-            // ordering where NaN is smaller than every value, including
-            // negative infinity.
-            yield return new object[] { Enumerable.Range(1, 10).Select(i => (double)i).Concat(Enumerable.Repeat(double.NaN, 1)).ToArray(), double.NaN };
-            yield return new object[] { new double[] { -1, -10, double.NaN, 10, 200, 1000 }, double.NaN };
-            yield return new object[] { new double[] { double.MinValue, 3000F, 100, 200, double.NaN, 1000 }, double.NaN };
+            for (int length = 2; length < 33; length++)
+            {
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (double)i)), (double)length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (double)i).ToArray()), (double)length };
+            }
         }
 
         [Theory]
@@ -242,17 +281,30 @@ namespace System.Linq.Tests
 
         public static IEnumerable<object[]> Min_Decimal_TestData()
         {
-            yield return new object[] { Enumerable.Repeat(42m, 1), 42m };
-            yield return new object[] { Enumerable.Range(1, 10).Select(i => (decimal)i).ToArray(), 1m };
-            yield return new object[] { new decimal[] { -1, -10, 10, 200, 1000 }, -10m };
-            yield return new object[] { new decimal[] { 3000, 100, 200, 1000 }, 100m };
-            yield return new object[] { new decimal[] { 3000, 100, 200, 1000 }.Concat(Enumerable.Repeat(decimal.MinValue, 1)), decimal.MinValue };
+            foreach ((decimal[] array, decimal expected) in new[]
+            {
+                (new[] { 42m }, 42m),
+                (Enumerable.Range(1, 10).Select(i => (decimal)i).ToArray(), 1m),
+                (new decimal[] { -1, -10, 10, 200, 1000 }, -10m),
+                (new decimal[] { 3000, 100, 200, 1000 }, 100m),
+                (new decimal[] { 3000, 100, 200, 1000 }.Concat(Enumerable.Repeat(decimal.MinValue, 1)).ToArray(), decimal.MinValue),
 
-            yield return new object[] { Enumerable.Repeat(5.5m, 1), 5.5m };
-            yield return new object[] { Enumerable.Repeat(-3.4m, 5), -3.4m };
-            yield return new object[] { new decimal[] { -2.5m, 4.9m, 130m, 4.7m, 28m }, -2.5m };
-            yield return new object[] { new decimal[] { 6.8m, 9.4m, 10m, 0m, 0m, decimal.MinValue }, decimal.MinValue };
-            yield return new object[] { new decimal[] { -5.5m, 0m, 9.9m, -5.5m, 5m }, -5.5m };
+                (new[] { 5.5m }, 5.5m),
+                (Enumerable.Repeat(-3.4m, 5).ToArray(), -3.4m),
+                (new decimal[] { -2.5m, 4.9m, 130m, 4.7m, 28m }, -2.5m),
+                (new decimal[] { 6.8m, 9.4m, 10m, 0m, 0m, decimal.MinValue }, decimal.MinValue),
+                (new decimal[] { -5.5m, 0m, 9.9m, -5.5m, 5m }, -5.5m),
+            })
+            {
+                yield return new object[] { new TestEnumerable<decimal>(array), expected };
+                yield return new object[] { array, expected };
+            }
+
+            for (int length = 2; length < 33; length++)
+            {
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (decimal)i)), (decimal)length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (decimal)i).ToArray()), (decimal)length };
+            }
         }
 
         [Theory]

--- a/src/libraries/System.Linq/tests/Shuffler.cs
+++ b/src/libraries/System.Linq/tests/Shuffler.cs
@@ -10,10 +10,11 @@ namespace System.Linq.Tests
     {
         public static T[] Shuffle<T>(T[] array)
         {
+            var r = new Random(42);
             int i = array.Length;
             while (i > 1)
             {
-                int j = Random.Shared.Next(i--);
+                int j = r.Next(i--);
                 (array[i], array[j]) = (array[j], array[i]);
             }
             return array;
@@ -47,7 +48,7 @@ namespace System.Linq.Tests
 
             public IEnumerator<T> GetEnumerator()
             {
-                Random rnd = _seed.HasValue ? new Random(_seed.GetValueOrDefault()) : new Random();
+                Random rnd = new Random(_seed.HasValue ? _seed.GetValueOrDefault() : 42);
                 T[] array = _source.ToArray();
                 int count = array.Length;
                 for (int i = array.Length - 1; i > 0; --i)


### PR DESCRIPTION
It's common to use these terminal functions for quick stats on arrays and lists of values.  Just the overhead of enumerating as an enumerable (involving multiple interface dispatch) per iteration is significant, and it's much faster to directly enumerate the contents of the array or the list.  In some cases, we can further use vectorization to speed up the processing.

This change:
- Adds a helper that does a fast check to see if it can extract a span from an enumerable that's actually an array or a list.  It could be augmented to detect other interesting types, but `T[]` and `List<T>` are the most relevant from the data I've seen, and we can fairly quickly do type checks to get the most benefit for a small amount of cost.
- Uses that helper in the int/long/float/double/decimal overloads of Sum/Average/Min/Max to add a span-based path.
- Vectorizes Sum for float and double
- Vectorizes Average for int, float, and double (the latter two via use of Sum)

@tannergooding, I assume the use of vectorization for floats/doubles could change the answer in some cases due to lack of associativity, yes?  Thoughts on how much we should care about that?  Also, it seemed like it should be possible to vectorize some of the methods doing checked arithmetic, but I wasn't sure how to do so correctly and skipped those.  It also seemed like it should be possible to vectorize min/max for floats/doubles, but they have special-handling of NaN I couldn't figure out how to replicate with Vector.

@eiriktsarpalis, please let me know in general if you're ok with the extra code here for this special-casing.  We don't have to do it, but it seems like an inexpensive win for what appears to be common, e.g. building up a `List<int>` and calling Average/Sum/Min/Max on it.  There are certainly other patterns common with these, e.g. calling Min on the result of a Select or on other collection types.  We could subsequently choose to also special-case `IList<T>` in order to save an interface dispatch per invocation, though I'm hopeful we'll get most of that for free with dynamic PGO, and we could subsequently choose to special-case the internal partitioning interfaces; the difficulty with those is the check for whether the type implements them is more expensive, and there's some aspect of diminishing returns because you're already doing more work to compute each element (whereas with arrays / lists, the amount of work per element is tiny).

|         Method |         Toolchain | Length |       Mode |       Mean |     Error | Ratio |
|--------------- |------------------ |------- |----------- |-----------:|----------:|------:|
|       MinFloat | \main\corerun.exe |      2 |      Array |  20.379 ns | 0.4283 ns |  1.00 |
|       MinFloat |   \pr\corerun.exe |      2 |      Array |   4.493 ns | 0.1502 ns |  0.23 |
|                |                   |        |            |            |           |       |
|     MinDecimal | \main\corerun.exe |      2 |      Array |  22.809 ns | 0.2779 ns |  1.00 |
|     MinDecimal |   \pr\corerun.exe |      2 |      Array |   8.633 ns | 0.1527 ns |  0.38 |
|                |                   |        |            |            |           |       |
|       SumInt32 | \main\corerun.exe |      2 |      Array |  18.643 ns | 0.3083 ns |  1.00 |
|       SumInt32 |   \pr\corerun.exe |      2 |      Array |   1.924 ns | 0.0544 ns |  0.10 |
|                |                   |        |            |            |           |       |
|       SumInt64 | \main\corerun.exe |      2 |      Array |  18.344 ns | 0.1885 ns |  1.00 |
|       SumInt64 |   \pr\corerun.exe |      2 |      Array |   1.972 ns | 0.0360 ns |  0.11 |
|                |                   |        |            |            |           |       |
|       SumFloat | \main\corerun.exe |      2 |      Array |  19.220 ns | 0.3734 ns |  1.00 |
|       SumFloat |   \pr\corerun.exe |      2 |      Array |   4.102 ns | 0.0312 ns |  0.21 |
|                |                   |        |            |            |           |       |
|     SumDecimal | \main\corerun.exe |      2 |      Array |  27.653 ns | 0.5665 ns |  1.00 |
|     SumDecimal |   \pr\corerun.exe |      2 |      Array |  13.084 ns | 0.1069 ns |  0.47 |
|                |                   |        |            |            |           |       |
|   AverageInt32 | \main\corerun.exe |      2 |      Array |  18.634 ns | 0.3122 ns |  1.00 |
|   AverageInt32 |   \pr\corerun.exe |      2 |      Array |   5.071 ns | 0.1270 ns |  0.27 |
|                |                   |        |            |            |           |       |
|   AverageInt64 | \main\corerun.exe |      2 |      Array |  18.582 ns | 0.3613 ns |  1.00 |
|   AverageInt64 |   \pr\corerun.exe |      2 |      Array |   3.473 ns | 0.0440 ns |  0.19 |
|                |                   |        |            |            |           |       |
|   AverageFloat | \main\corerun.exe |      2 |      Array |  19.145 ns | 0.2944 ns |  1.00 |
|   AverageFloat |   \pr\corerun.exe |      2 |      Array |   4.278 ns | 0.0346 ns |  0.22 |
|                |                   |        |            |            |           |       |
| AverageDecimal | \main\corerun.exe |      2 |      Array |  55.346 ns | 0.7298 ns |  1.00 |
| AverageDecimal |   \pr\corerun.exe |      2 |      Array |  49.087 ns | 0.1350 ns |  0.89 |
|                |                   |        |            |            |           |       |
|       MinFloat | \main\corerun.exe |      2 | Enumerable |  28.121 ns | 0.4956 ns |  1.00 |
|       MinFloat |   \pr\corerun.exe |      2 | Enumerable |  27.229 ns | 0.4659 ns |  0.97 |
|                |                   |        |            |            |           |       |
|     MinDecimal | \main\corerun.exe |      2 | Enumerable |  33.184 ns | 0.3598 ns |  1.00 |
|     MinDecimal |   \pr\corerun.exe |      2 | Enumerable |  34.396 ns | 0.6804 ns |  1.04 |
|                |                   |        |            |            |           |       |
|       SumInt32 | \main\corerun.exe |      2 | Enumerable |  21.329 ns | 0.2865 ns |  1.00 |
|       SumInt32 |   \pr\corerun.exe |      2 | Enumerable |  21.540 ns | 0.2581 ns |  1.01 |
|                |                   |        |            |            |           |       |
|       SumInt64 | \main\corerun.exe |      2 | Enumerable |  24.865 ns | 0.2726 ns |  1.00 |
|       SumInt64 |   \pr\corerun.exe |      2 | Enumerable |  25.556 ns | 0.4184 ns |  1.03 |
|                |                   |        |            |            |           |       |
|       SumFloat | \main\corerun.exe |      2 | Enumerable |  25.950 ns | 0.2292 ns |  1.00 |
|       SumFloat |   \pr\corerun.exe |      2 | Enumerable |  26.443 ns | 0.3911 ns |  1.02 |
|                |                   |        |            |            |           |       |
|     SumDecimal | \main\corerun.exe |      2 | Enumerable |  37.731 ns | 0.6087 ns |  1.00 |
|     SumDecimal |   \pr\corerun.exe |      2 | Enumerable |  38.357 ns | 0.7728 ns |  1.02 |
|                |                   |        |            |            |           |       |
|   AverageInt32 | \main\corerun.exe |      2 | Enumerable |  21.104 ns | 0.2414 ns |  1.00 |
|   AverageInt32 |   \pr\corerun.exe |      2 | Enumerable |  22.065 ns | 0.4544 ns |  1.05 |
|                |                   |        |            |            |           |       |
|   AverageInt64 | \main\corerun.exe |      2 | Enumerable |  24.994 ns | 0.5023 ns |  1.00 |
|   AverageInt64 |   \pr\corerun.exe |      2 | Enumerable |  26.308 ns | 0.5447 ns |  1.05 |
|                |                   |        |            |            |           |       |
|   AverageFloat | \main\corerun.exe |      2 | Enumerable |  27.288 ns | 0.5206 ns |  1.00 |
|   AverageFloat |   \pr\corerun.exe |      2 | Enumerable |  26.597 ns | 0.4992 ns |  0.97 |
|                |                   |        |            |            |           |       |
| AverageDecimal | \main\corerun.exe |      2 | Enumerable |  67.316 ns | 0.4518 ns |  1.00 |
| AverageDecimal |   \pr\corerun.exe |      2 | Enumerable |  80.256 ns | 0.3487 ns |  1.19 |
|                |                   |        |            |            |           |       |
|       MinFloat | \main\corerun.exe |     32 |      Array | 162.367 ns | 1.4179 ns |  1.00 |
|       MinFloat |   \pr\corerun.exe |     32 |      Array |  40.095 ns | 0.5829 ns |  0.25 |
|                |                   |        |            |            |           |       |
|     MinDecimal | \main\corerun.exe |     32 |      Array | 268.355 ns | 3.1338 ns |  1.00 |
|     MinDecimal |   \pr\corerun.exe |     32 |      Array | 172.761 ns | 1.5649 ns |  0.64 |
|                |                   |        |            |            |           |       |
|       SumInt32 | \main\corerun.exe |     32 |      Array | 138.323 ns | 1.1075 ns |  1.00 |
|       SumInt32 |   \pr\corerun.exe |     32 |      Array |  13.147 ns | 0.1089 ns |  0.10 |
|                |                   |        |            |            |           |       |
|       SumInt64 | \main\corerun.exe |     32 |      Array | 144.375 ns | 1.6040 ns |  1.00 |
|       SumInt64 |   \pr\corerun.exe |     32 |      Array |  12.756 ns | 0.2747 ns |  0.09 |
|                |                   |        |            |            |           |       |
|       SumFloat | \main\corerun.exe |     32 |      Array | 142.810 ns | 0.6627 ns |  1.00 |
|       SumFloat |   \pr\corerun.exe |     32 |      Array |   8.980 ns | 0.0286 ns |  0.06 |
|                |                   |        |            |            |           |       |
|     SumDecimal | \main\corerun.exe |     32 |      Array | 268.380 ns | 5.2945 ns |  1.00 |
|     SumDecimal |   \pr\corerun.exe |     32 |      Array | 158.555 ns | 2.0546 ns |  0.59 |
|                |                   |        |            |            |           |       |
|   AverageInt32 | \main\corerun.exe |     32 |      Array | 154.934 ns | 2.9998 ns |  1.00 |
|   AverageInt32 |   \pr\corerun.exe |     32 |      Array |  10.516 ns | 0.1869 ns |  0.07 |
|                |                   |        |            |            |           |       |
|   AverageInt64 | \main\corerun.exe |     32 |      Array | 148.826 ns | 2.9388 ns |  1.00 |
|   AverageInt64 |   \pr\corerun.exe |     32 |      Array |  14.362 ns | 0.3140 ns |  0.10 |
|                |                   |        |            |            |           |       |
|   AverageFloat | \main\corerun.exe |     32 |      Array | 146.798 ns | 2.5321 ns |  1.00 |
|   AverageFloat |   \pr\corerun.exe |     32 |      Array |   9.836 ns | 0.1240 ns |  0.07 |
|                |                   |        |            |            |           |       |
| AverageDecimal | \main\corerun.exe |     32 |      Array | 353.931 ns | 3.2577 ns |  1.00 |
| AverageDecimal |   \pr\corerun.exe |     32 |      Array | 173.172 ns | 3.3340 ns |  0.49 |
|                |                   |        |            |            |           |       |
|       MinFloat | \main\corerun.exe |     32 | Enumerable | 219.598 ns | 3.2260 ns |  1.00 |
|       MinFloat |   \pr\corerun.exe |     32 | Enumerable | 201.268 ns | 2.5158 ns |  0.92 |
|                |                   |        |            |            |           |       |
|     MinDecimal | \main\corerun.exe |     32 | Enumerable | 401.314 ns | 6.9631 ns |  1.00 |
|     MinDecimal |   \pr\corerun.exe |     32 | Enumerable | 396.958 ns | 4.2611 ns |  0.99 |
|                |                   |        |            |            |           |       |
|       SumInt32 | \main\corerun.exe |     32 | Enumerable | 130.008 ns | 2.4007 ns |  1.00 |
|       SumInt32 |   \pr\corerun.exe |     32 | Enumerable | 133.748 ns | 2.4726 ns |  1.03 |
|                |                   |        |            |            |           |       |
|       SumInt64 | \main\corerun.exe |     32 | Enumerable | 176.430 ns | 3.4085 ns |  1.00 |
|       SumInt64 |   \pr\corerun.exe |     32 | Enumerable | 175.259 ns | 3.0756 ns |  0.99 |
|                |                   |        |            |            |           |       |
|       SumFloat | \main\corerun.exe |     32 | Enumerable | 195.938 ns | 2.9538 ns |  1.00 |
|       SumFloat |   \pr\corerun.exe |     32 | Enumerable | 190.320 ns | 3.0678 ns |  0.97 |
|                |                   |        |            |            |           |       |
|     SumDecimal | \main\corerun.exe |     32 | Enumerable | 382.905 ns | 3.4056 ns |  1.00 |
|     SumDecimal |   \pr\corerun.exe |     32 | Enumerable | 384.330 ns | 4.6222 ns |  1.00 |
|                |                   |        |            |            |           |       |
|   AverageInt32 | \main\corerun.exe |     32 | Enumerable | 132.928 ns | 2.5226 ns |  1.00 |
|   AverageInt32 |   \pr\corerun.exe |     32 | Enumerable | 143.767 ns | 2.4111 ns |  1.08 |
|                |                   |        |            |            |           |       |
|   AverageInt64 | \main\corerun.exe |     32 | Enumerable | 181.207 ns | 1.6801 ns |  1.00 |
|   AverageInt64 |   \pr\corerun.exe |     32 | Enumerable | 177.174 ns | 2.1069 ns |  0.98 |
|                |                   |        |            |            |           |       |
|   AverageFloat | \main\corerun.exe |     32 | Enumerable | 203.800 ns | 2.0559 ns |  1.00 |
|   AverageFloat |   \pr\corerun.exe |     32 | Enumerable | 201.102 ns | 3.2647 ns |  0.99 |
|                |                   |        |            |            |           |       |
| AverageDecimal | \main\corerun.exe |     32 | Enumerable | 497.159 ns | 1.4778 ns |  1.00 |
| AverageDecimal |   \pr\corerun.exe |     32 | Enumerable | 492.052 ns | 2.3135 ns |  0.99 |

```C#
using System.Collections.Generic;
using System.Linq;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

public class Program
{
    public static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    [Params(2, 32)]
    public int Length { get; set; }

    [Params("Array", "Enumerable")]
    public string Mode { get; set; }

    private IEnumerable<int> _ints;
    private IEnumerable<long> _longs;
    private IEnumerable<float> _floats;
    private IEnumerable<decimal> _decimals;

    [Benchmark] public float MinFloat() => _floats.Min();

    [Benchmark] public int SumInt32() => _ints.Sum();
    [Benchmark] public long SumInt64() => _longs.Sum();
    [Benchmark] public float SumFloat() => _floats.Sum();
    [Benchmark] public decimal SumDecimal() => _decimals.Sum();

    [Benchmark] public double AverageInt32() => _ints.Average();
    [Benchmark] public double AverageInt64() => _longs.Average();
    [Benchmark] public float AverageFloat() => _floats.Average();
    [Benchmark] public decimal AverageDecimal() => _decimals.Average();

    [GlobalSetup]
    public void Setup()
    {
        _ints = Enumerable.Range(1, Length);
        if (Mode == "Array") _ints = _ints.ToArray();

        _longs = Enumerable.Range(1, Length).Select(i => (long)i);
        if (Mode == "Array") _longs = _longs.ToArray();

        _floats = Enumerable.Range(1, Length).Select(i => (float)i);
        if (Mode == "Array") _floats = _floats.ToArray();

        _decimals = Enumerable.Range(1, Length).Select(i => (decimal)i);
        if (Mode == "Array") _decimals = _decimals.ToArray();
    }
}
```