### PR TITLE
improve SslStream tests on server 2022

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
@@ -56,7 +56,12 @@ namespace System
         // >= Windows 10 20H1 Update
         public static bool IsWindows10Version2004OrGreater => IsWindowsVersionOrLater(10, 0, 19041);
 
-        public static bool IsWindows10Version2004Build19573OrGreater => IsWindowsVersionOrLater(10, 0, 19573);
+        // WinHTTP update
+        public static bool IsWindows10Version19573OrGreater => IsWindowsVersionOrLater(10, 0, 19573);
+
+        // Windows Server 2022
+        public static bool IsWindows10Version20348OrGreater => IsWindowsVersionOrLater(10, 0, 20348);
+
 
         // Windows 11 aka 21H2
         public static bool IsWindows10Version22000OrGreater => IsWindowsVersionOrLater(10, 0, 22000);

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -465,7 +465,7 @@ namespace System
                 // assume no if positive entry is missing on older Windows
                 // Latest insider builds have TLS 1.3 enabled by default.
                 // The build number is approximation.
-                bool defaultProtocolSupport = IsWindows10Version2004Build19573OrGreater;
+                bool defaultProtocolSupport = IsWindows10Version20348OrGreater;
 
 #if NETFRAMEWORK
                 return false;

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ClientCertificateTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ClientCertificateTest.cs
@@ -54,7 +54,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 
 // Disabling it for full .Net Framework due to a missing ALPN API which leads to a protocol downgrade
 #if !NETFRAMEWORK
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version2004Build19573OrGreater))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version19573OrGreater))]
         public async Task UseClientCertOnHttp2_OSSupportsIt_Success()
         {
             using X509Certificate2 clientCert = Test.Common.Configuration.Certificates.GetClientCertificate();

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -472,17 +472,12 @@ namespace System.Net.Security.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.SupportsTls13))]
+        [SkipOnPlatform(TestPlatforms.Windows, "unstable on Windows")]
         [InlineData(true)]
         [InlineData(false)]
         [PlatformSpecific(TestPlatforms.Windows)]
         public async Task SslStream_NegotiateClientCertificateAsyncTls13_Succeeds(bool sendClientCertificate)
         {
-            if (PlatformDetection.IsWindows10Version22000OrGreater)
-            {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/58927")]
-                throw new SkipTestException("Unstable on Windows 11");
-            }
-
             bool negotiateClientCertificateCalled = false;
             using CancellationTokenSource cts = new CancellationTokenSource();
             cts.CancelAfter(TestConfiguration.PassingTestTimeout);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -472,7 +472,7 @@ namespace System.Net.Security.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.SupportsTls13))]
-        [SkipOnPlatform(TestPlatforms.Windows, "unstable on Windows")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/58927", TestPlatforms.Windows)]
         [InlineData(true)]
         [InlineData(false)]
         [PlatformSpecific(TestPlatforms.Windows)]

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -73,7 +73,7 @@ namespace System.Net.Security.Tests
         public async Task SslStream_StreamToStream_Authentication_Success(X509Certificate serverCert = null, X509Certificate clientCert = null)
         {
 
-            if (PlatformDetection.IsWindows10Version22000OrGreater)
+            if (PlatformDetection.IsWindows10Version20348OrGreater)
             {
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/58927")]
                 throw new SkipTestException("Unstable on Windows 11");

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
@@ -76,7 +76,7 @@ namespace System.Net.Security.Tests
         [MemberData(nameof(OneOrBothUseDefaulData))]
         public async Task ClientAndServer_OneOrBothUseDefault_Ok(SslProtocols? clientProtocols, SslProtocols? serverProtocols)
         {
-            if (PlatformDetection.IsWindows10Version22000OrGreater)
+            if (PlatformDetection.IsWindows10Version20348OrGreater)
             {
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/58927")]
                 throw new SkipTestException("Unstable on Windows 11");


### PR DESCRIPTION
It seems like server 2022 also has TLS 1.3 enabled by default and it has similar issue like Windows 11. 

This updates some PlatformDetection references to work as intended. 

cc: @safern 
