### PR TITLE
[wasm] Print out the ws: address

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugHost/Program.cs
+++ b/src/mono/wasm/debugger/BrowserDebugHost/Program.cs
@@ -29,6 +29,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 .UseKestrel()
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseStartup<Startup>()
+                .UseSetting(WebHostDefaults.SuppressStatusMessagesKey, "True")
                 .ConfigureAppConfiguration((hostingContext, config) =>
                 {
                     config.AddCommandLine(args);

--- a/src/mono/wasm/debugger/BrowserDebugHost/Startup.cs
+++ b/src/mono/wasm/debugger/BrowserDebugHost/Startup.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 
 namespace Microsoft.WebAssembly.Diagnostics
 {
@@ -38,6 +39,11 @@ namespace Microsoft.WebAssembly.Diagnostics
         public void Configure(IApplicationBuilder app, IOptionsMonitor<ProxyOptions> optionsAccessor, IWebHostEnvironment env, IHostApplicationLifetime applicationLifetime)
         {
             ProxyOptions options = optionsAccessor.CurrentValue;
+            applicationLifetime.ApplicationStarted.Register(() => {
+                var uri = new Uri(app.ServerFeatures.Get<IServerAddressesFeature>().Addresses.First());
+                Console.WriteLine($"Now listening on: {(uri.Scheme == "http" ? "ws" : "wss")}://{uri.Authority}");
+                Console.WriteLine("Application started. Press Ctrl+C to shut down.");
+            });
 
             if (options.OwnerPid.HasValue)
             {

--- a/src/mono/wasm/debugger/BrowserDebugHost/Startup.cs
+++ b/src/mono/wasm/debugger/BrowserDebugHost/Startup.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -40,8 +41,10 @@ namespace Microsoft.WebAssembly.Diagnostics
         {
             ProxyOptions options = optionsAccessor.CurrentValue;
             applicationLifetime.ApplicationStarted.Register(() => {
-                var uri = new Uri(app.ServerFeatures.Get<IServerAddressesFeature>().Addresses.First());
-                Console.WriteLine($"Now listening on: {(uri.Scheme == "http" ? "ws" : "wss")}://{uri.Authority}");
+                foreach (var address in app.ServerFeatures.Get<IServerAddressesFeature>().Addresses)
+                {
+                    Console.WriteLine($"    Now listening on: {Regex.Replace(address, "^http(s?):", "ws$1:")}");
+                }
                 Console.WriteLine("Application started. Press Ctrl+C to shut down.");
             });
 
@@ -128,7 +131,6 @@ namespace Microsoft.WebAssembly.Diagnostics
                             context.Response.ContentLength = response.Content.Headers.ContentLength;
                         byte[] bytes = await response.Content.ReadAsByteArrayAsync();
                         await context.Response.Body.WriteAsync(bytes);
-
                     }
                 }
 


### PR DESCRIPTION
This resolves the core issue that required https://github.com/microsoft/vscode-js-debug/pull/1195 by reporting the connection address as a websocket (ws:) rather than http: for the proxy.