### PR TITLE
Delete StructLayoutAttribute.Pack adjustment

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
@@ -1873,12 +1873,6 @@ namespace System.Reflection
             }
             type.GetRuntimeModule().MetadataImport.GetClassLayout(type.MetadataToken, out int pack, out int size);
 
-            // Metadata parameter checking should not have allowed 0 for packing size.
-            // The runtime later converts a packing size of 0 to 8 so do the same here
-            // because it's more useful from a user perspective.
-            if (pack == 0)
-                pack = 8; // DEFAULT_PACKING_SIZE
-
             StructLayoutAttribute attribute = new StructLayoutAttribute(layoutKind);
 
             attribute.Pack = pack;

--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
@@ -129,8 +129,6 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
-                const int DefaultPackingSize = 8;
-
                 // Note: CoreClr checks HasElementType and IsGenericParameter in addition to IsInterface but those properties cannot be true here as this
                 // RuntimeTypeInfo subclass is solely for TypeDef types.)
                 if (IsInterface)
@@ -156,15 +154,7 @@ namespace System.Reflection.Runtime.TypeInfos
                     default: charSet = CharSet.None;  break;
                 }
 
-                int pack;
-                int size;
-                GetPackSizeAndSize(out pack, out size);
-
-                // Metadata parameter checking should not have allowed 0 for packing size.
-                // The runtime later converts a packing size of 0 to 8 so do the same here
-                // because it's more useful from a user perspective.
-                if (pack == 0)
-                    pack = DefaultPackingSize;
+                GetPackSizeAndSize(out int pack, out int size);
 
                 return new StructLayoutAttribute(layoutKind)
                 {

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoDefinitionType.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoDefinitionType.cs
@@ -146,8 +146,6 @@ namespace System.Reflection.TypeLoading
         {
             get
             {
-                const int DefaultPackingSize = 8;
-
                 // Note: CoreClr checks HasElementType and IsGenericParameter in addition to IsInterface but those properties cannot be true here as this
                 // RoType subclass is solely for TypeDef types.)
                 if (IsInterface)
@@ -169,12 +167,6 @@ namespace System.Reflection.TypeLoading
                     _ => CharSet.None,
                 };
                 GetPackSizeAndSize(out int pack, out int size);
-
-                // Metadata parameter checking should not have allowed 0 for packing size.
-                // The runtime later converts a packing size of 0 to 8 so do the same here
-                // because it's more useful from a user perspective.
-                if (pack == 0)
-                    pack = DefaultPackingSize;
 
                 return new StructLayoutAttribute(layoutKind)
                 {

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Type/TypeTests.StructLayoutAttribute.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Type/TypeTests.StructLayoutAttribute.cs
@@ -15,7 +15,7 @@ namespace System.Reflection.Tests
             StructLayoutAttribute s = t.StructLayoutAttribute;
             Assert.Equal(LayoutKind.Auto, s.Value);
             Assert.Equal(CharSet.Ansi, s.CharSet);
-            Assert.Equal(8, s.Pack);
+            Assert.Equal(0, s.Pack);
             Assert.Equal(0, s.Size);
         }
 
@@ -71,7 +71,7 @@ namespace System.Reflection.Tests
             StructLayoutAttribute s = t.StructLayoutAttribute;
             Assert.Equal(LayoutKind.Sequential, s.Value);
             Assert.Equal(CharSet.Auto, s.CharSet);
-            Assert.Equal(8, s.Pack);  // Not an error: Pack=0 is treated as if it were Pack=8.
+            Assert.Equal(0, s.Pack);
             Assert.Equal(0, s.Size);
         }
 
@@ -149,7 +149,7 @@ namespace System.Reflection.Tests
             StructLayoutAttribute s = t.StructLayoutAttribute;
             Assert.Equal(LayoutKind.Auto, s.Value);
             Assert.Equal(CharSet.Ansi, s.CharSet);
-            Assert.Equal(8, s.Pack);
+            Assert.Equal(0, s.Pack);
             Assert.Equal(0, s.Size);
         }
 

--- a/src/libraries/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/TypeInfoTests.cs
@@ -1490,9 +1490,9 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [InlineData(typeof(StructWithoutExplicitStructLayout), LayoutKind.Sequential, CharSet.Ansi, 8)]
+        [InlineData(typeof(StructWithoutExplicitStructLayout), LayoutKind.Sequential, CharSet.Ansi, 0)]
         [InlineData(typeof(StructWithExplicitStructLayout), LayoutKind.Explicit, CharSet.Ansi, 1)]
-        [InlineData(typeof(ClassWithoutExplicitStructLayout), LayoutKind.Auto, CharSet.Ansi, 8)]
+        [InlineData(typeof(ClassWithoutExplicitStructLayout), LayoutKind.Auto, CharSet.Ansi, 0)]
         [InlineData(typeof(ClassWithExplicitStructLayout), LayoutKind.Explicit, CharSet.Unicode, 2)]
         public void StructLayoutAttribute(Type type, LayoutKind kind, CharSet charset, int pack)
         {

--- a/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -2317,14 +2317,11 @@ namespace System
             return RuntimeTypeHandle.IsSubclassOf(this, rtType);
         }
 
-        private const int DEFAULT_PACKING_SIZE = 8;
-
         internal StructLayoutAttribute? GetStructLayoutAttribute()
         {
             if (IsInterface || HasElementType || IsGenericParameter)
                 return null;
 
-            int pack, size;
             LayoutKind layoutKind = LayoutKind.Auto;
             switch (Attributes & TypeAttributes.LayoutMask)
             {
@@ -2343,13 +2340,7 @@ namespace System
                 default: break;
             }
 
-            GetPacking(out pack, out size);
-
-            // Metadata parameter checking should not have allowed 0 for packing size.
-            // The runtime later converts a packing size of 0 to 8 so do the same here
-            // because it's more useful from a user perspective.
-            if (pack == 0)
-                pack = DEFAULT_PACKING_SIZE;
+            GetPacking(out int pack, out int size);
 
             return new StructLayoutAttribute(layoutKind) { Pack = pack, Size = size, CharSet = charSet };
         }


### PR DESCRIPTION
This adjustment was trying to minic adjustment performed by type loader, but the logic has been out-of-sync with the type loader evolution for years.
It does not make sense for custom attribute reading via reflection to perform this adjustment.

Fixes #12480