### PR TITLE
Set up an analyzer exception filter to make intermittent failures more actionable.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -172,7 +172,7 @@
     <MoqVersion>4.12.0</MoqVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
     <SdkVersionForWorkloadTesting>7.0.100-alpha.1.21528.1</SdkVersionForWorkloadTesting>
-    <CompilerPlatformTestingVersion>1.1.1-beta1.21467.5</CompilerPlatformTestingVersion>
+    <CompilerPlatformTestingVersion>1.1.1-beta1.22103.1</CompilerPlatformTestingVersion>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>6.0.0-preview-20211019.1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Verifiers/CSharpCodeFixVerifier.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Verifiers/CSharpCodeFixVerifier.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -113,6 +114,33 @@ namespace DllImportGenerator.UnitTests.Verifiers
                     solution = solution.WithProjectParseOptions(projectId, ((CSharpParseOptions)project.ParseOptions!).WithLanguageVersion(LanguageVersion.Preview));
                     return solution;
                 });
+            }
+
+            protected override CompilationWithAnalyzers CreateCompilationWithAnalyzers(Compilation compilation, ImmutableArray<DiagnosticAnalyzer> analyzers, AnalyzerOptions options, CancellationToken cancellationToken)
+            {
+                return new CompilationWithAnalyzers(
+                    compilation,
+                    analyzers,
+                    new CompilationWithAnalyzersOptions(
+                        options,
+                        onAnalyzerException: null,
+                        concurrentAnalysis: true,
+                        logAnalyzerExecutionTime: true,
+                        reportSuppressedDiagnostics: false,
+                        analyzerExceptionFilter: ex =>
+                        {
+                            // We're hunting down a intermittent issue that causes NullReferenceExceptions deep in Roslyn. To ensure that we get an actionable dump, we're going to FailFast here to force a process dump.
+                            if (ex is NullReferenceException)
+                            {
+                                // Break a debugger here so there's a chance to investigate if someone is already attached.
+                                if (System.Diagnostics.Debugger.IsAttached)
+                                {
+                                    System.Diagnostics.Debugger.Break();
+                                }
+                                Environment.FailFast($"Encountered a NullReferenceException while running an analyzer. Taking the process down to get an actionable crash dump. Exception information:{ex.ToString()}");
+                            }
+                            return true;
+                        }));
             }
 
             protected override async Task RunImplAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Update the Roslyn Testing SDK version and update the DllImportGenerator unit tests to crash in a way that produces a dump for some of our intermittent issues (https://github.com/dotnet/runtime/issues/60909, https://github.com/dotnet/runtime/issues/62223). This mechanism will crash the process during the "exception filter" phase, so it will still have the throwing frame on the stack (no unwinding). Hopefully this will enable us to get more actionable dumps to investigate these issues and determine if they're Roslyn bugs or GC holes.

cc: @dotnet/interop-contrib
cc: @agocke