### PR TITLE
Update RateLimiter queues on cancellation

### DIFF
--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
@@ -322,7 +322,7 @@ namespace System.Threading.RateLimiting
             public CancellationTokenRegistration CancellationTokenRegistration { get; }
         }
 
-        private class CancelQueueState : TaskCompletionSource<RateLimitLease>
+        private sealed class CancelQueueState : TaskCompletionSource<RateLimitLease>
         {
             private readonly int _permitCount;
             private readonly ConcurrencyLimiter _limiter;

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
@@ -382,7 +382,7 @@ namespace System.Threading.RateLimiting
             public CancellationTokenRegistration CancellationTokenRegistration { get; }
         }
 
-        private class CancelQueueState : TaskCompletionSource<RateLimitLease>
+        private sealed class CancelQueueState : TaskCompletionSource<RateLimitLease>
         {
             private readonly int _tokenCount;
             private readonly TokenBucketRateLimiter _limiter;

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
@@ -124,14 +124,13 @@ namespace System.Threading.RateLimiting
                     }
                 }
 
-                TaskCompletionSource<RateLimitLease> tcs = new TaskCompletionSource<RateLimitLease>(TaskCreationOptions.RunContinuationsAsynchronously);
-
+                WrappedTCS tcs = new WrappedTCS(tokenCount, this);
                 CancellationTokenRegistration ctr = default;
                 if (cancellationToken.CanBeCanceled)
                 {
                     ctr = cancellationToken.Register(static obj =>
                     {
-                        ((TaskCompletionSource<RateLimitLease>)obj!).TrySetException(new OperationCanceledException());
+                        ((WrappedTCS)obj!).TryCancel();
                     }, tcs);
                 }
 
@@ -140,7 +139,6 @@ namespace System.Threading.RateLimiting
                 _queueCount += tokenCount;
                 Debug.Assert(_queueCount <= _options.QueueLimit);
 
-                // handle cancellation
                 return new ValueTask<RateLimitLease>(registration.Tcs.Task);
             }
         }
@@ -276,15 +274,17 @@ namespace System.Threading.RateLimiting
 
                         _queueCount -= nextPendingRequest.Count;
                         _tokenCount -= nextPendingRequest.Count;
-                        Debug.Assert(_queueCount >= 0);
                         Debug.Assert(_tokenCount >= 0);
 
                         if (!nextPendingRequest.Tcs.TrySetResult(SuccessfulLease))
                         {
                             // Queued item was canceled so add count back
                             _tokenCount += nextPendingRequest.Count;
+                            // Updating queue count is handled by the cancellation code
+                            _queueCount += nextPendingRequest.Count;
                         }
                         nextPendingRequest.CancellationTokenRegistration.Dispose();
+                        Debug.Assert(_queueCount >= 0);
                     }
                     else
                     {
@@ -380,7 +380,29 @@ namespace System.Threading.RateLimiting
             public TaskCompletionSource<RateLimitLease> Tcs { get; }
 
             public CancellationTokenRegistration CancellationTokenRegistration { get; }
+        }
 
+        private class WrappedTCS : TaskCompletionSource<RateLimitLease>
+        {
+            private readonly int TokenCount;
+            private readonly TokenBucketRateLimiter Limiter;
+
+            public WrappedTCS(int tokenCount, TokenBucketRateLimiter limiter) : base(TaskCreationOptions.RunContinuationsAsynchronously)
+            {
+                TokenCount = tokenCount;
+                Limiter = limiter;
+            }
+
+            public void TryCancel()
+            {
+                if (TrySetException(new OperationCanceledException()))
+                {
+                    lock (Limiter.Lock)
+                    {
+                        Limiter._queueCount -= TokenCount;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/tests/BaseRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/BaseRateLimiterTests.cs
@@ -81,6 +81,9 @@ namespace System.Threading.RateLimiting.Test
         public abstract Task CanCancelWaitAsyncBeforeQueuing();
 
         [Fact]
+        public abstract Task CancelUpdatesQueueLimit();
+
+        [Fact]
         public abstract Task CanAcquireResourcesWithAcquireWithQueuedItemsIfNewestFirst();
 
         [Fact]

--- a/src/libraries/System.Threading.RateLimiting/tests/ConcurrencyLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/ConcurrencyLimiterTests.cs
@@ -401,7 +401,8 @@ namespace System.Threading.RateLimiting.Test
             var wait = limiter.WaitAsync(1, cts.Token);
 
             cts.Cancel();
-            await Assert.ThrowsAsync<OperationCanceledException>(() => wait.AsTask());
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
+            Assert.Equal(cts.Token, ex.CancellationToken);
 
             lease.Dispose();
 
@@ -418,7 +419,8 @@ namespace System.Threading.RateLimiting.Test
             var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            await Assert.ThrowsAsync<TaskCanceledException>(() => limiter.WaitAsync(1, cts.Token).AsTask());
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => limiter.WaitAsync(1, cts.Token).AsTask());
+            Assert.Equal(cts.Token, ex.CancellationToken);
 
             lease.Dispose();
 
@@ -436,7 +438,8 @@ namespace System.Threading.RateLimiting.Test
             var wait = limiter.WaitAsync(1, cts.Token);
 
             cts.Cancel();
-            await Assert.ThrowsAsync<OperationCanceledException>(() => wait.AsTask());
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
+            Assert.Equal(cts.Token, ex.CancellationToken);
 
             wait = limiter.WaitAsync(1);
             Assert.False(wait.IsCompleted);

--- a/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
@@ -354,7 +354,8 @@ namespace System.Threading.RateLimiting.Test
             var wait = limiter.WaitAsync(1, cts.Token);
 
             cts.Cancel();
-            await Assert.ThrowsAsync<OperationCanceledException>(() => wait.AsTask());
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
+            Assert.Equal(cts.Token, ex.CancellationToken);
 
             lease.Dispose();
             Assert.True(limiter.TryReplenish());
@@ -373,7 +374,8 @@ namespace System.Threading.RateLimiting.Test
             var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            await Assert.ThrowsAsync<TaskCanceledException>(() => limiter.WaitAsync(1, cts.Token).AsTask());
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => limiter.WaitAsync(1, cts.Token).AsTask());
+            Assert.Equal(cts.Token, ex.CancellationToken);
 
             lease.Dispose();
             Assert.True(limiter.TryReplenish());
@@ -393,7 +395,8 @@ namespace System.Threading.RateLimiting.Test
             var wait = limiter.WaitAsync(1, cts.Token);
 
             cts.Cancel();
-            await Assert.ThrowsAsync<OperationCanceledException>(() => wait.AsTask());
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
+            Assert.Equal(cts.Token, ex.CancellationToken);
 
             wait = limiter.WaitAsync(1);
             Assert.False(wait.IsCompleted);


### PR DESCRIPTION
Fixes #64078

Realized the issue wasn't specific to TokenBucket so updated the base test class.
Also, avoiding the extra allocations for a closure by implementing a custom TCS.