### PR TITLE
Adds Range Manipulation APIs for Collection<T> and ObservableCollection<T>

### DIFF
--- a/src/libraries/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
+++ b/src/libraries/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
@@ -26,6 +26,9 @@ namespace System.Collections.ObjectModel
         [NonSerialized]
         private int _blockReentrancyCount;
 
+        [NonSerialized]
+        private bool _skipRaisingEvents;
+
         /// <summary>
         /// Initializes a new instance of ObservableCollection that is empty and has default initial capacity.
         /// </summary>
@@ -110,9 +113,95 @@ namespace System.Collections.ObjectModel
 
             base.RemoveItem(index);
 
-            OnCountPropertyChanged();
-            OnIndexerPropertyChanged();
-            OnCollectionChanged(NotifyCollectionChangedAction.Remove, removedItem, index);
+            if (!_skipRaisingEvents)
+            {
+                OnCountPropertyChanged();
+                OnIndexerPropertyChanged();
+                OnCollectionChanged(NotifyCollectionChangedAction.Remove, removedItem, index);
+            }
+        }
+
+        /// <summary>
+        /// Called by base class Collection&lt;T&gt; when a count of items is removed from the list;
+        /// raises a CollectionChanged event to any listeners.
+        /// </summary>
+        protected override void RemoveItemsRange(int index, int count)
+        {
+            CheckReentrancy();
+
+            T[] removedItems = Array.Empty<T>();
+
+            bool ignore = _skipRaisingEvents;
+            if (!ignore)
+            {
+                _skipRaisingEvents = true;
+
+                if (count > 0)
+                {
+                    removedItems = new T[count];
+                    for (int i = 0; i < count; i++)
+                    {
+                        removedItems[i] = this[index + i];
+                    }
+                }
+            }
+
+            try
+            {
+                base.RemoveItemsRange(index, count);
+            }
+            finally
+            {
+                if (!ignore)
+                {
+                    _skipRaisingEvents = false;
+                }
+            }
+
+            if (count > 0 && !_skipRaisingEvents)
+            {
+                OnCountPropertyChanged();
+                OnIndexerPropertyChanged();
+                OnCollectionChanged(NotifyCollectionChangedAction.Remove, removedItems, index);
+            }
+        }
+
+        /// <summary>
+        /// Called by base class Collection&lt;T&gt; when a collection of items is added to list;
+        /// raises a CollectionChanged event to any listeners.
+        /// </summary>
+        protected override void ReplaceItemsRange(int index, int count, IEnumerable<T> collection)
+        {
+            CheckReentrancy();
+
+            _skipRaisingEvents = true;
+
+            T[] itemsToReplace = new T[count - index];
+            for (int i = index; i < count; i++)
+            {
+                itemsToReplace[i] = this[i];
+            }
+
+            try
+            {
+                base.ReplaceItemsRange(index, count, collection);
+            }
+            finally
+            {
+                _skipRaisingEvents = false;
+            }
+
+            if (!_skipRaisingEvents)
+            {
+                IList newItems = collection is IList list ? list : new List<T>(collection);
+
+                if (newItems.Count > 0)
+                {
+                    OnCountPropertyChanged();
+                    OnIndexerPropertyChanged();
+                    OnCollectionChanged(NotifyCollectionChangedAction.Replace, itemsToReplace, newItems, index);
+                }
+            }
         }
 
         /// <summary>
@@ -124,9 +213,51 @@ namespace System.Collections.ObjectModel
             CheckReentrancy();
             base.InsertItem(index, item);
 
-            OnCountPropertyChanged();
-            OnIndexerPropertyChanged();
-            OnCollectionChanged(NotifyCollectionChangedAction.Add, item, index);
+            if (!_skipRaisingEvents)
+            {
+                OnCountPropertyChanged();
+                OnIndexerPropertyChanged();
+                OnCollectionChanged(NotifyCollectionChangedAction.Add, item, index);
+            }
+        }
+
+        /// <summary>
+        /// Called by base class Collection&lt;T&gt; when a collection of items is added to list;
+        /// raises a CollectionChanged event to any listeners.
+        /// </summary>
+        protected override void InsertItemsRange(int index, IEnumerable<T> collection)
+        {
+            CheckReentrancy();
+
+            bool ignore = _skipRaisingEvents;
+            if (!ignore)
+            {
+                _skipRaisingEvents = true;
+            }
+
+            try
+            {
+                base.InsertItemsRange(index, collection);
+            }
+            finally
+            {
+                if (!ignore)
+                {
+                    _skipRaisingEvents = false;
+                }
+            }
+
+            if (!_skipRaisingEvents)
+            {
+                IList newItems = collection is IList list ? list : new List<T>(collection);
+
+                if (newItems.Count > 0)
+                {
+                    OnCountPropertyChanged();
+                    OnIndexerPropertyChanged();
+                    OnCollectionChanged(NotifyCollectionChangedAction.Add, newItems, index);
+                }
+            }
         }
 
         /// <summary>
@@ -260,6 +391,14 @@ namespace System.Collections.ObjectModel
         private void OnCollectionChanged(NotifyCollectionChangedAction action, object? item, int index, int oldIndex)
         {
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(action, item, index, oldIndex));
+        }
+
+        /// <summary>
+        /// Helper to raise CollectionChanged event to any listeners
+        /// </summary>
+        private void OnCollectionChanged(NotifyCollectionChangedAction action, IList? items, int index)
+        {
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(action, items, index));
         }
 
         /// <summary>

--- a/src/libraries/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
+++ b/src/libraries/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
@@ -134,6 +134,26 @@ namespace System.Collections.ObjectModel
             bool ignore = _skipRaisingEvents;
             if (!ignore)
             {
+                if (Items.IsReadOnly)
+                {
+                    throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
+                }
+
+                if ((uint)index > (uint)Items.Count)
+                {
+                    throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_InvalidThreshold);
+                }
+
+                if (count < 0)
+                {
+                    throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_NeedNonNegNum);
+                }
+
+                if (index > Items.Count - count)
+                {
+                    throw new ArgumentException(SR.Argument_ItemNotExist);
+                }
+
                 _skipRaisingEvents = true;
 
                 if (count > 0)

--- a/src/libraries/System.ObjectModel/tests/ObservableCollection/ObservableCollection_RangeTest.cs
+++ b/src/libraries/System.ObjectModel/tests/ObservableCollection/ObservableCollection_RangeTest.cs
@@ -1,0 +1,273 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using Xunit;
+
+namespace System.Collections.ObjectModel.Tests
+{
+    /// <summary>
+    /// Tests the public methods in ObservableCollection<T> as well as verifies
+    /// that the CollectionChanged events and eventargs are fired and populated
+    /// properly.
+    /// </summary>
+    public static class RangeTests
+    {
+        [Fact]
+        public static void InsertRange_NotifyCollectionChanged_Beginning_Test()
+        {
+            int[] dataToInsert = new int[] { 1, 2, 3, 4, 5 };
+            int[] initialData = new int[] { 10, 11, 12, 13 };
+            int eventCounter = 0;
+            ObservableCollection<int> collection = new ObservableCollection<int>(initialData);
+            collection.CollectionChanged += (o, e) => eventCounter++;
+
+            collection.InsertRange(0, dataToInsert);
+
+            Assert.Equal(dataToInsert.Length + initialData.Length, collection.Count);
+            Assert.Equal(1, eventCounter);
+
+            int[] collectionAssertion = collection.ToArray();
+            Assert.Equal(dataToInsert, collectionAssertion.AsSpan(0, 5).ToArray());
+            Assert.Equal(initialData, collectionAssertion.AsSpan(5).ToArray());
+        }
+
+        [Fact]
+        public static void InsertRange_NotifyCollectionChanged_Middle_Test()
+        {
+            int[] dataToInsert = new int[] { 1, 2, 3, 4, 5 };
+            int[] initialData = new int[] { 10, 11, 12, 13 };
+            int eventCounter = 0;
+            ObservableCollection<int> collection = new ObservableCollection<int>(initialData);
+            collection.CollectionChanged += (o, e) => eventCounter++;
+
+            collection.InsertRange(2, dataToInsert);
+
+            Assert.Equal(dataToInsert.Length + initialData.Length, collection.Count);
+            Assert.Equal(1, eventCounter);
+
+            int[] collectionAssertion = collection.ToArray();
+            Assert.Equal(initialData.AsSpan(0, 2).ToArray(), collectionAssertion.AsSpan(0, 2).ToArray());
+            Assert.Equal(dataToInsert, collectionAssertion.AsSpan(2, 5).ToArray());
+            Assert.Equal(initialData.AsSpan(2, 2).ToArray(), collectionAssertion.AsSpan(7, 2).ToArray());
+        }
+
+        [Fact]
+        public static void InsertRange_NotifyCollectionChanged_End_Test()
+        {
+            int[] dataToInsert = new int[] { 1, 2, 3, 4, 5 };
+            int[] initialData = new int[] { 10, 11, 12, 13 };
+            int eventCounter = 0;
+            ObservableCollection<int> collection = new ObservableCollection<int>(initialData);
+            collection.CollectionChanged += (o, e) => eventCounter++;
+
+            collection.InsertRange(4, dataToInsert);
+
+            Assert.Equal(dataToInsert.Length + initialData.Length, collection.Count);
+            Assert.Equal(1, eventCounter);
+
+            int[] collectionAssertion = collection.ToArray();
+            Assert.Equal(initialData, collectionAssertion.AsSpan(0, 4).ToArray());
+            Assert.Equal(dataToInsert, collectionAssertion.AsSpan(4).ToArray());
+        }
+
+        [Fact]
+        public static void AddRange_NotifyCollectionChanged_Test()
+        {
+            int[] dataToInsert = new int[] { 1, 2, 3, 4, 5 };
+            int[] initialData = new int[] { 10, 11, 12, 13 };
+            int eventCounter = 0;
+            ObservableCollection<int> collection = new ObservableCollection<int>(initialData);
+            collection.CollectionChanged += (o, e) => eventCounter++;
+
+            collection.AddRange(dataToInsert);
+
+            Assert.Equal(dataToInsert.Length + initialData.Length, collection.Count);
+            Assert.Equal(1, eventCounter);
+
+            int[] collectionAssertion = collection.ToArray();
+            Assert.Equal(initialData, collectionAssertion.AsSpan(0, 4).ToArray());
+            Assert.Equal(dataToInsert, collectionAssertion.AsSpan(4).ToArray());
+        }
+
+        [Fact]
+        public static void AddRange_NotifyCollectionChanged_EventArgs_Test()
+        {
+            int[] dataToAdd = new int[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            int[] actualDataAdded = new int[0];
+            ObservableCollection<int> collection = new ObservableCollection<int>();
+            collection.CollectionChanged += (o, e) => actualDataAdded = e.NewItems.Cast<int>().ToArray();
+
+            collection.AddRange(dataToAdd);
+
+            Assert.Equal(dataToAdd, actualDataAdded);
+        }
+
+        [Fact]
+        public static void InsertRange_NotifyCollectionChanged_EventArgs_Test()
+        {
+            int[] dataToAdd = new int[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            int[] actualDataAdded = new int[0];
+            ObservableCollection<int> collection = new ObservableCollection<int>();
+            collection.CollectionChanged += (o, e) => actualDataAdded = e.NewItems.Cast<int>().ToArray();
+
+            collection.InsertRange(0, dataToAdd);
+
+            Assert.Equal(dataToAdd, actualDataAdded);
+        }
+
+        [Fact]
+        public static void InsertRange_NotifyCollectionChanged_EventArgs_Middle_Test()
+        {
+            int[] dataToAdd = new int[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            int[] actualDataAdded = new int[0];
+            ObservableCollection<int> collection = new ObservableCollection<int>();
+            for (int i = 0; i < 4; i++)
+            {
+                collection.Add(i);
+            }
+
+            collection.CollectionChanged += (o, e) => actualDataAdded = e.NewItems.Cast<int>().ToArray();
+            collection.InsertRange(2, dataToAdd);
+
+            Assert.Equal(dataToAdd, actualDataAdded);
+        }
+
+        [Fact]
+        public static void InsertRange_NotifyCollectionChanged_EventArgs_End_Test()
+        {
+            int[] dataToAdd = new int[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            int[] actualDataAdded = new int[0];
+            ObservableCollection<int> collection = new ObservableCollection<int>();
+            for (int i = 0; i < 4; i++)
+            {
+                collection.Add(i);
+            }
+
+            collection.CollectionChanged += (o, e) => actualDataAdded = e.NewItems.Cast<int>().ToArray();
+            collection.InsertRange(4, dataToAdd);
+
+            Assert.Equal(dataToAdd, actualDataAdded);
+        }
+
+        [Fact]
+        public static void RemoveRange_NotifyCollectionChanged_FirstTwo_Test()
+        {
+            int[] initialData = new int[] { 10, 11, 12, 13 };
+            int itemsToRemove = 2;
+            int eventCounter = 0;
+            ObservableCollection<int> collection = new ObservableCollection<int>(initialData);
+            collection.CollectionChanged += (o, e) => eventCounter++;
+
+            collection.RemoveRange(0, itemsToRemove);
+
+            Assert.Equal(initialData.Length - itemsToRemove, collection.Count);
+            Assert.Equal(1, eventCounter);
+            Assert.Equal(initialData.AsSpan(2).ToArray(), collection.ToArray());
+        }
+
+        [Fact]
+        public static void RemoveRange_NotifyCollectionChanged_MiddleTwo_Test()
+        {
+            int[] initialData = new int[] { 10, 11, 12, 13 };
+            int itemsToRemove = 2;
+            int eventCounter = 0;
+            ObservableCollection<int> collection = new ObservableCollection<int>(initialData);
+            collection.CollectionChanged += (o, e) => eventCounter++;
+
+            collection.RemoveRange(1, itemsToRemove);
+
+            Assert.Equal(initialData.Length - itemsToRemove, collection.Count);
+            Assert.Equal(1, eventCounter);
+            Assert.Equal(initialData[0], collection[0]);
+            Assert.Equal(initialData[3], collection[1]);
+        }
+
+        [Fact]
+        public static void RemoveRange_NotifyCollectionChanged_LastTwo_Test()
+        {
+            int[] initialData = new int[] { 10, 11, 12, 13 };
+            int itemsToRemove = 2;
+            int eventCounter = 0;
+            ObservableCollection<int> collection = new ObservableCollection<int>(initialData);
+            collection.CollectionChanged += (o, e) => eventCounter++;
+
+            collection.RemoveRange(2, itemsToRemove);
+
+            Assert.Equal(initialData.Length - itemsToRemove, collection.Count);
+            Assert.Equal(1, eventCounter);
+            Assert.Equal(initialData.AsSpan(0, 2).ToArray(), collection.ToArray());
+        }
+
+        [Fact]
+        public static void RemoveRange_NotifyCollectionChanged_IntMaxValueOverflow_Test()
+        {
+            int count = 500;
+            ObservableCollection<int> collection = new ObservableCollection<int>();
+            for (int i = 0; i < count; i++)
+            {
+                collection.Add(i);
+            }
+
+            Assert.Throws<ArgumentException>(() => collection.RemoveRange(collection.Count - 2, int.MaxValue));
+        }
+
+        [Fact]
+        public static void RemoveRange_NotifyCollectionChanged_EventArgs_IndexOfZero_Test()
+        {
+            int[] initialData = new int[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            int[] actualDataRemoved = new int[0];
+            int numberOfItemsToRemove = 4;
+            ObservableCollection<int> collection = new ObservableCollection<int>();
+            foreach (int item in initialData)
+            {
+                collection.Add(item);
+            }
+
+            collection.CollectionChanged += (o, e) => actualDataRemoved = e.OldItems.Cast<int>().ToArray();
+            collection.RemoveRange(0, numberOfItemsToRemove);
+
+            Assert.Equal(initialData.Length - numberOfItemsToRemove, collection.Count);
+            Assert.Equal(initialData.AsSpan(0, numberOfItemsToRemove).ToArray(), actualDataRemoved);
+        }
+
+        [Fact]
+        public static void RemoveRange_NotifyCollectionChanged_EventArgs_IndexMiddle_Test()
+        {
+            int[] initialData = new int[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            int[] actualDataRemoved = new int[0];
+            int numberOfItemsToRemove = 4;
+            int startIndex = 3;
+            ObservableCollection<int> collection = new ObservableCollection<int>();
+            foreach (int item in initialData)
+            {
+                collection.Add(item);
+            }
+
+            collection.CollectionChanged += (o, e) => actualDataRemoved = e.OldItems.Cast<int>().ToArray();
+            collection.RemoveRange(startIndex, numberOfItemsToRemove);
+
+            Assert.Equal(initialData.Length - numberOfItemsToRemove, collection.Count);
+            Assert.Equal(initialData.AsSpan(startIndex, numberOfItemsToRemove).ToArray(), actualDataRemoved);
+        }
+
+        [Fact]
+        public static void ReplaceRange_NotifyCollectionChanged_Test()
+        {
+            int[] initialData = new int[] { 10, 11, 12, 13 };
+            int[] dataToReplace = new int[] { 3, 8 };
+            int eventCounter = 0;
+            ObservableCollection<int> collection = new ObservableCollection<int>(initialData);
+            collection.CollectionChanged += (o, e) => eventCounter++;
+
+            collection.ReplaceRange(0, 2, dataToReplace);
+
+            Assert.Equal(initialData.Length, collection.Count);
+            Assert.Equal(1, eventCounter);
+
+            int[] collectionAssertion = collection.ToArray();
+            Assert.Equal(dataToReplace, collectionAssertion.AsSpan(0, 2).ToArray());
+            Assert.Equal(initialData.AsSpan(2, 2).ToArray(), collectionAssertion.AsSpan(2, 2).ToArray());
+        }
+    }
+}

--- a/src/libraries/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
+++ b/src/libraries/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\Collections\IEnumerableTest.cs"
-             Link="Common\System\CollectionsIEnumerableTest.cs" />
+         Link="Common\System\CollectionsIEnumerableTest.cs" />
     <Compile Include="$(CommonTestPath)System\Collections\ICollectionTest.cs"
              Link="Common\System\CollectionsICollectionTest.cs" />
     <Compile Include="$(CommonTestPath)System\Collections\IListTest.cs"
@@ -16,6 +16,7 @@
     <Compile Include="$(CommonTestPath)System\Collections\IDictionaryTest.cs"
              Link="Common\System\CollectionsIDictionaryTest.cs" />
     <Compile Include="ObservableCollection\ObservableCollection_ConstructorAndPropertyTests.cs" />
+    <Compile Include="ObservableCollection\ObservableCollection_RangeTest.cs" />
     <Compile Include="ObservableCollection\ObservableCollection_MethodsTest.cs" />
     <Compile Include="ObservableCollection\ObservableCollection_ReentrancyTests.cs" />
     <Compile Include="ObservableCollection\ObservableCollection_Serialization.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/ObjectModel/Collection.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/ObjectModel/Collection.cs
@@ -62,6 +62,8 @@ namespace System.Collections.ObjectModel
             InsertItem(index, item);
         }
 
+        public void AddRange(IEnumerable<T> collection) => InsertItemsRange(items.Count, collection);
+
         public void Clear()
         {
             if (items.IsReadOnly)
@@ -107,6 +109,8 @@ namespace System.Collections.ObjectModel
             InsertItem(index, item);
         }
 
+        public void InsertRange(int index, IEnumerable<T> collection) => InsertItemsRange(index, collection);
+
         public bool Remove(T item)
         {
             if (items.IsReadOnly)
@@ -119,6 +123,10 @@ namespace System.Collections.ObjectModel
             RemoveItem(index);
             return true;
         }
+
+        public void RemoveRange(int index, int count) => RemoveItemsRange(index, count);
+
+        public void ReplaceRange(int index, int count, IEnumerable<T> collection) => ReplaceItemsRange(index, count, collection);
 
         public void RemoveAt(int index)
         {
@@ -133,6 +141,77 @@ namespace System.Collections.ObjectModel
             }
 
             RemoveItem(index);
+        }
+
+        protected virtual void InsertItemsRange(int index, IEnumerable<T> collection)
+        {
+            if (items.IsReadOnly)
+            {
+                ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ReadOnlyCollection);
+            }
+
+            if (collection == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.list);
+            }
+
+            if ((uint)index > (uint)items.Count)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_ListInsert);
+            }
+
+            if (GetType() == typeof(Collection<T>) && items is List<T> list)
+            {
+                list.InsertRange(index, collection);
+            }
+            else
+            {
+                foreach (T item in collection)
+                {
+                    InsertItem(index++, item);
+                }
+            }
+        }
+
+        protected virtual void RemoveItemsRange(int index, int count)
+        {
+            if (items.IsReadOnly)
+            {
+                ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ReadOnlyCollection);
+            }
+
+            if ((uint)index > (uint)items.Count)
+            {
+                ThrowHelper.ThrowArgumentOutOfRange_IndexException();
+            }
+
+            if (count < 0)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if (index > items.Count - count)
+            {
+                ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
+            }
+
+            if (GetType() == typeof(Collection<T>) && items is List<T> list)
+            {
+                list.RemoveRange(index, count);
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    RemoveItem(index);
+                }
+            }
+        }
+
+        protected virtual void ReplaceItemsRange(int index, int count, IEnumerable<T> collection)
+        {
+            RemoveItemsRange(index, count);
+            InsertItemsRange(index, collection);
         }
 
         protected virtual void ClearItems()

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -8610,6 +8610,7 @@ namespace System.Collections.ObjectModel
         bool System.Collections.IList.IsReadOnly { get { throw null; } }
         object? System.Collections.IList.this[int index] { get { throw null; } set { } }
         public void Add(T item) { }
+        public void AddRange(System.Collections.Generic.IEnumerable<T> collection) { }
         public void Clear() { }
         protected virtual void ClearItems() { }
         public bool Contains(T item) { throw null; }
@@ -8618,9 +8619,15 @@ namespace System.Collections.ObjectModel
         public int IndexOf(T item) { throw null; }
         public void Insert(int index, T item) { }
         protected virtual void InsertItem(int index, T item) { }
+        protected virtual void InsertItemsRange(int index, System.Collections.Generic.IEnumerable<T> collection) { }
+        public void InsertRange(int index, System.Collections.Generic.IEnumerable<T> collection) { }
         public bool Remove(T item) { throw null; }
         public void RemoveAt(int index) { }
         protected virtual void RemoveItem(int index) { }
+        protected virtual void RemoveItemsRange(int index, int count) { }
+        public void RemoveRange(int index, int count) { }
+        protected virtual void ReplaceItemsRange(int index, int count, System.Collections.Generic.IEnumerable<T> collection) { }
+        public void ReplaceRange(int index, int count, System.Collections.Generic.IEnumerable<T> collection) { }
         protected virtual void SetItem(int index, T item) { }
         void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="System\ByteTests.cs" />
     <Compile Include="System\CharTests.cs" />
     <Compile Include="System\CLSCompliantAttributeTests.cs" />
+    <Compile Include="System\Collections\ObjectModel\RangeCollectionTests.cs" />
     <Compile Include="System\DateOnlyTests.cs" />
     <Compile Include="System\DateTimeTests.cs" />
     <Compile Include="System\DateTimeOffsetTests.cs" />

--- a/src/libraries/System.Runtime/tests/System/Collections/ObjectModel/RangeCollectionTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Collections/ObjectModel/RangeCollectionTests.cs
@@ -1,0 +1,422 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace System.Collections.ObjectModel.Tests
+{
+    /// <summary>
+    /// Since <see cref="Collection{T}"/> is just a wrapper base class around an <see cref="IList{T}"/>,
+    /// we just verify that the underlying list is what we expect, validate that the calls which
+    /// we expect are forwarded to the underlying list, and verify that the exceptions we expect
+    /// are thrown.
+    /// </summary>
+    public class RangeCollectionTests : CollectionTestBase
+    {
+        [Fact]
+        public void Collection_AddRange_ToEmpty_Test()
+        {
+            int[] expected = new[] { 1, 2, 3, 4 };
+            Collection<int> collection = new Collection<int>();
+
+            collection.AddRange(expected);
+
+            Assert.NotNull(collection);
+            Assert.Equal(expected.Length, collection.Count);
+            Assert.Equal(expected, collection.ToArray());
+        }
+
+        [Fact]
+        public void Collection_AddRange_ToExisting_Test()
+        {
+            int[] initial = new int[] { 1, 2, 3, 4 };
+            int[] dataToInsert = new int[] { 5, 6, 7, 8 };
+            Collection<int> collection = new Collection<int>();
+            for (int i = 0; i < initial.Length; i++)
+                collection.Add(initial[i]);
+
+            collection.AddRange(dataToInsert);
+
+            Assert.NotNull(collection);
+            Assert.Equal(initial.Length + dataToInsert.Length, collection.Count);
+
+            int[] collectionAssertion = collection.ToArray();
+            Assert.Equal(initial, collectionAssertion.AsSpan(0, 4).ToArray());
+            Assert.Equal(dataToInsert, collectionAssertion.AsSpan(4, 4).ToArray());
+        }
+
+        [Fact]
+        public void Collection_AddRange_Empty_Test()
+        {
+            int[] expected = new int[0];
+            Collection<int> collection = new Collection<int>();
+
+            collection.AddRange(expected);
+
+            Assert.NotNull(collection);
+            Assert.Equal(expected.Length, collection.Count);
+        }
+
+        [Fact]
+        public void Collection_AddRange_Null_Test()
+        {
+            Collection<int> collection = new Collection<int>();
+            Exception ex = Assert.Throws<ArgumentNullException>(() => collection.AddRange(null));
+        }
+
+        [Fact]
+        public void Collection_AddRange_ReadOnly_Test()
+        {
+            int[] expected = new int[] { 1, 2, 3, 4 };
+            int[] baseCollection = new int[] { 5, 6, 7, 8 };
+            Collection<int> collection = new Collection<int>(baseCollection);
+
+            Exception ex = Assert.Throws<NotSupportedException>(() => collection.AddRange(expected));
+        }
+
+        [Fact]
+        public void Collection_InsertRange_Beginning_Test()
+        {
+            int[] expected = new int[] { 1, 2, 3, 4, 5 };
+            int[] originalCollection = new int[] { 10, 11, 12, 13 };
+            List<int> baseCollection = new List<int>(originalCollection);
+
+            int expectedLength = expected.Length + originalCollection.Length;
+            Collection<int> collection = new Collection<int>(baseCollection);
+
+            collection.InsertRange(0, expected);
+
+            Assert.NotNull(collection);
+            Assert.Equal(expectedLength, collection.Count);
+
+            int[] collectionAssertion = collection.ToArray();
+            Assert.Equal(expected, collectionAssertion.AsSpan(0, 5).ToArray());
+            Assert.Equal(originalCollection, collectionAssertion.AsSpan(5, 4).ToArray());
+        }
+
+        [Fact]
+        public void Collection_InsertRange_End_Test()
+        {
+            int[] expected = new int[] { 1, 2, 3, 4, 5 };
+            int[] originalCollection = new int[] { 10, 11, 12, 13 };
+            List<int> baseCollection = new List<int>(originalCollection);
+
+            int expectedLength = expected.Length + originalCollection.Length;
+            Collection<int> collection = new Collection<int>(baseCollection);
+
+            collection.InsertRange(expected.Length - 1, expected);
+
+            Assert.NotNull(collection);
+            Assert.Equal(expectedLength, collection.Count);
+
+            int[] collectionAssertion = collection.ToArray();
+            Assert.Equal(originalCollection, collectionAssertion.AsSpan(0, 4).ToArray());
+            Assert.Equal(expected, collectionAssertion.AsSpan(4, 5).ToArray());
+        }
+
+        [Fact]
+        public void Collection_InsertRange_Middle_Test()
+        {
+            int[] expected = new int[] { 1, 2, 3, 4, 5 };
+            int[] originalCollection = new int[] { 10, 11, 12, 13 };
+            List<int> baseCollection = new List<int>(originalCollection);
+
+            int expectedLength = expected.Length + originalCollection.Length;
+            Collection<int> collection = new Collection<int>(baseCollection);
+
+            collection.InsertRange(2, expected);
+
+            Assert.NotNull(collection);
+            Assert.Equal(expectedLength, collection.Count);
+
+            int[] collectionAssertion = collection.ToArray();
+            Assert.Equal(originalCollection.AsSpan(0, 2).ToArray(), collectionAssertion.AsSpan(0, 2).ToArray());
+            Assert.Equal(expected, collectionAssertion.AsSpan(2, 5).ToArray());
+            Assert.Equal(originalCollection.AsSpan(2, 2).ToArray(), collectionAssertion.AsSpan(7, 2).ToArray());
+        }
+
+        [Fact]
+        public void Collection_InsertRange_Empty_Test()
+        {
+            List<int> baseCollection = new List<int>(new[] { 10, 11, 12, 13 });
+            Collection<int> collection = new Collection<int>(baseCollection);
+
+            collection.InsertRange(0, new int[0]);
+
+            Assert.NotNull(collection);
+            Assert.Equal(baseCollection.Count, collection.Count);
+            Assert.Equal(baseCollection, collection.ToArray());
+        }
+
+        [Fact]
+        public void Collection_InsertRange_Null_Test()
+        {
+            Collection<int> collection = new Collection<int>();
+            Exception ex = Assert.Throws<ArgumentNullException>(() => collection.InsertRange(0, null));
+        }
+
+        [Fact]
+        public void Collection_InsertRange_ReadOnly_Test()
+        {
+            int[] expected = new int[] { 1, 2, 3, 4 };
+            int[] baseCollection = new int[] { 5, 6, 7, 8 };
+            Collection<int> collection = new Collection<int>(baseCollection);
+
+            Exception ex = Assert.Throws<NotSupportedException>(() => collection.InsertRange(0, expected));
+        }
+
+        [Fact]
+        public void Collection_InsertRange_IndexLessThan0_Test()
+        {
+            int[] expected = new int[] { 1, 2, 3, 4 };
+            Collection<int> collection = new Collection<int>();
+            Exception ex = Assert.Throws<ArgumentOutOfRangeException>(() => collection.InsertRange(-1, expected));
+        }
+
+        [Fact]
+        public void Collection_InsertRange_IndexGreaterThanCount_Test()
+        {
+            int[] expected = new int[] { 1, 2, 3, 4 };
+            Collection<int> collection = new Collection<int>();
+            Exception ex = Assert.Throws<ArgumentOutOfRangeException>(() => collection.InsertRange(10, expected));
+        }
+
+        [Fact]
+        public void Collection_RemoveRange_Overflow_Test()
+        {
+            Collection<int> collection = new Collection<int>();
+            collection.Add(1);
+            collection.Add(2);
+            collection.Add(3);
+
+            Assert.Throws<ArgumentException>(() => collection.RemoveRange(0, 4));
+        }
+
+        [Fact]
+        public void Collection_RemoveRange_IntMaxValueOverflow_Test()
+        {
+            var count = 500;
+            Collection<int> collection = new Collection<int>();
+            for (int i = 0; i < count; i++)
+            {
+                collection.Add(i);
+            }
+
+            Assert.Throws<ArgumentException>(() => collection.RemoveRange(collection.Count - 2, int.MaxValue));
+        }
+
+        [Fact]
+        public void Collection_RemoveRange_CountIsZero_Test()
+        {
+            int[] expected = new int[] { 1, 2, 3, 4, 5 };
+            Collection<int> collection = new Collection<int>();
+            for (int i = 0; i < expected.Length; i++)
+            {
+                collection.Add(expected[i]);
+            }
+
+            collection.RemoveRange(0, 0);
+
+            Assert.NotNull(collection);
+            Assert.Equal(expected.Length, collection.Count);
+            Assert.Equal(expected, collection.ToArray());
+        }
+
+        [Fact]
+        public void Collection_RemoveRange_CountIsLessThanZero_Test()
+        {
+            Collection<int> collection = new Collection<int>();
+            collection.Add(1);
+            collection.Add(2);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => collection.RemoveRange(0, -1));
+        }
+
+        [Fact]
+        public void Collection_RemoveRange_All_Test()
+        {
+            Collection<int> collection = new Collection<int>();
+            collection.Add(1);
+            collection.Add(2);
+            collection.Add(3);
+
+            collection.RemoveRange(0, 3);
+
+            Assert.NotNull(collection);
+            Assert.Equal(0, collection.Count);
+        }
+
+        [Fact]
+        public void Collection_RemoveRange_FirstTwoItems_Test()
+        {
+            Collection<int> collection = new Collection<int>();
+            collection.Add(1);
+            collection.Add(2);
+            collection.Add(3);
+
+            collection.RemoveRange(0, 2);
+
+            Assert.NotNull(collection);
+            Assert.Equal(1, collection.Count);
+            Assert.Equal(3, collection[0]);
+        }
+
+        [Fact]
+        public void Collection_RemoveRange_LastTwoItems_Test()
+        {
+            Collection<int> collection = new Collection<int>();
+            collection.Add(1);
+            collection.Add(2);
+            collection.Add(3);
+
+            collection.RemoveRange(1, 2);
+
+            Assert.NotNull(collection);
+            Assert.Equal(1, collection.Count);
+            Assert.Equal(1, collection[0]);
+        }
+
+        [Fact]
+        public void Collection_RemoveRange_ZeroItems_Test()
+        {
+            Collection<int> collection = new Collection<int>();
+            collection.Add(1);
+            collection.Add(2);
+            collection.Add(3);
+
+            collection.RemoveRange(0, 0);
+
+            Assert.NotNull(collection);
+            Assert.Equal(3, collection.Count);
+            Assert.Equal(1, collection[0]);
+            Assert.Equal(2, collection[1]);
+            Assert.Equal(3, collection[2]);
+        }
+
+        [Fact]
+        public void Collection_RemoveRange_IndexLessThanZero_Test()
+        {
+            Collection<int> collection = new Collection<int>();
+            collection.Add(1);
+            collection.Add(2);
+            collection.Add(3);
+
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => collection.RemoveRange(-1, 3));
+        }
+
+        [Fact]
+        public void Collection_RemoveRange_IndexGreaterThanCollection_Test()
+        {
+            Collection<int> collection = new Collection<int>();
+            collection.Add(1);
+            collection.Add(2);
+            collection.Add(3);
+
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => collection.RemoveRange(4, 3));
+        }
+
+        [Fact]
+        public void Collection_RemoveRange_ReadOnly_Test()
+        {
+            Collection<int> collection = new Collection<int>(new int[] { 1, 2, 3 });
+
+            Assert.Throws<NotSupportedException>(() => collection.RemoveRange(0, 2));
+        }
+
+        [Fact]
+        public void Collection_ReplaceRange_FirstTwo_Test()
+        {
+            int[] initial = new int[] { 1, 2, 3, 4 };
+            int[] replace = new int[] { 5, 6, 7, 8 };
+            Collection<int> collection = new Collection<int>();
+            foreach (var item in initial)
+                collection.Add(item);
+
+            collection.ReplaceRange(0, 2, replace);
+
+            Assert.NotNull(collection);
+            Assert.Equal(initial.Length + 2, collection.Count);
+
+            int[] collectionAssertion = collection.ToArray();
+            Assert.Equal(replace, collectionAssertion.AsSpan(0, 4).ToArray());
+            Assert.Equal(initial.AsSpan(2, 2).ToArray(), collectionAssertion.AsSpan(4, 2).ToArray());
+        }
+
+        [Fact]
+        public void Collection_ReplaceRange_LastTwo_Test()
+        {
+            int[] initial = new int[] { 1, 2, 3, 4 };
+            int[] replace = new int[] { 5, 6, 7, 8 };
+            Collection<int> collection = new Collection<int>();
+            foreach (var item in initial)
+                collection.Add(item);
+
+            collection.ReplaceRange(2, 2, replace);
+
+            Assert.NotNull(collection);
+            Assert.Equal(initial.Length + 2, collection.Count);
+
+            int[] collectionAssertion = collection.ToArray();
+            Assert.Equal(initial.AsSpan(0, 2).ToArray(), collectionAssertion.AsSpan(0, 2).ToArray());
+            Assert.Equal(replace.AsSpan(0, 4).ToArray(), collectionAssertion.AsSpan(2, 4).ToArray());
+        }
+
+        [Fact]
+        public void Collection_ReplaceRange_MiddleTwo_Test()
+        {
+            int[] initial = new int[] { 1, 2, 3, 4 };
+            int[] replace = new int[] { 5, 6, 7, 8 };
+            Collection<int> collection = new Collection<int>();
+            foreach (var item in initial)
+                collection.Add(item);
+
+            collection.ReplaceRange(1, 2, replace);
+
+            Assert.NotNull(collection);
+            Assert.Equal(initial.Length + 2, collection.Count);
+
+            Assert.Equal(initial[0], collection[0]);
+            Assert.Equal(replace, collection.ToArray().AsSpan(1, 4).ToArray());
+            Assert.Equal(initial[3], collection[5]);
+        }
+
+        [Fact]
+        public void Collection_ReplaceRange_NullCollection_Test()
+        {
+            Collection<int> collection = new Collection<int>();
+            collection.Add(1);
+            collection.Add(2);
+
+            Assert.Throws<ArgumentNullException>(() => collection.ReplaceRange(0, 2, null));
+        }
+
+        [Fact]
+        public void Collection_ReplaceRange_ReadOnly_Test()
+        {
+            Collection<int> collection = new Collection<int>(new int[] { 1, 2, 3 });
+            Assert.Throws<NotSupportedException>(() => collection.ReplaceRange(0, 2, new int[] { 4, 5 }));
+        }
+
+        [Fact]
+        public void Collection_ReplaceRange_IndexLessThanZero_Test()
+        {
+            Collection<int> collection = new Collection<int>();
+            collection.Add(1);
+            collection.Add(2);
+
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => collection.ReplaceRange(-2, 2, new int[] { 1, 2 }));
+        }
+
+        [Fact]
+        public void Collection_ReplaceRange_IndexGreaterThanCount_Test()
+        {
+            Collection<int> collection = new Collection<int>();
+            collection.Add(1);
+            collection.Add(2);
+
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => collection.ReplaceRange(4, 2, new int[] { 1, 2 }));
+        }
+    }
+}


### PR DESCRIPTION
Re-Adds range manipulation APIs for `Collection<T>` and `ObservableCollection<T>`

Resolves: #18087

Added the following new API that have been approved in #18087:
```csharp
// Adds a range to the end of the collection.
// Raises CollectionChanged (NotifyCollectionChangedAction.Add)
public void AddRange(IEnumerable<T> collection) => InsertItemsRange(0, collection);

// Inserts a range
// Raises CollectionChanged (NotifyCollectionChangedAction.Add)
public void InsertRange(int index, IEnumerable<T> collection) => InsertItemsRange(index, collection);

// Removes a range.
// Raises CollectionChanged (NotifyCollectionChangedAction.Remove)
public void RemoveRange(int index, int count) => RemoveItemsRange(index, count);

// Will allow to replace a range with fewer, equal, or more items.
// Raises CollectionChanged (NotifyCollectionChangedAction.Replace)
public void ReplaceRange(int index, int count, IEnumerable<T> collection)
{
     RemoveItemsRange(index, count);
     InsertItemsRange(index, collection);
}

// virtual methods
protected virtual void InsertItemsRange(int index, IEnumerable<T> collection);
protected virtual void RemoveItemsRange(int index, int count);
```

The code contained in this PR has already gone through a full PR review that was originally submitted in 2019 and was pulled due to downstream breaking changes in WPF. I have been talking with the .NET Team and the WPF Team and they both have approved the necessary changes to WPF to get this to work.

Original PRs
* https://github.com/dotnet/coreclr/pull/23018
* https://github.com/dotnet/corefx/pull/35772

Related WPF Issues/PRs
* https://github.com/dotnet/wpf/pull/6097
* https://github.com/dotnet/wpf/issues/1887

### Benchmarks - 2/11/2022
```
BenchmarkDotNet=v0.13.1.1694-nightly, OS=Windows 10 (10.0.19043.1466/21H1/May2021Update)
AMD Ryzen 9 3950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=7.0.100-dev
  [Host]     : .NET 7.0.0 (7.0.22.10302), X64 RyuJIT
  Job-WEEQYH : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:DebugType=portable,-bl:benchmarkdotnet.binlog  Toolchain=CoreRun
IterationTime=250.0000 ms  MaxIterationCount=20  MinIterationCount=15
WarmupCount=1

|                            Method | Size |       Mean |     Error |    StdDev |     Median |        Min |        Max |  Gen 0 |  Gen 1 | Allocated |
|---------------------------------- |----- |-----------:|----------:|----------:|-----------:|-----------:|-----------:|-------:|-------:|----------:|
|          ObservableCollection_Add |  512 |  13.312 us | 0.2078 us | 0.1943 us |  13.216 us |  13.139 us |  13.834 us | 5.3797 | 0.1582 |  44.24 KB |
|     ObservableCollection_AddRange |  512 |   7.043 us | 0.0797 us | 0.0706 us |   7.031 us |   6.941 us |   7.199 us | 1.0054 | 0.0279 |   8.34 KB |
|       ObservableCollection_Insert |  512 |  13.729 us | 0.2636 us | 0.2707 us |  13.604 us |  13.488 us |  14.310 us | 5.3926 | 0.1618 |  44.24 KB |
|  ObservableCollection_InsertRange |  512 |   6.986 us | 0.0343 us | 0.0268 us |   6.980 us |   6.958 us |   7.053 us | 1.0141 | 0.0290 |   8.34 KB |
|       ObservableCollection_Remove |  512 | 117.300 us | 0.6794 us | 0.6355 us | 117.100 us | 116.313 us | 118.329 us | 2.3321 |      - |  22.11 KB |
|  ObservableCollection_RemoveRange |  512 |  33.449 us | 0.2618 us | 0.2449 us |  33.412 us |  33.094 us |  33.839 us | 0.9328 |      - |    8.2 KB |
|      ObservableCollection_Replace |  512 |  93.224 us | 0.8643 us | 0.8085 us |  92.844 us |  92.183 us |  94.654 us | 9.2456 |      - |  76.11 KB |
| ObservableCollection_ReplaceRange |  512 |  39.413 us | 0.1830 us | 0.1712 us |  39.404 us |  39.126 us |  39.677 us | 0.9422 |      - |   8.26 KB |
```