### PR TITLE
FileSystemWatcher.Unix: use CLOEXEC when initializing an inotify instance.

### DIFF
--- a/src/native/libs/System.Native/pal_io.c
+++ b/src/native/libs/System.Native/pal_io.c
@@ -1350,7 +1350,7 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd, int64_t
 intptr_t SystemNative_INotifyInit(void)
 {
 #if HAVE_INOTIFY
-    return inotify_init();
+    return inotify_init1(IN_CLOEXEC);
 #else
     errno = ENOTSUP;
     return -1;


### PR DESCRIPTION
This stops inotify instances from leaking into child processes,
and helps reduce .NET applications hitting the system inotify limit.

@adamsitnik @stephentoub ptal.