### PR TITLE
Override DictionaryEntry.ToString to match KeyValuePair.ToString

### DIFF
--- a/src/libraries/Common/tests/System/Collections/DictionaryEntry.Tests.cs
+++ b/src/libraries/Common/tests/System/Collections/DictionaryEntry.Tests.cs
@@ -10,11 +10,20 @@ namespace System.Collections.Tests
     {
         public static IEnumerable<object?[]> ToString_Inputs()
         {
+            // Mainline scenarios
             yield return new object?[] { "key", "value", "[key, value]" };
             yield return new object?[] { 1, 2, "[1, 2]" };
+
+            // Types, nulls, and empty strings get standard ToString behavior
             yield return new object?[] { typeof(object), (object?)null, "[System.Object, ]" };
+            yield return new object?[] { (object?)null, (object?)null, "[, ]" };
+            yield return new object?[] { "", "", "[, ]" };
+
+            // There's no escaping; keys and values are emitted as-is
             yield return new object?[] { "[key, value", "]]", "[[key, value, ]]]" };
             yield return new object?[] { new DictionaryEntry("key", "key"), new DictionaryEntry("value", "value"), "[[key, key], [value, value]]" };
+
+            // There's no truncation; keys and values are emitted as-is
             yield return new object?[] { new String('K', 512), new String('V', 1024), $"[{new String('K', 512)}, {new String('V', 1024)}]" };
         }
 

--- a/src/libraries/Common/tests/System/Collections/DictionaryEntry.Tests.cs
+++ b/src/libraries/Common/tests/System/Collections/DictionaryEntry.Tests.cs
@@ -32,7 +32,7 @@ namespace System.Collections.Tests
         public void ToString_FormatsKeyValue(object key, object? value, string expected)
         {
             var entry = new DictionaryEntry(key, value);
-            var result = entry.ToString();
+            string result = entry.ToString();
 
             Assert.Equal(expected, result);
         }

--- a/src/libraries/Common/tests/System/Collections/DictionaryEntry.Tests.cs
+++ b/src/libraries/Common/tests/System/Collections/DictionaryEntry.Tests.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    public class DictionaryEntry_Tests
+    {
+        public static IEnumerable<object?[]> ToString_Inputs()
+        {
+            yield return new object?[] { "key", "value", "[key, value]" };
+            yield return new object?[] { 1, 2, "[1, 2]" };
+            yield return new object?[] { typeof(object), (object?)null, "[System.Object, ]" };
+            yield return new object?[] { "[key, value", "]]", "[[key, value, ]]]" };
+            yield return new object?[] { new DictionaryEntry("key", "key"), new DictionaryEntry("value", "value"), "[[key, key], [value, value]]" };
+            yield return new object?[] { new String('K', 512), new String('V', 1024), $"[{new String('K', 512)}, {new String('V', 1024)}]" };
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_Inputs))]
+        public void ToString_FormatsKeyValue(object key, object? value, string expected)
+        {
+            var entry = new DictionaryEntry(key, value);
+            var result = entry.ToString();
+
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/src/libraries/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/libraries/System.Collections/tests/System.Collections.Tests.csproj
@@ -37,6 +37,8 @@
              Link="Common\System\Collections\TestBase.Generic.Tests.cs" />
     <Compile Include="$(CommonTestPath)System\Collections\DebugView.Tests.cs"
              Link="Common\System\Collections\DebugView.Tests.cs" />
+    <Compile Include="$(CommonTestPath)System\Collections\DictionaryEntry.Tests.cs"
+             Link="Common\System\Collections\DictionaryEntry.Tests.cs" />
     <Compile Include="$(CommonTestPath)System\Collections\TestingTypes.cs"
              Link="Common\System\Collections\TestingTypes.cs" />
     <Compile Include="$(CommonTestPath)System\EnumTypes.cs"

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/DictionaryEntry.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/DictionaryEntry.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace System.Collections
@@ -40,5 +41,8 @@ namespace System.Collections
             key = Key;
             value = Value;
         }
+
+        public override string ToString() =>
+            KeyValuePair.PairToString(_key, _value);
     }
 }


### PR DESCRIPTION
Fixes #59292 by reusing the `ToString` implementation from `KeyValuePair`. This emits the unescaped, non-truncated key and value string representations.