### PR TITLE
disable TotalMemory2 test from gcstress runs

### DIFF
--- a/src/tests/GC/API/GC/TotalMemory.csproj
+++ b/src/tests/GC/API/GC/TotalMemory.csproj
@@ -3,6 +3,10 @@
     <OutputType>Exe</OutputType>
     <CLRTestExecutionArguments />
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- This test is failing under GCStress variations, so disabling it under GCStress till the issue is investigated:
+         Issue: https://github.com/dotnet/runtime/issues/63860
+    -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/GC/API/GC/TotalMemory2.csproj
+++ b/src/tests/GC/API/GC/TotalMemory2.csproj
@@ -2,6 +2,10 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- This test is failing under GCStress variations, so disabling it under GCStress till the issue is investigated:
+         Issue: https://github.com/dotnet/runtime/issues/63860
+    -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->


### PR DESCRIPTION
Remove TotalMemory test from GCStress runs. Related to this comment: https://github.com/dotnet/runtime/issues/63860#issuecomment-1033075171

