### PR TITLE
Add tests for `ref` field overlap with OBJECTREF and non-aligned `ref` fields.

### DIFF
--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -8492,7 +8492,7 @@ MethodTableBuilder::HandleExplicitLayout(
                 break;
             }
 
-            // Other than alignment, a byref can be treated like an native pointer.
+            // Other than alignment, a byref can be treated like a native pointer.
             if (CorTypeInfo::IsByRef(type))
                 type = ELEMENT_TYPE_I;
         }

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -8491,10 +8491,6 @@ MethodTableBuilder::HandleExplicitLayout(
                 // If we got here, OREF or BYREF field was not pointer aligned. THROW.
                 break;
             }
-
-            // Other than alignment, a byref can be treated like a native pointer.
-            if (CorTypeInfo::IsByRef(type))
-                type = ELEMENT_TYPE_I;
         }
 
         if (CorTypeInfo::IsObjRef(type))

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -8391,7 +8391,6 @@ MethodTableBuilder::HandleExplicitLayout(
 {
     STANDARD_VM_CONTRACT;
 
-
     // Instance slice size is the total size of an instance, and is calculated as
     // the field whose offset and size add to the greatest number.
     UINT instanceSliceSize = 0;
@@ -8426,15 +8425,15 @@ MethodTableBuilder::HandleExplicitLayout(
         pFieldLayout[i] = empty;
     }
 
-    // go through each field and look for invalid layout
+    // Go through each field and look for invalid layout.
     // (note that we are more permissive than what Ecma allows. We only disallow the minimum set necessary to
     // close security holes.)
     //
-    // This is what we implment:
+    // This is what we implement:
     //
-    // 1. Verify that every OREF is on a valid alignment
-    // 2. Verify that OREFs only overlap with other OREFs.
-    // 3. If an OREF does overlap with another OREF, the class is marked unverifiable.
+    // 1. Verify that every OREF or BYREF is on a valid alignment.
+    // 2. Verify that OREFs or BYREFs only overlap with other OREFs or BYREFs.
+    // 3. If an OREF or BYREF does overlap with another OREF or BYREF, the class is marked unverifiable.
     // 4. If an overlap of any kind occurs, the class will be marked NotTightlyPacked (affects ValueType.Equals()).
     //
     char emptyObject[TARGET_POINTER_SIZE];
@@ -8481,7 +8480,8 @@ MethodTableBuilder::HandleExplicitLayout(
         // "i" indexes all fields, valueClassCacheIndex indexes non-static fields only. Don't get them confused!
         valueClassCacheIndex++;
 
-        if (CorTypeInfo::IsObjRef(pFD->GetFieldType()))
+        CorElementType type = pFD->GetFieldType();
+        if (CorTypeInfo::IsObjRef(type) || CorTypeInfo::IsByRef(type))
         {
             // Check that the ref offset is pointer aligned
             if ((pFD->GetOffset_NoLogging() & ((ULONG)TARGET_POINTER_SIZE - 1)) != 0)
@@ -8489,13 +8489,13 @@ MethodTableBuilder::HandleExplicitLayout(
                 badOffset = pFD->GetOffset_NoLogging();
                 fieldTrust.SetTrust(ExplicitFieldTrust::kNone);
 
-                // If we got here, OREF field was not pointer aligned. THROW.
+                // If we got here, OREF or BYREF field was not pointer aligned. THROW.
                 break;
             }
             // check if overlaps another object
             if (memcmp((void *)&pFieldLayout[pFD->GetOffset_NoLogging()], (void *)isObject, sizeof(isObject)) == 0)
             {
-                // If we got here, an OREF overlapped another OREF. We permit this but mark the class unverifiable.
+                // If we got here, an OREF or BYREF overlapped another OREF or BYREF. We permit this but mark the class unverifiable.
                 fieldTrust.SetTrust(ExplicitFieldTrust::kLegal);
 
                 if (firstObjectOverlapOffset == ((DWORD)(-1)))
@@ -8508,13 +8508,13 @@ MethodTableBuilder::HandleExplicitLayout(
             // check if is empty at this point
             if (memcmp((void *)&pFieldLayout[pFD->GetOffset_NoLogging()], (void *)emptyObject, sizeof(emptyObject)) == 0)
             {
-                // If we got here, this OREF is overlapping no other fields (yet). Record that these bytes now contain an OREF.
+                // If we got here, this OREF or BYREF is overlapping no other fields (yet). Record that these bytes now contain an OREF or BYREF .
                 memset((void *)&pFieldLayout[pFD->GetOffset_NoLogging()], oref, sizeof(isObject));
                 fieldTrust.SetTrust(ExplicitFieldTrust::kNonOverLayed);
                 continue;
             }
 
-            // If we got here, the OREF overlaps a non-OREF. THROW.
+            // If we got here, the OREF or BYREF overlaps a non-OREF or non-BYREF. THROW.
             badOffset = pFD->GetOffset_NoLogging();
             fieldTrust.SetTrust(ExplicitFieldTrust::kNone);
             break;

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -347,7 +347,7 @@ mono_class_setup_fields (MonoClass *klass)
 				break;
 			}
 			if (m_type_is_byref (field->type) && (offset % MONO_ABI_ALIGNOF (gpointer) != 0)) {
-				mono_class_set_type_load_failure (klass, "Field '%s' has an invalid offset", field->name, offset);
+				mono_class_set_type_load_failure (klass, "Field '%s' has an invalid offset", field->name);
 				break;
 			}
 			if (offset < -1) { /*-1 is used to encode special static fields */

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -346,6 +346,10 @@ mono_class_setup_fields (MonoClass *klass)
 				mono_class_set_type_load_failure (klass, "Missing field layout info for %s", field->name);
 				break;
 			}
+			if (m_type_is_byref (field->type) && (offset % MONO_ABI_ALIGNOF (gpointer) != 0)) {
+				mono_class_set_type_load_failure (klass, "Field '%s' has an invalid offset", field->name, offset);
+				break;
+			}
 			if (offset < -1) { /*-1 is used to encode special static fields */
 				mono_class_set_type_load_failure (klass, "Field '%s' has a negative offset %d", field->name, offset);
 				break;

--- a/src/tests/Loader/classloader/RefFields/InvalidCSharp.il
+++ b/src/tests/Loader/classloader/RefFields/InvalidCSharp.il
@@ -5,17 +5,44 @@
 
 .assembly InvalidCSharp { }
 
-.class public auto ansi sealed beforefieldinit InvalidCSharp.InvalidStructWithRefField
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.InvalidStructWithRefField
     extends [System.Runtime]System.ValueType
 {
     // Type requires IsByRefLikeAttribute to be valid.
     .field public string& invalid
 }
 
+.class public explicit ansi sealed beforefieldinit InvalidCSharp.InvalidRefFieldAlignment
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .field [0] public int16 X
+    .field [2] public int32& Invalid
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.ContainsRef
+    extends [System.Runtime]System.ValueType
+{
+    .field public object OverlapsWithX
+    .field public int32 Y
+}
+
+.class public explicit ansi sealed beforefieldinit InvalidCSharp.InvalidRefFieldOverlap
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .field [0] public int32 X
+    .field [0] public valuetype InvalidCSharp.ContainsRef Invalid
+}
+
 // This is invalid metadata and is unable to be loaded.
 // -  [field sig] (0x80131815 (VER_E_FIELD_SIG))
 //
-// .class public auto ansi sealed beforefieldinit InvalidCSharp.InvalidStructWithStaticRefField
+// .class public sequential ansi sealed beforefieldinit InvalidCSharp.InvalidStructWithStaticRefField
 //     extends [System.Runtime]System.ValueType
 // {
 //     .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
@@ -24,7 +51,7 @@
 //     .field public static string& invalid
 // }
 
-.class public auto ansi sealed beforefieldinit InvalidCSharp.WithRefField
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.WithRefField
     extends [System.Runtime]System.ValueType
 {
     .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
@@ -57,7 +84,7 @@
     }
 }
 
-.class public auto ansi sealed beforefieldinit InvalidCSharp.WithRefStructField
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.WithRefStructField
     extends [System.Runtime]System.ValueType
 {
     .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
@@ -91,7 +118,7 @@
     }
 }
 
-.class public auto ansi sealed beforefieldinit InvalidCSharp.WithTypedReferenceField`1<T>
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.WithTypedReferenceField`1<T>
     extends [System.Runtime]System.ValueType
 {
     .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (

--- a/src/tests/Loader/classloader/RefFields/InvalidCSharp.il
+++ b/src/tests/Loader/classloader/RefFields/InvalidCSharp.il
@@ -9,7 +9,7 @@
     extends [System.Runtime]System.ValueType
 {
     // Type requires IsByRefLikeAttribute to be valid.
-    .field public string& invalid
+    .field public string& Invalid
 }
 
 .class public explicit ansi sealed beforefieldinit InvalidCSharp.InvalidRefFieldAlignment
@@ -18,25 +18,18 @@
     .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
         01 00 00 00
     )
-    .field [0] public int16 X
+    .field [0] public int16 Field
     .field [2] public int32& Invalid
 }
 
-.class public sequential ansi sealed beforefieldinit InvalidCSharp.ContainsRef
-    extends [System.Runtime]System.ValueType
-{
-    .field public object OverlapsWithX
-    .field public int32 Y
-}
-
-.class public explicit ansi sealed beforefieldinit InvalidCSharp.InvalidRefFieldOverlap
+.class public explicit ansi sealed beforefieldinit InvalidCSharp.InvalidObjectRefRefFieldOverlap
     extends [System.Runtime]System.ValueType
 {
     .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
         01 00 00 00
     )
-    .field [0] public int32 X
-    .field [0] public valuetype InvalidCSharp.ContainsRef Invalid
+    .field [0] public object Field
+    .field [0] public int32& Invalid
 }
 
 // This is invalid metadata and is unable to be loaded.
@@ -48,7 +41,7 @@
 //     .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
 //         01 00 00 00
 //     )
-//     .field public static string& invalid
+//     .field public static string& Invalid
 // }
 
 .class public sequential ansi sealed beforefieldinit InvalidCSharp.WithRefField

--- a/src/tests/Loader/classloader/RefFields/Validate.cs
+++ b/src/tests/Loader/classloader/RefFields/Validate.cs
@@ -15,6 +15,8 @@ class Validate
     {
         Console.WriteLine($"{nameof(Validate_Invalid_RefField_Fails)}...");
         Assert.Throws<TypeLoadException>(() => { var t = typeof(InvalidStructWithRefField); });
+        Assert.Throws<TypeLoadException>(() => { var t = typeof(InvalidRefFieldAlignment); });
+        Assert.Throws<TypeLoadException>(() => { var t = typeof(InvalidRefFieldOverlap); });
     }
 
     [Fact]

--- a/src/tests/Loader/classloader/RefFields/Validate.cs
+++ b/src/tests/Loader/classloader/RefFields/Validate.cs
@@ -16,7 +16,7 @@ class Validate
         Console.WriteLine($"{nameof(Validate_Invalid_RefField_Fails)}...");
         Assert.Throws<TypeLoadException>(() => { var t = typeof(InvalidStructWithRefField); });
         Assert.Throws<TypeLoadException>(() => { var t = typeof(InvalidRefFieldAlignment); });
-        Assert.Throws<TypeLoadException>(() => { var t = typeof(InvalidRefFieldOverlap); });
+        Assert.Throws<TypeLoadException>(() => { var t = typeof(InvalidObjectRefRefFieldOverlap); });
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #64520 

/cc @MichalStrehovsky @vargaz 