### PR TITLE
[wasm] Remove USE_ZLIB=1 on windows, as we are already including the …

### DIFF
--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -84,7 +84,6 @@
 
     <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
       <_EmccFlags Include="@(_EmccCommonFlags)" />
-      <_EmccFlags Include="-s USE_ZLIB=1" />
     </ItemGroup>
 
     <WriteLinesToFile File="$(_EmccDefaultsRspPath)"

--- a/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
@@ -21,17 +21,19 @@ if (CLR_CMAKE_TARGET_UNIX OR CLR_CMAKE_TARGET_BROWSER)
     append_extra_compression_libs(NATIVE_LIBS_EXTRA)
 
     if (CLR_CMAKE_TARGET_BROWSER)
-        add_definitions(-s USE_ZLIB)
-    else ()
-        # Disable implicit fallthrough warning for Brotli
-        set(FLAGS -Wno-implicit-fallthrough)
+        include(${CLR_SRC_NATIVE_DIR}/external/zlib.cmake)
+        add_definitions(-DINTERNAL_ZLIB)
+        set(NATIVECOMPRESSION_SOURCES ${ZLIB_SOURCES} ${NATIVECOMPRESSION_SOURCES})
+    endif()
 
-        # Delete this supression once brotli is upgraded to vNext (current latest v1.0.9
-        # does not contain upstream fix: https://github.com/google/brotli/commit/0a3944c)
-        set(FLAGS "${FLAGS} -Wno-vla-parameter")
+    # Disable implicit fallthrough warning for Brotli
+    set(FLAGS -Wno-implicit-fallthrough)
 
-        set_source_files_properties(${NATIVECOMPRESSION_SOURCES} PROPERTIES COMPILE_FLAGS ${FLAGS})
-    endif ()
+    # Delete this supression once brotli is upgraded to vNext (current latest v1.0.9
+    # does not contain upstream fix: https://github.com/google/brotli/commit/0a3944c)
+    set(FLAGS "${FLAGS} -Wno-vla-parameter")
+
+    set_source_files_properties(${NATIVECOMPRESSION_SOURCES} PROPERTIES COMPILE_FLAGS ${FLAGS})
 
     if (GEN_SHARED_LIB)
         add_definitions(-DBROTLI_SHARED_COMPILATION)
@@ -88,6 +90,7 @@ else ()
         include(${CLR_SRC_NATIVE_DIR}/external/zlib.cmake)
     endif ()
 
+    add_definitions(-DINTERNAL_ZLIB)
     set(NATIVECOMPRESSION_SOURCES ${ZLIB_SOURCES} ${NATIVECOMPRESSION_SOURCES})
 
     if (GEN_SHARED_LIB)

--- a/src/native/libs/System.IO.Compression.Native/pal_zlib.c
+++ b/src/native/libs/System.IO.Compression.Native/pal_zlib.c
@@ -5,8 +5,10 @@
 #include <stdlib.h>
 #include "pal_zlib.h"
 
-#ifdef  _WIN32
-    #define c_static_assert(e) static_assert((e),"")
+#ifdef INTERNAL_ZLIB
+    #ifdef  _WIN32
+        #define c_static_assert(e) static_assert((e),"")
+    #endif
     #include <external/zlib/zlib.h>
 #else
     #include "pal_utilities.h"


### PR DESCRIPTION
…sources.

Fixes https://github.com/dotnet/runtime/issues/62553