### PR TITLE
Test and document decision around CFB8 padding

### DIFF
--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoOneShot.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoOneShot.cs
@@ -50,6 +50,11 @@ namespace Internal.Cryptography
                 {
                     int transformWritten = cipher.TransformFinal(input, buffer);
                     decryptedBuffer = buffer.Slice(0, transformWritten);
+
+                    // This intentionally passes in BlockSizeInBytes instead of PaddingSizeInBytes. This is so that
+                    // "extra padded" CFB data can still be decrypted. The .NET Framework always padded CFB8 to the
+                    // block size, not the feedback size. We want the one-shot to be able to continue to decrypt
+                    // those ciphertexts, so for CFB8 we are more lenient on the number of allowed padding bytes.
                     int unpaddedLength = SymmetricPadding.GetPaddingLength(decryptedBuffer, paddingMode, cipher.BlockSizeInBytes); // validates padding
 
                     if (unpaddedLength > output.Length)

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/Symmetric/SymmetricOneShotBase.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/Symmetric/SymmetricOneShotBase.cs
@@ -410,7 +410,7 @@ namespace System.Security.Cryptography.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public void DeryptOneShot_Cfb8_ToleratesExtraPadding()
+        public void DecryptOneShot_Cfb8_ToleratesExtraPadding()
         {
             using (SymmetricAlgorithm alg = CreateAlgorithm())
             {

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/Symmetric/SymmetricOneShotBase.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/Symmetric/SymmetricOneShotBase.cs
@@ -430,7 +430,6 @@ namespace System.Security.Cryptography.Tests
                 // Use paddingMode: None since we manually padded our data
                 byte[] ciphertext = alg.EncryptCfb(excessPadding, IV, paddingMode: PaddingMode.None, feedbackSizeInBits: 8);
 
-
                 // Now decrypt it with PKCS7 padding mode. It should remove all but the first byte since it is not padding.
                 byte[] decrypted = alg.DecryptCfb(ciphertext, IV, paddingMode: PaddingMode.PKCS7, feedbackSizeInBits: 8);
                 Assert.Equal(new byte[] { 0x42 }, decrypted);

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/Symmetric/SymmetricOneShotBase.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/Symmetric/SymmetricOneShotBase.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Reflection;
 using System.Text;
 using System.Security.Cryptography;
+using Microsoft.DotNet.XUnitExtensions;
 using Test.Cryptography;
 using Xunit;
 
@@ -406,6 +407,34 @@ namespace System.Security.Cryptography.Tests
             }
 
             Assert.Empty(missingMethods);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        public void DeryptOneShot_Cfb8_ToleratesExtraPadding()
+        {
+            using (SymmetricAlgorithm alg = CreateAlgorithm())
+            {
+                if (alg is RC2)
+                {
+                    throw new SkipTestException("RC2 does not support CFB.");
+                }
+
+                alg.Key = Key;
+
+                // This is a plaintext that is manually padded. Though it is going to be
+                // encrypted with CFB8, it's padded to BlockSizeInBytes-1.
+                Span<byte> excessPadding = new byte[alg.BlockSize / 8];
+                excessPadding.Fill((byte)(alg.BlockSize / 8 - 1));
+                excessPadding[0] = 0x42;
+
+                // Use paddingMode: None since we manually padded our data
+                byte[] ciphertext = alg.EncryptCfb(excessPadding, IV, paddingMode: PaddingMode.None, feedbackSizeInBits: 8);
+
+
+                // Now decrypt it with PKCS7 padding mode. It should remove all but the first byte since it is not padding.
+                byte[] decrypted = alg.DecryptCfb(ciphertext, IV, paddingMode: PaddingMode.PKCS7, feedbackSizeInBits: 8);
+                Assert.Equal(new byte[] { 0x42 }, decrypted);
+            }
         }
 
         private static void AssertPlaintexts(ReadOnlySpan<byte> expected, ReadOnlySpan<byte> actual, PaddingMode padding)

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/Symmetric/SymmetricOneShotBase.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/Symmetric/SymmetricOneShotBase.cs
@@ -421,8 +421,8 @@ namespace System.Security.Cryptography.Tests
 
                 alg.Key = Key;
 
-                // This is a plaintext that is manually padded. Though it is going to be
-                // encrypted with CFB8, it's padded to BlockSizeInBytes-1.
+                // This is a plaintext that is manually padded. It contains one byte of
+                // data, padded up to the block size, in bytes, of the algorithm.
                 Span<byte> excessPadding = new byte[alg.BlockSize / 8];
                 excessPadding.Fill((byte)(alg.BlockSize / 8 - 1));
                 excessPadding[0] = 0x42;


### PR DESCRIPTION
I initially thought I found a small bug in how CFB8 padding was validated with the one shots. Fortunately, I remembered why the code was the way that it is. Unfortunately, this decision was neither documented in tests nor with a comment.

This PR aims to document why it is the way that it is, both with a comment and a test.

----

The core issue was that a place we expect to be passed "padding size" was being passed "block size". This is not correct for CFB since padding and block size are not the same for CFB8. However, this is a compatibility decision to be compatible with the .NET Framework CFB8 cipher texts. The .NET Framework always padded CFB to the block size, and we want the one-shot to be able to continue to do that.

That was not immediately obvious why decryption was using block size and not padding size.

Encryption is fine - it always pads to the feedback size.