### PR TITLE
fix few Filesystem tests on FreeBSD

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -44,6 +44,7 @@ namespace System
         public static bool IsAppleMobile => IsMacCatalyst || IsiOS || IstvOS;
         public static bool IsNotAppleMobile => !IsAppleMobile;
         public static bool IsNotNetFramework => !IsNetFramework;
+        public static bool IsBsdLike => IsOSXLike || IsFreeBSD || IsNetBSD;
 
         public static bool IsArmProcess => RuntimeInformation.ProcessArchitecture == Architecture.Arm;
         public static bool IsNotArmProcess => !IsArmProcess;

--- a/src/libraries/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Move.cs
@@ -343,7 +343,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX | TestPlatforms.FreeBSD | TestPlatforms.NetBSD)]
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
         public void MoveDirectory_FailToMoveLowerCaseDirectoryWhenUpperCaseDirectoryExists()
         {
             Directory.CreateDirectory($"{TestDirectory}/bar/FOO");

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/ctor_options.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/ctor_options.Unix.cs
@@ -15,20 +15,18 @@ namespace System.IO.Tests
             using var px = Process.Start(new ProcessStartInfo
             {
                 FileName = "stat",
-                ArgumentList = { isOSX ? "-f"    : "-c",
-                                 isOSX ? "%b %k" : "%b %B",
+                ArgumentList = { PlatformDetection.IsBsdLike ? "-f"    : "-c",
+                                 PlatformDetection.IsBsdLike ? "%z" : "%b %B",
                                  fileStream.Name },
                 RedirectStandardOutput = true
             });
             string stdout = px.StandardOutput.ReadToEnd();
 
             string[] parts = stdout.Split(' ');
-            return long.Parse(parts[0]) * long.Parse(parts[1]);
+            return PlatformDetection.IsBsdLike ? long.Parse(parts[0]) : long.Parse(parts[0]) * long.Parse(parts[1]);
         }
 
-        private static bool SupportsPreallocation =>
-            RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
-            RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        private static bool SupportsPreallocation => OperatingSystem.IsLinux() || PlatformDetection.IsBsdLike;
 
         // Mobile platforms don't support Process.Start.
         private static bool IsGetAllocatedSizeImplemented => !PlatformDetection.IsMobile;

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/ctor_options.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/ctor_options.Unix.cs
@@ -16,17 +16,19 @@ namespace System.IO.Tests
             {
                 FileName = "stat",
                 ArgumentList = { PlatformDetection.IsBsdLike ? "-f"    : "-c",
-                                 PlatformDetection.IsBsdLike ? "%z" : "%b %B",
+                                 PlatformDetection.IsBsdLike ? "%b %k" : "%b %B",
                                  fileStream.Name },
                 RedirectStandardOutput = true
             });
             string stdout = px.StandardOutput.ReadToEnd();
 
             string[] parts = stdout.Split(' ');
-            return PlatformDetection.IsBsdLike ? long.Parse(parts[0]) : long.Parse(parts[0]) * long.Parse(parts[1]);
+            return long.Parse(parts[0]) * long.Parse(parts[1]);
         }
 
-        private static bool SupportsPreallocation => OperatingSystem.IsLinux() || PlatformDetection.IsBsdLike;
+        private static bool SupportsPreallocation =>
+            RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+            RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
         // Mobile platforms don't support Process.Start.
         private static bool IsGetAllocatedSizeImplemented => !PlatformDetection.IsMobile;


### PR DESCRIPTION
The `MoveDirectory_FailToMoveLowerCaseDirectoryWhenUpperCaseDirectoryExists` is technically wrong on Unix IMHO. 
The case sensitivity is determined by given filesystem not by the OS itself. 

To ignore that, macOS has case _insensitive_ filesystem by default but default filesystem (zfs) on FreeBSD is case sensitive.
This seems like old oversight assuming (somewhat correctly) similarity between FreeBSD and macOS

Some other tests they fail with 
```
     System.IO.Tests.File_Open_str_options.ZeroPreallocationSizeDoesNotAllocate(mode: Truncate, createFile: True) [STARTING]
  stat: illegal option -- c
  usage: stat [-FLnq] [-f format | -l | -r | -s | -x] [-t timefmt] [file|handle ...]
      System.IO.Tests.File_Open_str_options.ZeroPreallocationSizeDoesNotAllocate(mode: Truncate, createFile: True) [FAIL]
```

In that regard, FreeBSD _is_ like macOS e.g. parameters for `stat` are the same. I assumed easy fix but I was wrong.
The behavior is somewhat different.

macOS
```
Shining:wfurt-runtime furt$ touch foo
Shining:wfurt-runtime furt$ stat -f "%b %k" foo
0 4096
```

FreeBSD
```
furt@d13:~ $ touch foo
furt@d13:~ $ stat -f "%b %k" foo
1 131072
```

The zfs shows one block used even if the file itself is empty. 
To fix that I decided to use %z that simply returns allocated size on both macOS and FreeBSD 

I did quick check and solaris seems to follow Linux e.g.  "%b %B" and updated code should still work.
cc: @am11


cc: @Thefrank  @rootwyrm  @emaste

