### PR TITLE
Mark cctor tests with RequiresProcessIsolation property

### DIFF
--- a/src/tests/Common/CoreCLRTestLibrary/OutOfProcessTest.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/OutOfProcessTest.cs
@@ -45,9 +45,10 @@ namespace TestLibrary
         public static void RunOutOfProcessTest(string basePath, string assemblyPath)
         {
             int ret = -100;
-            string outputFile = System.IO.Path.GetFullPath(reportBase + assemblyPath + "output.txt");
-            string errorFile = System.IO.Path.GetFullPath(reportBase + assemblyPath + "error.txt");
-            string outputDir = System.IO.Path.GetDirectoryName(outputFile)!;
+            string baseDir = Path.GetDirectoryName(basePath);
+            string outputDir = System.IO.Path.GetFullPath(Path.Combine(reportBase, Path.GetDirectoryName(assemblyPath)));
+            string outputFile = Path.Combine(outputDir, "output.txt");
+            string errorFile = Path.Combine(outputDir, "error.txt");
             string testExecutable = null;
             Exception infraEx = null;
 
@@ -57,14 +58,14 @@ namespace TestLibrary
 
                 if (OperatingSystem.IsWindows())
                 {
-                    testExecutable = Path.Combine(basePath, Path.ChangeExtension(assemblyPath, ".cmd"));
+                    testExecutable = Path.Combine(baseDir, Path.ChangeExtension(assemblyPath, ".cmd"));
                 }
                 else
                 {
-                    testExecutable = Path.Combine(basePath, Path.ChangeExtension(assemblyPath.Replace("\\", "/"), ".sh"));
+                    testExecutable = Path.Combine(baseDir, Path.ChangeExtension(assemblyPath.Replace("\\", "/"), ".sh"));
                 }
 
-                System.IO.Directory.CreateDirectory(reportBase + Path.GetDirectoryName(assemblyPath));
+                System.IO.Directory.CreateDirectory(outputDir);
 
                 ret = wrapper.RunTest(testExecutable, outputFile, errorFile, Assembly.GetEntryAssembly()!.FullName!, testBinaryBase, outputDir);
             }

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -12,7 +12,7 @@
   <!-- Default priority building values. -->
   <PropertyGroup>
     <DisableProjectBuild Condition="'$(IsMergedTestRunnerAssembly)' == 'true' and $(BuildAsStandalone)">true</DisableProjectBuild>
-    <OutputType Condition="'$(IsMergedTestRunnerAssembly)' == 'true' and !$(BuildAsStandalone)">Exe</OutputType>
+    <OutputType Condition="('$(IsMergedTestRunnerAssembly)' == 'true' and !$(BuildAsStandalone)) or '$(RequiresProcessIsolation)' == 'true'">Exe</OutputType>
     <CLRTestKind Condition="'$(CLRTestKind)' == '' and '$(OutputType)' == 'Exe'">BuildAndRun</CLRTestKind>
     <CLRTestKind Condition="'$(CLRTestKind)' == ''">BuildOnly</CLRTestKind>
     <CLRTestPriority Condition="'$(CLRTestPriority)' == ''">0</CLRTestPriority>
@@ -68,6 +68,10 @@
     <!-- Since bug in Roslyn for Linux empty DebugType property leads to build failure. See issue Roslyn@20343 -->
     <DebugType Condition=" '$(DebugType)' == '' and '$(RunningOnUnix)' == 'true' ">None</DebugType>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\tests\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj" Condition="'$(IsMergedTestRunnerAssembly)' == 'true'" />
+  </ItemGroup>
 
   <!--
   If it needs ProjectToRun, turn the project into a ProjectReference so it gets built
@@ -249,6 +253,11 @@
         Condition="'$(IsMergedTestRunnerAssembly)' == 'true'"
         File="$(OutputPath)\$(MSBuildProjectName).MergedTestAssembly"
         Lines="MergedTestAssembly" />
+
+    <WriteLinesToFile
+        Condition="'$(RequiresProcessIsolation)' == 'true'"
+        File="$(OutputPath)\$(MSBuildProjectName).OutOfProcessTest"
+        Lines="OutOfProcessTest" />
   </Target>
 
   <PropertyGroup>
@@ -410,14 +419,14 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="DiscoverProcessIsolatedTestProjectReferences" BeforeTargets="AssignProjectConfiguration">
+  <Target Name="DiscoverProcessIsolatedTestProjectReferences" BeforeTargets="AssignProjectConfiguration" Condition="'$(IsMergedTestRunnerAssembly)' == 'true'">
     <MSBuild Projects="@(ProjectReference)" Targets="GetRequiresProcessIsolation" SkipNonexistentTargets="true">
       <Output TaskParameter="TargetOutputs" ItemName="ReferencedProjectRequiringProcessIsolation" />
     </MSBuild>
 
     <ItemGroup>
-      <ProjectReference Remove="@(ReferencedProjectRequiringProcessIsolation)" />
-      <ProjectReference Include="@(ReferencedProjectRequiringProcessIsolation)" OutputItemType="OutOfProcessTests" BuildReference="true" ReferenceOutputAssembly="false" />
+      <ProjectReference Remove="@(ReferencedProjectRequiringProcessIsolation->'%(OriginalItemSpec)')" />
+      <ProjectReference Include="@(ReferencedProjectRequiringProcessIsolation->'%(OriginalItemSpec)')" OutputItemType="OutOfProcessTests" BuildReference="true" ReferenceOutputAssembly="false" />
     </ItemGroup>
   </Target>
 

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -255,7 +255,7 @@
         Lines="MergedTestAssembly" />
 
     <WriteLinesToFile
-        Condition="'$(RequiresProcessIsolation)' == 'true'"
+        Condition="'$(RequiresProcessIsolation)' == 'true' and '$(BuildAsStandalone)' != 'true'"
         File="$(OutputPath)\$(MSBuildProjectName).OutOfProcessTest"
         Lines="OutOfProcessTest" />
   </Target>

--- a/src/tests/JIT/Methodical/cctor/misc/threads1_cs_d.csproj
+++ b/src/tests/JIT/Methodical/cctor/misc/threads1_cs_d.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/Methodical/cctor/misc/threads1_cs_do.csproj
+++ b/src/tests/JIT/Methodical/cctor/misc/threads1_cs_do.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/Methodical/cctor/misc/threads1_cs_r.csproj
+++ b/src/tests/JIT/Methodical/cctor/misc/threads1_cs_r.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/Methodical/cctor/misc/threads1_cs_ro.csproj
+++ b/src/tests/JIT/Methodical/cctor/misc/threads1_cs_ro.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/Methodical/cctor/misc/threads2_cs_d.csproj
+++ b/src/tests/JIT/Methodical/cctor/misc/threads2_cs_d.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/Methodical/cctor/misc/threads2_cs_do.csproj
+++ b/src/tests/JIT/Methodical/cctor/misc/threads2_cs_do.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/Methodical/cctor/misc/threads2_cs_r.csproj
+++ b/src/tests/JIT/Methodical/cctor/misc/threads2_cs_r.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/Methodical/cctor/misc/threads2_cs_ro.csproj
+++ b/src/tests/JIT/Methodical/cctor/misc/threads2_cs_ro.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/Methodical/cctor/simple/prefldinit4_il_d.ilproj
+++ b/src/tests/JIT/Methodical/cctor/simple/prefldinit4_il_d.ilproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/cctor/simple/prefldinit4_il_r.ilproj
+++ b/src/tests/JIT/Methodical/cctor/simple/prefldinit4_il_r.ilproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise1_cs_d.csproj
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise1_cs_d.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise1_cs_do.csproj
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise1_cs_do.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise1_cs_r.csproj
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise1_cs_r.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise1_cs_ro.csproj
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise1_cs_ro.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise1b_cs_d.csproj
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise1b_cs_d.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise1b_cs_do.csproj
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise1b_cs_do.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise1b_cs_r.csproj
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise1b_cs_r.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise1b_cs_ro.csproj
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise1b_cs_ro.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise2_cs_d.csproj
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise2_cs_d.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise2_cs_do.csproj
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise2_cs_do.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise2_cs_r.csproj
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise2_cs_r.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise2_cs_ro.csproj
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise2_cs_ro.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise4_cs_d.csproj
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise4_cs_d.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise4_cs_do.csproj
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise4_cs_do.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise4_cs_r.csproj
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise4_cs_r.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/cctor/xassem/xprecise4_cs_ro.csproj
+++ b/src/tests/JIT/Methodical/cctor/xassem/xprecise4_cs_ro.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -386,13 +386,15 @@
       <AllRunnableTestPaths Remove="$(XunitTestBinBase)\**\run-v8.sh" Condition="'$(TargetArchitecture)' == 'wasm'" />
       <MergedAssemblyMarkerPaths Include="$(XunitTestBinBase)\**\*.MergedTestAssembly"/>
       <MergedRunnableTestPaths Include="$([System.IO.Path]::ChangeExtension('%(MergedAssemblyMarkerPaths.Identity)', '.$(TestScriptExtension)'))" />
+      <OutOfProcessTestMarkerPaths Include="$(XunitTestBinBase)\**\*.OutOfProcessTest"/>
+      <OutOfProcessTestPaths Include="$([System.IO.Path]::ChangeExtension('%(OutOfProcessTestMarkerPaths.Identity)', '.$(TestScriptExtension)'))" />
     </ItemGroup>
     <!-- Remove the cmd/sh scripts for merged test runner app bundles from our list. -->
     <PropertyGroup Condition="'$(TargetsMobile)' == 'true'">
       <MergedRunnableTestAppBundleScriptPathsPattern>@(MergedAssemblyMarkerPaths->'%(RootDir)%(Directory)AppBundle/**/*.$(TestScriptExtension)')</MergedRunnableTestAppBundleScriptPathsPattern>
     </PropertyGroup>
     <ItemGroup>
-      <LegacyRunnableTestPaths Include="@(AllRunnableTestPaths)" Exclude="@(MergedRunnableTestPaths);$(MergedRunnableTestAppBundleScriptPathsPattern)" />
+      <LegacyRunnableTestPaths Include="@(AllRunnableTestPaths)" Exclude="@(MergedRunnableTestPaths);@(OutOfProcessTestPaths);$(MergedRunnableTestAppBundleScriptPathsPattern)" />
     </ItemGroup>
   </Target>
 

--- a/src/tests/xunit-wrappers.targets
+++ b/src/tests/xunit-wrappers.targets
@@ -259,6 +259,7 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
       <AllCMDsPresent Include="$(_CMDDIR)\**\*.$(TestScriptExtension)" Exclude="$(_CMDDIR)\**\AppBundle\*.$(TestScriptExtension)" />
       <AllCMDsPresent Remove="$(_CMDDIR)\**\run-v8.sh" Condition="'$(TargetArchitecture)' == 'wasm'" />
       <AllCMDsPresent Remove="@(MergedRunnableTestPaths)" />
+      <AllCMDsPresent Remove="@(OutOfProcessTestPaths)" />
     </ItemGroup>
 
     <ItemGroup Condition="'@(AllCMDsPresent)' != ''">


### PR DESCRIPTION
This change marks several JIT/Methodical tests as requiring out-of-process
execution because they exercise managed runtime initialization. It also
includes various small fixes I had to apply to make the change fully
functional end to end.

Thanks

Tomas

/cc @dotnet/jit-contrib 