### PR TITLE
Record callee saves in patchpoint info

### DIFF
--- a/src/coreclr/inc/jiteeversionguid.h
+++ b/src/coreclr/inc/jiteeversionguid.h
@@ -43,13 +43,12 @@ typedef const GUID *LPCGUID;
 #define GUID_DEFINED
 #endif // !GUID_DEFINED
 
-constexpr GUID JITEEVersionIdentifier = { /* 63009f0c-662a-485b-bac1-ff67be6c7f9d */
-    0x63009f0c,
-    0x662a,
-    0x485b,
-    {0xba, 0xc1, 0xff, 0x67, 0xbe, 0x6c, 0x7f, 0x9d} 
-  };
-
+constexpr GUID JITEEVersionIdentifier = { /* e6a73797-0cbe-4cf8-b4ad-724a25466211 */
+    0xe6a73797,
+    0x0cbe,
+    0x4cf8,
+    {0xb4, 0xad, 0x72, 0x4a, 0x25, 0x46, 0x62, 0x11}
+};
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 //

--- a/src/coreclr/inc/patchpointinfo.h
+++ b/src/coreclr/inc/patchpointinfo.h
@@ -12,10 +12,11 @@
 
 // --------------------------------------------------------------------------------
 // Describes information needed to make an OSR transition
-//  - location of Il-visible locals and other important state on the 
+//  - location of IL-visible locals and other important state on the 
 //    original (Tier0) method frame, with respect to top of frame
 //    (hence these offsets will be negative as stack grows down)
 //  - total size of the original frame
+//  - callee save registers saved on the original (Tier0) frame
 //
 // Currently the patchpoint info is independent of the IL offset of the patchpoint.
 //
@@ -36,6 +37,7 @@ struct PatchpointInfo
     // Initialize
     void Initialize(unsigned localCount, int totalFrameSize)
     {
+        m_calleeSaveRegisters     = 0;
         m_totalFrameSize          = totalFrameSize;
         m_numberOfLocals          = localCount;
         m_genericContextArgOffset = -1;
@@ -47,6 +49,7 @@ struct PatchpointInfo
     // Copy
     void Copy(const PatchpointInfo* original)
     {
+        m_calleeSaveRegisters = original->m_calleeSaveRegisters;
         m_genericContextArgOffset = original->m_genericContextArgOffset;
         m_keptAliveThisOffset = original->m_keptAliveThisOffset;
         m_securityCookieOffset = original->m_securityCookieOffset;
@@ -162,12 +165,26 @@ struct PatchpointInfo
         m_offsetAndExposureData[localNum] = offset;
     }
 
+    // Callee save registers saved by the original method.
+    // Includes all saves that must be restored (eg includes pushed RBP on x64).
+    //
+    uint64_t CalleeSaveRegisters() const
+    {
+        return m_calleeSaveRegisters;
+    }
+
+    void SetCalleeSaveRegisters(uint64_t registerMask)
+    {
+        m_calleeSaveRegisters = registerMask;
+    }
+
 private:
     enum
     {
         EXPOSURE_MASK = 0x1
     };
 
+    uint64_t m_calleeSaveRegisters;
     unsigned m_numberOfLocals;
     int      m_totalFrameSize;
     int      m_genericContextArgOffset;

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5289,6 +5289,18 @@ void Compiler::generatePatchpointInfo()
                 patchpointInfo->MonitorAcquiredOffset());
     }
 
+#if defined(TARGET_AMD64)
+    // Record callee save registers.
+    // Currently only needed for x64.
+    //
+    regMaskTP rsPushRegs = codeGen->regSet.rsGetModifiedRegsMask() & RBM_CALLEE_SAVED;
+    rsPushRegs |= RBM_FPBASE;
+    patchpointInfo->SetCalleeSaveRegisters((uint64_t)rsPushRegs);
+    JITDUMP("--OSR-- Tier0 callee saves: ");
+    JITDUMPEXEC(dspRegMask((regMaskTP)patchpointInfo->CalleeSaveRegisters()));
+    JITDUMP("\n");
+#endif
+
     // Register this with the runtime.
     info.compCompHnd->setPatchpointInfo(patchpointInfo);
 }


### PR DESCRIPTION
Preparatory work for fixing the x64 epilog unwind problem for OSR methods.
Changes the jit guid since the PatchpointInfo data structure is altered.