### PR TITLE
Check for multicast delegate before comparing invocation lists

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/MulticastDelegate.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/MulticastDelegate.cs
@@ -65,9 +65,10 @@ namespace System
             // 1- Multicast (m_helperObject is Delegate[])
             // 2- Single-cast delegate, which can be compared with a structural comparision
 
-            if (m_functionPointer == GetThunk(MulticastThunk))
+            IntPtr multicastThunk = GetThunk(MulticastThunk);
+            if (m_functionPointer == multicastThunk)
             {
-                return InvocationListEquals(d);
+                return d.m_functionPointer == multicastThunk && InvocationListEquals(d);
             }
             else
             {


### PR DESCRIPTION
Fixes issue discovered in https://github.com/dotnet/runtime/pull/64404#discussion_r797220167.

The existing code worked but there is an off chance that a different kind of delegate (not multicast) could be storing a number in `m_extraFunctionPointerOrData` that matches the length of this delegate (length is stored in `m_extraFunctionPointerOrData`), making us fail with `InvalidCast`. We should only compare invocation lists once we know both delegates are multicast.

No test because it's difficult to make a test (either need a looong invocation list, or a sufficiently low pointer).