### PR TITLE
Track local var ranges for "interfering writes" LIR check

### DIFF
--- a/src/coreclr/jit/sideeffects.cpp
+++ b/src/coreclr/jit/sideeffects.cpp
@@ -136,7 +136,7 @@ AliasSet::AliasSet()
 //    node - The node in question.
 //
 AliasSet::NodeInfo::NodeInfo(Compiler* compiler, GenTree* node)
-    : m_compiler(compiler), m_node(node), m_flags(0), m_lclNum(0)
+    : m_compiler(compiler), m_node(node), m_flags(0), m_lclNum(0), m_lclOffs(0)
 {
     if (node->IsCall())
     {
@@ -174,6 +174,7 @@ AliasSet::NodeInfo::NodeInfo(Compiler* compiler, GenTree* node)
     bool     isMemoryAccess = false;
     bool     isLclVarAccess = false;
     unsigned lclNum         = 0;
+    unsigned lclOffs        = 0;
     if (node->OperIsIndir())
     {
         // If the indirection targets a lclVar, we can be more precise with regards to aliasing by treating the
@@ -183,6 +184,7 @@ AliasSet::NodeInfo::NodeInfo(Compiler* compiler, GenTree* node)
         {
             isLclVarAccess = true;
             lclNum         = address->AsLclVarCommon()->GetLclNum();
+            lclOffs        = address->AsLclVarCommon()->GetLclOffs();
         }
         else
         {
@@ -197,6 +199,7 @@ AliasSet::NodeInfo::NodeInfo(Compiler* compiler, GenTree* node)
     {
         isLclVarAccess = true;
         lclNum         = node->AsLclVarCommon()->GetLclNum();
+        lclOffs        = node->AsLclVarCommon()->GetLclOffs();
     }
     else
     {
@@ -221,7 +224,8 @@ AliasSet::NodeInfo::NodeInfo(Compiler* compiler, GenTree* node)
         if (isLclVarAccess)
         {
             m_flags |= ALIAS_READS_LCL_VAR;
-            m_lclNum = lclNum;
+            m_lclNum  = lclNum;
+            m_lclOffs = lclOffs;
         }
     }
     else
@@ -234,7 +238,8 @@ AliasSet::NodeInfo::NodeInfo(Compiler* compiler, GenTree* node)
         if (isLclVarAccess)
         {
             m_flags |= ALIAS_WRITES_LCL_VAR;
-            m_lclNum = lclNum;
+            m_lclNum  = lclNum;
+            m_lclOffs = lclOffs;
         }
     }
 }

--- a/src/coreclr/jit/sideeffects.h
+++ b/src/coreclr/jit/sideeffects.h
@@ -72,6 +72,7 @@ public:
         GenTree*  m_node;
         unsigned  m_flags;
         unsigned  m_lclNum;
+        unsigned  m_lclOffs;
 
     public:
         NodeInfo(Compiler* compiler, GenTree* node);
@@ -110,6 +111,12 @@ public:
         {
             assert(IsLclVarRead() || IsLclVarWrite());
             return m_lclNum;
+        }
+
+        inline unsigned LclOffs() const
+        {
+            assert(IsLclVarRead() || IsLclVarWrite());
+            return m_lclOffs;
         }
 
         inline bool WritesAnyLocation() const


### PR DESCRIPTION
For LIR we verify that we can really consider locals to be used at their
user by having a checker that looks for interfering stores to the same
locals. However, in some cases we may have "interfering"
GT_LCL_FLD/GT_STORE_LCL_FLD, in the sense that they work on the same
local but on a disjoint range of bytes. Add support to validate this.

This fixes #57919 which made the fuzzer jobs very noisy and made it easy
to miss actual new examples (e.g. #63720 was just merged even though
there were real examples found there).

Fix #57919