### PR TITLE
[release/6.0][wasm] Remove USE_ZLIB=1 and include the sources instead

### DIFF
--- a/src/libraries/Native/AnyOS/zlib/pal_zlib.c
+++ b/src/libraries/Native/AnyOS/zlib/pal_zlib.c
@@ -7,6 +7,9 @@
 
 #ifdef  _WIN32
     #define c_static_assert(e) static_assert((e),"")
+#endif
+
+#if defined(_WIN32) || defined(__EMSCRIPTEN__)
     #include "../../Windows/System.IO.Compression.Native/zlib/zlib.h"
 #else
     #include "pal_utilities.h"

--- a/src/libraries/Native/Unix/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.IO.Compression.Native/CMakeLists.txt
@@ -1,9 +1,5 @@
 project(System.IO.Compression.Native C)
 
-if (CLR_CMAKE_TARGET_BROWSER)
-    add_definitions(-s USE_ZLIB)
-endif()
-
 include(${CMAKE_CURRENT_LIST_DIR}/extra_libs.cmake)
 
 set(NATIVE_LIBS_EXTRA)
@@ -13,7 +9,21 @@ set(NATIVECOMPRESSION_SOURCES
     ../../AnyOS/zlib/pal_zlib.c
 )
 
-if (NOT CLR_CMAKE_TARGET_BROWSER)
+if (CLR_CMAKE_TARGET_BROWSER)
+    set (NATIVECOMPRESSION_SOURCES
+        ${NATIVECOMPRESSION_SOURCES}
+        ../../Windows/System.IO.Compression.Native/zlib/adler32.c
+        ../../Windows/System.IO.Compression.Native/zlib/compress.c
+        ../../Windows/System.IO.Compression.Native/zlib/crc32.c
+        ../../Windows/System.IO.Compression.Native/zlib/deflate.c
+        ../../Windows/System.IO.Compression.Native/zlib/inffast.c
+        ../../Windows/System.IO.Compression.Native/zlib/inflate.c
+        ../../Windows/System.IO.Compression.Native/zlib/inftrees.c
+        ../../Windows/System.IO.Compression.Native/zlib/trees.c
+        ../../Windows/System.IO.Compression.Native/zlib/zutil.c
+    )
+    set_source_files_properties(${NATIVECOMPRESSION_SOURCES} PROPERTIES COMPILE_FLAGS -Wno-implicit-fallthrough)
+else()
     #Include Brotli include files
     include_directories("../../AnyOS/brotli/include")
 

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -82,7 +82,6 @@
 
     <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
       <_EmccFlags Include="@(_EmccCommonFlags)" />
-      <_EmccFlags Include="-s USE_ZLIB=1" />
     </ItemGroup>
 
     <WriteLinesToFile File="$(_EmccDefaultsRspPath)"


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/64628 to release/6.0

/cc @lewing @radical 

## Customer Impact

During the dotnet/runtime build Emscripten would download and cache zlib sources for wasm builds that set `USE_ZLIB=1`. As we saw in https://github.com/dotnet/runtime/issues/62553 this can lead the failures if that download fails and also introduces an unnecessary dependency that we can avoid since we already have the sources in the repo.

Note: in main the zlib sources were refactored to not be in a Windows-specific folder path, but for release/6.0 including them from the Windows-specific path is less churn.

## Testing

Manual and CI testing.

## Risk

Low. We're replacing the zlib sources that emscripten downloads with the (identical) sources we already have in the repo.