### PR TITLE
[wasm][debugger] Fix (chrome|edge)://inspect for the debug proxy

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugHost/Startup.cs
+++ b/src/mono/wasm/debugger/BrowserDebugHost/Startup.cs
@@ -139,7 +139,9 @@ namespace Microsoft.WebAssembly.Diagnostics
                     Dictionary<string, string>[] tabs = await ProxyGetJsonAsync<Dictionary<string, string>[]>(GetEndpoint(context));
                     Dictionary<string, string>[] alteredTabs = tabs.Select(t => mapFunc(t, context, devToolsHost)).ToArray();
                     context.Response.ContentType = "application/json";
-                    await context.Response.WriteAsync(JsonSerializer.Serialize(alteredTabs));
+                    string text = JsonSerializer.Serialize(alteredTabs);
+                    context.Response.ContentLength = text.Length;
+                    await context.Response.WriteAsync(text);
                 }
 
                 async Task ConnectProxy(HttpContext context)


### PR DESCRIPTION
This is a targeted fix that makes inspector happy with the `/json` response we give so that it is simple to backport.  Other cleanups will happen in follup-up prs