### PR TITLE
Bump up visibility for several helper types under JIT/Methodical

### DIFF
--- a/src/tests/JIT/Methodical/MDArray/GaussJordan/classarr.cs
+++ b/src/tests/JIT/Methodical/MDArray/GaussJordan/classarr.cs
@@ -4,8 +4,9 @@
 //Solving AX=B and the inverse of A with Gauss-Jordan algorithm
 
 using System;
+using Xunit;
 
-internal class MatrixCls
+public class MatrixCls
 {
     public double[,] arr;
     public MatrixCls(int n, int m)
@@ -14,7 +15,7 @@ internal class MatrixCls
     }
 }
 
-internal class classarr
+public class classarr
 {
     private static double s_tolerance = 0.0000000000001;
     public static bool AreEqual(double left, double right)
@@ -94,7 +95,8 @@ internal class classarr
         }
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         bool pass = false;
 

--- a/src/tests/JIT/Methodical/MDArray/GaussJordan/structarr.cs
+++ b/src/tests/JIT/Methodical/MDArray/GaussJordan/structarr.cs
@@ -4,8 +4,9 @@
 //Solving AX=B and the inverse of A with Gauss-Jordan algorithm
 
 using System;
+using Xunit;
 
-internal struct MatrixStruct
+public struct MatrixStruct
 {
     public double[,] arr;
     public MatrixStruct(int n, int m)
@@ -14,7 +15,7 @@ internal struct MatrixStruct
     }
 }
 
-internal class structarr
+public class structarr
 {
     private static double s_tolerance = 0.0000000000001;
     public static bool AreEqual(double left, double right)
@@ -93,7 +94,8 @@ internal class structarr
         }
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         bool pass = false;
 

--- a/src/tests/JIT/Methodical/VT/etc/ctor_recurse.cs
+++ b/src/tests/JIT/Methodical/VT/etc/ctor_recurse.cs
@@ -2,16 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Xunit;
 
 namespace Test
 {
-    internal class S
+    public class S
     {
         private T _nvalue;
         public S(T t) { _nvalue = t; }
     }
 
-    internal struct T
+    public struct T
     {
         private static T s_stat;
         private S _gcref;
@@ -21,7 +22,8 @@ namespace Test
 
         private void DoMethod() { }
 
-        private static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             s_stat =
                 new T(new S(new T(new S(new T(new S(new T(new S(new T(new S(

--- a/src/tests/JIT/Methodical/VT/etc/han2.cs
+++ b/src/tests/JIT/Methodical/VT/etc/han2.cs
@@ -2,15 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Xunit;
 
 namespace JitTest
 {
-    internal struct Ring
+    public struct Ring
     {
         public int size;
     }
 
-    internal struct Column
+    public struct Column
     {
         public Ring[] rings;
         private int[] _heightPtr;
@@ -65,7 +66,8 @@ namespace JitTest
             return C;
         }
 
-        private static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             int NUM = 17;
             Column[] cols = new Column[3];

--- a/src/tests/JIT/Methodical/VT/etc/han3.cs
+++ b/src/tests/JIT/Methodical/VT/etc/han3.cs
@@ -2,15 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Xunit;
 
 namespace JitTest
 {
-    internal struct Ring
+    public struct Ring
     {
         public int size;
     }
 
-    internal struct Column
+    public struct Column
     {
         public Ring[] rings;
         private int[] _heightPtr;
@@ -65,7 +66,8 @@ namespace JitTest
             return C;
         }
 
-        private static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             int NUM = 17;
             Column c1 = new Column();

--- a/src/tests/JIT/Methodical/VT/etc/han3_ctor.cs
+++ b/src/tests/JIT/Methodical/VT/etc/han3_ctor.cs
@@ -2,15 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Xunit;
 
 namespace JitTest
 {
-    internal struct Ring
+    public struct Ring
     {
         public int size;
     }
 
-    internal struct Column
+    public struct Column
     {
         public Ring[] rings;
         private int[] _heightPtr;
@@ -68,7 +69,8 @@ namespace JitTest
             return C;
         }
 
-        private static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             return move(new Column(17, 17),
                         new Column(17, 0),

--- a/src/tests/JIT/Methodical/VT/etc/han3_ref.cs
+++ b/src/tests/JIT/Methodical/VT/etc/han3_ref.cs
@@ -2,15 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Xunit;
 
 namespace JitTest
 {
-    internal struct Ring
+    public struct Ring
     {
         public int size;
     }
 
-    internal struct Column
+    public struct Column
     {
         public Ring[] rings;
         private int[] _heightPtr;
@@ -68,7 +69,8 @@ namespace JitTest
             return C;
         }
 
-        private static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             Column c1 = new Column(17, 17);
             Column c2 = new Column(17, 0);

--- a/src/tests/JIT/Methodical/flowgraph/dev10_bug679008/GCOverReporting.cs
+++ b/src/tests/JIT/Methodical/flowgraph/dev10_bug679008/GCOverReporting.cs
@@ -30,13 +30,14 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
-internal struct MB8
+public struct MB8
 {
     public object foo;
 }
 
-internal class Repro
+public class Repro
 {
     private static int s_counter;
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -96,7 +97,8 @@ internal class Repro
         ConsumeStack(3);
     }
 
-    private static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         Method();
         TrashStack();

--- a/src/tests/JIT/Methodical/flowgraph/dev10_bug679008/singleRefField.cs
+++ b/src/tests/JIT/Methodical/flowgraph/dev10_bug679008/singleRefField.cs
@@ -9,13 +9,14 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
-internal struct MB8
+public struct MB8
 {
     public object foo;
 }
 
-internal class Repro
+public class Repro
 {
     private int _state = 1;
 
@@ -66,7 +67,8 @@ internal class Repro
         return loc0;
     }
 
-    private static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         new Repro().Bug(new MB8(), "Test");
         return 100;


### PR DESCRIPTION
This change converts a small number of special tests to use the
[Fact] style. These tests are atypical in using various internal
types declared in their source code as fields in the test class;
bumping up test class visibility to public requires transitive
modifications to visibility of the helper types.

Thanks

Tomas

/cc @dotnet/jit-contrib 