### PR TITLE
Remove not needed lines

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options.ConfigurationExtensions/src/OptionsBuilderConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Options.ConfigurationExtensions/src/OptionsBuilderConfigurationExtensions.cs
@@ -61,9 +61,6 @@ namespace Microsoft.Extensions.DependencyInjection
             Action<BinderOptions> configureBinder = null)
             where TOptions : class
         {
-            _ = optionsBuilder;
-            _ = configSectionPath;
-
             optionsBuilder.Configure<IConfiguration>((opts, config) => BindFromOptions<TOptions>(opts, config, configSectionPath, configureBinder));
             optionsBuilder.Services.AddSingleton<IOptionsChangeTokenSource<TOptions>, ConfigurationChangeTokenSource<TOptions>>();
             return optionsBuilder;


### PR DESCRIPTION
#64720 left two lines that do nothing:

![image](https://user-images.githubusercontent.com/6609929/153674064-e75f0188-a647-4dd7-a37c-1d0f8d68fd75.png)

Interestingly these are the only two places I've found. Searched through this repo with `  _ = \w*;`, and nothing else relevant turned up.
CC: @stephentoub