### PR TITLE
Process.Unix: reap all processes when running as pid 1.

### DIFF
--- a/src/native/libs/System.Native/pal_signal.c
+++ b/src/native/libs/System.Native/pal_signal.c
@@ -38,6 +38,8 @@ static volatile bool* g_hasPosixSignalRegistrations;
 
 static int g_signalPipe[2] = {-1, -1}; // Pipe used between signal handler and worker
 
+static pid_t g_pid;
+
 static int GetSignalMax() // Returns the highest usable signal number.
 {
 #ifdef SIGRTMAX
@@ -341,9 +343,15 @@ static void* SignalHandlerLoop(void* arg)
         bool usePosixSignalHandler = g_hasPosixSignalRegistrations[signalCode - 1];
         if (signalCode == SIGCHLD)
         {
-            // When the original disposition is SIG_IGN, children that terminated did not become zombies.
-            // Since we overwrote the disposition, we have become responsible for reaping those processes.
-            bool reapAll = IsSigIgn(OrigActionFor(signalCode));
+            // By default we only reap managed processes started using the 'Process' class.
+            // This allows other code to start processes without .NET reaping them.
+            //
+            // In two cases we reap all processes (and may inadvertently reap non-managed processes):
+            // - When the original disposition is SIG_IGN, children that terminated did not become zombies.
+            //   Because overwrote the disposition, we have become responsible for reaping those processes.
+            // - pid 1 (the init daemon) is responsible for reaping orphaned children.
+            //   Because containers usually don't have an init daemon .NET may be pid 1.
+            bool reapAll = g_pid == 1 || IsSigIgn(OrigActionFor(signalCode));
             SigChldCallback callback = g_sigChldCallback;
 
             // double-checked locking
@@ -551,6 +559,8 @@ int32_t InitializeSignalHandlingCore()
         errno = ENOMEM;
         return 0;
     }
+
+    g_pid = getpid();
 
     // Create a pipe we'll use to communicate with our worker
     // thread.  We can't do anything interesting in the signal handler,

--- a/src/native/libs/System.Native/pal_signal.c
+++ b/src/native/libs/System.Native/pal_signal.c
@@ -296,7 +296,7 @@ void SystemNative_HandleNonCanceledPosixSignal(int32_t signalCode)
 #ifdef HAS_CONSOLE_SIGNALS
             UninitializeTerminal();
 #endif
-            kill(getpid(), signalCode);
+            kill(g_pid, signalCode);
             break;
     }
 }


### PR DESCRIPTION
pid 1 (the init daemon) is responsible for reaping orphaned children.
Because containers usually don't have an init daemon .NET may be pid 1.

Fixes https://github.com/dotnet/runtime/issues/45017.

@adamsitnik ptal.