### PR TITLE
Remove the concept of fat dispatch tokens and fat type ids from 64 bit platforms

### DIFF
--- a/src/coreclr/inc/switches.h
+++ b/src/coreclr/inc/switches.h
@@ -23,7 +23,9 @@
 #define USE_CHECKED_OBJECTREFS
 #endif
 
+#ifdef TARGET_64BIT
 #define FAT_DISPATCH_TOKENS
+#endif
 
 #define FEATURE_SHARE_GENERIC_CODE
 

--- a/src/coreclr/inc/switches.h
+++ b/src/coreclr/inc/switches.h
@@ -23,7 +23,7 @@
 #define USE_CHECKED_OBJECTREFS
 #endif
 
-#ifdef TARGET_64BIT
+#ifndef TARGET_64BIT
 #define FAT_DISPATCH_TOKENS
 #endif
 

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -710,8 +710,7 @@ void BaseDomain::InitVSD()
 {
     STANDARD_VM_CONTRACT;
 
-    UINT32 startingId = TypeIDMap::STARTING_UNSHARED_DOMAIN_ID;
-    m_typeIDMap.Init(startingId, 2);
+    m_typeIDMap.Init();
 
     GetLoaderAllocator()->InitVirtualCallStubManager(this);
 }

--- a/src/coreclr/vm/generics.cpp
+++ b/src/coreclr/vm/generics.cpp
@@ -352,45 +352,6 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
     }
 #endif // FEATURE_TYPEEQUIVALENCE
 
-    if (pOldMT->IsInterface() && IsImplicitInterfaceOfSZArray(pOldMT))
-    {
-        // Determine if we are creating an interface methodtable that may be used to dispatch through VSD
-        // on an array object using a generic interface (such as IList<T>).
-        // Please read comments in IsArray block of code:MethodTable::FindDispatchImpl.
-        //
-        // Arrays are special because we use the same method table (object[]) for all arrays of reference
-        // classes (eg string[]). This means that the method table for an array is not a complete description of
-        // the type of the array and thus the target of if something list IList<T>::IndexOf can not be determined
-        // simply by looking at the method table of T[] (which might be the method table of object[], if T is a
-        // reference type).
-        //
-        // This is done to minimize MethodTables, but as a side-effect of this optimization,
-        // we end up using a domain-shared type (object[]) with a domain-specific dispatch token.
-        // This is a problem because the same domain-specific dispatch token value can appear in
-        // multiple unshared domains (VSD takes advantage of the fact that in general a shared type
-        // cannot implement an unshared interface). This means that the same <token, object[]> pair
-        // value can mean different things in different domains (since the token could represent
-        // IList<Foo> in one domain and IEnumerable<Bar> in another). This is a problem because the
-        // VSD polymorphic lookup mechanism relies on a process-wide cache table, and as a result
-        // these duplicate values would collide if we didn't use fat dispatch token to ensure uniqueness
-        // and the interface methodtable is not in the shared domain.
-        //
-        // Of note: there is also some interesting array-specific behaviour where if B inherits from A
-        // and you have an array of B (B[]) then B[] implements IList<B> and IList<A>, but a dispatch
-        // on an IList<A> reference results in a dispatch to SZArrayHelper<A> rather than
-        // SZArrayHelper<B> (i.e., the variance implemention is not done like virtual methods).
-        //
-        // For example If Sub inherits from Super inherits from Object, then
-        //     * Sub[] implements IList<Super>
-        //     * Sub[] implements IList<Sub>
-        //
-        // And as a result we have the following mappings:
-        //     * IList<Super>::IndexOf for Sub[] goes to SZArrayHelper<Super>::IndexOf
-        //     * IList<Sub>::IndexOf for Sub[] goes to SZArrayHelper<Sub>::IndexOf
-        //
-        pMT->SetRequiresFatDispatchTokens();
-    }
-
     // Number of slots only includes vtable slots
     pMT->SetNumVirtuals(cSlots);
 

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -255,25 +255,6 @@ struct GenericsStaticsInfo
 };  // struct GenericsStaticsInfo
 typedef DPTR(GenericsStaticsInfo) PTR_GenericsStaticsInfo;
 
-
-// CrossModuleGenericsStaticsInfo is used in NGen images for statics of cross-module
-// generic instantiations. CrossModuleGenericsStaticsInfo is optional member of
-// MethodTableWriteableData.
-struct CrossModuleGenericsStaticsInfo
-{
-    // Module this method table statics are attached to.
-    //
-    // The statics has to be attached to module referenced from the generic instantiation
-    // in domain-neutral code. We need to guarantee that the module for the statics
-    // has a valid local represenation in an appdomain.
-    //
-    PTR_Module          m_pModuleForStatics;
-
-    // Method table ID for statics
-    SIZE_T              m_DynamicTypeID;
-};  // struct CrossModuleGenericsStaticsInfo
-typedef DPTR(CrossModuleGenericsStaticsInfo) PTR_CrossModuleGenericsStaticsInfo;
-
 //
 // This struct consolidates the writeable parts of the MethodTable
 // so that we can layout a read-only MethodTable with a pointer
@@ -337,8 +318,6 @@ struct MethodTableWriteableData
 
 #endif
 
-    // Optional CrossModuleGenericsStaticsInfo may be here.
-
 public:
 #ifdef _DEBUG
     inline BOOL IsParentMethodTablePointerValid() const
@@ -393,15 +372,6 @@ public:
         m_dwFlags &= ~(MethodTableWriteableData::enum_flag_HasApproxParent);
 
     }
-
-    inline CrossModuleGenericsStaticsInfo * GetCrossModuleGenericsStaticsInfo()
-    {
-        LIMITED_METHOD_DAC_CONTRACT;
-
-        SIZE_T size = sizeof(MethodTableWriteableData);
-        return PTR_CrossModuleGenericsStaticsInfo(dac_cast<TADDR>(this) + size);
-    }
-
 };  // struct MethodTableWriteableData
 
 typedef DPTR(MethodTableWriteableData) PTR_MethodTableWriteableData;
@@ -1672,18 +1642,6 @@ public:
     PTR_FieldDesc GetFieldDescByIndex(DWORD fieldIndex);
 
     DWORD GetIndexForFieldDesc(FieldDesc *pField);
-
-    inline bool RequiresFatDispatchTokens()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return !!GetFlag(enum_flag_RequiresDispatchTokenFat);
-    }
-
-    inline void SetRequiresFatDispatchTokens()
-    {
-        LIMITED_METHOD_CONTRACT;
-        SetFlag(enum_flag_RequiresDispatchTokenFat);
-    }
 
     inline bool HasPreciseInitCctors()
     {
@@ -3503,7 +3461,7 @@ private:
 
         enum_flag_IsIntrinsicType           = 0x0100,
 
-        enum_flag_RequiresDispatchTokenFat  = 0x0200,
+        // unused                           = 0x0200,
 
         enum_flag_HasCctor                  = 0x0400,
         enum_flag_HasVirtualStaticMethods   = 0x0800,

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -10367,25 +10367,6 @@ MethodTableBuilder::SetupMethodTable2(
 #ifdef FEATURE_COMINTEROP
     if (bmtProp->fSparse)
         pClass->SetSparseForCOMInterop();
-
-    if (IsInterface() && IsComImport())
-    {
-        // Determine if we are creating an interface methodtable that may be used to dispatch through VSD
-        // on an object that has the methodtable of __ComObject.
-
-        // This is done to allow COM tearoff interfaces, but as a side-effect of this feature,
-        // we end up using a domain-shared type (__ComObject) with a domain-specific dispatch token.
-        // This is a problem because the same domain-specific dispatch token value can appear in
-        // multiple unshared domains (VSD takes advantage of the fact that in general a shared type
-        // cannot implement an unshared interface). This means that the same <token, __ComObject> pair
-        // value can mean different things in different domains (since the token could represent
-        // IFoo in one domain and IBar in another). This is a problem because the
-        // VSD polymorphic lookup mechanism relies on a process-wide cache table, and as a result
-        // these duplicate values would collide if we didn't use fat dispatch token to ensure uniqueness
-        // and the interface methodtable is not in the shared domain.
-
-        pMT->SetRequiresFatDispatchTokens();
-    }
 #endif // FEATURE_COMINTEROP
 
     if (bmtVT->pCCtor != NULL)


### PR DESCRIPTION
- Phase 1 of removing locking from interface dispatch generation for generic dispatch
- We no longer need these due to changes to remove AppDomains from CoreCLR
- Phase 2 will likely remove the MethodTableWriteableData structure and merge the contents into the normal MethodTable