### PR TITLE
JIT: verify containment safety before forming address modes

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -7065,7 +7065,16 @@ void Lowering::ContainCheckBitCast(GenTree* node)
 void Lowering::LowerStoreIndirCommon(GenTreeStoreInd* ind)
 {
     assert(ind->TypeGet() != TYP_STRUCT);
-    TryCreateAddrMode(ind->Addr(), true, ind);
+
+#if defined(TARGET_ARM64)
+    // Verify containment safety before creating an LEA that must be contained.
+    //
+    const bool isContainable = IsSafeToContainMem(ind, ind->Addr());
+#else
+    const bool     isContainable         = true;
+#endif
+    TryCreateAddrMode(ind->Addr(), isContainable, ind);
+
     if (!comp->codeGen->gcInfo.gcIsWriteBarrierStoreIndNode(ind))
     {
         if (varTypeIsFloating(ind) && ind->Data()->IsCnsFltOrDbl())
@@ -7085,7 +7094,7 @@ void Lowering::LowerStoreIndirCommon(GenTreeStoreInd* ind)
 #if defined(TARGET_XARCH) || defined(TARGET_ARM)
             bool shouldSwitchToInteger = true;
 #else // TARGET_ARM64
-            bool shouldSwitchToInteger = !data->IsCnsNonZeroFltOrDbl();
+            bool   shouldSwitchToInteger = !data->IsCnsNonZeroFltOrDbl();
 #endif
 
             if (shouldSwitchToInteger)
@@ -7133,7 +7142,17 @@ void Lowering::LowerIndir(GenTreeIndir* ind)
         // TODO-Cleanup: We're passing isContainable = true but ContainCheckIndir rejects
         // address containment in some cases so we end up creating trivial (reg + offfset)
         // or (reg + reg) LEAs that are not necessary.
-        TryCreateAddrMode(ind->Addr(), true, ind);
+        CLANG_FORMAT_COMMENT_ANCHOR;
+
+#if defined(TARGET_ARM64)
+        // Verify containment safety before creating an LEA that must be contained.
+        //
+        const bool isContainable = IsSafeToContainMem(ind, ind->Addr());
+#else
+        const bool isContainable         = true;
+#endif
+
+        TryCreateAddrMode(ind->Addr(), isContainable, ind);
         ContainCheckIndir(ind);
 
         if (ind->OperIs(GT_NULLCHECK) || ind->IsUnusedValue())
@@ -7182,7 +7201,7 @@ void Lowering::TransformUnusedIndirection(GenTreeIndir* ind, Compiler* comp, Bas
 #ifdef TARGET_ARM64
     bool useNullCheck = true;
 #elif TARGET_ARM
-    bool         useNullCheck          = false;
+    bool           useNullCheck          = false;
 #else  // TARGET_XARCH
     bool useNullCheck = !ind->Addr()->isContained();
 #endif // !TARGET_XARCH


### PR DESCRIPTION
At least on arm64, where LEAs must be contained.

Fixes #64936.