### PR TITLE
Improvements for SpanHelpers.IndexOf

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -105,6 +105,8 @@ namespace System
                     if (offset > searchSpaceMinusValueTailLengthAndVector)
                         offset = searchSpaceMinusValueTailLengthAndVector;
 
+                    continue;
+
                 CANDIDATE_FOUND:
                     uint mask = cmpAnd.ExtractMostSignificantBits();
                     do
@@ -163,6 +165,8 @@ namespace System
                     // Overlap with the current chunk for trailing elements
                     if (offset > searchSpaceMinusValueTailLengthAndVector)
                         offset = searchSpaceMinusValueTailLengthAndVector;
+
+                    continue;
 
                 CANDIDATE_FOUND:
                     uint mask = cmpAnd.ExtractMostSignificantBits();

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -77,7 +77,7 @@ namespace System
                 Vector256<byte> ch2 = Vector256.Create(ch2Val);
 
                 nint searchSpaceMinusValueTailLengthAndVector =
-                    searchSpaceMinusValueTailLength - (nint)Vector256<ushort>.Count;
+                    searchSpaceMinusValueTailLength - (nint)Vector256<byte>.Count;
 
                 do
                 {
@@ -138,7 +138,7 @@ namespace System
                 Vector128<byte> ch2 = Vector128.Create(ch2Val);
 
                 nint searchSpaceMinusValueTailLengthAndVector =
-                    searchSpaceMinusValueTailLength - (nint)Vector128<ushort>.Count;
+                    searchSpaceMinusValueTailLength - (nint)Vector128<byte>.Count;
 
                 do
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -26,7 +26,7 @@ namespace System
             if (valueTailLength == 0)
                 return IndexOf(ref searchSpace, value, searchSpaceLength); // for single-byte values use plain IndexOf
 
-            int offset = 0;
+            nint offset = 0;
             byte valueHead = value;
             int searchSpaceMinusValueTailLength = searchSpaceLength - valueTailLength;
             if (Vector128.IsHardwareAccelerated && searchSpaceMinusValueTailLength >= Vector128<byte>.Count)
@@ -54,7 +54,7 @@ namespace System
                 if (SequenceEqual(
                         ref Unsafe.Add(ref searchSpace, offset + 1),
                         ref valueTail, (nuint)(uint)valueTailLength))  // The (nuint)-cast is necessary to pick the correct overload
-                    return offset;  // The tail matched. Return a successful find.
+                    return (int)offset;  // The tail matched. Return a successful find.
 
                 remainingSearchSpaceLength--;
                 offset++;
@@ -69,12 +69,15 @@ namespace System
                 // Find the last unique (which is not equal to ch1) byte
                 // the algorithm is fine if both are equal, just a little bit less efficient
                 byte ch2Val = Unsafe.Add(ref value, valueTailLength);
-                int ch1ch2Distance = valueTailLength;
+                nint ch1ch2Distance = valueTailLength;
                 while (ch2Val == value && ch1ch2Distance > 1)
                     ch2Val = Unsafe.Add(ref value, --ch1ch2Distance);
 
                 Vector256<byte> ch1 = Vector256.Create(value);
                 Vector256<byte> ch2 = Vector256.Create(ch2Val);
+
+                nint searchSpaceMinusValueTailLengthAndVector =
+                    searchSpaceMinusValueTailLength - (nint)Vector256<ushort>.Count;
 
                 do
                 {
@@ -82,35 +85,42 @@ namespace System
                     // Make sure we don't go out of bounds
                     Debug.Assert(offset + ch1ch2Distance + Vector256<byte>.Count <= searchSpaceLength);
 
-                    Vector256<byte> cmpCh1 = Vector256.Equals(ch1, Vector256.LoadUnsafe(ref searchSpace, (nuint)offset));
                     Vector256<byte> cmpCh2 = Vector256.Equals(ch2, Vector256.LoadUnsafe(ref searchSpace, (nuint)(offset + ch1ch2Distance)));
+                    Vector256<byte> cmpCh1 = Vector256.Equals(ch1, Vector256.LoadUnsafe(ref searchSpace, (nuint)offset));
                     Vector256<byte> cmpAnd = (cmpCh1 & cmpCh2).AsByte();
 
                     // Early out: cmpAnd is all zeros
                     if (cmpAnd != Vector256<byte>.Zero)
                     {
-                        uint mask = cmpAnd.ExtractMostSignificantBits();
-                        do
-                        {
-                            int bitPos = BitOperations.TrailingZeroCount(mask);
-                            if (valueLength == 2 || // we already matched two bytes
-                                SequenceEqual(
-                                    ref Unsafe.Add(ref searchSpace, offset + bitPos),
-                                    ref value, (nuint)(uint)valueLength)) // The (nuint)-cast is necessary to pick the correct overload
-                            {
-                                return offset + bitPos;
-                            }
-                            mask = BitOperations.ResetLowestSetBit(mask); // Clear the lowest set bit
-                        } while (mask != 0);
+                        goto CANDIDATE_FOUND;
                     }
+
+                LOOP_FOOTER:
                     offset += Vector256<byte>.Count;
 
                     if (offset == searchSpaceMinusValueTailLength)
                         return -1;
 
                     // Overlap with the current chunk for trailing elements
-                    if (offset > searchSpaceMinusValueTailLength - Vector256<byte>.Count)
-                        offset = searchSpaceMinusValueTailLength - Vector256<byte>.Count;
+                    if (offset > searchSpaceMinusValueTailLengthAndVector)
+                        offset = searchSpaceMinusValueTailLengthAndVector;
+
+                CANDIDATE_FOUND:
+                    uint mask = cmpAnd.ExtractMostSignificantBits();
+                    do
+                    {
+                        int bitPos = BitOperations.TrailingZeroCount(mask);
+                        if (valueLength == 2 || // we already matched two bytes
+                            SequenceEqual(
+                                ref Unsafe.Add(ref searchSpace, offset + bitPos),
+                                ref value, (nuint)(uint)valueLength)) // The (nuint)-cast is necessary to pick the correct overload
+                        {
+                            return (int)(offset + bitPos);
+                        }
+                        mask = BitOperations.ResetLowestSetBit(mask); // Clear the lowest set bit
+                    } while (mask != 0);
+                    goto LOOP_FOOTER;
+
                 } while (true);
             }
             else // 128bit vector path (SSE2 or AdvSimd)
@@ -125,42 +135,52 @@ namespace System
                 Vector128<byte> ch1 = Vector128.Create(value);
                 Vector128<byte> ch2 = Vector128.Create(ch2Val);
 
+                nint searchSpaceMinusValueTailLengthAndVector =
+                    searchSpaceMinusValueTailLength - (nint)Vector128<ushort>.Count;
+
                 do
                 {
                     Debug.Assert(offset >= 0);
                     // Make sure we don't go out of bounds
                     Debug.Assert(offset + ch1ch2Distance + Vector128<byte>.Count <= searchSpaceLength);
 
-                    Vector128<byte> cmpCh1 = Vector128.Equals(ch1, Vector128.LoadUnsafe(ref searchSpace, (nuint)offset));
                     Vector128<byte> cmpCh2 = Vector128.Equals(ch2, Vector128.LoadUnsafe(ref searchSpace, (nuint)(offset + ch1ch2Distance)));
+                    Vector128<byte> cmpCh1 = Vector128.Equals(ch1, Vector128.LoadUnsafe(ref searchSpace, (nuint)offset));
                     Vector128<byte> cmpAnd = (cmpCh1 & cmpCh2).AsByte();
 
                     // Early out: cmpAnd is all zeros
                     if (cmpAnd != Vector128<byte>.Zero)
                     {
-                        uint mask = cmpAnd.ExtractMostSignificantBits();
-                        do
-                        {
-                            int bitPos = BitOperations.TrailingZeroCount(mask);
-                            if (valueLength == 2 || // we already matched two bytes
-                                SequenceEqual(
-                                    ref Unsafe.Add(ref searchSpace, offset + bitPos),
-                                    ref value, (nuint)(uint)valueLength)) // The (nuint)-cast is necessary to pick the correct overload
-                            {
-                                return offset + bitPos;
-                            }
-                            // Clear the lowest set bit
-                            mask = BitOperations.ResetLowestSetBit(mask);
-                        } while (mask != 0);
+                        goto CANDIDATE_FOUND;
                     }
+
+                LOOP_FOOTER:
                     offset += Vector128<byte>.Count;
 
                     if (offset == searchSpaceMinusValueTailLength)
                         return -1;
 
                     // Overlap with the current chunk for trailing elements
-                    if (offset > searchSpaceMinusValueTailLength - Vector128<byte>.Count)
-                        offset = searchSpaceMinusValueTailLength - Vector128<byte>.Count;
+                    if (offset > searchSpaceMinusValueTailLengthAndVector)
+                        offset = searchSpaceMinusValueTailLengthAndVector;
+
+                CANDIDATE_FOUND:
+                    uint mask = cmpAnd.ExtractMostSignificantBits();
+                    do
+                    {
+                        int bitPos = BitOperations.TrailingZeroCount(mask);
+                        if (valueLength == 2 || // we already matched two bytes
+                            SequenceEqual(
+                                ref Unsafe.Add(ref searchSpace, offset + bitPos),
+                                ref value, (nuint)(uint)valueLength)) // The (nuint)-cast is necessary to pick the correct overload
+                        {
+                            return (int)(offset + bitPos);
+                        }
+                        // Clear the lowest set bit
+                        mask = BitOperations.ResetLowestSetBit(mask);
+                    } while (mask != 0);
+                    goto LOOP_FOOTER;
+
                 } while (true);
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -177,6 +177,8 @@ namespace System
                     if (offset > searchSpaceMinusValueTailLengthAndVector)
                         offset = searchSpaceMinusValueTailLengthAndVector;
 
+                    continue;
+
                 CANDIDATE_FOUND:
                     uint mask = cmpAnd.ExtractMostSignificantBits();
                     do

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -29,7 +29,7 @@ namespace System
                 return IndexOf(ref searchSpace, value, searchSpaceLength);
             }
 
-            int offset = 0;
+            nint offset = 0;
             char valueHead = value;
             int searchSpaceMinusValueTailLength = searchSpaceLength - valueTailLength;
             if (Vector128.IsHardwareAccelerated && searchSpaceMinusValueTailLength >= Vector128<ushort>.Count)
@@ -59,7 +59,7 @@ namespace System
                         ref valueTail,
                         (nuint)(uint)valueTailLength * 2))
                 {
-                    return offset;  // The tail matched. Return a successful find.
+                    return (int)offset;  // The tail matched. Return a successful find.
                 }
 
                 remainingSearchSpaceLength--;
@@ -75,54 +75,66 @@ namespace System
                 // Find the last unique (which is not equal to ch1) character
                 // the algorithm is fine if both are equal, just a little bit less efficient
                 ushort ch2Val = Unsafe.Add(ref value, valueTailLength);
-                int ch1ch2Distance = valueTailLength;
+                nint ch1ch2Distance = valueTailLength;
                 while (ch2Val == valueHead && ch1ch2Distance > 1)
                     ch2Val = Unsafe.Add(ref value, --ch1ch2Distance);
 
                 Vector256<ushort> ch1 = Vector256.Create((ushort)valueHead);
                 Vector256<ushort> ch2 = Vector256.Create(ch2Val);
 
+                nint searchSpaceMinusValueTailLengthAndVector =
+                    searchSpaceMinusValueTailLength - (nint)Vector256<ushort>.Count;
+
                 do
                 {
                     // Make sure we don't go out of bounds
                     Debug.Assert(offset + ch1ch2Distance + Vector256<ushort>.Count <= searchSpaceLength);
 
-                    Vector256<ushort> cmpCh1 = Vector256.Equals(ch1, LoadVector256(ref searchSpace, offset));
                     Vector256<ushort> cmpCh2 = Vector256.Equals(ch2, LoadVector256(ref searchSpace, offset + ch1ch2Distance));
+                    Vector256<ushort> cmpCh1 = Vector256.Equals(ch1, LoadVector256(ref searchSpace, offset));
                     Vector256<byte> cmpAnd = (cmpCh1 & cmpCh2).AsByte();
 
                     // Early out: cmpAnd is all zeros
                     if (cmpAnd != Vector256<byte>.Zero)
                     {
-                        uint mask = cmpAnd.ExtractMostSignificantBits();
-                        do
-                        {
-                            int bitPos = BitOperations.TrailingZeroCount(mask);
-                            // div by 2 (shr) because we work with 2-byte chars
-                            int charPos = (int)((uint)bitPos / 2);
-                            if (valueLength == 2 || // we already matched two chars
-                                SequenceEqual(
-                                    ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, offset + charPos)),
-                                    ref Unsafe.As<char, byte>(ref value), (nuint)(uint)valueLength * 2))
-                            {
-                                return offset + charPos;
-                            }
-
-                            // Clear two the lowest set bits
-                            if (Bmi1.IsSupported)
-                                mask = Bmi1.ResetLowestSetBit(Bmi1.ResetLowestSetBit(mask));
-                            else
-                                mask &= ~(uint)(0b11 << bitPos);
-                        } while (mask != 0);
+                        goto CANDIDATE_FOUND;
                     }
+
+                LOOP_FOOTER:
                     offset += Vector256<ushort>.Count;
 
                     if (offset == searchSpaceMinusValueTailLength)
                         return -1;
 
                     // Overlap with the current chunk for trailing elements
-                    if (offset > searchSpaceMinusValueTailLength - Vector256<ushort>.Count)
-                        offset = searchSpaceMinusValueTailLength - Vector256<ushort>.Count;
+                    if (offset > searchSpaceMinusValueTailLengthAndVector)
+                        offset = searchSpaceMinusValueTailLengthAndVector;
+
+                    continue;
+
+                CANDIDATE_FOUND:
+                    uint mask = cmpAnd.ExtractMostSignificantBits();
+                    do
+                    {
+                        int bitPos = BitOperations.TrailingZeroCount(mask);
+                        // div by 2 (shr) because we work with 2-byte chars
+                        nint charPos = (nint)((uint)bitPos / 2);
+                        if (valueLength == 2 || // we already matched two chars
+                            SequenceEqual(
+                                ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, offset + charPos)),
+                                ref Unsafe.As<char, byte>(ref value), (nuint)(uint)valueLength * 2))
+                        {
+                            return (int)(offset + charPos);
+                        }
+
+                        // Clear two the lowest set bits
+                        if (Bmi1.IsSupported)
+                            mask = Bmi1.ResetLowestSetBit(Bmi1.ResetLowestSetBit(mask));
+                        else
+                            mask &= ~(uint)(0b11 << bitPos);
+                    } while (mask != 0);
+                    goto LOOP_FOOTER;
+
                 } while (true);
             }
             else // 128bit vector path (SSE2 or AdvSimd)
@@ -130,54 +142,64 @@ namespace System
                 // Find the last unique (which is not equal to ch1) character
                 // the algorithm is fine if both are equal, just a little bit less efficient
                 ushort ch2Val = Unsafe.Add(ref value, valueTailLength);
-                int ch1ch2Distance = valueTailLength;
+                nint ch1ch2Distance = valueTailLength;
                 while (ch2Val == valueHead && ch1ch2Distance > 1)
                     ch2Val = Unsafe.Add(ref value, --ch1ch2Distance);
 
                 Vector128<ushort> ch1 = Vector128.Create((ushort)valueHead);
                 Vector128<ushort> ch2 = Vector128.Create(ch2Val);
 
+                nint searchSpaceMinusValueTailLengthAndVector =
+                    searchSpaceMinusValueTailLength - (nint)Vector128<ushort>.Count;
+
                 do
                 {
                     // Make sure we don't go out of bounds
                     Debug.Assert(offset + ch1ch2Distance + Vector128<ushort>.Count <= searchSpaceLength);
 
-                    Vector128<ushort> cmpCh1 = Vector128.Equals(ch1, LoadVector128(ref searchSpace, offset));
                     Vector128<ushort> cmpCh2 = Vector128.Equals(ch2, LoadVector128(ref searchSpace, offset + ch1ch2Distance));
+                    Vector128<ushort> cmpCh1 = Vector128.Equals(ch1, LoadVector128(ref searchSpace, offset));
                     Vector128<byte> cmpAnd = (cmpCh1 & cmpCh2).AsByte();
 
                     // Early out: cmpAnd is all zeros
                     if (cmpAnd != Vector128<byte>.Zero)
                     {
-                        uint mask = cmpAnd.ExtractMostSignificantBits();
-                        do
-                        {
-                            int bitPos = BitOperations.TrailingZeroCount(mask);
-                            // div by 2 (shr) because we work with 2-byte chars
-                            int charPos = (int)((uint)bitPos / 2);
-                            if (valueLength == 2 || // we already matched two chars
-                                SequenceEqual(
-                                    ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, offset + charPos)),
-                                    ref Unsafe.As<char, byte>(ref value), (nuint)(uint)valueLength * 2))
-                            {
-                                return offset + charPos;
-                            }
-
-                            // Clear two lowest set bits
-                            if (Bmi1.IsSupported)
-                                mask = Bmi1.ResetLowestSetBit(Bmi1.ResetLowestSetBit(mask));
-                            else
-                                mask &= ~(uint)(0b11 << bitPos);
-                        } while (mask != 0);
+                        goto CANDIDATE_FOUND;
                     }
+
+                LOOP_FOOTER:
                     offset += Vector128<ushort>.Count;
 
                     if (offset == searchSpaceMinusValueTailLength)
                         return -1;
 
                     // Overlap with the current chunk for trailing elements
-                    if (offset > searchSpaceMinusValueTailLength - Vector128<ushort>.Count)
-                        offset = searchSpaceMinusValueTailLength - Vector128<ushort>.Count;
+                    if (offset > searchSpaceMinusValueTailLengthAndVector)
+                        offset = searchSpaceMinusValueTailLengthAndVector;
+
+                CANDIDATE_FOUND:
+                    uint mask = cmpAnd.ExtractMostSignificantBits();
+                    do
+                    {
+                        int bitPos = BitOperations.TrailingZeroCount(mask);
+                        // div by 2 (shr) because we work with 2-byte chars
+                        int charPos = (int)((uint)bitPos / 2);
+                        if (valueLength == 2 || // we already matched two chars
+                            SequenceEqual(
+                                ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, offset + charPos)),
+                                ref Unsafe.As<char, byte>(ref value), (nuint)(uint)valueLength * 2))
+                        {
+                            return (int)(offset + charPos);
+                        }
+
+                        // Clear two lowest set bits
+                        if (Bmi1.IsSupported)
+                            mask = Bmi1.ResetLowestSetBit(Bmi1.ResetLowestSetBit(mask));
+                        else
+                            mask &= ~(uint)(0b11 << bitPos);
+                    } while (mask != 0);
+                    goto LOOP_FOOTER;
+
                 } while (true);
             }
         }


### PR DESCRIPTION
Attempt to fix regressions caused by https://github.com/dotnet/runtime/pull/63285 for large input: https://github.com/dotnet/runtime/issues/64381

1) use `nint` instead of `int` where possible to avoid sign extensions
2) Slightly move "candidate found" block and assume we mostly find nothing (in theory, PGO will do the same)
3) Hoist invariant `searchSpaceMinusValueTailLength - Vector128<ushort>.Count` expression - JIT only does it for natural loops so I had to do it by hands.
3) Re-order `cmpCh1` and `cmpCh2` - it slightly improves pipelining (currently we emit a GPR instruction between two independent SIMD compare instructions)

Benchmarks: (Regressed ones and the ones from https://github.com/dotnet/runtime/pull/63285)

| Method |                   Toolchain |           Pattern |      Mean |    Error |   StdDev | Ratio |
|------- |---------------------------- |------------------ |----------:|---------:|---------:|------:|
|  Count |   \Core_Root_PR\corerun.exe |          Sherlock |  44.90 us | 0.267 us | 0.237 us |  1.00 |
|  Count | \Core_Root_base\corerun.exe |          Sherlock |  51.14 us | 0.136 us | 0.120 us |  1.14 |
|        |                             |                   |           |          |          |       |
|  Count |   \Core_Root_PR\corerun.exe |   Sherlock Holmes |  45.15 us | 0.281 us | 0.263 us |  1.00 |
|  Count | \Core_Root_base\corerun.exe |   Sherlock Holmes |  50.79 us | 0.089 us | 0.083 us |  1.12 |
|        |                             |                   |           |          |          |       |
|  Count |   \Core_Root_PR\corerun.exe | Sherlock\s+Holmes |  48.21 us | 0.182 us | 0.170 us |  1.00 |
|  Count | \Core_Root_base\corerun.exe | Sherlock\s+Holmes |  53.07 us | 0.105 us | 0.093 us |  1.10 |
|        |                             |                   |           |          |          |       |
|  Count |   \Core_Root_PR\corerun.exe |               The | 108.63 us | 0.157 us | 0.131 us |  1.00 |
|  Count | \Core_Root_base\corerun.exe |               The | 115.75 us | 0.115 us | 0.096 us |  1.07 |
|        |                             |                   |           |          |          |       |
|  Count |   \Core_Root_PR\corerun.exe |               zqj |  34.84 us | 0.209 us | 0.195 us |  1.00 |
|  Count | \Core_Root_base\corerun.exe |               zqj |  39.76 us | 0.131 us | 0.123 us |  1.14 |


|           Method |                   Toolchain |      Mean |     Error |    StdDev | Ratio |
|----------------- |---------------------------- |----------:|----------:|----------:|------:|
|  IndexOf_Walking |   \Core_Root_PR\corerun.exe |  9.277 ns | 0.0282 ns | 0.0264 ns |  1.00 |
|  IndexOf_Walking | \Core_Root_base\corerun.exe |  9.761 ns | 0.0105 ns | 0.0093 ns |  1.05 |
|                  |                             |           |           |           |       |
| Contains_HtmlTag |   \Core_Root_PR\corerun.exe |  8.836 ns | 0.0257 ns | 0.0228 ns |  1.00 |
| Contains_HtmlTag | \Core_Root_base\corerun.exe |  9.044 ns | 0.0099 ns | 0.0087 ns |  1.02 |
|                  |                             |           |           |           |       |
|    IndexOf_Cmake |   \Core_Root_PR\corerun.exe | 17.686 ns | 0.0659 ns | 0.0617 ns |  1.00 |
|    IndexOf_Cmake | \Core_Root_base\corerun.exe | 20.795 ns | 0.1066 ns | 0.0998 ns |  1.18 |

No changes for `LastIndexOf` for now (we also don't have reported regressions for it atm)

cc @stephentoub 