### PR TITLE
Move one more 20H2 queue to server 2022

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -159,7 +159,7 @@ jobs:
         - ${{ if or(ne(parameters.jobParameters.testScope, 'outerloop'), ne(parameters.jobParameters.runtimeFlavor, 'mono')) }}:
           - ${{ if or(eq(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
             - Windows.10.Amd64.ServerRS5.Open
-            - Windows.10.Amd64.Server20H2.Open
+            - Windows.Amd64.Server2022.Open
           - ${{ if or(ne(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
             - Windows.10.Amd64.Server19H1.ES.Open
             - Windows.7.Amd64.Open

--- a/src/libraries/System.Globalization/tests/IcuTests.cs
+++ b/src/libraries/System.Globalization/tests/IcuTests.cs
@@ -14,7 +14,6 @@ namespace System.Globalization.Tests
                                                         // Server core doesn't have icu.dll on SysWOW64
                                                         !(PlatformDetection.IsWindowsServerCore && PlatformDetection.IsX86Process));
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/64763", typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows), nameof(PlatformDetection.IsX86Process))]
         [ConditionalFact(nameof(IsIcuCompatiblePlatform))]
         public static void IcuShouldBeUsedByDefault()
         {

--- a/src/libraries/System.Globalization/tests/IcuTests.cs
+++ b/src/libraries/System.Globalization/tests/IcuTests.cs
@@ -10,8 +10,11 @@ namespace System.Globalization.Tests
     public class IcuTests
     {
         private static bool IsIcuCompatiblePlatform => PlatformDetection.IsNotWindows ||
-                                                       PlatformDetection.IsWindows10Version1903OrGreater;
+                                                       (PlatformDetection.IsWindows10Version1903OrGreater &&
+                                                        // Server core doesn't have icu.dll on SysWOW64
+                                                        !(PlatformDetection.IsWindowsServerCore && PlatformDetection.IsX86Process));
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/64763", typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows), nameof(PlatformDetection.IsX86Process))]
         [ConditionalFact(nameof(IsIcuCompatiblePlatform))]
         public static void IcuShouldBeUsedByDefault()
         {


### PR DESCRIPTION
Fix one more instance not covered by https://github.com/dotnet/runtime/pull/64827.
This should fix the same failure in runtime-extra-platforms.

Fixes https://github.com/dotnet/runtime/issues/64763