### PR TITLE
Allow ConfigBinder to bind arrays to Singular elements

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/ref/Microsoft.Extensions.Configuration.Binder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/ref/Microsoft.Extensions.Configuration.Binder.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Extensions.Configuration
         public BinderOptions() { }
         public bool BindNonPublicProperties { get { throw null; } set { } }
         public bool ErrorOnUnknownConfiguration { get { throw null; } set { } }
+        public bool BindSingleElementsToArray { get { throw null; } set { } }
     }
     public static partial class ConfigurationBinder
     {

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/BinderOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/BinderOptions.cs
@@ -21,5 +21,11 @@ namespace Microsoft.Extensions.Configuration
         /// of the missing properties.
         /// </summary>
         public bool ErrorOnUnknownConfiguration { get; set; }
+
+        /// <summary>
+        /// When false (the default), elements which don't have numbers as keys cannot be bound to arrays.
+        /// When true, elements without numbers are attempted to be bound as a single-element array.
+        /// </summary>
+        public bool BindSingleElementsToArray { get; set; }
     }
 }


### PR DESCRIPTION
When trying to bind a collection of type T, ConfigBinder will now try to bind to the current object instead of children objects when the provided configuration doesn't contain an array.

This change allows elements that are not arrays to be bound to arrays. For example, a type string[] can now be bound to "key" in case "key:0" doesn't exist.

Closes #57325
Previous attempt: https://github.com/dotnet/runtime/pull/57204
