### PR TITLE
Compliance CVE-2021-26701 fix for a test project

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="System.Net.Primitives" Version="$(SystemNetPrimitivesVersion)" />
     <PackageReference Include="System.Collections" Version="$(SystemCollectionsVersion)" />
     <PackageReference Include="System.Runtime.InteropServices" Version="$(SystemRuntimeInteropServicesVersion)" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.CompilerServices.Unsafe\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Attempting to force the [test project](https://dnceng.visualstudio.com/internal/_git/a2f9a77f-0d37-4eaf-aecc-5b3ff7457ad6?path=/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj), to use the recommended [System.Text.Encodings.Web](http://system.text.encodings.web/) as instructed in the [fix](https://dnceng.visualstudio.com/internal/_componentGovernance/dotnet-runtime/alert/6485160?typeId=10638774). 

I'm not exactly sure how to validate this in my local build - msbuild.binlog seems to indicate the correct version being used - but will check in the CI system compliance run.