### PR TITLE
fix ping tests on unsupported unix platforms

### DIFF
--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -78,9 +78,10 @@ namespace System.Net.NetworkInformation.Tests
                 ? TestSettings.PayloadAsBytes
                 : Array.Empty<byte>();
 
-        public static bool DoesNotUsePingUtility => !UsesPingUtility;
-
-        public static bool UsesPingUtility => (OperatingSystem.IsLinux() || OperatingSystem.IsAndroid()) && !Capability.CanUseRawSockets(TestSettings.GetLocalIPAddress().AddressFamily);
+        public static bool DoesNotUsePingUtility => OperatingSystem.IsWindows() ||
+                                OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsWatchOS() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() ||
+                                Capability.CanUseRawSockets(TestSettings.GetLocalIPAddress().AddressFamily);
+        public static bool UsesPingUtility => !DoesNotUsePingUtility;
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task SendPingAsync_InvalidArgs()


### PR DESCRIPTION
This is recent regression I bump to while running tests on FreeBSD. 

#64625 assumes we would use `ping` utility only on Linux. 
But that is how it works on pretty much on all UNIX like systems and macOS(like) is rare and recent exception. 
(event if the list of actual variations is annoyingly long)

This PR generally flips the condition and it assumes we _would_ use `ping` unless we know we don't have to. 
That should make it work again for Solaris(like) and (Free)BSD(like) OSes.

cc: @am11 @Thefrank 