### PR TITLE
Add notes about ignored checks to superpmi-asmdiffs and enterprise-linux pipelines

### DIFF
--- a/eng/pipelines/coreclr/superpmi-asmdiffs.yml
+++ b/eng/pipelines/coreclr/superpmi-asmdiffs.yml
@@ -9,6 +9,8 @@ pr:
     include:
     - main
   paths:
+    # If you are changing these and start including eng/common, adjust the Maestro subscriptions
+    # so that this build can block dependency auto-updates (this build is currently ignored)
     include:
     - src/coreclr/jit/*
     exclude:

--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -10,6 +10,8 @@ pr:
     - release/*.*
 
   paths:
+    # If you are changing these and start including eng/common, adjust the Maestro subscriptions
+    # so that this build can block dependency auto-updates (this build is currently ignored)
     include:
       - eng/pipelines/libraries/enterprise/*
       - src/libraries/Common/src/System/Net/*


### PR DESCRIPTION
Following pipelines are skipped for Maestro dependency updates:
- **runtime-coreclr superpmi-asmdiffs**
- **runtime-libraries enterprise-linux**

The dependency update PRs then cannot be auto-merged:

![image](https://user-images.githubusercontent.com/7013027/152194738-45a48dfd-b30f-444a-919f-4e88dff1ad73.png)

We cannot ignore skipped checks on Maestro side because someone could just add ignore paths to all pipelines and push a check-less PR through.

We have configured the repository policies to this:
```YAML
https://github.com/dotnet/runtime @ main
- Merge Policies:
  AllChecksSuccessful
    ignoreChecks =
                   [
                     "WIP",
                     "license/cla",
                     "runtime-coreclr superpmi-asmdiffs",
                     "runtime-libraries enterprise-linux"
                   ]
  NoRequestedChanges
```

In case we start running these pipelines for `eng/common`, `Versions.props` or `Versions.Details.xml` changes, we should remove these checks from the ignored column.