### PR TITLE
Send CA names on Linux and OSX

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.cs
@@ -131,10 +131,9 @@ internal static partial class Interop
         /// <param name="callbacks">Should be IntPtr.Zero</param>
         /// <returns>Returns a pointer to a CFArray on success; otherwise, returns IntPtr.Zero</returns>
         [GeneratedDllImport(Interop.Libraries.CoreFoundationLibrary)]
-        private static partial SafeCreateHandle CFArrayCreate(
+        private static unsafe partial SafeCreateHandle CFArrayCreate(
             IntPtr allocator,
-            [MarshalAs(UnmanagedType.LPArray)]
-            IntPtr[] values,
+            IntPtr* values,
             UIntPtr numValues,
             IntPtr callbacks);
 
@@ -146,7 +145,23 @@ internal static partial class Interop
         /// <returns>Returns a valid SafeCreateHandle to a CFArray on success; otherwise, returns an invalid SafeCreateHandle</returns>
         internal static SafeCreateHandle CFArrayCreate(IntPtr[] values, UIntPtr numValues)
         {
-            return CFArrayCreate(IntPtr.Zero, values, numValues, IntPtr.Zero);
+            fixed (IntPtr* pValues = values)
+            {
+                return CFArrayCreate(IntPtr.Zero, pValues, (UIntPtr)values.Length, IntPtr.Zero);
+            }
+        }
+
+        /// <summary>
+        /// Creates a pointer to an unmanaged CFArray containing the input values. Follows the "Create Rule" where if you create it, you delete it.
+        /// </summary>
+        /// <param name="values">The values to put in the array</param>
+        /// <returns>Returns a valid SafeCreateHandle to a CFArray on success; otherwise, returns an invalid SafeCreateHandle</returns>
+        internal static unsafe SafeCreateHandle CFArrayCreate(Span<IntPtr> values)
+        {
+            fixed (IntPtr* pValues = MemoryMarshal)
+            {
+                return CFArrayCreate(IntPtr.Zero, pValues, (UIntPtr)values.Length, IntPtr.Zero);
+            }
         }
 
         /// <summary>

--- a/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.cs
@@ -20,21 +20,21 @@ internal static partial class Interop
         /// </summary>
         private enum CFStringBuiltInEncodings : uint
         {
-            kCFStringEncodingMacRoman       = 0,
-            kCFStringEncodingWindowsLatin1  = 0x0500,
-            kCFStringEncodingISOLatin1      = 0x0201,
-            kCFStringEncodingNextStepLatin  = 0x0B01,
-            kCFStringEncodingASCII          = 0x0600,
-            kCFStringEncodingUnicode        = 0x0100,
-            kCFStringEncodingUTF8           = 0x08000100,
-            kCFStringEncodingNonLossyASCII  = 0x0BFF,
+            kCFStringEncodingMacRoman = 0,
+            kCFStringEncodingWindowsLatin1 = 0x0500,
+            kCFStringEncodingISOLatin1 = 0x0201,
+            kCFStringEncodingNextStepLatin = 0x0B01,
+            kCFStringEncodingASCII = 0x0600,
+            kCFStringEncodingUnicode = 0x0100,
+            kCFStringEncodingUTF8 = 0x08000100,
+            kCFStringEncodingNonLossyASCII = 0x0BFF,
 
-            kCFStringEncodingUTF16          = 0x0100,
-            kCFStringEncodingUTF16BE        = 0x10000100,
-            kCFStringEncodingUTF16LE        = 0x14000100,
-            kCFStringEncodingUTF32          = 0x0c000100,
-            kCFStringEncodingUTF32BE        = 0x18000100,
-            kCFStringEncodingUTF32LE        = 0x1c000100
+            kCFStringEncodingUTF16 = 0x0100,
+            kCFStringEncodingUTF16BE = 0x10000100,
+            kCFStringEncodingUTF16LE = 0x14000100,
+            kCFStringEncodingUTF32 = 0x0c000100,
+            kCFStringEncodingUTF32BE = 0x18000100,
+            kCFStringEncodingUTF32LE = 0x1c000100
         }
 
         /// <summary>
@@ -143,7 +143,7 @@ internal static partial class Interop
         /// <param name="values">The values to put in the array</param>
         /// <param name="numValues">The number of values in the array</param>
         /// <returns>Returns a valid SafeCreateHandle to a CFArray on success; otherwise, returns an invalid SafeCreateHandle</returns>
-        internal static SafeCreateHandle CFArrayCreate(IntPtr[] values, UIntPtr numValues)
+        internal static unsafe SafeCreateHandle CFArrayCreate(IntPtr[] values, UIntPtr numValues)
         {
             fixed (IntPtr* pValues = values)
             {
@@ -158,7 +158,7 @@ internal static partial class Interop
         /// <returns>Returns a valid SafeCreateHandle to a CFArray on success; otherwise, returns an invalid SafeCreateHandle</returns>
         internal static unsafe SafeCreateHandle CFArrayCreate(Span<IntPtr> values)
         {
-            fixed (IntPtr* pValues = MemoryMarshal)
+            fixed (IntPtr* pValues = &MemoryMarshal.GetReference(values))
             {
                 return CFArrayCreate(IntPtr.Zero, pValues, (UIntPtr)values.Length, IntPtr.Zero);
             }

--- a/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.cs
@@ -20,21 +20,21 @@ internal static partial class Interop
         /// </summary>
         private enum CFStringBuiltInEncodings : uint
         {
-            kCFStringEncodingMacRoman = 0,
-            kCFStringEncodingWindowsLatin1 = 0x0500,
-            kCFStringEncodingISOLatin1 = 0x0201,
-            kCFStringEncodingNextStepLatin = 0x0B01,
-            kCFStringEncodingASCII = 0x0600,
-            kCFStringEncodingUnicode = 0x0100,
-            kCFStringEncodingUTF8 = 0x08000100,
-            kCFStringEncodingNonLossyASCII = 0x0BFF,
+            kCFStringEncodingMacRoman       = 0,
+            kCFStringEncodingWindowsLatin1  = 0x0500,
+            kCFStringEncodingISOLatin1      = 0x0201,
+            kCFStringEncodingNextStepLatin  = 0x0B01,
+            kCFStringEncodingASCII          = 0x0600,
+            kCFStringEncodingUnicode        = 0x0100,
+            kCFStringEncodingUTF8           = 0x08000100,
+            kCFStringEncodingNonLossyASCII  = 0x0BFF,
 
-            kCFStringEncodingUTF16 = 0x0100,
-            kCFStringEncodingUTF16BE = 0x10000100,
-            kCFStringEncodingUTF16LE = 0x14000100,
-            kCFStringEncodingUTF32 = 0x0c000100,
-            kCFStringEncodingUTF32BE = 0x18000100,
-            kCFStringEncodingUTF32LE = 0x1c000100
+            kCFStringEncodingUTF16          = 0x0100,
+            kCFStringEncodingUTF16BE        = 0x10000100,
+            kCFStringEncodingUTF16LE        = 0x14000100,
+            kCFStringEncodingUTF32          = 0x0c000100,
+            kCFStringEncodingUTF32BE        = 0x18000100,
+            kCFStringEncodingUTF32LE        = 0x1c000100
         }
 
         /// <summary>

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
@@ -164,9 +164,9 @@ internal static partial class Interop
         [GeneratedDllImport(Interop.Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_SslSetCertificateAuthorities")]
         internal static partial int SslSetCertificateAuthorities(SafeSslHandle sslHandle, SafeCreateHandle certificateOrArray, int replaceExisting);
 
-        internal static unsafe void SslSetCertificateAuthorities(SafeSslHandle sslHandle, IntPtr[] certificates, bool replaceExisting)
+        internal static unsafe void SslSetCertificateAuthorities(SafeSslHandle sslHandle, Span<IntPtr> certificates, bool replaceExisting)
         {
-            using (SafeCreateHandle cfCertRefs = CoreFoundation.CFArrayCreate(certificates, (UIntPtr)certificates.Length))
+            using (SafeCreateHandle cfCertRefs = CoreFoundation.CFArrayCreate(certificates))
             {
                 int osStatus = SslSetCertificateAuthorities(sslHandle, cfCertRefs, replaceExisting ? 1 : 0);
 

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
@@ -161,6 +161,22 @@ internal static partial class Interop
         [GeneratedDllImport(Interop.Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_SslSetEnabledCipherSuites")]
         internal static unsafe partial int SslSetEnabledCipherSuites(SafeSslHandle sslHandle, uint* cipherSuites, int numCipherSuites);
 
+        [GeneratedDllImport(Interop.Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_SslSetCertificateAuthorities")]
+        internal static partial int SslSetCertificateAuthorities(SafeSslHandle sslHandle, SafeCreateHandle certificateOrArray, int replaceExisting);
+
+        internal static unsafe void SslSetCertificateAuthorities(SafeSslHandle sslHandle, IntPtr[] certificates, bool replaceExisting)
+        {
+            using (SafeCreateHandle cfCertRefs = CoreFoundation.CFArrayCreate(certificates, (UIntPtr)certificates.Length))
+            {
+                int osStatus = SslSetCertificateAuthorities(sslHandle, cfCertRefs, replaceExisting ? 1 : 0);
+
+                if (osStatus != 0)
+                {
+                    throw CreateExceptionForOSStatus(osStatus);
+                }
+            }
+        }
+
         internal static void SslSetAcceptClientCert(SafeSslHandle sslHandle)
         {
             int osStatus = AppleCryptoNative_SslSetAcceptClientCert(sslHandle);

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -12,6 +12,7 @@ using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
@@ -46,32 +47,32 @@ internal static partial class Interop
             return bindingHandle;
         }
 
-         private static volatile int s_disableTlsResume = -1;
+        private static volatile int s_disableTlsResume = -1;
 
-         private static bool DisableTlsResume
-         {
-             get
-             {
-                 int disableTlsResume = s_disableTlsResume;
-                 if (disableTlsResume != -1)
-                 {
-                     return disableTlsResume != 0;
-                 }
+        private static bool DisableTlsResume
+        {
+            get
+            {
+                int disableTlsResume = s_disableTlsResume;
+                if (disableTlsResume != -1)
+                {
+                    return disableTlsResume != 0;
+                }
 
-                 // First check for the AppContext switch, giving it priority over the environment variable.
-                 if (AppContext.TryGetSwitch(DisableTlsResumeCtxSwitch, out bool value))
-                 {
-                     s_disableTlsResume = value ? 1 : 0;
-                 }
-                 else
-                 {
-                     // AppContext switch wasn't used. Check the environment variable.
+                // First check for the AppContext switch, giving it priority over the environment variable.
+                if (AppContext.TryGetSwitch(DisableTlsResumeCtxSwitch, out bool value))
+                {
+                    s_disableTlsResume = value ? 1 : 0;
+                }
+                else
+                {
+                    // AppContext switch wasn't used. Check the environment variable.
                     s_disableTlsResume =
                         Environment.GetEnvironmentVariable(DisableTlsResumeEnvironmentVariable) is string envVar &&
                         (envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase)) ? 1 : 0;
-                 }
+                }
 
-                 return s_disableTlsResume != 0;
+                return s_disableTlsResume != 0;
             }
         }
 
@@ -147,7 +148,7 @@ internal static partial class Interop
                     // Sets policy and security level
                     if (!Ssl.SetEncryptionPolicy(sslCtx, sslAuthenticationOptions.EncryptionPolicy))
                     {
-                        throw new SslException( SR.Format(SR.net_ssl_encryptionpolicy_notsupported, sslAuthenticationOptions.EncryptionPolicy));
+                        throw new SslException(SR.Format(SR.net_ssl_encryptionpolicy_notsupported, sslAuthenticationOptions.EncryptionPolicy));
                     }
                 }
 
@@ -274,7 +275,7 @@ internal static partial class Interop
 
             if (cacheSslContext)
             {
-               sslAuthenticationOptions.CertificateContext!.SslContexts!.TryGetValue(protocols | (SslProtocols)(hasAlpn ? 1 : 0), out sslCtxHandle);
+                sslAuthenticationOptions.CertificateContext!.SslContexts!.TryGetValue(protocols | (SslProtocols)(hasAlpn ? 1 : 0), out sslCtxHandle);
             }
 
             if (sslCtxHandle == null)
@@ -339,10 +340,27 @@ internal static partial class Interop
                     // if server actually requests a certificate.
                     Ssl.SslSetClientCertCallback(sslHandle, 1);
                 }
-
-                if (sslAuthenticationOptions.IsServer && sslAuthenticationOptions.RemoteCertRequired)
+                else // sslAuthenticationOptions.IsServer
                 {
-                    Ssl.SslSetVerifyPeer(sslHandle);
+                    if (sslAuthenticationOptions.RemoteCertRequired)
+                    {
+                        Ssl.SslSetVerifyPeer(sslHandle);
+                    }
+
+                    if (sslAuthenticationOptions.CertificateContext?.Trust?._sendTrustInHandshake == true)
+                    {
+                        SslCertificateTrust trust = sslAuthenticationOptions.CertificateContext!.Trust!;
+                        X509Certificate2Collection certList = (trust._trustList ?? trust._store!.Certificates);
+
+                        Debug.Assert(certList != null, "certList != null");
+                        foreach (X509Certificate2 cert in certList)
+                        {
+                            if (!Ssl.SslAddClientCA(sslHandle, cert.Handle))
+                            {
+                                Debug.Fail("Failed to add issuer to trusted CA list.");
+                            }
+                        }
+                    }
                 }
             }
             catch
@@ -576,7 +594,7 @@ internal static partial class Interop
         {
             *outp = null;
             *outlen = 0;
-            IntPtr sslData =  Ssl.SslGetData(ssl);
+            IntPtr sslData = Ssl.SslGetData(ssl);
 
             // reset application data to avoid dangling pointer.
             Ssl.SslSetData(ssl, IntPtr.Zero);

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -350,25 +350,7 @@ internal static partial class Interop
                     if (sslAuthenticationOptions.CertificateContext?.Trust?._sendTrustInHandshake == true)
                     {
                         SslCertificateTrust trust = sslAuthenticationOptions.CertificateContext!.Trust!;
-                        X509Certificate2Collection certList = (trust._trustList ?? trust._store!.Certificates);
-
-                        Debug.Assert(certList != null, "certList != null");
-                        Span<IntPtr> handles = certList.Count <= 256
-                            ? stackalloc IntPtr[256]
-                            : new IntPtr[certList.Count];
-
-                        for (int i = 0; i < certList.Count; i++)
-                        {
-                            handles[i] = certList[i].Handle;
-                        }
-
-                        if (!Ssl.SslAddClientCAs(sslHandle, handles.Slice(0, certList.Count)))
-                        {
-                            // The method can fail only when the number of cert names exceeds the maximum capacity
-                            // supported by STACK_OF(X509_NAME) structure, which should not happen under normal
-                            // operation.
-                            Debug.Fail("Failed to add issuer to trusted CA list.");
-                        }
+                        SetCertificateAuthorities(sslHandle, trust._trustList ?? trust._store!.Certificates);
                     }
                 }
             }
@@ -387,6 +369,39 @@ internal static partial class Interop
             }
 
             return sslHandle;
+        }
+
+        internal static void SetCertificateAuthorities(SafeSslHandle sslHandle, X509Certificate2Collection certList)
+        {
+            Debug.Assert(certList != null, "certList != null");
+            Span<IntPtr> handles = certList.Count <= 256
+                ? stackalloc IntPtr[256]
+                : new IntPtr[certList.Count];
+
+            int certCount = 0;
+            for (int i = 0; i < certList.Count; i++)
+            {
+                foreach (X509Extension ext in certList[i].Extensions)
+                {
+                    // filter out non-CA certificates
+                    if (ext is X509BasicConstraintsExtension ex)
+                    {
+                        if (ex.CertificateAuthority)
+                        {
+                            handles[certCount++] = certList[i].Handle;
+                        }
+                        break;
+                    }
+                }
+            }
+
+            if (!Ssl.SslAddClientCAs(sslHandle, handles.Slice(0, certCount)))
+            {
+                // The method can fail only when the number of cert names exceeds the maximum capacity
+                // supported by STACK_OF(X509_NAME) structure, which should not happen under normal
+                // operation.
+                Debug.Fail("Failed to add issuer to trusted CA list.");
+            }
         }
 
         internal static SecurityStatusPal SslRenegotiate(SafeSslHandle sslContext, out byte[]? outputBuffer)

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -221,8 +221,16 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslAddExtraChainCert")]
         internal static partial bool SslAddExtraChainCert(SafeSslHandle ssl, SafeX509Handle x509);
 
-        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslAddClientCA")]
-        internal static partial bool SslAddClientCA(SafeSslHandle ssl, IntPtr x509);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslAddClientCAs")]
+        private static unsafe partial bool SslAddClientCAs(SafeSslHandle ssl, IntPtr* x509s, int count);
+
+        internal static unsafe bool SslAddClientCAs(SafeSslHandle ssl, Span<IntPtr> x509handles)
+        {
+            fixed (IntPtr* pHandles = &MemoryMarshal.GetReference(x509handles))
+            {
+                return SslAddClientCAs(ssl, pHandles, x509handles.Length);
+            }
+        }
 
         internal static bool AddExtraChainCertificates(SafeSslHandle ssl, X509Certificate2[] chain)
         {

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -221,6 +221,9 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslAddExtraChainCert")]
         internal static partial bool SslAddExtraChainCert(SafeSslHandle ssl, SafeX509Handle x509);
 
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslAddClientCA")]
+        internal static partial bool SslAddClientCA(SafeSslHandle ssl, IntPtr x509);
+
         internal static bool AddExtraChainCertificates(SafeSslHandle ssl, X509Certificate2[] chain)
         {
             // send pre-computed list of intermediates.

--- a/src/libraries/System.Net.Security/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Security/src/Resources/Strings.resx
@@ -386,4 +386,7 @@
   <data name="net_ssl_trust_collection" xml:space="preserve">
     <value>Sending trust from collection is not supported on Windows.</value>
   </data>
+  <data name="net_ssl_trust_handshake" xml:space="preserve">
+    <value>Sending trust in handshake is not supported on this platform.</value>
+  </data>
 </root>

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
@@ -115,38 +115,22 @@ namespace System.Net
                 if (sslAuthenticationOptions.CertificateContext?.Trust?._sendTrustInHandshake == true)
                 {
                     SslCertificateTrust trust = sslAuthenticationOptions.CertificateContext!.Trust!;
-                    SetCertificateAuthorities(trust._trustList ?? trust._store!.Certificates);
-                }
-            }
-        }
+                    X509Certificate2Collection certList = (trust._trustList ?? trust._store!.Certificates);
 
-        internal void SetCertificateAuthorities(X509Certificate2Collection certList)
-        {
-            Debug.Assert(certList != null, "certList != null");
-            Span<IntPtr> handles = certList.Count <= 256
-                ? stackalloc IntPtr[256]
-                : new IntPtr[certList.Count];
+                    Debug.Assert(certList != null, "certList != null");
+                    Span<IntPtr> handles = certList.Count <= 256
+                        ? stackalloc IntPtr[256]
+                        : new IntPtr[certList.Count];
 
-            int certCount = 0;
-            for (int i = 0; i < certList.Count; i++)
-            {
-                foreach (X509Extension ext in certList[i].Extensions)
-                {
-                    // filter out non-CA certificates
-                    if (ext is X509BasicConstraintsExtension ex)
+                    for (int i = 0; i < certList.Count; i++)
                     {
-                        if (ex.CertificateAuthority)
-                        {
-                            handles[certCount++] = certList[i].Handle;
-                        }
-                        break;
+                        handles[i] = certList[i].Handle;
                     }
+
+                    Interop.AppleCrypto.SslSetCertificateAuthorities(_sslContext, handles.Slice(0, certList.Count), true);
                 }
             }
-
-            Interop.AppleCrypto.SslSetCertificateAuthorities(_sslContext, handles.Slice(0, certCount), true);
         }
-
 
         private static SafeSslHandle CreateSslContext(SafeFreeSslCredentials credential, bool isServer)
         {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
@@ -92,6 +92,42 @@ namespace System.Net
                 Dispose();
                 throw;
             }
+
+            if (!string.IsNullOrEmpty(sslAuthenticationOptions.TargetHost) && !sslAuthenticationOptions.IsServer)
+            {
+                Interop.AppleCrypto.SslSetTargetName(_sslContext, sslAuthenticationOptions.TargetHost);
+            }
+
+            if (sslAuthenticationOptions.CertificateContext == null && sslAuthenticationOptions.CertSelectionDelegate != null)
+            {
+                // certificate was not provided but there is user callback. We can break handshake if server asks for certificate
+                // and we can try to get it based on remote certificate and trusted issuers.
+                Interop.AppleCrypto.SslBreakOnCertRequested(_sslContext, true);
+            }
+
+            if (sslAuthenticationOptions.IsServer)
+            {
+                if (sslAuthenticationOptions.RemoteCertRequired)
+                {
+                    Interop.AppleCrypto.SslSetAcceptClientCert(_sslContext);
+                }
+
+                if (sslAuthenticationOptions.CertificateContext?.Trust?._sendTrustInHandshake == true)
+                {
+                    SslCertificateTrust trust = sslAuthenticationOptions.CertificateContext!.Trust!;
+                    X509Certificate2Collection certList = (trust._trustList ?? trust._store!.Certificates);
+
+                    Debug.Assert(certList != null, "certList != null");
+                    IntPtr[] handles = new IntPtr[certList.Count];
+
+                    for (int i = 0; i < certList.Count; i++)
+                    {
+                        handles[i] = certList[i].Handle;
+                    }
+
+                    Interop.AppleCrypto.SslSetCertificateAuthorities(_sslContext, handles, true);
+                }
+            }
         }
 
         private static SafeSslHandle CreateSslContext(SafeFreeSslCredentials credential, bool isServer)

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
@@ -118,14 +118,16 @@ namespace System.Net
                     X509Certificate2Collection certList = (trust._trustList ?? trust._store!.Certificates);
 
                     Debug.Assert(certList != null, "certList != null");
-                    IntPtr[] handles = new IntPtr[certList.Count];
+                    Span<IntPtr> handles = certList.Count <= 256
+                        ? stackalloc IntPtr[256]
+                        : new IntPtr[certList.Count];
 
                     for (int i = 0; i < certList.Count; i++)
                     {
                         handles[i] = certList[i].Handle;
                     }
 
-                    Interop.AppleCrypto.SslSetCertificateAuthorities(_sslContext, handles, true);
+                    Interop.AppleCrypto.SslSetCertificateAuthorities(_sslContext, handles.Slice(0, certList.Count), true);
                 }
             }
         }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
@@ -144,7 +144,7 @@ namespace System.Net
                 }
             }
 
-            Interop.AppleCrypto.SslSetCertificateAuthorities(_sslContext, handles.Slice(0, certList.Count), true);
+            Interop.AppleCrypto.SslSetCertificateAuthorities(_sslContext, handles.Slice(0, certCount), true);
         }
 
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslCertificateTrust.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslCertificateTrust.cs
@@ -24,7 +24,7 @@ namespace System.Net.Security
             if (sendTrustInHandshake && !System.OperatingSystem.IsLinux() && !System.OperatingSystem.IsMacOS())
             {
                 // to be removed when implemented.
-                throw new PlatformNotSupportedException("Not supported yet.");
+                throw new PlatformNotSupportedException(SR.net_ssl_trust_handshake);
             }
 #endif
             if (!store.IsOpen)
@@ -44,7 +44,7 @@ namespace System.Net.Security
             if (sendTrustInHandshake && !System.OperatingSystem.IsLinux() && !System.OperatingSystem.IsMacOS())
             {
                 // to be removed when implemented.
-                throw new PlatformNotSupportedException("Not supported yet.");
+                throw new PlatformNotSupportedException(SR.net_ssl_trust_handshake);
             }
 
 #if TARGET_WINDOWS

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslCertificateTrust.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslCertificateTrust.cs
@@ -21,7 +21,7 @@ namespace System.Net.Security
                 throw new PlatformNotSupportedException(SR.net_ssl_trust_store);
             }
 #else
-            if (sendTrustInHandshake && !System.OperatingSystem.IsLinux())
+            if (sendTrustInHandshake && !System.OperatingSystem.IsLinux() && !System.OperatingSystem.IsMacOS())
             {
                 // to be removed when implemented.
                 throw new PlatformNotSupportedException("Not supported yet.");
@@ -41,7 +41,7 @@ namespace System.Net.Security
         [UnsupportedOSPlatform("windows")]
         public static SslCertificateTrust CreateForX509Collection(X509Certificate2Collection trustList, bool sendTrustInHandshake = false)
         {
-            if (sendTrustInHandshake && !System.OperatingSystem.IsLinux())
+            if (sendTrustInHandshake && !System.OperatingSystem.IsLinux() && !System.OperatingSystem.IsMacOS())
             {
                 // to be removed when implemented.
                 throw new PlatformNotSupportedException("Not supported yet.");

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslCertificateTrust.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslCertificateTrust.cs
@@ -21,7 +21,7 @@ namespace System.Net.Security
                 throw new PlatformNotSupportedException(SR.net_ssl_trust_store);
             }
 #else
-            if (sendTrustInHandshake)
+            if (sendTrustInHandshake && !System.OperatingSystem.IsLinux())
             {
                 // to be removed when implemented.
                 throw new PlatformNotSupportedException("Not supported yet.");
@@ -41,7 +41,7 @@ namespace System.Net.Security
         [UnsupportedOSPlatform("windows")]
         public static SslCertificateTrust CreateForX509Collection(X509Certificate2Collection trustList, bool sendTrustInHandshake = false)
         {
-            if (sendTrustInHandshake)
+            if (sendTrustInHandshake && !System.OperatingSystem.IsLinux())
             {
                 // to be removed when implemented.
                 throw new PlatformNotSupportedException("Not supported yet.");

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -747,6 +747,11 @@ namespace System.Net.Security
                 return frameSize;
             }
 
+            if (frameSize < int.MaxValue)
+            {
+                _buffer.EnsureAvailableSpace(frameSize - _buffer.EncryptedLength);
+            }
+
             while (_buffer.EncryptedLength < frameSize)
             {
                 // there should be space left to read into

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
@@ -248,23 +248,6 @@ namespace System.Net.Security
                 {
                     sslContext = new SafeDeleteSslContext((credential as SafeFreeSslCredentials)!, sslAuthenticationOptions);
                     context = sslContext;
-
-                    if (!string.IsNullOrEmpty(sslAuthenticationOptions.TargetHost) && !sslAuthenticationOptions.IsServer)
-                    {
-                        Interop.AppleCrypto.SslSetTargetName(sslContext.SslContext, sslAuthenticationOptions.TargetHost);
-                    }
-
-                    if (sslAuthenticationOptions.CertificateContext == null && sslAuthenticationOptions.CertSelectionDelegate != null)
-                    {
-                        // certificate was not provided but there is user callback. We can break handshake if server asks for certificate
-                        // and we can try to get it based on remote certificate and trusted issuers.
-                        Interop.AppleCrypto.SslBreakOnCertRequested(sslContext.SslContext, true);
-                    }
-
-                    if (sslAuthenticationOptions.IsServer && sslAuthenticationOptions.RemoteCertRequired)
-                    {
-                        Interop.AppleCrypto.SslSetAcceptClientCert(sslContext.SslContext);
-                    }
                 }
 
                 if (inputBuffer.Length > 0)

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateTrustTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateTrustTests.cs
@@ -20,19 +20,13 @@ namespace System.Net.Security.Tests
         [PlatformSpecific(TestPlatforms.Linux | TestPlatforms.OSX)]
         public async Task SslStream_SendCertificateTrust_CertificateCollection()
         {
-            using X509Store store = new X509Store("Root", StoreLocation.LocalMachine);
-            store.Open(OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly);
-            X509Certificate2[] certList = store.Certificates.DistinctBy(c => c.Subject).Take(2).ToArray();
+            (X509Certificate2 certificate, X509Certificate2Collection caCerts) = TestHelper.GenerateCertificates("foo");
 
-            SslCertificateTrust trust = SslCertificateTrust.CreateForX509Collection(
-                new X509Certificate2Collection(certList),
-                sendTrustInHandshake: true);
-
+            SslCertificateTrust trust = SslCertificateTrust.CreateForX509Collection(caCerts, sendTrustInHandshake: true);
             string[] acceptableIssuers = await ConnectAndGatherAcceptableIssuers(trust);
 
-            Assert.Equal(2, acceptableIssuers.Length);
-            Assert.Contains(certList[0].Subject, acceptableIssuers);
-            Assert.Contains(certList[1].Subject, acceptableIssuers);
+            Assert.Equal(caCerts.Count, acceptableIssuers.Length);
+            Assert.Equal(caCerts.Select(c => c.Subject), acceptableIssuers);
         }
 
         [Fact]

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateTrustTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateTrustTests.cs
@@ -16,7 +16,7 @@ namespace System.Net.Security.Tests
     {
         [Fact]
         // not supported on Windows, not implemented elsewhere
-        [PlatformSpecific(TestPlatforms.Linux)]
+        [PlatformSpecific(TestPlatforms.Linux | TestPlatforms.OSX)]
         public async Task SslStream_SendCertificateTrust_CertificateCollection()
         {
             (SslStream client, SslStream server) = TestHelper.GetConnectedSslStreams();
@@ -68,6 +68,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.Linux | TestPlatforms.OSX)]
         public async Task SslStream_SendCertificateTrust_CertificateStore()
         {
             (SslStream client, SslStream server) = TestHelper.GetConnectedSslStreams();

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateTrustTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateTrustTests.cs
@@ -42,7 +42,6 @@ namespace System.Net.Security.Tests
                 SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions
                 {
                     TargetHost = "localhost",
-                    EnabledSslProtocols = SslProtocols.Tls12,
                     RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true,
                     LocalCertificateSelectionCallback = (sender, targetHost, localCertificates, remoteCertificate, issuers) =>
                     {
@@ -93,7 +92,6 @@ namespace System.Net.Security.Tests
                 SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions
                 {
                     TargetHost = "localhost",
-                    EnabledSslProtocols = SslProtocols.Tls12,
                     RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true,
                     LocalCertificateSelectionCallback = (sender, targetHost, localCertificates, remoteCertificate, issuers) =>
                     {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateTrustTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateTrustTests.cs
@@ -30,6 +30,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/65515", TestPlatforms.Windows)]
         [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.Linux | TestPlatforms.OSX)]
         public async Task SslStream_SendCertificateTrust_CertificateStore()
         {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateTrustTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateTrustTests.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.IO.Tests;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Security.Tests
+{
+    using Configuration = System.Net.Test.Common.Configuration;
+
+    public class SslStreamCertificateTrustTest
+    {
+        [Fact]
+        // not supported on Windows, not implemented elsewhere
+        [PlatformSpecific(TestPlatforms.Linux)]
+        public async Task SslStream_SendCertificateTrust_CertificateCollection()
+        {
+            (SslStream client, SslStream server) = TestHelper.GetConnectedSslStreams();
+            using (client)
+            using (server)
+            using (X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate())
+            using (X509Certificate2 clientCertificate = Configuration.Certificates.GetClientCertificate())
+            {
+                SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions
+                {
+                    ServerCertificate = serverCertificate,
+                    ClientCertificateRequired = true,
+                    RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true,
+                    ServerCertificateContext = SslStreamCertificateContext.Create(
+                        serverCertificate,
+                        null,
+                        trust: SslCertificateTrust.CreateForX509Collection(
+                            new X509Certificate2Collection { serverCertificate, clientCertificate },
+                            sendTrustInHandshake: true))
+                };
+
+                string[] acceptableIssuers = Array.Empty<string>();
+                SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions
+                {
+                    TargetHost = "localhost",
+                    EnabledSslProtocols = SslProtocols.Tls12,
+                    RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true,
+                    LocalCertificateSelectionCallback = (sender, targetHost, localCertificates, remoteCertificate, issuers) =>
+                    {
+                        if (remoteCertificate == null)
+                        {
+                            // ignore the first call, we should receive acceptable issuers in the next one
+                            return null;
+                        }
+
+                        acceptableIssuers = issuers;
+                        return clientCertificate;
+                    },
+
+                };
+
+                await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
+                                client.AuthenticateAsClientAsync(clientOptions),
+                                server.AuthenticateAsServerAsync(serverOptions));
+
+                Assert.Equal(2, acceptableIssuers.Length);
+                Assert.Contains(serverCertificate.Subject, acceptableIssuers);
+                Assert.Contains(clientCertificate.Subject, acceptableIssuers);
+            }
+        }
+
+        [Fact]
+        public async Task SslStream_SendCertificateTrust_CertificateStore()
+        {
+            (SslStream client, SslStream server) = TestHelper.GetConnectedSslStreams();
+            using (client)
+            using (server)
+            using (X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate())
+            using (X509Certificate2 clientCertificate = Configuration.Certificates.GetClientCertificate())
+            using (X509Store store = new X509Store("Root", StoreLocation.LocalMachine))
+            {
+                SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions
+                {
+                    ServerCertificate = serverCertificate,
+                    ClientCertificateRequired = true,
+                    RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true,
+                    ServerCertificateContext = SslStreamCertificateContext.Create(
+                        serverCertificate,
+                        null,
+                        trust: SslCertificateTrust.CreateForX509Store(store, sendTrustInHandshake: true))
+                };
+
+                string[] acceptableIssuers = Array.Empty<string>();
+                SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions
+                {
+                    TargetHost = "localhost",
+                    EnabledSslProtocols = SslProtocols.Tls12,
+                    RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true,
+                    LocalCertificateSelectionCallback = (sender, targetHost, localCertificates, remoteCertificate, issuers) =>
+                    {
+                        if (remoteCertificate == null)
+                        {
+                            // ignore the first call, we should receive acceptable issuers in the next one
+                            return null;
+                        }
+
+                        acceptableIssuers = issuers;
+                        return clientCertificate;
+                    },
+
+                };
+
+                await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
+                                client.AuthenticateAsClientAsync(clientOptions),
+                                server.AuthenticateAsServerAsync(serverOptions));
+
+                // don't assert individual ellements, just that some issuers were sent
+                // we use Root cert store which should always contain at least some certs
+                Assert.NotEmpty(acceptableIssuers);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateTrustTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateTrustTests.cs
@@ -20,7 +20,7 @@ namespace System.Net.Security.Tests
         [PlatformSpecific(TestPlatforms.Linux | TestPlatforms.OSX)]
         public async Task SslStream_SendCertificateTrust_CertificateCollection()
         {
-            (X509Certificate2 certificate, X509Certificate2Collection caCerts) = TestHelper.GenerateCertificates("foo");
+            (X509Certificate2 certificate, X509Certificate2Collection caCerts) = TestHelper.GenerateCertificates(nameof(SslStream_SendCertificateTrust_CertificateCollection));
 
             SslCertificateTrust trust = SslCertificateTrust.CreateForX509Collection(caCerts, sendTrustInHandshake: true);
             string[] acceptableIssuers = await ConnectAndGatherAcceptableIssuers(trust);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateTrustTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateTrustTests.cs
@@ -64,12 +64,15 @@ namespace System.Net.Security.Tests
                 SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions
                 {
                     TargetHost = "localhost",
+                    // Force Tls 1.2 to avoid issues with certain OpenSSL versions and Tls 1.3
+                    // https://github.com/openssl/openssl/issues/7384
+                    EnabledSslProtocols = SslProtocols.Tls12,
                     RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true,
                     LocalCertificateSelectionCallback = (sender, targetHost, localCertificates, remoteCertificate, issuers) =>
                     {
                         if (remoteCertificate == null)
                         {
-                            // ignore the first call, we should receive acceptable issuers in the next one
+                            // ignore the first call that is called before handshake
                             return null;
                         }
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -100,6 +100,7 @@
     <Compile Include="SslStreamAlertsTest.cs" />
     <Compile Include="SslStreamAllowRenegotiationTests.cs" />
     <Compile Include="SslStreamAlpnTests.cs" />
+    <Compile Include="SslStreamCertificateTrustTests.cs" />
     <Compile Include="SslStreamDisposeTest.cs" />
     <Compile Include="SslStreamSniTest.cs" />
     <Compile Include="SslStreamEKUTest.cs" />

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/entrypoints.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/entrypoints.c
@@ -7,7 +7,9 @@
 #include "pal_digest.h"
 #include "pal_ecc.h"
 #include "pal_hmac.h"
+#include "pal_keyagree.h"
 #include "pal_keychain_macos.h"
+#include "pal_keyderivation_macos.h"
 #include "pal_random.h"
 #include "pal_rsa.h"
 #include "pal_sec.h"
@@ -20,8 +22,6 @@
 #include "pal_x509.h"
 #include "pal_x509_macos.h"
 #include "pal_x509chain.h"
-#include "pal_keyderivation_macos.h"
-#include "pal_keyagree.h"
 
 static const Entry s_cryptoAppleNative[] =
 {
@@ -84,6 +84,7 @@ static const Entry s_cryptoAppleNative[] =
     DllImportEntry(AppleCryptoNative_SslSetMinProtocolVersion)
     DllImportEntry(AppleCryptoNative_SslSetMaxProtocolVersion)
     DllImportEntry(AppleCryptoNative_SslSetCertificate)
+    DllImportEntry(AppleCryptoNative_SslSetCertificateAuthorities)
     DllImportEntry(AppleCryptoNative_SslSetTargetName)
     DllImportEntry(AppleCryptoNative_SSLSetALPNProtocols)
     DllImportEntry(AppleCryptoNative_SslGetAlpnSelected)

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -641,17 +641,28 @@ int32_t AppleCryptoNative_SslSetEnabledCipherSuites(SSLContextRef sslContext, co
     }
 }
 
+// This API is present on macOS 10.5 and newer only
+static OSStatus (*SSLSetCertificateAuthoritiesPtr)(SSLContextRef context, CFArrayRef certificates, int32_t replaceExisting) = NULL;
+
 PALEXPORT int32_t AppleCryptoNative_SslSetCertificateAuthorities(SSLContextRef sslContext, CFArrayRef certificates, int32_t replaceExisting)
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     // The underlying call handles NULL inputs, so just pass it through
-    return SSLSetCertificateAuthorities(sslContext, certificates, replaceExisting);
+
+    if (!SSLSetCertificateAuthoritiesPtr)
+    {
+        // not available.
+        return 0;
+    }
+
+    return SSLSetCertificateAuthoritiesPtr(sslContext, certificates, replaceExisting);
 #pragma clang diagnostic pop
 }
 
 __attribute__((constructor)) static void InitializeAppleCryptoSslShim()
 {
+    SSLSetCertificateAuthoritiesPtr = (OSStatus(*)(SSLContextRef, CFArrayRef, int32_t))dlsym(RTLD_DEFAULT, "SSLSetCertificateAuthorities");
     SSLSetALPNProtocolsPtr = (OSStatus(*)(SSLContextRef, CFArrayRef))dlsym(RTLD_DEFAULT, "SSLSetALPNProtocols");
     SSLCopyALPNProtocolsPtr = (OSStatus(*)(SSLContextRef, CFArrayRef*))dlsym(RTLD_DEFAULT, "SSLCopyALPNProtocols");
 }

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -641,6 +641,15 @@ int32_t AppleCryptoNative_SslSetEnabledCipherSuites(SSLContextRef sslContext, co
     }
 }
 
+PALEXPORT int32_t AppleCryptoNative_SslSetCertificateAuthorities(SSLContextRef sslContext, CFArrayRef certificates, int32_t replaceExisting)
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    // The underlying call handles NULL inputs, so just pass it through
+    return SSLSetCertificateAuthorities(sslContext, certificates, replaceExisting);
+#pragma clang diagnostic pop
+}
+
 __attribute__((constructor)) static void InitializeAppleCryptoSslShim()
 {
     SSLSetALPNProtocolsPtr = (OSStatus(*)(SSLContextRef, CFArrayRef))dlsym(RTLD_DEFAULT, "SSLSetALPNProtocols");

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_ssl.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_ssl.h
@@ -249,3 +249,10 @@ Sets enabled cipher suites for the current session.
 Returns the output of SSLSetEnabledCiphers.
 */
 PALEXPORT int32_t AppleCryptoNative_SslSetEnabledCipherSuites(SSLContextRef sslContext, const uint32_t* cipherSuites, int32_t numCipherSuites);
+
+/*
+Adds one or more certificates to a server's list of certification authorities (CAs) acceptable for client authentication.
+
+Returns the output of SSLSetCertificateAuthorities.
+*/
+PALEXPORT int32_t AppleCryptoNative_SslSetCertificateAuthorities(SSLContextRef sslContext, CFArrayRef certificates, int32_t replaceExisting);

--- a/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
+++ b/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
@@ -299,7 +299,7 @@ static const Entry s_cryptoNative[] =
     DllImportEntry(CryptoNative_SslCtxUseCertificate)
     DllImportEntry(CryptoNative_SslCtxUsePrivateKey)
     DllImportEntry(CryptoNative_SslAddExtraChainCert)
-    DllImportEntry(CryptoNative_SslAddClientCA)
+    DllImportEntry(CryptoNative_SslAddClientCAs)
     DllImportEntry(CryptoNative_SslDestroy)
     DllImportEntry(CryptoNative_SslDoHandshake)
     DllImportEntry(CryptoNative_SslGetClientCAList)

--- a/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
+++ b/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
@@ -299,6 +299,7 @@ static const Entry s_cryptoNative[] =
     DllImportEntry(CryptoNative_SslCtxUseCertificate)
     DllImportEntry(CryptoNative_SslCtxUsePrivateKey)
     DllImportEntry(CryptoNative_SslAddExtraChainCert)
+    DllImportEntry(CryptoNative_SslAddClientCA)
     DllImportEntry(CryptoNative_SslDestroy)
     DllImportEntry(CryptoNative_SslDoHandshake)
     DllImportEntry(CryptoNative_SslGetClientCAList)

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
@@ -460,6 +460,7 @@ const EVP_CIPHER* EVP_chacha20_poly1305(void);
     LIGHTUP_FUNCTION(SSL_CIPHER_get_name) \
     LIGHTUP_FUNCTION(SSL_CIPHER_get_version) \
     REQUIRED_FUNCTION(SSL_ctrl) \
+    REQUIRED_FUNCTION(SSL_add_client_CA) \
     REQUIRED_FUNCTION(SSL_set_alpn_protos) \
     REQUIRED_FUNCTION(SSL_set_quiet_shutdown) \
     REQUIRED_FUNCTION(SSL_CTX_check_private_key) \
@@ -923,6 +924,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define SSL_CIPHER_get_name SSL_CIPHER_get_name_ptr
 #define SSL_CIPHER_get_version SSL_CIPHER_get_version_ptr
 #define SSL_ctrl SSL_ctrl_ptr
+#define SSL_add_client_CA SSL_add_client_CA_ptr
 #define SSL_set_alpn_protos SSL_set_alpn_protos_ptr
 #define SSL_set_quiet_shutdown SSL_set_quiet_shutdown_ptr
 #define SSL_CTX_check_private_key SSL_CTX_check_private_key_ptr

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
@@ -772,14 +772,23 @@ int32_t CryptoNative_SslAddExtraChainCert(SSL* ssl, X509* x509)
     return 0;
 }
 
-int32_t CryptoNative_SslAddClientCA(SSL* ssl, X509* x509)
+int32_t CryptoNative_SslAddClientCAs(SSL* ssl, X509** x509s, uint32_t count)
 {
-    if (!x509 || !ssl)
+    if (!x509s || !ssl)
     {
         return 0;
     }
 
-    return SSL_add_client_CA(ssl, x509);
+    for (uint32_t i = 0; i < count; i++)
+    {
+        int res = SSL_add_client_CA(ssl, x509s[i]);
+        if (res != 1)
+        {
+            return res;
+        }
+    }
+
+    return 1;
 }
 
 void CryptoNative_SslCtxSetAlpnSelectCb(SSL_CTX* ctx, SslCtxSetAlpnCallback cb, void* arg)

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
@@ -772,6 +772,16 @@ int32_t CryptoNative_SslAddExtraChainCert(SSL* ssl, X509* x509)
     return 0;
 }
 
+int32_t CryptoNative_SslAddClientCA(SSL* ssl, X509* x509)
+{
+    if (!x509 || !ssl)
+    {
+        return 0;
+    }
+
+    return SSL_add_client_CA(ssl, x509);
+}
+
 void CryptoNative_SslCtxSetAlpnSelectCb(SSL_CTX* ctx, SslCtxSetAlpnCallback cb, void* arg)
 {
     // void shim functions don't lead to exceptions, so skip the unconditional error clearing.

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.h
@@ -406,6 +406,15 @@ Returns 1 if success and 0 in case of failure
 PALEXPORT int32_t CryptoNative_SslAddExtraChainCert(SSL* ssl, X509* x509);
 
 /*
+Adds the name of the given certificate to the list of acceptable issuers sent to
+client when requesting a client certificate. Shims the SSL_add_client_CA function.
+
+No transfer of ownership or refcount changes.
+Returns 1 if success and 0 in case of failure
+*/
+PALEXPORT int32_t CryptoNative_SslAddClientCA(SSL* ssl, X509* x509);
+
+/*
 Shims the ssl_ctx_set_alpn_select_cb method.
 */
 PALEXPORT void CryptoNative_SslCtxSetAlpnSelectCb(SSL_CTX* ctx, SslCtxSetAlpnCallback cb, void *arg);

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.h
@@ -406,13 +406,13 @@ Returns 1 if success and 0 in case of failure
 PALEXPORT int32_t CryptoNative_SslAddExtraChainCert(SSL* ssl, X509* x509);
 
 /*
-Adds the name of the given certificate to the list of acceptable issuers sent to
+Adds the names of the given certificates to the list of acceptable issuers sent to
 client when requesting a client certificate. Shims the SSL_add_client_CA function.
 
 No transfer of ownership or refcount changes.
 Returns 1 if success and 0 in case of failure
 */
-PALEXPORT int32_t CryptoNative_SslAddClientCA(SSL* ssl, X509* x509);
+PALEXPORT int32_t CryptoNative_SslAddClientCAs(SSL* ssl, X509** x509s, uint32_t count);
 
 /*
 Shims the ssl_ctx_set_alpn_select_cb method.


### PR DESCRIPTION
Fixes Issue #55802

This PR adds support for `SslCertificateTrust` on Linux and OSX, both platforms are implemented by enumerating the certificates in question (either from provided collection, or enumerating provided certificate store), and passing them to respective platform APIs:
- `SSL_add_client_CA` on Linux
- `SSLSetCertificateAuthorities` on OSX

on OSX, there seems to some additional validation on the passed certificates. When I tried to pass certificates normally used in tests, the call failed with `secErrParam` (One or more parameters passed to the function are not valid.). However, I have not been able to find out what is the problem, so I leave it currently as is, since there is probably not much we can do about it anyway. Certs taken out from the machine Root store sem to work okay.