### PR TITLE
One-shot decrypt directly in to destination with padding

### DIFF
--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoOneShot.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoOneShot.cs
@@ -38,6 +38,7 @@ namespace Internal.Cryptography
                     // block size, not the feedback size. We want the one-shot to be able to continue to decrypt
                     // those ciphertexts, so for CFB8 we are more lenient on the number of allowed padding bytes.
                     bytesWritten = SymmetricPadding.GetPaddingLength(transformBuffer, paddingMode, cipher.BlockSizeInBytes);
+                    CryptographicOperations.ZeroMemory(transformBuffer.Slice(bytesWritten));
                     return true;
                 }
                 catch (CryptographicException)


### PR DESCRIPTION
This is an experimental idea to see if we can make the one-shot decryption utilize the destination buffer better, but it does not come without some tradeoffs. I want to understand if others think these tradeoffs are worth it.

Today, when decrypting with the one shots, when there is any kind of padding removal, we always decrypt in to a rented buffer, then copy the resulting bytes from the rented buffer to the output buffer. This is largely because we don't know if the destination is big enough until after the decryption has already taken place.

However, if the output buffer supplied by the developer is big enough to do the transformation, we could just transform directly to the output buffer. This comes with a few trade offs:

1. The output buffer is written past what we report in `bytesWritten`, but those bytes are not material to the final answer of the decryption. They are just padding bytes. A [discussion on twitter](https://twitter.com/LeviBroderick/status/1367607494349004804) leads me to believe this is okay.
2. I'm not sure I like that in a crypto-sensitive area. Consider code like this:

    ```c#
    Aes aes = Aes.Create();
    // Set up AES
    Span<byte> destination = new byte[]; // Some overly large buffer
    int written = aes.DecryptCbc(ciphertext, iv, destination);
    // Do something with the decrypted data
    CryptographicOperations.ZeroMemory(destination.Slice(0, written));
    ```

    This decrypts in to the buffer, and the `written` amount is the actual plaintext. But there is padding in `destination` after the `written` amount that isn't getting zeroed because the developer reasonably assumed to slice destination by the amount written.

    My solution to this was to zero out the padding after the transformation. Though it does mean it's still writing beyond what was reported in `bytesWritten`, the buffer does not leak the length of the last block of data.

So, what are the benefits of this?

The biggest benefit is avoiding the copy and applying less pressure to the ArrayPool. The "tl;dr" story fairly predictable: the larger the plaintext, the better the improvement since there is no copy. For example, for a 5 MB with PKCS7 padding, it's an improvement from 611,535.8 ns down to 457,595.3 ns.

I would like to know if this is worth to continue to pursue - the benefits are not immediately clear to me except in the scenario with large data, which, I am not certain is a common use case for the one-shots. The main remaining work would be any tests, e.g. making sure padding is not left in the buffer.


<details>
<summary>Big Perf table</summary>

Benchmark code is available here: https://gist.github.com/vcsjones/209a8f263bc1ed96ecfc0c3fc4586fe3

Explanations:

1. "ExactBufferSize" are where we are forced to decrypt in to a temporary buffer.
2. "GuaranteedBufferSize" are where the destination buffer can be decrypted in to directly.


|                           Method |        Job | Toolchain | DataSize | Padding |         Mean |       Error |      StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 |
|--------------------------------- |----------- |---------- |--------- |-------- |-------------:|------------:|------------:|------:|-------:|------:|------:|
| Decrypt_Cbc_GuaranteedBufferSize | Job-NUITST |    branch |       16 |    None |     548.7 ns |     6.75 ns |     6.31 ns |  1.00 | 0.0200 |     - |     - |
| Decrypt_Cbc_GuaranteedBufferSize | Job-PGYWYV |      main |       16 |    None |     550.5 ns |     4.11 ns |     3.85 ns |  1.00 | 0.0200 |     - |     - |
|                                  |            |           |          |         |              |             |             |       |        |       |       |
|      Decrypt_Cbc_ExactBufferSize | Job-NUITST |    branch |       16 |    None |     556.3 ns |     5.59 ns |     5.22 ns |  1.03 | 0.0200 |     - |     - |
|      Decrypt_Cbc_ExactBufferSize | Job-PGYWYV |      main |       16 |    None |     542.3 ns |     4.12 ns |     3.44 ns |  1.00 | 0.0200 |     - |     - |
|                                  |            |           |          |         |              |             |             |       |        |       |       |
| Decrypt_Cbc_GuaranteedBufferSize | Job-NUITST |    branch |       16 |   PKCS7 |     587.0 ns |     4.80 ns |     4.49 ns |  0.98 | 0.0200 |     - |     - |
| Decrypt_Cbc_GuaranteedBufferSize | Job-PGYWYV |      main |       16 |   PKCS7 |     599.2 ns |     7.93 ns |     7.42 ns |  1.00 | 0.0200 |     - |     - |
|                                  |            |           |          |         |              |             |             |       |        |       |       |
|      Decrypt_Cbc_ExactBufferSize | Job-NUITST |    branch |       16 |   PKCS7 |     646.6 ns |     1.56 ns |     1.46 ns |  1.07 | 0.0200 |     - |     - |
|      Decrypt_Cbc_ExactBufferSize | Job-PGYWYV |      main |       16 |   PKCS7 |     605.4 ns |     8.61 ns |     8.05 ns |  1.00 | 0.0200 |     - |     - |
|                                  |            |           |          |         |              |             |             |       |        |       |       |
| Decrypt_Cbc_GuaranteedBufferSize | Job-NUITST |    branch |     1024 |    None |     629.9 ns |     6.24 ns |     5.84 ns |  0.99 | 0.0200 |     - |     - |
| Decrypt_Cbc_GuaranteedBufferSize | Job-PGYWYV |      main |     1024 |    None |     637.5 ns |     3.57 ns |     3.34 ns |  1.00 | 0.0200 |     - |     - |
|                                  |            |           |          |         |              |             |             |       |        |       |       |
|      Decrypt_Cbc_ExactBufferSize | Job-NUITST |    branch |     1024 |    None |     629.0 ns |     8.74 ns |     8.17 ns |  1.00 | 0.0200 |     - |     - |
|      Decrypt_Cbc_ExactBufferSize | Job-PGYWYV |      main |     1024 |    None |     628.1 ns |     5.62 ns |     5.26 ns |  1.00 | 0.0200 |     - |     - |
|                                  |            |           |          |         |              |             |             |       |        |       |       |
| Decrypt_Cbc_GuaranteedBufferSize | Job-NUITST |    branch |     1024 |   PKCS7 |     672.3 ns |     5.80 ns |     5.42 ns |  0.96 | 0.0200 |     - |     - |
| Decrypt_Cbc_GuaranteedBufferSize | Job-PGYWYV |      main |     1024 |   PKCS7 |     702.9 ns |     3.03 ns |     2.84 ns |  1.00 | 0.0200 |     - |     - |
|                                  |            |           |          |         |              |             |             |       |        |       |       |
|      Decrypt_Cbc_ExactBufferSize | Job-NUITST |    branch |     1024 |   PKCS7 |     696.1 ns |     6.58 ns |     6.16 ns |  0.99 | 0.0200 |     - |     - |
|      Decrypt_Cbc_ExactBufferSize | Job-PGYWYV |      main |     1024 |   PKCS7 |     704.8 ns |     2.23 ns |     1.86 ns |  1.00 | 0.0200 |     - |     - |
|                                  |            |           |          |         |              |             |             |       |        |       |       |
| Decrypt_Cbc_GuaranteedBufferSize | Job-NUITST |    branch |  1048576 |    None |  91,017.0 ns |   108.32 ns |    96.03 ns |  1.00 |      - |     - |     - |
| Decrypt_Cbc_GuaranteedBufferSize | Job-PGYWYV |      main |  1048576 |    None |  90,959.5 ns |   103.38 ns |    96.70 ns |  1.00 |      - |     - |     - |
|                                  |            |           |          |         |              |             |             |       |        |       |       |
|      Decrypt_Cbc_ExactBufferSize | Job-NUITST |    branch |  1048576 |    None |  90,989.2 ns |   105.53 ns |    98.71 ns |  1.00 |      - |     - |     - |
|      Decrypt_Cbc_ExactBufferSize | Job-PGYWYV |      main |  1048576 |    None |  90,981.0 ns |    72.17 ns |    60.27 ns |  1.00 |      - |     - |     - |
|                                  |            |           |          |         |              |             |             |       |        |       |       |
| Decrypt_Cbc_GuaranteedBufferSize | Job-NUITST |    branch |  1048576 |   PKCS7 |  91,056.1 ns |   137.39 ns |   128.51 ns |  0.75 |      - |     - |     - |
| Decrypt_Cbc_GuaranteedBufferSize | Job-PGYWYV |      main |  1048576 |   PKCS7 | 120,643.9 ns |    90.36 ns |    80.10 ns |  1.00 |      - |     - |     - |
|                                  |            |           |          |         |              |             |             |       |        |       |       |
|      Decrypt_Cbc_ExactBufferSize | Job-NUITST |    branch |  1048576 |   PKCS7 | 120,660.5 ns |    92.72 ns |    82.19 ns |  1.00 |      - |     - |     - |
|      Decrypt_Cbc_ExactBufferSize | Job-PGYWYV |      main |  1048576 |   PKCS7 | 120,698.7 ns |   130.24 ns |   115.46 ns |  1.00 |      - |     - |     - |
|                                  |            |           |          |         |              |             |             |       |        |       |       |
| Decrypt_Cbc_GuaranteedBufferSize | Job-NUITST |    branch |  5242880 |    None | 460,830.6 ns |   522.00 ns |   462.74 ns |  1.00 |      - |     - |     - |
| Decrypt_Cbc_GuaranteedBufferSize | Job-PGYWYV |      main |  5242880 |    None | 461,280.9 ns |   854.97 ns |   713.94 ns |  1.00 |      - |     - |     - |
|                                  |            |           |          |         |              |             |             |       |        |       |       |
|      Decrypt_Cbc_ExactBufferSize | Job-NUITST |    branch |  5242880 |    None | 467,739.2 ns | 1,109.34 ns | 1,037.67 ns |  1.00 |      - |     - |     - |
|      Decrypt_Cbc_ExactBufferSize | Job-PGYWYV |      main |  5242880 |    None | 468,123.9 ns |   676.93 ns |   633.20 ns |  1.00 |      - |     - |     - |
|                                  |            |           |          |         |              |             |             |       |        |       |       |
| Decrypt_Cbc_GuaranteedBufferSize | Job-NUITST |    branch |  5242880 |   PKCS7 | 457,595.3 ns | 1,326.97 ns | 1,241.25 ns |  0.75 |      - |     - |     - |
| Decrypt_Cbc_GuaranteedBufferSize | Job-PGYWYV |      main |  5242880 |   PKCS7 | 611,535.8 ns |   973.91 ns |   911.00 ns |  1.00 |      - |     - |     - |
|                                  |            |           |          |         |              |             |             |       |        |       |       |
|      Decrypt_Cbc_ExactBufferSize | Job-NUITST |    branch |  5242880 |   PKCS7 | 604,729.1 ns | 1,142.58 ns | 1,012.87 ns |  0.99 |      - |     - |     - |
|      Decrypt_Cbc_ExactBufferSize | Job-PGYWYV |      main |  5242880 |   PKCS7 | 611,380.8 ns | 1,667.38 ns | 1,559.66 ns |  1.00 |      - |     - |     - |
</details>