### PR TITLE
update expected exception for cases when all requested TLS versions are disabled

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Net.Security;
 using System.Net.Test.Common;
@@ -294,9 +295,10 @@ namespace System.Net.Http.Functional.Tests
                     {
                         await serverTask;
                     }
-                    catch (Exception e) when (e is IOException || e is AuthenticationException)
+                    catch (Exception e) when (e is IOException || e is AuthenticationException || e is Win32Exception)
                     {
                         // Some SSL implementations simply close or reset connection after protocol mismatch.
+                        // The call may fail if neither of the requested protocols is available
                         // Newer OpenSSL sends Fatal Alert message before closing.
                         return;
                     }


### PR DESCRIPTION
fixes #64941
This should be last part. I can get clean pass now on Server 2022 in Helix repro
```
  === TEST EXECUTION SUMMARY ===
     System.Net.Http.Functional.Tests  Total: 4142, Errors: 0, Failed: 0, Skipped: 14, Time: 168.416s
  ----- end Tue 02/08/2022 20:56:34.22 ----- exit code 0 ----------------------------------------------------------
```

