### PR TITLE
Add a new wrapper `runtime-wasm.yml` to be used from azdo

### DIFF
--- a/eng/pipelines/runtime-wasm.yml
+++ b/eng/pipelines/runtime-wasm.yml
@@ -4,6 +4,9 @@
 
 trigger: none
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 jobs:
 
 #

--- a/eng/pipelines/runtime-wasm.yml
+++ b/eng/pipelines/runtime-wasm.yml
@@ -1,0 +1,17 @@
+# This is a wrapper yml for `runtime-extra-platforms-wasm.yml`, which
+# has all the wasm jobs. This file is essentially so we can have point
+# the pipeline in azdo UI to this, and thus avoid any scheduled triggers
+
+trigger: none
+
+jobs:
+
+#
+# Evaluate paths
+#
+- ${{ if eq(variables.dependOnEvaluatePaths, true) }}:
+  - template: /eng/pipelines/common/evaluate-default-paths.yml
+
+- template: /eng/pipelines/runtime-extra-platforms-wasm.yml
+  parameters:
+    isExtraPlatformsBuild: false


### PR DESCRIPTION
Currently, we have `runtime-wasm` in azdo pointing to
`runtime-extra-platforms.yml`, which has some scheduled triggers
defined. azdo seems to use these for running `runtime-wasm` too.

Instead, in azdo use a new `runtime-wasm.yml` for `runtime-wasm` pipeline, so
we can explicitly avoid the scheduled triggers. This yml just uses the
existing `runtime-extra-platforms-wasm.yml`.