### PR TITLE
Convert over StandardOleMarshalObject to use either source-generated or manual interop.

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Ole32/Interop.CoGetStandardMarshal.cs
+++ b/src/libraries/Common/src/Interop/Windows/Ole32/Interop.CoGetStandardMarshal.cs
@@ -8,10 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Ole32
     {
-#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
-        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we annotate blittable types used in interop in CoreLib (like Guid)
-        [DllImport(Interop.Libraries.Ole32)]
-        internal static extern int CoGetStandardMarshal(ref Guid riid, IntPtr pv, int dwDestContext, IntPtr pvDestContext, int mshlflags, out IntPtr ppMarshal);
-#pragma warning restore DLLIMPORTGENANALYZER015
+        [GeneratedDllImport(Interop.Libraries.Ole32)]
+        internal static partial int CoGetStandardMarshal(ref Guid riid, IntPtr pv, int dwDestContext, IntPtr pvDestContext, int mshlflags, out IntPtr ppMarshal);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/StandardOleMarshalObject.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/StandardOleMarshalObject.Windows.cs
@@ -9,12 +9,6 @@ namespace System.Runtime.InteropServices
     {
         private static readonly Guid CLSID_StdMarshal = new Guid("00000017-0000-0000-c000-000000000046");
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate int GetMarshalSizeMaxDelegate(IntPtr _this, ref Guid riid, IntPtr pv, int dwDestContext, IntPtr pvDestContext, int mshlflags, out int pSize);
-
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate int MarshalInterfaceDelegate(IntPtr _this, IntPtr pStm, ref Guid riid, IntPtr pv, int dwDestContext, IntPtr pvDestContext, int mshlflags);
-
         protected StandardOleMarshalObject()
         {
         }
@@ -60,13 +54,12 @@ namespace System.Runtime.InteropServices
                 // would trigger QIs for random IIDs and the marshaler (aka stub
                 // manager object) does not really handle these well and we would
                 // risk triggering an AppVerifier break
-                IntPtr vtable = *(IntPtr*)pStandardMarshal.ToPointer();
-
-                // GetMarshalSizeMax is 4th slot
-                IntPtr method = *((IntPtr*)vtable.ToPointer() + 4);
-
-                GetMarshalSizeMaxDelegate del = (GetMarshalSizeMaxDelegate)Marshal.GetDelegateForFunctionPointer(method, typeof(GetMarshalSizeMaxDelegate));
-                return del(pStandardMarshal, ref riid, pv, dwDestContext, pvDestContext, mshlflags, out pSize);
+                fixed (Guid* riidPtr = &riid)
+                fixed (int* pSizePtr = &pSize)
+                {
+                    // GetMarshalSizeMax is 4th slot
+                    return ((delegate* unmanaged[Stdcall]<IntPtr, Guid*, IntPtr, int, IntPtr, int, int*, int>)(*(IntPtr**)pStandardMarshal)[4])(pStandardMarshal, riidPtr, pv, dwDestContext, pvDestContext, mshlflags, pSizePtr);
+                }
             }
             finally
             {
@@ -85,11 +78,11 @@ namespace System.Runtime.InteropServices
                 // would trigger QIs for random IIDs and the marshaler (aka stub
                 // manager object) does not really handle these well and we would
                 // risk triggering an AppVerifier break
-                IntPtr vtable = *(IntPtr*)pStandardMarshal.ToPointer();
-                IntPtr method = *((IntPtr*)vtable.ToPointer() + 5); // MarshalInterface is 5th slot
-
-                MarshalInterfaceDelegate del = (MarshalInterfaceDelegate)Marshal.GetDelegateForFunctionPointer(method, typeof(MarshalInterfaceDelegate));
-                return del(pStandardMarshal, pStm, ref riid, pv, dwDestContext, pvDestContext, mshlflags);
+                fixed (Guid* riidPtr = &riid)
+                {
+                    // MarshalInterface is 5th slot
+                    return ((delegate* unmanaged[Stdcall]<IntPtr, IntPtr, Guid*, IntPtr, int, IntPtr, int, int>)(*(IntPtr**)pStandardMarshal)[5])(pStandardMarshal, pStm, riidPtr, pv, dwDestContext, pvDestContext, mshlflags);
+                }
             }
             finally
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/StandardOleMarshalObject.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/StandardOleMarshalObject.Windows.cs
@@ -57,7 +57,7 @@ namespace System.Runtime.InteropServices
                 fixed (Guid* riidPtr = &riid)
                 fixed (int* pSizePtr = &pSize)
                 {
-                    // GetMarshalSizeMax is 4th slot
+                    // GetMarshalSizeMax is 5th slot (zero-based indexing)
                     return ((delegate* unmanaged[Stdcall]<IntPtr, Guid*, IntPtr, int, IntPtr, int, int*, int>)(*(IntPtr**)pStandardMarshal)[4])(pStandardMarshal, riidPtr, pv, dwDestContext, pvDestContext, mshlflags, pSizePtr);
                 }
             }
@@ -80,7 +80,7 @@ namespace System.Runtime.InteropServices
                 // risk triggering an AppVerifier break
                 fixed (Guid* riidPtr = &riid)
                 {
-                    // MarshalInterface is 5th slot
+                    // MarshalInterface is 6th slot (zero-based indexing)
                     return ((delegate* unmanaged[Stdcall]<IntPtr, IntPtr, Guid*, IntPtr, int, IntPtr, int, int>)(*(IntPtr**)pStandardMarshal)[5])(pStandardMarshal, pStm, riidPtr, pv, dwDestContext, pvDestContext, mshlflags);
                 }
             }


### PR DESCRIPTION
This should unblock https://github.com/dotnet/winforms/pull/6683