### PR TITLE
[Mono] Intrinsify Vector.Equals

### DIFF
--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -817,6 +817,7 @@ static guint16 vector_methods [] = {
 	SN_ConvertToSingle,
 	SN_ConvertToUInt32,
 	SN_ConvertToUInt64,
+	SN_Equals,
 	SN_Narrow,
 	SN_Widen,
 	SN_get_IsHardwareAccelerated,
@@ -866,6 +867,16 @@ emit_sys_numerics_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSigna
 	case SN_ConvertToInt64:
 	case SN_ConvertToUInt32:
 	case SN_ConvertToUInt64:
+		break;
+	case SN_Equals:
+		MonoType *type;
+		MonoClass *klass;
+		klass = cmethod->klass;
+		type = m_class_get_byval_arg (klass);
+		etype = get_vector_t_elem_type (fsig->params [0]);
+		g_assert (fsig->param_count == 2);
+		ins = emit_xcompare (cfg, klass, etype->type, args [0], args [1]);
+		return ins;
 	case SN_Narrow:
 	case SN_Widen:
 		// FIXME:

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -829,7 +829,8 @@ emit_sys_numerics_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSigna
 	MonoInst *ins;
 	gboolean supported = FALSE;
 	int id;
-	MonoType *etype;
+	MonoType *etype, *type;
+	MonoClass *klass;
 
 	id = lookup_intrins (vector_methods, sizeof (vector_methods), cmethod);
 	if (id == -1)
@@ -869,8 +870,6 @@ emit_sys_numerics_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSigna
 	case SN_ConvertToUInt64:
 		break;
 	case SN_Equals:
-		MonoType *type;
-		MonoClass *klass;
 		klass = cmethod->klass;
 		type = m_class_get_byval_arg (klass);
 		etype = get_vector_t_elem_type (fsig->params [0]);


### PR DESCRIPTION
Contribute to the list of #64072

This change enables SIMD intrinsics replacement for `Vector.Equals` on amd64 with and without LLVM.