### PR TITLE
[wasm][debugger] Fix some racy tests

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.WebAssembly.Diagnostics;
 using Newtonsoft.Json.Linq;
 using System.IO;
 using Xunit;
-using System.Threading;
+using Xunit.Sdk;
 
 namespace DebuggerTests
 {
@@ -294,11 +293,12 @@ namespace DebuggerTests
         }
 
         [Fact]
-        //[Trait("Category", "windows-failing")] // https://github.com/dotnet/runtime/issues/62823
-        //[Trait("Category", "linux-failing")] // https://github.com/dotnet/runtime/issues/62823
         public async Task BreakpointInAssemblyUsingTypeFromAnotherAssembly_BothDynamicallyLoaded()
         {
             int line = 7;
+
+            // Start the task earlier than loading the assemblies, so we don't miss the event
+            Task<JObject> bpResolved = WaitForBreakpointResolvedEvent();
             await SetBreakpoint(".*/library-dependency-debugger-test1.cs$", line, 0, use_regex: true);
             await LoadAssemblyDynamically(
                     Path.Combine(DebuggerTestAppPath, "library-dependency-debugger-test2.dll"),
@@ -309,6 +309,8 @@ namespace DebuggerTests
 
             var source_location = "dotnet://library-dependency-debugger-test1.dll/library-dependency-debugger-test1.cs";
             Assert.Contains(source_location, scripts.Values);
+
+            await bpResolved;
 
             var pause_location = await EvaluateAndCheck(
                "window.setTimeout(function () { invoke_static_method('[library-dependency-debugger-test1] TestDependency:IntAdd', 5, 10); }, 1);",

--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -294,8 +294,8 @@ namespace DebuggerTests
         }
 
         [Fact]
-        [Trait("Category", "windows-failing")] // https://github.com/dotnet/runtime/issues/62823
-        [Trait("Category", "linux-failing")] // https://github.com/dotnet/runtime/issues/62823
+        //[Trait("Category", "windows-failing")] // https://github.com/dotnet/runtime/issues/62823
+        //[Trait("Category", "linux-failing")] // https://github.com/dotnet/runtime/issues/62823
         public async Task BreakpointInAssemblyUsingTypeFromAnotherAssembly_BothDynamicallyLoaded()
         {
             int line = 7;

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -1328,6 +1328,20 @@ namespace DebuggerTests
             return await insp.WaitFor(Inspector.PAUSE);
         }
 
+        public async Task<JObject> WaitForBreakpointResolvedEvent()
+        {
+            try
+            {
+                var res = await insp.WaitForEvent("Debugger.breakpointResolved");
+                Console.WriteLine ($"breakpoint resolved to {res}");
+                return res;
+            }
+            catch (TaskCanceledException)
+            {
+                throw new XunitException($"Timed out waiting for Debugger.breakpointResolved event");
+            }
+        }
+
         internal async Task SetJustMyCode(bool enabled)
         {
             var req = JObject.FromObject(new { enabled = enabled });

--- a/src/mono/wasm/debugger/DebuggerTestSuite/ExceptionTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/ExceptionTests.cs
@@ -235,7 +235,6 @@ namespace DebuggerTests
         [Theory]
         [InlineData("[debugger-test] DebuggerTests.ExceptionTestsClassDefault:TestExceptions", "System.Exception", 76)]
         [InlineData("[debugger-test] DebuggerTests.ExceptionTestsClass:TestExceptions", "DebuggerTests.CustomException", 28)]
-        [Trait("Category", "linux-failing")] // https://github.com/dotnet/runtime/issues/62666
         public async Task ExceptionTestAllWithReload(string entry_method_name, string class_name, int line_number)
         {
             var debugger_test_loc = "dotnet://debugger-test.dll/debugger-exception-test.cs";
@@ -249,14 +248,26 @@ namespace DebuggerTests
                                     }), "Page.reload",null, 0, 0, null);
             Thread.Sleep(1000);
 
-            //send a lot of resumes to "skip" all the pauses on caught exception and completely reload the page
-            int i = 0;
-            while (i < 100)
+            // Hit resume to skip 
+            int count = 0;
+            while(true)
             {
-                Result res = await cli.SendCommand("Debugger.resume", null, token);
-                i++;
-            }
+                await cli.SendCommand("Debugger.resume", null, token);
+                count++;
 
+                try
+                {
+                    await insp.WaitFor(Inspector.PAUSE)
+                                .WaitAsync(TimeSpan.FromSeconds(10));
+                }
+                catch (TimeoutException)
+                {
+                    // timed out waiting for a PAUSE
+                    insp.ClearWaiterFor(Inspector.PAUSE);
+                    break;
+                }
+            }
+            Console.WriteLine ($"* Resumed {count} times");
 
             var eval_expr = "window.setTimeout(function() { invoke_static_method (" +
                 $"'{entry_method_name}'" +
@@ -309,7 +320,8 @@ namespace DebuggerTests
                     AssertEqual("exception", pause_location["reason"]?.Value<string>(), $"Expected to only pause because of an exception. {pause_location}");
 
                     // return in case of a managed exception, and ignore JS ones
-                    if (pause_location["data"]?["objectId"]?.Value<string>()?.StartsWith("dotnet:object:") == true)
+                    if (pause_location["data"]?["objectId"]?.Value<string>()?.StartsWith("dotnet:object:", StringComparison.Ordinal) == true ||
+                        pause_location["data"]?["uncaught"]?.Value<bool>() == true)
                     {
                         break;
                     }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Inspector.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Inspector.cs
@@ -73,6 +73,12 @@ namespace DebuggerTests
             }
         }
 
+        public void ClearWaiterFor(string what)
+        {
+            if (notifications.ContainsKey(what))
+                notifications.Remove(what);
+        }
+
         void NotifyOf(string what, JObject args)
         {
             if (notifications.TryGetValue(what, out TaskCompletionSource<JObject>? tcs))

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Inspector.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Inspector.cs
@@ -102,6 +102,18 @@ namespace DebuggerTests
             eventListeners[evtName] = cb;
         }
 
+        public Task<JObject> WaitForEvent(string evtName)
+        {
+            var eventReceived = new TaskCompletionSource<JObject>();
+            On(evtName, async (args, token) =>
+            {
+                eventReceived.SetResult(args);
+                await Task.CompletedTask;
+            });
+
+            return eventReceived.Task.WaitAsync(Token);
+        }
+
         void FailAllWaiters(Exception? exception = null)
         {
             // Because we can create already completed tasks,

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -755,7 +755,7 @@ namespace DebuggerTests
         }
 
         [Fact]
-        [Trait("Category", "linux-failing")] // https://github.com/dotnet/runtime/issues/62667
+        //[Trait("Category", "linux-failing")] // https://github.com/dotnet/runtime/issues/62667
         public async Task DebugLazyLoadedAssemblyWithEmbeddedPdb()
         {
             int line = 9;

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Sdk;
 
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]
 
@@ -736,6 +737,7 @@ namespace DebuggerTests
         [Fact]
         public async Task DebugLazyLoadedAssemblyWithPdb()
         {
+            Task<JObject> bpResolved = WaitForBreakpointResolvedEvent();
             int line = 9;
             await SetBreakpoint(".*/lazy-debugger-test.cs$", line, 0, use_regex: true);
             await LoadAssemblyDynamically(
@@ -744,7 +746,9 @@ namespace DebuggerTests
 
             var source_location = "dotnet://lazy-debugger-test.dll/lazy-debugger-test.cs";
             Assert.Contains(source_location, scripts.Values);
-            System.Threading.Thread.Sleep(1000);
+
+            await bpResolved;
+
             var pause_location = await EvaluateAndCheck(
                "window.setTimeout(function () { invoke_static_method('[lazy-debugger-test] LazyMath:IntAdd', 5, 10); }, 1);",
                source_location, line, 8,
@@ -755,9 +759,9 @@ namespace DebuggerTests
         }
 
         [Fact]
-        //[Trait("Category", "linux-failing")] // https://github.com/dotnet/runtime/issues/62667
         public async Task DebugLazyLoadedAssemblyWithEmbeddedPdb()
         {
+            Task<JObject> bpResolved = WaitForBreakpointResolvedEvent();
             int line = 9;
             await SetBreakpoint(".*/lazy-debugger-test-embedded.cs$", line, 0, use_regex: true);
             await LoadAssemblyDynamically(
@@ -766,6 +770,8 @@ namespace DebuggerTests
 
             var source_location = "dotnet://lazy-debugger-test-embedded.dll/lazy-debugger-test-embedded.cs";
             Assert.Contains(source_location, scripts.Values);
+
+            await bpResolved;
 
             var pause_location = await EvaluateAndCheck(
                "window.setTimeout(function () { invoke_static_method('[lazy-debugger-test-embedded] LazyMath:IntAdd', 5, 10); }, 1);",


### PR DESCRIPTION
- tests that use late loaded assemblies
`DebuggerTests.MiscTests.DebugLazyLoadedAssemblyWithEmbeddedPdb`
`DebuggerTests.BreakpointTests.BreakpointInAssemblyUsingTypeFromAnotherAssembly_BothDynamicallyLoaded`

- `ExceptionTestAllWithReload`

Fixes https://github.com/dotnet/runtime/issues/62666
Fixes https://github.com/dotnet/runtime/issues/62823
Fixes https://github.com/dotnet/runtime/issues/62667