### PR TITLE
Get rid of fallback to process ids enumeration in ProcessManager.IsProcessRunning (Windows)

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -29,13 +29,22 @@ namespace System.Diagnostics
         {
             // Performance optimization for the local machine:
             // First try to OpenProcess by id, if valid handle is returned verify that process is running
-            // Otherwise enumerate all processes and compare ids
+            // When the attempt to open a handle fails due to lack of permissions enumerate all processes and compare ids
             // Attempt to open handle for Idle process (processId == 0) fails with ERROR_INVALID_PARAMETER
             if (processId != 0 && !IsRemoteMachine(machineName))
             {
                 using (SafeProcessHandle processHandle = Interop.Kernel32.OpenProcess(ProcessOptions.PROCESS_QUERY_LIMITED_INFORMATION | ProcessOptions.SYNCHRONIZE, false, processId))
                 {
-                    if (!processHandle.IsInvalid)
+                    if (processHandle.IsInvalid)
+                    {
+                        int error = Marshal.GetLastWin32Error();
+                        if (error == Interop.Errors.ERROR_INVALID_PARAMETER)
+                        {
+                            Debug.Assert(processId != 0, "OpenProcess fails with ERROR_INVALID_PARAMETER for Idle Process");
+                            return false;
+                        }
+                    }
+                    else
                     {
                         bool signaled = false;
                         return !HasExited(processHandle, ref signaled, out _);

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -30,7 +30,8 @@ namespace System.Diagnostics
             // Performance optimization for the local machine:
             // First try to OpenProcess by id, if valid handle is returned verify that process is running
             // Otherwise enumerate all processes and compare ids
-            if (!IsRemoteMachine(machineName))
+            // Attempt to open handle for Idle process (processId == 0) fails with ERROR_INVALID_PARAMETER
+            if (processId != 0 && !IsRemoteMachine(machineName))
             {
                 using (SafeProcessHandle processHandle = Interop.Kernel32.OpenProcess(ProcessOptions.PROCESS_QUERY_LIMITED_INFORMATION | ProcessOptions.SYNCHRONIZE, false, processId))
                 {


### PR DESCRIPTION
Currently, when process Handle can't be opened for any reason (local machine case), `ProcessManager.IsProcessRunning` enumerates all processes in the system to ensure that no process with given Id exists. This enumeration implemented via `EnumProcesses` call which is very slow (~10ms) compared to good case when handle is successfully opened

I want to suggest some improvements to (mostly) get rid of this fallback to achieve better performance.

Main suggestion is assume that process doesn't exists when `OpenProcess` failed not due to lack of permissions (`ERROR_ACCESS_DENIED`).

But there are some special cases should be considered.

Handle to process couldn't be opened:

- for Idle processes (`id=0`) (`ERROR_INVALID_PARAMETER`)
- for protected (e.g. csrss.exe) processes (`ERROR_ACCESS_DENIED`)
- any other cases when our process is limited? maybe there is something special on Nano Server or old/future versions of Windows (who knows?)

In these cases we could (1 OR 2 OR 3):

1. fall back to slow enumeration (looks like the safest way, cases when enumeration does happen don't seem to be common)
2. optimistically assume that process is still running (allows to fully remove enumeration for local machine, but who knows if any other corner cases exists)
3. other suggestions?

`System.Diagnostics.ProcessManager.OpenProcess` still assumes `ERROR_ACCESS_DENIED` means still running process. So second way doesn't look completely wrong.

What do you think, which way should be used? In this PR, I've implemented the first way, but it's not a problem to rewrite with second way if these optimistic assumptions are reasonable.