### PR TITLE
Run System.Collections instead of System.Runtime tests

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -368,7 +368,7 @@
   <ItemGroup Condition="'$(TestNativeAot)' == 'true'">
     <!-- Run only a small randomly chosen set of passing test suites -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\*.Tests.csproj" />
-    <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" />
+    <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Collections\tests\System.Collections.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RunSmokeTestsOnly)' == 'true'">


### PR DESCRIPTION
The newly added NativeAOT libraries testing is very unstable. System.Collections are probably a less intense test, so run that one instead.

This will of course be revisited since we want to run more libraries tests but I want to stop turning people's PR's red.

If this is not sufficient, we'll have to pull the entire leg until it's root caused.