### PR TITLE
Avoid InitialTarget in libs tree for CoreLib

### DIFF
--- a/eng/references.targets
+++ b/eng/references.targets
@@ -15,7 +15,8 @@
   </ItemDefinitionGroup>
 
   <ItemGroup Condition="'@(ProjectReference)' != ''">
-    <ProjectReference Update="@(ProjectReference->WithMetadataValue('Identity', '$(CoreLibProject)'))">
+    <_coreLibProjectReference Include="@(ProjectReference->WithMetadataValue('Identity', '$(CoreLibProject)'))" />
+    <ProjectReference Update="@(_coreLibProjectReference)">
       <!-- Don't flow TargetFramework and Platform to use same inputs and outputs as the CoreLib's build as part of the runtime. -->
       <UndefineProperties>$(UndefineProperties);TargetFramework;Platform</UndefineProperties>
       <SetConfiguration Condition="'$(RuntimeFlavor)' == 'CoreCLR' and
@@ -27,13 +28,12 @@
     <!-- If a CoreLib ProjectReference is present, make all P2P assets non transitive. -->
     <ProjectReference Update="@(ProjectReference)"
                       PrivateAssets="all"
-                      Condition="@(ProjectReference->AnyHaveMetadataValue('Identity', '$(CoreLibProject)'))" />
+                      Condition="'@(_coreLibProjectReference)' != ''" />
   </ItemGroup>
 
   <!-- Disable TargetArchitectureMismatch warning when we reference CoreLib as it is platform specific. -->
   <Target Name="DisableProjectReferenceArchitectureMismatchWarningForCoreLib"
-          Condition="'@(ProjectReference)' != '' and
-                     @(ProjectReference->AnyHaveMetadataValue('Identity', '$(CoreLibProject)'))"
+          Condition="'@(_coreLibProjectReference)' != ''"
           BeforeTargets="ResolveAssemblyReferences">
     <PropertyGroup>
       <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>

--- a/eng/references.targets
+++ b/eng/references.targets
@@ -7,19 +7,38 @@
     <_FindDependencies>false</_FindDependencies>
   </PropertyGroup>
 
-   <!-- If a CoreLib ProjectReference is present, make all P2P assets non transitive. -->
-  <ItemGroup Condition="'@(ProjectReference)' != '' and
-                         @(ProjectReference->AnyHaveMetadataValue('Identity', '$(CoreLibProject)'))">
-    <ProjectReference Update="@(ProjectReference)"
-                      PrivateAssets="all" />
-  </ItemGroup>
-
   <!-- Project references shouldn't be copied to the output for non test apps. -->
   <ItemDefinitionGroup Condition="'$(IsTestProject)' != 'true' and '$(IsTestSupportProject)' != 'true' and '$(IsGeneratorProject)' != 'true'">
     <ProjectReference>
       <Private>false</Private>
     </ProjectReference>
   </ItemDefinitionGroup>
+
+  <ItemGroup Condition="'@(ProjectReference)' != ''">
+    <ProjectReference Update="@(ProjectReference->WithMetadataValue('Filename', 'System.Private.CoreLib'))">
+      <!-- Don't flow TargetFramework and Platform to use same inputs and outputs as the CoreLib's build as part of the runtime. -->
+      <UndefineProperties>$(UndefineProperties);TargetFramework;Platform</UndefineProperties>
+      <SetConfiguration Condition="'$(RuntimeFlavor)' == 'CoreCLR' and
+                                   '$(Configuration)' != '$(CoreCLRConfiguration)'">Configuration=$(CoreCLRConfiguration)</SetConfiguration>
+      <SetConfiguration Condition="'$(RuntimeFlavor)' == 'Mono' and
+                                   '$(Configuration)' != '$(MonoConfiguration)'">Configuration=$(MonoConfiguration)</SetConfiguration>
+      <Private>false</Private>
+    </ProjectReference>
+    <!-- If a CoreLib ProjectReference is present, make all P2P assets non transitive. -->
+    <ProjectReference Update="@(ProjectReference)"
+                      PrivateAssets="all"
+                      Condition="@(ProjectReference->AnyHaveMetadataValue('Filename', 'System.Private.CoreLib'))" />
+  </ItemGroup>
+
+  <!-- Disable TargetArchitectureMismatch warning when we reference CoreLib as it is platform specific. -->
+  <Target Name="DisableProjectReferenceArchitectureMismatchWarningForCoreLib"
+          Condition="'@(ProjectReference)' != '' and
+                     @(ProjectReference->AnyHaveMetadataValue('Filename', 'System.Private.CoreLib'))"
+          BeforeTargets="ResolveAssemblyReferences">
+    <PropertyGroup>
+      <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
+    </PropertyGroup>
+  </Target>
 
   <!-- Filter out transitive P2Ps which should be excluded. -->
   <Target Name="FilterTransitiveProjectReferences"

--- a/eng/references.targets
+++ b/eng/references.targets
@@ -74,8 +74,10 @@
     </TargetPathWithTargetPlatformMoniker>
   </ItemDefinitionGroup>
 
-  <Target Name="ValidateReferenceAssemblyProjectReferences" Condition="'$(IsReferenceAssembly)' == 'true'" AfterTargets="ResolveReferences">
-    <Error Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference' AND '%(ReferencePath.IsReferenceAssembly)' != 'true' AND '%(ReferencePath.ReferenceAssembly)' == ''"
+  <Target Name="ValidateReferenceAssemblyProjectReferences"
+          AfterTargets="ResolveReferences"
+          Condition="'$(IsReferenceAssembly)' == 'true'">
+    <Error Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference' and '%(ReferencePath.IsReferenceAssembly)' != 'true' and '%(ReferencePath.ReferenceAssembly)' == ''"
            Text="Reference assemblies must only reference other reference assemblies and '%(ReferencePath.ProjectReferenceOriginalItemSpec)' is not a reference assembly project and does not set 'ProduceReferenceAssembly'." />
   </Target>
 </Project>

--- a/eng/references.targets
+++ b/eng/references.targets
@@ -15,7 +15,7 @@
   </ItemDefinitionGroup>
 
   <ItemGroup Condition="'@(ProjectReference)' != ''">
-    <ProjectReference Update="@(ProjectReference->WithMetadataValue('Filename', 'System.Private.CoreLib'))">
+    <ProjectReference Update="@(ProjectReference->WithMetadataValue('Identity', '$(CoreLibProject)'))">
       <!-- Don't flow TargetFramework and Platform to use same inputs and outputs as the CoreLib's build as part of the runtime. -->
       <UndefineProperties>$(UndefineProperties);TargetFramework;Platform</UndefineProperties>
       <SetConfiguration Condition="'$(RuntimeFlavor)' == 'CoreCLR' and
@@ -27,13 +27,13 @@
     <!-- If a CoreLib ProjectReference is present, make all P2P assets non transitive. -->
     <ProjectReference Update="@(ProjectReference)"
                       PrivateAssets="all"
-                      Condition="@(ProjectReference->AnyHaveMetadataValue('Filename', 'System.Private.CoreLib'))" />
+                      Condition="@(ProjectReference->AnyHaveMetadataValue('Identity', '$(CoreLibProject)'))" />
   </ItemGroup>
 
   <!-- Disable TargetArchitectureMismatch warning when we reference CoreLib as it is platform specific. -->
   <Target Name="DisableProjectReferenceArchitectureMismatchWarningForCoreLib"
           Condition="'@(ProjectReference)' != '' and
-                     @(ProjectReference->AnyHaveMetadataValue('Filename', 'System.Private.CoreLib'))"
+                     @(ProjectReference->AnyHaveMetadataValue('Identity', '$(CoreLibProject)'))"
           BeforeTargets="ResolveAssemblyReferences">
     <PropertyGroup>
       <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -1,4 +1,4 @@
-<Project InitialTargets="UpdateProjectReferencesWithAttributes">
+<Project>
   <PropertyGroup>
     <!-- Override strong name key to default to Open for test projects,
          Tests which wish to control this should set TestStrongNameKeyId. -->
@@ -154,24 +154,6 @@
   </Target>
 
   <Import Project="$(RepositoryEngineeringDir)outerBuild.targets" Condition="'$(IsCrossTargetingBuild)' == 'true'" />
-
-  <Target Name="UpdateProjectReferencesWithAttributes" Condition="'@(ProjectReference)' != ''">
-    <ItemGroup>
-      <ProjectReference Condition="'%(Filename)' == 'System.Private.CoreLib'">
-        <!-- Don't flow TargetFramework and Platform to use same inputs and outputs as the CoreLib's build as part of the runtime. -->
-        <UndefineProperties>$(UndefineProperties);TargetFramework;Platform</UndefineProperties>
-        <SetConfiguration Condition="'$(RuntimeFlavor)' == 'CoreCLR' and
-                                     '$(Configuration)' != '$(CoreCLRConfiguration)'">Configuration=$(CoreCLRConfiguration)</SetConfiguration>
-        <SetConfiguration Condition="'$(RuntimeFlavor)' == 'Mono' and
-                                     '$(Configuration)' != '$(MonoConfiguration)'">Configuration=$(MonoConfiguration)</SetConfiguration>
-        <Private>false</Private>
-      </ProjectReference>
-    </ItemGroup>
-    <!-- Disable TargetArchitectureMismatch warning when we reference CoreLib which is platform specific. -->
-    <PropertyGroup Condition="@(ProjectReference->AnyHaveMetadataValue('Identity', '$(CoreLibProject)'))">
-      <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
-    </PropertyGroup>
-  </Target>
 
   <!--
     Do not clean binplace assets in the ref targeting pack to avoid incremental build failures


### PR DESCRIPTION
InitialTargets are quite expensive as they run for every project invocation, even if the target invoked doesn't require the InitialTarget to run. Libraries projects only have one InitialTarget for correctly referencing CoreLib which can be changed so that it runs before RAR.