### PR TITLE
Handle ((IAsyncResult)task).AsyncWaitHandle.Dispose better in task completion

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -260,7 +260,21 @@ namespace System.Threading.Tasks
             internal void SetCompleted()
             {
                 ManualResetEventSlim? mres = m_completionEvent;
-                if (mres != null) mres.Set();
+                if (mres != null) SetEvent(mres);
+            }
+
+            internal static void SetEvent(ManualResetEventSlim mres)
+            {
+                try
+                {
+                    mres.Set();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // The event may have been exposed to external code, in which case it could have been disposed
+                    // prematurely / erroneously.  To avoid that causing problems for the unrelated stack trying to
+                    // set the event, eat any disposed exceptions.
+                }
             }
 
             /// <summary>
@@ -1483,7 +1497,7 @@ namespace System.Threading.Tasks
                     {
                         // We published the event as unset, but the task has subsequently completed.
                         // Set the event's state properly so that callers don't deadlock.
-                        newMre.Set();
+                        ContingentProperties.SetEvent(newMre);
                     }
                 }
 
@@ -1619,7 +1633,7 @@ namespace System.Threading.Tasks
                         // will deadlock; an ensuing Set() will not wake them up.  In the event of an AppDomainUnload,
                         // there is no guarantee that anyone else is going to signal the event, and it does no harm to
                         // call Set() twice on m_completionEvent.
-                        if (!ev.IsSet) ev.Set();
+                        ContingentProperties.SetEvent(ev);
 
                         // Finally, dispose of the event
                         ev.Dispose();

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskAPMTest.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskAPMTest.cs
@@ -110,6 +110,14 @@ namespace System.Threading.Tasks.Tests
             Assert.False(asyncResult.CompletedSynchronously, "Should not have completed synchronously.");
         }
 
+        [Fact]
+        public void AsyncWaitHandle_DisposeHandleThenCompleteTask_Succeeds()
+        {
+            var tcs = new TaskCompletionSource();
+            ((IAsyncResult)tcs.Task).AsyncWaitHandle.Dispose();
+            tcs.SetResult();
+        }
+
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [OuterLoop]
         [InlineData(true)]


### PR DESCRIPTION
Task's IAsyncResult.AsyncWaitHandle implementation lazily creates a ManualResetEventSlim, which is then set as part of the Task completing.  That AsyncWaitHandle is exposed publicly out of the surface area.  If code (arguably erroneously) Dispose's of that WaitHandle before the Task has completed, the task's completion routine will incur an ObjectDisposedException, which will propagate out and potentially disrupt caller logic or even crash the process if allowed to propagate on a thread without user code to catch it.

This just adds a catch (ObjectDisposedException) block to eat such an exception in order to make the system more reliable in the face of such spooky action at a distance.

Fixes https://github.com/dotnet/runtime/issues/64400