### PR TITLE
[mono] Fix is_byreflike_set on big-endian platforms

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
@@ -74,7 +74,7 @@ namespace System.Reflection.Emit
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
         private TypeInfo? created;
-        private bool is_byreflike_set;
+        private int is_byreflike_set;
 
         private int state;
 #endregion
@@ -1534,7 +1534,7 @@ namespace System.Reflection.Emit
             }
             else if (attrname == "System.Runtime.CompilerServices.IsByRefLikeAttribute")
             {
-                is_byreflike_set = true;
+                is_byreflike_set = 1;
             }
 
             if (cattrs != null)

--- a/src/mono/mono/metadata/object-internals.h
+++ b/src/mono/mono/metadata/object-internals.h
@@ -1222,7 +1222,7 @@ struct _MonoReflectionTypeBuilder {
 	MonoGenericContainer *generic_container;
 	MonoArray *generic_params;
 	MonoReflectionType *created;
-	gboolean is_byreflike_set;
+	gint32 is_byreflike_set;
 	gint32 state;
 };
 

--- a/src/mono/mono/metadata/sre.c
+++ b/src/mono/mono/metadata/sre.c
@@ -3866,7 +3866,7 @@ ves_icall_TypeBuilder_create_runtime_class (MonoReflectionTypeBuilderHandle ref_
 	 * The IsByRefLike attribute only applies to value types and enums. This matches CoreCLR behavior.
 	 */
 	if (klass->enumtype || klass->valuetype)
-		klass->is_byreflike = MONO_HANDLE_GETVAL (MONO_HANDLE_CAST (MonoReflectionTypeBuilder, ref_tb), is_byreflike_set);
+		klass->is_byreflike = MONO_HANDLE_GETVAL (MONO_HANDLE_CAST (MonoReflectionTypeBuilder, ref_tb), is_byreflike_set) != 0;
 
 	/* enums are done right away */
 	if (!klass->enumtype)


### PR DESCRIPTION
* Use int / gint32 types to avoid C# vs. native type mismatches

* Fixes s390x regression after https://github.com/dotnet/runtime/pull/63985

CC @AaronRobinsonMSFT @lambdageek @vargaz @nealef 