### PR TITLE
Hosting: ConfigDoesReload tests: increase timeout.

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
@@ -259,8 +259,8 @@ namespace Microsoft.Extensions.Hosting.Tests
                 // Only update the config after we've registered the change callback
                 var dynamicConfigMessage2 = SaveRandomConfig(appSettingsPath);
 
-                // Wait for up to 1 minute, if config reloads at any time, cancel the wait.
-                await Task.WhenAny(Task.Delay(TimeSpan.FromMinutes(1), configReloadedCancelToken)); // Task.WhenAny ignores the task throwing on cancellation.
+                // Wait for up to 5 minutes, if config reloads at any time, cancel the wait.
+                await Task.WhenAny(Task.Delay(TimeSpan.FromMinutes(5), configReloadedCancelToken)); // Task.WhenAny ignores the task throwing on cancellation.
                 Assert.NotEqual(dynamicConfigMessage1, dynamicConfigMessage2); // Messages are different.
                 Assert.Equal(dynamicConfigMessage2, config["Hello"]); // Config DID reload from disk
             }
@@ -311,8 +311,8 @@ namespace Microsoft.Extensions.Hosting.Tests
             // Only update the secrets after we've registered the change callback
             var dynamicSecretMessage2 = SaveRandomSecret(secretPath);
 
-            // Wait for up to 1 minute, if config reloads at any time, cancel the wait.
-            await Task.WhenAny(Task.Delay(TimeSpan.FromMinutes(1), configReloadedCancelToken)); // Task.WhenAny ignores the task throwing on cancellation.
+            // Wait for up to 5 minutes, if config reloads at any time, cancel the wait.
+            await Task.WhenAny(Task.Delay(TimeSpan.FromMinutes(5), configReloadedCancelToken)); // Task.WhenAny ignores the task throwing on cancellation.
             Assert.NotEqual(dynamicSecretMessage1, dynamicSecretMessage2); // Messages are different.
             Assert.Equal(dynamicSecretMessage2, config["Hello"]);
         }


### PR DESCRIPTION
These tests sometimes fail on our internal CI machines.

```xml
<test name="Microsoft.Extensions.Hosting.Tests.HostTests.CreateDefaultBuilder_ConfigJsonDoesReload" type="Microsoft.Extensions.Hosting.Tests.HostTests" method="CreateDefaultBuilder_ConfigJsonDoesReload" time="64.7823405" result="Fail">
  <failure exception-type="Xunit.Sdk.EqualException">
    <message><![CDATA[Assert.Equal() Failure\n                                 ↓ (pos 21)\nExpected: ···ello ASP.NET Core: 5a70f772a8ab4e14a1df64df0cf56b94\nActual:   ···ello ASP.NET Core: 52920114bc1043abbdca05bd199b9e17\n                                 ↑ (pos 21)]]></message>
    <stack-trace><![CDATA[   at Microsoft.Extensions.Hosting.Tests.HostTests.CreateDefaultBuilder_ConfigJsonDoesReload() in /home/tester/runtime/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs:line 265
--- End of stack trace from previous location ---]]></stack-trace>
  </failure>
</test>
```

Because `time="64.7823405"` is about the test timeout, I'd like to increase it and see if that gets rid of the failures.