### PR TITLE
[mobile] Add extra HttpClientHandler linker substitution

### DIFF
--- a/src/libraries/System.Net.Http/src/ILLink/ILLink.Substitutions.mobile.xml
+++ b/src/libraries/System.Net.Http/src/ILLink/ILLink.Substitutions.mobile.xml
@@ -2,8 +2,6 @@
   <assembly fullname="System.Net.Http">
     <type fullname="System.Net.Http.HttpClientHandler">
       <method signature="System.Boolean get_IsNativeHandlerEnabled()" body="stub" value="false" feature="System.Net.Http.UseNativeHttpHandler" featurevalue="false" />
-    </type>
-    <type fullname="System.Net.Http.HttpClientHandler">
       <method signature="System.Boolean get_IsNativeHandlerEnabled()" body="stub" value="true" feature="System.Net.Http.UseNativeHttpHandler" featurevalue="true" />
     </type>
   </assembly>

--- a/src/libraries/System.Net.Http/src/ILLink/ILLink.Substitutions.mobile.xml
+++ b/src/libraries/System.Net.Http/src/ILLink/ILLink.Substitutions.mobile.xml
@@ -3,5 +3,8 @@
     <type fullname="System.Net.Http.HttpClientHandler">
       <method signature="System.Boolean get_IsNativeHandlerEnabled()" body="stub" value="false" feature="System.Net.Http.UseNativeHttpHandler" featurevalue="false" />
     </type>
+    <type fullname="System.Net.Http.HttpClientHandler">
+      <method signature="System.Boolean get_IsNativeHandlerEnabled()" body="stub" value="true" feature="System.Net.Http.UseNativeHttpHandler" featurevalue="true" />
+    </type>
   </assembly>
 </linker>


### PR DESCRIPTION
The linker substitution for HttpClientHandler.IsNativeHandlerEnabled only worked when <UseNativeHttpHandler> in a project was set to false.  Since the default for MAUI projects is true, this caused us to carry more assemblies than needed.

Fixes https://github.com/dotnet/runtime/issues/64361