### PR TITLE
Revert emscripten bump temporarily

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,9 +8,9 @@
       <Uri>https://github.com/dotnet/msquic</Uri>
       <Sha>a7213b4676c1803bb251771291a525482d42e511</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-7.0.100" Version="7.0.0-alpha.2.22078.1">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-7.0.100" Version="7.0.0-alpha.2.22077.1">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>b581f08ff228099e732aa8c8cde53995a5870901</Sha>
+      <Sha>b2054b98cb7b9e555cbbe19955df823ec81a93ad</Sha>
     </Dependency>
     <Dependency Name="System.ServiceModel.Primitives" Version="4.9.0-rc2.21473.1">
       <Uri>https://github.com/dotnet/wcf</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -193,7 +193,7 @@
     <runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>11.1.0-alpha.1.22081.2</runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
     <runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>11.1.0-alpha.1.22081.2</runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>
     <!-- emscripten / Node -->
-    <MicrosoftNETWorkloadEmscriptenManifest70100Version>7.0.0-alpha.2.22078.1</MicrosoftNETWorkloadEmscriptenManifest70100Version>
+    <MicrosoftNETWorkloadEmscriptenManifest70100Version>7.0.0-alpha.2.22077.1</MicrosoftNETWorkloadEmscriptenManifest70100Version>
     <MicrosoftNETRuntimeEmscriptenVersion>$(MicrosoftNETWorkloadEmscriptenManifest70100Version)</MicrosoftNETRuntimeEmscriptenVersion>
     <!-- workloads -->
     <SwixPackageVersion>1.1.87-gba258badda</SwixPackageVersion>


### PR DESCRIPTION
staging in case we can't land https://github.com/dotnet/runtime/pull/62499 quickly
<!-- runfo report start -->
|Build|Kind|Start Time|
|---|---|---|
[1586413](https://dev.azure.com/dnceng/public/_build/results?buildId=1586413)|Rolling|2022-02-02|
[1586484](https://dev.azure.com/dnceng/public/_build/results?buildId=1586484)|Rolling|2022-02-02|

<!-- runfo report end -->


