### PR TITLE
Include IsNetCoreAppRef in assembly version calculation for servicing

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -43,7 +43,7 @@
     <Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
     <_IsWindowsDesktopApp Condition="$(WindowsDesktopCoreAppLibrary.Contains('$(AssemblyName);'))">true</_IsWindowsDesktopApp>
     <_IsAspNetCoreApp Condition="$(AspNetCoreAppLibrary.Contains('$(AssemblyName);'))">true</_IsAspNetCoreApp>
-    <_AssemblyInTargetingPack Condition="('$(IsNETCoreAppSrc)' == 'true' or '$(_IsAspNetCoreApp)' == 'true' or '$(_IsWindowsDesktopApp)' == 'true') and '$(TargetFrameworkIdentifier)' != '.NETFramework'">true</_AssemblyInTargetingPack>
+    <_AssemblyInTargetingPack Condition="('$(IsNETCoreAppSrc)' == 'true' or '$(IsNetCoreAppRef)' == 'true' or '$(_IsAspNetCoreApp)' == 'true' or '$(_IsWindowsDesktopApp)' == 'true') and '$(TargetFrameworkIdentifier)' != '.NETFramework'">true</_AssemblyInTargetingPack>
     <!-- Assembly version do not get updated in non-netfx ref pack assemblies. -->
     <AssemblyVersion Condition="'$(_AssemblyInTargetingPack)' != 'true'">$(MajorVersion).$(MinorVersion).0.$(ServicingVersion)</AssemblyVersion>
   </PropertyGroup>


### PR DESCRIPTION
This is the long term fix for: https://github.com/dotnet/runtime/issues/65018

This new pattern of experimental ref only projects where the implementation is inbox, needs to be considered as an assembly in the targeting pack, so we should not bump the assembly version on servicing, with this we make sure that we catch such cases and not bump the assembly version for these experimental ref only nuget packages.

The fix to release/6.0 will be ported as part of: https://github.com/dotnet/runtime/pull/64556 as it is adding another ref only nuget package and needs to include it to unblock it's tests, however, we still need to have a PR created into release/6.0 to make sure we build `System.Runtime.Experimental` with `ServicingVersion` set to `2` and `GeneratePackageOnBuild` set to `true`. 