### PR TITLE
[mono][s390x] Fix OP_FCONV_TO_I and OP_RCONV_TO_I

### DIFF
--- a/src/mono/mono/mini/mini-s390x.c
+++ b/src/mono/mono/mini/mini-s390x.c
@@ -4286,7 +4286,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			}
 			break;
 		case OP_FCONV_TO_I4:
-		case OP_FCONV_TO_I:
 			s390_cfdbr (code, ins->dreg, 5, ins->sreg1);
 			break;
 		case OP_FCONV_TO_U4:
@@ -4297,6 +4296,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			}
 			break;
 		case OP_FCONV_TO_I8:
+		case OP_FCONV_TO_I:
 			s390_cgdbr (code, ins->dreg, 5, ins->sreg1);
 			break;
 		case OP_FCONV_TO_U8:
@@ -4341,7 +4341,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			}
 			break;
 		case OP_RCONV_TO_I4:
-		case OP_RCONV_TO_I:
 			s390_cfebr (code, ins->dreg, 5, ins->sreg1);
 			break;
 		case OP_RCONV_TO_U4:
@@ -4352,6 +4351,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			}
 			break;
 		case OP_RCONV_TO_I8:
+		case OP_RCONV_TO_I:
 			s390_cgebr (code, ins->dreg, 5, ins->sreg1);
 			break;
 		case OP_RCONV_TO_U8:


### PR DESCRIPTION
* OP_[FR]CONV_TO_I should result in an 8-byte integer

CC @lambdageek @vargaz @nealef 

Fix another fallout of the new test cases added by https://github.com/dotnet/runtime/pull/64234 on s390x, this time related to float-to-*signed*-int conversions.  As opposed to https://github.com/dotnet/runtime/pull/64618, this is just a simple back-end bug.  For some reason, this only showed up in the CI builder, not on my own machine.