### PR TITLE
Improve backport.yml to only check start of line and instructions for team visibility

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,7 +22,7 @@ jobs:
           if (context.eventName !== "issue_comment") throw "Error: This action only works on issue_comment events.";
 
           // extract the target branch name from the trigger phrase containing these characters: a-z, A-Z, digits, forward slash, dot, hyphen, underscore
-          const regex = /\/backport to ([a-zA-Z\d\/\.\-\_]+)/;
+          const regex = /^\/backport to ([a-zA-Z\d\/\.\-\_]+)/;
           target_branch = regex.exec(context.payload.comment.body);
           if (target_branch == null) throw "Error: No backport branch found in the trigger phrase.";
 

--- a/eng/actions/backport/index.js
+++ b/eng/actions/backport/index.js
@@ -39,7 +39,7 @@ async function run() {
       console.log(`Verified ${comment_user} is a repo collaborator.`);
     } catch (error) {
       console.log(error);
-      throw new BackportException(`Error: @${comment_user} is not a repo collaborator, backporting is not allowed.`);
+      throw new BackportException(`Error: @${comment_user} is not a repo collaborator, backporting is not allowed. If you're a collaborator please make sure your Microsoft team membership visibility is set to Public on https://github.com/orgs/microsoft/people?query=${comment_user}`);
     }
 
     try { await exec.exec(`git ls-remote --exit-code --heads origin ${target_branch}`) } catch { throw new BackportException(`Error: The specified backport target branch ${target_branch} wasn't found in the repo.`); }


### PR DESCRIPTION
Before the bot reacted to the /backport command anywhere in the comment, now it needs to be at the start of the line.

Additionally, if the check for repo collaborator fails print a link to the Microsoft team on GitHub to change visibility (most common failure case).