### PR TITLE
Move Msquic over to Source-generated delegate interop.

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -26,84 +26,65 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             uint status;
 
             SetParamDelegate =
-                Marshal.GetDelegateForFunctionPointer<SetParamDelegate>(
-                    vtable->SetParam);
+                new SetParamDelegate(new DelegateHelper(vtable->SetParam).SetParam);
 
             GetParamDelegate =
-                Marshal.GetDelegateForFunctionPointer<GetParamDelegate>(
-                    vtable->GetParam);
+                new GetParamDelegate(new DelegateHelper(vtable->GetParam).GetParam);
 
             SetCallbackHandlerDelegate =
-                Marshal.GetDelegateForFunctionPointer<SetCallbackHandlerDelegate>(
-                    vtable->SetCallbackHandler);
+                new SetCallbackHandlerDelegate(new DelegateHelper(vtable->SetCallbackHandler).SetCallbackHandler);
 
             RegistrationOpenDelegate =
-                Marshal.GetDelegateForFunctionPointer<RegistrationOpenDelegate>(
-                    vtable->RegistrationOpen);
+                new RegistrationOpenDelegate(new DelegateHelper(vtable->RegistrationOpen).RegistrationOpen);
             RegistrationCloseDelegate =
                 Marshal.GetDelegateForFunctionPointer<RegistrationCloseDelegate>(
                     vtable->RegistrationClose);
 
             ConfigurationOpenDelegate =
-                Marshal.GetDelegateForFunctionPointer<ConfigurationOpenDelegate>(
-                    vtable->ConfigurationOpen);
+                new ConfigurationOpenDelegate(new DelegateHelper(vtable->ConfigurationOpen).ConfigurationOpen);
             ConfigurationCloseDelegate =
                 Marshal.GetDelegateForFunctionPointer<ConfigurationCloseDelegate>(
                     vtable->ConfigurationClose);
             ConfigurationLoadCredentialDelegate =
-                Marshal.GetDelegateForFunctionPointer<ConfigurationLoadCredentialDelegate>(
-                    vtable->ConfigurationLoadCredential);
+                new ConfigurationLoadCredentialDelegate(new DelegateHelper(vtable->ConfigurationLoadCredential).ConfigurationLoadCredential);
 
             ListenerOpenDelegate =
-                Marshal.GetDelegateForFunctionPointer<ListenerOpenDelegate>(
-                    vtable->ListenerOpen);
+                new ListenerOpenDelegate(new DelegateHelper(vtable->ListenerOpen).ListenerOpen);
             ListenerCloseDelegate =
                 Marshal.GetDelegateForFunctionPointer<ListenerCloseDelegate>(
                     vtable->ListenerClose);
             ListenerStartDelegate =
-                Marshal.GetDelegateForFunctionPointer<ListenerStartDelegate>(
-                    vtable->ListenerStart);
+                new ListenerStartDelegate(new DelegateHelper(vtable->ListenerStart).ListenerStart);
             ListenerStopDelegate =
-                Marshal.GetDelegateForFunctionPointer<ListenerStopDelegate>(
-                    vtable->ListenerStop);
+                new ListenerStopDelegate(new DelegateHelper(vtable->ListenerStop).ListenerStop);
 
             ConnectionOpenDelegate =
-                Marshal.GetDelegateForFunctionPointer<ConnectionOpenDelegate>(
-                    vtable->ConnectionOpen);
+                new ConnectionOpenDelegate(new DelegateHelper(vtable->ConnectionOpen).ConnectionOpen);
             ConnectionCloseDelegate =
                 Marshal.GetDelegateForFunctionPointer<ConnectionCloseDelegate>(
                     vtable->ConnectionClose);
             ConnectionSetConfigurationDelegate =
-                Marshal.GetDelegateForFunctionPointer<ConnectionSetConfigurationDelegate>(
-                    vtable->ConnectionSetConfiguration);
+                new ConnectionSetConfigurationDelegate(new DelegateHelper(vtable->ConnectionSetConfiguration).ConnectionSetConfiguration);
             ConnectionShutdownDelegate =
-                Marshal.GetDelegateForFunctionPointer<ConnectionShutdownDelegate>(
-                    vtable->ConnectionShutdown);
+                new ConnectionShutdownDelegate(new DelegateHelper(vtable->ConnectionShutdown).ConnectionShutdown);
             ConnectionStartDelegate =
-                Marshal.GetDelegateForFunctionPointer<ConnectionStartDelegate>(
-                    vtable->ConnectionStart);
+                new ConnectionStartDelegate(new DelegateHelper(vtable->ConnectionStart).ConnectionStart);
 
             StreamOpenDelegate =
-                Marshal.GetDelegateForFunctionPointer<StreamOpenDelegate>(
-                    vtable->StreamOpen);
+                new StreamOpenDelegate(new DelegateHelper(vtable->StreamOpen).StreamOpen);
             StreamCloseDelegate =
                 Marshal.GetDelegateForFunctionPointer<StreamCloseDelegate>(
                     vtable->StreamClose);
             StreamStartDelegate =
-                Marshal.GetDelegateForFunctionPointer<StreamStartDelegate>(
-                    vtable->StreamStart);
+                new StreamStartDelegate(new DelegateHelper(vtable->StreamStart).StreamStart);
             StreamShutdownDelegate =
-                Marshal.GetDelegateForFunctionPointer<StreamShutdownDelegate>(
-                    vtable->StreamShutdown);
+                new StreamShutdownDelegate(new DelegateHelper(vtable->StreamShutdown).StreamShutdown);
             StreamSendDelegate =
-                Marshal.GetDelegateForFunctionPointer<StreamSendDelegate>(
-                    vtable->StreamSend);
+                new StreamSendDelegate(new DelegateHelper(vtable->StreamSend).StreamSend);
             StreamReceiveCompleteDelegate =
-                Marshal.GetDelegateForFunctionPointer<StreamReceiveCompleteDelegate>(
-                    vtable->StreamReceiveComplete);
+                new StreamReceiveCompleteDelegate(new DelegateHelper(vtable->StreamReceiveComplete).StreamReceiveComplete);
             StreamReceiveSetEnabledDelegate =
-                Marshal.GetDelegateForFunctionPointer<StreamReceiveSetEnabledDelegate>(
-                    vtable->StreamReceiveSetEnabled);
+                new StreamReceiveSetEnabledDelegate(new DelegateHelper(vtable->StreamReceiveSetEnabled).StreamReceiveSetEnabled);
 
             var cfg = new RegistrationConfig
             {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -123,9 +123,10 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                 {
                     if (NativeLibrary.TryGetExport(msQuicHandle, "MsQuicOpenVersion", out IntPtr msQuicOpenVersionAddress))
                     {
-                        delegate* unmanaged[Cdecl]<uint, out NativeApi*, uint> msQuicOpenVersion =
-                            (delegate* unmanaged[Cdecl]<uint, out NativeApi*, uint>)msQuicOpenVersionAddress;
-                        uint status = msQuicOpenVersion(MsQuicVersion, out NativeApi* vtable);
+                        NativeApi* vtable;
+                        delegate* unmanaged[Cdecl]<uint, NativeApi**, uint> msQuicOpenVersion =
+                            (delegate* unmanaged[Cdecl]<uint, NativeApi**, uint>)msQuicOpenVersionAddress;
+                        uint status = msQuicOpenVersion(MsQuicVersion, &vtable);
                         if (MsQuicStatusHelper.SuccessfulStatusCode(status))
                         {
                             IsQuicSupported = true;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicNativeMethods.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicNativeMethods.cs
@@ -8,7 +8,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
     /// <summary>
     /// Contains all native delegates and structs that are used with MsQuic.
     /// </summary>
-    internal static unsafe class MsQuicNativeMethods
+    internal static unsafe partial class MsQuicNativeMethods
     {
         [StructLayout(LayoutKind.Sequential)]
         internal struct NativeApi
@@ -91,12 +91,38 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         internal delegate void RegistrationCloseDelegate(
             IntPtr registrationContext);
 
-        [StructLayout(LayoutKind.Sequential)]
+        [NativeMarshalling(typeof(Native))]
         internal struct RegistrationConfig
         {
-            [MarshalAs(UnmanagedType.LPUTF8Str)]
             internal string AppName;
             internal QUIC_EXECUTION_PROFILE ExecutionProfile;
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct Native
+            {
+                private IntPtr AppName;
+                private QUIC_EXECUTION_PROFILE ExecutionProfile;
+
+                public Native(RegistrationConfig managed)
+                {
+                    AppName = Marshal.StringToCoTaskMemUTF8(managed.AppName);
+                    ExecutionProfile = managed.ExecutionProfile;
+                }
+
+                public RegistrationConfig ToManaged()
+                {
+                    return new RegistrationConfig()
+                    {
+                        AppName = Marshal.PtrToStringUTF8(AppName)!,
+                        ExecutionProfile = ExecutionProfile
+                    };
+                }
+
+                public void FreeNative()
+                {
+                    Marshal.FreeCoTaskMem(AppName);
+                }
+            }
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -117,6 +143,24 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         internal delegate uint ConfigurationLoadCredentialDelegate(
             SafeMsQuicConfigurationHandle configuration,
             ref CredentialConfig credConfig);
+
+        internal struct AnyDelegateMarshaller
+        {
+            private readonly Delegate _managed;
+
+            public AnyDelegateMarshaller(Delegate managed)
+            {
+                _managed = managed;
+                Value = Marshal.GetFunctionPointerForDelegate(_managed);
+            }
+
+            public IntPtr Value { get; }
+
+            public void FreeNative()
+            {
+                GC.KeepAlive(_managed);
+            }
+        }
 
         [StructLayout(LayoutKind.Sequential)]
         internal struct QuicSettings
@@ -193,18 +237,58 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             VersionNegotiationExtEnabled = 1 << 6,
         }
 
-        [StructLayout(LayoutKind.Sequential)]
+        [NativeMarshalling(typeof(Native))]
         internal struct CredentialConfig
         {
             internal QUIC_CREDENTIAL_TYPE Type;
             internal QUIC_CREDENTIAL_FLAGS Flags;
             // CredentialConfigCertificateUnion*
             internal IntPtr Certificate;
-            [MarshalAs(UnmanagedType.LPUTF8Str)]
+
             internal string Principal;
             internal IntPtr Reserved; // Currently unused
             // TODO: define delegate for AsyncHandler and make proper use of it.
             internal IntPtr AsyncHandler;
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct Native
+            {
+                internal QUIC_CREDENTIAL_TYPE Type;
+                internal QUIC_CREDENTIAL_FLAGS Flags;
+                // CredentialConfigCertificateUnion*
+                internal IntPtr Certificate;
+                internal IntPtr Principal;
+                internal IntPtr Reserved;
+                internal IntPtr AsyncHandler;
+
+                public Native(CredentialConfig managed)
+                {
+                    Type = managed.Type;
+                    Flags = managed.Flags;
+                    Certificate = managed.Certificate;
+                    Principal = Marshal.StringToCoTaskMemUTF8(managed.Principal);
+                    Reserved = managed.Reserved;
+                    AsyncHandler = managed.AsyncHandler;
+                }
+
+                public CredentialConfig ToManaged()
+                {
+                    return new CredentialConfig
+                    {
+                        Type = Type,
+                        Flags = Flags,
+                        Certificate = Certificate,
+                        Principal = Marshal.PtrToStringUTF8(Principal)!,
+                        Reserved = Reserved,
+                        AsyncHandler = AsyncHandler
+                    };
+                }
+
+                public void FreeNative()
+                {
+                    Marshal.FreeCoTaskMem(Principal);
+                }
+            }
         }
 
         [StructLayout(LayoutKind.Explicit)]
@@ -676,5 +760,758 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         }
 
         // TODO: DatagramSend missing
+
+        internal struct DelegateHelper
+        {
+            private IntPtr _functionPointer;
+
+            public DelegateHelper(IntPtr functionPointer)
+            {
+                _functionPointer = functionPointer;
+            }
+            internal uint SetContext(SafeHandle handle, IntPtr context)
+            {
+                IntPtr __handle_gen_native;
+                uint __retVal;
+                //
+                // Setup
+                //
+                bool handle__addRefd = false;
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    handle.DangerousAddRef(ref handle__addRefd);
+                    __handle_gen_native = handle.DangerousGetHandle();
+                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, IntPtr, uint>)_functionPointer)(__handle_gen_native, context);
+                }
+                finally
+                {
+                    //
+                    // Cleanup
+                    //
+                    if (handle__addRefd)
+                        handle.DangerousRelease();
+                }
+
+                return __retVal;
+            }
+            internal IntPtr GetContext(SafeHandle handle)
+            {
+                IntPtr __handle_gen_native;
+                IntPtr __retVal;
+                //
+                // Setup
+                //
+                bool handle__addRefd = false;
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    handle.DangerousAddRef(ref handle__addRefd);
+                    __handle_gen_native = handle.DangerousGetHandle();
+                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, IntPtr>)_functionPointer)(__handle_gen_native);
+                }
+                finally
+                {
+                    //
+                    // Cleanup
+                    //
+                    if (handle__addRefd)
+                        handle.DangerousRelease();
+                }
+
+                return __retVal;
+            }
+            internal void SetCallbackHandler(SafeHandle handle, Delegate del, IntPtr context)
+            {
+                //
+                // Setup
+                //
+                bool handle__addRefd = false;
+                AnyDelegateMarshaller __del_gen_native__marshaller = default;
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    handle.DangerousAddRef(ref handle__addRefd);
+                    IntPtr __handle_gen_native = handle.DangerousGetHandle();
+                    __del_gen_native__marshaller = new(del);
+                    IntPtr __del_gen_native = __del_gen_native__marshaller.Value;
+                    ((delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, void>)_functionPointer)(__handle_gen_native, __del_gen_native, context);
+                }
+                finally
+                {
+                    //
+                    // Cleanup
+                    //
+                    if (handle__addRefd)
+                        handle.DangerousRelease();
+                    __del_gen_native__marshaller.FreeNative();
+                }
+            }
+            internal uint SetParam(SafeHandle handle, QUIC_PARAM_LEVEL level, uint param, uint bufferLength, byte* buffer)
+            {
+                uint __retVal;
+                //
+                // Setup
+                //
+                bool handle__addRefd = false;
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    handle.DangerousAddRef(ref handle__addRefd);
+                    IntPtr __handle_gen_native = handle.DangerousGetHandle();
+                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, QUIC_PARAM_LEVEL, uint, uint, byte*, uint>)_functionPointer)(__handle_gen_native, level, param, bufferLength, buffer);
+                }
+                finally
+                {
+                    //
+                    // Cleanup
+                    //
+                    if (handle__addRefd)
+                        handle.DangerousRelease();
+                }
+
+                return __retVal;
+            }
+            internal uint GetParam(SafeHandle handle, QUIC_PARAM_LEVEL level, uint param, ref uint bufferLength, byte* buffer)
+            {
+                IntPtr __handle_gen_native = default;
+                uint __retVal;
+                //
+                // Setup
+                //
+                bool handle__addRefd = false;
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    handle.DangerousAddRef(ref handle__addRefd);
+                    __handle_gen_native = handle.DangerousGetHandle();
+                    fixed (uint* __bufferLength_gen_native = &bufferLength)
+                    {
+                        __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, QUIC_PARAM_LEVEL, uint, uint*, byte*, uint>)_functionPointer)(__handle_gen_native, level, param, __bufferLength_gen_native, buffer);
+                    }
+                }
+                finally
+                {
+                    //
+                    // Cleanup
+                    //
+                    if (handle__addRefd)
+                        handle.DangerousRelease();
+                }
+
+                return __retVal;
+            }
+            internal uint RegistrationOpen(ref RegistrationConfig config, out SafeMsQuicRegistrationHandle registrationContext)
+            {
+                RegistrationConfig.Native __config_gen_native = default;
+                registrationContext = default!;
+                IntPtr __registrationContext_gen_native = default;
+                uint __retVal;
+                bool __invokeSucceeded = default;
+                //
+                // Setup
+                //
+                SafeMsQuicRegistrationHandle registrationContext__newHandle = new SafeMsQuicRegistrationHandle();
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    __config_gen_native = new(config);
+                    __retVal = ((delegate* unmanaged[Cdecl]<RegistrationConfig.Native*, IntPtr*, uint>)_functionPointer)(&__config_gen_native, &__registrationContext_gen_native);
+                    __invokeSucceeded = true;
+                    //
+                    // Unmarshal
+                    //
+                    config = __config_gen_native.ToManaged();
+                }
+                finally
+                {
+                    if (__invokeSucceeded)
+                    {
+                        //
+                        // GuaranteedUnmarshal
+                        //
+                        Marshal.InitHandle(registrationContext__newHandle, __registrationContext_gen_native);
+                        registrationContext = registrationContext__newHandle;
+                    }
+
+                    //
+                    // Cleanup
+                    //
+                    __config_gen_native.FreeNative();
+                }
+
+                return __retVal;
+            }
+            internal uint ConfigurationOpen(SafeMsQuicRegistrationHandle registrationContext, QuicBuffer* alpnBuffers, uint alpnBufferCount, ref QuicSettings settings, uint settingsSize, IntPtr context, out SafeMsQuicConfigurationHandle configuration)
+            {
+                IntPtr __registrationContext_gen_native = default;
+                configuration = default!;
+                IntPtr __configuration_gen_native = default;
+                uint __retVal;
+                bool __invokeSucceeded = default;
+                //
+                // Setup
+                //
+                bool registrationContext__addRefd = false;
+                SafeMsQuicConfigurationHandle configuration__newHandle = new SafeMsQuicConfigurationHandle();
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    registrationContext.DangerousAddRef(ref registrationContext__addRefd);
+                    __registrationContext_gen_native = registrationContext.DangerousGetHandle();
+                    fixed (QuicSettings* __settings_gen_native = &settings)
+                    {
+                        __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, QuicBuffer*, uint, QuicSettings*, uint, IntPtr, IntPtr*, uint>)_functionPointer)(__registrationContext_gen_native, alpnBuffers, alpnBufferCount, __settings_gen_native, settingsSize, context, &__configuration_gen_native);
+                    }
+
+                    __invokeSucceeded = true;
+                }
+                finally
+                {
+                    if (__invokeSucceeded)
+                    {
+                        //
+                        // GuaranteedUnmarshal
+                        //
+                        Marshal.InitHandle(configuration__newHandle, __configuration_gen_native);
+                        configuration = configuration__newHandle;
+                    }
+
+                    //
+                    // Cleanup
+                    //
+                    if (registrationContext__addRefd)
+                        registrationContext.DangerousRelease();
+                }
+
+                return __retVal;
+            }
+            internal uint ConfigurationLoadCredential(SafeMsQuicConfigurationHandle configuration, ref CredentialConfig credConfig)
+            {
+                CredentialConfig.Native __credConfig_gen_native = default;
+                uint __retVal;
+                //
+                // Setup
+                //
+                bool configuration__addRefd = false;
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    configuration.DangerousAddRef(ref configuration__addRefd);
+                    IntPtr __configuration_gen_native = configuration.DangerousGetHandle();
+                    __credConfig_gen_native = new(credConfig);
+                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, CredentialConfig.Native*, uint>)_functionPointer)(__configuration_gen_native, &__credConfig_gen_native);
+                    //
+                    // Unmarshal
+                    //
+                    credConfig = __credConfig_gen_native.ToManaged();
+                }
+                finally
+                {
+                    //
+                    // Cleanup
+                    //
+                    if (configuration__addRefd)
+                        configuration.DangerousRelease();
+                    __credConfig_gen_native.FreeNative();
+                }
+
+                return __retVal;
+            }
+            internal uint ListenerCallback(IntPtr listener, IntPtr context, ref ListenerEvent evt)
+            {
+                uint __retVal;
+                fixed (ListenerEvent* __evt_gen_native = &evt)
+                {
+                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, IntPtr, ListenerEvent*, uint>)_functionPointer)(listener, context, __evt_gen_native);
+                }
+
+                return __retVal;
+            }
+            internal uint ListenerOpen(SafeMsQuicRegistrationHandle registration, ListenerCallbackDelegate handler, IntPtr context, out SafeMsQuicListenerHandle listener)
+            {
+                IntPtr __handler_gen_native = default;
+                listener = default!;
+                IntPtr __listener_gen_native = default;
+                uint __retVal;
+                bool __invokeSucceeded = default;
+                //
+                // Setup
+                //
+                bool registration__addRefd = false;
+                SafeMsQuicListenerHandle listener__newHandle = new SafeMsQuicListenerHandle();
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    registration.DangerousAddRef(ref registration__addRefd);
+                    IntPtr __registration_gen_native = registration.DangerousGetHandle();
+                    __handler_gen_native = handler != null ? Marshal.GetFunctionPointerForDelegate(handler) : default;
+                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, IntPtr*, uint>)_functionPointer)(__registration_gen_native, __handler_gen_native, context, &__listener_gen_native);
+                    __invokeSucceeded = true;
+                    //
+                    // KeepAlive
+                    //
+                    GC.KeepAlive(handler);
+                }
+                finally
+                {
+                    if (__invokeSucceeded)
+                    {
+                        //
+                        // GuaranteedUnmarshal
+                        //
+                        Marshal.InitHandle(listener__newHandle, __listener_gen_native);
+                        listener = listener__newHandle;
+                    }
+
+                    //
+                    // Cleanup
+                    //
+                    if (registration__addRefd)
+                        registration.DangerousRelease();
+                }
+
+                return __retVal;
+            }
+            internal uint ListenerStart(SafeMsQuicListenerHandle listener, QuicBuffer* alpnBuffers, uint alpnBufferCount, ref SOCKADDR_INET localAddress)
+            {
+                IntPtr __listener_gen_native = default;
+                uint __retVal;
+                //
+                // Setup
+                //
+                bool listener__addRefd = false;
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    listener.DangerousAddRef(ref listener__addRefd);
+                    __listener_gen_native = listener.DangerousGetHandle();
+                    fixed (SOCKADDR_INET* __localAddress_gen_native = &localAddress)
+                    {
+                        __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, QuicBuffer*, uint, SOCKADDR_INET*, uint>)_functionPointer)(__listener_gen_native, alpnBuffers, alpnBufferCount, __localAddress_gen_native);
+                    }
+                }
+                finally
+                {
+                    //
+                    // Cleanup
+                    //
+                    if (listener__addRefd)
+                        listener.DangerousRelease();
+                }
+
+                return __retVal;
+            }
+            internal void ListenerStop(SafeMsQuicListenerHandle listener)
+            {
+                //
+                // Setup
+                //
+                bool listener__addRefd = false;
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    listener.DangerousAddRef(ref listener__addRefd);
+                    IntPtr __listener_gen_native = listener.DangerousGetHandle();
+                    ((delegate* unmanaged[Cdecl]<IntPtr, void>)_functionPointer)(__listener_gen_native);
+                }
+                finally
+                {
+                    //
+                    // Cleanup
+                    //
+                    if (listener__addRefd)
+                        listener.DangerousRelease();
+                }
+            }
+            internal uint ConnectionCallback(IntPtr connection, IntPtr context, ref ConnectionEvent connectionEvent)
+            {
+                uint __retVal;
+                fixed (ConnectionEvent* __connectionEvent_gen_native = &connectionEvent)
+                {
+                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, IntPtr, ConnectionEvent*, uint>)_functionPointer)(connection, context, __connectionEvent_gen_native);
+                }
+
+                return __retVal;
+            }
+            internal uint ConnectionOpen(SafeMsQuicRegistrationHandle registration, ConnectionCallbackDelegate handler, IntPtr context, out SafeMsQuicConnectionHandle connection)
+            {
+                IntPtr __handler_gen_native = default;
+                connection = default!;
+                IntPtr __connection_gen_native = default;
+                uint __retVal;
+                bool __invokeSucceeded = default;
+                //
+                // Setup
+                //
+                bool registration__addRefd = false;
+                SafeMsQuicConnectionHandle connection__newHandle = new SafeMsQuicConnectionHandle();
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    registration.DangerousAddRef(ref registration__addRefd);
+                    IntPtr __registration_gen_native = registration.DangerousGetHandle();
+                    __handler_gen_native = handler != null ? Marshal.GetFunctionPointerForDelegate(handler) : default;
+                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, IntPtr*, uint>)_functionPointer)(__registration_gen_native, __handler_gen_native, context, &__connection_gen_native);
+                    __invokeSucceeded = true;
+                    //
+                    // KeepAlive
+                    //
+                    GC.KeepAlive(handler);
+                }
+                finally
+                {
+                    if (__invokeSucceeded)
+                    {
+                        //
+                        // GuaranteedUnmarshal
+                        //
+                        Marshal.InitHandle(connection__newHandle, __connection_gen_native);
+                        connection = connection__newHandle;
+                    }
+
+                    //
+                    // Cleanup
+                    //
+                    if (registration__addRefd)
+                        registration.DangerousRelease();
+                }
+
+                return __retVal;
+            }
+            internal uint ConnectionSetConfiguration(SafeMsQuicConnectionHandle connection, SafeMsQuicConfigurationHandle configuration)
+            {
+                uint __retVal;
+                //
+                // Setup
+                //
+                bool connection__addRefd = false;
+                bool configuration__addRefd = false;
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    connection.DangerousAddRef(ref connection__addRefd);
+                    IntPtr __connection_gen_native = connection.DangerousGetHandle();
+                    configuration.DangerousAddRef(ref configuration__addRefd);
+                    IntPtr __configuration_gen_native = configuration.DangerousGetHandle();
+                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, IntPtr, uint>)_functionPointer)(__connection_gen_native, __configuration_gen_native);
+                }
+                finally
+                {
+                    //
+                    // Cleanup
+                    //
+                    if (connection__addRefd)
+                        connection.DangerousRelease();
+                    if (configuration__addRefd)
+                        configuration.DangerousRelease();
+                }
+
+                return __retVal;
+            }
+            internal uint ConnectionStart(SafeMsQuicConnectionHandle connection, SafeMsQuicConfigurationHandle configuration, QUIC_ADDRESS_FAMILY family, string serverName, ushort serverPort)
+            {
+                IntPtr __connection_gen_native = default;
+                IntPtr __configuration_gen_native = default;
+                byte* __serverName_gen_native = default;
+                uint __retVal;
+                //
+                // Setup
+                //
+                bool connection__addRefd = false;
+                bool configuration__addRefd = false;
+                bool __serverName_gen_native__allocated = false;
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    connection.DangerousAddRef(ref connection__addRefd);
+                    __connection_gen_native = connection.DangerousGetHandle();
+                    configuration.DangerousAddRef(ref configuration__addRefd);
+                    __configuration_gen_native = configuration.DangerousGetHandle();
+                    if (serverName != null)
+                    {
+                        int __serverName_gen_native__bytelen = (serverName.Length + 1) * 3 + 1;
+                        if (__serverName_gen_native__bytelen > 260)
+                        {
+                            __serverName_gen_native = (byte*)Marshal.StringToCoTaskMemUTF8(serverName);
+                            __serverName_gen_native__allocated = true;
+                        }
+                        else
+                        {
+                            byte* __serverName_gen_native__stackptr = stackalloc byte[__serverName_gen_native__bytelen];
+                            {
+                                __serverName_gen_native__bytelen = Text.Encoding.UTF8.GetBytes(serverName, new Span<byte>(__serverName_gen_native__stackptr, __serverName_gen_native__bytelen));
+                                __serverName_gen_native__stackptr[__serverName_gen_native__bytelen] = 0;
+                            }
+
+                            __serverName_gen_native = (byte*)__serverName_gen_native__stackptr;
+                        }
+                    }
+
+                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, IntPtr, QUIC_ADDRESS_FAMILY, byte*, ushort, uint>)_functionPointer)(__connection_gen_native, __configuration_gen_native, family, __serverName_gen_native, serverPort);
+                }
+                finally
+                {
+                    //
+                    // Cleanup
+                    //
+                    if (connection__addRefd)
+                        connection.DangerousRelease();
+                    if (configuration__addRefd)
+                        configuration.DangerousRelease();
+                    if (__serverName_gen_native__allocated)
+                    {
+                        Marshal.FreeCoTaskMem((IntPtr)__serverName_gen_native);
+                    }
+                }
+
+                return __retVal;
+            }
+            internal void ConnectionShutdown(SafeMsQuicConnectionHandle connection, QUIC_CONNECTION_SHUTDOWN_FLAGS flags, long errorCode)
+            {
+                //
+                // Setup
+                //
+                bool connection__addRefd = false;
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    connection.DangerousAddRef(ref connection__addRefd);
+                    IntPtr __connection_gen_native = connection.DangerousGetHandle();
+                    ((delegate* unmanaged[Cdecl]<IntPtr, QUIC_CONNECTION_SHUTDOWN_FLAGS, long, void>)_functionPointer)(__connection_gen_native, flags, errorCode);
+                }
+                finally
+                {
+                    //
+                    // Cleanup
+                    //
+                    if (connection__addRefd)
+                        connection.DangerousRelease();
+                }
+            }
+            internal uint StreamCallback(IntPtr stream, IntPtr context, ref StreamEvent streamEvent)
+            {
+                uint __retVal;
+                fixed (StreamEvent* __streamEvent_gen_native = &streamEvent)
+                {
+                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, IntPtr, StreamEvent*, uint>)_functionPointer)(stream, context, __streamEvent_gen_native);
+                }
+
+                return __retVal;
+            }
+            internal uint StreamOpen(SafeMsQuicConnectionHandle connection, QUIC_STREAM_OPEN_FLAGS flags, StreamCallbackDelegate handler, IntPtr context, out SafeMsQuicStreamHandle stream)
+            {
+                IntPtr __handler_gen_native = default;
+                stream = default!;
+                IntPtr __stream_gen_native = default;
+                uint __retVal;
+                bool __invokeSucceeded = default;
+                //
+                // Setup
+                //
+                bool connection__addRefd = false;
+                SafeMsQuicStreamHandle stream__newHandle = new SafeMsQuicStreamHandle();
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    connection.DangerousAddRef(ref connection__addRefd);
+                    IntPtr __connection_gen_native = connection.DangerousGetHandle();
+                    __handler_gen_native = handler != null ? Marshal.GetFunctionPointerForDelegate(handler) : default;
+                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, QUIC_STREAM_OPEN_FLAGS, IntPtr, IntPtr, IntPtr*, uint>)_functionPointer)(__connection_gen_native, flags, __handler_gen_native, context, &__stream_gen_native);
+                    __invokeSucceeded = true;
+                    //
+                    // KeepAlive
+                    //
+                    GC.KeepAlive(handler);
+                }
+                finally
+                {
+                    if (__invokeSucceeded)
+                    {
+                        //
+                        // GuaranteedUnmarshal
+                        //
+                        Marshal.InitHandle(stream__newHandle, __stream_gen_native);
+                        stream = stream__newHandle;
+                    }
+
+                    //
+                    // Cleanup
+                    //
+                    if (connection__addRefd)
+                        connection.DangerousRelease();
+                }
+
+                return __retVal;
+            }
+            internal uint StreamStart(SafeMsQuicStreamHandle stream, QUIC_STREAM_START_FLAGS flags)
+            {
+                uint __retVal;
+                //
+                // Setup
+                //
+                bool stream__addRefd = false;
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    stream.DangerousAddRef(ref stream__addRefd);
+                    IntPtr __stream_gen_native = stream.DangerousGetHandle();
+                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, QUIC_STREAM_START_FLAGS, uint>)_functionPointer)(__stream_gen_native, flags);
+                }
+                finally
+                {
+                    //
+                    // Cleanup
+                    //
+                    if (stream__addRefd)
+                        stream.DangerousRelease();
+                }
+
+                return __retVal;
+            }
+            internal uint StreamShutdown(SafeMsQuicStreamHandle stream, QUIC_STREAM_SHUTDOWN_FLAGS flags, long errorCode)
+            {
+                uint __retVal;
+                //
+                // Setup
+                //
+                bool stream__addRefd = false;
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    stream.DangerousAddRef(ref stream__addRefd);
+                    IntPtr __stream_gen_native = stream.DangerousGetHandle();
+                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, QUIC_STREAM_SHUTDOWN_FLAGS, long, uint>)_functionPointer)(__stream_gen_native, flags, errorCode);
+                }
+                finally
+                {
+                    //
+                    // Cleanup
+                    //
+                    if (stream__addRefd)
+                        stream.DangerousRelease();
+                }
+
+                return __retVal;
+            }
+            internal uint StreamSend(SafeMsQuicStreamHandle stream, QuicBuffer* buffers, uint bufferCount, QUIC_SEND_FLAGS flags, IntPtr clientSendContext)
+            {
+                uint __retVal;
+                //
+                // Setup
+                //
+                bool stream__addRefd = false;
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    stream.DangerousAddRef(ref stream__addRefd);
+                    IntPtr __stream_gen_native = stream.DangerousGetHandle();
+                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, QuicBuffer*, uint, QUIC_SEND_FLAGS, IntPtr, uint>)_functionPointer)(__stream_gen_native, buffers, bufferCount, flags, clientSendContext);
+                }
+                finally
+                {
+                    //
+                    // Cleanup
+                    //
+                    if (stream__addRefd)
+                        stream.DangerousRelease();
+                }
+
+                return __retVal;
+            }
+            internal uint StreamReceiveComplete(SafeMsQuicStreamHandle stream, ulong bufferLength)
+            {
+                uint __retVal;
+                //
+                // Setup
+                //
+                bool stream__addRefd = false;
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    stream.DangerousAddRef(ref stream__addRefd);
+                    IntPtr __stream_gen_native = stream.DangerousGetHandle();
+                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, ulong, uint>)_functionPointer)(__stream_gen_native, bufferLength);
+                }
+                finally
+                {
+                    //
+                    // Cleanup
+                    //
+                    if (stream__addRefd)
+                        stream.DangerousRelease();
+                }
+
+                return __retVal;
+            }
+            internal uint StreamReceiveSetEnabled(SafeMsQuicStreamHandle stream, bool enabled)
+            {
+                uint __retVal;
+                //
+                // Setup
+                //
+                bool stream__addRefd = false;
+                try
+                {
+                    //
+                    // Marshal
+                    //
+                    stream.DangerousAddRef(ref stream__addRefd);
+                    IntPtr __stream_gen_native = stream.DangerousGetHandle();
+                    byte __enabled_gen_native = (byte)(enabled ? 1 : 0);
+                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, byte, uint>)_functionPointer)(__stream_gen_native, __enabled_gen_native);
+                }
+                finally
+                {
+                    //
+                    // Cleanup
+                    //
+                    if (stream__addRefd)
+                        stream.DangerousRelease();
+                }
+
+                return __retVal;
+            }
+        }
     }
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicNativeMethods.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicNativeMethods.cs
@@ -412,7 +412,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         internal delegate uint ListenerCallbackDelegate(
             IntPtr listener,
             IntPtr context,
-            ref ListenerEvent evt);
+            ListenerEvent* evt);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate uint ListenerOpenDelegate(
@@ -553,7 +553,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         internal delegate uint ConnectionCallbackDelegate(
             IntPtr connection,
             IntPtr context,
-            ref ConnectionEvent connectionEvent);
+            ConnectionEvent* connectionEvent);
 
         // TODO: order is Open, Close, Shutdown, Start, SetConfiguration, SendResumptionTicket
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -708,7 +708,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         internal delegate uint StreamCallbackDelegate(
             IntPtr stream,
             IntPtr context,
-            ref StreamEvent streamEvent);
+            StreamEvent* streamEvent);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate uint StreamOpenDelegate(
@@ -1034,16 +1034,6 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 
                 return __retVal;
             }
-            internal uint ListenerCallback(IntPtr listener, IntPtr context, ref ListenerEvent evt)
-            {
-                uint __retVal;
-                fixed (ListenerEvent* __evt_gen_native = &evt)
-                {
-                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, IntPtr, ListenerEvent*, uint>)_functionPointer)(listener, context, __evt_gen_native);
-                }
-
-                return __retVal;
-            }
             internal uint ListenerOpen(SafeMsQuicRegistrationHandle registration, ListenerCallbackDelegate handler, IntPtr context, out SafeMsQuicListenerHandle listener)
             {
                 IntPtr __handler_gen_native = default;
@@ -1145,16 +1135,6 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                     if (listener__addRefd)
                         listener.DangerousRelease();
                 }
-            }
-            internal uint ConnectionCallback(IntPtr connection, IntPtr context, ref ConnectionEvent connectionEvent)
-            {
-                uint __retVal;
-                fixed (ConnectionEvent* __connectionEvent_gen_native = &connectionEvent)
-                {
-                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, IntPtr, ConnectionEvent*, uint>)_functionPointer)(connection, context, __connectionEvent_gen_native);
-                }
-
-                return __retVal;
             }
             internal uint ConnectionOpen(SafeMsQuicRegistrationHandle registration, ConnectionCallbackDelegate handler, IntPtr context, out SafeMsQuicConnectionHandle connection)
             {
@@ -1318,16 +1298,6 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                     if (connection__addRefd)
                         connection.DangerousRelease();
                 }
-            }
-            internal uint StreamCallback(IntPtr stream, IntPtr context, ref StreamEvent streamEvent)
-            {
-                uint __retVal;
-                fixed (StreamEvent* __streamEvent_gen_native = &streamEvent)
-                {
-                    __retVal = ((delegate* unmanaged[Cdecl]<IntPtr, IntPtr, StreamEvent*, uint>)_functionPointer)(stream, context, __streamEvent_gen_native);
-                }
-
-                return __retVal;
             }
             internal uint StreamOpen(SafeMsQuicConnectionHandle connection, QUIC_STREAM_OPEN_FLAGS flags, StreamCallbackDelegate handler, IntPtr context, out SafeMsQuicStreamHandle stream)
             {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -16,7 +16,7 @@ namespace System.Net.Quic.Implementations.MsQuic
     internal sealed class MsQuicStream : QuicStreamProvider
     {
         // Delegate that wraps the static function that will be called when receiving an event.
-        internal static readonly StreamCallbackDelegate s_streamDelegate = new StreamCallbackDelegate(NativeCallbackHandler);
+        internal static unsafe readonly StreamCallbackDelegate s_streamDelegate = new StreamCallbackDelegate(NativeCallbackHandler);
 
         // The state is passed to msquic and then it's passed back by msquic to the callback handler.
         private readonly State _state = new State();
@@ -853,17 +853,17 @@ namespace System.Net.Quic.Implementations.MsQuic
         /// Callback calls for a single instance of a stream are serialized by msquic.
         /// They happen on a msquic thread and shouldn't take too long to not to block msquic.
         /// </summary>
-        private static uint NativeCallbackHandler(
+        private static unsafe uint NativeCallbackHandler(
             IntPtr stream,
             IntPtr context,
-            ref StreamEvent streamEvent)
+            StreamEvent* streamEvent)
         {
             GCHandle gcHandle = GCHandle.FromIntPtr(context);
             Debug.Assert(gcHandle.IsAllocated);
             Debug.Assert(gcHandle.Target is not null);
             var state = (State)gcHandle.Target;
 
-            return HandleEvent(state, ref streamEvent);
+            return HandleEvent(state, ref *streamEvent);
         }
 
         private static uint HandleEvent(State state, ref StreamEvent evt)


### PR DESCRIPTION
I missed this when turning on DisableRuntimeMarshalling because we don't run any Quic tests in our regular CI that actually use MsQuic and we don't have the DisableRuntimeMarshalling analyzer yet.

cc: @dotnet/interop-contrib 