### PR TITLE
Treat TZCNT/POPCNT/LZCNT as never negative

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -168,7 +168,8 @@ bool IntegralRange::Contains(int64_t value) const
         case GT_HWINTRINSIC:
             if (HWIntrinsicInfo::IsXCNTIntrinsic(node->AsHWIntrinsic()->GetHWIntrinsicId()))
             {
-                return {SymbolicIntegerValue::Zero, SymbolicIntegerValue::IntMax};
+                // TODO-Casts: specify more precise ranges once "IntegralRange" supports them.
+                return {SymbolicIntegerValue::Zero, SymbolicIntegerValue::ByteMax};
             }
             break;
 #endif // FEATURE_HW_INTRINSICS

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -164,6 +164,22 @@ bool IntegralRange::Contains(int64_t value) const
         case GT_CAST:
             return ForCastOutput(node->AsCast());
 
+#ifdef FEATURE_HW_INTRINSICS
+        case GT_HWINTRINSIC:
+            if (HWIntrinsicInfo::IsXCNTIntrinsic(node->AsHWIntrinsic()->GetHWIntrinsicId()))
+            {
+                return {SymbolicIntegerValue::Zero, SymbolicIntegerValue::IntMax};
+            }
+            break;
+#endif // FEATURE_HW_INTRINSICS
+
+        case GT_INTRINSIC:
+            if (node->AsIntrinsic()->gtIntrinsicName == NI_System_Numerics_BitOperations_PopCount)
+            {
+                return {SymbolicIntegerValue::Zero, SymbolicIntegerValue::IntMax};
+            }
+            break;
+
         default:
             break;
     }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -174,13 +174,6 @@ bool IntegralRange::Contains(int64_t value) const
             break;
 #endif // FEATURE_HW_INTRINSICS
 
-        case GT_INTRINSIC:
-            if (node->AsIntrinsic()->gtIntrinsicName == NI_System_Numerics_BitOperations_PopCount)
-            {
-                return {SymbolicIntegerValue::Zero, SymbolicIntegerValue::IntMax};
-            }
-            break;
-
         default:
             break;
     }

--- a/src/coreclr/jit/hwintrinsic.h
+++ b/src/coreclr/jit/hwintrinsic.h
@@ -610,15 +610,21 @@ struct HWIntrinsicInfo
     {
         switch (id)
         {
-            case NI_System_Numerics_BitOperations_PopCount:
 #ifdef TARGET_XARCH
-            case NI_POPCNT_PopCount:
             case NI_BMI1_TrailingZeroCount:
-            case NI_LZCNT_LeadingZeroCount:
-            case NI_POPCNT_X64_PopCount:
             case NI_BMI1_X64_TrailingZeroCount:
+            case NI_LZCNT_LeadingZeroCount:
             case NI_LZCNT_X64_LeadingZeroCount:
-#endif // TARGET_XARCH
+            case NI_POPCNT_PopCount:
+            case NI_POPCNT_X64_PopCount:
+#elif TARGET_ARM64
+            case NI_AdvSimd_PopCount:
+            case NI_AdvSimd_LeadingZeroCount:
+            case NI_AdvSimd_LeadingSignCount:
+            case NI_ArmBase_LeadingZeroCount:
+            case NI_ArmBase_Arm64_LeadingZeroCount:
+            case NI_ArmBase_Arm64_LeadingSignCount:
+#endif
                 return true;
             default:
                 break;

--- a/src/coreclr/jit/hwintrinsic.h
+++ b/src/coreclr/jit/hwintrinsic.h
@@ -611,14 +611,14 @@ struct HWIntrinsicInfo
 #if defined(FEATURE_HW_INTRINSICS)
         switch (id)
         {
-#ifdef TARGET_XARCH
+#if defined(TARGET_XARCH)
             case NI_BMI1_TrailingZeroCount:
             case NI_BMI1_X64_TrailingZeroCount:
             case NI_LZCNT_LeadingZeroCount:
             case NI_LZCNT_X64_LeadingZeroCount:
             case NI_POPCNT_PopCount:
             case NI_POPCNT_X64_PopCount:
-#elif TARGET_ARM64
+#elif defined(TARGET_ARM64)
             case NI_AdvSimd_PopCount:
             case NI_AdvSimd_LeadingZeroCount:
             case NI_AdvSimd_LeadingSignCount:

--- a/src/coreclr/jit/hwintrinsic.h
+++ b/src/coreclr/jit/hwintrinsic.h
@@ -608,6 +608,7 @@ struct HWIntrinsicInfo
 
     static bool IsXCNTIntrinsic(NamedIntrinsic id)
     {
+#if defined(FEATURE_HW_INTRINSICS)
         switch (id)
         {
 #ifdef TARGET_XARCH
@@ -629,6 +630,7 @@ struct HWIntrinsicInfo
             default:
                 break;
         }
+#endif // defined(FEATURE_HW_INTRINSICS)
 
         return false;
     }

--- a/src/coreclr/jit/hwintrinsic.h
+++ b/src/coreclr/jit/hwintrinsic.h
@@ -606,37 +606,6 @@ struct HWIntrinsicInfo
         return lookup(id).flags;
     }
 
-    static bool IsXCNTIntrinsic(NamedIntrinsic id)
-    {
-#if defined(FEATURE_HW_INTRINSICS)
-        switch (id)
-        {
-#if defined(TARGET_XARCH)
-            case NI_BMI1_TrailingZeroCount:
-            case NI_BMI1_X64_TrailingZeroCount:
-            case NI_LZCNT_LeadingZeroCount:
-            case NI_LZCNT_X64_LeadingZeroCount:
-            case NI_POPCNT_PopCount:
-            case NI_POPCNT_X64_PopCount:
-#elif defined(TARGET_ARM64)
-            case NI_AdvSimd_PopCount:
-            case NI_AdvSimd_LeadingZeroCount:
-            case NI_AdvSimd_LeadingSignCount:
-            case NI_ArmBase_LeadingZeroCount:
-            case NI_ArmBase_Arm64_LeadingZeroCount:
-            case NI_ArmBase_Arm64_LeadingSignCount:
-#else
-#error Unsupported platform
-#endif
-                return true;
-            default:
-                break;
-        }
-#endif // defined(FEATURE_HW_INTRINSICS)
-
-        return false;
-    }
-
     // Flags lookup
 
     static bool IsCommutative(NamedIntrinsic id)

--- a/src/coreclr/jit/hwintrinsic.h
+++ b/src/coreclr/jit/hwintrinsic.h
@@ -606,6 +606,27 @@ struct HWIntrinsicInfo
         return lookup(id).flags;
     }
 
+    static bool IsXCNTIntrinsic(NamedIntrinsic id)
+    {
+        switch (id)
+        {
+            case NI_System_Numerics_BitOperations_PopCount:
+#ifdef TARGET_XARCH
+            case NI_POPCNT_PopCount:
+            case NI_BMI1_TrailingZeroCount:
+            case NI_LZCNT_LeadingZeroCount:
+            case NI_POPCNT_X64_PopCount:
+            case NI_BMI1_X64_TrailingZeroCount:
+            case NI_LZCNT_X64_LeadingZeroCount:
+#endif // TARGET_XARCH
+                return true;
+            default:
+                break;
+        }
+
+        return false;
+    }
+
     // Flags lookup
 
     static bool IsCommutative(NamedIntrinsic id)

--- a/src/coreclr/jit/hwintrinsic.h
+++ b/src/coreclr/jit/hwintrinsic.h
@@ -625,6 +625,8 @@ struct HWIntrinsicInfo
             case NI_ArmBase_LeadingZeroCount:
             case NI_ArmBase_Arm64_LeadingZeroCount:
             case NI_ArmBase_Arm64_LeadingSignCount:
+#else
+#error Unsupported platform
 #endif
                 return true;
             default:


### PR DESCRIPTION
Check for population count, trailing zero count, and leading zero count intrinsics when determining integral rage.

This change makes most of these casts redundant:
![image](https://user-images.githubusercontent.com/23460729/153172820-2add670d-1c88-4075-a0f1-c1f148f69db7.png)

Closes #64909