### PR TITLE
Obsolete and put SerializationFormat.Binary behind an appcontext switch

### DIFF
--- a/src/libraries/Common/src/System/Obsoletions.cs
+++ b/src/libraries/Common/src/System/Obsoletions.cs
@@ -122,5 +122,8 @@ namespace System
 
         internal const string AssemblyNameMembersMessage = "AssemblyName members HashAlgorithm, ProcessorArchitecture, and VersionCompatibility are obsolete and not supported.";
         internal const string AssemblyNameMembersDiagId = "SYSLIB0037";
+
+        internal const string SystemDataSerializationFormatBinaryMessage = "SerializationFormat.Binary is obsolete and should not be used. See https://aka.ms/serializationformat-binary-obsolete for more information.";
+        internal const string SystemDataSerializationFormatBinaryDiagId = "SYSLIB0038";
     }
 }

--- a/src/libraries/System.Data.Common/src/System.Data.Common.csproj
+++ b/src/libraries/System.Data.Common/src/System.Data.Common.csproj
@@ -3,6 +3,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);SYSLIB0038</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Data.Common.TypeForwards.cs" />
@@ -301,6 +302,8 @@
     <Compile Include="System\Data\SQLTypes\SQLBytes.cs" />
     <Compile Include="System\Data\ProviderBase\DataReaderContainer.cs" />
     <Compile Include="System\Data\ProviderBase\SchemaMapping.cs" />
+    <Compile Include="$(CommonPath)System\Obsoletions.cs"
+             Link="Common\System\Obsoletions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CoreLibProject)" />

--- a/src/libraries/System.Data.Common/src/System/Data/DataException.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataException.cs
@@ -614,7 +614,8 @@ namespace System.Data
         public static Exception CannotChangeCaseLocale(Exception? innerException) => _Argument(SR.DataSet_CannotChangeCaseLocale, innerException);
         public static Exception CannotChangeSchemaSerializationMode() => _InvalidOperation(SR.DataSet_CannotChangeSchemaSerializationMode);
         public static Exception InvalidSchemaSerializationMode(Type enumType, string mode) => _InvalidEnumArgumentException(SR.Format(SR.ADP_InvalidEnumerationValue, enumType.Name, mode));
-        public static Exception InvalidRemotingFormat(SerializationFormat mode) => _InvalidEnumArgumentException<SerializationFormat>(mode);
+        public static Exception InvalidRemotingFormat(SerializationFormat mode) => _InvalidEnumArgumentException(mode);
+        public static Exception SerializationFormatBinaryNotSupported() => _InvalidEnumArgumentException(SerializationFormat.Binary);
 
         //
         // DataTable and DataTableCollection

--- a/src/libraries/System.Data.Common/src/System/Data/DataSerializationFormat.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataSerializationFormat.cs
@@ -6,6 +6,10 @@ namespace System.Data
     public enum SerializationFormat
     {
         Xml = 0,
+
+        [Obsolete(
+            Obsoletions.SystemDataSerializationFormatBinaryMessage,
+            DiagnosticId = Obsoletions.SystemDataSerializationFormatBinaryDiagId)]
         Binary = 1
     }
 }

--- a/src/libraries/System.Data.Common/src/System/Data/DataSet.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataSet.cs
@@ -105,10 +105,22 @@ namespace System.Data
             get { return _remotingFormat; }
             set
             {
-                if (value != SerializationFormat.Binary && value != SerializationFormat.Xml)
+                switch (value)
                 {
-                    throw ExceptionBuilder.InvalidRemotingFormat(value);
+                    case SerializationFormat.Xml:
+                        break;
+
+                    case SerializationFormat.Binary:
+                        if (LocalAppContextSwitches.AllowUnsafeSerializationFormatBinary)
+                        {
+                            break;
+                        }
+                        throw ExceptionBuilder.SerializationFormatBinaryNotSupported();
+
+                    default:
+                        throw ExceptionBuilder.InvalidRemotingFormat(value);
                 }
+
                 _remotingFormat = value;
                 // this property is inherited to DataTable from DataSet.So we set this value to DataTable also
                 for (int i = 0; i < Tables.Count; i++)
@@ -253,6 +265,12 @@ namespace System.Data
                         schemaSerializationMode = (SchemaSerializationMode)e.Value!;
                         break;
                 }
+            }
+
+            if (remotingFormat == SerializationFormat.Binary &&
+                !LocalAppContextSwitches.AllowUnsafeSerializationFormatBinary)
+            {
+                throw ExceptionBuilder.SerializationFormatBinaryNotSupported();
             }
 
             if (schemaSerializationMode == SchemaSerializationMode.ExcludeSchema)

--- a/src/libraries/System.Data.Common/src/System/Data/DataTable.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataTable.cs
@@ -210,6 +210,12 @@ namespace System.Data
                 }
             }
 
+            if (remotingFormat == SerializationFormat.Binary &&
+                !LocalAppContextSwitches.AllowUnsafeSerializationFormatBinary)
+            {
+                throw ExceptionBuilder.SerializationFormatBinaryNotSupported();
+            }
+
             DeserializeDataTable(info, context, isSingleTable, remotingFormat);
         }
 
@@ -1127,10 +1133,22 @@ namespace System.Data
             get { return _remotingFormat; }
             set
             {
-                if (value != SerializationFormat.Binary && value != SerializationFormat.Xml)
+                switch (value)
                 {
-                    throw ExceptionBuilder.InvalidRemotingFormat(value);
+                    case SerializationFormat.Xml:
+                        break;
+
+                    case SerializationFormat.Binary:
+                        if (LocalAppContextSwitches.AllowUnsafeSerializationFormatBinary)
+                        {
+                            break;
+                        }
+                        throw ExceptionBuilder.SerializationFormatBinaryNotSupported();
+
+                    default:
+                        throw ExceptionBuilder.InvalidRemotingFormat(value);
                 }
+
                 // table can not have different format than its dataset, unless it is stand alone datatable
                 if (DataSet != null && value != DataSet.RemotingFormat)
                 {

--- a/src/libraries/System.Data.Common/src/System/Data/LocalAppContextSwitches.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/LocalAppContextSwitches.cs
@@ -8,10 +8,18 @@ namespace System
     internal static partial class LocalAppContextSwitches
     {
         private static int s_allowArbitraryTypeInstantiation;
+        private static int s_allowUnsafeSerializationFormatBinary;
+
         public static bool AllowArbitraryTypeInstantiation
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => GetCachedSwitchValue("Switch.System.Data.AllowArbitraryDataSetTypeInstantiation", ref s_allowArbitraryTypeInstantiation);
+        }
+
+        public static bool AllowUnsafeSerializationFormatBinary
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => GetCachedSwitchValue("Switch.System.Data.AllowUnsafeSerializationFormatBinary", ref s_allowUnsafeSerializationFormatBinary);
         }
     }
 }

--- a/src/libraries/System.Data.Common/tests/System.Data.Common.Tests.csproj
+++ b/src/libraries/System.Data.Common/tests/System.Data.Common.Tests.csproj
@@ -3,6 +3,7 @@
     <NoWarn>$(NoWarn),0168,0169,0414,0219,0649</NoWarn>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Data\Common\DataColumnMappingTest.cs" />

--- a/src/libraries/System.Data.Common/tests/System/Data/DataSetTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataSetTest.cs
@@ -28,6 +28,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System.ComponentModel;
 using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
@@ -36,6 +37,7 @@ using System.Data.SqlTypes;
 using System.Globalization;
 using System.Text;
 using System.Diagnostics;
+using System.Runtime.Serialization.Formatters.Binary;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 using System.Tests;
@@ -1577,6 +1579,42 @@ namespace System.Data.Tests
             DataSet data2 = new DataSet();
             data2.ReadXml(new StringReader(
                 writer.GetStringBuilder().ToString()));
+        }
+
+        [Fact]
+        public void SerializationFormat_Binary_does_not_work_by_default()
+        {
+            DataSet ds = new DataSet();
+            Assert.Throws<InvalidEnumArgumentException>(() => ds.RemotingFormat = SerializationFormat.Binary);
+        }
+
+        [Fact]
+        public void SerializationFormat_Binary_works_with_appconfig_switch()
+        {
+            RemoteExecutor.Invoke(RunTest).Dispose();
+
+            static void RunTest()
+            {
+                AppContext.SetSwitch("Switch.System.Data.AllowUnsafeSerializationFormatBinary", true);
+
+                DataSet ds = new DataSet();
+                DataTable dt = new DataTable("MyTable");
+                DataColumn dc = new DataColumn("dc", typeof(int));
+                dt.Columns.Add(dc);
+                ds.Tables.Add(dt);
+                ds.RemotingFormat = SerializationFormat.Binary;
+
+                DataSet dsDeserialized;
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    BinaryFormatter bf = new BinaryFormatter();
+                    bf.Serialize(ms, ds);
+                    ms.Seek(0, SeekOrigin.Begin);
+                    dsDeserialized = (DataSet)bf.Deserialize(ms);
+                }
+
+                Assert.Equal(dc.DataType, dsDeserialized.Tables[0].Columns[0].DataType);
+            }
         }
 
         #region DataSet.CreateDataReader Tests and DataSet.Load Tests

--- a/src/libraries/System.Data.Common/tests/System/Data/DataSetTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataSetTest.cs
@@ -1588,7 +1588,7 @@ namespace System.Data.Tests
             Assert.Throws<InvalidEnumArgumentException>(() => ds.RemotingFormat = SerializationFormat.Binary);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void SerializationFormat_Binary_works_with_appconfig_switch()
         {
             RemoteExecutor.Invoke(RunTest).Dispose();

--- a/src/libraries/System.Data.Common/tests/System/Data/DataTableTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataTableTest.cs
@@ -28,6 +28,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data.SqlTypes;
 using System.Diagnostics;
 using System.Globalization;
@@ -376,23 +377,18 @@ namespace System.Data.Tests
 
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported), nameof(PlatformDetection.IsNotInvariantGlobalization))]
-        public void DataColumnTypeSerialization()
+        [Fact]
+        public void SerializationFormat_Binary_does_not_work_by_default_on_DataTable()
         {
             DataTable dt = new DataTable("MyTable");
-            DataColumn dc = new DataColumn("dc", typeof(int));
-            dt.Columns.Add(dc);
-            dt.RemotingFormat = SerializationFormat.Binary;
+            Assert.Throws<InvalidEnumArgumentException>(() => dt.RemotingFormat = SerializationFormat.Binary);
+        }
 
-            DataTable dtDeserialized;
-            using (MemoryStream ms = new MemoryStream())
-            {
-                BinaryFormatter bf = new BinaryFormatter();
-                bf.Serialize(ms, dt);
-                ms.Seek(0, SeekOrigin.Begin);
-                dtDeserialized = (DataTable)bf.Deserialize(ms);
-            }
-            Assert.Equal(dc.DataType, dtDeserialized.Columns[0].DataType);
+        [Fact]
+        public void SerializationFormat_Binary_does_not_work_by_default_on_DataSet()
+        {
+            DataSet ds = new DataSet();
+            Assert.Throws<InvalidEnumArgumentException>(() => ds.RemotingFormat = SerializationFormat.Binary);
         }
 
         [Fact]

--- a/src/libraries/System.Data.Common/tests/System/Data/DataTableTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataTableTest.cs
@@ -384,7 +384,7 @@ namespace System.Data.Tests
             Assert.Throws<InvalidEnumArgumentException>(() => dt.RemotingFormat = SerializationFormat.Binary);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void SerializationFormat_Binary_works_with_appconfig_switch()
         {
             RemoteExecutor.Invoke(RunTest).Dispose();


### PR DESCRIPTION
As discussed, this obsoletes System.Data's SerializationFormat.Binary, and adds checks to throw if DataTable/DataSet's RemotingFormat property is set to it, or if the serialization constructor encounters data with it. Added the appcontext switch `Switch.System.Data.AllowUnsafeSerializationFormatBinary` to allow this to still be used in .NET 7.0; we'd remove these code paths entirely in .NET 8.0.

Part of #39289

/cc @ajcvickers @jeffhandley @blowdart @bricelam