### PR TITLE
Limit number of JIT/HardwareIntrinsics/* under GCStress

### DIFF
--- a/src/tests/Common/CoreCLRTestLibrary/Utilities.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/Utilities.cs
@@ -101,6 +101,7 @@ namespace TestLibrary
         public static bool IsReflectionEmitSupported => true;
 #endif
         public static bool SupportsExceptionInterop => IsWindows && IsNotMonoRuntime && !IsNativeAot; // matches definitions in clr.featuredefines.props
+        public static bool IsGCStress => (Environment.GetEnvironmentVariable("COMPlus_GCStress") != null) || (Environment.GetEnvironmentVariable("DOTNET_GCStress") != null);
 
         public static string ByteArrayToString(byte[] bytes)
         {

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/Program.cs
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/Program.cs
@@ -12,6 +12,7 @@ namespace JIT.HardwareIntrinsics.Arm
     {
         private const int PASS = 100;
         private const int FAIL = 0;
+        private const int MaximumTestCountGCStress = 30;
 
         private static readonly IDictionary<string, Action> TestList;
 
@@ -63,7 +64,17 @@ namespace JIT.HardwareIntrinsics.Arm
                 testsToRun.Add(testName);
             }
 
-            return (testsToRun.Count == 0) ? TestList.Keys : testsToRun;
+            if (testsToRun.Count != 0)
+            {
+                return testsToRun;
+            }
+
+            if (TestLibrary.Utilities.IsGCStress)
+            {
+                return TestList.Keys.Take(MaximumTestCountGCStress).ToArray();
+            }
+
+            return TestList.Keys;
         }
 
         private static void PrintSupportedIsa()

--- a/src/tests/JIT/HardwareIntrinsics/General/Shared/Program.cs
+++ b/src/tests/JIT/HardwareIntrinsics/General/Shared/Program.cs
@@ -12,6 +12,7 @@ namespace JIT.HardwareIntrinsics.General
     {
         private const int PASS = 100;
         private const int FAIL = 0;
+        private const int MaximumTestCountGCStress = 30;
 
         private static readonly IDictionary<string, Action> TestList;
 
@@ -61,7 +62,17 @@ namespace JIT.HardwareIntrinsics.General
                 testsToRun.Add(testName);
             }
 
-            return (testsToRun.Count == 0) ? TestList.Keys : testsToRun;
+            if (testsToRun.Count != 0)
+            {
+                return testsToRun;
+            }
+
+            if (TestLibrary.Utilities.IsGCStress)
+            {
+                return TestList.Keys.Take(MaximumTestCountGCStress).ToArray();
+            }
+
+            return TestList.Keys;
         }
 
         private static void PrintUsage()

--- a/src/tests/JIT/HardwareIntrinsics/X86/Shared/Program.cs
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Shared/Program.cs
@@ -12,6 +12,7 @@ namespace JIT.HardwareIntrinsics.X86
     {
         private const int PASS = 100;
         private const int FAIL = 0;
+        private const int MaximumTestCountGCStress = 30;
 
         private static readonly IDictionary<string, Action> TestList;
 
@@ -63,7 +64,17 @@ namespace JIT.HardwareIntrinsics.X86
                 testsToRun.Add(testName);
             }
 
-            return (testsToRun.Count == 0) ? TestList.Keys : testsToRun;
+            if (testsToRun.Count != 0)
+            {
+                return testsToRun;
+            }
+
+            if (TestLibrary.Utilities.IsGCStress)
+            {
+                return TestList.Keys.Take(MaximumTestCountGCStress).ToArray();
+            }
+
+            return TestList.Keys;
         }
 
         private static void PrintSupportedIsa()


### PR DESCRIPTION
Limit the number of `JIT/HardwareIntrinsics/*` to be under 30 when running under GCStress.
Fixes #64956