### PR TITLE
Fix RegionInfo creation when using LOCALE_CUSTOM_UNSPECIFIED LCID

### DIFF
--- a/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
@@ -254,5 +254,18 @@ namespace System.Globalization.Tests
                 Assert.Equal(expected, regionInfo1.GetHashCode().Equals(obj.GetHashCode()));
             }
         }
+
+        [Fact]
+        public void ValidateThrowingWhenUsingCustomUnspecifiedLcid()
+        {
+            // When trying to create RegionInfo using Lcid, we call LcidToLocaleName to map the Lcid to the culture name.
+            // LOCALE_CUSTOM_UNSPECIFIED (0x1000) is considered invalid Lcid to create cultures with. Sometime Windows can
+            // map which is wrong. This happen if we enumerate the cultures before trying to create the RegionInfo object.
+            // This test is to ensure we'll not allow this creation in .NET.
+
+            CultureInfo [] cultures = CultureInfo.GetCultures(CultureTypes.SpecificCultures);
+
+            AssertExtensions.Throws<ArgumentException>(() => new RegionInfo(4096));
+        }
     }
 }

--- a/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
@@ -259,7 +259,7 @@ namespace System.Globalization.Tests
         public void ValidateThrowingWhenUsingCustomUnspecifiedLcid()
         {
             // When trying to create RegionInfo using Lcid, we call LcidToLocaleName to map the Lcid to the culture name.
-            // LOCALE_CUSTOM_UNSPECIFIED (0x1000) is considered invalid Lcid to create cultures with. Sometime Windows can
+            // LOCALE_CUSTOM_UNSPECIFIED (0x1000) is considered invalid Lcid to create cultures with. Sometimes Windows can
             // map which is wrong. This happen if we enumerate the cultures before trying to create the RegionInfo object.
             // This test is to ensure we'll not allow this creation in .NET.
 

--- a/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
@@ -265,7 +265,7 @@ namespace System.Globalization.Tests
 
             CultureInfo [] cultures = CultureInfo.GetCultures(CultureTypes.SpecificCultures);
 
-            AssertExtensions.Throws<ArgumentException>(() => new RegionInfo(4096));
+            AssertExtensions.Throws<ArgumentException>("culture", () => new RegionInfo(4096));
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Windows.cs
@@ -186,6 +186,11 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
+            if (culture == CultureInfo.LOCALE_CUSTOM_UNSPECIFIED)
+            {
+                return null;
+            }
+
             char* pBuffer = stackalloc char[Interop.Kernel32.LOCALE_NAME_MAX_LENGTH + 1]; // +1 for the null termination
             int length = Interop.Kernel32.LCIDToLocaleName(culture, pBuffer, Interop.Kernel32.LOCALE_NAME_MAX_LENGTH + 1, Interop.Kernel32.LOCALE_ALLOW_NEUTRAL_NAMES);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Windows.cs
@@ -186,6 +186,8 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
+            // LOCALE_CUSTOM_UNSPECIFIED ia an unspecified custom locale, used to identify all supplemental locales.
+            // Supplemental locales cannot be distinguished from one another by their locale identifiers, but can be distinguished by their locale names.
             if (culture == CultureInfo.LOCALE_CUSTOM_UNSPECIFIED)
             {
                 return null;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/RegionInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/RegionInfo.cs
@@ -63,7 +63,7 @@ namespace System.Globalization
                 throw new ArgumentException(SR.Format(SR.Argument_CultureIsNeutral, culture), nameof(culture));
             }
 
-            if (culture == CultureInfo.LOCALE_CUSTOM_DEFAULT)
+            if (culture == CultureInfo.LOCALE_CUSTOM_DEFAULT || culture == CultureInfo.LOCALE_CUSTOM_UNSPECIFIED)
             {
                 // Not supposed to be neutral
                 throw new ArgumentException(SR.Format(SR.Argument_CustomCultureCannotBePassedByNumber, culture), nameof(culture));


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/64893

Don't allow creating RegionInfo when using LOCALE_CUSTOM_UNSPECIFIED (0x1000) Lcid. 