### PR TITLE
Update Maui Workload Install Process for Perf 

### DIFF
--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -114,398 +114,398 @@ jobs:
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
-  # build coreclr and libraries
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-      buildConfig: release
-      platforms:
-      - Linux_x64
-      - windows_x64
-      - windows_x86
-      - Linux_musl_x64
-      jobParameters:
-        testGroup: perf
+  ## build coreclr and libraries
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+  #    buildConfig: release
+  #    platforms:
+  #    - Linux_x64
+  #    - windows_x64
+  #    - windows_x86
+  #    - Linux_musl_x64
+  #    jobParameters:
+  #      testGroup: perf
 
-  # build mono on wasm
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Browser_wasm
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: wasm
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: Browser Wasm Artifacts
-          artifactName: BrowserWasm
-          archiveType: zip
-          archiveExtension: .zip
+  ## build mono on wasm
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Browser_wasm
+  #    jobParameters:
+  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #      nameSuffix: wasm
+  #      isOfficialBuild: false
+  #      extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+  #      extraStepsParameters:
+  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #        includeRootFolder: true
+  #        displayName: Browser Wasm Artifacts
+  #        artifactName: BrowserWasm
+  #        archiveType: zip
+  #        archiveExtension: .zip
 
-  # build mono for AOT
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Linux_x64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: AOT
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: AOT Mono Artifacts
-          artifactName: LinuxMonoAOTx64
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  ## build mono for AOT
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #      nameSuffix: AOT
+  #      isOfficialBuild: false
+  #      extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+  #      extraStepsParameters:
+  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #        includeRootFolder: true
+  #        displayName: AOT Mono Artifacts
+  #        artifactName: LinuxMonoAOTx64
+  #        archiveExtension: '.tar.gz'
+  #        archiveType: tar
+  #        tarCompression: gz
 
-  # build mono Android scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Android_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: AndroidMono
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: Android Mono Artifacts
-          artifactName: AndroidMonoarm64
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  ## build mono Android scenarios
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Android_arm64
+  #    jobParameters:
+  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #      nameSuffix: AndroidMono
+  #      isOfficialBuild: false
+  #      extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+  #      extraStepsParameters:
+  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #        includeRootFolder: true
+  #        displayName: Android Mono Artifacts
+  #        artifactName: AndroidMonoarm64
+  #        archiveExtension: '.tar.gz'
+  #        archiveType: tar
+  #        tarCompression: gz
     
-  # build mono iOS scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - iOS_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: iOSMono
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: iOS Mono Artifacts
-          artifactName: iOSMonoarm64
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  ## build mono iOS scenarios
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - iOS_arm64
+  #    jobParameters:
+  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #      nameSuffix: iOSMono
+  #      isOfficialBuild: false
+  #      extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+  #      extraStepsParameters:
+  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #        includeRootFolder: true
+  #        displayName: iOS Mono Artifacts
+  #        artifactName: iOSMonoarm64
+  #        archiveExtension: '.tar.gz'
+  #        archiveType: tar
+  #        tarCompression: gz
 
-  # build mono
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-      runtimeFlavor: mono
-      buildConfig: release
-      platforms:
-      - Linux_x64
+  ## build mono
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+  #    runtimeFlavor: mono
+  #    buildConfig: release
+  #    platforms:
+  #    - Linux_x64
 
-  # run mono and maui android scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - Windows_x64
-      jobParameters:
-        testGroup: perf
-        runtimeType: AndroidMono
-        projectFile: android_scenarios.proj
-        runKind: android_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
+  ## run mono and maui android scenarios
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #      - Windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      runtimeType: AndroidMono
+  #      projectFile: android_scenarios.proj
+  #      runKind: android_scenarios
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #      logicalmachine: 'perfpixel4a'
 
-  # run mono iOS scenarios and maui iOS scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - Windows_x64
-      jobParameters:
-        testGroup: perf
-        runtimeType: iOSMono
-        projectFile: ios_scenarios.proj
-        runKind: ios_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
-        iosLlvmBuild: False
+  ## run mono iOS scenarios and maui iOS scenarios
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #      - Windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      runtimeType: iOSMono
+  #      projectFile: ios_scenarios.proj
+  #      runKind: ios_scenarios
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #      logicalmachine: 'perfpixel4a'
+  #      iosLlvmBuild: False
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - Windows_x64
-      jobParameters:
-        testGroup: perf
-        runtimeType: iOSMono
-        projectFile: ios_scenarios.proj
-        runKind: ios_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
-        iosLlvmBuild: True
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #      - Windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      runtimeType: iOSMono
+  #      projectFile: ios_scenarios.proj
+  #      runKind: ios_scenarios
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #      logicalmachine: 'perfpixel4a'
+  #      iosLlvmBuild: True
 
-  # run mono microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  ## run mono microbenchmarks perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      runtimeType: mono
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro_mono
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
 
-  # run mono interpreter perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'Interpreter'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  ## run mono interpreter perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      runtimeType: mono
+  #      codeGenType: 'Interpreter'
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro_mono
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
 
-  # run mono wasm interpreter (default) microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: release
-      runtimeFlavor: wasm
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        codeGenType: 'wasm'
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        javascriptEngine: 'v8'
+  ## run mono wasm interpreter (default) microbenchmarks perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+  #    buildConfig: release
+  #    runtimeFlavor: wasm
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      runtimeType: wasm
+  #      codeGenType: 'wasm'
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
+  #      javascriptEngine: 'v8'
 
-  #run mono wasm aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildconfig: release
-      runtimeflavor: wasm
-      platforms:
-      - linux_x64
-      jobparameters:
-        testgroup: perf
-        livelibrariesbuildconfig: Release
-        runtimetype: wasm
-        codegentype: 'aot'
-        projectfile: microbenchmarks.proj
-        runkind: micro
-        runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        javascriptEngine: 'v8'
+  ##run mono wasm aot microbenchmarks perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
+  #    buildconfig: release
+  #    runtimeflavor: wasm
+  #    platforms:
+  #    - linux_x64
+  #    jobparameters:
+  #      testgroup: perf
+  #      livelibrariesbuildconfig: Release
+  #      runtimetype: wasm
+  #      codegentype: 'aot'
+  #      projectfile: microbenchmarks.proj
+  #      runkind: micro
+  #      runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
+  #      javascriptEngine: 'v8'
 
-  # run mono aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: release
-      runtimeFlavor: aot
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'AOT'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  ## run mono aot microbenchmarks perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+  #    buildConfig: release
+  #    runtimeFlavor: aot
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      runtimeType: mono
+  #      codeGenType: 'AOT'
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro_mono
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
 
-  # run coreclr perftiger microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_x64
-      - windows_x64
-      - windows_x86
-      - Linux_musl_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  ## run coreclr perftiger microbenchmarks perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: coreclr
+  #    platforms:
+  #    - Linux_x64
+  #    - windows_x64
+  #    - windows_x86
+  #    - Linux_musl_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
 
-  # run coreclr perftiger microbenchmarks pgo perf jobs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -NoPgo
+  ## run coreclr perftiger microbenchmarks pgo perf jobs
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: coreclr
+  #    platforms:
+  #    - windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
+  #      pgoRunType: -NoPgo
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -DynamicPgo
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: coreclr
+  #    platforms:
+  #    - windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
+  #      pgoRunType: -DynamicPgo
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -FullPgo
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: coreclr
+  #    platforms:
+  #    - windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
+  #      pgoRunType: -FullPgo
 
-  # run coreclr perfowl microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_x64
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perfowl'
+  ## run coreclr perfowl microbenchmarks perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: coreclr
+  #    platforms:
+  #    - Linux_x64
+  #    - windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perfowl'
 
-  # run coreclr crossgen perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_x64
-      - windows_x64
-      - windows_x86
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: crossgen_perf.proj
-        runKind: crossgen_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perftiger'
+  ## run coreclr crossgen perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: coreclr
+  #    platforms:
+  #    - Linux_x64
+  #    - windows_x64
+  #    - windows_x86
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      projectFile: crossgen_perf.proj
+  #      runKind: crossgen_scenarios
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #      logicalmachine: 'perftiger'
 
-  # run mono wasm blazor perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: wasm
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        projectFile: blazor_perf.proj
-        runKind: blazor_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        additionalSetupParameters: '--latestdotnet'
-        logicalmachine: 'perftiger'
+  ## run mono wasm blazor perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: wasm
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      runtimeType: wasm
+  #      projectFile: blazor_perf.proj
+  #      runKind: blazor_scenarios
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #      additionalSetupParameters: '--latestdotnet'
+  #      logicalmachine: 'perftiger'
 
-  # build maui runtime packs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Android_x86
-      - Android_x64
-      - Android_arm
-      - Android_arm64
-      - MacCatalyst_x64
-      - iOSSimulator_x64
-      - iOS_arm64
-      - iOS_arm
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: Maui_Packs_Mono
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-        extraStepsParameters:
-          name: MonoRuntimePacks
+  ## build maui runtime packs
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Android_x86
+  #    - Android_x64
+  #    - Android_arm
+  #    - Android_arm64
+  #    - MacCatalyst_x64
+  #    - iOSSimulator_x64
+  #    - iOS_arm64
+  #    - iOS_arm
+  #    jobParameters:
+  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #      nameSuffix: Maui_Packs_Mono
+  #      isOfficialBuild: false
+  #      extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+  #      extraStepsParameters:
+  #        name: MonoRuntimePacks
   
   # build maui app
   - template: /eng/pipelines/common/platform-matrix.yml
@@ -516,13 +516,13 @@ jobs:
       platforms:
       - iOS_arm64
       jobParameters:
-        dependsOn:
-          - Build_Android_arm_release_Maui_Packs_Mono
-          - Build_Android_arm64_release_Maui_Packs_Mono
-          - Build_Android_x86_release_Maui_Packs_Mono
-          - Build_Android_x64_release_Maui_Packs_Mono
-          - Build_MacCatalyst_x64_release_Maui_Packs_Mono
-          - Build_iOSSimulator_x64_release_Maui_Packs_Mono
+        #dependsOn:
+        #  - Build_Android_arm_release_Maui_Packs_Mono
+        #  - Build_Android_arm64_release_Maui_Packs_Mono
+        #  - Build_Android_x86_release_Maui_Packs_Mono
+        #  - Build_Android_x64_release_Maui_Packs_Mono
+        #  - Build_MacCatalyst_x64_release_Maui_Packs_Mono
+        #  - Build_iOSSimulator_x64_release_Maui_Packs_Mono
         buildArgs: -s mono -c $(_BuildConfig)
         nameSuffix: MACiOSAndroidMaui
         isOfficialBuild: false

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -114,398 +114,398 @@ jobs:
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
-  ## build coreclr and libraries
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-  #    buildConfig: release
-  #    platforms:
-  #    - Linux_x64
-  #    - windows_x64
-  #    - windows_x86
-  #    - Linux_musl_x64
-  #    jobParameters:
-  #      testGroup: perf
+  # build coreclr and libraries
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+      buildConfig: release
+      platforms:
+      - Linux_x64
+      - windows_x64
+      - windows_x86
+      - Linux_musl_x64
+      jobParameters:
+        testGroup: perf
 
-  ## build mono on wasm
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Browser_wasm
-  #    jobParameters:
-  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #      nameSuffix: wasm
-  #      isOfficialBuild: false
-  #      extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-  #      extraStepsParameters:
-  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #        includeRootFolder: true
-  #        displayName: Browser Wasm Artifacts
-  #        artifactName: BrowserWasm
-  #        archiveType: zip
-  #        archiveExtension: .zip
+  # build mono on wasm
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Browser_wasm
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: wasm
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: Browser Wasm Artifacts
+          artifactName: BrowserWasm
+          archiveType: zip
+          archiveExtension: .zip
 
-  ## build mono for AOT
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #      nameSuffix: AOT
-  #      isOfficialBuild: false
-  #      extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-  #      extraStepsParameters:
-  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #        includeRootFolder: true
-  #        displayName: AOT Mono Artifacts
-  #        artifactName: LinuxMonoAOTx64
-  #        archiveExtension: '.tar.gz'
-  #        archiveType: tar
-  #        tarCompression: gz
+  # build mono for AOT
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Linux_x64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: AOT
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: AOT Mono Artifacts
+          artifactName: LinuxMonoAOTx64
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
 
-  ## build mono Android scenarios
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Android_arm64
-  #    jobParameters:
-  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #      nameSuffix: AndroidMono
-  #      isOfficialBuild: false
-  #      extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-  #      extraStepsParameters:
-  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #        includeRootFolder: true
-  #        displayName: Android Mono Artifacts
-  #        artifactName: AndroidMonoarm64
-  #        archiveExtension: '.tar.gz'
-  #        archiveType: tar
-  #        tarCompression: gz
+  # build mono Android scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Android_arm64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: AndroidMono
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: Android Mono Artifacts
+          artifactName: AndroidMonoarm64
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
     
-  ## build mono iOS scenarios
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - iOS_arm64
-  #    jobParameters:
-  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #      nameSuffix: iOSMono
-  #      isOfficialBuild: false
-  #      extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-  #      extraStepsParameters:
-  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #        includeRootFolder: true
-  #        displayName: iOS Mono Artifacts
-  #        artifactName: iOSMonoarm64
-  #        archiveExtension: '.tar.gz'
-  #        archiveType: tar
-  #        tarCompression: gz
+  # build mono iOS scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - iOS_arm64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: iOSMono
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: iOS Mono Artifacts
+          artifactName: iOSMonoarm64
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
 
-  ## build mono
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-  #    runtimeFlavor: mono
-  #    buildConfig: release
-  #    platforms:
-  #    - Linux_x64
+  # build mono
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+      runtimeFlavor: mono
+      buildConfig: release
+      platforms:
+      - Linux_x64
 
-  ## run mono and maui android scenarios
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #      - Windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      runtimeType: AndroidMono
-  #      projectFile: android_scenarios.proj
-  #      runKind: android_scenarios
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #      logicalmachine: 'perfpixel4a'
+  # run mono and maui android scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+        - Windows_x64
+      jobParameters:
+        testGroup: perf
+        runtimeType: AndroidMono
+        projectFile: android_scenarios.proj
+        runKind: android_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perfpixel4a'
 
-  ## run mono iOS scenarios and maui iOS scenarios
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #      - Windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      runtimeType: iOSMono
-  #      projectFile: ios_scenarios.proj
-  #      runKind: ios_scenarios
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #      logicalmachine: 'perfpixel4a'
-  #      iosLlvmBuild: False
+  # run mono iOS scenarios and maui iOS scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+        - Windows_x64
+      jobParameters:
+        testGroup: perf
+        runtimeType: iOSMono
+        projectFile: ios_scenarios.proj
+        runKind: ios_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perfpixel4a'
+        iosLlvmBuild: False
 
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #      - Windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      runtimeType: iOSMono
-  #      projectFile: ios_scenarios.proj
-  #      runKind: ios_scenarios
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #      logicalmachine: 'perfpixel4a'
-  #      iosLlvmBuild: True
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+        - Windows_x64
+      jobParameters:
+        testGroup: perf
+        runtimeType: iOSMono
+        projectFile: ios_scenarios.proj
+        runKind: ios_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perfpixel4a'
+        iosLlvmBuild: True
 
-  ## run mono microbenchmarks perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      runtimeType: mono
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro_mono
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
+  # run mono microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  ## run mono interpreter perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      runtimeType: mono
-  #      codeGenType: 'Interpreter'
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro_mono
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
+  # run mono interpreter perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'Interpreter'
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  ## run mono wasm interpreter (default) microbenchmarks perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-  #    buildConfig: release
-  #    runtimeFlavor: wasm
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      runtimeType: wasm
-  #      codeGenType: 'wasm'
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
-  #      javascriptEngine: 'v8'
+  # run mono wasm interpreter (default) microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildConfig: release
+      runtimeFlavor: wasm
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: wasm
+        codeGenType: 'wasm'
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        javascriptEngine: 'v8'
 
-  ##run mono wasm aot microbenchmarks perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
-  #    buildconfig: release
-  #    runtimeflavor: wasm
-  #    platforms:
-  #    - linux_x64
-  #    jobparameters:
-  #      testgroup: perf
-  #      livelibrariesbuildconfig: Release
-  #      runtimetype: wasm
-  #      codegentype: 'aot'
-  #      projectfile: microbenchmarks.proj
-  #      runkind: micro
-  #      runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
-  #      javascriptEngine: 'v8'
+  #run mono wasm aot microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildconfig: release
+      runtimeflavor: wasm
+      platforms:
+      - linux_x64
+      jobparameters:
+        testgroup: perf
+        livelibrariesbuildconfig: Release
+        runtimetype: wasm
+        codegentype: 'aot'
+        projectfile: microbenchmarks.proj
+        runkind: micro
+        runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        javascriptEngine: 'v8'
 
-  ## run mono aot microbenchmarks perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-  #    buildConfig: release
-  #    runtimeFlavor: aot
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      runtimeType: mono
-  #      codeGenType: 'AOT'
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro_mono
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
+  # run mono aot microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildConfig: release
+      runtimeFlavor: aot
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'AOT'
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  ## run coreclr perftiger microbenchmarks perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: coreclr
-  #    platforms:
-  #    - Linux_x64
-  #    - windows_x64
-  #    - windows_x86
-  #    - Linux_musl_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
+  # run coreclr perftiger microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - Linux_x64
+      - windows_x64
+      - windows_x86
+      - Linux_musl_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  ## run coreclr perftiger microbenchmarks pgo perf jobs
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: coreclr
-  #    platforms:
-  #    - windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
-  #      pgoRunType: -NoPgo
+  # run coreclr perftiger microbenchmarks pgo perf jobs
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: -NoPgo
 
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: coreclr
-  #    platforms:
-  #    - windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
-  #      pgoRunType: -DynamicPgo
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: -DynamicPgo
 
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: coreclr
-  #    platforms:
-  #    - windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
-  #      pgoRunType: -FullPgo
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: -FullPgo
 
-  ## run coreclr perfowl microbenchmarks perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: coreclr
-  #    platforms:
-  #    - Linux_x64
-  #    - windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perfowl'
+  # run coreclr perfowl microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - Linux_x64
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perfowl'
 
-  ## run coreclr crossgen perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: coreclr
-  #    platforms:
-  #    - Linux_x64
-  #    - windows_x64
-  #    - windows_x86
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      projectFile: crossgen_perf.proj
-  #      runKind: crossgen_scenarios
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #      logicalmachine: 'perftiger'
+  # run coreclr crossgen perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - Linux_x64
+      - windows_x64
+      - windows_x86
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: crossgen_perf.proj
+        runKind: crossgen_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perftiger'
 
-  ## run mono wasm blazor perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: wasm
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      runtimeType: wasm
-  #      projectFile: blazor_perf.proj
-  #      runKind: blazor_scenarios
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #      additionalSetupParameters: '--latestdotnet'
-  #      logicalmachine: 'perftiger'
+  # run mono wasm blazor perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: wasm
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: wasm
+        projectFile: blazor_perf.proj
+        runKind: blazor_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        additionalSetupParameters: '--latestdotnet'
+        logicalmachine: 'perftiger'
 
-  ## build maui runtime packs
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Android_x86
-  #    - Android_x64
-  #    - Android_arm
-  #    - Android_arm64
-  #    - MacCatalyst_x64
-  #    - iOSSimulator_x64
-  #    - iOS_arm64
-  #    - iOS_arm
-  #    jobParameters:
-  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #      nameSuffix: Maui_Packs_Mono
-  #      isOfficialBuild: false
-  #      extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-  #      extraStepsParameters:
-  #        name: MonoRuntimePacks
+  # build maui runtime packs
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Android_x86
+      - Android_x64
+      - Android_arm
+      - Android_arm64
+      - MacCatalyst_x64
+      - iOSSimulator_x64
+      - iOS_arm64
+      - iOS_arm
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: Maui_Packs_Mono
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+        extraStepsParameters:
+          name: MonoRuntimePacks
   
   # build maui app
   - template: /eng/pipelines/common/platform-matrix.yml
@@ -516,13 +516,15 @@ jobs:
       platforms:
       - iOS_arm64
       jobParameters:
-        #dependsOn:
-        #  - Build_Android_arm_release_Maui_Packs_Mono
-        #  - Build_Android_arm64_release_Maui_Packs_Mono
-        #  - Build_Android_x86_release_Maui_Packs_Mono
-        #  - Build_Android_x64_release_Maui_Packs_Mono
-        #  - Build_MacCatalyst_x64_release_Maui_Packs_Mono
-        #  - Build_iOSSimulator_x64_release_Maui_Packs_Mono
+        dependsOn:
+          - Build_Android_arm_release_Maui_Packs_Mono
+          - Build_Android_arm64_release_Maui_Packs_Mono
+          - Build_Android_x86_release_Maui_Packs_Mono
+          - Build_Android_x64_release_Maui_Packs_Mono
+          - Build_MacCatalyst_x64_release_Maui_Packs_Mono
+          - Build_iOSSimulator_x64_release_Maui_Packs_Mono
+          - Build_iOS_arm_release_Maui_Packs_Mono
+          - Build_iOS_arm64_release_Maui_Packs_Mono
         buildArgs: -s mono -c $(_BuildConfig)
         nameSuffix: MACiOSAndroidMaui
         isOfficialBuild: false

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -507,33 +507,48 @@ jobs:
   #      extraStepsParameters:
   #        name: MonoRuntimePacks
   
-  # build maui app
+  ## build maui app
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - iOS_arm64
+  #    jobParameters:
+  #      dependsOn:
+  #        - Build_Android_arm_release_Maui_Packs_Mono
+  #        - Build_Android_arm64_release_Maui_Packs_Mono
+  #        - Build_Android_x86_release_Maui_Packs_Mono
+  #        - Build_Android_x64_release_Maui_Packs_Mono
+  #        - Build_MacCatalyst_x64_release_Maui_Packs_Mono
+  #        - Build_iOSSimulator_x64_release_Maui_Packs_Mono
+  #      buildArgs: -s mono -c $(_BuildConfig)
+  #      nameSuffix: MACiOSAndroidMaui
+  #      isOfficialBuild: false
+  #      pool:
+  #        vmImage: 'macos-11'
+  #      extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+  #      extraStepsParameters:
+  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #        includeRootFolder: true
+  #        displayName: MAC, iOS, and Android Maui Artifacts
+  #        artifactName: MACiOSAndroidMauiArm
+  #        archiveExtension: '.tar.gz'
+  #        archiveType: tar
+  #        tarCompression: gz
+
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
+      jobTemplate: /eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
       platforms:
       - iOS_arm64
-      jobParameters:
-        #dependsOn:
-        #  - Build_Android_arm_release_Maui_Packs_Mono
-        #  - Build_Android_arm64_release_Maui_Packs_Mono
-        #  - Build_Android_x86_release_Maui_Packs_Mono
-        #  - Build_Android_x64_release_Maui_Packs_Mono
-        #  - Build_MacCatalyst_x64_release_Maui_Packs_Mono
-        #  - Build_iOSSimulator_x64_release_Maui_Packs_Mono
-        buildArgs: -s mono -c $(_BuildConfig)
-        nameSuffix: MACiOSAndroidMaui
-        isOfficialBuild: false
-        pool:
-          vmImage: 'macos-11'
-        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: MAC, iOS, and Android Maui Artifacts
-          artifactName: MACiOSAndroidMauiArm
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+      pool:
+        vmImage: 'macos-11'
+      rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+      includeRootFolder: true
+      displayName: MAC, iOS, and Android Maui Artifacts
+      artifactName: MACiOSAndroidMauiArm
+      archiveExtension: '.tar.gz'
+      archiveType: tar
+      tarCompression: gz

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -484,28 +484,28 @@ jobs:
   #      additionalSetupParameters: '--latestdotnet'
   #      logicalmachine: 'perftiger'
 
-  # build maui runtime packs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Android_x86
-      - Android_x64
-      - Android_arm
-      - Android_arm64
-      - MacCatalyst_x64
-      - iOSSimulator_x64
-      - iOS_arm64
-      - iOS_arm
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: Maui_Packs_Mono
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-        extraStepsParameters:
-          name: MonoRuntimePacks
+  ## build maui runtime packs
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Android_x86
+  #    - Android_x64
+  #    - Android_arm
+  #    - Android_arm64
+  #    - MacCatalyst_x64
+  #    - iOSSimulator_x64
+  #    - iOS_arm64
+  #    - iOS_arm
+  #    jobParameters:
+  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #      nameSuffix: Maui_Packs_Mono
+  #      isOfficialBuild: false
+  #      extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+  #      extraStepsParameters:
+  #        name: MonoRuntimePacks
   
   # build maui app
   - template: /eng/pipelines/common/platform-matrix.yml
@@ -516,13 +516,13 @@ jobs:
       platforms:
       - iOS_arm64
       jobParameters:
-        dependsOn:
-          - Build_Android_arm_release_Maui_Packs_Mono
-          - Build_Android_arm64_release_Maui_Packs_Mono
-          - Build_Android_x86_release_Maui_Packs_Mono
-          - Build_Android_x64_release_Maui_Packs_Mono
-          - Build_MacCatalyst_x64_release_Maui_Packs_Mono
-          - Build_iOSSimulator_x64_release_Maui_Packs_Mono
+        #dependsOn:
+        #  - Build_Android_arm_release_Maui_Packs_Mono
+        #  - Build_Android_arm64_release_Maui_Packs_Mono
+        #  - Build_Android_x86_release_Maui_Packs_Mono
+        #  - Build_Android_x64_release_Maui_Packs_Mono
+        #  - Build_MacCatalyst_x64_release_Maui_Packs_Mono
+        #  - Build_iOSSimulator_x64_release_Maui_Packs_Mono
         buildArgs: -s mono -c $(_BuildConfig)
         nameSuffix: MACiOSAndroidMaui
         isOfficialBuild: false

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -484,28 +484,28 @@ jobs:
   #      additionalSetupParameters: '--latestdotnet'
   #      logicalmachine: 'perftiger'
 
-  ## build maui runtime packs
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Android_x86
-  #    - Android_x64
-  #    - Android_arm
-  #    - Android_arm64
-  #    - MacCatalyst_x64
-  #    - iOSSimulator_x64
-  #    - iOS_arm64
-  #    - iOS_arm
-  #    jobParameters:
-  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #      nameSuffix: Maui_Packs_Mono
-  #      isOfficialBuild: false
-  #      extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-  #      extraStepsParameters:
-  #        name: MonoRuntimePacks
+  # build maui runtime packs
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Android_x86
+      - Android_x64
+      - Android_arm
+      - Android_arm64
+      - MacCatalyst_x64
+      - iOSSimulator_x64
+      - iOS_arm64
+      - iOS_arm
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: Maui_Packs_Mono
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+        extraStepsParameters:
+          name: MonoRuntimePacks
   
   # build maui app
   - template: /eng/pipelines/common/platform-matrix.yml
@@ -516,13 +516,13 @@ jobs:
       platforms:
       - iOS_arm64
       jobParameters:
-        #dependsOn:
-        #  - Build_Android_arm_release_Maui_Packs_Mono
-        #  - Build_Android_arm64_release_Maui_Packs_Mono
-        #  - Build_Android_x86_release_Maui_Packs_Mono
-        #  - Build_Android_x64_release_Maui_Packs_Mono
-        #  - Build_MacCatalyst_x64_release_Maui_Packs_Mono
-        #  - Build_iOSSimulator_x64_release_Maui_Packs_Mono
+        dependsOn:
+          - Build_Android_arm_release_Maui_Packs_Mono
+          - Build_Android_arm64_release_Maui_Packs_Mono
+          - Build_Android_x86_release_Maui_Packs_Mono
+          - Build_Android_x64_release_Maui_Packs_Mono
+          - Build_MacCatalyst_x64_release_Maui_Packs_Mono
+          - Build_iOSSimulator_x64_release_Maui_Packs_Mono
         buildArgs: -s mono -c $(_BuildConfig)
         nameSuffix: MACiOSAndroidMaui
         isOfficialBuild: false

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -507,48 +507,33 @@ jobs:
   #      extraStepsParameters:
   #        name: MonoRuntimePacks
   
-  ## build maui app
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - iOS_arm64
-  #    jobParameters:
-  #      dependsOn:
-  #        - Build_Android_arm_release_Maui_Packs_Mono
-  #        - Build_Android_arm64_release_Maui_Packs_Mono
-  #        - Build_Android_x86_release_Maui_Packs_Mono
-  #        - Build_Android_x64_release_Maui_Packs_Mono
-  #        - Build_MacCatalyst_x64_release_Maui_Packs_Mono
-  #        - Build_iOSSimulator_x64_release_Maui_Packs_Mono
-  #      buildArgs: -s mono -c $(_BuildConfig)
-  #      nameSuffix: MACiOSAndroidMaui
-  #      isOfficialBuild: false
-  #      pool:
-  #        vmImage: 'macos-11'
-  #      extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
-  #      extraStepsParameters:
-  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #        includeRootFolder: true
-  #        displayName: MAC, iOS, and Android Maui Artifacts
-  #        artifactName: MACiOSAndroidMauiArm
-  #        archiveExtension: '.tar.gz'
-  #        archiveType: tar
-  #        tarCompression: gz
-
+  # build maui app
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
       platforms:
       - iOS_arm64
-      pool:
-        vmImage: 'macos-11'
-      rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-      includeRootFolder: true
-      displayName: MAC, iOS, and Android Maui Artifacts
-      artifactName: MACiOSAndroidMauiArm
-      archiveExtension: '.tar.gz'
-      archiveType: tar
-      tarCompression: gz
+      jobParameters:
+        #dependsOn:
+        #  - Build_Android_arm_release_Maui_Packs_Mono
+        #  - Build_Android_arm64_release_Maui_Packs_Mono
+        #  - Build_Android_x86_release_Maui_Packs_Mono
+        #  - Build_Android_x64_release_Maui_Packs_Mono
+        #  - Build_MacCatalyst_x64_release_Maui_Packs_Mono
+        #  - Build_iOSSimulator_x64_release_Maui_Packs_Mono
+        buildArgs: -s mono -c $(_BuildConfig)
+        nameSuffix: MACiOSAndroidMaui
+        isOfficialBuild: false
+        pool:
+          vmImage: 'macos-11'
+        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: MAC, iOS, and Android Maui Artifacts
+          artifactName: MACiOSAndroidMauiArm
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -117,15 +117,12 @@ steps:
       ls -la
       dotnet --info
       ./dotnet --info
-    displayName: Install MAUI workload
-    workingDirectory: $(Build.SourcesDirectory)
-  - script: |
-      dotnet workload install maui --from-rollback-file https://aka.ms/dotnet/maui/main.json --source https://aka.ms/dotnet6/nuget/index.json
+      ./dotnet workload install maui --from-rollback-file https://aka.ms/dotnet/maui/main.json --source https://aka.ms/dotnet6/nuget/index.json
     displayName: Install MAUI workload
     workingDirectory: $(Build.SourcesDirectory)
 
   - script: |
-      dotnet new maui -n MauiTesting
+      ./dotnet new maui -n MauiTesting
       cd MauiTesting
       cp $(Build.SourcesDirectory)/src/tests/Common/maui/MauiScenario.props ./Directory.Build.props
       cp $(Build.SourcesDirectory)/src/tests/Common/maui/MauiScenario.targets ./Directory.Build.targets

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -18,7 +18,7 @@ parameters:
   tarCompression: ''
 
 
-#steps:
+steps:
   #- task: DownloadPipelineArtifact@2
   #  displayName: Download runtime packages
   #  inputs:
@@ -111,6 +111,8 @@ parameters:
 
   - script: |
       curl -o dotnet-install.sh 'https://dot.net/v1/dotnet-install.sh'
+      chmod -R a+rx .
+      ls
       ./dotnet-install.sh --channel 6.0.2xx --quality daily --install-dir --verbose
       dotnet --info
       dotnet workload install maui --from-rollback-file https://aka.ms/dotnet/maui/main.json --source https://aka.ms/dotnet6/nuget/index.json

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -135,7 +135,7 @@ steps:
 
   - script: |
       chmod -R a+r .
-      ../dotnet publish -bl:MauiiOS.binlog -f net6.0-ios -c Release
+      ../dotnet publish -bl:MauiiOS.binlog -f net6.0-ios -c Release -r ios-arm64
       mv ./bin/Release/net6.0-ios/iossimulator-x64/MauiTesting.app ./MauiiOSDefault.app
     displayName: Build MAUI iOS
     workingDirectory: $(Build.SourcesDirectory)/MauiTesting

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -113,8 +113,10 @@ steps:
       curl -o dotnet-install.sh 'https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh'
       chmod -R a+rx .
       ls -la
-      ./dotnet-install.sh --channel 6.0.2xx --quality daily --install-dir . --verbose
+      ./dotnet-install.sh --channel 6.0.2xx --quality daily --install-dir .
+      ls -la
       dotnet --info
+      ./dotnet --info
     displayName: Install MAUI workload
     workingDirectory: $(Build.SourcesDirectory)
   - script: |

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -19,105 +19,106 @@ parameters:
 
 
 steps:
-  - task: DownloadPipelineArtifact@2
-    displayName: Download runtime packages
-    inputs:
-      artifact: 'IntermediateArtifacts'
-      path: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
-      patterns: |
-        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.android-!(*.symbols).nupkg
-        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.ios-!(*.symbols).nupkg
-        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.iossimulator-!(*.symbols).nupkg
-        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-!(*.symbols).nupkg
+  #- task: DownloadPipelineArtifact@2
+  #  displayName: Download runtime packages
+  #  inputs:
+  #    artifact: 'IntermediateArtifacts'
+  #    path: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
+  #    patterns: |
+  #      IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.android-!(*.symbols).nupkg
+  #      IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.ios-!(*.symbols).nupkg
+  #      IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.iossimulator-!(*.symbols).nupkg
+  #      IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-!(*.symbols).nupkg
         
-      # Other artifacts to include once they are being built
-      # EX. IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-*.nupkg
+  #    # Other artifacts to include once they are being built
+  #    # EX. IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-*.nupkg
 
-  - task: CopyFiles@2
-    displayName: Flatten packages
-    inputs:
-      sourceFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
-      contents: '*/Shipping/*.nupkg'
-      cleanTargetFolder: false
-      targetFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
-      flattenFolders: true
+  #- task: CopyFiles@2
+  #  displayName: Flatten packages
+  #  inputs:
+  #    sourceFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
+  #    contents: '*/Shipping/*.nupkg'
+  #    cleanTargetFolder: false
+  #    targetFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
+  #    flattenFolders: true
   
-  - script: |
-      for file in *.nupkg
-        do     
-          mv -v "$file" "${file%.nupkg}.zip" 
-        done
-    displayName: Change nupkgs to zips
-    workingDirectory: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
+  #- script: |
+  #    for file in *.nupkg
+  #      do     
+  #        mv -v "$file" "${file%.nupkg}.zip" 
+  #      done
+  #  displayName: Change nupkgs to zips
+  #  workingDirectory: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
     
 
-  #Unzip the nuget packages to make the actual runtimes accessible
-  - task: ExtractFiles@1
-    displayName: Extract android-arm runtime
-    inputs:
-        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm.*.zip
-        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm
-        overwriteExistingFiles: true
-        cleanDestinationFolder: false
-  - task: ExtractFiles@1
-    displayName: Extract android-arm64 runtime
-    inputs:
-        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm64.*.zip
-        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm64
-        overwriteExistingFiles: true
-        cleanDestinationFolder: false
-  - task: ExtractFiles@1
-    displayName: Extract android-x86 runtime
-    inputs:
-        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x86.*.zip
-        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x86
-        overwriteExistingFiles: true
-        cleanDestinationFolder: false
-  - task: ExtractFiles@1
-    displayName: Extract android-x64 runtime
-    inputs:
-        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x64.*.zip
-        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x64
-        overwriteExistingFiles: true
-        cleanDestinationFolder: false
-  - task: ExtractFiles@1
-    displayName: Extract ios-arm runtime
-    inputs:
-        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm.*.zip
-        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm
-        overwriteExistingFiles: true
-        cleanDestinationFolder: false
-  - task: ExtractFiles@1
-    displayName: Extract ios-arm64 runtime
-    inputs:
-        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm64.*.zip
-        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm64
-        overwriteExistingFiles: true
-        cleanDestinationFolder: false
-  - task: ExtractFiles@1
-    displayName: Extract maccatalyst-x64 runtime
-    inputs:
-        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64.*.zip
-        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64
-        overwriteExistingFiles: true
-        cleanDestinationFolder: false
-  - task: ExtractFiles@1
-    displayName: Extract iossimulator-x64 runtime
-    inputs:
-        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64.*.zip
-        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64
-        overwriteExistingFiles: true
-        cleanDestinationFolder: false
+  ##Unzip the nuget packages to make the actual runtimes accessible
+  #- task: ExtractFiles@1
+  #  displayName: Extract android-arm runtime
+  #  inputs:
+  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm.*.zip
+  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm
+  #      overwriteExistingFiles: true
+  #      cleanDestinationFolder: false
+  #- task: ExtractFiles@1
+  #  displayName: Extract android-arm64 runtime
+  #  inputs:
+  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm64.*.zip
+  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm64
+  #      overwriteExistingFiles: true
+  #      cleanDestinationFolder: false
+  #- task: ExtractFiles@1
+  #  displayName: Extract android-x86 runtime
+  #  inputs:
+  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x86.*.zip
+  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x86
+  #      overwriteExistingFiles: true
+  #      cleanDestinationFolder: false
+  #- task: ExtractFiles@1
+  #  displayName: Extract android-x64 runtime
+  #  inputs:
+  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x64.*.zip
+  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x64
+  #      overwriteExistingFiles: true
+  #      cleanDestinationFolder: false
+  #- task: ExtractFiles@1
+  #  displayName: Extract ios-arm runtime
+  #  inputs:
+  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm.*.zip
+  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm
+  #      overwriteExistingFiles: true
+  #      cleanDestinationFolder: false
+  #- task: ExtractFiles@1
+  #  displayName: Extract ios-arm64 runtime
+  #  inputs:
+  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm64.*.zip
+  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm64
+  #      overwriteExistingFiles: true
+  #      cleanDestinationFolder: false
+  #- task: ExtractFiles@1
+  #  displayName: Extract maccatalyst-x64 runtime
+  #  inputs:
+  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64.*.zip
+  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64
+  #      overwriteExistingFiles: true
+  #      cleanDestinationFolder: false
+  #- task: ExtractFiles@1
+  #  displayName: Extract iossimulator-x64 runtime
+  #  inputs:
+  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64.*.zip
+  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64
+  #      overwriteExistingFiles: true
+  #      cleanDestinationFolder: false
 
   - script: |
-      curl -o ./rollback.json 'maui.blob.core.windows.net/metadata/rollbacks/main.json'
-      ./dotnet.sh workload update --from-rollback-file ./rollback.json
-      ./dotnet.sh workload install maui --skip-manifest-update
+      curl -o dotnet-install.sh 'https://dot.net/v1/dotnet-install.sh'
+      ./dotnet-install.sh --channel 6.0.2xx --quality daily --install-dir --verbose
+      dotnet --info
+      dotnet workload install maui --from-rollback-file https://aka.ms/dotnet/maui/main.json --source https://aka.ms/dotnet6/nuget/index.json
     displayName: Install MAUI workload
     workingDirectory: $(Build.SourcesDirectory)
 
   - script: |
-      ./dotnet.sh new maui -n MauiTesting
+      dotnet new maui -n MauiTesting
       cd MauiTesting
       cp $(Build.SourcesDirectory)/src/tests/Common/maui/MauiScenario.props ./Directory.Build.props
       cp $(Build.SourcesDirectory)/src/tests/Common/maui/MauiScenario.targets ./Directory.Build.targets

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -19,95 +19,95 @@ parameters:
 
 
 steps:
-  #- task: DownloadPipelineArtifact@2
-  #  displayName: Download runtime packages
-  #  inputs:
-  #    artifact: 'IntermediateArtifacts'
-  #    path: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
-  #    patterns: |
-  #      IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.android-!(*.symbols).nupkg
-  #      IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.ios-!(*.symbols).nupkg
-  #      IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.iossimulator-!(*.symbols).nupkg
-  #      IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-!(*.symbols).nupkg
+  - task: DownloadPipelineArtifact@2
+    displayName: Download runtime packages
+    inputs:
+      artifact: 'IntermediateArtifacts'
+      path: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
+      patterns: |
+        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.android-!(*.symbols).nupkg
+        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.ios-!(*.symbols).nupkg
+        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.iossimulator-!(*.symbols).nupkg
+        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-!(*.symbols).nupkg
         
-  #    # Other artifacts to include once they are being built
-  #    # EX. IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-*.nupkg
+      # Other artifacts to include once they are being built
+      # EX. IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-*.nupkg
 
-  #- task: CopyFiles@2
-  #  displayName: Flatten packages
-  #  inputs:
-  #    sourceFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
-  #    contents: '*/Shipping/*.nupkg'
-  #    cleanTargetFolder: false
-  #    targetFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
-  #    flattenFolders: true
+  - task: CopyFiles@2
+    displayName: Flatten packages
+    inputs:
+      sourceFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
+      contents: '*/Shipping/*.nupkg'
+      cleanTargetFolder: false
+      targetFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
+      flattenFolders: true
   
-  #- script: |
-  #    for file in *.nupkg
-  #      do     
-  #        mv -v "$file" "${file%.nupkg}.zip" 
-  #      done
-  #  displayName: Change nupkgs to zips
-  #  workingDirectory: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
+  - script: |
+      for file in *.nupkg
+        do     
+          mv -v "$file" "${file%.nupkg}.zip" 
+        done
+    displayName: Change nupkgs to zips
+    workingDirectory: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
     
 
-  ##Unzip the nuget packages to make the actual runtimes accessible
-  #- task: ExtractFiles@1
-  #  displayName: Extract android-arm runtime
-  #  inputs:
-  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm.*.zip
-  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm
-  #      overwriteExistingFiles: true
-  #      cleanDestinationFolder: false
-  #- task: ExtractFiles@1
-  #  displayName: Extract android-arm64 runtime
-  #  inputs:
-  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm64.*.zip
-  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm64
-  #      overwriteExistingFiles: true
-  #      cleanDestinationFolder: false
-  #- task: ExtractFiles@1
-  #  displayName: Extract android-x86 runtime
-  #  inputs:
-  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x86.*.zip
-  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x86
-  #      overwriteExistingFiles: true
-  #      cleanDestinationFolder: false
-  #- task: ExtractFiles@1
-  #  displayName: Extract android-x64 runtime
-  #  inputs:
-  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x64.*.zip
-  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x64
-  #      overwriteExistingFiles: true
-  #      cleanDestinationFolder: false
-  #- task: ExtractFiles@1
-  #  displayName: Extract ios-arm runtime
-  #  inputs:
-  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm.*.zip
-  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm
-  #      overwriteExistingFiles: true
-  #      cleanDestinationFolder: false
-  #- task: ExtractFiles@1
-  #  displayName: Extract ios-arm64 runtime
-  #  inputs:
-  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm64.*.zip
-  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm64
-  #      overwriteExistingFiles: true
-  #      cleanDestinationFolder: false
-  #- task: ExtractFiles@1
-  #  displayName: Extract maccatalyst-x64 runtime
-  #  inputs:
-  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64.*.zip
-  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64
-  #      overwriteExistingFiles: true
-  #      cleanDestinationFolder: false
-  #- task: ExtractFiles@1
-  #  displayName: Extract iossimulator-x64 runtime
-  #  inputs:
-  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64.*.zip
-  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64
-  #      overwriteExistingFiles: true
-  #      cleanDestinationFolder: false
+  #Unzip the nuget packages to make the actual runtimes accessible
+  - task: ExtractFiles@1
+    displayName: Extract android-arm runtime
+    inputs:
+        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm.*.zip
+        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm
+        overwriteExistingFiles: true
+        cleanDestinationFolder: false
+  - task: ExtractFiles@1
+    displayName: Extract android-arm64 runtime
+    inputs:
+        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm64.*.zip
+        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm64
+        overwriteExistingFiles: true
+        cleanDestinationFolder: false
+  - task: ExtractFiles@1
+    displayName: Extract android-x86 runtime
+    inputs:
+        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x86.*.zip
+        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x86
+        overwriteExistingFiles: true
+        cleanDestinationFolder: false
+  - task: ExtractFiles@1
+    displayName: Extract android-x64 runtime
+    inputs:
+        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x64.*.zip
+        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x64
+        overwriteExistingFiles: true
+        cleanDestinationFolder: false
+  - task: ExtractFiles@1
+    displayName: Extract ios-arm runtime
+    inputs:
+        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm.*.zip
+        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm
+        overwriteExistingFiles: true
+        cleanDestinationFolder: false
+  - task: ExtractFiles@1
+    displayName: Extract ios-arm64 runtime
+    inputs:
+        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm64.*.zip
+        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm64
+        overwriteExistingFiles: true
+        cleanDestinationFolder: false
+  - task: ExtractFiles@1
+    displayName: Extract maccatalyst-x64 runtime
+    inputs:
+        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64.*.zip
+        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64
+        overwriteExistingFiles: true
+        cleanDestinationFolder: false
+  - task: ExtractFiles@1
+    displayName: Extract iossimulator-x64 runtime
+    inputs:
+        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64.*.zip
+        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64
+        overwriteExistingFiles: true
+        cleanDestinationFolder: false
 
   - script: |
       curl -o dotnet-install.sh 'https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh'

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -112,12 +112,9 @@ steps:
   - script: |
       curl -o dotnet-install.sh 'https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh'
       chmod -R a+rx .
-      ls -la
-      ./dotnet-install.sh --channel 6.0.2xx --quality daily --install-dir .
-      ls -la
-      dotnet --info
+      ./dotnet-install.sh --channel 6.0.2xx --quality signed --install-dir .
       ./dotnet --info
-      ./dotnet workload install maui --from-rollback-file https://aka.ms/dotnet/maui/main.json --source https://aka.ms/dotnet6/nuget/index.json
+      ./dotnet workload install maui --from-rollback-file https://aka.ms/dotnet/maui/main.json --source https://aka.ms/dotnet6/nuget/index.json --source https://api.nuget.org/v3/index.json
     displayName: Install MAUI workload
     workingDirectory: $(Build.SourcesDirectory)
 
@@ -131,21 +128,21 @@ steps:
 
   - script: |
       chmod -R a+r .
-      ../dotnet.sh publish -bl:MauiAndroid.binlog -f net6.0-android -c Release
+      ../dotnet publish -bl:MauiAndroid.binlog -f net6.0-android -c Release
       mv ./bin/Release/net6.0-android/com.companyname.MauiTesting-Signed.apk ./MauiAndroidDefault.apk
     displayName: Build MAUI Android
     workingDirectory: $(Build.SourcesDirectory)/MauiTesting
 
   - script: |
       chmod -R a+r .
-      ../dotnet.sh publish -bl:MauiiOS.binlog -f net6.0-ios -c Release
+      ../dotnet publish -bl:MauiiOS.binlog -f net6.0-ios -c Release
       mv ./bin/Release/net6.0-ios/iossimulator-x64/MauiTesting.app ./MauiiOSDefault.app
     displayName: Build MAUI iOS
     workingDirectory: $(Build.SourcesDirectory)/MauiTesting
 
   - script: |
       chmod -R a+r .
-      ../dotnet.sh publish -bl:MauiMacCatalyst.binlog -f net6.0-maccatalyst -c Release
+      ../dotnet publish -bl:MauiMacCatalyst.binlog -f net6.0-maccatalyst -c Release
       mv ./bin/Release/net6.0-maccatalyst/maccatalyst-x64/MauiTesting.app ./MauiMacCatalystDefault.app
     displayName: Build MAUI MacCatalyst
     workingDirectory: $(Build.SourcesDirectory)/MauiTesting

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -110,20 +110,13 @@ steps:
   #      cleanDestinationFolder: false
 
   - script: |
-      curl -o dotnet-install.sh 'https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh' -v
+      curl -o dotnet-install.sh 'https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh'
       chmod -R a+rx .
       ls -la
-      ./dotnet-install.sh --channel 6.0.2xx --quality daily --install-dir --verbose
+      ./dotnet-install.sh --channel 6.0.2xx --quality daily --install-dir . --verbose
       dotnet --info
     displayName: Install MAUI workload
     workingDirectory: $(Build.SourcesDirectory)
-  - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk'
-    inputs:
-      packageType: sdk
-      version: 6.0.2xx
-      installationPath: $(Build.SourcesDirectory)/dotnet
-      includePreviewVersions: true
   - script: |
       dotnet workload install maui --from-rollback-file https://aka.ms/dotnet/maui/main.json --source https://aka.ms/dotnet6/nuget/index.json
     displayName: Install MAUI workload

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -19,95 +19,95 @@ parameters:
 
 
 steps:
-  - task: DownloadPipelineArtifact@2
-    displayName: Download runtime packages
-    inputs:
-      artifact: 'IntermediateArtifacts'
-      path: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
-      patterns: |
-        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.android-!(*.symbols).nupkg
-        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.ios-!(*.symbols).nupkg
-        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.iossimulator-!(*.symbols).nupkg
-        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-!(*.symbols).nupkg
+  #- task: DownloadPipelineArtifact@2
+  #  displayName: Download runtime packages
+  #  inputs:
+  #    artifact: 'IntermediateArtifacts'
+  #    path: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
+  #    patterns: |
+  #      IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.android-!(*.symbols).nupkg
+  #      IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.ios-!(*.symbols).nupkg
+  #      IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.iossimulator-!(*.symbols).nupkg
+  #      IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-!(*.symbols).nupkg
         
-      # Other artifacts to include once they are being built
-      # EX. IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-*.nupkg
+  #    # Other artifacts to include once they are being built
+  #    # EX. IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-*.nupkg
 
-  - task: CopyFiles@2
-    displayName: Flatten packages
-    inputs:
-      sourceFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
-      contents: '*/Shipping/*.nupkg'
-      cleanTargetFolder: false
-      targetFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
-      flattenFolders: true
+  #- task: CopyFiles@2
+  #  displayName: Flatten packages
+  #  inputs:
+  #    sourceFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
+  #    contents: '*/Shipping/*.nupkg'
+  #    cleanTargetFolder: false
+  #    targetFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
+  #    flattenFolders: true
   
-  - script: |
-      for file in *.nupkg
-        do     
-          mv -v "$file" "${file%.nupkg}.zip" 
-        done
-    displayName: Change nupkgs to zips
-    workingDirectory: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
+  #- script: |
+  #    for file in *.nupkg
+  #      do     
+  #        mv -v "$file" "${file%.nupkg}.zip" 
+  #      done
+  #  displayName: Change nupkgs to zips
+  #  workingDirectory: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
     
 
-  #Unzip the nuget packages to make the actual runtimes accessible
-  - task: ExtractFiles@1
-    displayName: Extract android-arm runtime
-    inputs:
-        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm.*.zip
-        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm
-        overwriteExistingFiles: true
-        cleanDestinationFolder: false
-  - task: ExtractFiles@1
-    displayName: Extract android-arm64 runtime
-    inputs:
-        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm64.*.zip
-        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm64
-        overwriteExistingFiles: true
-        cleanDestinationFolder: false
-  - task: ExtractFiles@1
-    displayName: Extract android-x86 runtime
-    inputs:
-        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x86.*.zip
-        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x86
-        overwriteExistingFiles: true
-        cleanDestinationFolder: false
-  - task: ExtractFiles@1
-    displayName: Extract android-x64 runtime
-    inputs:
-        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x64.*.zip
-        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x64
-        overwriteExistingFiles: true
-        cleanDestinationFolder: false
-  - task: ExtractFiles@1
-    displayName: Extract ios-arm runtime
-    inputs:
-        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm.*.zip
-        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm
-        overwriteExistingFiles: true
-        cleanDestinationFolder: false
-  - task: ExtractFiles@1
-    displayName: Extract ios-arm64 runtime
-    inputs:
-        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm64.*.zip
-        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm64
-        overwriteExistingFiles: true
-        cleanDestinationFolder: false
-  - task: ExtractFiles@1
-    displayName: Extract maccatalyst-x64 runtime
-    inputs:
-        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64.*.zip
-        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64
-        overwriteExistingFiles: true
-        cleanDestinationFolder: false
-  - task: ExtractFiles@1
-    displayName: Extract iossimulator-x64 runtime
-    inputs:
-        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64.*.zip
-        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64
-        overwriteExistingFiles: true
-        cleanDestinationFolder: false
+  ##Unzip the nuget packages to make the actual runtimes accessible
+  #- task: ExtractFiles@1
+  #  displayName: Extract android-arm runtime
+  #  inputs:
+  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm.*.zip
+  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm
+  #      overwriteExistingFiles: true
+  #      cleanDestinationFolder: false
+  #- task: ExtractFiles@1
+  #  displayName: Extract android-arm64 runtime
+  #  inputs:
+  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm64.*.zip
+  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm64
+  #      overwriteExistingFiles: true
+  #      cleanDestinationFolder: false
+  #- task: ExtractFiles@1
+  #  displayName: Extract android-x86 runtime
+  #  inputs:
+  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x86.*.zip
+  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x86
+  #      overwriteExistingFiles: true
+  #      cleanDestinationFolder: false
+  #- task: ExtractFiles@1
+  #  displayName: Extract android-x64 runtime
+  #  inputs:
+  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x64.*.zip
+  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x64
+  #      overwriteExistingFiles: true
+  #      cleanDestinationFolder: false
+  #- task: ExtractFiles@1
+  #  displayName: Extract ios-arm runtime
+  #  inputs:
+  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm.*.zip
+  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm
+  #      overwriteExistingFiles: true
+  #      cleanDestinationFolder: false
+  #- task: ExtractFiles@1
+  #  displayName: Extract ios-arm64 runtime
+  #  inputs:
+  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm64.*.zip
+  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.ios-arm64
+  #      overwriteExistingFiles: true
+  #      cleanDestinationFolder: false
+  #- task: ExtractFiles@1
+  #  displayName: Extract maccatalyst-x64 runtime
+  #  inputs:
+  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64.*.zip
+  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64
+  #      overwriteExistingFiles: true
+  #      cleanDestinationFolder: false
+  #- task: ExtractFiles@1
+  #  displayName: Extract iossimulator-x64 runtime
+  #  inputs:
+  #      archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64.*.zip
+  #      destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64
+  #      overwriteExistingFiles: true
+  #      cleanDestinationFolder: false
 
   - script: |
       curl -o dotnet-install.sh 'https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh'

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -135,7 +135,7 @@ steps:
 
   - script: |
       chmod -R a+r .
-      ../dotnet publish -bl:MauiiOS.binlog -f net6.0-ios -c Release -r ios-arm64
+      ../dotnet publish -bl:MauiiOS.binlog -f net6.0-ios --runtime ios-arm64 -c Release
       mv ./bin/Release/net6.0-ios/iossimulator-x64/MauiTesting.app ./MauiiOSDefault.app
     displayName: Build MAUI iOS
     workingDirectory: $(Build.SourcesDirectory)/MauiTesting

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -135,7 +135,7 @@ steps:
 
   - script: |
       chmod -R a+r .
-      ../dotnet publish -bl:MauiiOS.binlog -f net6.0-ios -c Release
+      ../dotnet build -bl:MauiiOS.binlog -f net6.0-ios -c Release
       mv ./bin/Release/net6.0-ios/iossimulator-x64/MauiTesting.app ./MauiiOSDefault.app
     displayName: Build MAUI iOS
     workingDirectory: $(Build.SourcesDirectory)/MauiTesting

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -18,7 +18,7 @@ parameters:
   tarCompression: ''
 
 
-steps:
+#steps:
   #- task: DownloadPipelineArtifact@2
   #  displayName: Download runtime packages
   #  inputs:

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -135,7 +135,7 @@ steps:
 
   - script: |
       chmod -R a+r .
-      ../dotnet build -bl:MauiiOS.binlog -f net6.0-ios -c Release -r iossimulator-x64
+      ../dotnet build -bl:MauiiOS.binlog -f net6.0-ios -c Release
       mv ./bin/Release/net6.0-ios/iossimulator-x64/MauiTesting.app ./MauiiOSDefault.app
     displayName: Build MAUI iOS
     workingDirectory: $(Build.SourcesDirectory)/MauiTesting

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -135,7 +135,7 @@ steps:
 
   - script: |
       chmod -R a+r .
-      ../dotnet build -bl:MauiiOS.binlog -f net6.0-ios -c Release
+      ../dotnet build -bl:MauiiOS.binlog -f net6.0-ios -c Release -r iossimulator-x64
       mv ./bin/Release/net6.0-ios/iossimulator-x64/MauiTesting.app ./MauiiOSDefault.app
     displayName: Build MAUI iOS
     workingDirectory: $(Build.SourcesDirectory)/MauiTesting

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -112,7 +112,7 @@ steps:
   - script: |
       curl -o dotnet-install.sh 'https://dot.net/v1/dotnet-install.sh'
       chmod -R a+rx .
-      ls
+      ls -la
       ./dotnet-install.sh --channel 6.0.2xx --quality daily --install-dir --verbose
       dotnet --info
       dotnet workload install maui --from-rollback-file https://aka.ms/dotnet/maui/main.json --source https://aka.ms/dotnet6/nuget/index.json

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -115,6 +115,16 @@ steps:
       ls -la
       ./dotnet-install.sh --channel 6.0.2xx --quality daily --install-dir --verbose
       dotnet --info
+    displayName: Install MAUI workload
+    workingDirectory: $(Build.SourcesDirectory)
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
+    inputs:
+      packageType: sdk
+      version: 6.0.x
+      installationPath: $(Build.SourcesDirectory)/dotnet
+      includePreviewVersions: true
+  - script: |
       dotnet workload install maui --from-rollback-file https://aka.ms/dotnet/maui/main.json --source https://aka.ms/dotnet6/nuget/index.json
     displayName: Install MAUI workload
     workingDirectory: $(Build.SourcesDirectory)

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -135,7 +135,7 @@ steps:
 
   - script: |
       chmod -R a+r .
-      ../dotnet publish -bl:MauiiOS.binlog -f net6.0-ios --runtime ios-arm64 -c Release
+      ../dotnet publish -bl:MauiiOS.binlog -f net6.0-ios -c Release
       mv ./bin/Release/net6.0-ios/iossimulator-x64/MauiTesting.app ./MauiiOSDefault.app
     displayName: Build MAUI iOS
     workingDirectory: $(Build.SourcesDirectory)/MauiTesting

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -110,7 +110,7 @@ steps:
   #      cleanDestinationFolder: false
 
   - script: |
-      curl -o dotnet-install.sh 'https://dot.net/v1/dotnet-install.sh'
+      curl -o dotnet-install.sh 'https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh' -v
       chmod -R a+rx .
       ls -la
       ./dotnet-install.sh --channel 6.0.2xx --quality daily --install-dir --verbose
@@ -121,7 +121,7 @@ steps:
     displayName: 'Use .NET Core sdk'
     inputs:
       packageType: sdk
-      version: 6.0.x
+      version: 6.0.2xx
       installationPath: $(Build.SourcesDirectory)/dotnet
       includePreviewVersions: true
   - script: |

--- a/eng/testing/performance/android_scenarios.proj
+++ b/eng/testing/performance/android_scenarios.proj
@@ -56,7 +56,7 @@
     <HelixWorkItem Include="Startup - Android Maui">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <PreCommands>echo on;set XHARNESSPATH=$(XharnessPath);cd $(ScenarioDirectory)mauiandroid;copy %HELIX_CORRELATION_PAYLOAD%\MauiAndroidDefault.apk .;$(Python) pre.py</PreCommands>
-      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\MauiAndroidDefault.apk --package-name com.companyname.MauiTesting --scenario-name &quot;%(Identity)&quot;</Command>
+      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\MauiAndroidDefault.apk --package-name com.companyname.mauitesting --scenario-name &quot;%(Identity)&quot;</Command>
       <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
   </ItemGroup>

--- a/src/tests/Common/maui/MauiScenario.props
+++ b/src/tests/Common/maui/MauiScenario.props
@@ -7,4 +7,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.*-*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.*-*" />
   </ItemGroup>
+  <PropertyGroup>
+    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-ios'">ios-arm64</RuntimeIdentifier>
+  </PropertyGroup>
 </Project>

--- a/src/tests/Common/maui/MauiScenario.props
+++ b/src/tests/Common/maui/MauiScenario.props
@@ -8,6 +8,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.*-*" />
   </ItemGroup>
   <PropertyGroup>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-ios'">ios-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-ios'">iossimulator-x64</RuntimeIdentifier>
   </PropertyGroup>
 </Project>

--- a/src/tests/Common/maui/MauiScenario.props
+++ b/src/tests/Common/maui/MauiScenario.props
@@ -7,7 +7,4 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.*-*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.*-*" />
   </ItemGroup>
-  <PropertyGroup>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-ios'">iossimulator-x64</RuntimeIdentifier>
-  </PropertyGroup>
 </Project>

--- a/src/tests/Common/maui/MauiScenario.targets
+++ b/src/tests/Common/maui/MauiScenario.targets
@@ -1,9 +1,9 @@
 <Project>
-  <!--<Target Name="PrintRuntimePackLocation" AfterTargets="UpdateTargetingAndRuntimePack">
+  <Target Name="PrintRuntimePackLocation" AfterTargets="UpdateTargetingAndRuntimePack">
     <Message Text="Used runtime pack: %(ResolvedRuntimePack.PackageDirectory)" Importance="high" />
   </Target>
 
-  --><!-- Use local targeting pack for NetCoreAppCurrent. --><!--
+   <!--Use local targeting pack for NetCoreAppCurrent.--> 
   <Target Name="UpdateTargetingAndRuntimePack"
           AfterTargets="ResolveFrameworkReferences">
     <PropertyGroup>
@@ -27,5 +27,5 @@
       <ResolvedRuntimePack PackageDirectory="$(MicrosoftNetCoreAppRuntimePackDir)/Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64"
                              Condition="'%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App' and '%(ResolvedRuntimePack.RuntimeIdentifier)' == 'iossimulator-x64'" />
     </ItemGroup>
-  </Target>-->
+  </Target>
 </Project>

--- a/src/tests/Common/maui/MauiScenario.targets
+++ b/src/tests/Common/maui/MauiScenario.targets
@@ -1,9 +1,9 @@
 <Project>
-  <Target Name="PrintRuntimePackLocation" AfterTargets="UpdateTargetingAndRuntimePack">
+  <!--<Target Name="PrintRuntimePackLocation" AfterTargets="UpdateTargetingAndRuntimePack">
     <Message Text="Used runtime pack: %(ResolvedRuntimePack.PackageDirectory)" Importance="high" />
   </Target>
 
-  <!-- Use local targeting pack for NetCoreAppCurrent. -->
+  --><!-- Use local targeting pack for NetCoreAppCurrent. --><!--
   <Target Name="UpdateTargetingAndRuntimePack"
           AfterTargets="ResolveFrameworkReferences">
     <PropertyGroup>
@@ -27,5 +27,5 @@
       <ResolvedRuntimePack PackageDirectory="$(MicrosoftNetCoreAppRuntimePackDir)/Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64"
                              Condition="'%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App' and '%(ResolvedRuntimePack.RuntimeIdentifier)' == 'iossimulator-x64'" />
     </ItemGroup>
-  </Target>
+  </Target>-->
 </Project>

--- a/src/tests/Common/maui/MauiScenario.targets
+++ b/src/tests/Common/maui/MauiScenario.targets
@@ -18,6 +18,10 @@
                              Condition="'%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App' and '%(ResolvedRuntimePack.RuntimeIdentifier)' == 'android-x86'" />
       <ResolvedRuntimePack PackageDirectory="$(MicrosoftNetCoreAppRuntimePackDir)/Microsoft.NETCore.App.Runtime.Mono.android-x64"
                              Condition="'%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App' and '%(ResolvedRuntimePack.RuntimeIdentifier)' == 'android-x64'" />
+      <ResolvedRuntimePack PackageDirectory="$(MicrosoftNetCoreAppRuntimePackDir)/Microsoft.NETCore.App.Runtime.Mono.ios-arm"
+                             Condition="'%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App' and '%(ResolvedRuntimePack.RuntimeIdentifier)' == 'ios-arm'" />
+      <ResolvedRuntimePack PackageDirectory="$(MicrosoftNetCoreAppRuntimePackDir)/Microsoft.NETCore.App.Runtime.Mono.ios-arm64"
+                             Condition="'%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App' and '%(ResolvedRuntimePack.RuntimeIdentifier)' == 'ios-arm64'" />
       <ResolvedRuntimePack PackageDirectory="$(MicrosoftNetCoreAppRuntimePackDir)/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64"
                              Condition="'%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App' and '%(ResolvedRuntimePack.RuntimeIdentifier)' == 'maccatalyst-x64'" />
       <ResolvedRuntimePack PackageDirectory="$(MicrosoftNetCoreAppRuntimePackDir)/Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64"


### PR DESCRIPTION
Fixes https://github.com/dotnet/performance/issues/2230, where an error with installing the latest Maui workload would occur but not error out the pipeline. This fixes that by installing the latest 6.0.2xx dotnet sdk for installing the workload and building the Maui apps. Includes some minor name fixes and adds ios runtime building.