### PR TITLE
disable GetGCMemoryInfo on FreeBSD

### DIFF
--- a/src/libraries/System.Runtime/tests/System/GCTests.cs
+++ b/src/libraries/System.Runtime/tests/System/GCTests.cs
@@ -802,6 +802,7 @@ namespace System.Tests
 
         private static bool IsNotArmProcessAndRemoteExecutorSupported => PlatformDetection.IsNotArmProcess && RemoteExecutor.IsSupported;
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/64935", TestPlatforms.FreeBSD)]
         [ActiveIssue("https://github.com/mono/mono/issues/15236", TestRuntimes.Mono)]
         [ConditionalFact(nameof(IsNotArmProcessAndRemoteExecutorSupported))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/29434")]
         public static void GetGCMemoryInfo()


### PR DESCRIPTION
#64935 tracks the underlying issue. Disabling the test to get clean test pass. 


on my FreeBSD 13.0 VM
```
/usr/home/furt/github/wfurt-runtime/artifacts/bin/testhost/net7.0-FreeBSD-Debug-x64/dotnet exec --runtimeconfig System.Runtime.Tests.runtimeconfig.json --depsfile System.Runtime.Tests.deps.json xunit.console.dll System.Runtime.Tests.dll -xml testResults.xml -nologo -notrait category=OuterLoop -notrait category=failing
  popd
  ===========================================================================================================  
/usr/home/furt/github/wfurt-runtime/artifacts/bin/System.Runtime.Tests/Debug/net7.0-unix ~/github/wfurt-runtime/src/libraries/System.Runtime/tests
    Discovering: System.Runtime.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Runtime.Tests (found 6253 of 6299 test cases)
    Starting:    System.Runtime.Tests (parallel test collections = on, max threads = 2)
      System.Runtime.Tests.JitInfoTests.JitInfoIsNotPopulated [SKIP]
        Condition(s) not met: "IsMonoAOT"
      System.Tests.ArgIteratorTests.ArgIterator_GetNextArgType [SKIP]
        Condition(s) not met: "IsArgIteratorSupported"
      System.Tests.ArgIteratorTests.ArgIterator_GetRemainingCount_GetNextArg [SKIP]
        Condition(s) not met: "IsArgIteratorSupported"
      System.Tests.DateTimeOffsetTests.ToLocalTime_MaxValue [SKIP]
        Condition(s) not met: "IsMaxValuePositiveLocalOffset"
      System.Tests.DateTimeOffsetTests.ToLocalTime_Ambiguous [SKIP]
        Condition(s) not met: "IsPacificTime"
      System.Tests.TimeZoneInfoTests.UnsupportedImplicitConversionTest [SKIP]
        Condition(s) not met: "DoesNotSupportIanaNamesConversion"
      System.Tests.StringTests.IndexOf_SingleLetter(s: "Hello", target: '\0', startIndex: 0, count: 5, expected: -1) [SKIP]
        Target \0 is not supported in ICU
      System.Tests.StringTests.LastIndexOf_NullInStrings [SKIP]
        Condition(s) not met: "IsNlsGlobalization"
      System.Tests.StringTests.IndexOf_NullInStrings [SKIP]
        Condition(s) not met: "IsNlsGlobalization"
      System.Tests.StringTests.EndsWith_NullInStrings_NonOrdinal [SKIP]
        Condition(s) not met: "IsNlsGlobalization"
      System.Tests.StringTests.StartsWith_NullInStrings_NonOrdinal [SKIP]
        Condition(s) not met: "IsNlsGlobalization"
      System.Tests.StringTests.EndsWith_NullInStrings [SKIP]
        Condition(s) not met: "IsNlsGlobalization"
      System.Tests.StringTests.StartsWith_NullInStrings [SKIP]
        Condition(s) not met: "IsNlsGlobalization"
    Finished:    System.Runtime.Tests
  === TEST EXECUTION SUMMARY ===
     System.Runtime.Tests  Total: 35285, Errors: 0, Failed: 0, Skipped: 13, Time: 21.277s

```

cc: @Thefrank 