### PR TITLE
Use global caching in JsonSerializerOptions

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -247,6 +247,8 @@ System.Text.Json.Nodes.JsonValue</PackageDescription>
     <Compile Include="System\Text\Json\Serialization\Metadata\MemberAccessor.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\ParameterRef.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\PropertyRef.cs" />
+    <Compile Include="System\Text\Json\Serialization\Metadata\ReflectionEmitCachingMemberAccessor.Cache.cs" />
+    <Compile Include="System\Text\Json\Serialization\Metadata\ReflectionEmitCachingMemberAccessor.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\ReflectionEmitMemberAccessor.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\ReflectionMemberAccessor.cs" />
     <Compile Include="System\Text\Json\Serialization\MetadataPropertyName.cs" />

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -121,6 +121,7 @@ System.Text.Json.Nodes.JsonValue</PackageDescription>
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Write.Element.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Write.Node.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializerContext.cs" />
+    <Compile Include="System\Text\Json\Serialization\JsonSerializerOptions.Caching.cs" />
     <Compile Include="System\Text\Json\Serialization\ReferenceEqualsWrapper.cs" />
     <Compile Include="System\Text\Json\Serialization\ConverterStrategy.cs" />
     <Compile Include="System\Text\Json\Serialization\ConverterList.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
@@ -76,7 +76,7 @@ namespace System.Text.Json.Serialization.Converters
             if (!state.SupportContinuation &&
                 jsonTypeInfo is JsonTypeInfo<T> info &&
                 info.SerializeHandler != null &&
-                info.Options._context?.CanUseSerializationLogic == true)
+                info.Options._serializerContext?.CanUseSerializationLogic == true)
             {
                 info.SerializeHandler(writer, value);
                 return true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
@@ -18,12 +18,12 @@ namespace System.Text.Json
             Debug.Assert(runtimeType != null);
 
             options ??= JsonSerializerOptions.Default;
-            if (!options.IsInitializedForReflectionSerializer)
+            if (!JsonSerializerOptions.IsInitializedForReflectionSerializer)
             {
-                options.InitializeForReflectionSerializer();
+                JsonSerializerOptions.InitializeForReflectionSerializer();
             }
 
-            return options.GetOrAddClassForRootType(runtimeType);
+            return options.GetOrAddJsonTypeInfoForRootType(runtimeType);
         }
 
         private static JsonTypeInfo GetTypeInfo(JsonSerializerContext context, Type type)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -287,9 +287,9 @@ namespace System.Text.Json
             CancellationToken cancellationToken = default)
         {
             options ??= JsonSerializerOptions.Default;
-            if (!options.IsInitializedForReflectionSerializer)
+            if (!JsonSerializerOptions.IsInitializedForReflectionSerializer)
             {
-                options.InitializeForReflectionSerializer();
+                JsonSerializerOptions.InitializeForReflectionSerializer();
             }
 
             return CreateAsyncEnumerableDeserializer(utf8Json, options, cancellationToken);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -41,7 +41,7 @@ namespace System.Text.Json
 
             if (jsonTypeInfo.HasSerialize &&
                 jsonTypeInfo is JsonTypeInfo<TValue> typedInfo &&
-                typedInfo.Options._context?.CanUseSerializationLogic == true)
+                typedInfo.Options._serializerContext?.CanUseSerializationLogic == true)
             {
                 Debug.Assert(typedInfo.SerializeHandler != null);
                 typedInfo.SerializeHandler(writer, value);
@@ -59,8 +59,8 @@ namespace System.Text.Json
 
             Debug.Assert(!jsonTypeInfo.HasSerialize ||
                 jsonTypeInfo is not JsonTypeInfo<TValue> ||
-                jsonTypeInfo.Options._context == null ||
-                !jsonTypeInfo.Options._context.CanUseSerializationLogic,
+                jsonTypeInfo.Options._serializerContext == null ||
+                !jsonTypeInfo.Options._serializerContext.CanUseSerializationLogic,
                 "Incorrect method called. WriteUsingGeneratedSerializer() should have been called instead.");
 
             WriteStack state = default;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
@@ -30,7 +30,7 @@ namespace System.Text.Json.Serialization
                 if (_options == null)
                 {
                     _options = new JsonSerializerOptions();
-                    _options._context = this;
+                    _options._serializerContext = this;
                 }
 
                 return _options;
@@ -97,13 +97,13 @@ namespace System.Text.Json.Serialization
         {
             if (options != null)
             {
-                if (options._context != null)
+                if (options._serializerContext != null)
                 {
                     ThrowHelper.ThrowInvalidOperationException_JsonSerializerOptionsAlreadyBoundToContext();
                 }
 
                 _options = options;
-                options._context = this;
+                options._serializerContext = this;
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -172,7 +172,7 @@ namespace System.Text.Json
                 // Worst case scenario, the cache has been saturated with permanent entries.
                 // We want to avoid iterating needlessly through the entire cache every time
                 // a new options instance is created. For this reason we implement a backoff
-                // strategy to amortize the cost of eviction across multiple cache initializations.
+                // strategy to average out the cost of eviction across multiple cache initializations.
                 // The backoff count is determined by the eviction rates of the most recent eviction runs.
 
                 if (s_evictionRunsToSkip > 0)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -158,7 +158,7 @@ namespace System.Text.Json
 
                     // Use a defensive copy of the options instance as key to
                     // avoid capturing references to any caching contexts.
-                    var key = new JsonSerializerOptions(options) { _context = options._context };
+                    var key = new JsonSerializerOptions(options) { _serializerContext = options._serializerContext };
                     Debug.Assert(key._cachingContext == null);
 
                     ctx = new CachingContext(options);
@@ -265,7 +265,7 @@ namespace System.Text.Json
                     left._includeFields == right._includeFields &&
                     left._propertyNameCaseInsensitive == right._propertyNameCaseInsensitive &&
                     left._writeIndented == right._writeIndented &&
-                    left._context == right._context &&
+                    left._serializerContext == right._serializerContext &&
                     CompareConverters(left.Converters, right.Converters);
 
                 static bool CompareConverters(IList<JsonConverter> left, IList<JsonConverter> right)
@@ -309,7 +309,7 @@ namespace System.Text.Json
                 hc.Add(options._includeFields);
                 hc.Add(options._propertyNameCaseInsensitive);
                 hc.Add(options._writeIndented);
-                hc.Add(options._context);
+                hc.Add(options._serializerContext);
 
                 foreach (JsonConverter converter in options.Converters)
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -82,7 +82,7 @@ namespace System.Text.Json
         /// this is to prevent multiple options instances from leaking into the object graphs of converters which
         /// could break user invariants.
         /// </summary>
-        private sealed class CachingContext
+        internal sealed class CachingContext
         {
             private readonly ConcurrentDictionary<Type, JsonConverter> _converterCache = new();
             private readonly ConcurrentDictionary<Type, JsonTypeInfo> _jsonTypeInfoCache = new();
@@ -112,7 +112,7 @@ namespace System.Text.Json
         /// this approach uses a regular dictionary pointing to weak references of <see cref="CachingContext"/>.
         /// Relevant caching contexts are looked up using the equality comparison defined by <see cref="EqualityComparer"/>.
         /// </summary>
-        private static class TrackedCachingContexts
+        internal static class TrackedCachingContexts
         {
             private const int MaxTrackedContexts = 64;
             private static readonly ConcurrentDictionary<JsonSerializerOptions, WeakReference<CachingContext>> s_cache =
@@ -166,6 +166,16 @@ namespace System.Text.Json
                     Debug.Assert(success);
 
                     return ctx;
+                }
+            }
+
+            public static void Clear()
+            {
+                lock (s_cache)
+                {
+                    s_cache.Clear();
+                    s_recentEvictionCounts.Clear();
+                    s_evictionRunsToSkip = 0;
                 }
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -1,0 +1,321 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+namespace System.Text.Json
+{
+    public sealed partial class JsonSerializerOptions
+    {
+        /// <summary>
+        /// Encapsulates all cached metadata referenced by the current <see cref="JsonSerializerOptions" /> instance.
+        /// Context can be shared across multiple equivalent options instances.
+        /// </summary>
+        private CachingContext? _cachingContext;
+
+        // Simple LRU cache for the public (de)serialize entry points that avoid some lookups in _cachingContext.
+        // Although this may be written by multiple threads, 'volatile' was not added since any local affinity is fine.
+        private JsonTypeInfo? _lastTypeInfo;
+
+        internal JsonTypeInfo GetOrAddJsonTypeInfo(Type type)
+        {
+            if (_cachingContext == null)
+            {
+                InitializeCachingContext();
+                Debug.Assert(_cachingContext != null);
+            }
+
+            return _cachingContext.GetOrAddJsonTypeInfo(type);
+        }
+
+        internal bool TryGetJsonTypeInfo(Type type, [NotNullWhen(true)] out JsonTypeInfo? typeInfo)
+        {
+            if (_cachingContext == null)
+            {
+                typeInfo = null;
+                return false;
+            }
+
+            return _cachingContext.TryGetJsonTypeInfo(type, out typeInfo);
+        }
+
+        internal bool IsJsonTypeInfoCached(Type type) => _cachingContext?.IsJsonTypeInfoCached(type) == true;
+
+        /// <summary>
+        /// Return the TypeInfo for root API calls.
+        /// This has an LRU cache that is intended only for public API calls that specify the root type.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal JsonTypeInfo GetOrAddJsonTypeInfoForRootType(Type type)
+        {
+            JsonTypeInfo? jsonTypeInfo = _lastTypeInfo;
+
+            if (jsonTypeInfo?.Type != type)
+            {
+                jsonTypeInfo = GetOrAddJsonTypeInfo(type);
+                _lastTypeInfo = jsonTypeInfo;
+            }
+
+            return jsonTypeInfo;
+        }
+
+        internal void ClearCaches()
+        {
+            _cachingContext?.Clear();
+            _lastTypeInfo = null;
+        }
+
+        private void InitializeCachingContext()
+        {
+#if NETCOREAPP
+            _cachingContext = TrackedCachingContexts.GetOrCreate(this);
+#else
+            _cachingContext = new CachingContext(this);
+#endif
+        }
+
+        /// <summary>
+        /// Stores and manages all reflection caches for one or more <see cref="JsonSerializerOptions"/> instances.
+        /// NB the type encapsulates the original options instance and only consults that one when building new types;
+        /// this is to prevent multiple options instances from leaking into the object graphs of converters which
+        /// could break user invariants.
+        /// </summary>
+        private sealed class CachingContext
+        {
+            private readonly ConcurrentDictionary<Type, JsonConverter> _converterCache = new();
+            private readonly ConcurrentDictionary<Type, JsonTypeInfo> _jsonTypeInfoCache = new();
+
+            public CachingContext(JsonSerializerOptions options)
+            {
+                Options = options;
+                _ = Count;
+            }
+
+            public JsonSerializerOptions Options { get; }
+            public int Count => _converterCache.Count + _jsonTypeInfoCache.Count;
+            public JsonConverter GetOrAddConverter(Type type) => _converterCache.GetOrAdd(type, Options.GetConverterFromType);
+            public JsonTypeInfo GetOrAddJsonTypeInfo(Type type) => _jsonTypeInfoCache.GetOrAdd(type, Options.GetJsonTypeInfoFromContextOrCreate);
+            public bool TryGetJsonTypeInfo(Type type, [NotNullWhen(true)] out JsonTypeInfo? typeInfo) => _jsonTypeInfoCache.TryGetValue(type, out typeInfo);
+            public bool IsJsonTypeInfoCached(Type type) => _jsonTypeInfoCache.ContainsKey(type);
+
+            public void Clear()
+            {
+                _converterCache.Clear();
+                _jsonTypeInfoCache.Clear();
+            }
+        }
+
+#if NETCOREAPP
+        /// <summary>
+        /// Defines a cache of CachingContexts; instead of using a ConditionalWeakTable which can be slow to traverse
+        /// this approach uses a regular dictionary pointing to weak references of <see cref="CachingContext"/>.
+        /// Relevant caching contexts are looked up using the equality comparison defined by <see cref="EqualityComparer"/>.
+        /// </summary>
+        private static class TrackedCachingContexts
+        {
+            private const int MaxTrackedContexts = 64;
+            private static readonly ConcurrentDictionary<JsonSerializerOptions, WeakReference<CachingContext>> s_cache =
+                new(concurrencyLevel: 1, capacity: MaxTrackedContexts, new EqualityComparer());
+
+            private const int EvictionCountHistory = 10;
+            private static Queue<int> s_recentEvictionCounts = new(EvictionCountHistory);
+            private static int s_evictionRunsToSkip;
+
+            public static CachingContext GetOrCreate(JsonSerializerOptions options)
+            {
+                if (s_cache.TryGetValue(options, out WeakReference<CachingContext>? wr) && wr.TryGetTarget(out CachingContext? ctx))
+                {
+                    return ctx;
+                }
+
+                lock (s_cache)
+                {
+                    if (s_cache.TryGetValue(options, out wr))
+                    {
+                        if (!wr.TryGetTarget(out ctx))
+                        {
+                            // Found a dangling weak reference; replenish with a fresh instance.
+                            ctx = new CachingContext(options);
+                            wr.SetTarget(ctx);
+                        }
+
+                        return ctx;
+                    }
+
+                    if (s_cache.Count == MaxTrackedContexts)
+                    {
+                        if (!TryEvictDanglingEntries())
+                        {
+                            // Cache is full; return a fresh instance.
+                            return new CachingContext(options);
+                        }
+                    }
+
+                    Debug.Assert(s_cache.Count < MaxTrackedContexts);
+
+                    // Use a defensive copy of the options instance as key to
+                    // avoid capturing references to any caching contexts.
+                    var key = new JsonSerializerOptions(options) { _context = options._context };
+                    Debug.Assert(key._cachingContext == null);
+
+                    ctx = new CachingContext(options);
+                    bool success = s_cache.TryAdd(key, new(ctx));
+                    Debug.Assert(success);
+
+                    return ctx;
+                }
+            }
+
+            private static bool TryEvictDanglingEntries()
+            {
+                // Worst case scenario, the cache has been saturated with permanent entries.
+                // We want to avoid iterating needlessly through the entire cache every time
+                // a new options instance is created. For this reason we implement a backoff
+                // strategy to amortize the cost of eviction across multiple cache initializations.
+                // The backoff count is determined by the eviction rates of the most recent eviction runs.
+
+                if (s_evictionRunsToSkip > 0)
+                {
+                    --s_evictionRunsToSkip;
+                    return false;
+                }
+
+                int currentEvictions = 0;
+                foreach (KeyValuePair<JsonSerializerOptions, WeakReference<CachingContext>> kvp in s_cache)
+                {
+                    if (!kvp.Value.TryGetTarget(out _))
+                    {
+                        bool result = s_cache.TryRemove(kvp.Key, out _);
+                        Debug.Assert(result);
+                        currentEvictions++;
+                    }
+                }
+
+                s_evictionRunsToSkip = EstimateEvictionRunsToSkip(currentEvictions);
+                return currentEvictions > 0;
+
+                // Estimate the number of eviction runs to skip based on recent eviction rates.
+                static int EstimateEvictionRunsToSkip(int latestEvictionCount)
+                {
+                    if (s_recentEvictionCounts.Count < EvictionCountHistory)
+                    {
+                        // Insufficient data to determine a skip count.
+                        s_recentEvictionCounts.Enqueue(latestEvictionCount);
+                        return 0;
+                    }
+                    else
+                    {
+                        s_recentEvictionCounts.Dequeue();
+                        s_recentEvictionCounts.Enqueue(latestEvictionCount);
+
+                        // Calculate the average evictions per run.
+                        double avgEvictionsPerRun = 0;
+
+                        foreach (int rate in s_recentEvictionCounts)
+                        {
+                            avgEvictionsPerRun += rate;
+                        }
+
+                        avgEvictionsPerRun /= EvictionCountHistory;
+
+                        // - If avgEvictionsPerRun >= 1 we skip no subsequent eviction calls.
+                        // - If avgEvictionsPerRun < 1 we skip ~ `1 / avgEvictionsPerRun` calls.
+                        int runsPerEviction = (int)Math.Round(1 / Math.Clamp(avgEvictionsPerRun, 0.1, 1));
+                        Debug.Assert(runsPerEviction >= 1 && runsPerEviction <= 10);
+                        return runsPerEviction - 1;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Provides a conservative equality comparison for JsonSerializerOptions instances.
+        /// If two instances are equivalent, they should generate identical metadata caches;
+        /// the converse however does not necessarily hold.
+        /// </summary>
+        private class EqualityComparer : IEqualityComparer<JsonSerializerOptions>
+        {
+            public bool Equals(JsonSerializerOptions? left, JsonSerializerOptions? right)
+            {
+                Debug.Assert(left != null && right != null);
+                return
+                    left._dictionaryKeyPolicy == right._dictionaryKeyPolicy &&
+                    left._jsonPropertyNamingPolicy == right._jsonPropertyNamingPolicy &&
+                    left._readCommentHandling == right._readCommentHandling &&
+                    left._referenceHandler == right._referenceHandler &&
+                    left._encoder == right._encoder &&
+                    left._defaultIgnoreCondition == right._defaultIgnoreCondition &&
+                    left._numberHandling == right._numberHandling &&
+                    left._unknownTypeHandling == right._unknownTypeHandling &&
+                    left._defaultBufferSize == right._defaultBufferSize &&
+                    left._maxDepth == right._maxDepth &&
+                    left._allowTrailingCommas == right._allowTrailingCommas &&
+                    left._ignoreNullValues == right._ignoreNullValues &&
+                    left._ignoreReadOnlyProperties == right._ignoreReadOnlyProperties &&
+                    left._ignoreReadonlyFields == right._ignoreReadonlyFields &&
+                    left._includeFields == right._includeFields &&
+                    left._propertyNameCaseInsensitive == right._propertyNameCaseInsensitive &&
+                    left._writeIndented == right._writeIndented &&
+                    left._context == right._context &&
+                    CompareConverters(left.Converters, right.Converters);
+
+                static bool CompareConverters(IList<JsonConverter> left, IList<JsonConverter> right)
+                {
+                    int n;
+                    if ((n = left.Count) != right.Count)
+                    {
+                        return false;
+                    }
+
+                    for (int i = 0; i < n; i++)
+                    {
+                        if (left[i] != right[i])
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+            }
+
+            public int GetHashCode(JsonSerializerOptions options)
+            {
+                HashCode hc = default;
+
+                hc.Add(options._dictionaryKeyPolicy);
+                hc.Add(options._jsonPropertyNamingPolicy);
+                hc.Add(options._readCommentHandling);
+                hc.Add(options._referenceHandler);
+                hc.Add(options._encoder);
+                hc.Add(options._defaultIgnoreCondition);
+                hc.Add(options._numberHandling);
+                hc.Add(options._unknownTypeHandling);
+                hc.Add(options._defaultBufferSize);
+                hc.Add(options._maxDepth);
+                hc.Add(options._allowTrailingCommas);
+                hc.Add(options._ignoreNullValues);
+                hc.Add(options._ignoreReadOnlyProperties);
+                hc.Add(options._ignoreReadonlyFields);
+                hc.Add(options._includeFields);
+                hc.Add(options._propertyNameCaseInsensitive);
+                hc.Add(options._writeIndented);
+                hc.Add(options._context);
+
+                foreach (JsonConverter converter in options.Converters)
+                {
+                    hc.Add(converter);
+                }
+
+                return hc.ToHashCode();
+            }
+        }
+#endif
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -24,11 +23,8 @@ namespace System.Text.Json
         // The global list of built-in converters that override CanConvert().
         private static JsonConverter[]? s_defaultFactoryConverters;
 
-        // The cached converters (custom or built-in).
-        private readonly ConcurrentDictionary<Type, JsonConverter?> _converters = new ConcurrentDictionary<Type, JsonConverter?>();
-
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
-        private void RootBuiltInConverters()
+        private static void RootBuiltInConverters()
         {
             s_defaultSimpleConverters = GetDefaultSimpleConverters();
             s_defaultFactoryConverters = new JsonConverter[]
@@ -97,7 +93,7 @@ namespace System.Text.Json
         /// </remarks>
         public IList<JsonConverter> Converters { get; }
 
-        internal JsonConverter DetermineConverter(Type? parentClassType, Type runtimePropertyType, MemberInfo? memberInfo)
+        internal JsonConverter GetConverterForMember(Type? parentClassType, Type runtimePropertyType, MemberInfo? memberInfo)
         {
             JsonConverter converter = null!;
 
@@ -174,16 +170,21 @@ namespace System.Text.Json
 
         internal JsonConverter GetConverterInternal(Type typeToConvert)
         {
-            Debug.Assert(typeToConvert != null);
-
-            if (_converters.TryGetValue(typeToConvert, out JsonConverter? converter))
+            // Only cache the value once (de)serialization has occurred since new converters can be added that may change the result.
+            if (_cachingContext != null)
             {
-                Debug.Assert(converter != null);
-                return converter;
+                return _cachingContext.GetOrAddConverter(typeToConvert);
             }
 
+            return GetConverterFromType(typeToConvert);
+        }
+
+        private JsonConverter GetConverterFromType(Type typeToConvert)
+        {
+            Debug.Assert(typeToConvert != null);
+
             // Priority 1: If there is a JsonSerializerContext, fetch the converter from there.
-            converter = _context?.GetTypeInfo(typeToConvert)?.PropertyInfoForTypeInfo?.ConverterBase;
+            JsonConverter? converter = _context?.GetTypeInfo(typeToConvert)?.PropertyInfoForTypeInfo?.ConverterBase;
 
             // Priority 2: Attempt to get custom converter added at runtime.
             // Currently there is not a way at runtime to override the [JsonConverter] when applied to a property.
@@ -257,15 +258,6 @@ namespace System.Text.Json
                 && !typeToConvert.IsAssignableFromInternal(converterTypeToConvert))
             {
                 ThrowHelper.ThrowInvalidOperationException_SerializationConverterNotCompatible(converter.GetType(), typeToConvert);
-            }
-
-            // Only cache the value once (de)serialization has occurred since new converters can be added that may change the result.
-            if (_haveTypesBeenCreated)
-            {
-                // A null converter is allowed here and cached.
-
-                // Ignore failure case here in multi-threaded cases since the cached item will be equivalent.
-                _converters.TryAdd(typeToConvert, converter);
             }
 
             return converter;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -184,7 +184,7 @@ namespace System.Text.Json
             Debug.Assert(typeToConvert != null);
 
             // Priority 1: If there is a JsonSerializerContext, fetch the converter from there.
-            JsonConverter? converter = _context?.GetTypeInfo(typeToConvert)?.PropertyInfoForTypeInfo?.ConverterBase;
+            JsonConverter? converter = _serializerContext?.GetTypeInfo(typeToConvert)?.PropertyInfoForTypeInfo?.ConverterBase;
 
             // Priority 2: Attempt to get custom converter added at runtime.
             // Currently there is not a way at runtime to override the [JsonConverter] when applied to a property.
@@ -311,7 +311,7 @@ namespace System.Text.Json
 
         internal bool TryGetDefaultSimpleConverter(Type typeToConvert, [NotNullWhen(true)] out JsonConverter? converter)
         {
-            if (_context == null && // For consistency do not return any default converters for
+            if (_serializerContext == null && // For consistency do not return any default converters for
                                     // options instances linked to a JsonSerializerContext,
                                     // even if the default converters might have been rooted.
                 s_defaultSimpleConverters != null &&

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -93,7 +93,7 @@ namespace System.Text.Json
         /// </remarks>
         public IList<JsonConverter> Converters { get; }
 
-        internal JsonConverter GetConverterForMember(Type? parentClassType, Type runtimePropertyType, MemberInfo? memberInfo)
+        internal JsonConverter GetConverterFromMember(Type? parentClassType, Type runtimePropertyType, MemberInfo? memberInfo)
         {
             JsonConverter converter = null!;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -568,10 +568,10 @@ namespace System.Text.Json
 #if NETCOREAPP
                     // if dynamic code isn't supported, fallback to reflection
                     _memberAccessorStrategy = RuntimeFeature.IsDynamicCodeSupported ?
-                        new ReflectionEmitMemberAccessor() :
+                        new ReflectionEmitCachingMemberAccessor() :
                         new ReflectionMemberAccessor();
 #elif NETFRAMEWORK
-                    _memberAccessorStrategy = new ReflectionEmitMemberAccessor();
+                    _memberAccessorStrategy = new ReflectionEmitCachingMemberAccessor();
 #else
                     _memberAccessorStrategy = new ReflectionMemberAccessor();
 #endif

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -33,7 +33,7 @@ namespace System.Text.Json
         /// </remarks>
         public static JsonSerializerOptions Default { get; } = CreateDefaultImmutableInstance();
 
-        internal JsonSerializerContext? _context;
+        internal JsonSerializerContext? _serializerContext;
 
         // Stores the JsonTypeInfo factory, which requires unreferenced code and must be rooted by the reflection-based serializer.
         private static Func<Type, JsonSerializerOptions, JsonTypeInfo>? s_typeInfoCreationFunc;
@@ -150,13 +150,13 @@ namespace System.Text.Json
         /// </remarks>
         public void AddContext<TContext>() where TContext : JsonSerializerContext, new()
         {
-            if (_context != null)
+            if (_serializerContext != null)
             {
                 ThrowHelper.ThrowInvalidOperationException_JsonSerializerOptionsAlreadyBoundToContext();
             }
 
             TContext context = new();
-            _context = context;
+            _serializerContext = context;
             context._options = this;
         }
 
@@ -598,7 +598,7 @@ namespace System.Text.Json
 
         private JsonTypeInfo GetJsonTypeInfoFromContextOrCreate(Type type)
         {
-            JsonTypeInfo? info = _context?.GetTypeInfo(type);
+            JsonTypeInfo? info = _serializerContext?.GetTypeInfo(type);
             if (info != null)
             {
                 return info;
@@ -656,9 +656,9 @@ namespace System.Text.Json
 
         internal void VerifyMutable()
         {
-            if (_cachingContext != null || _context != null)
+            if (_cachingContext != null || _serializerContext != null)
             {
-                ThrowHelper.ThrowInvalidOperationException_SerializerOptionsImmutable(_context);
+                ThrowHelper.ThrowInvalidOperationException_SerializerOptionsImmutable(_serializerContext);
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -32,17 +31,12 @@ namespace System.Text.Json
         /// so using fresh default instances every time one is needed can result in redundant recomputation of converters.
         /// This property provides a shared instance that can be consumed by any number of components without necessitating any converter recomputation.
         /// </remarks>
-        public static JsonSerializerOptions Default { get; } = new JsonSerializerOptions { _haveTypesBeenCreated = true };
-
-        private readonly ConcurrentDictionary<Type, JsonTypeInfo> _classes = new ConcurrentDictionary<Type, JsonTypeInfo>();
-
-        // Simple LRU cache for the public (de)serialize entry points that avoid some lookups in _classes.
-        // Although this may be written by multiple threads, 'volatile' was not added since any local affinity is fine.
-        private JsonTypeInfo? _lastClass { get; set; }
+        public static JsonSerializerOptions Default { get; } = CreateDefaultImmutableInstance();
 
         internal JsonSerializerContext? _context;
 
-        private Func<Type, JsonSerializerOptions, JsonTypeInfo>? _typeInfoCreationFunc;
+        // Stores the JsonTypeInfo factory, which requires unreferenced code and must be rooted by the reflection-based serializer.
+        private static Func<Type, JsonSerializerOptions, JsonTypeInfo>? s_typeInfoCreationFunc;
 
         // For any new option added, adding it to the options copied in the copy constructor below must be considered.
 
@@ -59,7 +53,6 @@ namespace System.Text.Json
         private int _defaultBufferSize = BufferSizeDefault;
         private int _maxDepth;
         private bool _allowTrailingCommas;
-        private bool _haveTypesBeenCreated;
         private bool _ignoreNullValues;
         private bool _ignoreReadOnlyProperties;
         private bool _ignoreReadonlyFields;
@@ -584,37 +577,26 @@ namespace System.Text.Json
         /// <summary>
         /// Whether <see cref="InitializeForReflectionSerializer()"/> needs to be called.
         /// </summary>
-        internal bool IsInitializedForReflectionSerializer { get; set; }
+        internal static bool IsInitializedForReflectionSerializer { get; set; }
 
         /// <summary>
         /// Initializes the converters for the reflection-based serializer.
         /// <seealso cref="InitializeForReflectionSerializer"/> must be checked before calling.
         /// </summary>
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
-        internal void InitializeForReflectionSerializer()
+        internal static void InitializeForReflectionSerializer()
         {
             // For threading cases, the state that is set here can be overwritten.
             RootBuiltInConverters();
-            _typeInfoCreationFunc = CreateJsonTypeInfo;
+            s_typeInfoCreationFunc = CreateJsonTypeInfo;
             IsInitializedForReflectionSerializer = true;
 
             [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
             static JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options) => new JsonTypeInfo(type, options);
         }
 
-        internal JsonTypeInfo GetOrAddClass(Type type)
-        {
-            _haveTypesBeenCreated = true;
 
-            if (!TryGetClass(type, out JsonTypeInfo? result))
-            {
-                result = _classes.GetOrAdd(type, GetClassFromContextOrCreate(type));
-            }
-
-            return result;
-        }
-
-        internal JsonTypeInfo GetClassFromContextOrCreate(Type type)
+        private JsonTypeInfo GetJsonTypeInfoFromContextOrCreate(Type type)
         {
             JsonTypeInfo? info = _context?.GetTypeInfo(type);
             if (info != null)
@@ -622,55 +604,13 @@ namespace System.Text.Json
                 return info;
             }
 
-            if (_typeInfoCreationFunc == null)
+            if (s_typeInfoCreationFunc == null)
             {
                 ThrowHelper.ThrowNotSupportedException_NoMetadataForType(type);
                 return null!;
             }
 
-            return _typeInfoCreationFunc(type, this);
-        }
-
-        /// <summary>
-        /// Return the TypeInfo for root API calls.
-        /// This has a LRU cache that is intended only for public API calls that specify the root type.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal JsonTypeInfo GetOrAddClassForRootType(Type type)
-        {
-            JsonTypeInfo? jsonTypeInfo = _lastClass;
-            if (jsonTypeInfo?.Type != type)
-            {
-                jsonTypeInfo = GetOrAddClass(type);
-                _lastClass = jsonTypeInfo;
-            }
-
-            return jsonTypeInfo;
-        }
-
-        internal bool TryGetClass(Type type, [NotNullWhen(true)] out JsonTypeInfo? jsonTypeInfo)
-        {
-            // todo: for performance and reduced instances, consider using the converters and JsonTypeInfo from s_defaultOptions by cloning (or reference directly if no changes).
-            // https://github.com/dotnet/runtime/issues/32357
-            if (!_classes.TryGetValue(type, out JsonTypeInfo? result))
-            {
-                jsonTypeInfo = null;
-                return false;
-            }
-
-            jsonTypeInfo = result;
-            return true;
-        }
-
-        internal bool TypeIsCached(Type type)
-        {
-            return _classes.ContainsKey(type);
-        }
-
-        internal void ClearClasses()
-        {
-            _classes.Clear();
-            _lastClass = null;
+            return s_typeInfoCreationFunc(type, this);
         }
 
         internal JsonDocumentOptions GetDocumentOptions()
@@ -716,10 +656,17 @@ namespace System.Text.Json
 
         internal void VerifyMutable()
         {
-            if (_haveTypesBeenCreated || _context != null)
+            if (_cachingContext != null || _context != null)
             {
                 ThrowHelper.ThrowInvalidOperationException_SerializerOptionsImmutable(_context);
             }
+        }
+
+        private static JsonSerializerOptions CreateDefaultImmutableInstance()
+        {
+            var options = new JsonSerializerOptions();
+            options.InitializeCachingContext(); // eagerly initialize caching context to close type for modification.
+            return options;
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptionsUpdateHandler.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptionsUpdateHandler.cs
@@ -21,7 +21,7 @@ namespace System.Text.Json
                 options.Key.ClearCaches();
             }
 
-            // Flush the shared caching context cache
+            // Flush the shared caching contexts
             JsonSerializerOptions.TrackedCachingContexts.Clear();
 
             // Flush the dynamic method cache

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptionsUpdateHandler.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptionsUpdateHandler.cs
@@ -18,7 +18,7 @@ namespace System.Text.Json
             // Ignore the types, and just clear out all reflection caches from serializer options.
             foreach (KeyValuePair<JsonSerializerOptions, object?> options in JsonSerializerOptions.TrackedOptionsInstances.All)
             {
-                options.Key.ClearClasses();
+                options.Key.ClearCaches();
             }
 
             // Flush the dynamic method cache

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptionsUpdateHandler.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptionsUpdateHandler.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Reflection.Metadata;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 
 [assembly: MetadataUpdateHandler(typeof(JsonSerializerOptionsUpdateHandler))]
 
@@ -19,6 +20,9 @@ namespace System.Text.Json
             {
                 options.Key.ClearClasses();
             }
+
+            // Flush the dynamic method cache
+            ReflectionEmitCachingMemberAccessor.Clear();
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptionsUpdateHandler.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptionsUpdateHandler.cs
@@ -21,6 +21,9 @@ namespace System.Text.Json
                 options.Key.ClearCaches();
             }
 
+            // Flush the shared caching context cache
+            JsonSerializerOptions.TrackedCachingContexts.Clear();
+
             // Flush the dynamic method cache
             ReflectionEmitCachingMemberAccessor.Clear();
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfo.cs
@@ -41,7 +41,7 @@ namespace System.Text.Json.Serialization.Metadata
                 if (_runtimeTypeInfo == null)
                 {
                     Debug.Assert(Options != null);
-                    _runtimeTypeInfo = Options!.GetOrAddClass(RuntimePropertyType);
+                    _runtimeTypeInfo = Options!.GetOrAddJsonTypeInfo(RuntimePropertyType);
                 }
 
                 return _runtimeTypeInfo;
@@ -102,7 +102,7 @@ namespace System.Text.Json.Serialization.Metadata
                 Type parameterType = parameterInfo.ParameterType;
 
                 DefaultValueHolder holder;
-                if (matchingProperty.Options.TryGetClass(parameterType, out JsonTypeInfo? typeInfo))
+                if (matchingProperty.Options.TryGetJsonTypeInfo(parameterType, out JsonTypeInfo? typeInfo))
                 {
                     holder = typeInfo.DefaultValueHolder;
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -473,7 +473,7 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 if (_runtimeTypeInfo == null)
                 {
-                    _runtimeTypeInfo = Options.GetOrAddClass(RuntimePropertyType!);
+                    _runtimeTypeInfo = Options.GetOrAddJsonTypeInfo(RuntimePropertyType!);
                 }
 
                 return _runtimeTypeInfo;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
@@ -580,7 +580,7 @@ namespace System.Text.Json.Serialization.Metadata
             Debug.Assert(PropertyCache == null);
             Debug.Assert(PropertyInfoForTypeInfo.ConverterStrategy == ConverterStrategy.Object);
 
-            JsonSerializerContext? context = Options._context;
+            JsonSerializerContext? context = Options._serializerContext;
             Debug.Assert(context != null);
 
             JsonPropertyInfo[] array;
@@ -636,7 +636,7 @@ namespace System.Text.Json.Serialization.Metadata
             Debug.Assert(PropertyCache != null);
             Debug.Assert(PropertyInfoForTypeInfo.ConverterStrategy == ConverterStrategy.Object);
 
-            JsonSerializerContext? context = Options._context;
+            JsonSerializerContext? context = Options._serializerContext;
             Debug.Assert(context != null);
 
             JsonParameterInfoValues[] array;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -52,7 +52,7 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 if (_elementTypeInfo == null && ElementType != null)
                 {
-                    _elementTypeInfo = Options.GetOrAddClass(ElementType);
+                    _elementTypeInfo = Options.GetOrAddJsonTypeInfo(ElementType);
                 }
 
                 return _elementTypeInfo;
@@ -85,7 +85,7 @@ namespace System.Text.Json.Serialization.Metadata
                 {
                     Debug.Assert(PropertyInfoForTypeInfo.ConverterStrategy == ConverterStrategy.Dictionary);
 
-                    _keyTypeInfo = Options.GetOrAddClass(KeyType);
+                    _keyTypeInfo = Options.GetOrAddJsonTypeInfo(KeyType);
                 }
 
                 return _keyTypeInfo;
@@ -600,7 +600,7 @@ namespace System.Text.Json.Serialization.Metadata
             Debug.Assert(type != null);
             ValidateType(type, parentClassType, memberInfo, options);
 
-            JsonConverter converter = options.DetermineConverter(parentClassType, type, memberInfo);
+            JsonConverter converter = options.GetConverterForMember(parentClassType, type, memberInfo);
 
             // The runtimeType is the actual value being assigned to the property.
             // There are three types to consider for the runtimeType:
@@ -649,7 +649,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         private static void ValidateType(Type type, Type? parentClassType, MemberInfo? memberInfo, JsonSerializerOptions options)
         {
-            if (!options.TypeIsCached(type) && IsInvalidForSerialization(type))
+            if (!options.IsJsonTypeInfoCached(type) && IsInvalidForSerialization(type))
             {
                 ThrowHelper.ThrowInvalidOperationException_CannotSerializeInvalidType(type, parentClassType, memberInfo);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -600,7 +600,7 @@ namespace System.Text.Json.Serialization.Metadata
             Debug.Assert(type != null);
             ValidateType(type, parentClassType, memberInfo, options);
 
-            JsonConverter converter = options.GetConverterForMember(parentClassType, type, memberInfo);
+            JsonConverter converter = options.GetConverterFromMember(parentClassType, type, memberInfo);
 
             // The runtimeType is the actual value being assigned to the property.
             // There are three types to consider for the runtimeType:

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.Cache.cs
@@ -38,7 +38,7 @@ namespace System.Text.Json.Serialization.Metadata
                 long utcNowTicks = DateTime.UtcNow.Ticks;
                 Volatile.Write(ref entry.LastUsedTicks, utcNowTicks);
 
-                if (utcNowTicks - Volatile.Read(ref _lastEvictedTicks) > _evictionIntervalTicks)
+                if (utcNowTicks - Volatile.Read(ref _lastEvictedTicks) >= _evictionIntervalTicks)
                 {
                     if (Interlocked.CompareExchange(ref _lock, 1, 0) == 0)
                     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.Cache.cs
@@ -1,0 +1,87 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NETFRAMEWORK || NETCOREAPP
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    internal sealed partial class ReflectionEmitCachingMemberAccessor
+    {
+        private sealed class Cache<TKey> where TKey : notnull
+        {
+            private int _lock;
+            private long _lastEvictedTicks; // tracks total number of invocations to the cache; can be allowed to overflow.
+            private readonly long _evictionIntervalTicks; // number of cache invocations needed before triggering an eviction run.
+            private readonly long _slidingExpirationTicks; // max timespan allowed for cache entries to remain inactive.
+            private readonly ConcurrentDictionary<TKey, CacheEntry> _cache = new();
+
+            public Cache(TimeSpan slidingExpiration, TimeSpan evictionInterval)
+            {
+                _slidingExpirationTicks = slidingExpiration.Ticks;
+                _evictionIntervalTicks = evictionInterval.Ticks;
+                _lastEvictedTicks = DateTime.UtcNow.Ticks;
+            }
+
+            public TValue GetOrAdd<TValue>(TKey key, Func<TKey, TValue> valueFactory) where TValue : class?
+            {
+                CacheEntry entry = _cache.GetOrAdd(key,
+#if NETCOREAPP
+                    static (TKey key, Func<TKey, TValue> valueFactory) => new(valueFactory(key)),
+                    valueFactory);
+#else
+                    key => new(valueFactory(key)));
+#endif
+                long utcNowTicks = DateTime.UtcNow.Ticks;
+                Volatile.Write(ref entry.LastUsedTicks, utcNowTicks);
+
+                if (utcNowTicks - Volatile.Read(ref _lastEvictedTicks) > _evictionIntervalTicks)
+                {
+                    if (Interlocked.CompareExchange(ref _lock, 1, 0) == 0)
+                    {
+                        if (utcNowTicks - _lastEvictedTicks >= _evictionIntervalTicks)
+                        {
+                            EvictStaleCacheEntries(utcNowTicks);
+                            Volatile.Write(ref _lastEvictedTicks, utcNowTicks);
+                            Volatile.Write(ref _lock, 0);
+                        }
+                    }
+                }
+
+                return (TValue)entry.Value!;
+            }
+
+            public void Clear()
+            {
+                _cache.Clear();
+                _lastEvictedTicks = DateTime.UtcNow.Ticks;
+            }
+
+            private void EvictStaleCacheEntries(long utcNowTicks)
+            {
+                foreach (KeyValuePair<TKey, CacheEntry> kvp in _cache)
+                {
+                    if (utcNowTicks - Volatile.Read(ref kvp.Value.LastUsedTicks) >= _slidingExpirationTicks)
+                    {
+                        _cache.TryRemove(kvp.Key, out _);
+                    }
+                }
+            }
+
+            private class CacheEntry
+            {
+                public readonly object? Value;
+                public long LastUsedTicks;
+
+                public CacheEntry(object? value)
+                {
+                    Value = value;
+                }
+            }
+        }
+    }
+}
+#endif

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json.Serialization.Metadata
         public override Action<TCollection, object?> CreateAddMethodDelegate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TCollection>()
             => s_cache.GetOrAdd((nameof(CreateAddMethodDelegate), typeof(TCollection), null),
                 [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2091:UnrecognizedReflectionPattern",
-                    Justification = "DynamicallyAccessedMembersAttribute is not inherited by scoped generic parameter in lambda body.")]
+                    Justification = "Parent method annotation does not flow to lambda method, cf. https://github.com/dotnet/roslyn/issues/46646")]
                 static (_) => s_sourceAccessor.CreateAddMethodDelegate<TCollection>());
 
         public override JsonTypeInfo.ConstructorDelegate? CreateConstructor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type classType)
@@ -38,14 +38,14 @@ namespace System.Text.Json.Serialization.Metadata
         public override Func<IEnumerable<KeyValuePair<TKey, TValue>>, TCollection> CreateImmutableDictionaryCreateRangeDelegate<TCollection, TKey, TValue>()
             => s_cache.GetOrAdd((nameof(CreateImmutableDictionaryCreateRangeDelegate), typeof((TCollection, TKey, TValue)), null),
                 [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-                    Justification = "Factory method calls into chained RequiresUnreferencedCode method.")]
+                    Justification = "Parent method annotation does not flow to lambda method, cf. https://github.com/dotnet/roslyn/issues/46646")]
                 static (_) => s_sourceAccessor.CreateImmutableDictionaryCreateRangeDelegate<TCollection, TKey, TValue>());
 
         [RequiresUnreferencedCode(IEnumerableConverterFactoryHelpers.ImmutableConvertersUnreferencedCodeMessage)]
         public override Func<IEnumerable<TElement>, TCollection> CreateImmutableEnumerableCreateRangeDelegate<TCollection, TElement>()
             => s_cache.GetOrAdd((nameof(CreateImmutableEnumerableCreateRangeDelegate), typeof((TCollection, TElement)), null),
                 [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-                    Justification = "Factory method calls into chained RequiresUnreferencedCode method.")]
+                    Justification = "Parent method annotation does not flow to lambda method, cf. https://github.com/dotnet/roslyn/issues/46646")]
                 static (_) => s_sourceAccessor.CreateImmutableEnumerableCreateRangeDelegate<TCollection, TElement>());
 
         public override Func<object[], T>? CreateParameterizedConstructor<T>(ConstructorInfo constructor)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json.Serialization.Metadata
     {
         private static readonly ReflectionEmitMemberAccessor s_sourceAccessor = new();
         private static readonly Cache<(string id, Type declaringType, MemberInfo? member)> s_cache =
-            new(slidingExpiration: TimeSpan.FromSeconds(5), evictionInterval: TimeSpan.FromSeconds(1));
+            new(slidingExpiration: TimeSpan.FromMilliseconds(1000), evictionInterval: TimeSpan.FromMilliseconds(200));
 
         public static void Clear() => s_cache.Clear();
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NETFRAMEWORK || NETCOREAPP
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    internal sealed partial class ReflectionEmitCachingMemberAccessor : MemberAccessor
+    {
+        private static readonly ReflectionEmitMemberAccessor s_sourceAccessor = new();
+        private static readonly Cache<(string id, Type declaringType, MemberInfo? member)> s_cache =
+            new(slidingExpiration: TimeSpan.FromSeconds(5), evictionInterval: TimeSpan.FromSeconds(1));
+
+        public static void Clear() => s_cache.Clear();
+
+        public override Action<TCollection, object?> CreateAddMethodDelegate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TCollection>()
+            => s_cache.GetOrAdd((nameof(CreateAddMethodDelegate), typeof(TCollection), null),
+                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2091:UnrecognizedReflectionPattern",
+                    Justification = "DynamicallyAccessedMembersAttribute is not inherited by scoped generic parameter in lambda body.")]
+                static (_) => s_sourceAccessor.CreateAddMethodDelegate<TCollection>());
+
+        public override JsonTypeInfo.ConstructorDelegate? CreateConstructor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type classType)
+            => s_cache.GetOrAdd((nameof(CreateConstructor), classType, null),
+                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2077:UnrecognizedReflectionPattern",
+                    Justification = "Cannot apply DynamicallyAccessedMembersAttribute to tuple properties.")]
+                static (key) => s_sourceAccessor.CreateConstructor(key.declaringType));
+
+        public override Func<object, TProperty> CreateFieldGetter<TProperty>(FieldInfo fieldInfo)
+            => s_cache.GetOrAdd((nameof(CreateFieldGetter), typeof(TProperty), fieldInfo), static key => s_sourceAccessor.CreateFieldGetter<TProperty>((FieldInfo)key.member!));
+
+        public override Action<object, TProperty> CreateFieldSetter<TProperty>(FieldInfo fieldInfo)
+            => s_cache.GetOrAdd((nameof(CreateFieldSetter), typeof(TProperty), fieldInfo), static key => s_sourceAccessor.CreateFieldSetter<TProperty>((FieldInfo)key.member!));
+
+        [RequiresUnreferencedCode(IEnumerableConverterFactoryHelpers.ImmutableConvertersUnreferencedCodeMessage)]
+        public override Func<IEnumerable<KeyValuePair<TKey, TValue>>, TCollection> CreateImmutableDictionaryCreateRangeDelegate<TCollection, TKey, TValue>()
+            => s_cache.GetOrAdd((nameof(CreateImmutableDictionaryCreateRangeDelegate), typeof((TCollection, TKey, TValue)), null),
+                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+                    Justification = "Factory method calls into chained RequiresUnreferencedCode method.")]
+                static (_) => s_sourceAccessor.CreateImmutableDictionaryCreateRangeDelegate<TCollection, TKey, TValue>());
+
+        [RequiresUnreferencedCode(IEnumerableConverterFactoryHelpers.ImmutableConvertersUnreferencedCodeMessage)]
+        public override Func<IEnumerable<TElement>, TCollection> CreateImmutableEnumerableCreateRangeDelegate<TCollection, TElement>()
+            => s_cache.GetOrAdd((nameof(CreateImmutableEnumerableCreateRangeDelegate), typeof((TCollection, TElement)), null),
+                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+                    Justification = "Factory method calls into chained RequiresUnreferencedCode method.")]
+                static (_) => s_sourceAccessor.CreateImmutableEnumerableCreateRangeDelegate<TCollection, TElement>());
+
+        public override Func<object[], T>? CreateParameterizedConstructor<T>(ConstructorInfo constructor)
+            => s_cache.GetOrAdd((nameof(CreateParameterizedConstructor), typeof(T), constructor), static key => s_sourceAccessor.CreateParameterizedConstructor<T>((ConstructorInfo)key.member!));
+
+        public override JsonTypeInfo.ParameterizedConstructorDelegate<T, TArg0, TArg1, TArg2, TArg3>? CreateParameterizedConstructor<T, TArg0, TArg1, TArg2, TArg3>(ConstructorInfo constructor)
+            => s_cache.GetOrAdd((nameof(CreateParameterizedConstructor), typeof(T), constructor), static key => s_sourceAccessor.CreateParameterizedConstructor<T, TArg0, TArg1, TArg2, TArg3>((ConstructorInfo)key.member!));
+
+        public override Func<object, TProperty> CreatePropertyGetter<TProperty>(PropertyInfo propertyInfo)
+            => s_cache.GetOrAdd((nameof(CreatePropertyGetter), typeof(TProperty), propertyInfo), static key => s_sourceAccessor.CreatePropertyGetter<TProperty>((PropertyInfo)key.member!));
+
+        public override Action<object, TProperty> CreatePropertySetter<TProperty>(PropertyInfo propertyInfo)
+            => s_cache.GetOrAdd((nameof(CreatePropertySetter), typeof(TProperty), propertyInfo), static key => s_sourceAccessor.CreatePropertySetter<TProperty>((PropertyInfo)key.member!));
+    }
+}
+#endif

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -83,7 +83,7 @@ namespace System.Text.Json
 
         public void Initialize(Type type, JsonSerializerOptions options, bool supportContinuation)
         {
-            JsonTypeInfo jsonTypeInfo = options.GetOrAddClassForRootType(type);
+            JsonTypeInfo jsonTypeInfo = options.GetOrAddJsonTypeInfoForRootType(type);
             Initialize(jsonTypeInfo, supportContinuation);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -98,7 +98,7 @@ namespace System.Text.Json
         /// </summary>
         public JsonConverter Initialize(Type type, JsonSerializerOptions options, bool supportContinuation)
         {
-            JsonTypeInfo jsonTypeInfo = options.GetOrAddClassForRootType(type);
+            JsonTypeInfo jsonTypeInfo = options.GetOrAddJsonTypeInfoForRootType(type);
             Debug.Assert(options == jsonTypeInfo.Options);
             return Initialize(jsonTypeInfo, supportContinuation);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
@@ -114,7 +114,7 @@ namespace System.Text.Json
             // if the current element is the same type as the previous element.
             if (PolymorphicJsonPropertyInfo?.RuntimePropertyType != type)
             {
-                JsonTypeInfo typeInfo = options.GetOrAddClass(type);
+                JsonTypeInfo typeInfo = options.GetOrAddJsonTypeInfo(type);
                 PolymorphicJsonPropertyInfo = typeInfo.PropertyInfoForTypeInfo;
             }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
@@ -45,6 +45,9 @@ namespace System.Text.Json.SourceGeneration.Tests
                     AssertFieldNull("s_defaultSimpleConverters", optionsInstance: null);
                     AssertFieldNull("s_defaultFactoryConverters", optionsInstance: null);
 
+                    // Confirm type info dynamic creator not set.
+                    AssertFieldNull("s_typeInfoCreationFunc", optionsInstance: null);
+
                     static void AssertFieldNull(string fieldName, JsonSerializerOptions? optionsInstance)
                     {
                         BindingFlags bindingFlags = BindingFlags.NonPublic | (optionsInstance == null ? BindingFlags.Static : BindingFlags.Instance);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
@@ -38,16 +38,12 @@ namespace System.Text.Json.SourceGeneration.Tests
                     // This test uses reflection to:
                     // - Access JsonSerializerOptions.s_defaultSimpleConverters
                     // - Access JsonSerializerOptions.s_defaultFactoryConverters
-                    // - Access JsonSerializerOptions._typeInfoCreationFunc
                     //
                     // If any of them changes, this test will need to be kept in sync.
 
                     // Confirm built-in converters not set.
                     AssertFieldNull("s_defaultSimpleConverters", optionsInstance: null);
                     AssertFieldNull("s_defaultFactoryConverters", optionsInstance: null);
-
-                    // Confirm type info dynamic creator not set.
-                    AssertFieldNull("_typeInfoCreationFunc", MetadataContext.Default.Options);
 
                     static void AssertFieldNull(string fieldName, JsonSerializerOptions? optionsInstance)
                     {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CacheTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CacheTests.cs
@@ -1,12 +1,15 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Text.Encodings.Web;
+using System.Text.Json.Serialization.Metadata;
 using System.Threading.Tasks;
 using Xunit;
+using Microsoft.DotNet.RemoteExecutor;
 
 namespace System.Text.Json.Serialization.Tests
 {
@@ -205,36 +208,218 @@ namespace System.Text.Json.Serialization.Tests
             await Task.WhenAll(tasks);
         }
 
-        [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        public static async Task JsonSerializerOptionsUpdateHandler_ClearingDoesntPreventSerialization()
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public static void JsonSerializerOptionsUpdateHandler_ClearingDoesntPreventSerialization()
         {
             // This test uses reflection to:
-            // - Access JsonSerializerOptions._classes
+            // - Access JsonSerializerOptions._cachingContext.Count
             // - Access JsonSerializerOptionsUpdateHandler.ClearCache
             //
             // If either of them changes, this test will need to be kept in sync.
 
-            var options = new JsonSerializerOptions();
+            RemoteExecutor.Invoke(() =>
+                {
+                    var options = new JsonSerializerOptions();
 
-            FieldInfo classesField = options.GetType().GetField("_classes", BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.NotNull(classesField);
-            IDictionary classes = (IDictionary)classesField.GetValue(options);
-            Assert.Equal(0, classes.Count);
+                    Func<JsonSerializerOptions, int> getCount = CreateCacheCountAccessor();
 
-            SimpleTestClass testObj = new SimpleTestClass();
-            testObj.Initialize();
-            await JsonSerializer.SerializeAsync<SimpleTestClass>(new MemoryStream(), testObj, options);
-            Assert.NotEqual(0, classes.Count);
+                    Assert.Equal(0, getCount(options));
 
-            Type updateHandler = typeof(JsonSerializerOptions).Assembly.GetType("System.Text.Json.JsonSerializerOptionsUpdateHandler", throwOnError: true, ignoreCase: false);
-            MethodInfo clearCache = updateHandler.GetMethod("ClearCache");
-            Assert.NotNull(clearCache);
-            clearCache.Invoke(null, new object[] { null });
-            Assert.Equal(0, classes.Count);
+                    SimpleTestClass testObj = new SimpleTestClass();
+                    testObj.Initialize();
+                    JsonSerializer.Serialize<SimpleTestClass>(testObj, options);
+                    Assert.NotEqual(0, getCount(options));
 
-            await JsonSerializer.SerializeAsync<SimpleTestClass>(new MemoryStream(), testObj, options);
-            Assert.NotEqual(0, classes.Count);
+                    Type updateHandler = typeof(JsonSerializerOptions).Assembly.GetType("System.Text.Json.JsonSerializerOptionsUpdateHandler", throwOnError: true, ignoreCase: false);
+                    MethodInfo clearCache = updateHandler.GetMethod("ClearCache");
+                    Assert.NotNull(clearCache);
+                    clearCache.Invoke(null, new object[] { null });
+                    Assert.Equal(0, getCount(options));
+
+                    JsonSerializer.Serialize<SimpleTestClass>(testObj, options);
+                    Assert.NotEqual(0, getCount(options));
+                }).Dispose();
+
+            static Func<JsonSerializerOptions, int> CreateCacheCountAccessor()
+            {
+                FieldInfo cacheField = typeof(JsonSerializerOptions).GetField("_cachingContext", BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.NotNull(cacheField);
+                PropertyInfo countProperty = cacheField.FieldType.GetProperty("Count", BindingFlags.Public | BindingFlags.Instance);
+                Assert.NotNull(countProperty);
+                return options =>
+                {
+                    object? cache = cacheField.GetValue(options);
+                    return cache is null ? 0 : (int)countProperty.GetValue(cache);
+                };
+            }
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [MemberData(nameof(GetJsonSerializerOptions))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void JsonSerializerOptions_ReuseConverterCaches()
+        {
+            // This test uses reflection to:
+            // - Access JsonSerializerOptions._cachingContext._options
+            // - Access JsonSerializerOptions.EqualityComparer.AreEquivalent
+            //
+            // If either of them changes, this test will need to be kept in sync.
+
+            RemoteExecutor.Invoke(static () =>
+            {
+                Func<JsonSerializerOptions, JsonSerializerOptions?> getCacheOptions = CreateCacheOptionsAccessor();
+                IEqualityComparer<JsonSerializerOptions> equalityComparer = CreateEqualityComparerAccessor();
+
+                foreach (var args in GetJsonSerializerOptions())
+                {
+                    var options = (JsonSerializerOptions)args[0];
+                    Assert.Null(getCacheOptions(options));
+
+                    JsonSerializer.Serialize(42, options);
+
+                    JsonSerializerOptions originalCacheOptions = getCacheOptions(options);
+                    Assert.NotNull(originalCacheOptions);
+                    Assert.True(equalityComparer.Equals(options, originalCacheOptions));
+                    Assert.Equal(equalityComparer.GetHashCode(options), equalityComparer.GetHashCode(originalCacheOptions));
+
+                    for (int i = 0; i < 5; i++)
+                    {
+                        var options2 = new JsonSerializerOptions(options);
+                        Assert.True(equalityComparer.Equals(options2, originalCacheOptions));
+                        Assert.Equal(equalityComparer.GetHashCode(options2), equalityComparer.GetHashCode(originalCacheOptions));
+                        Assert.Null(getCacheOptions(options2));
+                        JsonSerializer.Serialize(42, options2);
+                        Assert.Same(originalCacheOptions, getCacheOptions(options2));
+                    }
+                }
+            }).Dispose();
+
+            static Func<JsonSerializerOptions, JsonSerializerOptions?> CreateCacheOptionsAccessor()
+            {
+                FieldInfo cacheField = typeof(JsonSerializerOptions).GetField("_cachingContext", BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.NotNull(cacheField);
+                PropertyInfo optionsField = cacheField.FieldType.GetProperty("Options", BindingFlags.Public | BindingFlags.Instance);
+                Assert.NotNull(optionsField);
+                return options =>
+                {
+                    object? cache = cacheField.GetValue(options);
+                    return cache is null ? null : (JsonSerializerOptions)optionsField.GetValue(cache);
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> GetJsonSerializerOptions()
+        {
+            yield return new[] { new JsonSerializerOptions() };
+            yield return new[] { new JsonSerializerOptions(JsonSerializerDefaults.Web) };
+            yield return new[] { new JsonSerializerOptions { WriteIndented = true } };
+            yield return new[] { new JsonSerializerOptions { Converters = { new JsonStringEnumConverter() } } };
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void JsonSerializerOptions_EqualityComparer_ChangingAnySettingShouldReturnFalse()
+        {
+            // This test uses reflection to:
+            // - Access JsonSerializerOptions.EqualityComparer.AreEquivalent
+            // - All public setters in JsonSerializerOptions
+            //
+            // If either of them changes, this test will need to be kept in sync.
+            IEqualityComparer<JsonSerializerOptions> equalityComparer = CreateEqualityComparerAccessor();
+
+            (PropertyInfo prop, object value)[] propertySettersAndValues = GetPropertiesWithSettersAndNonDefaultValues().ToArray();
+
+            // Ensure we're testing equality for all JsonSerializerOptions settings
+            foreach (PropertyInfo prop in GetAllPublicPropertiesWithSetters().Except(propertySettersAndValues.Select(x => x.prop)))
+            {
+                Assert.Fail($"{nameof(GetPropertiesWithSettersAndNonDefaultValues)} missing property declaration for {prop.Name}, please update the method.");
+            }
+
+            Assert.True(equalityComparer.Equals(JsonSerializerOptions.Default, JsonSerializerOptions.Default));
+            Assert.Equal(equalityComparer.GetHashCode(JsonSerializerOptions.Default), equalityComparer.GetHashCode(JsonSerializerOptions.Default));
+
+            foreach ((PropertyInfo prop, object? value) in propertySettersAndValues)
+            {
+                var options = new JsonSerializerOptions();
+                prop.SetValue(options, value);
+
+                Assert.True(equalityComparer.Equals(options, options));
+                Assert.Equal(equalityComparer.GetHashCode(options), equalityComparer.GetHashCode(options));
+
+                Assert.False(equalityComparer.Equals(JsonSerializerOptions.Default, options));
+                Assert.NotEqual(equalityComparer.GetHashCode(JsonSerializerOptions.Default), equalityComparer.GetHashCode(options));
+            }
+
+            static IEnumerable<(PropertyInfo, object)> GetPropertiesWithSettersAndNonDefaultValues()
+            {
+                yield return (GetProp(nameof(JsonSerializerOptions.AllowTrailingCommas)), true);
+                yield return (GetProp(nameof(JsonSerializerOptions.DefaultBufferSize)), 42);
+                yield return (GetProp(nameof(JsonSerializerOptions.Encoder)), JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+                yield return (GetProp(nameof(JsonSerializerOptions.DictionaryKeyPolicy)), JsonNamingPolicy.CamelCase);
+                yield return (GetProp(nameof(JsonSerializerOptions.IgnoreNullValues)), true);
+                yield return (GetProp(nameof(JsonSerializerOptions.DefaultIgnoreCondition)), JsonIgnoreCondition.WhenWritingDefault);
+                yield return (GetProp(nameof(JsonSerializerOptions.NumberHandling)), JsonNumberHandling.AllowReadingFromString);
+                yield return (GetProp(nameof(JsonSerializerOptions.IgnoreReadOnlyProperties)), true);
+                yield return (GetProp(nameof(JsonSerializerOptions.IgnoreReadOnlyFields)), true);
+                yield return (GetProp(nameof(JsonSerializerOptions.IncludeFields)), true);
+                yield return (GetProp(nameof(JsonSerializerOptions.MaxDepth)), 11);
+                yield return (GetProp(nameof(JsonSerializerOptions.PropertyNamingPolicy)), JsonNamingPolicy.CamelCase);
+                yield return (GetProp(nameof(JsonSerializerOptions.PropertyNameCaseInsensitive)), true);
+                yield return (GetProp(nameof(JsonSerializerOptions.ReadCommentHandling)), JsonCommentHandling.Skip);
+                yield return (GetProp(nameof(JsonSerializerOptions.UnknownTypeHandling)), JsonUnknownTypeHandling.JsonNode);
+                yield return (GetProp(nameof(JsonSerializerOptions.WriteIndented)), true);
+                yield return (GetProp(nameof(JsonSerializerOptions.ReferenceHandler)), ReferenceHandler.Preserve);
+
+                static PropertyInfo GetProp(string name)
+                {
+                    PropertyInfo property = typeof(JsonSerializerOptions).GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
+                    Assert.True(property.CanWrite);
+                    return property;
+                }
+            }
+
+            static IEnumerable<PropertyInfo> GetAllPublicPropertiesWithSetters()
+                => typeof(JsonSerializerOptions)
+                    .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                    .Where(p => p.CanWrite);
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void JsonSerializerOptions_EqualityComparer_ApplyingJsonSerializerContextShouldReturnFalse()
+        {
+            // This test uses reflection to:
+            // - Access JsonSerializerOptions.EqualityComparer
+            //
+            // If either of them changes, this test will need to be kept in sync.
+
+            IEqualityComparer<JsonSerializerOptions> equalityComparer = CreateEqualityComparerAccessor();
+            var options1 = new JsonSerializerOptions { WriteIndented = true };
+            var options2 = new JsonSerializerOptions { WriteIndented = true };
+
+            Assert.True(equalityComparer.Equals(options1, options2));
+            Assert.Equal(equalityComparer.GetHashCode(options1), equalityComparer.GetHashCode(options2));
+
+            _ = new MyJsonContext(options1); // Associate copy with a JsonSerializerContext
+            Assert.False(equalityComparer.Equals(options1, options2));
+            Assert.NotEqual(equalityComparer.GetHashCode(options1), equalityComparer.GetHashCode(options2));
+        }
+
+        private class MyJsonContext : JsonSerializerContext
+        {
+            public MyJsonContext(JsonSerializerOptions options) : base(options) { }
+
+            public override JsonTypeInfo? GetTypeInfo(Type _) => null;
+
+            protected override JsonSerializerOptions? GeneratedSerializerOptions => Options;
+        }
+
+        public static IEqualityComparer<JsonSerializerOptions> CreateEqualityComparerAccessor()
+        {
+            Type equalityComparerType = typeof(JsonSerializerOptions).GetNestedType("EqualityComparer", BindingFlags.NonPublic);
+            Assert.NotNull(equalityComparerType);
+            return (IEqualityComparer<JsonSerializerOptions>)Activator.CreateInstance(equalityComparerType, nonPublic: true);
         }
 
         public static IEnumerable<object[]> WriteSuccessCases

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/MetadataTests.Options.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/MetadataTests.Options.cs
@@ -55,7 +55,7 @@ namespace System.Text.Json.Serialization.Tests
             // Those options are overwritten when context is binded via options.AddContext<TContext>();
             JsonSerializerOptions options = new();
             options.AddContext<MyJsonContextThatSetsOptionsInParameterlessCtor>(); // No error.
-            FieldInfo contextField = typeof(JsonSerializerOptions).GetField("_context", BindingFlags.NonPublic | BindingFlags.Instance);
+            FieldInfo contextField = typeof(JsonSerializerOptions).GetField("_serializerContext", BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.NotNull(contextField);
             Assert.Same(options, ((JsonSerializerContext)contextField.GetValue(options)).Options);
         }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
@@ -11,6 +11,7 @@
     <!-- Needed for JsonSerializerOptionsUpdateHandler tests -->
     <MetadataUpdaterSupport Condition="'$(MetadataUpdaterSupport)' == '' and '$(TargetOS)' == 'Browser'">true</MetadataUpdaterSupport>
     <WasmXHarnessArgs>$(WasmXHarnessArgs) --timeout=1800</WasmXHarnessArgs>
+    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>


### PR DESCRIPTION
Applies global caching for reflection metadata in two separate layers:

1. At the `MethodAccessor` layer caching generated dynamic methods.
2. Refactors the `JsonSerializerOptions` caching, using shared caching contexts shared across multiple `JsonSerializerOptions` instances "up to equivalence".

Contributes to #40072.

## Performance

Using benchmarks from https://github.com/dotnet/performance/pull/2236

|                   Method |        Job |                                                                                                        Toolchain |         Mean |        Error |       StdDev |       Median |          Min |          Max | Ratio | MannWhitney(3%) | RatioSD |  Gen 0 |  Gen 1 |  Gen 2 | Allocated | Alloc Ratio |
|------------------------- |----------- |----------------------------------------------------------------------------------------------------------------- |-------------:|-------------:|-------------:|-------------:|-------------:|-------------:|------:|---------------- |--------:|-------:|-------:|-------:|----------:|------------:|
|     CachedDefaultOptions | Job-IDHNJC | main |     742.3 ns |     55.64 ns |     64.08 ns |     730.1 ns |     618.9 ns |     837.6 ns |  1.00 |            Base |    0.00 | 0.0317 |      - |      - |     320 B |        1.00 |
|     CachedDefaultOptions | Job-VHZIGZ |   PR |     779.1 ns |     40.98 ns |     47.20 ns |     783.2 ns |     698.4 ns |     850.5 ns |  1.06 |            Same |    0.11 | 0.0292 |      - |      - |     320 B |        1.00 |
|                          |            |                                                                                                                  |              |              |              |              |              |              |       |                 |         |        |        |        |           |             |
|        NewDefaultOptions | Job-IDHNJC | main | 462,649.4 ns | 29,400.08 ns | 33,857.17 ns | 466,119.9 ns | 378,260.7 ns | 508,198.9 ns | 1.000 |            Base |    0.00 |      - |      - |      - |   13234 B |        1.00 |
|        NewDefaultOptions | Job-VHZIGZ |   PR |   1,281.0 ns |     76.38 ns |     87.96 ns |   1,285.5 ns |   1,109.7 ns |   1,449.0 ns | 0.003 |          Faster |    0.00 | 0.0586 | 0.0098 | 0.0049 |     637 B |        0.05 |
|                          |            |                                                                                                                  |              |              |              |              |              |              |       |                 |         |        |        |        |           |             |
|     NewCustomizedOptions | Job-IDHNJC | main | 450,203.9 ns | 26,126.89 ns | 29,039.97 ns | 453,785.3 ns | 408,028.4 ns | 502,898.1 ns | 1.000 |            Base |    0.00 |      - |      - |      - |   13317 B |        1.00 |
|     NewCustomizedOptions | Job-VHZIGZ |   PR |   1,402.5 ns |     85.25 ns |     98.18 ns |   1,383.5 ns |   1,245.4 ns |   1,577.6 ns | 0.003 |          Faster |    0.00 | 0.0631 | 0.0105 | 0.0053 |     662 B |        0.05 |
|                          |            |                                                                                                                  |              |              |              |              |              |              |       |                 |         |        |        |        |           |             |
|       NewCustomConverter | Job-IDHNJC | main | 388,271.0 ns | 18,375.55 ns | 19,661.63 ns | 387,544.6 ns | 348,863.4 ns | 426,233.6 ns |  1.00 |            Base |    0.00 |      - |      - |      - |   13356 B |        1.00 |
|       NewCustomConverter | Job-VHZIGZ |   PR |  17,386.3 ns |    970.16 ns |  1,078.34 ns |  17,761.1 ns |  15,454.0 ns |  19,390.9 ns |  0.04 |          Faster |    0.00 | 0.5618 | 0.0702 |      - |    6098 B |        0.46 |
|                          |            |                                                                                                                  |              |              |              |              |              |              |       |                 |         |        |        |        |           |             |
| NewCachedCustomConverter | Job-IDHNJC | main | 450,729.7 ns | 30,334.93 ns | 34,933.76 ns | 451,971.2 ns | 383,972.0 ns | 517,959.8 ns | 1.000 |            Base |    0.00 |      - |      - |      - |   13319 B |        1.00 |
| NewCachedCustomConverter | Job-VHZIGZ |   PR |   1,461.3 ns |     93.35 ns |    107.50 ns |   1,455.3 ns |   1,240.6 ns |   1,659.3 ns | 0.003 |          Faster |    0.00 | 0.0696 | 0.0107 | 0.0054 |     719 B |        0.05 |
