### PR TITLE
Change `OSX.1015.Arm64.Open` to `OSX.1100.Arm64.Open`

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -105,7 +105,7 @@ jobs:
 
     # iOS Simulator/Mac Catalyst arm64
     - ${{ if in(parameters.platform, 'MacCatalyst_arm64', 'iOSSimulator_arm64') }}:
-      - OSX.1015.ARM64.Open
+      - OSX.1100.Arm64.Open
 
     # iOS/tvOS simulator x64/x86 & MacCatalyst x64
     - ${{ if in(parameters.platform, 'iOSSimulator_x64', 'iOSSimulator_x86', 'tvOSSimulator_x64', 'MacCatalyst_x64') }}:


### PR DESCRIPTION
The former does not exist
Fix of #65070