### PR TITLE
Prefer "mov reg, wzr" over "mov reg, #0"

### DIFF
--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -2159,8 +2159,10 @@ void CodeGen::instGen_Set_Reg_To_Zero(emitAttr size, regNumber reg, insFlags fla
 {
 #if defined(TARGET_XARCH)
     GetEmitter()->emitIns_R_R(INS_xor, size, reg, reg);
-#elif defined(TARGET_ARMARCH)
+#elif defined(TARGET_ARM)
     GetEmitter()->emitIns_R_I(INS_mov, size, reg, 0 ARM_ARG(flags));
+#elif defined(TARGET_ARM64)
+    GetEmitter()->emitIns_Mov(INS_mov, size, reg, REG_ZR, /* canSkip */ true);
 #else
 #error "Unknown TARGET"
 #endif


### PR DESCRIPTION
it's slightly more efficient.

```csharp
int Test() => 0;
```
```diff
; Assembly listing for method Runtime:Test():int:this

-    mov     w0, #0
+    mov     w0, wzr
```
