### PR TITLE
Clean up several special tests under JIT/Methodical

### DIFF
--- a/src/tests/JIT/Methodical/Coverage/b518440.il
+++ b/src/tests/JIT/Methodical/Coverage/b518440.il
@@ -13,7 +13,7 @@
 
 .class public A
 {
-  .method public hidebysig static int32 main(string[] args)
+  .method public hidebysig static int32 main()
   {
     .entrypoint
     .maxstack 2

--- a/src/tests/JIT/Methodical/cctor/misc/deadlock.il
+++ b/src/tests/JIT/Methodical/cctor/misc/deadlock.il
@@ -38,6 +38,8 @@ ret
 }
 }
 
+.class public Test_deadlock extends[mscorlib]System.Object
+{
 .method public static int32 Main()
 {
 .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -48,5 +50,6 @@ ldsfld class Test_deadlock.B Test_deadlock.A::b
 pop
 ldc.i4 100
 ret
+}
 }
 }

--- a/src/tests/JIT/Methodical/cctor/simple/prefldinit1.il
+++ b/src/tests/JIT/Methodical/cctor/simple/prefldinit1.il
@@ -48,7 +48,7 @@
 
 } // end of class measure
 
-.class private auto ansi  beforefieldinit test
+.class private auto ansi test
        extends [mscorlib]System.Object
 {
   .method public hidebysig static void  f(unsigned int8& b) cil managed

--- a/src/tests/JIT/Methodical/cctor/simple/prefldinit1.il
+++ b/src/tests/JIT/Methodical/cctor/simple/prefldinit1.il
@@ -21,43 +21,6 @@
   .ver 0:0:0:0
 }
 .assembly extern xunit.core {}
-// MVID: {D664E737-135B-4517-AFBA-875EBEA1C810}
-.imagebase 0x00400000
-.subsystem 0x00000003
-.file alignment 512
-.corflags 0x00000001
-// Image base: 0x076c0000
-//
-// ============== CLASS STRUCTURE DECLARATION ==================
-//
-.class private auto ansi beforefieldinit measure
-       extends [mscorlib]System.Object
-{
-} // end of class measure
-
-.class private auto ansi test
-       extends [mscorlib]System.Object
-{
-} // end of class test
-
-.class private auto ansi beforefieldinit Driver
-       extends [mscorlib]System.Object
-{
-} // end of class Driver
-
-
-// =============================================================
-
-
-// =============== GLOBAL FIELDS AND METHODS ===================
-
-
-// =============================================================
-
-
-// =============== CLASS MEMBERS DECLARATION ===================
-//   note that class flags, 'extends' and 'implements' clauses
-//          are provided here for information only
 
 .class private auto ansi beforefieldinit measure
        extends [mscorlib]System.Object

--- a/src/tests/JIT/Methodical/cctor/simple/prefldinit2.il
+++ b/src/tests/JIT/Methodical/cctor/simple/prefldinit2.il
@@ -48,7 +48,7 @@
 
 } // end of class measure
 
-.class private auto ansi beforefieldinit test
+.class private auto ansi test
        extends [mscorlib]System.Object
 {
   .method private hidebysig specialname rtspecialname static 

--- a/src/tests/JIT/Methodical/cctor/simple/prefldinit2.il
+++ b/src/tests/JIT/Methodical/cctor/simple/prefldinit2.il
@@ -21,43 +21,6 @@
   .ver 0:0:0:0
 }
 .assembly extern xunit.core {}
-// MVID: {C486E388-5E60-42FA-B093-89857CB047D8}
-.imagebase 0x00400000
-.subsystem 0x00000003
-.file alignment 512
-.corflags 0x00000001
-// Image base: 0x076c0000
-//
-// ============== CLASS STRUCTURE DECLARATION ==================
-//
-.class private auto ansi beforefieldinit measure
-       extends [mscorlib]System.Object
-{
-} // end of class measure
-
-.class private auto ansi test
-       extends [mscorlib]System.Object
-{
-} // end of class test
-
-.class private auto ansi beforefieldinit Driver
-       extends [mscorlib]System.Object
-{
-} // end of class Driver
-
-
-// =============================================================
-
-
-// =============== GLOBAL FIELDS AND METHODS ===================
-
-
-// =============================================================
-
-
-// =============== CLASS MEMBERS DECLARATION ===================
-//   note that class flags, 'extends' and 'implements' clauses
-//          are provided here for information only
 
 .class private auto ansi beforefieldinit measure
        extends [mscorlib]System.Object

--- a/src/tests/JIT/Methodical/cctor/simple/prefldinit4.il
+++ b/src/tests/JIT/Methodical/cctor/simple/prefldinit4.il
@@ -21,43 +21,6 @@
   .ver 0:0:0:0
 }
 .assembly extern xunit.core {}
-// MVID: {623817A9-BEA6-4892-A378-D2135E123200}
-.imagebase 0x00400000
-.subsystem 0x00000003
-.file alignment 512
-.corflags 0x00000001
-// Image base: 0x076c0000
-//
-// ============== CLASS STRUCTURE DECLARATION ==================
-//
-.class private auto ansi beforefieldinit measure
-       extends [mscorlib]System.Object
-{
-} // end of class measure
-
-.class private auto ansi test
-       extends [mscorlib]System.Object
-{
-} // end of class test
-
-.class private auto ansi beforefieldinit Driver
-       extends [mscorlib]System.Object
-{
-} // end of class Driver
-
-
-// =============================================================
-
-
-// =============== GLOBAL FIELDS AND METHODS ===================
-
-
-// =============================================================
-
-
-// =============== CLASS MEMBERS DECLARATION ===================
-//   note that class flags, 'extends' and 'implements' clauses
-//          are provided here for information only
 
 .class private auto ansi beforefieldinit measure
        extends [mscorlib]System.Object

--- a/src/tests/JIT/Methodical/cctor/simple/prefldinit4.il
+++ b/src/tests/JIT/Methodical/cctor/simple/prefldinit4.il
@@ -48,7 +48,7 @@
 
 } // end of class measure
 
-.class private auto ansi beforefieldinit test
+.class private auto ansi test
        extends [mscorlib]System.Object
 {
   .field public static unsigned int8 b

--- a/src/tests/JIT/Methodical/eh/deadcode/deadEHregionacrossBB.il
+++ b/src/tests/JIT/Methodical/eh/deadcode/deadEHregionacrossBB.il
@@ -26,27 +26,15 @@
 .class private auto ansi beforefieldinit test
        extends [mscorlib]System.Object
 {
-	.field private static class [eh_common]TestUtil.TestLog testLog
-  	.method private hidebysig specialname rtspecialname static void  .cctor() cil managed
-    {
-      		.maxstack  2
-      		newobj     instance void [eh_common]TestUtil.TestLog::.ctor()
-      		stsfld     class [eh_common]TestUtil.TestLog test::testLog
-      		ret
-    } // end of method test::.cctor
-} // end of class test
+  .field private static class [eh_common]TestUtil.TestLog testLog
+  .method private hidebysig specialname rtspecialname static void  .cctor() cil managed
+  {
+    .maxstack  2
+    newobj     instance void [eh_common]TestUtil.TestLog::.ctor()
+    stsfld     class [eh_common]TestUtil.TestLog test::testLog
+    ret
+  } // end of method test::.cctor
 
-
-
-
-
-
-
-
-
-.class private auto ansi beforefieldinit test
-       extends [mscorlib]System.Object
-{
   .method public hidebysig static int32  Main() cil managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -57,9 +45,9 @@
     .locals init (int32 V_0)
     ldsfld     class [eh_common]TestUtil.TestLog test::testLog
     callvirt   instance void [eh_common]TestUtil.TestLog::StartRecording()
-    
+
     L:
-    br	IL_0019
+    br  IL_0019
     .try
     {
       IL_0000:  ldstr      "In try"
@@ -72,10 +60,10 @@
          leave.s L
       } finally {
          endfinally
-      } 
+      }
       IL_000a:  leave.s    IL_0019
     }  // end .try
-    catch [mscorlib]System.Object 
+    catch [mscorlib]System.Object
     {
       IL_000c:  pop
       IL_000d:  ldstr      "In catch"
@@ -83,17 +71,17 @@
       IL_0017:  leave.s    IL_0019
 
     }  // end handler
-    IL_0019: 
-		ldsfld     class [eh_common]TestUtil.TestLog test::testLog
-      	callvirt   instance void [eh_common]TestUtil.TestLog::StopRecording()
-      
-      	ldsfld     class [eh_common]TestUtil.TestLog test::testLog
-      	callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
-        
+    IL_0019:
+        ldsfld     class [eh_common]TestUtil.TestLog test::testLog
+        callvirt   instance void [eh_common]TestUtil.TestLog::StopRecording()
+
+        ldsfld     class [eh_common]TestUtil.TestLog test::testLog
+        callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
+
     IL_0022:  ret
   } // end of method test::Main
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     .maxstack  1
@@ -101,8 +89,4 @@
     IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
     IL_0006:  ret
   } // end of method test::.ctor
-
 } // end of class test
-
-
-

--- a/src/tests/JIT/Methodical/eh/deadcode/deadcodeincatch.il
+++ b/src/tests/JIT/Methodical/eh/deadcode/deadcodeincatch.il
@@ -19,15 +19,7 @@
   .ver 0:0:0:0
 }
 .assembly extern xunit.core {}
-// MVID: {3B8B6D1B-A317-4591-BD66-1D1000E3767F}
-.imagebase 0x00400000
-.subsystem 0x00000003
-.file alignment 512
-.corflags 0x00000001
-// Image base: 0x03010000
-//
-// ============== CLASS STRUCTURE DECLARATION ==================
-//
+
 .namespace hello
 {
   .class private auto ansi beforefieldinit Class1
@@ -60,30 +52,7 @@
             stsfld     class [eh_common]TestUtil.TestLog hello.Class1::testLog
             ret
     } // end of method Class1::.cctor
-    
-  } // end of class Class1
 
-} // end of namespace hello
-
-
-// =============================================================
-
-
-// =============== GLOBAL FIELDS AND METHODS ===================
-
-
-// =============================================================
-
-
-// =============== CLASS MEMBERS DECLARATION ===================
-//   note that class flags, 'extends' and 'implements' clauses
-//          are provided here for information only
-
-.namespace hello
-{
-  .class private auto ansi beforefieldinit Class1
-         extends [mscorlib]System.Object
-  {
     .method public hidebysig static void 
             inTry() cil managed
     {
@@ -212,11 +181,4 @@
     } // end of method Class1::.ctor
 
   } // end of class Class1
-
-
-// =============================================================
-
 } // end of namespace hello
-
-//*********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file deadcodeincatch.res

--- a/src/tests/JIT/Methodical/eh/deadcode/deadoponerrorinfunclet.il
+++ b/src/tests/JIT/Methodical/eh/deadcode/deadoponerrorinfunclet.il
@@ -18,54 +18,35 @@
   .ver 0:0:0:0
 }
 .assembly extern xunit.core {}
-.imagebase 0x00400000
-.subsystem 0x00000003
-.file alignment 512
-.corflags 0x00000001
-.namespace hello
-{
-  .class private auto ansi beforefieldinit Class1
-         extends [mscorlib]System.Object
-  {
-		.field private static class [eh_common]TestUtil.TestLog testLog
-  		.method private hidebysig specialname rtspecialname static void  .cctor() cil managed
-    	{
-      		.maxstack  2
-      		.locals init (class [mscorlib]System.IO.StringWriter expectedOut)
-      		newobj     instance void [mscorlib]System.IO.StringWriter::.ctor()
-      		stloc.s    expectedOut
-      		ldloc.s    expectedOut
-      		ldstr      "1234"
-      		callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(string)
-      		ldloc.s    expectedOut
-      		ldstr      "test2"
-      		callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(string)
-      		ldloc.s    expectedOut
-      		ldstr      "1234"
-      		callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(string)
-      		ldloc.s    expectedOut
-      		newobj     instance void [eh_common]TestUtil.TestLog::.ctor(object)
-      		stsfld     class [eh_common]TestUtil.TestLog hello.Class1::testLog
-      		ret
-		} 
-  } 
-
-} 
-
-
-
-
-
-
-
-
 
 .namespace hello
 {
   .class private auto ansi beforefieldinit Class1
          extends [mscorlib]System.Object
   {
-    .method public hidebysig static int32 
+    .field private static class [eh_common]TestUtil.TestLog testLog
+    .method private hidebysig specialname rtspecialname static void  .cctor() cil managed
+    {
+        .maxstack  2
+        .locals init (class [mscorlib]System.IO.StringWriter expectedOut)
+        newobj     instance void [mscorlib]System.IO.StringWriter::.ctor()
+        stloc.s    expectedOut
+        ldloc.s    expectedOut
+        ldstr      "1234"
+        callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(string)
+        ldloc.s    expectedOut
+        ldstr      "test2"
+        callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(string)
+        ldloc.s    expectedOut
+        ldstr      "1234"
+        callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(string)
+        ldloc.s    expectedOut
+        newobj     instance void [eh_common]TestUtil.TestLog::.ctor(object)
+        stsfld     class [eh_common]TestUtil.TestLog hello.Class1::testLog
+        ret
+    }
+
+    .method public hidebysig static int32
             Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -76,9 +57,9 @@
       .locals init (int32 V_0,
                string V_1,
                int32 V_2)
-               
-				ldsfld     class [eh_common]TestUtil.TestLog hello.Class1::testLog
-				callvirt   instance void [eh_common]TestUtil.TestLog::StartRecording()         
+
+                ldsfld     class [eh_common]TestUtil.TestLog hello.Class1::testLog
+                callvirt   instance void [eh_common]TestUtil.TestLog::StartRecording()
       IL_0000:  ldc.i4   1234
       IL_0002:  stloc.0
       IL_0003:  ldloc.0
@@ -96,8 +77,8 @@
         IL_001d:  newobj     instance void [mscorlib]System.Exception::.ctor()
         IL_0022:  throw
 
-      }  
-      catch [mscorlib]System.Object 
+      }
+      catch [mscorlib]System.Object
       {
         IL_0023:  pop
         leave.s  IL_0066
@@ -124,8 +105,8 @@
 
           IL_0036:  leave.s    IL_004a
 
-        }  
-        catch [mscorlib]System.Object 
+        }
+        catch [mscorlib]System.Object
         {
           IL_0038:  pop
           IL_0039:  ldloc.0
@@ -137,7 +118,7 @@
           IL_0043:  call       void [System.Console]System.Console::WriteLine(string)
           IL_0048:  leave.s    IL_004a
 
-        }  
+        }
         IL_004a:  ldstr      "unreached"
         IL_004f:  call       void [System.Console]System.Console::WriteLine(string)
         IL_0054:  ldstr      "end outer catch "
@@ -147,33 +128,29 @@
         IL_005f:  call       void [System.Console]System.Console::WriteLine(string)
         IL_0064:  leave.s    IL_0066
 
-      }  
+      }
       IL_0066:  ldloc.0
       IL_0067:  stloc.2
       IL_0068:  br.s       IL_006a
 
       IL_006a:  ldloc.2
-				call  void [System.Console]System.Console::WriteLine(int32)
-				ldsfld     class [eh_common]TestUtil.TestLog hello.Class1::testLog
-      			callvirt   instance void [eh_common]TestUtil.TestLog::StopRecording()
-      
-      			ldsfld     class [eh_common]TestUtil.TestLog hello.Class1::testLog
-      			callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
-        
-      IL_006b:  ret
-    } 
+                call  void [System.Console]System.Console::WriteLine(int32)
+                ldsfld     class [eh_common]TestUtil.TestLog hello.Class1::testLog
+                callvirt   instance void [eh_common]TestUtil.TestLog::StopRecording()
 
-    .method public hidebysig specialname rtspecialname 
+                ldsfld     class [eh_common]TestUtil.TestLog hello.Class1::testLog
+                callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
+
+      IL_006b:  ret
+    }
+
+    .method public hidebysig specialname rtspecialname
             instance void  .ctor() cil managed
     {
       .maxstack  1
       IL_0000:  ldarg.0
       IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
-	  IL_0006:  ret
-    } 
-
-  } 
-
-
-
-} 
+      IL_0006:  ret
+    }
+  }
+}

--- a/src/tests/JIT/Methodical/eh/finallyexec/catchrettoinnertry.il
+++ b/src/tests/JIT/Methodical/eh/finallyexec/catchrettoinnertry.il
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
- 
+
 
 .assembly extern System.Console
 {
@@ -18,54 +18,34 @@
    .ver 0:0:0:0
  }
 .assembly extern xunit.core {}
- .imagebase 0x00400000
- .subsystem 0x00000003
- .file alignment 512
- .corflags 0x00000001
- .namespace strswitch
- {
+
+.namespace strswitch
+{
    .class private auto ansi beforefieldinit Class1
           extends [mscorlib]System.Object
    {
-   } 
- 
- } 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- .namespace strswitch
- {
-   .class private auto ansi beforefieldinit Class1
-          extends [mscorlib]System.Object
-   {
-	.field private static class [eh_common]TestUtil.TestLog testLog
-  	.method private hidebysig specialname rtspecialname static void  .cctor() cil managed
-    	{
-      		.maxstack  2
-      		.locals init (class [mscorlib]System.IO.StringWriter expectedOut)
-      		newobj     instance void [mscorlib]System.IO.StringWriter::.ctor()
-      		stloc.s    expectedOut
-      		ldloc.s    expectedOut
-      		ldstr      "Caught an exception"
-      		callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(string)
-      		ldloc.s    expectedOut
-      		ldstr      "bye"
-      		callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(string)
-      		ldloc.s    expectedOut
-      		ldstr      "In outer finally"
-      		callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(string)
-      		ldloc.s    expectedOut
-      		newobj     instance void [eh_common]TestUtil.TestLog::.ctor(object)
-      		stsfld     class [eh_common]TestUtil.TestLog strswitch.Class1::testLog
-      		ret
-    } 
-     .method private hidebysig static int32 
+    .field private static class [eh_common]TestUtil.TestLog testLog
+    .method private hidebysig specialname rtspecialname static void  .cctor() cil managed
+        {
+            .maxstack  2
+            .locals init (class [mscorlib]System.IO.StringWriter expectedOut)
+            newobj     instance void [mscorlib]System.IO.StringWriter::.ctor()
+            stloc.s    expectedOut
+            ldloc.s    expectedOut
+            ldstr      "Caught an exception"
+            callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(string)
+            ldloc.s    expectedOut
+            ldstr      "bye"
+            callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(string)
+            ldloc.s    expectedOut
+            ldstr      "In outer finally"
+            callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(string)
+            ldloc.s    expectedOut
+            newobj     instance void [eh_common]TestUtil.TestLog::.ctor(object)
+            stsfld     class [eh_common]TestUtil.TestLog strswitch.Class1::testLog
+            ret
+    }
+     .method private hidebysig static int32
              Main() cil managed
      {
        .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -73,10 +53,10 @@
        )
        .entrypoint
        .maxstack  2
-       
-		ldsfld     class [eh_common]TestUtil.TestLog strswitch.Class1::testLog
-		callvirt   instance void [eh_common]TestUtil.TestLog::StartRecording()
-		
+
+        ldsfld     class [eh_common]TestUtil.TestLog strswitch.Class1::testLog
+        callvirt   instance void [eh_common]TestUtil.TestLog::StartRecording()
+
        .locals init (int32 V_0,
                 class [mscorlib]System.Exception V_1,
                 int32 V_2)
@@ -89,20 +69,20 @@
            branch_0002:  ldloc.0
              ldc.i4.3
              bne.un.s   branch_000c
- 
+
              newobj     instance void [mscorlib]System.IndexOutOfRangeException::.ctor()
              throw
- 
+
            branch_000c:  ldloc.0
              ldc.i4.4
              bne.un.s   branch_001a
- 
+
              ldstr      "bye"
              call       void [System.Console]System.Console::WriteLine(string)
            branch_001a:  leave.s    branch_002d
- 
-         }  
-         catch [mscorlib]System.Exception 
+
+         }
+         catch [mscorlib]System.Exception
          {
              stloc.1
              ldstr      "Caught an exception"
@@ -112,39 +92,34 @@
              add
              stloc.0
              leave.s    branch_0002
- 
-         }  
+
+         }
          branch_002d:  leave.s    branch_003a
- 
-       }  
+
+       }
        finally
        {
            ldstr      "In outer finally"
            call       void [System.Console]System.Console::WriteLine(string)
            endfinally
-       }  
-       branch_003a:  
-		ldsfld     class [eh_common]TestUtil.TestLog strswitch.Class1::testLog
-      	callvirt   instance void [eh_common]TestUtil.TestLog::StopRecording()
-      
-      	ldsfld     class [eh_common]TestUtil.TestLog strswitch.Class1::testLog
-      	callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
-        
+       }
+       branch_003a:
+        ldsfld     class [eh_common]TestUtil.TestLog strswitch.Class1::testLog
+        callvirt   instance void [eh_common]TestUtil.TestLog::StopRecording()
+
+        ldsfld     class [eh_common]TestUtil.TestLog strswitch.Class1::testLog
+        callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
+
          ret
-     } 
- 
-     .method public hidebysig specialname rtspecialname 
+     }
+
+     .method public hidebysig specialname rtspecialname
              instance void  .ctor() cil managed
      {
        .maxstack  1
          ldarg.0
          call       instance void [mscorlib]System.Object::.ctor()
           ret
-     } 
- 
-   } 
- 
- 
- 
- } 
- 
+     }
+   }
+}

--- a/src/tests/JIT/Methodical/stringintern/test1.cs
+++ b/src/tests/JIT/Methodical/stringintern/test1.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Runtime.CompilerServices;
 
-class
+public class
 #if XASSEM
 Test1_xassem
 #else

--- a/src/tests/JIT/Methodical/stringintern/test2.cs
+++ b/src/tests/JIT/Methodical/stringintern/test2.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Runtime.CompilerServices;
 
-class
+public class
 #if XASSEM
 Test2_xassem
 #else

--- a/src/tests/JIT/Methodical/stringintern/test4.cs
+++ b/src/tests/JIT/Methodical/stringintern/test4.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Runtime.CompilerServices;
 
-class
+public class
 #if XASSEM
 Test4_xassem
 #else

--- a/src/tests/JIT/Methodical/structs/ExplicitLayout.cs
+++ b/src/tests/JIT/Methodical/structs/ExplicitLayout.cs
@@ -5,8 +5,9 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Xunit;
 
-class ExplicitLayout
+public class ExplicitLayout
 {
 #pragma warning disable 618
     [StructLayout(LayoutKind.Explicit, Size = SIZE)]
@@ -25,9 +26,10 @@ class ExplicitLayout
     }
 #pragma warning restore 618
 
-    internal class Program
+    public class Program
     {
-        private static int Main()
+        [Fact]
+        public static int TestEntrypoint()
         {
             int returnVal = 100;
 


### PR DESCRIPTION
Several IL tests listed their classes twice - presumably once as a
'declaration' and a second time as the 'definition'. Apart from
the fact that this causes trouble in my semi-automatic IL rewriter,
I don't see any reason for keeping this moving forward as it just
clutters the files and complicates their maintenance. I also found
one remaining test with main accepting command-line arguments
(previously overlooked due to lowercase m) and I manually made
the stringintern test classes public as the ILTransform tool now has
trouble understanding them due to the presence of preprocessor
directives.

Thanks

Tomas

/cc @dotnet/jit-contrib 