### PR TITLE
Fix runtime tests on Android

### DIFF
--- a/src/tests/Common/XHarnessRunnerLibrary/RunnerEntryPoint.cs
+++ b/src/tests/Common/XHarnessRunnerLibrary/RunnerEntryPoint.cs
@@ -96,11 +96,11 @@ public static class RunnerEntryPoint
         {
             get
             {
-                string? publicDir = Environment.GetEnvironmentVariable("DOCSDIR");
-                if (string.IsNullOrEmpty(publicDir))
-                    throw new ArgumentException("DOCSDIR should not be empty");
+                string? testResultsDir = Environment.GetEnvironmentVariable("TEST_RESULTS_DIR");
+                if (string.IsNullOrEmpty(testResultsDir))
+                    throw new ArgumentException("TEST_RESULTS_DIR should not be empty");
 
-                return Path.Combine(publicDir, "testResults.xml");
+                return Path.Combine(testResultsDir, "testResults.xml");
             }
         }
         protected override IEnumerable<TestAssemblyInfo> GetTestAssemblies() => Array.Empty<TestAssemblyInfo>();


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/64744 I changed the name of the env variable used to store the test results directoy but I didn't notice that the runtime tests don't use the same runner.

Fixes https://github.com/dotnet/runtime/issues/64920