### PR TITLE
JIT: fix containment safety check in LowerHWIntrinsicGetElement

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -2512,7 +2512,7 @@ void Lowering::LowerHWIntrinsicGetElement(GenTreeHWIntrinsic* node)
 
     assert(0 <= imm8 && imm8 < count);
 
-    if (IsContainableMemoryOp(op1))
+    if (IsContainableMemoryOp(op1) && IsSafeToContainMem(node, op1))
     {
         // We will specially handle GetElement in codegen when op1 is already in memory
         op2->AsIntCon()->SetIconValue(imm8);


### PR DESCRIPTION
Missing call to IsSafeToContainMem was causing us to mistakenly think
an operand was going to be contained when it wasn't.

Fixes #64918