### PR TITLE
Support IgnoreElementNameForRepeats

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/ref/Microsoft.Extensions.Configuration.Xml.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/ref/Microsoft.Extensions.Configuration.Xml.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Extensions.Configuration.Xml
     public partial class XmlConfigurationSource : Microsoft.Extensions.Configuration.FileConfigurationSource
     {
         public XmlConfigurationSource() { }
+        public bool IgnoreElementNameForRepeats { get; set; }
         public override Microsoft.Extensions.Configuration.IConfigurationProvider Build(Microsoft.Extensions.Configuration.IConfigurationBuilder builder) { throw null; }
     }
     public partial class XmlDocumentDecryptor
@@ -41,10 +42,12 @@ namespace Microsoft.Extensions.Configuration.Xml
         public XmlStreamConfigurationProvider(Microsoft.Extensions.Configuration.Xml.XmlStreamConfigurationSource source) : base (default(Microsoft.Extensions.Configuration.StreamConfigurationSource)) { }
         public override void Load(System.IO.Stream stream) { }
         public static System.Collections.Generic.IDictionary<string, string> Read(System.IO.Stream stream, Microsoft.Extensions.Configuration.Xml.XmlDocumentDecryptor decryptor) { throw null; }
+        public static System.Collections.Generic.IDictionary<string, string> Read(System.IO.Stream stream, Microsoft.Extensions.Configuration.Xml.XmlDocumentDecryptor decryptor, bool ignoreElementNameForRepeats) { throw null; }
     }
     public partial class XmlStreamConfigurationSource : Microsoft.Extensions.Configuration.StreamConfigurationSource
     {
         public XmlStreamConfigurationSource() { }
+        public bool IgnoreElementNameForRepeats { get; set; }
         public override Microsoft.Extensions.Configuration.IConfigurationProvider Build(Microsoft.Extensions.Configuration.IConfigurationBuilder builder) { throw null; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationProvider.cs
@@ -10,13 +10,20 @@ namespace Microsoft.Extensions.Configuration.Xml
     /// </summary>
     public class XmlConfigurationProvider : FileConfigurationProvider
     {
+        private readonly XmlConfigurationSource configSource;
+
         /// <summary>
         /// Initializes a new instance with the specified source.
         /// </summary>
         /// <param name="source">The source settings.</param>
-        public XmlConfigurationProvider(XmlConfigurationSource source) : base(source) { }
+        public XmlConfigurationProvider(XmlConfigurationSource source) : base(source)
+        {
+            this.configSource = source;
+        }
 
         internal XmlDocumentDecryptor Decryptor { get; set; } = XmlDocumentDecryptor.Instance;
+
+        internal System.Collections.Generic.IDictionary<string, string> Data2 => Data;
 
         /// <summary>
         /// Loads the XML data from a stream.
@@ -24,7 +31,7 @@ namespace Microsoft.Extensions.Configuration.Xml
         /// <param name="stream">The stream to read.</param>
         public override void Load(Stream stream)
         {
-            Data = XmlStreamConfigurationProvider.Read(stream, Decryptor);
+            Data = XmlStreamConfigurationProvider.Read(stream, Decryptor, this.configSource.IgnoreElementNameForRepeats);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationSource.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationSource.cs
@@ -9,6 +9,18 @@ namespace Microsoft.Extensions.Configuration.Xml
     public class XmlConfigurationSource : FileConfigurationSource
     {
         /// <summary>
+        /// When false (default), repeated elements are included as path of the
+        /// configuration key along with their index. When true, the name of the
+        /// repeated element is ignored and replaced with the index itself.
+        /// </summary>
+        /// <example>
+        /// When false, a repeated element might produce keys like "root:repeat:0",
+        /// "root:repeat:1". When true, the same repeated element produces keys like
+        /// "root:0", "root:1"
+        /// </example>
+        public bool IgnoreElementNameForRepeats { get; set; }
+
+        /// <summary>
         /// Builds the <see cref="XmlConfigurationProvider"/> for this source.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/>.</param>

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlStreamConfigurationSource.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlStreamConfigurationSource.cs
@@ -9,6 +9,18 @@ namespace Microsoft.Extensions.Configuration.Xml
     public class XmlStreamConfigurationSource : StreamConfigurationSource
     {
         /// <summary>
+        /// When false (default), repeated elements are included as path of the
+        /// configuration key along with their index. When true, the name of the
+        /// repeated element is ignored and replaced with the index itself.
+        /// </summary>
+        /// <example>
+        /// When false, a repeated element might produce keys like "root:repeat:0",
+        /// "root:repeat:1". When true, the same repeated element produces keys like
+        /// "root:0", "root:1"
+        /// </example>
+        public bool IgnoreElementNameForRepeats { get; set; }
+
+        /// <summary>
         /// Builds the <see cref="XmlStreamConfigurationProvider"/> for this source.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/>.</param>

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/XmlConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/XmlConfigurationTest.cs
@@ -266,6 +266,29 @@ namespace Microsoft.Extensions.Configuration.Xml.Test
         }
 
         [Fact]
+        public void RepeatedElementDoNotContributeToPrefixWithIgnoreElementNameForRepeats()
+        {
+            var xml =
+              @"<settings>
+                  <DefaultConnection>
+                      <ConnectionString>TestConnectionString1</ConnectionString>
+                      <Provider>SqlClient1</Provider>
+                  </DefaultConnection>
+                  <DefaultConnection>
+                      <ConnectionString>TestConnectionString2</ConnectionString>
+                      <Provider>SqlClient2</Provider>
+                  </DefaultConnection>
+                </settings>";
+            var xmlConfigSrc = new XmlConfigurationProvider(new XmlConfigurationSource() { IgnoreElementNameForRepeats = true });
+            xmlConfigSrc.Load(TestStreamHelpers.StringToStream(xml));
+
+            Assert.Equal("TestConnectionString1", xmlConfigSrc.Get("0:ConnectionString"));
+            Assert.Equal("SqlClient1", xmlConfigSrc.Get("0:Provider"));
+            Assert.Equal("TestConnectionString2", xmlConfigSrc.Get("1:ConnectionString"));
+            Assert.Equal("SqlClient2", xmlConfigSrc.Get("1:Provider"));
+        }
+
+        [Fact]
         public void RepeatedElementDetectionIsCaseInsensitive()
         {
             var xml =


### PR DESCRIPTION
Consider this example

```
<PurchaseOrder>
    <customerName>...</customerName>
    <items>
        <Item>...</Item>
        <Item>...</Item>
        <Item>...</Item>
        ...
    </items>
    <comments>
        <string>...</string>
        <string>...</string>
        <string>...</string>
        ...
    </comments>
</PurchaseOrder>
```

This requires the following classes to fully deserialize in Extensions.Configuration


```
Class PurchaseOrder {
                Public string CustomerName {get; set;}
                Public ItemList Items {get;set;}
				...
}
Class ItemList {
                Public Item[] Item
} 
Class Item {…}
```

Compared to the data contract serialization requirements, which look like

```
[DataContract]
Class PurchaseOrder {
                [DataMember]
                Public string CustomerName {get; set;}
                [DataMember] 
                Public Item[] Items {get;set;}
…
}
[DataContract]
Class Item {…}
```

This PR introduces a setting `IgnoreElementNameForRepeats` which allows configuration to work on classes that look like the data contract serialization requirements.