### PR TITLE
Use generic `Enum` methods where possible.

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ReadyToRunInstructionSetSupportSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ReadyToRunInstructionSetSupportSignature.cs
@@ -67,9 +67,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _instructionSetsSupport = instructionSetsSupport;
         }
 
-        private ReadyToRunInstructionSet? InstructionSetFromString(string instructionSetString)
+        private ReadyToRunInstructionSet InstructionSetFromString(string instructionSetString)
         {
-            return (ReadyToRunInstructionSet)Enum.Parse(typeof(ReadyToRunInstructionSet), instructionSetString);
+            return Enum.Parse<ReadyToRunInstructionSet>(instructionSetString);
         }
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)

--- a/src/coreclr/tools/dotnet-pgo/CommandLineOptions.cs
+++ b/src/coreclr/tools/dotnet-pgo/CommandLineOptions.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
         {
             try
             {
-                return (Verbosity)Enum.Parse(typeof(Verbosity), s);
+                return Enum.Parse<Verbosity>(s);
             }
             catch 
             {

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DataTypeAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DataTypeAttribute.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel.DataAnnotations
         AllowMultiple = false)]
     public class DataTypeAttribute : ValidationAttribute
     {
-        private static readonly string[] _dataTypeStrings = Enum.GetNames(typeof(DataType));
+        private static readonly string[] _dataTypeStrings = Enum.GetNames<DataType>();
 
         /// <summary>
         ///     Constructor that accepts a data type enumeration

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemFilterAttribute.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemFilterAttribute.cs
@@ -104,6 +104,6 @@ namespace System.ComponentModel
                 && other.FilterString.Equals(FilterString);
         }
 
-        public override string ToString() => FilterString + "," + Enum.GetName(typeof(ToolboxItemFilterType), FilterType);
+        public override string ToString() => FilterString + "," + Enum.GetName<ToolboxItemFilterType(FilterType);
     }
 }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemFilterAttribute.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemFilterAttribute.cs
@@ -104,6 +104,6 @@ namespace System.ComponentModel
                 && other.FilterString.Equals(FilterString);
         }
 
-        public override string ToString() => FilterString + "," + Enum.GetName<ToolboxItemFilterType(FilterType);
+        public override string ToString() => FilterString + "," + Enum.GetName<ToolboxItemFilterType>(FilterType);
     }
 }

--- a/src/libraries/System.Data.Common/src/System/Data/DataViewManager.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataViewManager.cs
@@ -132,7 +132,7 @@ namespace System.Data
                     }
                     if (r.MoveToAttribute("RowStateFilter"))
                     {
-                        _dataViewSettingsCollection[table]!.RowStateFilter = (DataViewRowState)Enum.Parse(typeof(DataViewRowState), r.Value);
+                        _dataViewSettingsCollection[table]!.RowStateFilter = Enum.Parse<DataViewRowState>(r.Value);
                     }
                 }
             }

--- a/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/SourceSwitch.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/SourceSwitch.cs
@@ -33,7 +33,7 @@ namespace System.Diagnostics
 
         protected override void OnValueChanged()
         {
-            SwitchSetting = (int)Enum.Parse(typeof(SourceLevels), Value, true);
+            SwitchSetting = (int)Enum.Parse<SourceLevels>(Value, true);
         }
     }
 }

--- a/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceSwitch.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceSwitch.cs
@@ -118,7 +118,7 @@ namespace System.Diagnostics
 
         protected override void OnValueChanged()
         {
-            SwitchSetting = (int)Enum.Parse(typeof(TraceLevel), Value, true);
+            SwitchSetting = (int)Enum.Parse<TraceLevel>(Value, true);
         }
     }
 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/FontConverter.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/FontConverter.cs
@@ -197,7 +197,7 @@ namespace System.Drawing
                         string styleText = styleTokens[tokenCount];
                         styleText = styleText.Trim();
 
-                        fontStyle |= (FontStyle)Enum.Parse(typeof(FontStyle), styleText, true);
+                        fontStyle |= Enum.Parse<FontStyle>(styleText, true);
 
                         // Enum.IsDefined doesn't do what we want on flags enums...
                         FontStyle validBits = FontStyle.Regular | FontStyle.Bold | FontStyle.Italic | FontStyle.Underline | FontStyle.Strikeout;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/Opcode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/Opcode.cs
@@ -103,7 +103,7 @@ namespace System.Reflection.Emit
                     return name;
 
                 // Create ilasm style name from the enum value name.
-                name = Enum.GetName(typeof(OpCodeValues), opCodeValue)!.ToLowerInvariant().Replace('_', '.');
+                name = Enum.GetName<OpCodeValues>(opCodeValue)!.ToLowerInvariant().Replace('_', '.');
                 Volatile.Write(ref nameCache[idx], name);
                 return name;
             }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/OptimizerPatterns.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/OptimizerPatterns.cs
@@ -54,7 +54,7 @@ namespace System.Xml.Xsl.IlGen
     /// </summary>
     internal sealed class OptimizerPatterns : IQilAnnotation
     {
-        private static readonly int s_patternCount = Enum.GetValues(typeof(OptimizerPatternName)).Length;
+        private static readonly int s_patternCount = Enum.GetValues<OptimizerPatternName>().Length;
 
         private int _patterns;               // Set of patterns that the annotated Qil node and its subtree matches
         private bool _isReadOnly;            // True if setters are disabled in the case of singleton OptimizerPatterns


### PR DESCRIPTION
This PR updates all non-test projects that exclusively target .NET 6 and above to use the generic `Enum` methods (#2364), reducing boxing and (perhaps?) making the code more AOT-friendly.