### PR TITLE
Subtract instead of building the cartesian product in targets

### DIFF
--- a/eng/references.targets
+++ b/eng/references.targets
@@ -27,11 +27,13 @@
           Condition="'$(DisableTransitiveProjectReferences)' != 'true' and
                      '@(DefaultReferenceExclusion)' != ''">
     <ItemGroup>
-      <_transitiveProjectReferenceWithExclusion Include="@(ProjectReference)">
-        <Exclusion>%(DefaultReferenceExclusion.Identity)</Exclusion>
-      </_transitiveProjectReferenceWithExclusion>
-      <ProjectReference Remove="@(_transitiveProjectReferenceWithExclusion)"
-                        Condition="'%(_transitiveProjectReferenceWithExclusion.NuGetPackageId)' == '%(_transitiveProjectReferenceWithExclusion.Exclusion)'" />
+      <_transitiveProjectReferenceWithProjectName Include="@(ProjectReference->Metadata('NuGetPackageId'))"
+                                                  OriginalIdentity="%(Identity)" />
+      <_transitiveIncludedProjectReferenceWithProjectName Include="@(_transitiveProjectReferenceWithProjectName)"
+                                                          Exclude="@(DefaultReferenceExclusion)" />
+      <_transitiveExcludedProjectReferenceWithProjectName Include="@(_transitiveProjectReferenceWithProjectName)"
+                                                          Exclude="@(_transitiveIncludedProjectReferenceWithProjectName)" />
+      <ProjectReference Remove="@(_transitiveExcludedProjectReferenceWithProjectName->Metadata('OriginalIdentity'))" />
     </ItemGroup>
   </Target>
 

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -42,9 +42,12 @@
     </PropertyGroup>
     <!-- Clear the ReferenceAssembly attribute on resolved P2Ps that set SkipUseReferenceAssembly to true. -->
     <ItemGroup>
-      <_resolvedP2PFiltered Include="@(ProjectReference->WithMetadataValue('SkipUseReferenceAssembly', 'true'))"
-                            ProjectReferenceItemSpec="$([System.IO.Path]::GetFullPath('%(ProjectReference.Identity)'))" />
-      <_ResolvedProjectReferencePaths Condition="'%(_resolvedP2PFiltered.ProjectReferenceItemSpec)' == '%(_resolvedP2PFiltered.MSBuildSourceProjectFile)'"
+      <_resolvedP2PFiltered Include="@(ProjectReference)">
+        <ProjectReferenceItemSpec>$([System.IO.Path]::GetFullPath('%(ProjectReference.Identity)'))</ProjectReferenceItemSpec>
+        <SkipUseReferenceAssembly>%(ProjectReference.SkipUseReferenceAssembly)</SkipUseReferenceAssembly>
+      </_resolvedP2PFiltered>
+      <_ResolvedProjectReferencePaths Condition="'%(_resolvedP2PFiltered.ProjectReferenceItemSpec)' == '%(_resolvedP2PFiltered.MSBuildSourceProjectFile)' and
+                                                 '%(_resolvedP2PFiltered.SkipUseReferenceAssembly)' == 'true'"
                                       ReferenceAssembly="" />
     </ItemGroup>
   </Target>

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -42,13 +42,9 @@
     </PropertyGroup>
     <!-- Clear the ReferenceAssembly attribute on resolved P2Ps that set SkipUseReferenceAssembly to true. -->
     <ItemGroup>
-       <_resolvedP2PFiltered Include="@(ProjectReference)">
-        <ProjectReferenceItemSpec>$([System.IO.Path]::GetFullPath('%(ProjectReference.Identity)'))</ProjectReferenceItemSpec>
-        <SkipUseReferenceAssembly>%(ProjectReference.SkipUseReferenceAssembly)</SkipUseReferenceAssembly>
-      </_resolvedP2PFiltered>
-      <_ResolvedProjectReferencePaths Update="@(_resolvedP2PFiltered)"
-                                      Condition="'%(_resolvedP2PFiltered.ProjectReferenceItemSpec)' == '%(_resolvedP2PFiltered.MSBuildSourceProjectFile)' and
-                                                 '%(_resolvedP2PFiltered.SkipUseReferenceAssembly)' == 'true'"
+      <_resolvedP2PFiltered Include="@(ProjectReference->WithMetadataValue('SkipUseReferenceAssembly', 'true'))"
+                            ProjectReferenceItemSpec="$([System.IO.Path]::GetFullPath('%(ProjectReference.Identity)'))" />
+      <_ResolvedProjectReferencePaths Condition="'%(_resolvedP2PFiltered.ProjectReferenceItemSpec)' == '%(_resolvedP2PFiltered.MSBuildSourceProjectFile)'"
                                       ReferenceAssembly="" />
     </ItemGroup>
   </Target>

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -42,10 +42,9 @@
     </PropertyGroup>
     <!-- Clear the ReferenceAssembly attribute on resolved P2Ps that set SkipUseReferenceAssembly to true. -->
     <ItemGroup>
-      <_resolvedP2PFiltered Include="@(ProjectReference)">
-        <ProjectReferenceItemSpec>$([System.IO.Path]::GetFullPath('%(ProjectReference.Identity)'))</ProjectReferenceItemSpec>
-        <SkipUseReferenceAssembly>%(ProjectReference.SkipUseReferenceAssembly)</SkipUseReferenceAssembly>
-      </_resolvedP2PFiltered>
+      <_resolvedP2PFiltered Include="@(ProjectReference)"
+                            ProjectReferenceItemSpec="$([System.IO.Path]::GetFullPath('%(ProjectReference.Identity)'))" 
+                            SkipUseReferenceAssembly="%(ProjectReference.SkipUseReferenceAssembly)" />
       <_ResolvedProjectReferencePaths Condition="'%(_resolvedP2PFiltered.ProjectReferenceItemSpec)' == '%(_resolvedP2PFiltered.MSBuildSourceProjectFile)' and
                                                  '%(_resolvedP2PFiltered.SkipUseReferenceAssembly)' == 'true'"
                                       ReferenceAssembly="" />

--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -142,16 +142,18 @@
           AfterTargets="ResolveTargetingPackAssets">
     <ItemGroup>
       <_targetingPackReferenceExclusion Include="$(TargetName)" />
-      <_targetingPackReferenceExclusion Include="@(_ResolvedProjectReferencePaths->'%(Filename)')" />
+      <_targetingPackReferenceExclusion Include="@(_ResolvedProjectReferencePaths->Metadata('Filename'))" />
       <_targetingPackReferenceExclusion Include="@(DefaultReferenceExclusion)" />
     </ItemGroup>
 
     <ItemGroup>
-      <_targetingPackReferenceWithExclusion Include="@(Reference)">
-        <Exclusion>%(_targetingPackReferenceExclusion.Identity)</Exclusion>
-      </_targetingPackReferenceWithExclusion>
-      <Reference Remove="@(_targetingPackReferenceWithExclusion)"
-                 Condition="'%(_targetingPackReferenceWithExclusion.ExternallyResolved)' == 'true' and '%(_targetingPackReferenceWithExclusion.Filename)' == '%(_targetingPackReferenceWithExclusion.Exclusion)'" />
+      <_targetingPackReferenceWithProjectName Include="@(Reference->WithMetadataValue('ExternallyResolved', 'true')->Metadata('Filename'))"
+                                              OriginalIdentity="%(Identity)" />
+      <_targetingPackIncludedReferenceWithProjectName Include="@(_targetingPackReferenceWithProjectName)"
+                                                      Exclude="@(_targetingPackReferenceExclusion)" />
+      <_targetingPackExcludedReferenceWithProjectName Include="@(_targetingPackReferenceWithProjectName)"
+                                                      Exclude="@(_targetingPackIncludedReferenceWithProjectName)" />
+      <Reference Remove="@(_targetingPackExcludedReferenceWithProjectName->Metadata('OriginalIdentity'))" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
See https://github.com/dotnet/runtime/pull/64000#issuecomment-1030460532. These targets were quite expensive and noticeable in no-op builds. Instead of building the cartesian product via item batching, using subtraction which avoids unnecessary items to be computed.