### PR TITLE
Fix runtime-official when executed against PRs in azdo

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -392,7 +392,7 @@ stages:
       jobParameters:
         isOfficialBuild: ${{ variables.isOfficialBuild }}
         liveRuntimeBuildConfig: release
-        liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+        liveLibrariesBuildConfig: Release
         pgoType: 'PGO'
       platforms:
       - windows_x64


### PR DESCRIPTION
We noticed this while servicing 6.0, a PR was sent in azdo and runtime-official failed because all legs there are built on Release and this variable was setting the dependencies for the PGO legs to the libraries legs as Debug on the PR build. This will help our future servicing releases. The fix is in 6.0 already. 