### PR TITLE
Use lite ciphers for CNG one shots

### DIFF
--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
@@ -173,64 +173,6 @@ namespace Internal.Cryptography
             base.Dispose(disposing);
         }
 
-        public override unsafe bool TransformOneShot(ReadOnlySpan<byte> input, Span<byte> output, out int bytesWritten)
-        {
-            if (input.Length % PaddingSizeBytes != 0)
-                throw new CryptographicException(SR.Cryptography_PartialBlock);
-
-            // If there is no padding that needs to be removed, and the output buffer is large enough to hold
-            // the resulting plaintext, we can decrypt directly in to the output buffer.
-            // We do not do this for modes that require padding removal.
-            //
-            // This is not done for padded ciphertexts because we don't know if the padding is valid
-            // until it's been decrypted. We don't want to decrypt in to a user-supplied buffer and then throw
-            // a padding exception after we've already filled the user buffer with plaintext. We should only
-            // release the plaintext to the caller once we know the padding is valid.
-            if (!SymmetricPadding.DepaddingRequired(PaddingMode))
-            {
-                if (output.Length >= input.Length)
-                {
-                    bytesWritten = BasicSymmetricCipher.TransformFinal(input, output);
-                    return true;
-                }
-
-                // If no padding is going to be removed, we know the buffer is too small and we can bail out.
-                bytesWritten = 0;
-                return false;
-            }
-
-            byte[] rentedBuffer = CryptoPool.Rent(input.Length);
-            Span<byte> buffer = rentedBuffer.AsSpan(0, input.Length);
-            Span<byte> decryptedBuffer = default;
-
-            fixed (byte* pBuffer = buffer)
-            {
-                try
-                {
-                    int transformWritten = BasicSymmetricCipher.TransformFinal(input, buffer);
-                    decryptedBuffer = buffer.Slice(0, transformWritten);
-
-                    // validates padding
-                    int unpaddedLength = SymmetricPadding.GetPaddingLength(decryptedBuffer, PaddingMode, InputBlockSize);
-
-                    if (unpaddedLength > output.Length)
-                    {
-                        bytesWritten = 0;
-                        return false;
-                    }
-
-                    decryptedBuffer.Slice(0, unpaddedLength).CopyTo(output);
-                    bytesWritten = unpaddedLength;
-                    return true;
-                }
-                finally
-                {
-                    CryptographicOperations.ZeroMemory(decryptedBuffer);
-                    CryptoPool.Return(rentedBuffer, clearSize: 0); // ZeroMemory clears the part of the buffer that was written to.
-                }
-            }
-        }
-
         private void Reset()
         {
             if (_heldoverCipher != null)

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
@@ -51,32 +51,5 @@ namespace Internal.Cryptography
             Debug.Assert(written == buffer.Length);
             return buffer;
         }
-
-        public override bool TransformOneShot(ReadOnlySpan<byte> input, Span<byte> output, out int bytesWritten)
-        {
-            int ciphertextLength = SymmetricPadding.GetCiphertextLength(input.Length, PaddingSizeBytes, PaddingMode);
-
-            if (output.Length < ciphertextLength)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            // Copy the input to the output, and apply padding if required. This will not throw since the
-            // output length has already been checked, and PadBlock will not copy from input to output
-            // until it has checked that it will be able to apply padding correctly.
-            int padWritten = SymmetricPadding.PadBlock(input, output, PaddingSizeBytes, PaddingMode);
-
-            // Do an in-place encrypt. All of our implementations support this, either natively
-            // or making a temporary buffer themselves if in-place is not supported by the native
-            // implementation.
-            Span<byte> paddedOutput = output.Slice(0, padWritten);
-            bytesWritten = BasicSymmetricCipher.TransformFinal(paddedOutput, paddedOutput);
-
-            // After padding, we should have an even number of blocks, and the same applies
-            // to the transform.
-            Debug.Assert(padWritten == bytesWritten);
-            return true;
-        }
     }
 }

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoTransform.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoTransform.cs
@@ -106,8 +106,6 @@ namespace Internal.Cryptography
             return output;
         }
 
-        public abstract bool TransformOneShot(ReadOnlySpan<byte> input, Span<byte> output, out int bytesWritten);
-
         protected virtual void Dispose(bool disposing)
         {
             if (disposing)

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -1720,6 +1720,7 @@
     <Compile Include="System\Security\Cryptography\AsnFormatter.Windows.cs" />
     <Compile Include="System\Security\Cryptography\BasicSymmetricCipherCsp.cs" />
     <Compile Include="System\Security\Cryptography\BasicSymmetricCipherNCrypt.cs" />
+    <Compile Include="System\Security\Cryptography\BasicSymmetricCipherLiteNCrypt.cs" />
     <Compile Include="System\Security\Cryptography\CapiHelper.DSA.Shared.cs" />
     <Compile Include="System\Security\Cryptography\CapiHelper.DSA.Windows.cs" />
     <Compile Include="System\Security\Cryptography\CapiHelper.Shared.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesCng.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesCng.Windows.cs
@@ -103,16 +103,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            UniversalCryptoTransform transform = _core.CreateCryptoTransform(
-                iv: null,
+            ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
+                iv: default,
                 encrypting: false,
                 paddingMode,
                 CipherMode.ECB,
                 feedbackSizeInBits: 0);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(ciphertext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
             }
         }
 
@@ -122,16 +122,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            UniversalCryptoTransform transform = _core.CreateCryptoTransform(
-                iv: null,
+            ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
+                iv: default,
                 encrypting: true,
                 paddingMode,
                 CipherMode.ECB,
                 feedbackSizeInBits: 0);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(plaintext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
             }
         }
 
@@ -142,16 +142,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            UniversalCryptoTransform transform = _core.CreateCryptoTransform(
-                iv: iv.ToArray(),
+            ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
+                iv,
                 encrypting: true,
                 paddingMode,
                 CipherMode.CBC,
                 feedbackSizeInBits: 0);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(plaintext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
             }
         }
 
@@ -162,16 +162,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            UniversalCryptoTransform transform = _core.CreateCryptoTransform(
-                iv: iv.ToArray(),
+            ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
+                iv,
                 encrypting: false,
                 paddingMode,
                 CipherMode.CBC,
                 feedbackSizeInBits: 0);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(ciphertext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
             }
         }
 
@@ -183,16 +183,16 @@ namespace System.Security.Cryptography
             int feedbackSizeInBits,
             out int bytesWritten)
         {
-            UniversalCryptoTransform transform = _core.CreateCryptoTransform(
-                iv: iv.ToArray(),
+            ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
+                iv,
                 encrypting: false,
                 paddingMode,
                 CipherMode.CFB,
                 feedbackSizeInBits);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(ciphertext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
             }
         }
 
@@ -204,16 +204,16 @@ namespace System.Security.Cryptography
             int feedbackSizeInBits,
             out int bytesWritten)
         {
-            UniversalCryptoTransform transform = _core.CreateCryptoTransform(
-                iv: iv.ToArray(),
+            ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
+                iv,
                 encrypting: true,
                 paddingMode,
                 CipherMode.CFB,
                 feedbackSizeInBits);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(plaintext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/BasicSymmetricCipherLiteNCrypt.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/BasicSymmetricCipherLiteNCrypt.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography;
 using System.Text;
 using Internal.Cryptography;
 using Internal.NativeCrypto;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/BasicSymmetricCipherLiteNCrypt.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/BasicSymmetricCipherLiteNCrypt.cs
@@ -1,0 +1,161 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using Internal.Cryptography;
+using Internal.NativeCrypto;
+using Microsoft.Win32.SafeHandles;
+
+using ErrorCode = Interop.NCrypt.ErrorCode;
+using AsymmetricPaddingMode = Interop.NCrypt.AsymmetricPaddingMode;
+
+namespace System.Security.Cryptography
+{
+    internal sealed class BasicSymmetricCipherLiteNCrypt : ILiteSymmetricCipher
+    {
+        private static readonly CngProperty s_ECBMode =
+            new CngProperty(KeyPropertyName.ChainingMode, Encoding.Unicode.GetBytes(Cng.BCRYPT_CHAIN_MODE_ECB + "\0"), CngPropertyOptions.None);
+        private static readonly CngProperty s_CBCMode =
+            new CngProperty(KeyPropertyName.ChainingMode, Encoding.Unicode.GetBytes(Cng.BCRYPT_CHAIN_MODE_CBC + "\0"), CngPropertyOptions.None);
+        private static readonly CngProperty s_CFBMode =
+            new CngProperty(KeyPropertyName.ChainingMode, Encoding.Unicode.GetBytes(Cng.BCRYPT_CHAIN_MODE_CFB + "\0"), CngPropertyOptions.None);
+
+        private readonly bool _encrypting;
+        private CngKey _key;
+
+        public int BlockSizeInBytes { get; }
+        public int PaddingSizeInBytes { get; }
+
+        public BasicSymmetricCipherLiteNCrypt(
+            Func<CngKey> cngKeyFactory,
+            CipherMode cipherMode,
+            int blockSizeInBytes,
+            ReadOnlySpan<byte> iv,
+            bool encrypting,
+            int paddingSizeInBytes)
+        {
+            BlockSizeInBytes = blockSizeInBytes;
+            PaddingSizeInBytes = paddingSizeInBytes;
+            _encrypting = encrypting;
+            _key = cngKeyFactory();
+            CngProperty chainingModeProperty = cipherMode switch
+            {
+                CipherMode.ECB => s_ECBMode,
+                CipherMode.CBC => s_CBCMode,
+                CipherMode.CFB => s_CFBMode,
+                _ => throw new CryptographicException(SR.Cryptography_InvalidCipherMode),
+            };
+            _key.SetProperty(chainingModeProperty);
+
+            Reset(iv);
+        }
+
+        public int Transform(ReadOnlySpan<byte> input, Span<byte> output)
+        {
+            Debug.Assert(input.Length > 0);
+            Debug.Assert((input.Length % PaddingSizeInBytes) == 0);
+
+            int numBytesWritten = 0;
+
+            // NCryptEncrypt and NCryptDecrypt can do in place encryption, but if the buffers overlap
+            // the offset must be zero. In that case, we need to copy to a temporary location.
+            if (input.Overlaps(output, out int offset) && offset != 0)
+            {
+                byte[] rented = CryptoPool.Rent(output.Length);
+
+                try
+                {
+                    numBytesWritten = NCryptTransform(input, rented);
+                    rented.AsSpan(0, numBytesWritten).CopyTo(output);
+                }
+                finally
+                {
+                    CryptoPool.Return(rented, clearSize: numBytesWritten);
+                }
+            }
+            else
+            {
+                numBytesWritten = NCryptTransform(input, output);
+            }
+
+            if (numBytesWritten != input.Length)
+            {
+                // CNG gives us no way to tell NCryptDecrypt() that we're decrypting the final block, nor is it performing any
+                // padding /depadding for us. So there's no excuse for a provider to hold back output for "future calls." Though
+                // this isn't technically our problem to detect, we might as well detect it now for easier diagnosis.
+                throw new CryptographicException(SR.Cryptography_UnexpectedTransformTruncation);
+            }
+
+            return numBytesWritten;
+
+            int NCryptTransform(ReadOnlySpan<byte> input, Span<byte> output)
+            {
+                int bytesWritten;
+
+                using (SafeNCryptKeyHandle keyHandle = _key!.Handle)
+                {
+                    unsafe
+                    {
+                        ErrorCode errorCode = _encrypting ?
+                            Interop.NCrypt.NCryptEncrypt(keyHandle, input, input.Length, null, output, output.Length, out bytesWritten, AsymmetricPaddingMode.None) :
+                            Interop.NCrypt.NCryptDecrypt(keyHandle, input, input.Length, null, output, output.Length, out bytesWritten, AsymmetricPaddingMode.None);
+
+                        if (errorCode != ErrorCode.ERROR_SUCCESS)
+                        {
+                            throw errorCode.ToCryptographicException();
+                        }
+                    }
+                }
+
+                return bytesWritten;
+            }
+        }
+
+        public unsafe void Reset(ReadOnlySpan<byte> iv)
+        {
+            if (!iv.IsEmpty)
+            {
+                fixed (byte* pIv = &MemoryMarshal.GetReference(iv))
+                {
+                    ErrorCode errorCode = Interop.NCrypt.NCryptSetProperty(
+                        _key.Handle,
+                        KeyPropertyName.InitializationVector,
+                        pIv,
+                        iv.Length,
+                        CngPropertyOptions.None);
+
+                    if (errorCode != ErrorCode.ERROR_SUCCESS)
+                    {
+                        throw errorCode.ToCryptographicException();
+                    }
+                }
+            }
+        }
+
+        public int TransformFinal(ReadOnlySpan<byte> input, Span<byte> output)
+        {
+            Debug.Assert((input.Length % PaddingSizeInBytes) == 0);
+
+            int numBytesWritten = 0;
+
+            if (input.Length != 0)
+            {
+                numBytesWritten = Transform(input, output);
+                Debug.Assert(numBytesWritten == input.Length); // Our implementation of Transform() guarantees this. See comment above.
+            }
+
+            return numBytesWritten;
+        }
+
+        public void Dispose()
+        {
+            _key?.Dispose();
+            _key = null!;
+        }
+
+    }
+}

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/BasicSymmetricCipherLiteNCrypt.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/BasicSymmetricCipherLiteNCrypt.cs
@@ -95,7 +95,8 @@ namespace System.Security.Cryptography
             {
                 int bytesWritten;
 
-                using (SafeNCryptKeyHandle keyHandle = _key!.Handle)
+                // The Handle property duplicates the handle.
+                using (SafeNCryptKeyHandle keyHandle = _key.Handle)
                 {
                     unsafe
                     {
@@ -120,16 +121,20 @@ namespace System.Security.Cryptography
             {
                 fixed (byte* pIv = &MemoryMarshal.GetReference(iv))
                 {
-                    ErrorCode errorCode = Interop.NCrypt.NCryptSetProperty(
-                        _key.Handle,
-                        KeyPropertyName.InitializationVector,
-                        pIv,
-                        iv.Length,
-                        CngPropertyOptions.None);
-
-                    if (errorCode != ErrorCode.ERROR_SUCCESS)
+                    // The Handle property duplicates the handle.
+                    using (SafeNCryptKeyHandle keyHandle = _key.Handle)
                     {
-                        throw errorCode.ToCryptographicException();
+                        ErrorCode errorCode = Interop.NCrypt.NCryptSetProperty(
+                            keyHandle,
+                            KeyPropertyName.InitializationVector,
+                            pIv,
+                            iv.Length,
+                            CngPropertyOptions.None);
+
+                        if (errorCode != ErrorCode.ERROR_SUCCESS)
+                        {
+                            throw errorCode.ToCryptographicException();
+                        }
                     }
                 }
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngSymmetricAlgorithmCore.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngSymmetricAlgorithmCore.cs
@@ -123,16 +123,6 @@ namespace System.Security.Cryptography
             return CreatePersistedCryptoTransformCore(ProduceCngKey, _outer.IV, encrypting, _outer.Padding, _outer.Mode, _outer.FeedbackSize);
         }
 
-        public UniversalCryptoTransform CreateCryptoTransform(byte[]? iv, bool encrypting, PaddingMode padding, CipherMode mode, int feedbackSizeInBits)
-        {
-            if (KeyInPlainText)
-            {
-                return CreateCryptoTransform(_outer.BaseKey, iv, encrypting, padding, mode, feedbackSizeInBits);
-            }
-
-            return CreatePersistedCryptoTransformCore(ProduceCngKey, iv, encrypting, padding, mode, feedbackSizeInBits);
-        }
-
         public ILiteSymmetricCipher CreateLiteSymmetricCipher(ReadOnlySpan<byte> iv, bool encrypting, PaddingMode padding, CipherMode mode, int feedbackSizeInBits)
         {
             if (KeyInPlainText)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/TripleDESCng.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/TripleDESCng.Windows.cs
@@ -104,16 +104,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            UniversalCryptoTransform transform = _core.CreateCryptoTransform(
-                iv: null,
+            ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
+                iv: default,
                 encrypting: false,
                 paddingMode,
                 CipherMode.ECB,
                 feedbackSizeInBits: 0);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(ciphertext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
             }
         }
 
@@ -123,16 +123,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            UniversalCryptoTransform transform = _core.CreateCryptoTransform(
-                iv: null,
+            ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
+                iv: default,
                 encrypting: true,
                 paddingMode,
                 CipherMode.ECB,
                 feedbackSizeInBits: 0);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(plaintext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
             }
         }
 
@@ -143,16 +143,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            UniversalCryptoTransform transform = _core.CreateCryptoTransform(
-                iv: iv.ToArray(),
+            ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
+                iv,
                 encrypting: true,
                 paddingMode,
                 CipherMode.CBC,
                 feedbackSizeInBits: 0);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(plaintext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
             }
         }
 
@@ -163,16 +163,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            UniversalCryptoTransform transform = _core.CreateCryptoTransform(
-                iv: iv.ToArray(),
+            ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
+                iv,
                 encrypting: false,
                 paddingMode,
                 CipherMode.CBC,
                 feedbackSizeInBits: 0);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(ciphertext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
             }
         }
 
@@ -184,16 +184,16 @@ namespace System.Security.Cryptography
             int feedbackSizeInBits,
             out int bytesWritten)
         {
-            UniversalCryptoTransform transform = _core.CreateCryptoTransform(
-                iv: iv.ToArray(),
+            ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
+                iv,
                 encrypting: false,
                 paddingMode,
                 CipherMode.CFB,
                 feedbackSizeInBits);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(ciphertext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
             }
         }
 
@@ -205,16 +205,16 @@ namespace System.Security.Cryptography
             int feedbackSizeInBits,
             out int bytesWritten)
         {
-            UniversalCryptoTransform transform = _core.CreateCryptoTransform(
-                iv: iv.ToArray(),
+            ILiteSymmetricCipher cipher = _core.CreateLiteSymmetricCipher(
+                iv,
                 encrypting: true,
                 paddingMode,
                 CipherMode.CFB,
                 feedbackSizeInBits);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(plaintext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
             }
         }
 


### PR DESCRIPTION
This gives `AesCng` and `TripleDESCng` the lite cipher treatment. The primary motivation for this is so that all of the one-shots go through `UniversalCryptoOneShot` and use the respective lite ciphers instead of having a separate implementation. As a bonus `UniversalCryptoDecryptor` and `UniversalCryptoEncryptor` can remove their one-shot implementation, and the one-shots for the CNG types allocate less frequently.