### PR TITLE
Disable tests on Debug CoreClr that are already disabled on Checked CoreClr

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -60,6 +60,14 @@ namespace System
         public static bool Is64BitProcess => IntPtr.Size == 8;
         public static bool IsNotWindows => !IsWindows;
 
+        private static Lazy<bool> s_isCheckedRuntime => new Lazy<bool>(() => AssemblyConfigurationEquals("Checked"));
+        private static Lazy<bool> s_isReleaseRuntime => new Lazy<bool>(() => AssemblyConfigurationEquals("Release"));
+        private static Lazy<bool> s_isDebugRuntime => new Lazy<bool>(() => AssemblyConfigurationEquals("Debug"));
+
+        public static bool IsCheckedRuntime => s_isCheckedRuntime.Value;
+        public static bool IsReleaseRuntime => s_isReleaseRuntime.Value;
+        public static bool IsDebugRuntime => s_isDebugRuntime.Value;
+
         public static bool IsCaseInsensitiveOS => IsWindows || IsOSX || IsMacCatalyst;
 
 #if NETCOREAPP
@@ -68,7 +76,7 @@ namespace System
 #else
         public static bool IsCaseSensitiveOS => !IsCaseInsensitiveOS;
 #endif
-        
+
         public static bool IsThreadingSupported => !IsBrowser;
         public static bool IsBinaryFormatterSupported => IsNotMobile && !IsNativeAot;
         public static bool IsSymLinkSupported => !IsiOS && !IstvOS;
@@ -86,9 +94,9 @@ namespace System
         public static bool IsUsingLimitedCultures => !IsNotMobile;
         public static bool IsNotUsingLimitedCultures => IsNotMobile;
 
-        public static bool IsLinqExpressionsBuiltWithIsInterpretingOnly => s_LinqExpressionsBuiltWithIsInterpretingOnly.Value;
+        public static bool IsLinqExpressionsBuiltWithIsInterpretingOnly => s_linqExpressionsBuiltWithIsInterpretingOnly.Value;
         public static bool IsNotLinqExpressionsBuiltWithIsInterpretingOnly => !IsLinqExpressionsBuiltWithIsInterpretingOnly;
-        private static readonly Lazy<bool> s_LinqExpressionsBuiltWithIsInterpretingOnly = new Lazy<bool>(GetLinqExpressionsBuiltWithIsInterpretingOnly);
+        private static readonly Lazy<bool> s_linqExpressionsBuiltWithIsInterpretingOnly = new Lazy<bool>(GetLinqExpressionsBuiltWithIsInterpretingOnly);
         private static bool GetLinqExpressionsBuiltWithIsInterpretingOnly()
         {
             return !(bool)typeof(LambdaExpression).GetMethod("get_CanCompileToIL").Invoke(null, Array.Empty<object>());
@@ -203,7 +211,7 @@ namespace System
                 {
                     return true;
                 }
-                
+
                 return OpenSslVersion.Major == 1 && (OpenSslVersion.Minor >= 1 || OpenSslVersion.Build >= 2);
             }
 
@@ -489,6 +497,14 @@ namespace System
 
             var val = Environment.GetEnvironmentVariable(variableName);
             return (val != null && val == "true");
+        }
+
+        private static bool AssemblyConfigurationEquals(string configuration)
+        {
+            AssemblyConfigurationAttribute assemblyConfigurationAttribute = typeof(string).Assembly.GetCustomAttribute<AssemblyConfigurationAttribute>();
+
+            return assemblyConfigurationAttribute != null &&
+                string.Equals(assemblyConfigurationAttribute.Configuration, configuration, StringComparison.InvariantCulture);
         }
     }
 }

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -68,6 +68,10 @@ namespace System
         public static bool IsReleaseRuntime => s_isReleaseRuntime.Value;
         public static bool IsDebugRuntime => s_isDebugRuntime.Value;
 
+        // For use as needed on tests that time out when run on a Debug runtime.
+        // Not relevant for timeouts on external activities, such as network timeouts.
+        public static int SlowRuntimeTimeoutModifier = (PlatformDetection.IsDebugRuntime ? 5 : 1);
+
         public static bool IsCaseInsensitiveOS => IsWindows || IsOSX || IsMacCatalyst;
 
 #if NETCOREAPP

--- a/src/libraries/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/RegistrationBuilderAttributedOverrideUnitTests.cs
+++ b/src/libraries/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/RegistrationBuilderAttributedOverrideUnitTests.cs
@@ -10,7 +10,7 @@ using Xunit.Sdk;
 
 namespace System.ComponentModel.Composition.Registration.Tests
 {
-    [SkipOnCoreClr("Test failures on stress tests", RuntimeConfiguration.Checked)]
+    [SkipOnCoreClr("Test failures on stress tests", ~RuntimeConfiguration.Release)]
     [SkipOnMono("Test failures on stress tests")]
     public class RegistrationBuilderAttributedOverrideUnitTests
     {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTestBase.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTestBase.cs
@@ -13,7 +13,7 @@ namespace System.Diagnostics.Tests
 {
     public partial class ProcessTestBase : FileCleanupTestBase
     {
-        protected readonly int WaitInMS = 30 * 1000 * (PlatformDetection.IsReleaseRuntime ? 1 : 3);
+        protected readonly int WaitInMS = 30 * 1000 * PlatformDetection.SlowRuntimeTimeoutModifier;
         protected Process _process;
         protected readonly List<Process> _processes = new List<Process>();
 

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTestBase.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTestBase.cs
@@ -13,7 +13,7 @@ namespace System.Diagnostics.Tests
 {
     public partial class ProcessTestBase : FileCleanupTestBase
     {
-        protected const int WaitInMS = 30 * 1000;
+        protected readonly int WaitInMS = 30 * 1000 * (PlatformDetection.IsReleaseRuntime ? 1 : 3);
         protected Process _process;
         protected readonly List<Process> _processes = new List<Process>();
 

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
@@ -46,7 +46,7 @@ using Xunit;
 namespace MonoTests.System.Drawing
 {
 
-    [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/37082", TestPlatforms.AnyUnix, RuntimeConfiguration.Checked)]
+    [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/37082", TestPlatforms.AnyUnix, ~RuntimeConfiguration.Release)]
     public class TestBitmap
     {
 

--- a/src/libraries/System.Linq.Expressions/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Linq.Expressions/tests/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using Xunit;
 
-[assembly: SkipOnCoreClr("Long running tests: https://github.com/dotnet/runtime/issues/12927", RuntimeConfiguration.Checked)]
+[assembly: SkipOnCoreClr("Long running tests: https://github.com/dotnet/runtime/issues/12927", ~RuntimeConfiguration.Release)]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/AssemblyInfo.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/AssemblyInfo.cs
@@ -4,6 +4,6 @@
 using System;
 using Xunit;
 
-[assembly: SkipOnCoreClr("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131", RuntimeConfiguration.Checked)]
+[assembly: SkipOnCoreClr("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131", ~RuntimeConfiguration.Release)]
 [assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/131", ~(TestPlatforms.Android | TestPlatforms.Browser), TargetFrameworkMonikers.Any, TestRuntimes.Mono)] // System.Net.Tests are flaky and/or long running
 

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerAuthenticationTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerAuthenticationTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace System.Net.Tests
 {
-    [SkipOnCoreClr("System.Net.Tests may timeout in stress configurations", RuntimeConfiguration.Checked)]
+    [SkipOnCoreClr("System.Net.Tests may timeout in stress configurations", ~RuntimeConfiguration.Release)]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/2391", TestRuntimes.Mono)]
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // httpsys component missing in Nano.
     public class HttpListenerAuthenticationTests : IDisposable

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerContextTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerContextTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace System.Net.Tests
 {
-    [SkipOnCoreClr("System.Net.Tests may timeout in stress configurations", RuntimeConfiguration.Checked)]
+    [SkipOnCoreClr("System.Net.Tests may timeout in stress configurations", ~RuntimeConfiguration.Release)]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/2391", TestRuntimes.Mono)]
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // httpsys component missing in Nano.
     public class HttpListenerContextTests : IDisposable

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Net.Tests
 {
-    [SkipOnCoreClr("System.Net.Tests may timeout in stress configurations", RuntimeConfiguration.Checked)]
+    [SkipOnCoreClr("System.Net.Tests may timeout in stress configurations", ~RuntimeConfiguration.Release)]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/2391", TestRuntimes.Mono)]
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // httpsys component missing in Nano.
     public class HttpListenerResponseCookiesTests : HttpListenerResponseTestBase

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
@@ -56,7 +56,7 @@ namespace System.Net.Tests
         }
     }
 
-    [SkipOnCoreClr("System.Net.Tests may timeout in stress configurations", RuntimeConfiguration.Checked)]
+    [SkipOnCoreClr("System.Net.Tests may timeout in stress configurations", ~RuntimeConfiguration.Release)]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/2391", TestRuntimes.Mono)]
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // httpsys component missing in Nano.
     public class HttpListenerResponseTests : HttpListenerResponseTestBase

--- a/src/libraries/System.Net.Requests/tests/LoggingTest.cs
+++ b/src/libraries/System.Net.Requests/tests/LoggingTest.cs
@@ -9,7 +9,7 @@ namespace System.Net.Tests
     public class LoggingTest
     {
         [Fact]
-        [SkipOnCoreClr("System.Net.Tests are flaky", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("System.Net.Tests are flaky", ~RuntimeConfiguration.Release)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public void EventSource_ExistsWithCorrectId()
         {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
@@ -133,7 +133,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [SkipOnCoreClr("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131", ~RuntimeConfiguration.Release)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/131", TestRuntimes.Mono)] // System.Net.Tests are flaky and/or long running
         public async Task SslStream_NoSniFromClient_CallbackReturnsNull()
         {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/AssemblyInfo.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/AssemblyInfo.cs
@@ -3,6 +3,6 @@
 
 using Xunit;
 
-[assembly: SkipOnCoreClr("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131", RuntimeConfiguration.Checked)]
+[assembly: SkipOnCoreClr("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131", ~RuntimeConfiguration.Release)]
 [assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/34690", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
 [assembly: SkipOnPlatform(TestPlatforms.Browser, "System.Net.Sockets is not supported on Browser")]

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
@@ -207,7 +207,7 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
-        [SkipOnCoreClr("Long running tests: https://github.com/dotnet/runtime/issues/11980", TestPlatforms.Linux, RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("Long running tests: https://github.com/dotnet/runtime/issues/11980", TestPlatforms.Linux, ~RuntimeConfiguration.Release)]
         public static void RunRegionSpecificStandardFormatToStringTests()
         {
             CultureInfo[] cultures = new CultureInfo[] { new CultureInfo("en-US"), new CultureInfo("en-GB"), new CultureInfo("fr-CA"),

--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
     {
         // On 32-bit we can't test these high inputs as they cause OutOfMemoryExceptions.
         [ConditionalTheory(typeof(Environment), nameof(Environment.Is64BitProcess))]
-        [SkipOnCoreClr("Long running tests: https://github.com/dotnet/runtime/issues/11191", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("Long running tests: https://github.com/dotnet/runtime/issues/11191", ~RuntimeConfiguration.Release)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/35915", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
         [InlineData(2 * 6_584_983 - 2)] // previous limit
         [InlineData(2 * 7_199_369 - 2)] // last pre-computed prime number
@@ -47,7 +47,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
         }
 
         [Theory]
-        [SkipOnCoreClr("Takes too long on Checked", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("Takes too long on Checked", ~RuntimeConfiguration.Release)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34008", TestPlatforms.Linux, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34753", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [SkipOnPlatform(TestPlatforms.Browser, "Takes too long on Browser.")]
@@ -65,14 +65,14 @@ namespace System.Runtime.Serialization.Formatters.Tests
         }
 
         [Theory]
-        [SkipOnCoreClr("Takes too long on Checked", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("Takes too long on Checked", ~RuntimeConfiguration.Release)]
         [ActiveIssue("https://github.com/mono/mono/issues/15115", TestRuntimes.Mono)]
         [MemberData(nameof(SerializableObjects_MemberData))]
         public void ValidateAgainstBlobs(object obj, TypeSerializableValue[] blobs)
             => ValidateAndRoundtrip(obj, blobs, false);
 
         [Theory]
-        [SkipOnCoreClr("Takes too long on Checked", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("Takes too long on Checked", ~RuntimeConfiguration.Release)]
         [MemberData(nameof(SerializableEqualityComparers_MemberData))]
         public void ValidateEqualityComparersAgainstBlobs(object obj, TypeSerializableValue[] blobs)
             => ValidateAndRoundtrip(obj, blobs, true);

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Cache.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Cache.cs
@@ -125,7 +125,7 @@ namespace System.Text.Json.Serialization.Tests
         private JsonSerializerOptions s_options = new JsonSerializerOptions();
 
         [Fact]
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", ~RuntimeConfiguration.Release)]
         public async Task MultipleTypes()
         {
             async Task Serialize<T>(object[] args)

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Stream.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Stream.cs
@@ -11,7 +11,7 @@ namespace System.Text.Json.Serialization.Tests
     public abstract partial class ConstructorTests
     {
         [Fact]
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", ~RuntimeConfiguration.Release)]
         public async Task ReadSimpleObjectAsync()
         {
             async Task RunTestAsync<T>(byte[] testData)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonDocumentTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonDocumentTests.cs
@@ -472,7 +472,7 @@ namespace System.Text.Json.Tests
 
         [Theory]
         [MemberData(nameof(BadBOMCases))]
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", ~RuntimeConfiguration.Release)]
         public static Task ParseJson_UnseekableStream_Async_BadBOM(string json)
         {
             byte[] data = Encoding.UTF8.GetBytes(json);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ContinuationTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ContinuationTests.cs
@@ -181,7 +181,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [MemberData(nameof(TestData), /* enumeratePayloadTweaks: */ false)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/42677", platforms: TestPlatforms.Windows, runtimes: TestRuntimes.Mono)]
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", ~RuntimeConfiguration.Release)]
         public static void ShouldWorkAtAnyPosition_Sequence(
             string json,
             int bufferSize,

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NumberHandlingTests.cs
@@ -602,7 +602,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/39674", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", ~RuntimeConfiguration.Release)]
         public static void DictionariesRoundTrip()
         {
             RunAllDictionariessRoundTripTest(JsonNumberTestData.ULongs);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Stream.WriteTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Stream.WriteTests.cs
@@ -54,7 +54,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", ~RuntimeConfiguration.Release)]
         public async Task RoundTripAsync()
         {
             byte[] buffer;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -1839,7 +1839,7 @@ namespace System.Text.Json.Tests
         [InlineData("{\"Property1\": {\"Property1.1\": 42} // comment\n,5}")]
         [InlineData("{\"Property1\": {\"Property1.1\": 42}, // comment\n // comment\n5}")]
         [InlineData("{// comment\n5}")]
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", ~RuntimeConfiguration.Release)]
         public static void ReadInvalidJsonStringsWithComments(string jsonString)
         {
             byte[] input = Encoding.UTF8.GetBytes(jsonString);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonWriterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonWriterTests.cs
@@ -3196,7 +3196,7 @@ namespace System.Text.Json.Tests
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", ~RuntimeConfiguration.Release)]
         public void Writing3MBBase64Bytes(bool formatted, bool skipValidation)
         {
             byte[] value = new byte[3 * 1024 * 1024];

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -309,7 +309,7 @@ namespace System.Text.RegularExpressions.Tests
                 // Using beginning/end of string chars \A, \Z: Actual - "\\Aaaa\\w+zzz\\Z"
                 yield return (@"\Aaaa\w+zzz\Z", "aaaasdfajsdlfjzzz", RegexOptions.IgnoreCase, 0, 17, true, "aaaasdfajsdlfjzzz");
                 yield return (@"\Aaaaaa\w+zzz\Z", "aaaa", RegexOptions.IgnoreCase, 0, 4, false, string.Empty);
-                if (!RegexHelpers.IsNonBacktracking(engine))
+                //if (!RegexHelpers.IsNonBacktracking(engine))
                 {
                     yield return (@"\Aaaaaa\w+zzz\Z", "aaaa", RegexOptions.RightToLeft, 0, 4, false, string.Empty);
                     yield return (@"\Aaaaaa\w+zzzzz\Z", "aaaa", RegexOptions.RightToLeft, 0, 4, false, string.Empty);

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -1555,7 +1555,7 @@ namespace System.Text.RegularExpressions.Tests
 
         [ConditionalTheory(nameof(IsNotArmProcessAndRemoteExecutorSupported))] // times out on ARM
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework does not have fix for https://github.com/dotnet/runtime/issues/24749")]
-        [SkipOnCoreClr("Long running tests: https://github.com/dotnet/runtime/issues/10680", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("Long running tests: https://github.com/dotnet/runtime/issues/10680", ~RuntimeConfiguration.Release)]
         [SkipOnCoreClr("Long running tests: https://github.com/dotnet/runtime/issues/10680", RuntimeTestModes.JitMinOpts)]
         [MemberData(nameof(RegexHelpers.AvailableEngines_MemberData), MemberType = typeof(RegexHelpers))]
         public void Match_ExcessPrefix(RegexEngine engine)

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -309,7 +309,7 @@ namespace System.Text.RegularExpressions.Tests
                 // Using beginning/end of string chars \A, \Z: Actual - "\\Aaaa\\w+zzz\\Z"
                 yield return (@"\Aaaa\w+zzz\Z", "aaaasdfajsdlfjzzz", RegexOptions.IgnoreCase, 0, 17, true, "aaaasdfajsdlfjzzz");
                 yield return (@"\Aaaaaa\w+zzz\Z", "aaaa", RegexOptions.IgnoreCase, 0, 4, false, string.Empty);
-                //if (!RegexHelpers.IsNonBacktracking(engine))
+                if (!RegexHelpers.IsNonBacktracking(engine))
                 {
                     yield return (@"\Aaaaaa\w+zzz\Z", "aaaa", RegexOptions.RightToLeft, 0, 4, false, string.Empty);
                     yield return (@"\Aaaaaa\w+zzzzz\Z", "aaaa", RegexOptions.RightToLeft, 0, 4, false, string.Empty);

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWithTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWithTests.cs
@@ -41,7 +41,7 @@ namespace System.Threading.Tasks.Tests
 
         // Stresses on multiple continuations from a single antecedent
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [SkipOnCoreClr("Test timing out: https://github.com/dotnet/runtime/issues/2271", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("Test timing out: https://github.com/dotnet/runtime/issues/2271", ~RuntimeConfiguration.Release)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/2271")]
         public static void RunContinueWithStressTestsNoState()
         {


### PR DESCRIPTION
A number of tests are disabled for Checked runtime. I assume these intended to also disable for Debug runtime, which is even slower.

Also increased timeout when not on a release runtime for some Process tests that are timing out on a debug runtime.