### PR TITLE
Clean up remaining tests under JIT/Methodical using Environment.Exit

### DIFF
--- a/src/tests/JIT/Methodical/ldtoken/types.il
+++ b/src/tests/JIT/Methodical/ldtoken/types.il
@@ -13,6 +13,8 @@
   .class private auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
+    .field private static int32 s_exitCode;
+
     .method private hidebysig static void
             test_token(object boxed_vt,
                        valuetype [mscorlib]System.RuntimeTypeHandle vt) cil managed
@@ -33,7 +35,7 @@
       call       string [mscorlib]System.String::Concat(string, string)
       call       void [System.Console]System.Console::WriteLine(string)
       ldc.i4.s   101
-      call       void [System.Runtime.Extensions]System.Environment::Exit(int32)
+      stsfld     int32 JitTest.Test::s_exitCode
       IL_EXIT:
       ret
     }
@@ -45,6 +47,8 @@
       )
       .entrypoint
       .maxstack  8
+      ldc.i4     100
+      stsfld     int32 JitTest.Test::s_exitCode
       ldc.i4.1
       box        [mscorlib]System.Byte
       ldtoken    [mscorlib]System.Byte
@@ -195,7 +199,7 @@
 
       ldstr      "Passed"
       call       void [System.Console]System.Console::WriteLine(string)
-      ldc.i4.s   100
+      ldsfld     int32 JitTest.Test::s_exitCode
       ret
     }
     .method public hidebysig specialname rtspecialname

--- a/src/tests/JIT/Methodical/switch/switch1.il
+++ b/src/tests/JIT/Methodical/switch/switch1.il
@@ -17,6 +17,8 @@
 .class public auto ansi Test_switch1
        extends ['mscorlib']System.Object
 {
+  .field private static int32 s_exitCode;
+
   .method private hidebysig static void  DoSwitch(int32 'value') il managed
   {
     .maxstack  2
@@ -32,7 +34,7 @@
     IL_0012:  br.s       IL_0033
 
     IL_0014:  ldc.i4.s   100
-    IL_0016:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_0016:  stsfld     int32 Test_switch1::s_exitCode
     IL_001b:  ldstr      "Test passed"
     IL_0020:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0025:  br.s       IL_003f
@@ -48,7 +50,7 @@
     IL_003f:  ret
   }
 
-  .method public hidebysig static void Main() il managed
+  .method public hidebysig static int32 Main() il managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
@@ -57,8 +59,7 @@
     .maxstack  8
     IL_0000:  ldc.i4.1
     IL_0001:  call       void Test_switch1::DoSwitch(int32)
-    IL_0006:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
-              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
+    IL_0006:  ldsfld     int32 Test_switch1::s_exitCode
               ret
   }
 

--- a/src/tests/JIT/Methodical/switch/switch10.il
+++ b/src/tests/JIT/Methodical/switch/switch10.il
@@ -17,6 +17,8 @@
 .class public auto ansi Test_switch10
        extends ['mscorlib']System.Object
 {
+  .field private static int32 s_exitCode;
+
   .method private hidebysig static int32
           Square(int32 i) il managed
   {
@@ -59,19 +61,19 @@
     IL_0018:  bne.un.s   IL_002d
 
     IL_001a:  ldc.i4.s   100
-    IL_001c:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_001c:  stsfld     int32 Test_switch10::s_exitCode
     IL_0021:  ldstr      "Test passed"
     IL_0026:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_002b:  br.s       IL_003d
 
     IL_002d:  ldc.i4.1
-    IL_002e:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_002e:  stsfld     int32 Test_switch10::s_exitCode
     IL_0033:  ldstr      "Test failed"
     IL_0038:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_003d:  ret
   }
 
-  .method public hidebysig static void Main() il managed
+  .method public hidebysig static int32 Main() il managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
@@ -80,8 +82,7 @@
     .maxstack  8
     IL_0000:  ldc.i4.1
     IL_0001:  call       void Test_switch10::DoSwitch(int32)
-    IL_0006:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
-              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
+    IL_0006:  ldsfld     int32 Test_switch10::s_exitCode
               ret
   }
 

--- a/src/tests/JIT/Methodical/switch/switch11.il
+++ b/src/tests/JIT/Methodical/switch/switch11.il
@@ -17,7 +17,9 @@
 .class public auto ansi Test_switch11
        extends ['mscorlib']System.Object
 {
-  .method public hidebysig static void Main() il managed
+  .field private static int32 s_exitCode;
+
+  .method public hidebysig static int32 Main() il managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
@@ -30,12 +32,11 @@
     IL_0002:  br.s       IL_0004
 
     IL_0004:  ldc.i4.s   100
-    IL_0006:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_0006:  stsfld     int32 Test_switch11::s_exitCode
     IL_000b:  ldstr      "Test passed"
     IL_0010:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0015:  pop
-              call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
-              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
+              ldsfld     int32 Test_switch11::s_exitCode
               ret
   }
 

--- a/src/tests/JIT/Methodical/switch/switch2.il
+++ b/src/tests/JIT/Methodical/switch/switch2.il
@@ -16,6 +16,8 @@
 .class public auto ansi Test_switch2
        extends ['mscorlib']System.Object
 {
+  .field private static int32 s_exitCode;
+
   .method private hidebysig static void  DoSwitch(int32 'value') il managed
   {
     .maxstack  2
@@ -46,7 +48,7 @@
     IL_001e:  bne.un.s   IL_0031
 
     IL_0020:  ldc.i4.s   100
-    IL_0022:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_0022:  stsfld     int32 Test_switch2::s_exitCode
     IL_0027:  ldstr      "Test passed"
     IL_002c:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0031:  br.s       IL_005f
@@ -60,13 +62,13 @@
     IL_0039:  bne.un.s   IL_004b
 
     IL_003b:  ldc.i4.1
-    IL_003c:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_003c:  stsfld     int32 Test_switch2::s_exitCode
     IL_0041:  ldstr      "Test failed"
     IL_0046:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_004b:  br.s       IL_005f
 
     IL_004d:  ldc.i4.1
-    IL_004e:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_004e:  stsfld     int32 Test_switch2::s_exitCode
     IL_0053:  ldstr      "Test failed"
     IL_0058:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_005d:  br.s       IL_005f
@@ -74,7 +76,7 @@
     IL_005f:  ret
   }
 
-  .method public hidebysig static void Main() il managed
+  .method public hidebysig static int32 Main() il managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
@@ -83,8 +85,7 @@
     .maxstack  8
     IL_0000:  ldc.i4.1
     IL_0001:  call       void Test_switch2::DoSwitch(int32)
-    IL_0006:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
-              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
+              ldsfld     int32 Test_switch2::s_exitCode
               ret
   }
 

--- a/src/tests/JIT/Methodical/switch/switch3.il
+++ b/src/tests/JIT/Methodical/switch/switch3.il
@@ -17,6 +17,8 @@
 .class public auto ansi Test_switch3
        extends ['mscorlib']System.Object
 {
+  .field private static int32 s_exitCode;
+
   .method private hidebysig static void  DoSwitch(int32 'value') il managed
   {
     .maxstack  2
@@ -34,13 +36,13 @@
     IL_0014:  br.s       IL_0016
 
     IL_0016:  ldc.i4.s   100
-    IL_0018:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_0018:  stsfld     int32 Test_switch3::s_exitCode
     IL_001d:  ldstr      "Test passed"
     IL_0022:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0027:  br.s       IL_003b
 
     IL_0029:  ldc.i4.1
-    IL_002a:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_002a:  stsfld     int32 Test_switch3::s_exitCode
     IL_002f:  ldstr      "Test failed"
     IL_0034:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0039:  br.s       IL_003b
@@ -48,7 +50,7 @@
     IL_003b:  ret
   }
 
-  .method public hidebysig static void Main() il managed
+  .method public hidebysig static int32 Main() il managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
@@ -57,8 +59,7 @@
     .maxstack  8
     IL_0000:  ldc.i4.1
     IL_0001:  call       void Test_switch3::DoSwitch(int32)
-    IL_0006:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
-              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
+              ldsfld     int32 Test_switch3::s_exitCode
               ret
   }
 

--- a/src/tests/JIT/Methodical/switch/switch4.il
+++ b/src/tests/JIT/Methodical/switch/switch4.il
@@ -17,6 +17,7 @@
 .class public auto ansi Test_switch4
        extends ['mscorlib']System.Object
 {
+  .field private static int32 s_exitCode;
   .field public static int32 count
   .method private hidebysig static void  DoSwitch(int32 'value') il managed
   {
@@ -58,19 +59,19 @@
     IL_002e:  bne.un.s   IL_0043
 
     IL_0030:  ldc.i4.s   100
-    IL_0032:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_0032:  stsfld     int32 Test_switch4::s_exitCode
     IL_0037:  ldstr      "Test passed"
     IL_003c:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0041:  br.s       IL_0053
 
     IL_0043:  ldc.i4.1
-    IL_0044:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_0044:  stsfld     int32 Test_switch4::s_exitCode
     IL_0049:  ldstr      "Test failed"
     IL_004e:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0053:  ret
   }
 
-  .method public hidebysig static void Main() il managed
+  .method public hidebysig static int32 Main() il managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
@@ -79,8 +80,7 @@
     .maxstack  8
     IL_0000:  ldc.i4.1
     IL_0001:  call       void Test_switch4::DoSwitch(int32)
-    IL_0006:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
-              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
+              ldsfld     int32 Test_switch4::s_exitCode
               ret
   }
 

--- a/src/tests/JIT/Methodical/switch/switch5.il
+++ b/src/tests/JIT/Methodical/switch/switch5.il
@@ -17,6 +17,7 @@
 .class public auto ansi TestStack
        extends ['mscorlib']System.Object
 {
+  .field public static int32 s_exitCode;
   .field public int32[] Stack
   .field public int32 top
   .method public hidebysig instance void
@@ -58,13 +59,13 @@
     IL_003c:  brtrue.s   IL_0051
 
     IL_003e:  ldc.i4.s   100
-    IL_0040:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_0040:  stsfld     int32 TestStack::s_exitCode
     IL_0045:  ldstr      "Test passed"
     IL_004a:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_004f:  br.s       IL_0061
 
     IL_0051:  ldc.i4.1
-    IL_0052:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_0052:  stsfld     int32 TestStack::s_exitCode
     IL_0057:  ldstr      "Test failed"
     IL_005c:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0061:  br.s       IL_0063
@@ -139,7 +140,7 @@
 .class public auto ansi Test_switch5
        extends ['mscorlib']System.Object
 {
-  .method public hidebysig static void Main() il managed
+  .method public hidebysig static int32 Main() il managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
@@ -161,8 +162,7 @@
     IL_001b:  ldloc.0
     IL_001c:  ldc.i4.3
     IL_001d:  call       instance void TestStack::DoSwitch(int32)
-    IL_0022:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
-              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
+              ldsfld     int32 TestStack::s_exitCode
               ret
   }
 

--- a/src/tests/JIT/Methodical/switch/switch6.il
+++ b/src/tests/JIT/Methodical/switch/switch6.il
@@ -18,6 +18,8 @@
 .class public auto ansi Test_switch6
        extends ['mscorlib']System.Object
 {
+  .field private static int32 s_exitCode;
+
   .method private hidebysig static void  DoSwitch(int32 'value') il managed
   {
     .maxstack  2
@@ -68,19 +70,19 @@
     IL_002f:  bne.un.s   IL_0044
 
     IL_0031:  ldc.i4.s   100
-    IL_0033:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_0033:  stsfld     int32 Test_switch6::s_exitCode
     IL_0038:  ldstr      "Test passed"
     IL_003d:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0042:  br.s       IL_0054
 
     IL_0044:  ldc.i4.1
-    IL_0045:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_0045:  stsfld     int32 Test_switch6::s_exitCode
     IL_004a:  ldstr      "Test failed"
     IL_004f:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0054:  ret
   }
 
-  .method public hidebysig static void Main() il managed
+  .method public hidebysig static int32 Main() il managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
@@ -89,8 +91,7 @@
     .maxstack  8
     IL_0000:  ldc.i4.1
     IL_0001:  call       void Test_switch6::DoSwitch(int32)
-    IL_0006:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
-              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
+              ldsfld     int32 Test_switch6::s_exitCode
               ret
   }
 

--- a/src/tests/JIT/Methodical/switch/switch7.il
+++ b/src/tests/JIT/Methodical/switch/switch7.il
@@ -17,6 +17,7 @@
 .class public auto ansi Test_switch7
        extends ['mscorlib']System.Object
 {
+  .field private static int32 s_exitCode;
   .field private static int32 count
   .method private hidebysig static void  DoSwitch(int32 'value') il managed
   {
@@ -56,7 +57,7 @@
     IL_0044:  ret
   }
 
-  .method public hidebysig static void Main() il managed
+  .method public hidebysig static int32 Main() il managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
@@ -83,17 +84,16 @@
     IL_0018:  bne.un.s   IL_002d
 
     IL_001a:  ldc.i4.s   100
-    IL_001c:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_001c:  stsfld     int32 Test_switch7::s_exitCode
     IL_0021:  ldstr      "Test passed"
     IL_0026:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_002b:  br.s       IL_003d
 
     IL_002d:  ldc.i4.1
-    IL_002e:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_002e:  stsfld     int32 Test_switch7::s_exitCode
     IL_0033:  ldstr      "Test failed"
     IL_0038:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
-    IL_003d:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
-              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
+    IL_003d:  ldsfld     int32 Test_switch7::s_exitCode
               ret
   }
 

--- a/src/tests/JIT/Methodical/switch/switch8.il
+++ b/src/tests/JIT/Methodical/switch/switch8.il
@@ -17,6 +17,8 @@
 .class public auto ansi Test_switch8
        extends ['mscorlib']System.Object
 {
+  .field private static int32 s_exitCode;
+
   .method private hidebysig static void  DoSwitch(int32 'value') il managed
   {
     .maxstack  2
@@ -38,19 +40,19 @@
     IL_0018:  br.s       IL_002d
 
     IL_001a:  ldc.i4.s   100
-    IL_001c:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_001c:  stsfld     int32 Test_switch8::s_exitCode
     IL_0021:  ldstr      "Test passed"
     IL_0026:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_002b:  br.s       IL_003d
 
     IL_002d:  ldc.i4.1
-    IL_002e:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_002e:  stsfld     int32 Test_switch8::s_exitCode
     IL_0033:  ldstr      "Test failed"
     IL_0038:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_003d:  ret
   }
 
-  .method public hidebysig static void Main() il managed
+  .method public hidebysig static int32 Main() il managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
@@ -59,8 +61,7 @@
     .maxstack  8
     IL_0000:  ldc.i4.2
     IL_0001:  call       void Test_switch8::DoSwitch(int32)
-    IL_0006:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
-              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
+              ldsfld     int32 Test_switch8::s_exitCode
               ret
   }
 

--- a/src/tests/JIT/Methodical/switch/switch9.il
+++ b/src/tests/JIT/Methodical/switch/switch9.il
@@ -17,6 +17,8 @@
 .class public auto ansi Test_switch9
        extends ['mscorlib']System.Object
 {
+  .field private static int32 s_exitCode;
+
   .method private hidebysig static void  DoSwitch(int32 val1,
                                                   int32 val2) il managed
   {
@@ -43,19 +45,19 @@
     IL_0026:  br.s       IL_004d
 
     IL_0028:  ldc.i4.s   100
-    IL_002a:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_002a:  stsfld     int32 Test_switch9::s_exitCode
     IL_002f:  ldstr      "Test passed"
     IL_0034:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0039:  br.s       IL_005f
 
     IL_003b:  ldc.i4.1
-    IL_003c:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_003c:  stsfld     int32 Test_switch9::s_exitCode
     IL_0041:  ldstr      "Test failed"
     IL_0046:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_004b:  br.s       IL_005f
 
     IL_004d:  ldc.i4.1
-    IL_004e:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_004e:  stsfld     int32 Test_switch9::s_exitCode
     IL_0053:  ldstr      "Test failed"
     IL_0058:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_005d:  br.s       IL_005f
@@ -63,13 +65,13 @@
     IL_005f:  br.s       IL_0085
 
     IL_0061:  ldc.i4.1
-    IL_0062:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_0062:  stsfld     int32 Test_switch9::s_exitCode
     IL_0067:  ldstr      "Test failed"
     IL_006c:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0071:  br.s       IL_0085
 
     IL_0073:  ldc.i4.1
-    IL_0074:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_0074:  stsfld     int32 Test_switch9::s_exitCode
     IL_0079:  ldstr      "Test failed"
     IL_007e:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0083:  br.s       IL_0085
@@ -77,7 +79,7 @@
     IL_0085:  ret
   }
 
-  .method public hidebysig static void Main() il managed
+  .method public hidebysig static int32 Main() il managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
@@ -88,8 +90,7 @@
     IL_0001:  ldc.i4.1
     IL_0002:  call       void Test_switch9::DoSwitch(int32,
                                              int32)
-    IL_0007:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
-              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
+              ldsfld     int32 Test_switch9::s_exitCode
               ret
   }
 

--- a/src/tests/JIT/Methodical/tailcall/test_implicit.il
+++ b/src/tests/JIT/Methodical/tailcall/test_implicit.il
@@ -84,7 +84,6 @@ ret
     IL_0049:  br.s       IL_004b
 
     IL_004b:  ldloc.0
-exit:
     IL_004c:  ret
   }
 

--- a/src/tests/JIT/Methodical/tailcall/test_implicit.il
+++ b/src/tests/JIT/Methodical/tailcall/test_implicit.il
@@ -26,6 +26,7 @@
 .class public auto ansi beforefieldinit Class1
        extends [mscorlib]System.Object
 {
+  .field private static bool s_failure
   .field private static int32 MaxDepth
   .field private int32 'value'
   .method public hidebysig instance int32
@@ -33,6 +34,9 @@
   {
     .maxstack  5
     .locals init (int32 V_0)
+              ldsfld     bool Class1::s_failure
+              brtrue.s   IL_0003
+
     IL_0000:  ldarg.1
     IL_0001:  brtrue.s   IL_000c
 
@@ -80,6 +84,7 @@ ret
     IL_0049:  br.s       IL_004b
 
     IL_004b:  ldloc.0
+exit:
     IL_004c:  ret
   }
 
@@ -91,6 +96,9 @@ ret
     .maxstack  4
     .locals init (string V_0,
              int32 V_1)
+              ldsfld     bool Class1::s_failure
+              brtrue.s   IL_0003
+
     IL_0000:  ldarg.1
     IL_0001:  brtrue.s   IL_000c
 
@@ -122,8 +130,10 @@ ret
     IL_0039:  call       void [System.Console]System.Console::WriteLine(string)
     IL_003e:  ldstr      "Test Failed"
     IL_0043:  call       void [System.Console]System.Console::WriteLine(string)
-    IL_0048:  ldc.i4.0
-    IL_0049:  call       void [System.Runtime.Extensions]System.Environment::Exit(int32)
+    IL_0048:  ldc.i4.1
+              stsfld     bool Class1::s_failure
+              br.s       IL_0003
+
     IL_004e:  call       void [mscorlib]System.GC::Collect()
     IL_0053:  ldarg.0
     IL_0054:  dup
@@ -155,6 +165,9 @@ ret
   {
     .maxstack  5
     .locals init (int32 V_0)
+              ldsfld     bool Class1::s_failure
+              brtrue.s   IL_0003
+
     IL_0000:  ldarg.1
     IL_0001:  brtrue.s   IL_000c
 
@@ -209,6 +222,9 @@ ret
     .maxstack  4
     .locals init (string V_0,
              int32 V_1)
+              ldsfld     bool Class1::s_failure
+              brtrue.s   IL_0003
+
     IL_0000:  ldarg.1
     IL_0001:  brtrue.s   IL_000c
 
@@ -241,8 +257,10 @@ ret
     IL_0041:  call       void [System.Console]System.Console::WriteLine(string)
     IL_0046:  ldstr      "Test Failed"
     IL_004b:  call       void [System.Console]System.Console::WriteLine(string)
-    IL_0050:  ldc.i4.0
-    IL_0051:  call       void [System.Runtime.Extensions]System.Environment::Exit(int32)
+    IL_0050:  ldc.i4.1
+              stsfld     bool Class1::s_failure
+              br.s       IL_0003
+
     IL_0056:  ldarg.0
     IL_0057:  dup
     IL_0058:  ldfld      int32 Class1::'value'
@@ -287,6 +305,9 @@ ret
     IL_0011:  ldsfld     int32 Class1::MaxDepth
     IL_0016:  callvirt   instance int32 Class1::Recurse1(int32)
     IL_001b:  pop
+              ldsfld     bool Class1::s_failure
+              brtrue.s   IL_0060
+
     IL_001c:  ldc.i4     41963520
     IL_001d:  stloc.1
     IL_001e:  ldloc.0


### PR DESCRIPTION
I have manually rewritten the few remaining tests under JIT/Methodical to stop using Environment.Exit
to report their results (this was preventing in-process execution and subsequently their merging).

Thanks

Tomas

/cc @dotnet/jit-contrib 