### PR TITLE
Use ordinal comparison for known header values

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderDescriptor.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderDescriptor.cs
@@ -132,7 +132,7 @@ namespace System.Net.Http.Headers
                 {
                     for (int i = 0; i < knownValues.Length; i++)
                     {
-                        if (ByteArrayHelpers.EqualsOrdinalAsciiIgnoreCase(knownValues[i], headerValue))
+                        if (ByteArrayHelpers.EqualsOrdinalAscii(knownValues[i], headerValue))
                         {
                             return knownValues[i];
                         }
@@ -166,45 +166,45 @@ namespace System.Net.Http.Headers
             switch (contentTypeValue.Length)
             {
                 case 8:
-                    switch (contentTypeValue[7] | 0x20)
+                    switch (contentTypeValue[7])
                     {
-                        case 'l': candidate = "text/xml"; break; // text/xm[l]
-                        case 's': candidate = "text/css"; break; // text/cs[s]
-                        case 'v': candidate = "text/csv"; break; // text/cs[v]
+                        case (byte)'l': candidate = "text/xml"; break; // text/xm[l]
+                        case (byte)'s': candidate = "text/css"; break; // text/cs[s]
+                        case (byte)'v': candidate = "text/csv"; break; // text/cs[v]
                     }
                     break;
 
                 case 9:
-                    switch (contentTypeValue[6] | 0x20)
+                    switch (contentTypeValue[6])
                     {
-                        case 'g': candidate = "image/gif"; break; // image/[g]if
-                        case 'p': candidate = "image/png"; break; // image/[p]ng
-                        case 't': candidate = "text/html"; break; // text/h[t]ml
+                        case (byte)'g': candidate = "image/gif"; break; // image/[g]if
+                        case (byte)'p': candidate = "image/png"; break; // image/[p]ng
+                        case (byte)'t': candidate = "text/html"; break; // text/h[t]ml
                     }
                     break;
 
                 case 10:
-                    switch (contentTypeValue[0] | 0x20)
+                    switch (contentTypeValue[0])
                     {
-                        case 't': candidate = "text/plain"; break; // [t]ext/plain
-                        case 'i': candidate = "image/jpeg"; break; // [i]mage/jpeg
+                        case (byte)'t': candidate = "text/plain"; break; // [t]ext/plain
+                        case (byte)'i': candidate = "image/jpeg"; break; // [i]mage/jpeg
                     }
                     break;
 
                 case 15:
-                    switch (contentTypeValue[12] | 0x20)
+                    switch (contentTypeValue[12])
                     {
-                        case 'p': candidate = "application/pdf"; break; // application/[p]df
-                        case 'x': candidate = "application/xml"; break; // application/[x]ml
-                        case 'z': candidate = "application/zip"; break; // application/[z]ip
+                        case (byte)'p': candidate = "application/pdf"; break; // application/[p]df
+                        case (byte)'x': candidate = "application/xml"; break; // application/[x]ml
+                        case (byte)'z': candidate = "application/zip"; break; // application/[z]ip
                     }
                     break;
 
                 case 16:
-                    switch (contentTypeValue[12] | 0x20)
+                    switch (contentTypeValue[12])
                     {
-                        case 'g': candidate = "application/grpc"; break; // application/[g]rpc
-                        case 'j': candidate = "application/json"; break; // application/[j]son
+                        case (byte)'g': candidate = "application/grpc"; break; // application/[g]rpc
+                        case (byte)'j': candidate = "application/json"; break; // application/[j]son
                     }
                     break;
 
@@ -217,10 +217,10 @@ namespace System.Net.Http.Headers
                     break;
 
                 case 24:
-                    switch (contentTypeValue[0] | 0x20)
+                    switch (contentTypeValue[0])
                     {
-                        case 'a': candidate = "application/octet-stream"; break; // application/octet-stream
-                        case 't': candidate = "text/html; charset=utf-8"; break; // text/html; charset=utf-8
+                        case (byte)'a': candidate = "application/octet-stream"; break; // application/octet-stream
+                        case (byte)'t': candidate = "text/html; charset=utf-8"; break; // text/html; charset=utf-8
                     }
                     break;
 
@@ -239,7 +239,7 @@ namespace System.Net.Http.Headers
 
             Debug.Assert(candidate is null || candidate.Length == contentTypeValue.Length);
 
-            return candidate != null && ByteArrayHelpers.EqualsOrdinalAsciiIgnoreCase(candidate, contentTypeValue) ?
+            return candidate != null && ByteArrayHelpers.EqualsOrdinalAscii(candidate, contentTypeValue) ?
                 candidate :
                 null;
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderDescriptor.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderDescriptor.cs
@@ -217,10 +217,11 @@ namespace System.Net.Http.Headers
                     break;
 
                 case 24:
-                    switch (contentTypeValue[0])
+                    switch (contentTypeValue[19])
                     {
-                        case (byte)'a': candidate = "application/octet-stream"; break; // application/octet-stream
-                        case (byte)'t': candidate = "text/html; charset=utf-8"; break; // text/html; charset=utf-8
+                        case (byte)'t': candidate = "application/octet-stream"; break; // application/octet-s[t]ream
+                        case (byte)'u': candidate = "text/html; charset=utf-8"; break; // text/html; charset=[u]tf-8
+                        case (byte)'U': candidate = "text/html; charset=UTF-8"; break; // text/html; charset=[U]TF-8
                     }
                     break;
 

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/KnownHeadersTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/KnownHeadersTest.cs
@@ -177,6 +177,7 @@ namespace System.Net.Http.Tests
         [InlineData("Content-Type", "application/javascript")]
         [InlineData("Content-Type", "application/octet-stream")]
         [InlineData("Content-Type", "text/html; charset=utf-8")]
+        [InlineData("Content-Type", "text/html; charset=UTF-8")]
         [InlineData("Content-Type", "text/plain; charset=utf-8")]
         [InlineData("Content-Type", "application/json; charset=utf-8")]
         [InlineData("Content-Type", "application/x-www-form-urlencoded")]

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/KnownHeadersTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/KnownHeadersTest.cs
@@ -213,27 +213,46 @@ namespace System.Net.Http.Tests
         [InlineData("X-XSS-Protection", "1; mode=block")]
         public void GetKnownHeaderValue_Known_Found(string name, string value)
         {
-            foreach (string casedValue in new[] { value, value.ToUpperInvariant(), value.ToLowerInvariant() })
+            KnownHeader knownHeader = KnownHeaders.TryGetKnownHeader(name);
+            Assert.NotNull(knownHeader);
+
+            string v1 = knownHeader.Descriptor.GetHeaderValue(value.Select(c => (byte)c).ToArray(), valueEncoding: null);
+            Assert.NotNull(v1);
+            Assert.Equal(value, v1);
+
+            string v2 = knownHeader.Descriptor.GetHeaderValue(value.Select(c => (byte)c).ToArray(), valueEncoding: null);
+            Assert.Same(v1, v2);
+
+            if (TryChangeCasing(value, out string newValue)) // Doesn't make sense for values that are just numbers
             {
-                Validate(KnownHeaders.TryGetKnownHeader(name), casedValue);
+                GetKnownHeaderValue_Unknown_NotFound(name, newValue);
             }
 
-            static void Validate(KnownHeader knownHeader, string value)
+            static bool TryChangeCasing(string value, out string newValue)
             {
-                Assert.NotNull(knownHeader);
+                string upper = value.ToUpperInvariant();
+                if (upper != value)
+                {
+                    newValue = upper;
+                    return true;
+                }
 
-                string v1 = knownHeader.Descriptor.GetHeaderValue(value.Select(c => (byte)c).ToArray(), valueEncoding: null);
-                Assert.NotNull(v1);
-                Assert.Equal(value, v1, StringComparer.OrdinalIgnoreCase);
+                string lower = value.ToLowerInvariant();
+                if (lower != value)
+                {
+                    newValue = lower;
+                    return true;
+                }
 
-                string v2 = knownHeader.Descriptor.GetHeaderValue(value.Select(c => (byte)c).ToArray(), valueEncoding: null);
-                Assert.Same(v1, v2);
+                newValue = null;
+                return false;
             }
         }
 
         [Theory]
         [InlineData("Content-Type", "application/jsot")]
         [InlineData("Content-Type", "application/jsons")]
+        [InlineData("Transfer-Encoding", "foo")]
         public void GetKnownHeaderValue_Unknown_NotFound(string name, string value)
         {
             KnownHeader knownHeader = KnownHeaders.TryGetKnownHeader(name);


### PR DESCRIPTION
Fixes #64053

I ran [this code](https://gist.github.com/MihaZupan/26261d4b709d1a4a3966ae7a8cf3b679) with this patch, and these are the headers from ~14k sites that responded
(only showing those that repeated at least 20 times):

<details>
<summary>List</summary>

```
2946 Accept-Ranges: bytes
 184 Accept-Ranges: none
 140 Access-Control-Allow-Credentials: true
  33 Access-Control-Allow-Headers: Content-Type
  27 Access-Control-Allow-Headers: *
 643 Access-Control-Allow-Origin: *
  32 Access-Control-Expose-Headers: Request-Context
  25 Access-Control-Max-Age: 86400
 432 Age: 0
  23 Age: 1
  30 Allow: GET,HEAD
1137 Alt-Svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
 156 Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
  55 Alt-Svc: clear
  45 Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
 637 Cache-Control: private
 456 Cache-Control: no-store, no-cache, must-revalidate
 401 Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
 382 Cache-Control: no-cache
 274 Cache-Control: max-age=0, private, must-revalidate
 203 Cache-Control: max-age=600, must-revalidate
 172 Cache-Control: max-age=0
 172 Cache-Control: private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
 145 Cache-Control: no-cache, no-store, must-revalidate
 144 Cache-Control: no-cache, must-revalidate
 130 Cache-Control: private, max-age=0
 110 Cache-Control: max-age=0, no-cache, no-store
 108 Cache-Control: max-age=3600
 107 Cache-Control: max-age=600
  96 Cache-Control: max-age=300
  90 Cache-Control: no-cache, no-store
  87 Cache-Control: no-cache, private
  76 Cache-Control: no-store, no-cache
  70 Cache-Control: max-age=3600, public
  66 Cache-Control: max-age=3, must-revalidate
  64 Cache-Control: max-age=300, must-revalidate
  63 Cache-Control: no-store
  60 Cache-Control: public, max-age=0, must-revalidate
  58 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
  57 Cache-Control: no-cache, must-revalidate, max-age=0
  55 Cache-Control: max-age=0, no-cache, no-store, must-revalidate
  55 Cache-Control: no-cache, no-store, must-revalidate, post-check=0, pre-check=0
  48 Cache-Control: max-age=60
  47 Cache-Control: max-age=0, no-cache
  47 Cache-Control: max-age=86400
  46 Cache-Control: public, max-age=0
  46 Cache-Control: max-age=30
  43 Cache-Control: max-age=0, public
  42 Cache-Control: public
  40 Cache-Control: private, no-store
  38 Cache-Control: public, max-age=300
  36 Cache-Control: max-age=0, must-revalidate, private
  35 Cache-Control: public, max-age=5
  35 Cache-Control: private, must-revalidate
  35 Cache-Control: max-age=31536000
  33 Cache-Control: private, max-age=60
  33 Cache-Control: s-maxage=14400, max-age=0
  33 Cache-Control: max-age=2592000
  33 Cache-Control: public, max-age=600
  32 Cache-Control: max-age=1800
  29 Cache-Control: max-age=0, no-store, private, no-transform
  28 Cache-Control: public, max-age=3600
  28 Cache-Control: public, max-age=86400
  27 Cache-Control: private, no-cache, no-store, must-revalidate
  27 Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate
  26 Cache-Control: private, no-cache, max-age=0
  25 Cache-Control: public, max-age=14400
  23 Cache-Control: max-age=14400
  22 Cache-Control: max-age=86400, public
  21 Cache-Control: must-revalidate, no-cache, private
  21 Cache-Control: max-age=0, no-cache, s-maxage=10
  20 Cache-Control: private, max-age=0, no-cache, no-store, must-revalidate
1539 CF-Cache-Status: DYNAMIC
 153 CF-Cache-Status: HIT
  40 CF-Cache-Status: MISS
  29 CF-Cache-Status: EXPIRED
  88 CF-Chl-Bypass: 1
  52 cf-edge-cache: cache,platform=wordpress
7778 Connection: keep-alive
1167 Connection: close
 639 Connection: Upgrade
 478 Connection: keep-alive, Transfer-Encoding
 331 Connection: Keep-Alive
  52 Connection: Upgrade, close
 105 Content-Encoding: gzip
 332 Content-Language: en
  79 Content-Language: en-US
  33 Content-Language: de
  21 Content-Language: fr
 568 Content-Length: 0
 220 Content-Length: 275
 181 Content-Length: 118
  98 Content-Length: 10
  90 Content-Length: 146
  83 Content-Length: 77564
  70 Content-Length: 162
  70 Content-Length: 315
  62 Content-Length: 178
  49 Content-Length: 16
  43 Content-Length: 17
  35 Content-Length: 318
  32 Content-Length: 167
  29 Content-Length: 163
  28 Content-Length: 919
  25 Content-Length: 44
  24 Content-Length: 8915
  22 Content-Length: 202
  21 Content-Length: 199
  20 Content-Length: 234
  20 Content-Length: 232
 210 Content-Security-Policy: upgrade-insecure-requests
 108 Content-Security-Policy: frame-ancestors 'self'
  93 Content-Security-Policy: upgrade-insecure-requests;
  54 Content-Security-Policy: frame-ancestors 'self';
  35 Content-Security-Policy: frame-ancestors about: 'self'
  23 Content-Security-Policy: base-uri 'self' https://hcaptcha.com https://*.hcaptcha.com; child-src https://*.craigslist.org; connect-src https://*.craigslist.org https://hcaptcha.com https://*.hcaptcha.com; font-src data:; form-action https://*.craigslist.org; frame-ancestors 'self'; frame-src https://*.craigslist.org https://hcaptcha.com https://*.hcaptcha.com; media-src data:; object-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' https://*.craigslist.org https://hcaptcha.com https://*.hcaptcha.com; style-src 'unsafe-inline' https://*.craigslist.org https://hcaptcha.com https://*.hcaptcha.com
5284 Content-Type: text/html; charset=UTF-8
3689 Content-Type: text/html
2912 Content-Type: text/html; charset=utf-8
 527 Content-Type: text/html; charset=iso-8859-1
 370 Content-Type: text/html;charset=UTF-8
 214 Content-Type: text/html;charset=utf-8
 136 Content-Type: text/html; charset=ISO-8859-1
 113 Content-Type: text/plain; charset=utf-8
  67 Content-Type: text/html; charset=us-ascii
  51 Content-Type: text/plain; charset=UTF-8
  33 Content-Type: text/html; charset=windows-1251
  28 Content-Type: text/html; charset="utf-8"
  24 Content-Type: text/html;charset=ISO-8859-1
  22 Cross-Origin-Resource-Policy: cross-origin
  48 ETag: "61f94ab8-113"
  23 ETag: "5e52d3ca-22d3"
  20 ETag: "61f94af2-113"
2029 Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
  45 Expect-CT: max-age=31536000, report-uri="http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only"
  25 Expect-CT: max-age=0
 849 Expires: Thu, 19 Nov 1981 08:52:00 GMT
 293 Expires: -1
 243 Expires: Thu, 01 Jan 1970 00:00:01 GMT
 174 Expires: Sun, 19 Nov 1978 05:00:00 GMT
 103 Expires: 0
  85 Expires: Thu, 01 Jan 1970 00:00:00 UTC
  84 Expires: Mon, 26 Jul 1997 05:00:00 GMT
  71 Expires: Wed, 17 Aug 2005 00:00:00 GMT
  68 Expires: Wed, 11 Jan 1984 05:00:00 GMT
  59 Expires: Thu, 01 Jan 1970 00:00:00 GMT
  36 Expires: Mon, 29 Oct 1923 20:30:00 GMT
  22 Expires: Sat, 01 Jan 2000 00:00:00 GMT
  20 Expires: Mon, 01 Jan 1990 00:00:00 GMT
  40 Fastly-Restarts: 1
  87 Host-Header: a9130478a60e5f9135f765b23f26593b
  58 Host-Header: c2hhcmVkLmJsdWVob3N0LmNvbQ==
  47 Host-Header: 8441280b0c35cbc1147f8ba998a563a7
  37 Host-Header: 6b7412fb82ca5edfd0917e3957f05d89
  30 Host-Header: WordPress.com
 216 Keep-Alive: timeout=5, max=100
 209 Keep-Alive: timeout=20
 102 Keep-Alive: timeout=15
  48 Keep-Alive: timeout=60
  33 Keep-Alive: timeout=30
  27 Keep-Alive: timeout=10
  20 Keep-Alive: timeout=5
  42 ki-edge: v=16.8
  29 Link: https://s3-media0.fl.yelpcdn.com; rel=preconnect, https://www.google-analytics.com; rel=preconnect
 122 Mime-Version: 1.0
1243 NEL: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
  37 NEL: {"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}
  97 P3P: CP="This is not a P3P policy! See g.co/p3phelp for more info."
  55 P3P: CP="NOI ADM DEV PSAi COM NAV OUR OTRo STP IND DEM"
  39 P3P: CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
  35 P3P: CP="CAO PSA OUR"
  33 P3P: policyref="/bitrix/p3p.xml", CP="NON DSP COR CUR ADM DEV PSA PSD OUR UNR BUS UNI COM NAV INT DEM STA"
 281 permissions-policy: interest-cohort=()
 114 permissions-policy: accelerometer=(),autoplay=(),camera=(),clipboard-read=(),clipboard-write=(),fullscreen=(),geolocation=(),gyroscope=(),hid=(),interest-cohort=(),magnetometer=(),microphone=(),payment=(),publickey-credentials-get=(),screen-wake-lock=(),serial=(),sync-xhr=(),usb=()
2054 Pragma: no-cache
  76 Pragma: public
 462 Referrer-Policy: no-referrer-when-downgrade
 328 Referrer-Policy: strict-origin-when-cross-origin
 126 Referrer-Policy: same-origin
  90 Referrer-Policy: origin-when-cross-origin
  53 Referrer-Policy: unsafe-url
  47 Referrer-Policy: no-referrer
  23 Referrer-Policy: strict-origin
  21 Referrer-Policy:
  90 Retry-After: 0
2530 Server: nginx
2204 Server: Apache
2053 Server: cloudflare
 651 Server: openresty
 267 Server: LiteSpeed
 221 Server: Microsoft-IIS/10.0
 191 Server: awselb/2.0
 164 Server: Microsoft-IIS/8.5
 160 Server: AmazonS3
 135 Server: Cowboy
 129 Server: Apache/2.4.25 (Debian)
 121 Server: Apache/2
 118 Server: AkamaiGHost
  99 Server: Varnish
  95 Server: gws
  87 Server: Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips mod_fcgid/2.3.9
  86 Server: Microsoft-HTTPAPI/2.0
  83 Server: Microsoft-IIS/7.5
  82 Server: envoy
  82 Server: Squarespace
  77 Server: nginx/1.20.1
  63 Server: nginx/1.16.1
  63 Server: nginx/1.18.0
  63 Server: Apache/2.4.29 (Ubuntu)
  59 Server: nginx/1.19.10
  57 Server: Tengine
  53 Server: nginx/1.14.0 (Ubuntu)
  52 Server: CloudFront
  50 Server: ATS
  48 Server: Sucuri/Cloudproxy
  47 Server: nginx/1.18.0 (Ubuntu)
  44 Server: NginX
  41 Server: Apache/2.4.41 (Ubuntu)
  40 Server: Apache/2.4.18 (Ubuntu)
  37 Server: Apache/2.2.15 (CentOS)
  36 Server: nginx/1.14.2
  36 Server: Apache/2.4.38 (Debian)
  35 Server:
  34 Server: Server
  33 Server: nginx/1.20.2
  33 Server: Netlify
  31 Server: nginx/1.10.3 (Ubuntu)
  30 Server: openresty/1.13.6.1
  30 Server: nginx/1.10.3
  28 Server: nginx/1.12.2
  27 Server: Apache-Coyote/1.1
  26 Server: Apache/2.4.52 (Unix)
  25 Server: Apache/2.4.6 (CentOS)
  24 Server: MerlinCDN
  24 Server: Nginx Microsoft-HTTPAPI/2.0
  22 Server: DPS/1.13.2
  21 Server: openresty/1.19.9.1
  20 Server: AkamaiNetStorage
  85 Server-Timing: cdn-cache; desc=HIT, edge; dur=1
  38 service-worker-allowed: /
  69 status: 200 OK
 635 Strict-Transport-Security: max-age=31536000
 290 Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
 269 Strict-Transport-Security: max-age=31536000; includeSubDomains
 140 Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 124 Strict-Transport-Security: max-age=15768000
 100 Strict-Transport-Security: max-age=63072000
  97 Strict-Transport-Security: max-age=300
  66 Strict-Transport-Security: max-age=15552000; includeSubDomains
  62 Strict-Transport-Security: max-age=15552000
  58 Strict-Transport-Security: max-age=15724800; includeSubDomains
  55 Strict-Transport-Security: max-age=86400
  55 Strict-Transport-Security: max-age=63072000; includeSubDomains
  49 Strict-Transport-Security: max-age=31536000;
  42 Strict-Transport-Security: max-age=0
  42 Strict-Transport-Security: max-age=31536000; preload
  38 Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
  37 Strict-Transport-Security: max-age=15552000; includeSubDomains; preload
  36 Strict-Transport-Security: max-age=31557600
  35 Strict-Transport-Security: max-age=63072000; includeSubdomains; preload
  35 Strict-Transport-Security: max-age=2592000; includeSubDomains;
  32 Strict-Transport-Security: max-age=15552000; preload
  32 Strict-Transport-Security: max-age=31536000 ; includeSubDomains
  30 Strict-Transport-Security: max-age=2592000
  26 Strict-Transport-Security: max-age=63072000; preload
  26 Strict-Transport-Security: max-age=15768000; includeSubDomains
  20 Strict-Transport-Security: max-age=604800
  57 Timing-Allow-Origin: *
6919 Transfer-Encoding: chunked
 531 Upgrade: h2,h2c
 185 Upgrade: h2
4340 Vary: Accept-Encoding
 379 Vary: Accept-Encoding,User-Agent
 295 Vary: Accept-Encoding, Accept-Encoding
 200 Vary: Accept-Encoding, Accept-Encoding, Accept-Encoding,Cookie
 163 Vary: User-Agent
  90 Vary: Accept-Encoding, User-Agent
  77 Vary: Accept-Encoding,Cookie
  74 Vary: Accept-Encoding, Cookie
  72 Vary: Cookie,Accept-Encoding
  53 Vary: accept-encoding
  47 Vary: Cookie
  43 Vary: Accept-Encoding, Accept-Encoding,User-Agent
  35 Vary: Accept-Encoding,X-NFL-Geo,Origin
  32 Vary: User-Agent,Accept-Encoding
  28 Vary: Accept-Encoding, Cookie, Cookie
  27 Vary: Accept-Encoding, Accept-Encoding, Accept-Encoding
  26 Vary: Origin
  26 Vary: Accept-Encoding, Accept-Encoding,Cookie
  26 Vary: Accept-Encoding,Cookie,User-Agent
  25 Vary: *
  21 Vary: Accept-Encoding, Origin
  21 Vary: Host
 352 Via: 1.1 google
 259 Via: 1.1 varnish
 223 Via: 1.1 varnish, 1.1 varnish
  38 Via: 1.1 varnish-v4
  31 Via: varnish
  29 Via: 1.1 varnish, 1.1 varnish, 1.1 varnish
  24 Via: HTTP/1.1 Merlin CDN
  23 Via: 1.1 vegur
  20 Via: 1.1 varnish (Varnish/6.0)
  21 X-ac: 2.hhn _dfw
  42 X-AH-Environment: prod
  30 X-Akam-SW-Version: 0.5.0
  40 X-Akamai-Transformed: 9 - 0 pmb=mRUM,2
  21 X-Akamai-Transformed: 9 - 0 pmb=mRUM,1
 613 X-Amz-Cf-Pop: PRG50-C1
  25 x-amz-server-side-encryption: AES256
  35 x-app-info: captcha-pwa,386c2e778219a6d1ca2afdf7fcb169d070dba013
 235 X-AspNet-Version: 4.0.30319
  20 X-AspNet-Version: 2.0.50727
  86 X-AspNetMvc-Version: 5.2
  29 x-b3-sampled: 0
  24 x-backend: local
 350 X-Cache: Miss from cloudfront
 334 X-Cache: HIT
 217 X-Cache: Hit from cloudfront
 180 X-Cache: MISS
  94 X-Cache: HIT, HIT
  82 X-Cache: MISS, MISS
  66 X-Cache: HIT, MISS
  60 X-Cache: Error from cloudfront
  41 X-Cache: RefreshHit from cloudfront
  41 X-Cache: hit
  35 X-Cache: miss
  29 X-Cache: MISS, HIT
  23 X-Cache: HIT: 1
  23 X-Cache: cached
  21 X-Cache: HIT: 2
  40 X-Cache-Enabled: True
 230 X-Cache-Group: normal
 205 X-Cache-Hits: 0
  85 X-Cache-Hits: 0, 0
  80 X-Cache-Hits: 1
  73 X-Cache-Hits: 1, 1
  57 X-Cache-Hits: 1, 0
  21 X-Cache-Hits: 0, 1
  45 x-cache-status: MISS
  39 x-cache-status: HIT
 210 X-Cacheable: SHORT
  73 X-Cacheable: YES
  26 X-Cacheable: YES:Forced
  59 X-CDN: Imperva
  29 x-cloudmap: routing_useast1
  38 X-Cluster-Name: eu-west-1-prod-eks-15
2837 X-Content-Type-Options: nosniff
 103 X-Content-Type-Options: nosniff, nosniff
  54 X-Dc: gcp-europe-west1
  93 X-DNS-Prefetch-Control: off
  43 X-DNS-Prefetch-Control: on
 337 X-Download-Options: noopen
 100 X-Drupal-Cache: HIT
  45 X-Drupal-Cache: MISS
  57 X-Drupal-Dynamic-Cache: MISS
  32 X-Drupal-Dynamic-Cache: UNCACHEABLE
  42 X-Edge-Location-Klb: 1
  35 X-EdgeConnect-Cache-Status: 0
  36 X-Endurance-Cache-Level: 2
2510 X-Frame-Options: SAMEORIGIN
 386 X-Frame-Options: DENY
 232 X-Frame-Options: sameorigin
  75 X-Frame-Options: SAMEORIGIN, SAMEORIGIN
  49 X-Frame-Options: deny
  21 X-FW-Dynamic: TRUE
  36 X-FW-Serve: TRUE
  36 X-FW-Static: NO
  35 X-FW-Type: FLYWHEEL_BOT
  22 X-FW-Version: 5.0.0
  71 X-Generator: Drupal 9 (https://www.drupal.org)
  42 X-Generator: Drupal 7 (http://drupal.org)
  36 X-Generator: Drupal 8 (https://www.drupal.org)
  78 X-hacker: If you're reading this, you should visit wpvip.com/careers and apply to join the fun, mention this header.
  30 X-hacker: If you're reading this, you should visit automattic.com/jobs and apply to join the fun, mention this header.
  25 X-HS-Cache-Config: BrowserCache-5s-EdgeCache-180s
  25 X-HS-CF-Cache-Status: HIT
  33 X-HS-Combine-CSS: Disabled
  64 X-Httpd: 1
  39 X-Kinsta-Cache: HIT
  78 x-litespeed-cache: hit
  45 X-Mod-Pagespeed: 1.13.35.2-0
  29 x-mode: ro
  35 X-NFL-Dma: -1
  35 X-NFL-Geo: country_code=CZ
  36 x-oneagent-js-injection: true
  35 x-page-id: arkose-challenge-forced
 240 X-Permitted-Cross-Domain-Policies: none
  23 X-Permitted-Cross-Domain-Policies: master-only
 653 X-Powered-By: ASP.NET
 233 X-Powered-By: WP Engine
 169 X-Powered-By: Express
 120 X-Powered-By: PHP/5.6.40
 114 X-Powered-By: PHP/7.4.27
 108 X-Powered-By: PHP/5.4.16
  80 X-Powered-By: PleskLin
  73 X-Powered-By: WordPress VIP <https://wpvip.com>
  70 X-Powered-By: Next.js
  59 X-Powered-By: PHP/7.2.34
  48 X-Powered-By: PHP/7.3.33
  45 X-Powered-By: PHP/7.4.27, PleskLin
  41 X-Powered-By: PHP/7.4.26
  34 X-Powered-By: HubSpot
  34 X-Powered-By: PHP/7.4.25
  28 X-Powered-By: PHP/5.3.3
  25 X-Powered-By: PHP/7.0.33
  24 X-Powered-By: Nginx
  23 X-Powered-By: PHP/7.1.33
  22 X-Powered-By: PHP/5.3.29
  21 X-Powered-By: Element
  38 X-Powered-By-Plesk: PleskWin
  75 x-proxy-cache: HIT
  70 x-proxy-cache: MISS
  33 x-proxy-cache: EXPIRED
  37 x-robots-tag: all
  22 x-robots-tag: noarchive
  28 X-rq: hhn2 0 2 9980
  23 X-rq: hhn1 0 4 9980
  20 X-rq: hhn2 0 4 9980
  24 X-ruxit-JS-Agent: true
  49 X-Server-Cache: true
  20 X-Sucuri-Cache: HIT
  42 X-TEC-API-VERSION: v1
  84 x-turbo-charged-by: LiteSpeed
 321 X-UA-Compatible: IE=edge
  81 X-UA-Compatible: IE=edge,chrome=1
  59 X-UA-Compatible: IE=Edge,chrome=1
  50 X-UA-Compatible: IE=Edge
  41 X-UA-Device: desktop
  29 X-Vhost: publish
1899 X-XSS-Protection: 1; mode=block
 210 X-XSS-Protection: 0
 177 X-XSS-Protection: 1
  30 X-XSS-Protection: 1;mode=block
  29 X-XSS-Protection: 1; report=https://www.yelp.com/xss_protection_report
  25 X-XSS-Protection: 1; mode=block, 1; mode=block
```

</details>

After making `Content-Type` matching case-sensitive, I added back `text/html; charset=UTF-8` as the only common case that we would previously match (e8f4850d8940c508d1001bf0a949cca1c8bb12ad).

This change can theoretically break someone if they were checking for a given value without `IgnoreCase`, the server responded in a different casing and we no longer normalized it to a lowercase representation.