### PR TITLE
Disable tests using external TLS1.2 server on win7

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -17,7 +17,7 @@ namespace System.Net.Security.Tests
     public class CertificateValidationRemoteServer
     {
         [OuterLoop("Uses external servers")]
-        [ConditionalTheory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.SupportsTls12))] // external server does not support TLS1.1 and below
         [InlineData(false)]
         [InlineData(true)]
         public async Task CertificateValidationRemoteServer_EndToEnd_Ok(bool useAsync)


### PR DESCRIPTION
Recent environmental change, the site only supports TLS 1.2 now, but Win7 does not support TLS 1.2 by default

contributes to  #65168