### PR TITLE
Move explicit coverage entry points into separate public classes

### DIFF
--- a/src/tests/JIT/Methodical/explicit/coverage/expl_byte_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_byte_1.cs
@@ -70,15 +70,18 @@ internal struct AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_expl_byte_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_double_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_double_1.cs
@@ -61,15 +61,18 @@ internal struct AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_expl_double_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_float_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_float_1.cs
@@ -61,15 +61,18 @@ internal struct AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_expl_float_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_byte_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_byte_1.cs
@@ -64,15 +64,18 @@ internal class AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_expl_gc_byte_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_double_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_double_1.cs
@@ -70,15 +70,18 @@ internal class AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_expl_gc_double_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_float_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_float_1.cs
@@ -73,15 +73,18 @@ internal class AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_expl_gc_float_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_int_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_int_1.cs
@@ -64,15 +64,18 @@ internal class AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_expl_gc_int_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_long_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_long_1.cs
@@ -61,15 +61,18 @@ internal class AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_expl_gc_long_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_obj_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_obj_1.cs
@@ -68,15 +68,18 @@ internal class AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_expl_gc_obj_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_short_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_short_1.cs
@@ -70,15 +70,18 @@ internal class AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_expl_gc_short_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_val_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_val_1.cs
@@ -77,15 +77,18 @@ internal class AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_expl_gc_val_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_int_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_int_1.cs
@@ -70,15 +70,18 @@ internal struct AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_expl_int_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_long_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_long_1.cs
@@ -73,15 +73,18 @@ internal struct AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_expl_long_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_obj_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_obj_1.cs
@@ -77,15 +77,18 @@ internal struct AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_expl_obj_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_short_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_short_1.cs
@@ -64,15 +64,18 @@ internal struct AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_expl_short_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_val_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_val_1.cs
@@ -77,15 +77,18 @@ internal struct AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_expl_val_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_byte_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_byte_1.cs
@@ -61,15 +61,18 @@ internal struct AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_seq_byte_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_double_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_double_1.cs
@@ -60,15 +60,18 @@ internal struct AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_seq_double_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_float_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_float_1.cs
@@ -60,15 +60,18 @@ internal struct AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_seq_float_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_byte_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_byte_1.cs
@@ -64,15 +64,18 @@ internal class AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_seq_gc_byte_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_double_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_double_1.cs
@@ -69,15 +69,18 @@ internal class AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_seq_gc_double_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_float_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_float_1.cs
@@ -72,15 +72,18 @@ internal class AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_seq_gc_float_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_int_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_int_1.cs
@@ -63,15 +63,18 @@ internal class AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_seq_gc_int_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_long_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_long_1.cs
@@ -60,15 +60,18 @@ internal class AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_seq_gc_long_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_obj_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_obj_1.cs
@@ -68,15 +68,18 @@ internal class AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_seq_gc_obj_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_short_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_short_1.cs
@@ -70,15 +70,18 @@ internal class AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_seq_gc_short_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_val_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_val_1.cs
@@ -77,15 +77,18 @@ internal class AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_seq_gc_val_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_int_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_int_1.cs
@@ -69,15 +69,18 @@ internal struct AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_seq_int_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_long_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_long_1.cs
@@ -72,15 +72,18 @@ internal struct AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_seq_long_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_obj_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_obj_1.cs
@@ -77,15 +77,18 @@ internal struct AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_seq_obj_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_short_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_short_1.cs
@@ -64,15 +64,18 @@ internal struct AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_seq_short_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_val_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_val_1.cs
@@ -68,15 +68,18 @@ internal struct AA
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
     }
-
-    [Fact]
-    public static int TestEntrypoint()
-    {
-        return TestApp.RunAllTests();
-    }
 }
 
 internal struct BB
 {
     public static AA f_init, f_zero;
+}
+
+public static class Test_seq_val_1
+{
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
+    }
 }


### PR DESCRIPTION
Previously I refactored these tests by moving the entrypoints from
the shared body_xxx source files into the test-specific expl_*
and seq_* source files but I didn't realize I'd also need to put
them into new uniquely named classes as the merged wrapper
clearly cannot distinguish 30 different methods named
AA.TestEntrypoint().

Thanks

Tomas

/cc @dotnet/jit-contrib 