### PR TITLE
Add check for Android NDK 23 to AndroidAppBuilder

### DIFF
--- a/src/tasks/AndroidAppBuilder/Templates/CMakeLists-android.txt
+++ b/src/tasks/AndroidAppBuilder/Templates/CMakeLists-android.txt
@@ -4,6 +4,10 @@ project(monodroid)
 
 enable_language(C ASM)
 
+if(ANDROID_NDK_MAJOR VERSION_LESS "23")
+    message(FATAL_ERROR "Error: need at least Android NDK 23, got ${ANDROID_NDK_REVISION}!")
+endif()
+
 add_library(
     monodroid
     SHARED


### PR DESCRIPTION
We recently bumped the Android NDK in https://github.com/dotnet/runtime/pull/64567, add a check to CMakeLists-android.txt to validate it.