### PR TITLE
Consolidate _handshakeBuffer and _internalBuffer in SslStream

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -17,9 +17,6 @@ namespace System.Net.Security
     // Provides an additional abstraction layer over SSPI for SslStream.
     internal sealed class SecureChannel
     {
-        // When reading a frame from the wire first read this many bytes for the header.
-        internal const int ReadHeaderSize = 5;
-
         private SafeFreeCredentials? _credentialsHandle;
         private SafeDeleteSslContext? _securityContext;
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -273,7 +273,7 @@ namespace System.Net.Security
                     throw SslStreamPal.GetException(status);
                 }
 
-                _buffer.EnsureAvailableSpace(InitialHandshakeBufferSize);
+                _buffer.EnsureAvailableSpace(InitialBufferSize);
 
                 ProtocolToken message = null!;
                 do {
@@ -345,7 +345,7 @@ namespace System.Net.Security
 
                 if (!handshakeCompleted)
                 {
-                    _buffer.EnsureAvailableSpace(InitialHandshakeBufferSize);
+                    _buffer.EnsureAvailableSpace(InitialBufferSize);
                 }
 
                 while (!handshakeCompleted)
@@ -750,7 +750,7 @@ namespace System.Net.Security
             // We may have enough space to complete frame, but we may still do extra IO if the frame is small.
             // So we will attempt larger read - that is trade of with extra copy.
             // This may be updated at some point based on size of existing chunk, rented buffer and size of 'buffer'.
-            _buffer.EnsureAvailableSpace(ReadBufferSize - _buffer.ActiveLength);
+            _buffer.EnsureAvailableSpace(Math.Min(frameSize, InitialBufferSize) - _buffer.ActiveLength);
 
             while (_buffer.EncryptedLength < frameSize)
             {
@@ -775,6 +775,7 @@ namespace System.Net.Security
                 {
                     // recalculate frame size if needed e.g. we could not get it before.
                     frameSize = GetFrameSize(_buffer.EncryptedReadOnlySpan);
+                    _buffer.EnsureAvailableSpace(frameSize - _buffer.ActiveLength);
                 }
             }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -812,6 +812,11 @@ namespace System.Net.Security
             // This may be updated at some point based on size of existing chunk, rented buffer and size of 'buffer'.
             //ResetReadBuffer();
 
+            // make sure there is enough space at the end of the buffer, if not, move contents to the beginning of the buffer
+            // note that frameSize may be int.MaxValue if not we didn't receive the TLS header yet.
+            // TODO: check how this behaves when stressed
+            _buffer.EnsureAvailableSpace(Math.Min(frameSize, _buffer.Capacity - _buffer.ActiveBytes));
+
             // _internalOffset is 0 after ResetReadBuffer and we use _internalBufferCount to determined where to read.
             //while (_internalBufferCount < frameSize)
             while (_buffer.EncryptedBytes < frameSize)

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -273,7 +273,7 @@ namespace System.Net.Security
                     throw SslStreamPal.GetException(status);
                 }
 
-                _buffer.EnsureAvailableSpace(InitialBufferSize);
+                _buffer.EnsureAvailableSpace(InitialHandshakeBufferSize);
 
                 ProtocolToken message = null!;
                 do {
@@ -345,7 +345,7 @@ namespace System.Net.Security
 
                 if (!handshakeCompleted)
                 {
-                    _buffer.EnsureAvailableSpace(InitialBufferSize);
+                    _buffer.EnsureAvailableSpace(InitialHandshakeBufferSize);
                 }
 
                 while (!handshakeCompleted)
@@ -747,11 +747,6 @@ namespace System.Net.Security
                 return frameSize;
             }
 
-            // We may have enough space to complete frame, but we may still do extra IO if the frame is small.
-            // So we will attempt larger read - that is trade of with extra copy.
-            // This may be updated at some point based on size of existing chunk, rented buffer and size of 'buffer'.
-            _buffer.EnsureAvailableSpace(Math.Min(frameSize, InitialBufferSize) - _buffer.ActiveLength);
-
             while (_buffer.EncryptedLength < frameSize)
             {
                 // there should be space left to read into
@@ -775,7 +770,7 @@ namespace System.Net.Security
                 {
                     // recalculate frame size if needed e.g. we could not get it before.
                     frameSize = GetFrameSize(_buffer.EncryptedReadOnlySpan);
-                    _buffer.EnsureAvailableSpace(frameSize - _buffer.ActiveLength);
+                    _buffer.EnsureAvailableSpace(frameSize - _buffer.EncryptedLength);
                 }
             }
 
@@ -869,6 +864,8 @@ namespace System.Net.Security
                 }
 
                 Debug.Assert(_buffer.DecryptedLength == 0);
+
+                _buffer.EnsureAvailableSpace(ReadBufferSize - _buffer.ActiveLength);
 
                 while (true)
                 {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -57,13 +57,6 @@ namespace System.Net.Security
         private bool _shutdown;
         private bool _handshakeCompleted;
 
-        // Never updated directly, special properties are used.  This is the read buffer.
-        //internal byte[]? _internalBuffer;
-        //internal int _internalOffset;
-        //internal int _internalBufferCount;
-        //internal int _decryptedBytesOffset;
-        //internal int _decryptedBytesCount;
-
         // FrameOverhead = 5 byte header + HMAC trailer + padding (if block cipher)
         // HMAC: 32 bytes for SHA-256 or 20 bytes for SHA-1 or 16 bytes for the MD5
         private const int FrameOverhead = 64;
@@ -100,6 +93,8 @@ namespace System.Net.Security
             public Span<byte> AvailableSpan => _buffer.AvailableSpan;
 
             public Memory<byte> AvailableMemory => _buffer.AvailableMemory;
+
+            public int AvailableBytes => _buffer.AvailableLength;
 
             public int Capacity => _buffer.Capacity;
 
@@ -836,9 +831,6 @@ namespace System.Net.Security
                 //if (_decryptedBytesCount > 0)
                 if (_buffer.DecryptedBytes > 0)
                 {
-                    //int b = _internalBuffer![_decryptedBytesOffset++];
-                    //_decryptedBytesCount--;
-                    //ReturnReadBufferIfEmpty();
                     int b = _buffer.DecryptedSpan[0];
                     _buffer.Discard(1);
                     return b;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -60,8 +60,8 @@ namespace System.Net.Security
         // FrameOverhead = 5 byte header + HMAC trailer + padding (if block cipher)
         // HMAC: 32 bytes for SHA-256 or 20 bytes for SHA-1 or 16 bytes for the MD5
         private const int FrameOverhead = 64;
-        // try to fit at least 4K ServerCertificate during handshake, the buffer will later expand as needed
-        private const int InitialBufferSize = 4096 + FrameOverhead;
+        private const int InitialHandshakeBufferSize = 4096 + FrameOverhead; // try to fit at least 4K ServerCertificate
+        private const int ReadBufferSize = 4096 * 4 + FrameOverhead;         // We read in 16K chunks + headers.
 
         private SslBuffer _buffer;
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -60,8 +60,8 @@ namespace System.Net.Security
         // FrameOverhead = 5 byte header + HMAC trailer + padding (if block cipher)
         // HMAC: 32 bytes for SHA-256 or 20 bytes for SHA-1 or 16 bytes for the MD5
         private const int FrameOverhead = 64;
-        private const int InitialHandshakeBufferSize = 4096 + FrameOverhead; // try to fit at least 4K ServerCertificate
-        private const int ReadBufferSize = 4096 * 4 + FrameOverhead;         // We read in 16K chunks + headers.
+        // try to fit at least 4K ServerCertificate during handshake, the buffer will later expand as needed
+        private const int InitialBufferSize = 4096 + FrameOverhead;
 
         private SslBuffer _buffer;
 

--- a/src/libraries/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
@@ -28,9 +28,9 @@ namespace System.Net.Security
             }
             _context = null;
             _exception = null;
-            _internalBuffer = null;
-            _internalBufferCount = 0;
-            _internalOffset = 0;
+            //_internalBuffer = null;
+            //_internalBufferCount = 0;
+            //_internalOffset = 0;
             _nestedWrite = 0;
             _handshakeCompleted = false;
         }

--- a/src/libraries/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
@@ -28,9 +28,6 @@ namespace System.Net.Security
             }
             _context = null;
             _exception = null;
-            //_internalBuffer = null;
-            //_internalBufferCount = 0;
-            //_internalOffset = 0;
             _nestedWrite = 0;
             _handshakeCompleted = false;
         }
@@ -56,7 +53,7 @@ namespace System.Net.Security
         //
         private Task ProcessAuthenticationAsync(bool isAsync = false, bool isApm = false, CancellationToken cancellationToken = default)
         {
-            return Task.Run(() => {});
+            return Task.Run(() => { });
         }
 
         private Task RenegotiateAsync(AsyncReadWriteAdapter adapter) => throw new PlatformNotSupportedException();

--- a/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
@@ -79,5 +79,8 @@
              Link="ProductionCode\Common\System\Net\Logging\NetEventSource.Common.cs" />
     <Compile Include="$(CommonPath)System\Net\InternalException.cs"
              Link="ProductionCode\Common\System\Net\InternalException.cs" />
+    <!-- System.Net common -->
+    <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs"
+             Link="Common\System\Net\ArrayBuffer.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #52037.

I the two buffers have been merged together since they are never used in parallel (i.e. receciving appdata is not allowed during renegotiation etc.).

One thing that is kinda open still is when to rent/return the actual buffer, currently, the code rents the buffer during construction and keeps it until the `SslStream` is disposed. Maybe we can do better.

Should probably undergo performance testing before merging.