### PR TITLE
Fix link in readytorun-format.md

### DIFF
--- a/docs/design/coreclr/botr/readytorun-format.md
+++ b/docs/design/coreclr/botr/readytorun-format.md
@@ -66,8 +66,9 @@ The limitations of the current format are:
 
 # Structures
 
-The structures and accompanying constants are defined in the [readytorun.h]
-(https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/readytorun.h) header file.
+The structures and accompanying constants are defined in the
+[readytorun.h](https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/readytorun.h)
+header file.
 Basically the entire R2R executable image is addressed through the READYTORUN_HEADER singleton
 pointed to by the well-known export RTR_HEADER in the export section of the native executable
 envelope.


### PR DESCRIPTION
The link was not rendering correctly, as the link text and target were on separate lines.