### PR TITLE
Deduplicate class names under JIT/Methodical/cctor

### DIFF
--- a/src/tests/JIT/Methodical/cctor/misc/assemname.cs
+++ b/src/tests/JIT/Methodical/cctor/misc/assemname.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace Precise
 {
-    internal class Driver
+    internal class Driver_assemname
     {
         public static int Main()
         {

--- a/src/tests/JIT/Methodical/cctor/misc/deadlock.il
+++ b/src/tests/JIT/Methodical/cctor/misc/deadlock.il
@@ -9,30 +9,31 @@
 }
 .assembly deadlock {}
 .assembly extern xunit.core {}
+.namespace Test_deadlock {
 .class public A extends [mscorlib]System.Object
 {
-.field static public class A a
-.field static public class B b
+.field static public class Test_deadlock.A a
+.field static public class Test_deadlock.B b
 .method public static rtspecialname specialname void .cctor ()
 {
 ldnull
-stsfld class B A::b
-ldsfld class A B::a
-stsfld class A A::a
+stsfld class Test_deadlock.B Test_deadlock.A::b
+ldsfld class Test_deadlock.A Test_deadlock.B::a
+stsfld class Test_deadlock.A Test_deadlock.A::a
 ret
 }
 }
 
 .class public B extends [mscorlib]System.Object
 {
-.field static public class A a
-.field static public class B b
+.field static public class Test_deadlock.A a
+.field static public class Test_deadlock.B b
 .method public static rtspecialname specialname void .cctor ()
 {
 ldnull
-stsfld class A B::a
-ldsfld class B A::b
-stsfld class B B::b
+stsfld class Test_deadlock.A Test_deadlock.B::a
+ldsfld class Test_deadlock.B Test_deadlock.A::b
+stsfld class Test_deadlock.B Test_deadlock.B::b
 ret
 }
 }
@@ -43,8 +44,9 @@ ret
     01 00 00 00
 )
 .entrypoint
-ldsfld class B A::b
+ldsfld class Test_deadlock.B Test_deadlock.A::b
 pop
 ldc.i4 100
 ret
+}
 }

--- a/src/tests/JIT/Methodical/cctor/misc/threads1.cs
+++ b/src/tests/JIT/Methodical/cctor/misc/threads1.cs
@@ -8,7 +8,7 @@ using System.Threading;
 
 namespace Precise
 {
-    internal class Driver
+    internal class Driver_threads1
     {
         public static void f()
         {

--- a/src/tests/JIT/Methodical/cctor/misc/threads2.cs
+++ b/src/tests/JIT/Methodical/cctor/misc/threads2.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 
 namespace Precise
 {
-    internal class Driver
+    internal class Driver_threads2
     {
         public static void f()
         {

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise1.cs
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise1.cs
@@ -3,7 +3,7 @@
 // static method
 using System;
 namespace Precise {
-class Driver
+class Driver_xprecise1
 {
 	public static int Main()
 	{

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise1b.cs
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise1b.cs
@@ -5,7 +5,7 @@
 using System;
 namespace Precise
 {
-    class Driver
+    class Driver_xprecise1b
     {
         public static int Main()
         {

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise2.cs
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise2.cs
@@ -5,7 +5,7 @@
 using System;
 namespace Precise
 {
-    class Driver
+    class Driver_xprecise2
     {
         public static int Main()
         {

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise4.cs
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise4.cs
@@ -5,7 +5,7 @@
 using System;
 namespace Precise
 {
-    class Driver
+    class Driver_xprecise4
     {
         public static int Main()
         {


### PR DESCRIPTION
In this particular class of tests deduplicating tests via namespace names
(which is what my rewriting tool does by default) is not useful as they use common
modules expecting the namespaces to match. For this reason I have manually
deduplicated the class names instead. (In case of the one IL test, we can use
namespace deduplication, we just need to get rid of the super-common type
names like A or B).

Thanks

Tomas

/cc @dotnet/jit-contrib 