### PR TITLE
Fix SymbolixRegexRunner handling of "beginning"

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexRunnerFactory.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexRunnerFactory.cs
@@ -89,14 +89,17 @@ namespace System.Text.RegularExpressions.Symbolic
 
             protected override void Go()
             {
-                ReadOnlySpan<char> inputSpan = runtext;
+                int beginning = runtextbeg;
+                ReadOnlySpan<char> inputSpan = runtext.AsSpan(beginning, runtextend - beginning);
 
                 // Perform the match.
-                SymbolicMatch pos = _matcher.FindMatch(quick, inputSpan, runtextpos, runtextend);
+                SymbolicMatch pos = _matcher.FindMatch(quick, inputSpan, runtextpos - beginning);
+
+                // Transfer the result back to the RegexRunner state.
                 if (pos.Success)
                 {
                     // If we successfully matched, capture the match, and then jump the current position to the end of the match.
-                    int start = pos.Index;
+                    int start = pos.Index + beginning;
                     int end = start + pos.Length;
                     Capture(0, start, end);
                     runtextpos = end;

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -1474,22 +1474,18 @@ namespace System.Text.RegularExpressions.Tests
         {
             foreach (RegexEngine engine in RegexHelpers.AvailableEngines)
             {
-                if (RegexHelpers.IsNonBacktracking(engine))
-                {
-                    continue;
-                }
-
-                foreach (RegexOptions options in new[] { RegexOptions.None, RegexOptions.Singleline, RegexOptions.Multiline })
+                foreach (RegexOptions options in new[] { RegexOptions.None, RegexOptions.Singleline, RegexOptions.Multiline, RegexOptions.Singleline | RegexOptions.Multiline })
                 {
                     // Anchors
                     yield return new object[] { engine, @"^.*", "abc", options, 0, true, true };
                     yield return new object[] { engine, @"^.*", "abc", options, 1, false, true };
+                }
 
-                    // Positive Lookbehinds
-                    yield return new object[] { engine, @"(?<=abc)def", "abcdef", options, 3, true, false };
-
-                    // Negative Lookbehinds
-                    yield return new object[] { engine, @"(?<!abc)def", "abcdef", options, 3, false, true };
+                if (!RegexHelpers.IsNonBacktracking(engine))
+                {
+                    // Positive and negative lookbehinds
+                    yield return new object[] { engine, @"(?<=abc)def", "abcdef", RegexOptions.None, 3, true, false };
+                    yield return new object[] { engine, @"(?<!abc)def", "abcdef", RegexOptions.None, 3, false, true };
                 }
             }
         }


### PR DESCRIPTION
The Runner's Go implementation is loading the `runtext` but ignoring `runtextbeg`.  If a non-0 beginning were passed in, the matcher could end up evaluating beginning anchors incorrectly, as it always considers beginning == 0.  This fixes that by slicing the input to ensure the matcher is always called with a span representing the full beginning-end length, such that its beginning==0 assumption is true.

@joperezr, this will likely get cleaned up further with your span changes, assuming the calling Run/Scan loop ends up creating the span and passing that in, ensuring the span is always the full range such that runtextbeg and runtextend can be ignored.

cc: @olsaarik, @veanes 