### PR TITLE
Workaround permission issue on Android API30 emulators when pulling test results

### DIFF
--- a/src/libraries/Common/tests/AndroidTestRunner/AndroidTestRunner.cs
+++ b/src/libraries/Common/tests/AndroidTestRunner/AndroidTestRunner.cs
@@ -96,11 +96,11 @@ public class SimpleAndroidTestRunner : AndroidApplicationEntryPoint, IDevice
     {
         get
         {
-            string? publicDir = Environment.GetEnvironmentVariable("DOCSDIR");
-            if (string.IsNullOrEmpty(publicDir))
-                throw new ArgumentException("DOCSDIR should not be empty");
+            string? testResultsDir = Environment.GetEnvironmentVariable("TEST_RESULTS_DIR");
+            if (string.IsNullOrEmpty(testResultsDir))
+                throw new ArgumentException("TEST_RESULTS_DIR should not be empty");
 
-            return Path.Combine(publicDir, "testResults.xml");
+            return Path.Combine(testResultsDir, "testResults.xml");
         }
     }
 }

--- a/src/tasks/AndroidAppBuilder/Templates/AndroidManifest.xml
+++ b/src/tasks/AndroidAppBuilder/Templates/AndroidManifest.xml
@@ -9,7 +9,7 @@
   <uses-permission a:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
   <application a:label="%PackageName%" 
                a:largeHeap="true">
-    <activity a:name="net.dot.MainActivity">
+    <activity a:name="net.dot.MainActivity" a:exported="true">
       <intent-filter>
         <category a:name="android.intent.category.LAUNCHER"/>
         <action a:name="android.intent.action.MAIN"/>

--- a/src/tasks/AndroidAppBuilder/Templates/MonoRunner.java
+++ b/src/tasks/AndroidAppBuilder/Templates/MonoRunner.java
@@ -35,6 +35,7 @@ public class MonoRunner extends Instrumentation
         System.loadLibrary("monodroid");
     }
 
+    static String testResultsDir;
     static String entryPointLibName = "%EntryPointLibName%";
     static Bundle result = new Bundle();
 
@@ -68,24 +69,24 @@ public class MonoRunner extends Instrumentation
         start();
     }
 
-    private static String getDocsDir(Context ctx) {
-        File docsPath  = ctx.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS);
-        if (docsPath == null) {
-            docsPath = ctx.getCacheDir();
-        }
-        return docsPath.getAbsolutePath();
-    }
-
     public static int initialize(String entryPointLibName, String[] args, Context context) {
         String filesDir = context.getFilesDir().getAbsolutePath();
         String cacheDir = context.getCacheDir().getAbsolutePath();
-        String docsDir = getDocsDir(context);
+
+        File docsPath = context.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS);
+
+        // on Android API 30 there are "adb pull" permission issues with getExternalFilesDir() paths on emulators, see https://github.com/dotnet/xharness/issues/385
+        if (docsPath == null || android.os.Build.VERSION.SDK_INT == 30) {
+            testResultsDir = context.getCacheDir().getAbsolutePath();
+        } else {
+            testResultsDir = docsPath.getAbsolutePath();
+        }
 
         // unzip libs and test files to filesDir
         unzipAssets(context, filesDir, "assets.zip");
 
         Log.i("DOTNET", "MonoRunner initialize,, entryPointLibName=" + entryPointLibName);
-        return initRuntime(filesDir, cacheDir, docsDir, entryPointLibName, args);
+        return initRuntime(filesDir, cacheDir, testResultsDir, entryPointLibName, args);
     }
 
     @Override
@@ -103,7 +104,7 @@ public class MonoRunner extends Instrumentation
         result.putInt("return-code", retcode);
 
         // Xharness cli expects "test-results-path" with test results
-        File testResults = new File(getDocsDir(getContext()) + "/testResults.xml");
+        File testResults = new File(testResultsDir + "/testResults.xml");
         if (testResults.exists()) {
             Log.i("DOTNET", "MonoRunner finished, test-results-path=" + testResults.getAbsolutePath());
             result.putString("test-results-path", testResults.getAbsolutePath());
@@ -146,7 +147,7 @@ public class MonoRunner extends Instrumentation
         }
     }
 
-    static native int initRuntime(String libsDir, String cacheDir, String docsDir, String entryPointLibName, String[] args);
+    static native int initRuntime(String libsDir, String cacheDir, String testResultsDir, String entryPointLibName, String[] args);
 
     static native int setEnv(String key, String value);
 }

--- a/src/tasks/AndroidAppBuilder/Templates/monodroid.c
+++ b/src/tasks/AndroidAppBuilder/Templates/monodroid.c
@@ -313,15 +313,15 @@ Java_net_dot_MonoRunner_setEnv (JNIEnv* env, jobject thiz, jstring j_key, jstrin
 }
 
 int
-Java_net_dot_MonoRunner_initRuntime (JNIEnv* env, jobject thiz, jstring j_files_dir, jstring j_cache_dir, jstring j_docs_dir, jstring j_entryPointLibName, jobjectArray j_args)
+Java_net_dot_MonoRunner_initRuntime (JNIEnv* env, jobject thiz, jstring j_files_dir, jstring j_cache_dir, jstring j_testresults_dir, jstring j_entryPointLibName, jobjectArray j_args)
 {
     char file_dir[2048];
     char cache_dir[2048];
-    char docs_dir[2048];
+    char testresults_dir[2048];
     char entryPointLibName[2048];
     strncpy_str (env, file_dir, j_files_dir, sizeof(file_dir));
     strncpy_str (env, cache_dir, j_cache_dir, sizeof(cache_dir));
-    strncpy_str (env, docs_dir, j_docs_dir, sizeof(docs_dir));
+    strncpy_str (env, testresults_dir, j_testresults_dir, sizeof(testresults_dir));
     strncpy_str (env, entryPointLibName, j_entryPointLibName, sizeof(entryPointLibName));
 
     bundle_path = file_dir;
@@ -329,7 +329,7 @@ Java_net_dot_MonoRunner_initRuntime (JNIEnv* env, jobject thiz, jstring j_files_
 
     setenv ("HOME", bundle_path, true);
     setenv ("TMPDIR", cache_dir, true);
-    setenv ("DOCSDIR", docs_dir, true);
+    setenv ("TEST_RESULTS_DIR", testresults_dir, true);
 
     int args_len = (*env)->GetArrayLength(env, j_args);
     int managed_argc = args_len + 1;


### PR DESCRIPTION
See https://github.com/dotnet/xharness/issues/385, we use the cache dir instead on API 30.

Also add `a:exported="true"` which is required when targetting a newer minSdkVersion.