### PR TITLE
Move 20H2 queues to server 2022

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -126,13 +126,13 @@ jobs:
         # libraries on mono outerloop
         - ${{ if and(eq(parameters.jobParameters.testScope, 'outerloop'), eq(parameters.jobParameters.runtimeFlavor, 'mono')) }}:
           - Windows.81.Amd64.Open
-          - Windows.10.Amd64.Server20H2.Open
+          - Windows.Amd64.Server2022.Open
         # libraries on coreclr (outerloop and innerloop), or libraries on mono innerloop
         - ${{ if or(ne(parameters.jobParameters.testScope, 'outerloop'), ne(parameters.jobParameters.runtimeFlavor, 'mono')) }}:
           - ${{ if or(eq(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
             - Windows.10.Amd64.ServerRS5.Open
             - ${{ if ne(parameters.jobParameters.testScope, 'outerloop') }}:
-              - Windows.10.Amd64.Server20H2.Open
+              - Windows.Amd64.Server2022.Open
               - (Windows.Server.Core.1909.Amd64.Open)windows.10.amd64.server20h2.open@mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-2004-helix-amd64-20200904200251-272704c
           - ${{ if or(ne(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
             - Windows.81.Amd64.Open


### PR DESCRIPTION
Fixes: #64763 

The 20H2 queues are Server Core, and Server Core doesn't contain icu.dll on the SysWOW64 directory, so the tests that expect ICU to be loaded on SKUs newer or equal to 1903 fail when running on x86.

Since we already have coverage for Server Core on the docker images, move to the next Data Center LTS release which is Server 2022.

FYI: @tarekgh 