### PR TITLE
#55822 Disable CanRecurseFrom root for Android

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/RootTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/RootTests.cs
@@ -31,7 +31,7 @@ namespace System.IO.Tests.Enumeration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55821", TestPlatforms.Android)]
+        [SkipOnPlatform(TestPlatforms.Android, "Test could not work on android since accessing '/' isn't allowed.")]
         public void CanRecurseFromRoot()
         {
             string root = Path.GetPathRoot(Path.GetTempPath());


### PR DESCRIPTION
#55822 Disabling CanRecurseFromRoot test case for Android platforms.
Test could not work on android since accessing '/' isn't allowed.