### PR TITLE
[Mono] Fix potential crash when handling image load event.

### DIFF
--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -2953,6 +2953,8 @@ get_module_event_data (
 			module_data->module_flags |= MODULE_FLAGS_NATIVE_MODULE;
 
 		module_data->module_il_path = image && image->filename ? image->filename : "";
+		module_data->module_il_pdb_path = "";
+		module_data->module_il_pdb_age = 0;
 
 		if (image && image->image_info) {
 			MonoPEDirEntry *debug_dir_entry = (MonoPEDirEntry *)&image->image_info->cli_header.datadir.pe_debug;
@@ -2994,6 +2996,7 @@ ep_rt_mono_write_event_module_load (MonoImage *image)
 
 	if (image) {
 		ModuleEventData module_data;
+		memset (&module_data, 0, sizeof (module_data));
 		if (get_module_event_data (image, &module_data)) {
 			FireEtwModuleLoad_V2 (
 				module_data.module_id,
@@ -3037,6 +3040,7 @@ ep_rt_mono_write_event_module_unload (MonoImage *image)
 
 	if (image) {
 		ModuleEventData module_data;
+		memset (&module_data, 0, sizeof (module_data));
 		if (get_module_event_data (image, &module_data)) {
 			FireEtwModuleUnload_V2 (
 				module_data.module_id,
@@ -3095,6 +3099,7 @@ ep_rt_mono_write_event_assembly_load (MonoAssembly *assembly)
 
 	if (assembly) {
 		AssemblyEventData assembly_data;
+		memset (&assembly_data, 0, sizeof (assembly_data));
 		if (get_assembly_event_data (assembly, &assembly_data)) {
 			FireEtwAssemblyLoad_V1 (
 				assembly_data.assembly_id,
@@ -3121,6 +3126,7 @@ ep_rt_mono_write_event_assembly_unload (MonoAssembly *assembly)
 
 	if (assembly) {
 		AssemblyEventData assembly_data;
+		memset (&assembly_data, 0, sizeof (assembly_data));
 		if (get_assembly_event_data (assembly, &assembly_data)) {
 			FireEtwAssemblyUnload_V1 (
 				assembly_data.assembly_id,
@@ -5473,6 +5479,7 @@ mono_profiler_module_loaded (
 
 	if (image) {
 		ModuleEventData module_data;
+		memset (&module_data, 0, sizeof (module_data));
 		if (get_module_event_data (image, &module_data))
 			module_path = (const ep_char8_t *)module_data.module_il_path;
 		module_guid = (const ep_char8_t *)mono_image_get_guid (image);
@@ -5524,6 +5531,7 @@ mono_profiler_module_unloaded (
 
 	if (image) {
 		ModuleEventData module_data;
+		memset (&module_data, 0, sizeof (module_data));
 		if (get_module_event_data (image, &module_data))
 			module_path = (const ep_char8_t *)module_data.module_il_path;
 		module_guid = (const ep_char8_t *)mono_image_get_guid (image);


### PR DESCRIPTION
Running dotnet-trace against MonoVM running on Android and including the loader (image/assembly load/unload) events from Microsoft-Windows-DotNETRuntime caused a runtime crash when handling Mono.Android.dll assembly. Happens since that assembly didn't include a debug directory entry in release build, that in turn left a field on the stack uninitialized, causing potential crash depending on current stack content.

Fix makes sure the struct always gets initialized and that we explicitly set that field (module_il_pdb_path) to an empty string if assembly doesn't include a debug directory entry.

Fixes:

https://github.com/dotnet/runtime/issues/64458
https://github.com/xamarin/xamarin-android/issues/6700