### PR TITLE
Account for HWI stores in LIR side effects code

### DIFF
--- a/src/coreclr/jit/sideeffects.cpp
+++ b/src/coreclr/jit/sideeffects.cpp
@@ -168,6 +168,14 @@ AliasSet::NodeInfo::NodeInfo(Compiler* compiler, GenTree* node)
     {
         isWrite = true;
     }
+#ifdef FEATURE_HW_INTRINSICS
+    else if (node->OperIsHWIntrinsic() && node->AsHWIntrinsic()->OperIsMemoryStore())
+    {
+        isWrite = true;
+    }
+#endif // FEATURE_HW_INTRINSICS
+
+    assert(isWrite || !node->OperRequiresAsgFlag());
 
     // `node` is the location being accessed. Determine whether or not it is a memory or local variable access, and if
     // it is the latter, get the number of the lclVar.

--- a/src/coreclr/jit/sideeffects.cpp
+++ b/src/coreclr/jit/sideeffects.cpp
@@ -164,7 +164,7 @@ AliasSet::NodeInfo::NodeInfo(Compiler* compiler, GenTree* node)
         isWrite = true;
         node    = node->gtGetOp1();
     }
-    else if (node->OperIsStore())
+    else if (node->OperIsStore() || node->OperIs(GT_MEMORYBARRIER))
     {
         isWrite = true;
     }

--- a/src/tests/JIT/HardwareIntrinsics/General/HwiOp/HwiSideEffects.cs
+++ b/src/tests/JIT/HardwareIntrinsics/General/HwiOp/HwiSideEffects.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.CompilerServices;
+
+// Tests that side effects induced by the HWI nodes are correctly accounted for.
+
+unsafe class HwiSideEffects
+{
+    public static int Main()
+    {
+        if (ProblemWithInterferenceChecks(2) != 2)
+        {
+            return 101;
+        }
+
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static uint ProblemWithInterferenceChecks(uint a)
+    {
+        uint x;
+        if (Bmi2.IsSupported)
+        {
+            // Make sure we don't try to contain "a" under the "add" here.
+            x = a + Bmi2.MultiplyNoFlags(a, a, &a);
+        }
+        else
+        {
+            x = a;
+        }
+
+        return x;
+    }
+}

--- a/src/tests/JIT/HardwareIntrinsics/General/HwiOp/HwiSideEffects.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/HwiOp/HwiSideEffects.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
We must do so for correctness.

Also added an assert to catch unhanded cases like these in the future.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1602547&view=ms.vss-build-web.run-extensions-tab) as expected.