### PR TITLE
Add ActivitySource support to DiagnosticsHandler

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -15,8 +15,8 @@ namespace System.Net.Http
     /// </summary>
     internal sealed class DiagnosticsHandler : HttpMessageHandlerStage
     {
-        private static readonly DiagnosticListener s_diagnosticListener =
-                new DiagnosticListener(DiagnosticsHandlerLoggingStrings.DiagnosticListenerName);
+        private static readonly DiagnosticListener s_diagnosticListener = new DiagnosticListener(DiagnosticsHandlerLoggingStrings.DiagnosticListenerName);
+        private static readonly ActivitySource s_activitySource = new ActivitySource(DiagnosticsHandlerLoggingStrings.Namespace);
 
         private readonly HttpMessageHandler _innerHandler;
         private readonly DistributedContextPropagator _propagator;
@@ -47,8 +47,24 @@ namespace System.Net.Http
 
         private static bool IsEnabled()
         {
-            // check if there is a parent Activity or if someone listens to HttpHandlerDiagnosticListener
-            return Activity.Current != null || s_diagnosticListener.IsEnabled();
+            // check if there is a parent Activity or if someone listens to "System.Net.Http" ActivitySource or "HttpHandlerDiagnosticListener" DiagnosticListener.
+            return Activity.Current != null ||
+                   s_activitySource.HasListeners() ||
+                   s_diagnosticListener.IsEnabled();
+        }
+
+        private static Activity? CreateActivity(HttpRequestMessage requestMessage)
+        {
+            if (s_activitySource.HasListeners())
+            {
+                return s_activitySource.CreateActivity(DiagnosticsHandlerLoggingStrings.ActivityName, ActivityKind.Client);
+            }
+            if (Activity.Current != null || s_diagnosticListener.IsEnabled(DiagnosticsHandlerLoggingStrings.ActivityName, requestMessage))
+            {
+                return new Activity(DiagnosticsHandlerLoggingStrings.ActivityName);
+            }
+
+            return null;
         }
 
         internal static bool IsGloballyEnabled() => GlobalHttpSettings.DiagnosticsHandler.EnableActivityPropagation;
@@ -91,60 +107,38 @@ namespace System.Net.Http
                 }
             }
 
-            Activity? activity = null;
             DiagnosticListener diagnosticListener = s_diagnosticListener;
 
-            // if there is no listener, but propagation is enabled (with previous IsEnabled() check)
-            // do not write any events just start/stop Activity and propagate Ids
-            if (!diagnosticListener.IsEnabled())
-            {
-                activity = new Activity(DiagnosticsHandlerLoggingStrings.ActivityName);
-                activity.Start();
-                InjectHeaders(activity, request);
-
-                try
-                {
-                    return async ?
-                        await _innerHandler.SendAsync(request, cancellationToken).ConfigureAwait(false) :
-                        _innerHandler.Send(request, cancellationToken);
-                }
-                finally
-                {
-                    activity.Stop();
-                }
-            }
-
             Guid loggingRequestId = Guid.Empty;
+            Activity? activity = CreateActivity(request);
 
-            // There is a listener. Check if listener wants to be notified about HttpClient Activities
-            if (diagnosticListener.IsEnabled(DiagnosticsHandlerLoggingStrings.ActivityName, request))
+            // Start activity anyway if it was created.
+            if (activity is not null)
             {
-                activity = new Activity(DiagnosticsHandlerLoggingStrings.ActivityName);
+                activity.Start();
 
-                // Only send start event to users who subscribed for it, but start activity anyway
+                // Only send start event to users who subscribed for it.
                 if (diagnosticListener.IsEnabled(DiagnosticsHandlerLoggingStrings.ActivityStartName))
                 {
-                    StartActivity(diagnosticListener, activity, new ActivityStartData(request));
-                }
-                else
-                {
-                    activity.Start();
+                    Write(diagnosticListener, DiagnosticsHandlerLoggingStrings.ActivityStartName, new ActivityStartData(request));
                 }
             }
-            // try to write System.Net.Http.Request event (deprecated)
+
+            // Try to write System.Net.Http.Request event (deprecated)
             if (diagnosticListener.IsEnabled(DiagnosticsHandlerLoggingStrings.RequestWriteNameDeprecated))
             {
                 long timestamp = Stopwatch.GetTimestamp();
                 loggingRequestId = Guid.NewGuid();
                 Write(diagnosticListener, DiagnosticsHandlerLoggingStrings.RequestWriteNameDeprecated,
-                    new RequestData(request, loggingRequestId, timestamp));
+                    new RequestData(
+                        request,
+                        loggingRequestId,
+                        timestamp));
             }
 
-            // If we are on at all, we propagate current activity information
-            Activity? currentActivity = Activity.Current;
-            if (currentActivity != null)
+            if (activity is not null)
             {
-                InjectHeaders(currentActivity, request);
+                InjectHeaders(activity, request);
             }
 
             HttpResponseMessage? response = null;
@@ -178,17 +172,20 @@ namespace System.Net.Http
             }
             finally
             {
-                // always stop activity if it was started
-                if (activity != null)
+                // Always stop activity if it was started.
+                if (activity is not null)
                 {
-                    StopActivity(diagnosticListener, activity, new ActivityStopData(
-                        response,
-                        // If request is failed or cancelled, there is no response, therefore no information about request;
-                        // pass the request in the payload, so consumers can have it in Stop for failed/canceled requests
-                        // and not retain all requests in Start
-                        request,
-                        taskStatus));
+                    activity.SetEndTime(DateTime.UtcNow);
+
+                    // Only send stop event to users who subscribed for it.
+                    if (diagnosticListener.IsEnabled(DiagnosticsHandlerLoggingStrings.ActivityStopName))
+                    {
+                        Write(diagnosticListener, DiagnosticsHandlerLoggingStrings.ActivityStopName, new ActivityStopData(response, request, taskStatus));
+                    }
+
+                    activity.Stop();
                 }
+
                 // Try to write System.Net.Http.Response event (deprecated)
                 if (diagnosticListener.IsEnabled(DiagnosticsHandlerLoggingStrings.ResponseWriteNameDeprecated))
                 {
@@ -335,27 +332,6 @@ namespace System.Net.Http
         {
             diagnosticSource.Write(name, value);
         }
-
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
-            Justification = "The args being passed into StartActivity have the commonly used properties being preserved with DynamicDependency.")]
-        private static Activity StartActivity<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
-            DiagnosticSource diagnosticSource,
-            Activity activity,
-            T? args)
-        {
-            return diagnosticSource.StartActivity(activity, args);
-        }
-
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
-            Justification = "The args being passed into StopActivity have the commonly used properties being preserved with DynamicDependency.")]
-        private static void StopActivity<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
-            DiagnosticSource diagnosticSource,
-            Activity activity,
-            T? args)
-        {
-            diagnosticSource.StopActivity(activity, args);
-        }
-
         #endregion
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -55,16 +55,21 @@ namespace System.Net.Http
 
         private static Activity? CreateActivity(HttpRequestMessage requestMessage)
         {
+            Activity? activity = null;
             if (s_activitySource.HasListeners())
             {
-                return s_activitySource.CreateActivity(DiagnosticsHandlerLoggingStrings.ActivityName, ActivityKind.Client);
-            }
-            if (Activity.Current != null || s_diagnosticListener.IsEnabled(DiagnosticsHandlerLoggingStrings.ActivityName, requestMessage))
-            {
-                return new Activity(DiagnosticsHandlerLoggingStrings.ActivityName);
+                activity = s_activitySource.CreateActivity(DiagnosticsHandlerLoggingStrings.ActivityName, ActivityKind.Client);
             }
 
-            return null;
+            if (activity is null)
+            {
+                if (Activity.Current is not null || s_diagnosticListener.IsEnabled(DiagnosticsHandlerLoggingStrings.ActivityName, requestMessage))
+                {
+                    activity = new Activity(DiagnosticsHandlerLoggingStrings.ActivityName);
+                }
+            }
+
+            return activity;
         }
 
         internal static bool IsGloballyEnabled() => GlobalHttpSettings.DiagnosticsHandler.EnableActivityPropagation;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandlerLoggingStrings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandlerLoggingStrings.cs
@@ -8,12 +8,13 @@ namespace System.Net.Http
     /// </summary>
     internal static class DiagnosticsHandlerLoggingStrings
     {
-        public const string DiagnosticListenerName = "HttpHandlerDiagnosticListener";
-        public const string RequestWriteNameDeprecated = "System.Net.Http.Request";
-        public const string ResponseWriteNameDeprecated = "System.Net.Http.Response";
-
-        public const string ExceptionEventName = "System.Net.Http.Exception";
-        public const string ActivityName = "System.Net.Http.HttpRequestOut";
-        public const string ActivityStartName = "System.Net.Http.HttpRequestOut.Start";
+        public const string DiagnosticListenerName         = "HttpHandlerDiagnosticListener";
+        public const string Namespace                      = "System.Net.Http";
+        public const string RequestWriteNameDeprecated     = Namespace + ".Request";
+        public const string ResponseWriteNameDeprecated    = Namespace + ".Response";
+        public const string ExceptionEventName             = Namespace + ".Exception";
+        public const string ActivityName                   = Namespace + ".HttpRequestOut";
+        public const string ActivityStartName              = ActivityName + ".Start";
+        public const string ActivityStopName               = ActivityName + ".Stop";
     }
 }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -962,25 +962,30 @@ namespace System.Net.Http.Functional.Tests
                 });
         }
 
+        public static IEnumerable<object[]> SocketsHttpHandler_ActivityCreation_MemberData()
+        {
+            foreach (var currentActivitySet in new bool[] {
+                true,    // Activity was set
+                false }) // No Activity is set
+            {
+                foreach (var diagnosticListenerActivityEnabled in new bool?[] {
+                    true,   // DiagnosticListener requested an Activity
+                    false,  // DiagnosticListener does not want an Activity
+                    null }) // There is no DiagnosticListener
+                {
+                    foreach (var activitySourceCreatesActivity in new bool?[] {
+                        true,   // ActivitySource created an Activity
+                        false,  // ActivitySource chose not to create an Activity
+                        null }) // ActivitySource had no listeners
+                    {
+                        yield return new object[] { currentActivitySet, diagnosticListenerActivityEnabled, activitySourceCreatesActivity };
+                    }
+                }
+            }
+        }
+
         [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [InlineData(true, true, true)]      // Activity was set and ActivitySource created an Activity
-        [InlineData(true, false, true)]     // Activity was set and ActivitySource created an Activity
-        [InlineData(true, null, true)]      // Activity was set and ActivitySource created an Activity
-        [InlineData(true, true, false)]     // Activity was set, ActivitySource chose not to create an Activity, so one was manually created
-        [InlineData(true, false, false)]    // Activity was set, ActivitySource chose not to create an Activity, so one was manually created
-        [InlineData(true, null, false)]     // Activity was set, ActivitySource chose not to create an Activity, so one was manually created
-        [InlineData(true, true, null)]      // Activity was set, ActivitySource had no listeners, so an Activity was manually created
-        [InlineData(true, false, null)]     // Activity was set, ActivitySource had no listeners, so an Activity was manually created
-        [InlineData(true, null, null)]      // Activity was set, ActivitySource had no listeners, so an Activity was manually created
-        [InlineData(false, true, true)]     // DiagnosticListener requested an Activity and ActivitySource created an Activity
-        [InlineData(false, true, false)]    // DiagnosticListener requested an Activity, ActivitySource chose not to create an Activity, so one was manually created
-        [InlineData(false, true, null)]     // DiagnosticListener requested an Activity, ActivitySource had no listeners, so an Activity was manually created
-        [InlineData(false, false, true)]    // No Activity is set, DiagnosticListener does not want one, but ActivitySource created an Activity
-        [InlineData(false, false, false)]   // No Activity is set, DiagnosticListener does not want one and ActivitySource chose not to create an Activity
-        [InlineData(false, false, null)]    // No Activity is set, DiagnosticListener does not want one and ActivitySource has no listeners
-        [InlineData(false, null, true)]     // No Activity is set, there is no DiagnosticListener, but ActivitySource created an Activity
-        [InlineData(false, null, false)]    // No Activity is set, there is no DiagnosticListener and ActivitySource chose not to create an Activity
-        [InlineData(false, null, null)]     // No Activity is set, there is no DiagnosticListener and ActivitySource has no listeners
+        [MemberData(nameof(SocketsHttpHandler_ActivityCreation_MemberData))]
         public void SendAsync_ActivityIsCreatedIfRequested(bool currentActivitySet, bool? diagnosticListenerActivityEnabled, bool? activitySourceCreatesActivity)
         {
             string parameters = $"{currentActivitySet},{diagnosticListenerActivityEnabled},{activitySourceCreatesActivity}";


### PR DESCRIPTION
### This is an attempt to bring the logic from #54437 in main.
Description from the original PR:

Today, `DiagnosticsHandler` will create a new `Activity` if either is true:
- An `Activity` was already set (`Activity.Current` is not null)
- A `DiagnosticListener` requested one (was enabled for the activity name)

This PR preserves the same behaviour when no `ActivityListener` is present.

The behaviour changes for `Activity` creation if an `ActivityListener` is present:
- `ActivitySource` is given chance to create an activity
- if none was created, the logic falls back to original behaviour: either `Activity.Current` is set or `DiagnosticListener` is enabled for the activity name
~- An `Activity` was already set (`Activity.Current` was not null)~
~- No `DiagnosticListener` was enabled for the activity name~
~- `ActivitySource` had listeners present~
~- Listeners decided not to sample the request~

~In this case, no `Activity` is created (and so we also won't inject context headers).~
If a `DiagnosticListener` is enabled for the activity, one is always created (regardless of sampling decisions).


The PR moves the decision of whether to ~log events~/create an activity out of the `SendAsync` call into
```c#
// The interesting part of the PR - this method decides on the actual behaviour
static Activity? CreateActivity(HttpRequestMessage request)
```

~I also removed the internal `Settings` and `LoggingStrings` classes - am I missing something and they actually provide value?~

Note that the PR is only a slight refactor + adding `ActivitySource`. It does not address other known `DiagnosticsHandler` issues.
This is runtime's equivalent of what dotnet/aspnetcore#30089 was for AspNet.

---

@MihaZupan could you please give it a look if I'm not missing anything? I had to adapt the PR and I tried to not to do much unnecessary churn.

Contributes to #63868

cc @denisivan0v @cijothomas 