### PR TITLE
improve SslStream tests on misconfigured systems

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -423,7 +423,7 @@ namespace System.Net.Security.Tests
                     await clientAuthentication.WaitAsync(TestConfiguration.PassingTestTimeout);
                     _logVerbose.WriteLine("ServerAsyncAuthenticateTest.clientAuthentication complete.");
                 }
-                catch (Exception ex) when (ex is AuthenticationException)
+                catch (AuthenticationException ex)
                 {
                     // Ignore client-side errors: we're only interested in server-side behavior.
                     _log.WriteLine("Client exception : " + ex);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -423,7 +423,7 @@ namespace System.Net.Security.Tests
                     await clientAuthentication.WaitAsync(TestConfiguration.PassingTestTimeout);
                     _logVerbose.WriteLine("ServerAsyncAuthenticateTest.clientAuthentication complete.");
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is AuthenticationException)
                 {
                     // Ignore client-side errors: we're only interested in server-side behavior.
                     _log.WriteLine("Client exception : " + ex);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -13,7 +13,7 @@ namespace System.Net.Security.Tests
 {
     internal static class TestConfiguration
     {
-        public const int PassingTestTimeoutMilliseconds = 4 * 60 * 1000;
+        public const int PassingTestTimeoutMilliseconds = 1 * 60 * 1000;
         public static TimeSpan PassingTestTimeout => TimeSpan.FromMilliseconds(PassingTestTimeoutMilliseconds);
 
         public const string Realm = "TEST.COREFX.NET";


### PR DESCRIPTION
fixes #64943
I did not any real hangs. But since _LOT_ of tests failing, the run takes very long time ~ 17 minutes on my repro machine.

The most problematic are tests _expecting_ failures. However since we fail to even send something in many cases we basically wait 4 minutes for each failing test. 

This change has two parts: 
When we expect failure, ignore only Authentication exceptions. That will raise `Win32Exception` and fail the test in cases we even fail so send something. 

It drops PassingTestTimeoutMilliseconds to 1 minute. Since we generally use it to time box single SSL it is still plenty but still much less than original value. 

With this failed runs takes ~ 7 minutes and it _should_ finish in CI. 

Better platform detection and failure avoidance comes from #64923.

cc: @safern we should take this to 6.0 if we ever back-port the 2022 queue. 