### PR TITLE
NativeAOT Fix error during unwrap existing instance

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.CoreRT.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.CoreRT.cs
@@ -504,7 +504,7 @@ namespace System.Runtime.InteropServices
                     if (_rcwCache.TryGetValue(externalComObject, out GCHandle handle))
                     {
                         retValue = handle.Target;
-                        return false;
+                        return true;
                     }
                 }
             }


### PR DESCRIPTION
If element in the cache, properly return success creation status 