### PR TITLE
Fix DacEnumerableHashTable enumerator

### DIFF
--- a/src/coreclr/vm/dacenumerablehash.inl
+++ b/src/coreclr/vm/dacenumerablehash.inl
@@ -499,7 +499,7 @@ DPTR(VALUE) DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::BaseIterator::Next()
     DPTR(PTR_VolatileEntry) curBuckets = m_pTable->GetBuckets();
     DWORD cBuckets = GetLength(curBuckets);
 
-    while (m_dwBucket < cBuckets)
+    while (m_dwBucket < cBuckets + SKIP_SPECIAL_SLOTS)
     {
         if (m_pEntry == NULL)
         {


### PR DESCRIPTION
The enumerator was missing the last 2 buckets

Fixes #65013