### PR TITLE
Avoid using object_gennum for objects that could come from frozen segments

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -43578,7 +43578,11 @@ Object * GCHeap::NextObj (Object * object)
 #else //MULTIPLE_HEAPS
     gc_heap* hp = 0;
 #endif //MULTIPLE_HEAPS
+#ifdef USE_REGIONS
+    unsigned int g = heap_segment_gen_num (hs);
+#else
     unsigned int g = hp->object_gennum ((uint8_t*)object);
+#endif
     if ((g == 0) && hp->settings.demotion)
         return NULL;//could be racing with another core allocating.
     int align_const = get_alignment_constant (!large_object_p);


### PR DESCRIPTION
The function we are changing is `GCHeap::NextObj`, which is a public API that could be called externally.

The `object` could be any managed object, potentially an object coming from a frozen segment.

The code, as is, will call the `object_gennum` function, which will fail if an object is not in the region's range as follow:

`object_gennum` -> `get_region_gen_num` -> `region_of` would return an invalid `heap_segment` pointer.

Attempting to dereference it to get the generation number would fail.

Looking in retrospect, I have no idea why the test case wasn't failing before under regions, it should be always crashing.