### PR TITLE
[release/6.0] Fix Logging source generator failures with various syntax

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
@@ -78,7 +78,7 @@ namespace {lc.Namespace}
                 // loop until you find top level nested class
                 while (parent != null)
                 {
-                    parentClasses.Add($"partial {parent.Keyword} {parent.Name} {parent.Constraints}");
+                    parentClasses.Add($"partial {parent.Keyword} {parent.Name} ");
                     parent = parent.ParentClass;
                 }
 
@@ -92,7 +92,7 @@ namespace {lc.Namespace}
                 }
 
                 _builder.Append($@"
-    {nestedIndentation}partial {lc.Keyword} {lc.Name} {lc.Constraints}
+    {nestedIndentation}partial {lc.Keyword} {lc.Name} 
     {nestedIndentation}{{");
 
                 foreach (LoggerMethod lm in lc.Methods)
@@ -309,6 +309,10 @@ namespace {lc.Namespace}
                         _builder.Append(", ");
                     }
 
+                    if (p.Qualifier != null)
+                    {
+                        _builder.Append($"{p.Qualifier} ");
+                    }
                     _builder.Append($"{p.Type} {p.Name}");
                 }
             }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
@@ -196,7 +196,7 @@ namespace {lc.Namespace}
             {
                 foreach (LoggerParameter p in lm.TemplateParameters)
                 {
-                    _builder.AppendLine($"                {nestedIndentation}this._{p.Name} = {p.Name};");
+                    _builder.AppendLine($"                {nestedIndentation}this._{p.Name} = {p.CodeName};");
                 }
             }
 
@@ -255,7 +255,7 @@ namespace {lc.Namespace}
             {
                 foreach (LoggerParameter p in lm.TemplateParameters)
                 {
-                    _builder.Append($"{p.Name}, ");
+                    _builder.Append($"{p.CodeName}, ");
                 }
             }
 
@@ -313,7 +313,7 @@ namespace {lc.Namespace}
                     {
                         _builder.Append($"{p.Qualifier} ");
                     }
-                    _builder.Append($"{p.Type} {p.Name}");
+                    _builder.Append($"{p.Type} {p.CodeName}");
                 }
             }
 
@@ -331,7 +331,7 @@ namespace {lc.Namespace}
                         _builder.Append(", ");
                     }
 
-                    _builder.Append($"{p.Type} {p.Name}");
+                    _builder.Append($"{p.Type} {p.CodeName}");
                 }
             }
 
@@ -347,7 +347,7 @@ namespace {lc.Namespace}
                         _builder.Append(", ");
                     }
 
-                    _builder.Append(p.Name);
+                    _builder.Append(p.CodeName);
                 }
 
                 _builder.Append(')');

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -308,6 +308,15 @@ namespace Microsoft.Extensions.Logging.Generators
                                         foreach (IParameterSymbol paramSymbol in methodSymbol.Parameters)
                                         {
                                             string paramName = paramSymbol.Name;
+                                            bool needsAtSign = false;
+                                            if (paramSymbol.DeclaringSyntaxReferences.Length > 0)
+                                            {
+                                                ParameterSyntax paramSyntax = paramSymbol.DeclaringSyntaxReferences[0].GetSyntax(_cancellationToken) as ParameterSyntax;
+                                                if (paramSyntax != null && !string.IsNullOrEmpty(paramSyntax.Identifier.Text))
+                                                {
+                                                    needsAtSign = paramSyntax.Identifier.Text[0] == '@';
+                                                }
+                                            }
                                             if (string.IsNullOrWhiteSpace(paramName))
                                             {
                                                 // semantic problem, just bail quietly
@@ -341,6 +350,7 @@ namespace Microsoft.Extensions.Logging.Generators
                                                 Name = paramName,
                                                 Type = typeName,
                                                 Qualifier = qualifier,
+                                                CodeName = needsAtSign ? "@" + paramName : paramName,
                                                 IsLogger = !foundLogger && IsBaseOrIdentity(paramTypeSymbol!, loggerSymbol),
                                                 IsException = !foundException && IsBaseOrIdentity(paramTypeSymbol!, exceptionSymbol),
                                                 IsLogLevel = !foundLogLevel && IsBaseOrIdentity(paramTypeSymbol!, logLevelSymbol),
@@ -719,6 +729,7 @@ namespace Microsoft.Extensions.Logging.Generators
         {
             public string Name = string.Empty;
             public string Type = string.Empty;
+            public string CodeName = string.Empty;
             public string? Qualifier;
             public bool IsLogger;
             public bool IsException;

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -323,6 +323,15 @@ namespace Microsoft.Extensions.Logging.Generators
                                                 break;
                                             }
 
+                                            string? qualifier = null;
+                                            if (paramSymbol.RefKind == RefKind.In)
+                                            {
+                                                qualifier = "in";
+                                            }
+                                            else if (paramSymbol.RefKind == RefKind.Ref)
+                                            {
+                                                qualifier = "ref";
+                                            }
                                             string typeName = paramTypeSymbol.ToDisplayString(
                                                 SymbolDisplayFormat.FullyQualifiedFormat.WithMiscellaneousOptions(
                                                     SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier));
@@ -331,6 +340,7 @@ namespace Microsoft.Extensions.Logging.Generators
                                             {
                                                 Name = paramName,
                                                 Type = typeName,
+                                                Qualifier = qualifier,
                                                 IsLogger = !foundLogger && IsBaseOrIdentity(paramTypeSymbol!, loggerSymbol),
                                                 IsException = !foundException && IsBaseOrIdentity(paramTypeSymbol!, exceptionSymbol),
                                                 IsLogLevel = !foundLogLevel && IsBaseOrIdentity(paramTypeSymbol!, logLevelSymbol),
@@ -476,7 +486,6 @@ namespace Microsoft.Extensions.Logging.Generators
                                                 Keyword = classDec.Keyword.ValueText,
                                                 Namespace = nspace,
                                                 Name = classDec.Identifier.ToString() + classDec.TypeParameterList,
-                                                Constraints = classDec.ConstraintClauses.ToString(),
                                                 ParentClass = null,
                                             };
 
@@ -495,7 +504,6 @@ namespace Microsoft.Extensions.Logging.Generators
                                                     Keyword = parentLoggerClass.Keyword.ValueText,
                                                     Namespace = nspace,
                                                     Name = parentLoggerClass.Identifier.ToString() + parentLoggerClass.TypeParameterList,
-                                                    Constraints = parentLoggerClass.ConstraintClauses.ToString(),
                                                     ParentClass = null,
                                                 };
 
@@ -681,7 +689,6 @@ namespace Microsoft.Extensions.Logging.Generators
             public string Keyword = string.Empty;
             public string Namespace = string.Empty;
             public string Name = string.Empty;
-            public string Constraints = string.Empty;
             public LoggerClass? ParentClass;
         }
 
@@ -712,6 +719,7 @@ namespace Microsoft.Extensions.Logging.Generators
         {
             public string Name = string.Empty;
             public string Type = string.Empty;
+            public string? Qualifier;
             public bool IsLogger;
             public bool IsException;
             public bool IsLogLevel;

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/Microsoft.Extensions.Logging.Abstractions.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/Microsoft.Extensions.Logging.Abstractions.csproj
@@ -17,6 +17,8 @@ Microsoft.Extensions.Logging.LogLevel
 Microsoft.Extensions.Logging.Logger&lt;T&gt;
 Microsoft.Extensions.Logging.LoggerMessage
 Microsoft.Extensions.Logging.Abstractions.NullLogger</PackageDescription>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>1</ServicingVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithNestedClass.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithNestedClass.generated.txt
@@ -9,11 +9,11 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses.NestedNamesp
         {
             partial record NestedRecord 
             {
-                partial class NestedClassTestsExtensions<T1> where T1 : Class1
+                partial class NestedClassTestsExtensions<T1> 
                 {
                     partial class NestedMiddleParentClass 
                     {
-                        partial class Nested<T2> where T2 : Class2
+                        partial class Nested<T2> 
                         {
                             [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "%VERSION%")]
                             private static readonly global::System.Action<global::Microsoft.Extensions.Logging.ILogger, global::System.Exception?> __M9Callback =

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratedCodeTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratedCodeTests.cs
@@ -3,8 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Generators.Tests.TestClasses;
+using Microsoft.Extensions.Logging.Generators.Tests.TestClasses.UsesConstraintInAnotherNamespace;
 using Xunit;
+using NamespaceForABC;
+using ConstraintInAnotherNamespace;
 
 namespace Microsoft.Extensions.Logging.Generators.Tests
 {
@@ -409,6 +413,71 @@ namespace Microsoft.Extensions.Logging.Generators.Tests
             Assert.Equal(LogLevel.Debug, logger.LastLogLevel);
             Assert.Equal(1, logger.CallCount);
             Assert.Equal("LoggerMethodWithTrueSkipEnabledCheck", logger.LastEventId.Name);
+        }
+        private struct MyStruct { }
+
+        [Fact]
+        public void ConstraintsTests()
+        {
+            var logger = new MockLogger();
+
+            var printer = new MessagePrinter<Message>();
+            logger.Reset();
+            printer.Print(logger, new Message() { Text = "Hello" });
+            Assert.Equal(LogLevel.Information, logger.LastLogLevel);
+            Assert.Null(logger.LastException);
+            Assert.Equal("The message is Hello.", logger.LastFormattedString);
+            Assert.Equal(1, logger.CallCount);
+
+            var printer2 = new MessagePrinterHasConstraintOnLogClassAndLogMethod<Message>();
+            logger.Reset();
+            printer2.Print(logger, new Message() { Text = "Hello" });
+            Assert.Equal(LogLevel.Information, logger.LastLogLevel);
+            Assert.Null(logger.LastException);
+            Assert.Equal("The message is `Hello`.", logger.LastFormattedString);
+            Assert.Equal(1, logger.CallCount);
+
+            logger.Reset();
+            ConstraintsTestExtensions<Object>.M0(logger, 12);
+            Assert.Equal(LogLevel.Debug, logger.LastLogLevel);
+            Assert.Null(logger.LastException);
+            Assert.Equal("M012", logger.LastFormattedString);
+            Assert.Equal(1, logger.CallCount);
+
+            logger.Reset();
+            ConstraintsTestExtensions1<MyStruct>.M0(logger, 12);
+            Assert.Equal(LogLevel.Debug, logger.LastLogLevel);
+            Assert.Null(logger.LastException);
+            Assert.Equal("M012", logger.LastFormattedString);
+            Assert.Equal(1, logger.CallCount);
+
+            logger.Reset();
+            ConstraintsTestExtensions2<MyStruct>.M0(logger, 12);
+            Assert.Equal(LogLevel.Debug, logger.LastLogLevel);
+            Assert.Null(logger.LastException);
+            Assert.Equal("M012", logger.LastFormattedString);
+            Assert.Equal(1, logger.CallCount);
+
+            logger.Reset();
+            ConstraintsTestExtensions3<MyStruct>.M0(logger, 12);
+            Assert.Equal(LogLevel.Debug, logger.LastLogLevel);
+            Assert.Null(logger.LastException);
+            Assert.Equal("M012", logger.LastFormattedString);
+            Assert.Equal(1, logger.CallCount);
+
+            logger.Reset();
+            ConstraintsTestExtensions4<Attribute>.M0(logger, 12);
+            Assert.Equal(LogLevel.Debug, logger.LastLogLevel);
+            Assert.Null(logger.LastException);
+            Assert.Equal("M012", logger.LastFormattedString);
+            Assert.Equal(1, logger.CallCount);
+
+            logger.Reset();
+            ConstraintsTestExtensions5<MyStruct>.M0(logger, 12);
+            Assert.Equal(LogLevel.Debug, logger.LastLogLevel);
+            Assert.Null(logger.LastException);
+            Assert.Equal("M012", logger.LastFormattedString);
+            Assert.Equal(1, logger.CallCount);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
@@ -606,6 +606,21 @@ namespace Microsoft.Extensions.Logging.Generators.Tests
             Assert.Equal(DiagnosticDescriptors.LoggingMethodIsGeneric.Id, diagnostics[0].Id);
         }
 
+        [Theory]
+        [InlineData("ref")]
+        [InlineData("in")]
+        public async Task SupportsRefKindsInAndRef(string modifier)
+        {
+            IReadOnlyList<Diagnostic> diagnostics = await RunGenerator(@$"
+                partial class C
+                {{
+                    [LoggerMessage(EventId = 0, Level = LogLevel.Debug, Message = ""Parameter {{P1}}"")]
+                    static partial void M(ILogger logger, {modifier} int p1);
+                }}");
+
+            Assert.Empty(diagnostics);
+        }
+
         [Fact]
         public async Task Templates()
         {

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/TestClasses/AtSymbolTestExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/TestClasses/AtSymbolTestExtensions.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
+{
+    internal static partial class AtSymbolTestExtensions
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "M0 {event}")]
+        internal static partial void M0(ILogger logger, string @event);
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/TestClasses/ConstaintsTestExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/TestClasses/ConstaintsTestExtensions.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
+{
+    using ConstraintInAnotherNamespace;
+    namespace UsesConstraintInAnotherNamespace
+    {
+        public partial class MessagePrinter<T>
+            where T : Message
+        {
+            public void Print(ILogger logger, T message)
+            {
+                Log.Message(logger, message.Text);
+            }
+
+            internal static partial class Log
+            {
+                [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "The message is {Text}.")]
+                internal static partial void Message(ILogger logger, string? text);
+            }
+        }
+
+        public partial class MessagePrinterHasConstraintOnLogClassAndLogMethod<T>
+            where T : Message
+        {
+            public void Print(ILogger logger, T message)
+            {
+                Log<Message>.Message(logger, message);
+            }
+
+            internal static partial class Log<U> where U : Message
+            {
+                [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "The message is {Text}.")]
+                internal static partial void Message(ILogger logger, U text);
+            }
+        }
+    }
+
+    internal static partial class ConstraintsTestExtensions<T>
+        where T : class
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Debug, Message = "M0{p0}")]
+        public static partial void M0(ILogger logger, int p0);
+
+        public static void Foo(T dummy)
+        {
+        }
+    }
+
+    internal static partial class ConstraintsTestExtensions1<T>
+        where T : struct
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Debug, Message = "M0{p0}")]
+        public static partial void M0(ILogger logger, int p0);
+
+        public static void Foo(T dummy)
+        {
+        }
+    }
+
+    internal static partial class ConstraintsTestExtensions2<T>
+        where T : unmanaged
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Debug, Message = "M0{p0}")]
+        public static partial void M0(ILogger logger, int p0);
+
+        public static void Foo(T dummy)
+        {
+        }
+    }
+
+    internal static partial class ConstraintsTestExtensions3<T>
+        where T : new()
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Debug, Message = "M0{p0}")]
+        public static partial void M0(ILogger logger, int p0);
+
+        public static void Foo(T dummy)
+        {
+        }
+    }
+
+    internal static partial class ConstraintsTestExtensions4<T>
+        where T : System.Attribute
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Debug, Message = "M0{p0}")]
+        public static partial void M0(ILogger logger, int p0);
+
+        public static void Foo(T dummy)
+        {
+        }
+    }
+
+    internal static partial class ConstraintsTestExtensions5<T>
+        where T : notnull
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Debug, Message = "M0{p0}")]
+        public static partial void M0(ILogger logger, int p0);
+
+        public static void Foo(T dummy)
+        {
+        }
+    }
+}
+
+namespace ConstraintInAnotherNamespace
+{
+    public class Message
+    {
+        public string? Text { get; set; }
+
+        public override string ToString()
+        {
+            return $"`{Text}`";
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/TestClasses/NestedClassTestsExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/TestClasses/NestedClassTestsExtensions.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
 {
+    using NamespaceForABC;
+
     internal static partial class NestedClassTestsExtensions<T> where T : ABC
     {
         internal static partial class NestedMiddleParentClass
@@ -26,7 +28,6 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
             }
         }
     }
-    public class ABC {}
 
     public partial struct NestedStruct
     {
@@ -60,4 +61,9 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
             }
         }
     }
+}
+
+namespace NamespaceForABC
+{
+    public class ABC {}
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/TestClasses/ParameterTestExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/TestClasses/ParameterTestExtensions.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
+{
+    internal static partial class ParameterTestExtensions
+    {
+        internal struct S
+        {
+            public override string ToString() => "Hello from S";
+        }
+
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "UseInParameter {s}")]
+        internal static partial void UseInParameter(ILogger logger, in S s);
+
+        [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "UseRefParameter {s}")]
+        internal static partial void UseRefParameter(ILogger logger, ref S s);
+    }
+}


### PR DESCRIPTION
## Customer Impact

Presenting 3 customer-reported issues, being blocked from using the Logging Source Generator when using the following use cases below. (Workarounds require customers to significantly change their usage which prevents them from adopting the feature).

---

- Issue https://github.com/dotnet/runtime/issues/60968 was the most requested by community as part of post-release 6.0 feedback so it would be good to backport it to 6.0:

If a C# keyword is used as a parameter name for a `[LoggerMessage]` method using the logging source generator prefixed with an `@`, such as the example below, the application will fail to compile due to the source generator creating invalid C#.

```csharp
[LoggerMessage(1, LogLevel.Information, "Event: {event}")]
public static partial void LogEvent(ILogger logger, object @event);
```

If the `@` is included in the template to match the parameter, it will also fail to compile.

---

- Issue https://github.com/dotnet/runtime/issues/58550 helps with the logging source generator robustness and to developers wanting to migrate to the new logging approach fixes a variety of use cases having to do with constraints:

For example, as originally reported, the generator fails to compile due to CS0246 and CS0265 errors if type for generic constraint is in a different namespace. There's more constraint-related use cases covered within the PR.

---

- Issue https://github.com/dotnet/runtime/issues/62644 helps with the logging source generator support the `in` or `ref` modifier, rather than producing a compile failure with the repro sample seen below:

```c#
[LoggerMessage(2, LogLevel.Information, "Foo: {my}")]
public static partial void LogSomething1(this ILogger logger, in MyReadOnlyStruct my);
```

## Regression

No

## Testing

Automated test cases added to cover the missed syntax. Included in the PRs:
- [x] https://github.com/dotnet/runtime/pull/64663
- [x] https://github.com/dotnet/runtime/pull/64593 

## Risk

Low. Very targeted changes were selected to handle missed syntax. 
Test cases were added and more variants to reported repro cases were also explored. 

When fixing for generic constrains, we reduced risk by avoiding duplication of constraints/derived types.

The other two fixes (`ref`/`in` support and `@` prefixed parameter support) only impact use cases for which we are otherwise unsupported and produce ambiguous compilation errors, has also been reviewed by Roslyn members and therefore are clear improvements with low risk.

## Packaging impact:

- [x] Requires packaging of Microsoft.Extensions.Logging.Abstractions

## Ref pack impact:

Yes, modifies inbox source-generator contained in ASP.NET ref-pack. 