### PR TITLE
Move iOS/tvOS simulator runs back to the OSX.1015.Amd64.Open queue

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -29,7 +29,7 @@ jobs:
 
     # iOS/tvOS simulator x64/x86
     - ${{ if in(parameters.platform, 'iOSSimulator_x64', 'tvOSSimulator_x64') }}:
-      - OSX.1200.Amd64.Open
+      - OSX.1015.Amd64.Open
 
     # Android arm64
     - ${{ if in(parameters.platform, 'Android_arm64') }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -105,11 +105,11 @@ jobs:
 
     # iOS Simulator/Mac Catalyst arm64
     - ${{ if in(parameters.platform, 'MacCatalyst_arm64', 'iOSSimulator_arm64') }}:
-      - OSX.1200.ARM64.Open
+      - OSX.1015.ARM64.Open
 
     # iOS/tvOS simulator x64/x86 & MacCatalyst x64
     - ${{ if in(parameters.platform, 'iOSSimulator_x64', 'iOSSimulator_x86', 'tvOSSimulator_x64', 'MacCatalyst_x64') }}:
-      - OSX.1200.Amd64.Open
+      - OSX.1015.Amd64.Open
 
     # iOS devices
     - ${{ if in(parameters.platform, 'iOS_arm64') }}:


### PR DESCRIPTION
There's a problem with exit code detection on the 12.00 queue: https://github.com/dotnet/xharness/issues/819