### PR TITLE
Delete InternalModuleBuilder and InternalAssemblyBuilder

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -48,7 +48,7 @@ namespace System.Reflection.Emit
 
         private const string ManifestModuleName = "RefEmit_InMemoryManifestModule";
 
-        internal ModuleBuilder GetModuleBuilder(InternalModuleBuilder module)
+        internal ModuleBuilder GetModuleBuilder(RuntimeModule module)
         {
             Debug.Assert(module != null);
             Debug.Assert(InternalAssembly == module.Assembly);
@@ -128,7 +128,7 @@ namespace System.Reflection.Emit
         [MemberNotNull(nameof(_manifestModuleBuilder))]
         private void InitManifestModule()
         {
-            InternalModuleBuilder modBuilder = (InternalModuleBuilder)GetInMemoryAssemblyModule(InternalAssembly);
+            RuntimeModule modBuilder = (RuntimeModule)GetInMemoryAssemblyModule(InternalAssembly);
 
             // Note that this ModuleBuilder cannot be used for RefEmit yet
             // because it hasn't been initialized.
@@ -298,17 +298,9 @@ namespace System.Reflection.Emit
             }
         }
 
-        public override bool Equals(object? obj)
-        {
-            if (obj is AssemblyBuilder ab)
-            {
-                return InternalAssembly.Equals(ab.InternalAssembly);
-            }
-            return false;
-        }
+        public override bool Equals(object? obj) => base.Equals(obj);
 
-        // Need a dummy GetHashCode to pair with Equals
-        public override int GetHashCode() => InternalAssembly.GetHashCode();
+        public override int GetHashCode() => base.GetHashCode();
 
         #region ICustomAttributeProvider Members
         public override object[] GetCustomAttributes(bool inherit) =>

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -32,94 +32,6 @@ using System.Threading;
 
 namespace System.Reflection.Emit
 {
-    // When the user calls AppDomain.DefineDynamicAssembly the loader creates a new InternalAssemblyBuilder.
-    // This InternalAssemblyBuilder can be retrieved via a call to Assembly.GetAssemblies() by untrusted code.
-    // In the past, when InternalAssemblyBuilder was AssemblyBuilder, the untrusted user could down cast the
-    // Assembly to an AssemblyBuilder and emit code with the elevated permissions of the trusted code which
-    // originally created the AssemblyBuilder via DefineDynamicAssembly. Today, this can no longer happen
-    // because the Assembly returned via AssemblyGetAssemblies() will be an InternalAssemblyBuilder.
-
-    // Only the caller of DefineDynamicAssembly will get an AssemblyBuilder.
-    // There is a 1-1 relationship between InternalAssemblyBuilder and AssemblyBuilder.
-    // AssemblyBuilder is composed of its InternalAssemblyBuilder.
-    // The AssemblyBuilder data members (e.g. m_foo) were changed to properties which then delegate
-    // the access to the composed InternalAssemblyBuilder. This way, AssemblyBuilder simply wraps
-    // InternalAssemblyBuilder and still operates on InternalAssemblyBuilder members.
-    // This also makes the change transparent to the loader. This is good because most of the complexity
-    // of Assembly building is in the loader code so not touching that code reduces the chance of
-    // introducing new bugs.
-    internal sealed class InternalAssemblyBuilder : RuntimeAssembly
-    {
-        private InternalAssemblyBuilder() { }
-
-        public override bool Equals(object? obj)
-        {
-            if (obj == null)
-            {
-                return false;
-            }
-
-            if (obj is InternalAssemblyBuilder)
-            {
-                return (object)this == obj;
-            }
-
-            return obj.Equals(this);
-        }
-
-        public override int GetHashCode() => base.GetHashCode();
-
-        // Assembly methods that are overridden by AssemblyBuilder should be overridden by InternalAssemblyBuilder too
-        #region Methods inherited from Assembly
-
-        public override string[] GetManifestResourceNames()
-        {
-            throw new NotSupportedException(SR.NotSupported_DynamicAssembly);
-        }
-
-        [RequiresAssemblyFiles(ThrowingMessageInRAF)]
-        public override FileStream GetFile(string name)
-        {
-            throw new NotSupportedException(SR.NotSupported_DynamicAssembly);
-        }
-
-        [RequiresAssemblyFiles(ThrowingMessageInRAF)]
-        public override FileStream[] GetFiles(bool getResourceModules)
-        {
-            throw new NotSupportedException(SR.NotSupported_DynamicAssembly);
-        }
-
-        public override Stream? GetManifestResourceStream(Type type, string name)
-        {
-            throw new NotSupportedException(SR.NotSupported_DynamicAssembly);
-        }
-
-        public override Stream? GetManifestResourceStream(string name)
-        {
-            throw new NotSupportedException(SR.NotSupported_DynamicAssembly);
-        }
-
-        public override ManifestResourceInfo? GetManifestResourceInfo(string resourceName)
-        {
-            throw new NotSupportedException(SR.NotSupported_DynamicAssembly);
-        }
-
-        public override string Location => string.Empty;
-
-        [RequiresAssemblyFiles(ThrowingMessageInRAF)]
-        public override string? CodeBase => throw new NotSupportedException(SR.NotSupported_DynamicAssembly);
-
-        [RequiresUnreferencedCode("Types might be removed")]
-        public override Type[] GetExportedTypes()
-        {
-            throw new NotSupportedException(SR.NotSupported_DynamicAssembly);
-        }
-
-        public override string ImageRuntimeVersion => Assembly.GetExecutingAssembly().ImageRuntimeVersion;
-
-        #endregion
-    }
-
     public sealed partial class AssemblyBuilder : Assembly
     {
         [MethodImpl(MethodImplOptions.InternalCall)]
@@ -129,7 +41,7 @@ namespace System.Reflection.Emit
 
         // This is only valid in the "external" AssemblyBuilder
         internal AssemblyBuilderData _assemblyData;
-        private readonly InternalAssemblyBuilder _internalAssemblyBuilder;
+        private readonly RuntimeAssembly _internalAssembly;
         private ModuleBuilder _manifestModuleBuilder;
         // Set to true if the manifest module was returned by code:DefineDynamicModule to the user
         private bool _isManifestModuleUsedAsDefinedModule;
@@ -155,7 +67,7 @@ namespace System.Reflection.Emit
 
         internal object SyncRoot => InternalAssembly.SyncRoot;
 
-        internal InternalAssemblyBuilder InternalAssembly => _internalAssemblyBuilder;
+        internal RuntimeAssembly InternalAssembly => _internalAssembly;
 
         #endregion
 
@@ -190,13 +102,13 @@ namespace System.Reflection.Emit
                 assemblyAttributes = new List<CustomAttributeBuilder>(unsafeAssemblyAttributes);
             }
 
-            Assembly? retAssembly = null;
+            RuntimeAssembly? retAssembly = null;
             CreateDynamicAssembly(ObjectHandleOnStack.Create(ref name),
                                   new StackCrawlMarkHandle(ref stackMark),
                                   (int)access,
                                   ObjectHandleOnStack.Create(ref assemblyLoadContext),
                                   ObjectHandleOnStack.Create(ref retAssembly));
-            _internalAssemblyBuilder = (InternalAssemblyBuilder)retAssembly!;
+            _internalAssembly = retAssembly!;
 
             _assemblyData = new AssemblyBuilderData(access);
 
@@ -386,7 +298,14 @@ namespace System.Reflection.Emit
             }
         }
 
-        public override bool Equals(object? obj) => InternalAssembly.Equals(obj);
+        public override bool Equals(object? obj)
+        {
+            if (obj is AssemblyBuilder ab)
+            {
+                return InternalAssembly.Equals(ab.InternalAssembly);
+            }
+            return false;
+        }
 
         // Need a dummy GetHashCode to pair with Equals
         public override int GetHashCode() => InternalAssembly.GetHashCode();

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -41,7 +41,7 @@ namespace System.Reflection.Emit
         // We capture the creation context so that we can do the checks against the same context,
         // irrespective of when the method gets compiled. Note that the DynamicMethod does not know when
         // it is ready for use since there is not API which indictates that IL generation has completed.
-        private static volatile InternalModuleBuilder? s_anonymouslyHostedDynamicMethodsModule;
+        private static volatile RuntimeModule? s_anonymouslyHostedDynamicMethodsModule;
         private static readonly object s_anonymouslyHostedDynamicMethodsModuleLock = new object();
 
         //
@@ -244,7 +244,7 @@ namespace System.Reflection.Emit
                     null);
 
                 // this always gets the internal module.
-                s_anonymouslyHostedDynamicMethodsModule = (InternalModuleBuilder)assembly.ManifestModule!;
+                s_anonymouslyHostedDynamicMethodsModule = (RuntimeModule)assembly.ManifestModule!;
             }
 
             return s_anonymouslyHostedDynamicMethodsModule;

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
@@ -10,31 +10,6 @@ using System.Runtime.InteropServices;
 
 namespace System.Reflection.Emit
 {
-    internal sealed partial class InternalModuleBuilder : RuntimeModule
-    {
-        // InternalModuleBuilder should not contain any data members as its reflectbase is the same as Module.
-
-        private InternalModuleBuilder() { }
-
-        public override bool Equals(object? obj)
-        {
-            if (obj == null)
-            {
-                return false;
-            }
-
-            if (obj is InternalModuleBuilder)
-            {
-                return (object)this == obj;
-            }
-
-            return obj.Equals(this);
-        }
-
-        // Need a dummy GetHashCode to pair with Equals
-        public override int GetHashCode() => base.GetHashCode();
-    }
-
     // deliberately not [serializable]
     public partial class ModuleBuilder : Module
     {
@@ -75,7 +50,7 @@ namespace System.Reflection.Emit
         // _TypeBuilder contains both TypeBuilder and EnumBuilder objects
         private Dictionary<string, Type> _typeBuilderDict = null!;
         internal ModuleBuilderData _moduleData = null!;
-        internal InternalModuleBuilder _internalModuleBuilder;
+        internal RuntimeModule _internalModule;
         // This is the "external" AssemblyBuilder
         // only the "external" ModuleBuilder has this set
         private readonly AssemblyBuilder _assemblyBuilder;
@@ -85,9 +60,9 @@ namespace System.Reflection.Emit
 
         #region Constructor
 
-        internal ModuleBuilder(AssemblyBuilder assemblyBuilder, InternalModuleBuilder internalModuleBuilder)
+        internal ModuleBuilder(AssemblyBuilder assemblyBuilder, RuntimeModule internalModule)
         {
-            _internalModuleBuilder = internalModuleBuilder;
+            _internalModule = internalModule;
             _assemblyBuilder = assemblyBuilder;
         }
 
@@ -323,8 +298,7 @@ namespace System.Reflection.Emit
 
         #region Module Overrides
 
-        // _internalModuleBuilder is null iff this is a "internal" ModuleBuilder
-        internal InternalModuleBuilder InternalModule => _internalModuleBuilder;
+        internal RuntimeModule InternalModule => _internalModule;
 
         protected override ModuleHandle GetModuleHandleImpl() => new ModuleHandle(InternalModule);
 
@@ -513,10 +487,9 @@ namespace System.Reflection.Emit
 
         #endregion
 
-        public override bool Equals(object? obj) => InternalModule.Equals(obj);
+        public override bool Equals(object? obj) => base.Equals(obj);
 
-        // Need a dummy GetHashCode to pair with Equals
-        public override int GetHashCode() => InternalModule.GetHashCode();
+        public override int GetHashCode() => base.GetHashCode();
 
         #region ICustomAttributeProvider Members
 
@@ -1127,7 +1100,7 @@ namespace System.Reflection.Emit
                 // the file name of the referenced module.
                 if (refedModuleBuilder == null)
                 {
-                    refedModuleBuilder = ContainingAssemblyBuilder.GetModuleBuilder((InternalModuleBuilder)refedModule);
+                    refedModuleBuilder = ContainingAssemblyBuilder.GetModuleBuilder((RuntimeModule)refedModule);
                 }
                 referencedModuleFileName = refedModuleBuilder._moduleData._moduleName;
             }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -16,7 +16,7 @@ using System.Threading;
 
 namespace System.Reflection
 {
-    internal partial class RuntimeAssembly : Assembly
+    internal sealed partial class RuntimeAssembly : Assembly
     {
         internal RuntimeAssembly() { throw new NotSupportedException(); }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 
 namespace System.Reflection
 {
-    internal partial class RuntimeModule : Module
+    internal sealed partial class RuntimeModule : Module
     {
         internal RuntimeModule() { throw new NotSupportedException(); }
 

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -575,10 +575,6 @@ DEFINE_FIELD_U(m_pFields,                   ReflectModuleBaseObject,    m_pGloba
 DEFINE_CLASS(MODULE,                Reflection,             RuntimeModule)
 DEFINE_FIELD(MODULE,                DATA,                   m_pData)
 
-DEFINE_CLASS(MODULE_BUILDER,        ReflectionEmit,         InternalModuleBuilder)
-#if FOR_ILLINK
-DEFINE_METHOD(MODULE_BUILDER,       CTOR,                   .ctor,                      IM_RetVoid)
-#endif
 DEFINE_CLASS(TYPE_BUILDER,          ReflectionEmit,         TypeBuilder)
 DEFINE_CLASS(ENUM_BUILDER,          ReflectionEmit,         EnumBuilder)
 

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -113,13 +113,6 @@ DEFINE_FIELD(ARRAY_WITH_OFFSET,     M_ARRAY,                m_array)
 DEFINE_FIELD(ARRAY_WITH_OFFSET,     M_OFFSET,               m_offset)
 DEFINE_FIELD(ARRAY_WITH_OFFSET,     M_COUNT,                m_count)
 
-
-DEFINE_CLASS(ASSEMBLY_BUILDER,      ReflectionEmit,         AssemblyBuilder)
-DEFINE_CLASS(INTERNAL_ASSEMBLY_BUILDER,      ReflectionEmit,         InternalAssemblyBuilder)
-#if FOR_ILLINK
-DEFINE_METHOD(INTERNAL_ASSEMBLY_BUILDER,     CTOR,          .ctor,                      IM_RetVoid)
-#endif
-
 DEFINE_CLASS(ASSEMBLY_HASH_ALGORITHM,   Assemblies,         AssemblyHashAlgorithm)
 DEFINE_CLASS(PORTABLE_EXECUTABLE_KINDS, Reflection,         PortableExecutableKinds)
 DEFINE_CLASS(IMAGE_FILE_MACHINE,        Reflection,         ImageFileMachine)

--- a/src/coreclr/vm/domainassembly.cpp
+++ b/src/coreclr/vm/domainassembly.cpp
@@ -353,14 +353,7 @@ OBJECTREF DomainAssembly::GetExposedModuleObject()
 
         GCPROTECT_BEGIN(refClass);
 
-        if (GetPEAssembly()->IsDynamic())
-        {
-            refClass = (REFLECTMODULEBASEREF) AllocateObject(CoreLibBinder::GetClass(CLASS__MODULE_BUILDER));
-        }
-        else
-        {
-            refClass = (REFLECTMODULEBASEREF) AllocateObject(CoreLibBinder::GetClass(CLASS__MODULE));
-        }
+        refClass = (REFLECTMODULEBASEREF) AllocateObject(CoreLibBinder::GetClass(CLASS__MODULE));
         refClass->SetModule(m_pModule);
 
         // Attach the reference to the assembly to keep the LoaderAllocator for this collectible type

--- a/src/coreclr/vm/domainassembly.cpp
+++ b/src/coreclr/vm/domainassembly.cpp
@@ -666,9 +666,6 @@ OBJECTREF DomainAssembly::GetExposedAssemblyObject()
         ASSEMBLYREF   assemblyObj = NULL;
         MethodTable * pMT;
 
-        // This is unnecessary because the managed RuntimeAssembly object
-        // should have already been created at the time of DefineDynamicAssembly
-        OVERRIDE_TYPE_LOAD_LEVEL_LIMIT(CLASS_LOADED);
         pMT = CoreLibBinder::GetClass(CLASS__ASSEMBLY);
 
         // Will be TRUE only if LoaderAllocator managed object was already collected and therefore we should

--- a/src/coreclr/vm/domainassembly.cpp
+++ b/src/coreclr/vm/domainassembly.cpp
@@ -672,18 +672,11 @@ OBJECTREF DomainAssembly::GetExposedAssemblyObject()
     {
         ASSEMBLYREF   assemblyObj = NULL;
         MethodTable * pMT;
-        if (GetPEAssembly()->IsDynamic())
-        {
-            // This is unnecessary because the managed InternalAssemblyBuilder object
-            // should have already been created at the time of DefineDynamicAssembly
-            OVERRIDE_TYPE_LOAD_LEVEL_LIMIT(CLASS_LOADED);
-            pMT = CoreLibBinder::GetClass(CLASS__INTERNAL_ASSEMBLY_BUILDER);
-        }
-        else
-        {
-            OVERRIDE_TYPE_LOAD_LEVEL_LIMIT(CLASS_LOADED);
-            pMT = CoreLibBinder::GetClass(CLASS__ASSEMBLY);
-        }
+
+        // This is unnecessary because the managed RuntimeAssembly object
+        // should have already been created at the time of DefineDynamicAssembly
+        OVERRIDE_TYPE_LOAD_LEVEL_LIMIT(CLASS_LOADED);
+        pMT = CoreLibBinder::GetClass(CLASS__ASSEMBLY);
 
         // Will be TRUE only if LoaderAllocator managed object was already collected and therefore we should
         // return NULL


### PR DESCRIPTION
These wrapper types were required for CAS (Code Access Security). They should not be needed anymore. Mono does not have them either.