### PR TITLE
Do not number partial definitions and `ARGPLACE` nodes

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -8120,6 +8120,7 @@ void Compiler::fgValueNumberBlockAssignment(GenTree* tree)
             JITDUMP("Tree [%06u] assigned VN to the only field V%02u/%u of promoted struct V%02u: new uniq ",
                     dspTreeID(tree), lhsVarDsc->lvFieldLclStart, lclVarTree->GetSsaNum(), lhsLclNum);
             JITDUMPEXEC(vnPrint(newUniqueVN, 1));
+            JITDUMP("\n");
         }
         else if (lhsVarDsc->IsAddressExposed())
         {


### PR DESCRIPTION
Three changes in this set:

1) Refactor the numbering of `LCL_VAR` "uses" - preserve the old behavior, reduce confusion on what should and should not be numbered, make the kinds of type mismatches we expect (and tolerate) explicit via asserts.
2) Do not number partial definitions as uses. This is wasted work.
2) Do not give unique VNs to `ARGPLACE` nodes - this, again, is simply wasting memory, as the nodes in question will have their VNs always reset by `fgValueNumberCall` anyway.

Overall, we are saving a little under `0.4%` in memory consumption when CG-ing x64 Release CoreLib with these changes.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1596503&view=ms.vss-build-web.run-extensions-tab) as expected.