### PR TITLE
Fix nullability in `IOptionsMonitor`

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.cs
+++ b/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Extensions.Options
     {
         TOptions CurrentValue { get; }
         TOptions Get(string? name);
-        System.IDisposable OnChange(System.Action<TOptions, string?> listener);
+        System.IDisposable? OnChange(System.Action<TOptions, string?> listener);
     }
     public partial interface IOptionsSnapshot<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] out TOptions> : Microsoft.Extensions.Options.IOptions<TOptions> where TOptions : class
     {

--- a/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.cs
+++ b/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Extensions.Options
     }
     public static partial class OptionsMonitorExtensions
     {
-        public static System.IDisposable OnChange<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(this Microsoft.Extensions.Options.IOptionsMonitor<TOptions> monitor, System.Action<TOptions> listener) { throw null; }
+        public static System.IDisposable? OnChange<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(this Microsoft.Extensions.Options.IOptionsMonitor<TOptions> monitor, System.Action<TOptions> listener) { throw null; }
     }
     public partial class OptionsMonitor<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions> : Microsoft.Extensions.Options.IOptionsMonitor<TOptions>, System.IDisposable where TOptions : class
     {

--- a/src/libraries/Microsoft.Extensions.Options/src/IOptionsMonitor.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IOptionsMonitor.cs
@@ -27,6 +27,6 @@ namespace Microsoft.Extensions.Options
         /// </summary>
         /// <param name="listener">The action to be invoked when <typeparamref name="TOptions"/> has changed.</param>
         /// <returns>An <see cref="IDisposable"/> which should be disposed to stop listening for changes.</returns>
-        IDisposable OnChange(Action<TOptions, string?> listener);
+        IDisposable? OnChange(Action<TOptions, string?> listener);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitorExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitorExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.Options
         /// <param name="monitor">The IOptionsMonitor.</param>
         /// <param name="listener">The action to be invoked when <typeparamref name="TOptions"/> has changed.</param>
         /// <returns>An <see cref="IDisposable"/> which should be disposed to stop listening for changes.</returns>
-        public static IDisposable OnChange<[DynamicallyAccessedMembers(Options.DynamicallyAccessedMembers)] TOptions>(
+        public static IDisposable? OnChange<[DynamicallyAccessedMembers(Options.DynamicallyAccessedMembers)] TOptions>(
             this IOptionsMonitor<TOptions> monitor,
             Action<TOptions> listener)
                 => monitor.OnChange((o, _) => listener(o));


### PR DESCRIPTION
Quick follow-up to #63767

While annotating `Microsoft.Extensions.Logging`, it turns out that `IOptionsMonitor.OnChange` could return `null`: 
https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.Logging/src/StaticFilterOptionsMonitor.cs#L16