### PR TITLE
Fixes for CFG dispatcher on ARM64

### DIFF
--- a/eng/pipelines/coreclr/jit-cfg.yml
+++ b/eng/pipelines/coreclr/jit-cfg.yml
@@ -37,8 +37,6 @@ jobs:
     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
     buildConfig: checked
     platforms:
-    - OSX_arm64
-    - OSX_x64
     - Linux_arm64
     - Linux_x64
     - windows_arm64

--- a/eng/pipelines/coreclr/jit-cfg.yml
+++ b/eng/pipelines/coreclr/jit-cfg.yml
@@ -15,8 +15,6 @@ jobs:
     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
     buildConfig: checked
     platforms:
-    - OSX_arm64
-    - OSX_x64
     - Linux_arm64
     - Linux_x64
     - windows_arm64

--- a/src/coreclr/jit/targetarm64.h
+++ b/src/coreclr/jit/targetarm64.h
@@ -111,8 +111,8 @@
   #define CALLEE_SAVED_FLOAT_MAXSZ  (CNT_CALLEE_SAVED_FLOAT * FPSAVE_REGSIZE_BYTES)
 
   // Temporary registers used for the GS cookie check.
-  #define REG_GSCOOKIE_TMP_0       REG_R9
-  #define REG_GSCOOKIE_TMP_1       REG_R10
+  #define REG_GSCOOKIE_TMP_0       REG_IP0
+  #define REG_GSCOOKIE_TMP_1       REG_IP1
 
   // register to hold shift amount; no special register is required on ARM64.
   #define REG_SHIFT                REG_NA

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -1026,5 +1026,5 @@ LEAF_ENTRY JIT_ValidateIndirectCall, _TEXT
 LEAF_END JIT_ValidateIndirectCall, _TEXT
 
 LEAF_ENTRY JIT_DispatchIndirectCall, _TEXT
-    br x15
+    br x9
 LEAF_END JIT_DispatchIndirectCall, _TEXT

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -1440,7 +1440,7 @@ __HelperNakedFuncName SETS "$helper":CC:"Naked"
     LEAF_END
 
     LEAF_ENTRY  JIT_DispatchIndirectCall
-        br x15
+        br x9
     LEAF_END
 
 ; Must be at very end of file


### PR DESCRIPTION
I used the wrong register in the VM stub implementation for this function.
In addition, some changes are necessary for VSD calls through dispatcher
(that we cannot do on x64).

Fix #65111

Also remove macOS from the jit-cfg job. jit-cfg includes a GCStress
scenario which is not supported on macOS x64. Rather than
excluding it just there, just exclude all of macOS since CFG is a
Windows only feature anyway.

I am still keeping the Linux-x64/Linux-arm64 jobs as we produce
different IR for arguments on these ABIs and I want to keep the CFG
handling working in general for all the forms of IR we can produce
related to calls.