### PR TITLE
Skip System.Net.NetworkInformation.Tests.PingTest.SendPingWithIPAddressAndBigSize test on Android

### DIFF
--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -80,7 +80,7 @@ namespace System.Net.NetworkInformation.Tests
 
         public static bool DoesNotUsePingUtility => !UsesPingUtility;
 
-        public static bool UsesPingUtility => OperatingSystem.IsLinux() && !Capability.CanUseRawSockets(TestSettings.GetLocalIPAddress().AddressFamily);
+        public static bool UsesPingUtility => (OperatingSystem.IsLinux() || OperatingSystem.IsAndroid()) && !Capability.CanUseRawSockets(TestSettings.GetLocalIPAddress().AddressFamily);
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task SendPingAsync_InvalidArgs()


### PR DESCRIPTION
Addresses https://github.com/dotnet/runtime/issues/64798.

The `System.Net.NetworkInformation.Tests.PingTest.SendPingWithIPAddressAndBigSize` test passes non-default and non-empty buffer when ping sending:
```
// Assert.DoesNotThrow
PingReply pingReply = await p.SendPingAsync(localIpAddress, TestSettings.PingTimeout, new byte[10001]);
```
which hits a new check was added in PingUtility class added in https://github.com/dotnet/runtime/pull/64625:
```
// although the ping utility supports custom pattern via -p option, it supports
// specifying only up to 16B pattern which repeats in the payload. The option also might
// not be present in all distributions, so we forbid ping payload in general.
if (buffer != DefaultSendBuffer && buffer != Array.Empty<byte>())
{
    throw new PlatformNotSupportedException(SR.net_ping_utility_custom_payload);
}
```

The test was also marked with `[ConditionalFact(nameof(DoesNotUsePingUtility))]` so that it started failing with PNSE on Android.

This pull request is to update `DoesNotUsePingUtility` by adding Android to `UsesPingUtility` condition, so that the mentioned test is skipped on Android. 