### PR TITLE
Move test with expected crash to outerloop

### DIFF
--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -132,11 +132,7 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
   # files already in /cores/ at this point. This is being done to prevent
   # inadvertently flooding the CI machines with dumps.
   if [[ ! -d "/cores" || ! "$(ls -A /cores)" ]]; then
-    # TODO: Re-enable core dumps - https://github.com/dotnet/runtime/issues/65000
-    # Temporarily disabling core dumps on osx as runtime work items uploading dumps
-    # are affecting the entire queue
-    # ulimit -c unlimited
-    ulimit -c 0
+    ulimit -c unlimited
   fi
 
 elif [[ "$(uname -s)" == "Linux" ]]; then

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/PosixSignalRegistrationTests.Unix.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/PosixSignalRegistrationTests.Unix.cs
@@ -159,13 +159,19 @@ namespace System.Tests
             }
         }
 
+        [ConditionalFact(nameof(NotMobileAndRemoteExecutable))]
+        [OuterLoop("SIGQUIT will generate a coredump")]
+        public void SignalCanCancelTermination_ExpectedCrash()
+        {
+            SignalCanCancelTermination(PosixSignal.SIGQUIT, false, 131);
+        }
+
         [ConditionalTheory(nameof(NotMobileAndRemoteExecutable))]
         [InlineData(PosixSignal.SIGINT, true, 0)]
         [InlineData(PosixSignal.SIGINT, false, 130)]
         [InlineData(PosixSignal.SIGTERM, true, 0)]
         [InlineData(PosixSignal.SIGTERM, false, 143)]
         [InlineData(PosixSignal.SIGQUIT, true, 0)]
-        [InlineData(PosixSignal.SIGQUIT, false, 131)]
         public void SignalCanCancelTermination(PosixSignal signal, bool cancel, int expectedExitCode)
         {
             // Mono doesn't restore and call SIG_DFL on SIGQUIT.

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/PosixSignalRegistrationTests.Unix.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/PosixSignalRegistrationTests.Unix.cs
@@ -161,6 +161,7 @@ namespace System.Tests
 
         [ConditionalFact(nameof(NotMobileAndRemoteExecutable))]
         [OuterLoop("SIGQUIT will generate a coredump")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/65000", TestPlatforms.OSX)] // large (~6 GB) coredump on OSX leads to timeout on upload
         public void SignalCanCancelTermination_ExpectedCrash()
         {
             SignalCanCancelTermination(PosixSignal.SIGQUIT, false, 131);


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/65000

- Re-enable core dumps on OSX for libraries test runs
- Move test with expected crash (`PosixSignalRegistrationTests.SignalCanCancelTermination` with `SIGQUIT`, not cancelled) to outerloop
- Disable test with expected crash OSX - trying to upload the core dump will still cause timeouts / leave machines in bad states until we have https://github.com/dotnet/core-eng/issues/15333#issuecomment-1034275061.