### PR TITLE
Fix test build command in docs/workflow/building/coreclr/nativeaot.md

### DIFF
--- a/docs/workflow/building/coreclr/nativeaot.md
+++ b/docs/workflow/building/coreclr/nativeaot.md
@@ -59,7 +59,7 @@ The workflow looks like this:
 
 ## Running tests
 
-If you haven't built the tests yet, run `src\tests\build[.cmd|.sh] -nativeaot [Debug|Release] -tree:nativeaot`. This will build the smoke tests only - they usually suffice to ensure the runtime and compiler is in a workable shape. To build all Pri-0 tests, drop the `-tree:nativeaot` parameter. The `Debug`/`Release` parameter should match the build configuration you used to build the runtime.
+If you haven't built the tests yet, run `src\tests\build.cmd nativeaot [Debug|Release] tree nativeaot` on windows, or `src/tests/build.sh -nativeaot [Debug|Release] -tree:nativeaot` on linux. This will build the smoke tests only - they usually suffice to ensure the runtime and compiler is in a workable shape. To build all Pri-0 tests, drop the `tree nativeaot` parameter. The `Debug`/`Release` parameter should match the build configuration you used to build the runtime.
 
 To run all the tests that got built, run `src\tests\run.cmd runnativeaottests [Debug|Release]` on Windows, or `src/tests/run.sh --runnativeaottests [Debug|Release]` on Linux. The `Debug`/`Release` flag should match the flag that was passed to `build.cmd` in the previous step.
 

--- a/docs/workflow/building/coreclr/nativeaot.md
+++ b/docs/workflow/building/coreclr/nativeaot.md
@@ -59,7 +59,7 @@ The workflow looks like this:
 
 ## Running tests
 
-If you haven't built the tests yet, run `src\tests\build.cmd nativeaot [Debug|Release] tree nativeaot` on windows, or `src/tests/build.sh -nativeaot [Debug|Release] -tree:nativeaot` on linux. This will build the smoke tests only - they usually suffice to ensure the runtime and compiler is in a workable shape. To build all Pri-0 tests, drop the `tree nativeaot` parameter. The `Debug`/`Release` parameter should match the build configuration you used to build the runtime.
+If you haven't built the tests yet, run `src\tests\build.cmd nativeaot [Debug|Release] tree nativeaot` on Windows, or `src/tests/build.sh -nativeaot [Debug|Release] -tree:nativeaot` on Linux. This will build the smoke tests only - they usually suffice to ensure the runtime and compiler is in a workable shape. To build all Pri-0 tests, drop the `tree nativeaot` parameter. The `Debug`/`Release` parameter should match the build configuration you used to build the runtime.
 
 To run all the tests that got built, run `src\tests\run.cmd runnativeaottests [Debug|Release]` on Windows, or `src/tests/run.sh --runnativeaottests [Debug|Release]` on Linux. The `Debug`/`Release` flag should match the flag that was passed to `build.cmd` in the previous step.
 

--- a/docs/workflow/building/coreclr/nativeaot.md
+++ b/docs/workflow/building/coreclr/nativeaot.md
@@ -59,7 +59,7 @@ The workflow looks like this:
 
 ## Running tests
 
-If you haven't built the tests yet, run `src\tests\build[.cmd|.sh] nativeaot [Debug|Release] tree nativeaot`. This will build the smoke tests only - they usually suffice to ensure the runtime and compiler is in a workable shape. To build all Pri-0 tests, drop the `tree nativeaot` parameter. The `Debug`/`Release` parameter should match the build configuration you used to build the runtime.
+If you haven't built the tests yet, run `src\tests\build[.cmd|.sh] -nativeaot [Debug|Release] -tree:nativeaot`. This will build the smoke tests only - they usually suffice to ensure the runtime and compiler is in a workable shape. To build all Pri-0 tests, drop the `-tree:nativeaot` parameter. The `Debug`/`Release` parameter should match the build configuration you used to build the runtime.
 
 To run all the tests that got built, run `src\tests\run.cmd runnativeaottests [Debug|Release]` on Windows, or `src/tests/run.sh --runnativeaottests [Debug|Release]` on Linux. The `Debug`/`Release` flag should match the flag that was passed to `build.cmd` in the previous step.
 


### PR DESCRIPTION
The command `src/tests/build[.cmd|.sh] nativeaot [Debug|Release] tree nativeaot` seems not to work as expected on linux.
Namely it seems to build not only the nativeaot smoke tests.
Fixed to show windows and linux command separately.
Correct linux command is `src/tests/build.sh -nativeaot [Debug|Release] -tree:nativeaot`