### PR TITLE
Throw PNSE if insufficient privileges when custom Ping payload was specified

### DIFF
--- a/src/libraries/System.Net.Ping/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Ping/src/Resources/Strings.resx
@@ -87,4 +87,7 @@
   <data name="SystemNetPing_PlatformNotSupported" xml:space="preserve">
     <value>System.Net.Ping is not supported on this platform.</value>
   </data>
+  <data name="net_ping_utility_custom_payload" xml:space="preserve">
+    <value>Unable to send custom ping payload. Run program with privileged user or grant cap_net_raw capability using setcap(8).</value>
+  </data>
 </root>

--- a/src/libraries/System.Net.Ping/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Ping/src/Resources/Strings.resx
@@ -88,6 +88,6 @@
     <value>System.Net.Ping is not supported on this platform.</value>
   </data>
   <data name="net_ping_utility_custom_payload" xml:space="preserve">
-    <value>Unable to send custom ping payload. Run program with privileged user or grant cap_net_raw capability using setcap(8).</value>
+    <value>Unable to send custom ping payload. Run program under privileged user account or grant cap_net_raw capability using setcap(8).</value>
   </data>
 </root>

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
@@ -24,7 +24,9 @@ namespace System.Net.NetworkInformation
                 throw new PlatformNotSupportedException(SR.net_ping_utility_not_found);
             }
 
-            // ping utility does not support specifying custom payload
+            // although the ping utility supports custom pattern via -p option, it supports
+            // specifying only up to 16B pattern which repeats in the payload. The option also might
+            // not be present in all distributions, so we forbid ping payload in general.
             if (buffer != DefaultSendBuffer && buffer != Array.Empty<byte>())
             {
                 throw new PlatformNotSupportedException(SR.net_ping_utility_custom_payload);

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
@@ -24,6 +24,12 @@ namespace System.Net.NetworkInformation
                 throw new PlatformNotSupportedException(SR.net_ping_utility_not_found);
             }
 
+            // ping utility does not support specifying custom payload
+            if (buffer != DefaultSendBuffer && buffer != Array.Empty<byte>())
+            {
+                throw new PlatformNotSupportedException(SR.net_ping_utility_custom_payload);
+            }
+
             UnixCommandLinePing.PingFragmentOptions fragmentOption = UnixCommandLinePing.PingFragmentOptions.Default;
             if (options != null && address.AddressFamily == AddressFamily.InterNetwork)
             {

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
@@ -227,7 +227,7 @@ namespace System.Net.NetworkInformation
             {
                 return SendPingCore(addressSnapshot, buffer, timeout, options);
             }
-            catch (Exception e)
+            catch (Exception e) when (e is not PlatformNotSupportedException)
             {
                 throw new PingException(SR.net_ping, e);
             }
@@ -336,7 +336,7 @@ namespace System.Net.NetworkInformation
                 Task<PingReply> pingReplyTask = SendPingAsyncCore(addressSnapshot, buffer, timeout, options);
                 return await pingReplyTask.ConfigureAwait(false);
             }
-            catch (Exception e)
+            catch (Exception e) when (e is not PlatformNotSupportedException)
             {
                 throw new PingException(SR.net_ping, e);
             }
@@ -388,7 +388,7 @@ namespace System.Net.NetworkInformation
                 IPAddress[] addresses = Dns.GetHostAddresses(hostNameOrAddress);
                 return SendPingCore(addresses[0], buffer, timeout, options);
             }
-            catch (Exception e)
+            catch (Exception e) when (e is not PlatformNotSupportedException)
             {
                 throw new PingException(SR.net_ping, e);
             }
@@ -407,7 +407,7 @@ namespace System.Net.NetworkInformation
                 Task<PingReply> pingReplyTask = SendPingAsyncCore(addresses[0], buffer, timeout, options);
                 return await pingReplyTask.ConfigureAwait(false);
             }
-            catch (Exception e)
+            catch (Exception e) when (e is not PlatformNotSupportedException)
             {
                 throw new PingException(SR.net_ping, e);
             }

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -80,7 +80,7 @@ namespace System.Net.NetworkInformation.Tests
 
         public static bool DoesNotUsePingUtility => !UsesPingUtility;
 
-        public static bool UsesPingUtility => OperatingSystem.IsLinux() && !(Capability.CanUseRawSockets(TestSettings.GetLocalIPAddress().AddressFamily) || PlatformDetection.IsOSXLike);
+        public static bool UsesPingUtility => OperatingSystem.IsLinux() && !Capability.CanUseRawSockets(TestSettings.GetLocalIPAddress().AddressFamily);
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task SendPingAsync_InvalidArgs()

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -6,14 +6,11 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net.Sockets;
 using System.Net.Test.Common;
-using System.Runtime.InteropServices;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
 
 using Xunit;
 using Xunit.Abstractions;
-using System.Runtime.InteropServices.GeneratedMarshalling;
 
 namespace System.Net.NetworkInformation.Tests
 {
@@ -74,6 +71,12 @@ namespace System.Net.NetworkInformation.Tests
 
             Assert.Contains(pingReply.Address, localIpAddresses); ///, "Reply address {pingReply.Address} is not expected local address.");
         }
+
+        private static byte[] GetPingPayloadForUnix(AddressFamily addressFamily)
+            // On Unix, Non-root processes cannot send arbitrary data in the ping packet payload
+            => Capability.CanUseRawSockets(addressFamily) || PlatformDetection.IsOSXLike
+                ? TestSettings.PayloadAsBytes
+                : Array.Empty<byte>();
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task SendPingAsync_InvalidArgs()
@@ -259,10 +262,7 @@ namespace System.Net.NetworkInformation.Tests
         {
             IPAddress localIpAddress = TestSettings.GetLocalIPAddress();
 
-            // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-            byte[] buffer = Capability.CanUseRawSockets(localIpAddress.AddressFamily) || PlatformDetection.IsOSXLike
-                ? TestSettings.PayloadAsBytes
-                : Array.Empty<byte>();
+            byte[] buffer = GetPingPayloadForUnix(localIpAddress.AddressFamily);
 
             SendBatchPing(
                 (ping) => ping.Send(localIpAddress, TestSettings.PingTimeout, buffer),
@@ -279,10 +279,7 @@ namespace System.Net.NetworkInformation.Tests
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddressAsync();
 
-            // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-            byte[] buffer = Capability.CanUseRawSockets(localIpAddress.AddressFamily) || PlatformDetection.IsOSXLike
-                ? TestSettings.PayloadAsBytes
-                : Array.Empty<byte>();
+            byte[] buffer = GetPingPayloadForUnix(localIpAddress.AddressFamily);
 
             await SendBatchPingAsync(
                 (ping) => ping.SendPingAsync(localIpAddress, TestSettings.PingTimeout, buffer),
@@ -342,10 +339,7 @@ namespace System.Net.NetworkInformation.Tests
                 return;
             }
 
-            // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-            byte[] buffer = Capability.CanUseRawSockets(localIpAddress.AddressFamily) || PlatformDetection.IsOSXLike
-                ? TestSettings.PayloadAsBytes
-                : Array.Empty<byte>();
+            byte[] buffer = GetPingPayloadForUnix(localIpAddress.AddressFamily);
 
             SendBatchPing(
                 (ping) => ping.Send(localIpAddress, TestSettings.PingTimeout, buffer, new PingOptions()),
@@ -369,10 +363,7 @@ namespace System.Net.NetworkInformation.Tests
                 return;
             }
 
-            // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-            byte[] buffer = Capability.CanUseRawSockets(localIpAddress.AddressFamily) || PlatformDetection.IsOSXLike
-                ? TestSettings.PayloadAsBytes
-                : Array.Empty<byte>();
+            byte[] buffer = GetPingPayloadForUnix(localIpAddress.AddressFamily);
 
             await SendBatchPingAsync(
                 (ping) => ping.SendPingAsync(localIpAddress, TestSettings.PingTimeout, buffer, new PingOptions()),
@@ -473,16 +464,7 @@ namespace System.Net.NetworkInformation.Tests
         {
             IPAddress[] localIpAddresses = TestSettings.GetLocalIPAddresses();
 
-            if (localIpAddresses.Length == 0)
-            {
-                // no local addresses
-                return;
-            }
-
-            // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-            byte[] buffer = Capability.CanUseRawSockets(localIpAddresses[0].AddressFamily) || PlatformDetection.IsOSXLike
-                ? TestSettings.PayloadAsBytes
-                : Array.Empty<byte>();
+            byte[] buffer = GetPingPayloadForUnix(localIpAddresses[0].AddressFamily);
 
             SendBatchPing(
                 (ping) => ping.Send(TestSettings.LocalHost, TestSettings.PingTimeout, buffer),
@@ -499,16 +481,7 @@ namespace System.Net.NetworkInformation.Tests
         {
             IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();
 
-            if (localIpAddresses.Length == 0)
-            {
-                // no local addresses
-                return;
-            }
-
-            // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-            byte[] buffer = Capability.CanUseRawSockets(localIpAddresses[0].AddressFamily) || PlatformDetection.IsOSXLike
-                ? TestSettings.PayloadAsBytes
-                : Array.Empty<byte>();
+            byte[] buffer = GetPingPayloadForUnix(localIpAddresses[0].AddressFamily);
 
             await SendBatchPingAsync(
                 (ping) => ping.SendPingAsync(TestSettings.LocalHost, TestSettings.PingTimeout, buffer),
@@ -559,16 +532,7 @@ namespace System.Net.NetworkInformation.Tests
         {
             IPAddress[] localIpAddresses = TestSettings.GetLocalIPAddresses();
 
-            if (localIpAddresses.Length == 0)
-            {
-                // no local addresses
-                return;
-            }
-
-            // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-            byte[] buffer = Capability.CanUseRawSockets(localIpAddresses[0].AddressFamily) || PlatformDetection.IsOSXLike
-                ? TestSettings.PayloadAsBytes
-                : Array.Empty<byte>();
+            byte[] buffer = GetPingPayloadForUnix(localIpAddresses[0].AddressFamily);
 
             SendBatchPing(
                 (ping) => ping.Send(TestSettings.LocalHost, TestSettings.PingTimeout, buffer, new PingOptions()),
@@ -585,16 +549,7 @@ namespace System.Net.NetworkInformation.Tests
         {
             IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();
 
-            if (localIpAddresses.Length == 0)
-            {
-                // no local addresses
-                return;
-            }
-
-            // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-            byte[] buffer = Capability.CanUseRawSockets(localIpAddresses[0].AddressFamily) || PlatformDetection.IsOSXLike
-                ? TestSettings.PayloadAsBytes
-                : Array.Empty<byte>();
+            byte[] buffer = GetPingPayloadForUnix(localIpAddresses[0].AddressFamily);
 
             await SendBatchPingAsync(
                 (ping) => ping.SendPingAsync(TestSettings.LocalHost, TestSettings.PingTimeout, buffer, new PingOptions()),
@@ -1003,7 +958,7 @@ namespace System.Net.NetworkInformation.Tests
 
             byte[] buffer = TestSettings.PayloadAsBytes;
             Ping ping = new Ping();
-            var ex = Assert.Throws<PlatformNotSupportedException>(() => ping.Send(TestSettings.LocalHost, TestSettings.PingTimeout, buffer));
+            Assert.Throws<PlatformNotSupportedException>(() => ping.Send(TestSettings.LocalHost, TestSettings.PingTimeout, buffer));
         }
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]
@@ -1020,7 +975,7 @@ namespace System.Net.NetworkInformation.Tests
 
             byte[] buffer = TestSettings.PayloadAsBytes;
             Ping ping = new Ping();
-            var ex = await Assert.ThrowsAsync<PlatformNotSupportedException>(() => ping.SendPingAsync(TestSettings.LocalHost, TestSettings.PingTimeout, buffer));
+            await Assert.ThrowsAsync<PlatformNotSupportedException>(() => ping.SendPingAsync(TestSettings.LocalHost, TestSettings.PingTimeout, buffer));
         }
     }
 }

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -13,6 +13,7 @@ using Microsoft.DotNet.RemoteExecutor;
 
 using Xunit;
 using Xunit.Abstractions;
+using System.Runtime.InteropServices.GeneratedMarshalling;
 
 namespace System.Net.NetworkInformation.Tests
 {
@@ -220,7 +221,7 @@ namespace System.Net.NetworkInformation.Tests
                 });
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+        [PlatformSpecific(TestPlatforms.Windows)]
         [Fact]
         public void SendPingWithIPAddressAndTimeoutAndBuffer()
         {
@@ -236,7 +237,7 @@ namespace System.Net.NetworkInformation.Tests
                 });
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+        [PlatformSpecific(TestPlatforms.Windows)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task SendPingAsyncWithIPAddressAndTimeoutAndBuffer()
         {
@@ -252,57 +253,47 @@ namespace System.Net.NetworkInformation.Tests
                 });
         }
 
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
         [Fact]
         public void SendPingWithIPAddressAndTimeoutAndBuffer_Unix()
         {
-            byte[] buffer = TestSettings.PayloadAsBytes;
             IPAddress localIpAddress = TestSettings.GetLocalIPAddress();
+
+            // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+            byte[] buffer = Capability.CanUseRawSockets(localIpAddress.AddressFamily) || PlatformDetection.IsOSXLike
+                ? TestSettings.PayloadAsBytes
+                : Array.Empty<byte>();
 
             SendBatchPing(
                 (ping) => ping.Send(localIpAddress, TestSettings.PingTimeout, buffer),
                 (pingReply) =>
                 {
                     PingResultValidator(pingReply, localIpAddress);
-
-                    // Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-                    if (Capability.CanUseRawSockets(localIpAddress.AddressFamily) || PlatformDetection.IsOSXLike)
-                    {
-                        Assert.Equal(buffer, pingReply.Buffer);
-                    }
-                    else
-                    {
-                        Assert.Equal(Array.Empty<byte>(), pingReply.Buffer);
-                    }
+                    Assert.Equal(buffer, pingReply.Buffer);
                 });
         }
 
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task SendPingAsyncWithIPAddressAndTimeoutAndBuffer_Unix()
         {
-            byte[] buffer = TestSettings.PayloadAsBytes;
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddressAsync();
+
+            // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+            byte[] buffer = Capability.CanUseRawSockets(localIpAddress.AddressFamily) || PlatformDetection.IsOSXLike
+                ? TestSettings.PayloadAsBytes
+                : Array.Empty<byte>();
 
             await SendBatchPingAsync(
                 (ping) => ping.SendPingAsync(localIpAddress, TestSettings.PingTimeout, buffer),
                 (pingReply) =>
                 {
                     PingResultValidator(pingReply, localIpAddress);
-
-                    // Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-                    if (Capability.CanUseRawSockets(localIpAddress.AddressFamily) || PlatformDetection.IsOSXLike)
-                    {
-                        Assert.Equal(buffer, pingReply.Buffer);
-                    }
-                    else
-                    {
-                        Assert.Equal(Array.Empty<byte>(), pingReply.Buffer);
-                    }
+                    Assert.Equal(buffer, pingReply.Buffer);
                 });
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+        [PlatformSpecific(TestPlatforms.Windows)]
         [Fact]
         public void SendPingWithIPAddressAndTimeoutAndBufferAndPingOptions()
         {
@@ -320,7 +311,7 @@ namespace System.Net.NetworkInformation.Tests
                 });
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+        [PlatformSpecific(TestPlatforms.Windows)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task SendPingAsyncWithIPAddressAndTimeoutAndBufferAndPingOptions()
         {
@@ -338,7 +329,7 @@ namespace System.Net.NetworkInformation.Tests
                 });
         }
 
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
         [Theory]
         [InlineData(AddressFamily.InterNetwork)]
         [InlineData(AddressFamily.InterNetworkV6)]
@@ -351,26 +342,21 @@ namespace System.Net.NetworkInformation.Tests
                 return;
             }
 
-            byte[] buffer = TestSettings.PayloadAsBytes;
+            // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+            byte[] buffer = Capability.CanUseRawSockets(localIpAddress.AddressFamily) || PlatformDetection.IsOSXLike
+                ? TestSettings.PayloadAsBytes
+                : Array.Empty<byte>();
+
             SendBatchPing(
                 (ping) => ping.Send(localIpAddress, TestSettings.PingTimeout, buffer, new PingOptions()),
                 (pingReply) =>
                 {
                     PingResultValidator(pingReply, localIpAddress);
-
-                    // Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-                    if (Capability.CanUseRawSockets(localIpAddress.AddressFamily) || PlatformDetection.IsOSXLike)
-                    {
-                        Assert.Equal(buffer, pingReply.Buffer);
-                    }
-                    else
-                    {
-                        Assert.Equal(Array.Empty<byte>(), pingReply.Buffer);
-                    }
+                    Assert.Equal(buffer, pingReply.Buffer);
                 });
         }
 
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(AddressFamily.InterNetwork)]
         [InlineData(AddressFamily.InterNetworkV6)]
@@ -383,22 +369,17 @@ namespace System.Net.NetworkInformation.Tests
                 return;
             }
 
-            byte[] buffer = TestSettings.PayloadAsBytes;
+            // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+            byte[] buffer = Capability.CanUseRawSockets(localIpAddress.AddressFamily) || PlatformDetection.IsOSXLike
+                ? TestSettings.PayloadAsBytes
+                : Array.Empty<byte>();
+
             await SendBatchPingAsync(
                 (ping) => ping.SendPingAsync(localIpAddress, TestSettings.PingTimeout, buffer, new PingOptions()),
                 (pingReply) =>
                 {
                     PingResultValidator(pingReply, localIpAddress);
-
-                    // Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-                    if (Capability.CanUseRawSockets(localIpAddress.AddressFamily) || PlatformDetection.IsOSXLike)
-                    {
-                        Assert.Equal(buffer, pingReply.Buffer);
-                    }
-                    else
-                    {
-                        Assert.Equal(Array.Empty<byte>(), pingReply.Buffer);
-                    }
+                    Assert.Equal(buffer, pingReply.Buffer);
                 });
         }
 
@@ -454,7 +435,7 @@ namespace System.Net.NetworkInformation.Tests
                 });
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+        [PlatformSpecific(TestPlatforms.Windows)]
         [Fact]
         public void SendPingWithHostAndTimeoutAndBuffer()
         {
@@ -470,7 +451,7 @@ namespace System.Net.NetworkInformation.Tests
                 });
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+        [PlatformSpecific(TestPlatforms.Windows)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task SendPingAsyncWithHostAndTimeoutAndBuffer()
         {
@@ -486,57 +467,59 @@ namespace System.Net.NetworkInformation.Tests
                 });
         }
 
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
         [Fact]
         public void SendPingWithHostAndTimeoutAndBuffer_Unix()
         {
             IPAddress[] localIpAddresses = TestSettings.GetLocalIPAddresses();
 
-            byte[] buffer = TestSettings.PayloadAsBytes;
+            if (localIpAddresses.Length == 0)
+            {
+                // no local addresses
+                return;
+            }
+
+            // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+            byte[] buffer = Capability.CanUseRawSockets(localIpAddresses[0].AddressFamily) || PlatformDetection.IsOSXLike
+                ? TestSettings.PayloadAsBytes
+                : Array.Empty<byte>();
+
             SendBatchPing(
                 (ping) => ping.Send(TestSettings.LocalHost, TestSettings.PingTimeout, buffer),
                 (pingReply) =>
                 {
                     PingResultValidator(pingReply, localIpAddresses);
-
-                    // Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-                    if (Capability.CanUseRawSockets(pingReply.Address.AddressFamily) || PlatformDetection.IsOSXLike)
-                    {
-                        Assert.Equal(buffer, pingReply.Buffer);
-                    }
-                    else
-                    {
-                        Assert.Equal(Array.Empty<byte>(), pingReply.Buffer);
-                    }
+                    Assert.Equal(buffer, pingReply.Buffer);
                 });
         }
 
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task SendPingAsyncWithHostAndTimeoutAndBuffer_Unix()
         {
             IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();
 
-            byte[] buffer = TestSettings.PayloadAsBytes;
+            if (localIpAddresses.Length == 0)
+            {
+                // no local addresses
+                return;
+            }
+
+            // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+            byte[] buffer = Capability.CanUseRawSockets(localIpAddresses[0].AddressFamily) || PlatformDetection.IsOSXLike
+                ? TestSettings.PayloadAsBytes
+                : Array.Empty<byte>();
+
             await SendBatchPingAsync(
                 (ping) => ping.SendPingAsync(TestSettings.LocalHost, TestSettings.PingTimeout, buffer),
                 (pingReply) =>
                 {
                     PingResultValidator(pingReply, localIpAddresses);
-
-                    // Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-                    if (Capability.CanUseRawSockets(pingReply.Address.AddressFamily) || PlatformDetection.IsOSXLike)
-                    {
-                        Assert.Equal(buffer, pingReply.Buffer);
-                    }
-                    else
-                    {
-                        Assert.Equal(Array.Empty<byte>(), pingReply.Buffer);
-                    }
+                    Assert.Equal(buffer, pingReply.Buffer);
                 });
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+        [PlatformSpecific(TestPlatforms.Windows)]
         [Fact]
         public void SendPingWithHostAndTimeoutAndBufferAndPingOptions()
         {
@@ -553,7 +536,7 @@ namespace System.Net.NetworkInformation.Tests
                 });
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+        [PlatformSpecific(TestPlatforms.Windows)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task SendPingAsyncWithHostAndTimeoutAndBufferAndPingOptions()
         {
@@ -570,53 +553,55 @@ namespace System.Net.NetworkInformation.Tests
                 });
         }
 
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
         [Fact]
         public void SendPingWithHostAndTimeoutAndBufferAndPingOptions_Unix()
         {
             IPAddress[] localIpAddresses = TestSettings.GetLocalIPAddresses();
 
-            byte[] buffer = TestSettings.PayloadAsBytes;
+            if (localIpAddresses.Length == 0)
+            {
+                // no local addresses
+                return;
+            }
+
+            // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+            byte[] buffer = Capability.CanUseRawSockets(localIpAddresses[0].AddressFamily) || PlatformDetection.IsOSXLike
+                ? TestSettings.PayloadAsBytes
+                : Array.Empty<byte>();
+
             SendBatchPing(
                 (ping) => ping.Send(TestSettings.LocalHost, TestSettings.PingTimeout, buffer, new PingOptions()),
                 (pingReply) =>
                 {
                     PingResultValidator(pingReply, localIpAddresses);
-
-                    // Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-                    if (Capability.CanUseRawSockets(pingReply.Address.AddressFamily) || PlatformDetection.IsOSXLike)
-                    {
-                        Assert.Equal(buffer, pingReply.Buffer);
-                    }
-                    else
-                    {
-                        Assert.Equal(Array.Empty<byte>(), pingReply.Buffer);
-                    }
+                    Assert.Equal(buffer, pingReply.Buffer);
                 });
         }
 
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task SendPingAsyncWithHostAndTimeoutAndBufferAndPingOptions_Unix()
         {
             IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();
 
-            byte[] buffer = TestSettings.PayloadAsBytes;
+            if (localIpAddresses.Length == 0)
+            {
+                // no local addresses
+                return;
+            }
+
+            // On Unix, Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
+            byte[] buffer = Capability.CanUseRawSockets(localIpAddresses[0].AddressFamily) || PlatformDetection.IsOSXLike
+                ? TestSettings.PayloadAsBytes
+                : Array.Empty<byte>();
+
             await SendBatchPingAsync(
                 (ping) => ping.SendPingAsync(TestSettings.LocalHost, TestSettings.PingTimeout, buffer, new PingOptions()),
                 (pingReply) =>
                 {
                     PingResultValidator(pingReply, localIpAddresses);
-
-                    // Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-                    if (Capability.CanUseRawSockets(pingReply.Address.AddressFamily) || PlatformDetection.IsOSXLike)
-                    {
-                        Assert.Equal(buffer, pingReply.Buffer);
-                    }
-                    else
-                    {
-                        Assert.Equal(Array.Empty<byte>(), pingReply.Buffer);
-                    }
+                    Assert.Equal(buffer, pingReply.Buffer);
                 });
         }
 
@@ -1002,6 +987,40 @@ namespace System.Net.NetworkInformation.Tests
                         PingResultValidator(pingReply, new IPAddress[] { IPAddress.Parse(address) }, null);
                     });
             }, localIpAddress.ToString(), new RemoteInvokeOptions { StartInfo = remoteInvokeStartInfo }).Dispose();
+        }
+
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [Fact]
+        public void SendPing_CustomPayload_InsufficientPrivileges_Throws()
+        {
+            IPAddress[] localIpAddresses = TestSettings.GetLocalIPAddresses();
+
+            if (!(Capability.CanUseRawSockets(localIpAddresses[0].AddressFamily) || PlatformDetection.IsOSXLike))
+            {
+                // running on sufficiently privileged process
+                return;
+            }
+
+            byte[] buffer = TestSettings.PayloadAsBytes;
+            Ping ping = new Ping();
+            var ex = Assert.Throws<PlatformNotSupportedException>(() => ping.Send(TestSettings.LocalHost, TestSettings.PingTimeout, buffer));
+        }
+
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [Fact]
+        public async Task SendPingAsync_CustomPayload_InsufficientPrivileges_Throws()
+        {
+            IPAddress[] localIpAddresses = TestSettings.GetLocalIPAddresses();
+
+            if (!(Capability.CanUseRawSockets(localIpAddresses[0].AddressFamily) || PlatformDetection.IsOSXLike))
+            {
+                // running on sufficiently privileged process
+                return;
+            }
+
+            byte[] buffer = TestSettings.PayloadAsBytes;
+            Ping ping = new Ping();
+            var ex = await Assert.ThrowsAsync<PlatformNotSupportedException>(() => ping.SendPingAsync(TestSettings.LocalHost, TestSettings.PingTimeout, buffer));
         }
     }
 }


### PR DESCRIPTION
Fixes #62458 

I had to refactor tests a bit since they depended on the fact that such invocation would not throw.