### PR TITLE
[wasm] Some cleanup of wasm jobs in runtime-extra-platforms

### DIFF
--- a/eng/pipelines/runtime-extra-platforms.yml
+++ b/eng/pipelines/runtime-extra-platforms.yml
@@ -155,11 +155,6 @@ jobs:
         extraHelixArguments: /p:NeedsToBuildWasmAppsOnHelix=true $(_runSmokeTestsOnlyArg)
         scenarios:
         - normal
-        condition: >-
-          or(
-          eq(variables['librariesContainsChange'], true),
-          eq(variables['monoContainsChange'], true),
-          eq(variables['isRollingBuild'], true))
 
 #
 # Build for Browser/wasm with RunAOTCompilation=true
@@ -199,11 +194,6 @@ jobs:
         extraHelixArguments: /p:NeedsToBuildWasmAppsOnHelix=true $(_runSmokeTestsOnlyArg) /p:BrowserHost=$(_hostedOs)
         scenarios:
         - normal
-        condition: >-
-          or(
-          eq(variables['librariesContainsChange'], true),
-          eq(variables['monoContainsChange'], true),
-          eq(variables['isRollingBuild'], true))
 
 #
 # Build the whole product using Mono and run libraries tests
@@ -360,11 +350,6 @@ jobs:
         - normal
         - WasmTestOnBrowser
         - WasmTestOnNodeJs
-        condition: >-
-          or(
-            eq(variables['librariesContainsChange'], true),
-            eq(variables['monoContainsChange'], true),
-            eq(variables['isRollingBuild'], true))
 
 #
 # Build the whole product using Mono and run runtime tests

--- a/eng/pipelines/runtime-extra-platforms.yml
+++ b/eng/pipelines/runtime-extra-platforms.yml
@@ -119,46 +119,6 @@ jobs:
 #### MONO LEGS
 
 #
-# Build the whole product using Mono and run libraries tests, for Wasm.Build.Tests
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    # BuildWasmApps should only happen on the extra platforms build as we already have coverage for this build on PRs.
-    - Browser_wasm
-    - Browser_wasm_win
-    variables:
-      # map dependencies variables to local variables
-      - name: wasmbuildtestsContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_wasmbuildtests.containsChange'] ]
-    jobParameters:
-      isExtraPlatforms: ${{ variables.isExtraPlatformsBuild }}
-      testGroup: innerloop
-      nameSuffix: WasmBuildTests
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:TestWasmBuildTests=true /p:TestAssemblies=false /p:BrowserHost=$(_hostedOs)
-      timeoutInMinutes: 180
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_wasmbuildtests.containsChange'], true),
-          eq(variables['isRollingBuild'], true))
-      # extra steps, run tests
-      extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-      extraStepsParameters:
-        creator: dotnet-bot
-        testRunNamePrefixSuffix: Mono_$(_BuildConfig)_$(_hostedOs)
-        extraHelixArguments: /p:BrowserHost=$(_hostedOs)
-        scenarios:
-        - buildwasmapps
-        condition: >-
-          or(
-            eq(variables['wasmbuildtestsContainsChange'], true),
-            eq(variables['isRollingBuild'], true))
-
-#
 # Build Browser_wasm, on windows, run console and browser tests
 #
 - template: /eng/pipelines/common/platform-matrix.yml

--- a/eng/pipelines/runtime-extra-platforms.yml
+++ b/eng/pipelines/runtime-extra-platforms.yml
@@ -119,49 +119,6 @@ jobs:
 #### MONO LEGS
 
 #
-# Build Browser_wasm, on windows, run console and browser tests
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: release
-    runtimeFlavor: mono
-    platforms:
-    - Browser_wasm_win
-    variables:
-      # map dependencies variables to local variables
-      - name: librariesContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      - name: monoContainsChange
-        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: LibraryTests
-      buildArgs: -subset mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:BrowserHost=windows
-      timeoutInMinutes: 180
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isRollingBuild'], true))
-      # extra steps, run tests
-      extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-      extraStepsParameters:
-        creator: dotnet-bot
-        testRunNamePrefixSuffix: Windows_wasm_$(_BuildConfig)
-        extraHelixArguments: /p:BrowserHost=windows
-        scenarios:
-        - normal
-        - wasmtestonbrowser
-        condition: >-
-          or(
-            eq(variables['librariesContainsChange'], true),
-            eq(variables['monoContainsChange'], true),
-            eq(variables['isRollingBuild'], true))
-
-#
 # Build for Browser/wasm, with EnableAggressiveTrimming=true
 #
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -375,32 +332,39 @@ jobs:
     runtimeFlavor: mono
     platforms:
     - Browser_wasm
+    - Browser_wasm_win
     variables:
       # map dependencies variables to local variables
+      - name: librariesContainsChange
+        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
       - name: monoContainsChange
         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
     jobParameters:
       testGroup: innerloop
-      nameSuffix: AllSubsets_Mono
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
+      nameSuffix: LibraryTests
+      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:BrowserHost=$(_hostedOs)
       timeoutInMinutes: 180
       condition: >-
         or(
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
           eq(variables['isRollingBuild'], true))
       # extra steps, run tests
       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
       extraStepsParameters:
         creator: dotnet-bot
         testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+        extraHelixArguments: /p:BrowserHost=$(_hostedOs)
         scenarios:
         - normal
         - WasmTestOnBrowser
         - WasmTestOnNodeJs
         condition: >-
           or(
-          eq(variables['monoContainsChange'], true),
-          eq(variables['isRollingBuild'], true))
+            eq(variables['librariesContainsChange'], true),
+            eq(variables['monoContainsChange'], true),
+            eq(variables['isRollingBuild'], true))
 
 #
 # Build the whole product using Mono and run runtime tests


### PR DESCRIPTION
- Remove WBT from extra-platforms, as it runs in `runtime`, and `runtime-staging`
- Run library tests on NodeJS for windows too in `runtime-extra-platforms`.