### PR TITLE
Couple optimization to MultiRegStoreLoc

### DIFF
--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3291,7 +3291,7 @@ void LinearScan::BuildStoreLocDef(GenTreeLclVarCommon* storeLoc,
     assert(varDsc->lvTracked);
     unsigned  varIndex       = varDsc->lvVarIndex;
     Interval* varDefInterval = getIntervalForLocalVar(varIndex);
-    if ((storeLoc->gtFlags & GTF_VAR_DEATH) == 0)
+    if (!storeLoc->IsLastUse(index))
     {
         VarSetOps::AddElemD(compiler, currentLiveVars, varIndex);
     }

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3396,7 +3396,8 @@ int LinearScan::BuildMultiRegStoreLoc(GenTreeLclVar* storeLoc)
     //
     for (unsigned int i = 0; i < dstCount; ++i)
     {
-        LclVarDsc* fieldVarDsc = compiler->lvaGetDesc(varDsc->lvFieldLclStart + i);
+        LclVarDsc*   fieldVarDsc  = compiler->lvaGetDesc(varDsc->lvFieldLclStart + i);
+        RefPosition* singleUseRef = nullptr;
 
         if (isMultiRegSrc)
         {
@@ -3408,10 +3409,10 @@ int LinearScan::BuildMultiRegStoreLoc(GenTreeLclVar* storeLoc)
                 srcCandidates = allByteRegs();
             }
 #endif // TARGET_X86
-            BuildUse(op1, srcCandidates, i);
+            singleUseRef = BuildUse(op1, srcCandidates, i);
         }
         assert(isCandidateVar(fieldVarDsc));
-        BuildStoreLocDef(storeLoc, fieldVarDsc, nullptr, i);
+        BuildStoreLocDef(storeLoc, fieldVarDsc, singleUseRef, i);
         if (isMultiRegSrc && (i < (dstCount - 1)))
         {
             currentLoc += 2;


### PR DESCRIPTION
The [diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1612523&view=artifacts&pathAsName=false&type=publishedArtifacts) are net positive. There are some regressions. Looked at couple of them - do not see how they can be mitigated - they are due to re-shuffling of the registers in LSRA.

Here is a description of the change:

1. Preference the source registers to the destination of multi-register `GT_STORE_LCL_VAR` if the source is last-use local or not a local (i.e. a multi-reg call or hardware intrinsic). The similar strategy is already done for single reg `GT_STORE_LCL_VAR`.
2. Properly check for the last use of a field of a multi-reg local in `LinearScan::BuildStoreLocDef()`. 
The second issue can be demonstrated by examples. 

Consider the following program:
```cs
using System;
using System.Runtime.CompilerServices;

namespace Runtime_64857
{
    class Program
    {
        struct int64x2
        {
            public ulong _0;
            public ulong _1;
        }

        [MethodImpl(MethodImplOptions.NoInlining)]
        static int64x2 Def()
        {
            return default(int64x2);
        }

        [MethodImpl(MethodImplOptions.NoInlining)]
        static void Use(ulong x0, ulong x1)
        {
        }

        static void Main(string[] args)
        {
            var val = Def();
            Use(val._0, val._0);
        }
    }
}
```
The code diffs for `Main` (on win-arm64):
```diff
diff --git a/base.txt b/diff.txt
index d080ead..b5176ec 100644
--- a/base.txt
+++ b/diff.txt
@@ -11,34 +11,31 @@
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [sp+00H]   "OutgoingArgSpace"
 ;* V03 tmp1         [V03    ] (  0,  0   )  struct (16) zero-ref    do-not-enreg[SBR] multireg-ret "Return value temp for multireg return"
 ;  V04 tmp2         [V04,T00] (  3,  3   )    long  ->   x0         V01._0(offs=0x00) P-INDEP "field V01._0 (fldOffset=0x0)"
-;  V05 tmp3         [V05,T01] (  1,  1   )    long  ->  x19         V01._1(offs=0x08) P-INDEP "field V01._1 (fldOffset=0x8)"
+;  V05 tmp3         [V05,T01] (  1,  1   )    long  ->   x1         V01._1(offs=0x08) P-INDEP "field V01._1 (fldOffset=0x8)"
 ;* V06 tmp4         [V06    ] (  0,  0   )    long  ->  zero-ref    V03._0(offs=0x00) P-DEP "field V03._0 (fldOffset=0x0)"
 ;* V07 tmp5         [V07    ] (  0,  0   )    long  ->  zero-ref    V03._1(offs=0x08) P-DEP "field V03._1 (fldOffset=0x8)"
 ;
-; Lcl frame size = 8
+; Lcl frame size = 0
 
 G_M3731_IG01:              ;; offset=0000H
-        A9BE7BFD          stp     fp, lr, [sp,#-32]!
-        F9000FF3          str     x19, [sp,#24]
+        A9BF7BFD          stp     fp, lr, [sp,#-16]!
         910003FD          mov     fp, sp
-						;; bbWeight=1    PerfScore 2.50
-G_M3731_IG02:              ;; offset=000CH
+						;; bbWeight=1    PerfScore 1.50
+G_M3731_IG02:              ;; offset=0008H
         94000000          bl      Runtime_64857.Program:Def():int64x2
-        AA0103F3          mov     x19, x1
         AA0003E1          mov     x1, x0
         94000000          bl      Runtime_64857.Program:Use(long,long)
-						;; bbWeight=1    PerfScore 3.00
-G_M3731_IG03:              ;; offset=001CH
-        F9400FF3          ldr     x19, [sp,#24]
-        A8C27BFD          ldp     fp, lr, [sp],#32
+						;; bbWeight=1    PerfScore 2.50
+G_M3731_IG03:              ;; offset=0014H
+        A8C17BFD          ldp     fp, lr, [sp],#16
         D65F03C0          ret     lr
-						;; bbWeight=1    PerfScore 4.00
+						;; bbWeight=1    PerfScore 2.00
 
-; Total bytes of code 40, prolog size 12, PerfScore 13.50, instruction count 10, allocated bytes for code 40 (MethodHash=8297f16c) for method Runtime_64857.Program:Main(System.String[])
+; Total bytes of code 28, prolog size 8, PerfScore 8.80, instruction count 7, allocated bytes for code 28 (MethodHash=8297f16c) for method Runtime_64857.Program:Main(System.String[])
```

Note that in the base case a variable that corresponds to promoted `val._1` was added (unnecessarily) to `currentLiveVars` and, as a consequence, `x19` was used to keep a dead value of the variable.

Now, if you consider another program:
```cs
using System;
using System.Runtime.CompilerServices;

namespace Runtime_64857
{
    class Program
    {
        struct int64x2
        {
            public ulong _0;
            public ulong _1;
        }

        [MethodImpl(MethodImplOptions.NoInlining)]
        static int64x2 Def()
        {
            return default(int64x2);
        }

        [MethodImpl(MethodImplOptions.NoInlining)]
        static void TrashRegs()
        {
        }

        [MethodImpl(MethodImplOptions.NoInlining)]
        static void Use(ulong x0, ulong x1)
        {
        }

        static void Main(string[] args)
        {
            var val = Def();
            TrashRegs();
            Use(val._1, val._1);
        }
    }
}
```
the diffs are opposite in some sense
```diff
diff --git a/base.txt b/diff.txt
index c3b5ab8..181e57b 100644
--- a/base.txt
+++ b/diff.txt
@@ -11,34 +11,36 @@
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [sp+00H]   "OutgoingArgSpace"
 ;* V03 tmp1         [V03    ] (  0,  0   )  struct (16) zero-ref    do-not-enreg[SBR] multireg-ret "Return value temp for multireg return"
 ;  V04 tmp2         [V04,T01] (  1,  1   )    long  ->   x0         V01._0(offs=0x00) P-INDEP "field V01._0 (fldOffset=0x0)"
-;  V05 tmp3         [V05,T00] (  3,  3   )    long  ->  [fp+18H]   V01._1(offs=0x08) P-INDEP "field V01._1 (fldOffset=0x8)"
+;  V05 tmp3         [V05,T00] (  3,  3   )    long  ->  x19         V01._1(offs=0x08) P-INDEP "field V01._1 (fldOffset=0x8)"
 ;* V06 tmp4         [V06    ] (  0,  0   )    long  ->  zero-ref    V03._0(offs=0x00) P-DEP "field V03._0 (fldOffset=0x0)"
 ;* V07 tmp5         [V07    ] (  0,  0   )    long  ->  zero-ref    V03._1(offs=0x08) P-DEP "field V03._1 (fldOffset=0x8)"
 ;
-; Lcl frame size = 16
+; Lcl frame size = 8
 
 G_M3731_IG01:              ;; offset=0000H
         A9BE7BFD          stp     fp, lr, [sp,#-32]!
+        F9000FF3          str     x19, [sp,#24]
         910003FD          mov     fp, sp
-						;; bbWeight=1    PerfScore 1.50
-G_M3731_IG02:              ;; offset=0008H
+						;; bbWeight=1    PerfScore 2.50
+G_M3731_IG02:              ;; offset=000CH
         94000000          bl      Runtime_64857.Program:Def():int64x2
-        F9000FA1          str     x1, [fp,#24]
+        AA0103F3          mov     x19, x1
         94000000          bl      Runtime_64857.Program:TrashRegs()
-        F9400FA0          ldr     x0, [fp,#24]	// [V05 tmp3]
-        AA0003E1          mov     x1, x0
+        AA1303E0          mov     x0, x19
+        AA1303E1          mov     x1, x19
         94000000          bl      Runtime_64857.Program:Use(long,long)
-						;; bbWeight=1    PerfScore 6.50
-G_M3731_IG03:              ;; offset=0020H
+						;; bbWeight=1    PerfScore 4.50
+G_M3731_IG03:              ;; offset=0024H
+        F9400FF3          ldr     x19, [sp,#24]
         A8C27BFD          ldp     fp, lr, [sp],#32
         D65F03C0          ret     lr
-						;; bbWeight=1    PerfScore 2.00
+						;; bbWeight=1    PerfScore 4.00
 
-; Total bytes of code 40, prolog size 8, PerfScore 14.00, instruction count 10, allocated bytes for code 40 (MethodHash=8297f16c) for method Runtime_64857.Program:Main(System.String[])
+; Total bytes of code 48, prolog size 12, PerfScore 15.80, instruction count 12, allocated bytes for code 48 (MethodHash=8297f16c) for method Runtime_64857.Program:Main(System.String[])
```
`val._1` was NOT added to `currentLiveVars` and instead of assigning a callee-saved register to `val._1` (to be able to survive a call to `TrashRegs()`) the value had to be spilled on the stack.