### PR TITLE
Avoid downcasting NewSize

### DIFF
--- a/src/coreclr/pal/src/map/map.cpp
+++ b/src/coreclr/pal/src/map/map.cpp
@@ -1604,7 +1604,7 @@ static PAL_ERROR MAPGrowLocalFile( INT UnixFD, off_t NewSize )
     TruncateRetVal = ftruncate( UnixFD, NewSize );
     fstat( UnixFD, &FileInfo );
 
-    if ( TruncateRetVal != 0 || FileInfo.st_size != (int) NewSize )
+    if ( TruncateRetVal != 0 || FileInfo.st_size != NewSize )
     {
         INT OrigSize;
         CONST UINT  BUFFER_SIZE = 128;


### PR DESCRIPTION
I missed this when I expanded the range of `MapGrowLocalFile` from `UINT` to `off_t` in https://github.com/dotnet/runtime/pull/61123.