### PR TITLE
Add Nullable.GetValueRefOrDefaultRef API

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Nullable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Nullable.cs
@@ -125,5 +125,22 @@ namespace System
             }
             return null;
         }
+
+        /// <summary>
+        /// Retrieves a readonly reference to the value of the current <see cref="Nullable{T}"/> object, or to the default value of the underlying type.
+        /// </summary>
+        /// <typeparam name="T">The underlying value type of the <see cref="Nullable{T}"/> generic type.</typeparam>
+        /// <param name="nullable">The readonly reference to the input <see cref="Nullable{T}"/> value.</param>
+        /// <returns>A readonly reference to the value of <paramref name="nullable"/>, or to its containing default <typeparamref name="T"/> value.</returns>
+        /// <remarks>
+        /// As the returned readonly reference refers to data that is stored in the input <paramref name="nullable"/> value, this method should only ever be
+        /// called when the input reference points to a value with an actual location and not an rvalue. That is, if this API is called and the input reference
+        /// points to a value that is produced by the compiler as a defensive copy or a temporary copy, the behavior might not match the desired one.
+        /// </remarks>
+        public static ref readonly T GetValueRefOrDefaultRef<T>(in T? nullable)
+            where T : struct
+        {
+            return ref nullable.value;
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Nullable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Nullable.cs
@@ -127,14 +127,14 @@ namespace System
         }
 
         /// <summary>
-        /// Retrieves a readonly reference to the value of the current <see cref="Nullable{T}"/> object, or to the default value of the underlying type.
+        /// Retrieves a readonly reference to the location in the <see cref="Nullable{T}"/> instance where the value is stored.
         /// </summary>
         /// <typeparam name="T">The underlying value type of the <see cref="Nullable{T}"/> generic type.</typeparam>
         /// <param name="nullable">The readonly reference to the input <see cref="Nullable{T}"/> value.</param>
-        /// <returns>A readonly reference to the value of <paramref name="nullable"/>, or to its containing default <typeparamref name="T"/> value.</returns>
+        /// <returns>A readonly reference to the location where the instance's <typeparamref name="T"/> value is stored. If the instance's <see cref="Nullable{T}.HasValue"/> is false, the current value at that location may be the default value.</returns>
         /// <remarks>
         /// As the returned readonly reference refers to data that is stored in the input <paramref name="nullable"/> value, this method should only ever be
-        /// called when the input reference points to a value with an actual location and not an rvalue. That is, if this API is called and the input reference
+        /// called when the input reference points to a value with an actual location and not an "rvalue" (an expression that may appear on the right side but not left side of an assignment). That is, if this API is called and the input reference
         /// points to a value that is produced by the compiler as a defensive copy or a temporary copy, the behavior might not match the desired one.
         /// </remarks>
         public static ref readonly T GetValueRefOrDefaultRef<T>(in T? nullable)

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -4931,6 +4931,7 @@ namespace System
         public static int Compare<T>(T? n1, T? n2) where T : struct { throw null; }
         public static bool Equals<T>(T? n1, T? n2) where T : struct { throw null; }
         public static System.Type? GetUnderlyingType(System.Type nullableType) { throw null; }
+        public static ref readonly T GetValueRefOrDefaultRef<T>(in T? nullable) where T : struct { throw null; }
     }
     public partial struct Nullable<T> where T : struct
     {

--- a/src/libraries/System.Runtime/tests/System/NullableTests.cs
+++ b/src/libraries/System.Runtime/tests/System/NullableTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Tests
@@ -91,6 +92,48 @@ namespace System.Tests
         public static void GetUnderlyingType_NullType_ThrowsArgumentNullException()
         {
             AssertExtensions.Throws<ArgumentNullException>("nullableType", () => Nullable.GetUnderlyingType((Type)null));
+        }
+
+        [Fact]
+        public static void GetValueRefOrDefaultRef_WithValue()
+        {
+            static void Test<T>(T before, T after)
+                where T : struct
+            {
+                T? nullable = before;
+                ref readonly T reference = ref Nullable.GetValueRefOrDefaultRef(nullable);
+
+                Assert.Equal(nullable!.Value, before);
+
+                Unsafe.AsRef<T>(reference) = after;
+
+                Assert.Equal(nullable.Value, after);
+            }
+
+            Test((byte)0, (byte)42);
+            Test(0, 42);
+            Test(1.3f, 3.14f);
+            Test(0.555, 8.49);
+            Test(Guid.NewGuid(), Guid.NewGuid());
+        }
+
+        [Fact]
+        public static void GetValueRefOrDefaultRef_WithDefault()
+        {
+            static void Test<T>()
+                where T : struct
+            {
+                T? nullable = null;
+                ref readonly T reference = ref Nullable.GetValueRefOrDefaultRef(nullable);
+
+                Assert.Equal(nullable!.GetValueOrDefault(), reference);
+            }
+
+            Test<byte>();
+            Test<int>();
+            Test<float>();
+            Test<double>();
+            Test<Guid>();
         }
 
         public static IEnumerable<object[]> Compare_Equals_TestData()


### PR DESCRIPTION
### Closes #1534

This PR adds the following API:

```csharp
namespace System
{
    public static partial class Nullable
    {
        public static ref readonly T GetValueRefOrDefaultRef<T>(in T? nullable) where T : struct;
    }
}
```