### PR TITLE
[release/6.0] Port ICU tests fix for server core x86

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -48,6 +48,7 @@ namespace System
         public static bool IsNotArm64Process => !IsArm64Process;
         public static bool IsArmOrArm64Process => IsArmProcess || IsArm64Process;
         public static bool IsNotArmNorArm64Process => !IsArmOrArm64Process;
+        public static bool IsX86Process => RuntimeInformation.ProcessArchitecture == Architecture.X86;
         public static bool IsArgIteratorSupported => IsMonoRuntime || (IsWindows && IsNotArmProcess);
         public static bool IsArgIteratorNotSupported => !IsArgIteratorSupported;
         public static bool Is32BitProcess => IntPtr.Size == 4;

--- a/src/libraries/System.Globalization/tests/IcuTests.cs
+++ b/src/libraries/System.Globalization/tests/IcuTests.cs
@@ -10,7 +10,9 @@ namespace System.Globalization.Tests
     public class IcuTests
     {
         private static bool IsIcuCompatiblePlatform => PlatformDetection.IsNotWindows ||
-                                                       PlatformDetection.IsWindows10Version1903OrGreater;
+                                                       PlatformDetection.IsWindows10Version1903OrGreater &&
+                                                        // Server core doesn't have icu.dll on SysWOW64
+                                                        !(PlatformDetection.IsWindowsServerCore && PlatformDetection.IsX86Process));
 
         [ConditionalFact(nameof(IsIcuCompatiblePlatform))]
         public static void IcuShouldBeUsedByDefault()

--- a/src/libraries/System.Globalization/tests/IcuTests.cs
+++ b/src/libraries/System.Globalization/tests/IcuTests.cs
@@ -12,7 +12,7 @@ namespace System.Globalization.Tests
         private static bool IsIcuCompatiblePlatform => PlatformDetection.IsNotWindows ||
                                                        PlatformDetection.IsWindows10Version1903OrGreater &&
                                                         // Server core doesn't have icu.dll on SysWOW64
-                                                        !(PlatformDetection.IsWindowsServerCore && PlatformDetection.IsX86Process));
+                                                        !(PlatformDetection.IsWindowsServerCore && PlatformDetection.IsX86Process);
 
         [ConditionalFact(nameof(IsIcuCompatiblePlatform))]
         public static void IcuShouldBeUsedByDefault()


### PR DESCRIPTION
icu is not present on Server Core in the SysWOW64.

Test only change to help get release branch CI green. 

Branch is closed at the moment, but this can be merged when it is opened. 