### PR TITLE
Do not run jit-cfg on macOS

### DIFF
--- a/eng/pipelines/coreclr/jit-cfg.yml
+++ b/eng/pipelines/coreclr/jit-cfg.yml
@@ -15,8 +15,6 @@ jobs:
     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
     buildConfig: checked
     platforms:
-    - OSX_arm64
-    - OSX_x64
     - Linux_arm64
     - Linux_x64
     - windows_arm64


### PR DESCRIPTION
jit-cfg includes a GCStress scenario which is not supported on macOS
x64. Rather than excluding it just there, just exclude all of macOS
since CFG is a Windows only feature anyway.

I am still keeping the Linux-x64/Linux-arm64 jobs as we produce
different IR for arguments on these ABIs and I want to keep the CFG
handling working in general for all the forms of IR we can produce
related to calls.