### PR TITLE
Avoid Attribute.GetCustomAttributes() returning null for open generic type

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs
@@ -438,9 +438,6 @@ namespace System
         {
             return (Attribute[])Array.CreateInstance(elementType, elementCount);
         }
-
-        private static Attribute[] ToAttributeArray(object[] getCustomAttributesResult) =>
-            getCustomAttributesResult as Attribute[] ?? Array.Empty<Attribute>();
         #endregion
 
         #endregion
@@ -462,7 +459,7 @@ namespace System
             {
                 MemberTypes.Property => InternalGetCustomAttributes((PropertyInfo)element, attributeType, inherit),
                 MemberTypes.Event => InternalGetCustomAttributes((EventInfo)element, attributeType, inherit),
-                _ => ToAttributeArray(element.GetCustomAttributes(attributeType, inherit))
+                _ => (Attribute[])element.GetCustomAttributes(attributeType, inherit)
             };
         }
 
@@ -477,7 +474,7 @@ namespace System
             {
                 MemberTypes.Property => InternalGetCustomAttributes((PropertyInfo)element, typeof(Attribute), inherit),
                 MemberTypes.Event => InternalGetCustomAttributes((EventInfo)element, typeof(Attribute), inherit),
-                _ => ToAttributeArray(element.GetCustomAttributes(typeof(Attribute), inherit))
+                _ => (Attribute[])element.GetCustomAttributes(typeof(Attribute), inherit)
             };
         }
 
@@ -543,7 +540,7 @@ namespace System
             if (member.MemberType == MemberTypes.Method && inherit)
                 return InternalParamGetCustomAttributes(element, attributeType, inherit);
 
-            return ToAttributeArray(element.GetCustomAttributes(attributeType, inherit));
+            return (Attribute[])element.GetCustomAttributes(attributeType, inherit);
         }
 
         public static Attribute[] GetCustomAttributes(ParameterInfo element!!, bool inherit)
@@ -555,7 +552,7 @@ namespace System
             if (member.MemberType == MemberTypes.Method && inherit)
                 return InternalParamGetCustomAttributes(element, null, inherit);
 
-            return ToAttributeArray(element.GetCustomAttributes(typeof(Attribute), inherit));
+            return (Attribute[])element.GetCustomAttributes(typeof(Attribute), inherit);
         }
 
         public static bool IsDefined(ParameterInfo element, Type attributeType)

--- a/src/coreclr/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs
@@ -438,6 +438,9 @@ namespace System
         {
             return (Attribute[])Array.CreateInstance(elementType, elementCount);
         }
+
+        private static Attribute[] ToAttributeArray(object[] getCustomAttributesResult) =>
+            getCustomAttributesResult as Attribute[] ?? Array.Empty<Attribute>();
         #endregion
 
         #endregion
@@ -459,7 +462,7 @@ namespace System
             {
                 MemberTypes.Property => InternalGetCustomAttributes((PropertyInfo)element, attributeType, inherit),
                 MemberTypes.Event => InternalGetCustomAttributes((EventInfo)element, attributeType, inherit),
-                _ => (element.GetCustomAttributes(attributeType, inherit) as Attribute[])!,
+                _ => ToAttributeArray(element.GetCustomAttributes(attributeType, inherit))
             };
         }
 
@@ -474,7 +477,7 @@ namespace System
             {
                 MemberTypes.Property => InternalGetCustomAttributes((PropertyInfo)element, typeof(Attribute), inherit),
                 MemberTypes.Event => InternalGetCustomAttributes((EventInfo)element, typeof(Attribute), inherit),
-                _ => (element.GetCustomAttributes(typeof(Attribute), inherit) as Attribute[])!,
+                _ => ToAttributeArray(element.GetCustomAttributes(typeof(Attribute), inherit))
             };
         }
 
@@ -536,12 +539,11 @@ namespace System
             if (element.Member == null)
                 throw new ArgumentException(SR.Argument_InvalidParameterInfo, nameof(element));
 
-
             MemberInfo member = element.Member;
             if (member.MemberType == MemberTypes.Method && inherit)
                 return InternalParamGetCustomAttributes(element, attributeType, inherit);
 
-            return (element.GetCustomAttributes(attributeType, inherit) as Attribute[])!;
+            return ToAttributeArray(element.GetCustomAttributes(attributeType, inherit));
         }
 
         public static Attribute[] GetCustomAttributes(ParameterInfo element!!, bool inherit)
@@ -549,12 +551,11 @@ namespace System
             if (element.Member == null)
                 throw new ArgumentException(SR.Argument_InvalidParameterInfo, nameof(element));
 
-
             MemberInfo member = element.Member;
             if (member.MemberType == MemberTypes.Method && inherit)
                 return InternalParamGetCustomAttributes(element, null, inherit);
 
-            return (element.GetCustomAttributes(typeof(Attribute), inherit) as Attribute[])!;
+            return ToAttributeArray(element.GetCustomAttributes(typeof(Attribute), inherit));
         }
 
         public static bool IsDefined(ParameterInfo element, Type attributeType)

--- a/src/coreclr/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs
@@ -434,10 +434,8 @@ namespace System
                 SR.Format(SR.Format_AttributeUsage, type));
         }
 
-        private static Attribute[] CreateAttributeArrayHelper(Type elementType, int elementCount)
-        {
-            return (Attribute[])Array.CreateInstance(elementType, elementCount);
-        }
+        private static Attribute[] CreateAttributeArrayHelper(Type elementType, int elementCount) =>
+            elementType.ContainsGenericParameters ? new Attribute[elementCount] : (Attribute[])Array.CreateInstance(elementType, elementCount);
         #endregion
 
         #endregion

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
@@ -509,11 +509,11 @@ namespace System.Reflection
 
         public override object[] GetCustomAttributes(Type attributeType!!, bool inherit)
         {
-            if (MdToken.IsNullToken(m_tkParamDef))
-                return Array.Empty<object>();
-
             if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
+
+            if (MdToken.IsNullToken(m_tkParamDef))
+                return CustomAttribute.CreateAttributeArrayHelper(attributeRuntimeType, 0);
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
         }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Attribute.CoreRT.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Attribute.CoreRT.cs
@@ -141,19 +141,9 @@ namespace System
                 attributes.Add(instantiatedAttribute);
             }
             int count = attributes.Count;
-            Attribute[] result;
-            try
-            {
-                result = (Attribute[])Array.CreateInstance(actualElementType, count);
-            }
-            catch (NotSupportedException) when (actualElementType.ContainsGenericParameters)
-            {
-                // This is here for desktop compatibility (using try-catch as control flow to avoid slowing down the mainline case.)
-                // GetCustomAttributes() normally returns an array of the exact attribute type requested except when
-                // the requested type is an open type. Its ICustomAttributeProvider counterpart would return an Object[] array but that's
-                // not possible with this api's return type so it returns null instead.
-                return null;
-            }
+            Attribute[] result = actualElementType.ContainsGenericParameters
+                ? new Attribute[count]
+                : (Attribute[])Array.CreateInstance(actualElementType, count);
             attributes.CopyTo(result, 0);
             return result;
         }

--- a/src/libraries/System.Reflection/tests/ParameterInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/ParameterInfoTests.cs
@@ -246,6 +246,14 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        public static void GetCustomAttributesOnParameterWithNullMetadataTokenReturnsArrayOfCorrectType()
+        {
+            var parameterWithNullMetadataToken = typeof(int[]).GetProperty(nameof(Array.Length)).GetMethod.ReturnParameter;
+            Assert.Equal(typeof(Attribute[]), Attribute.GetCustomAttributes(parameterWithNullMetadataToken).GetType());
+            Assert.Equal(typeof(MyAttribute[]), Attribute.GetCustomAttributes(parameterWithNullMetadataToken, typeof(MyAttribute)).GetType());
+        }
+
+        [Fact]
         public void VerifyGetCustomAttributesData()
         {
             ParameterInfo p = GetParameterInfo(typeof(ParameterInfoMetadata), "MethodWithCustomAttribute", 0);

--- a/src/libraries/System.Runtime/tests/System/Attributes.cs
+++ b/src/libraries/System.Runtime/tests/System/Attributes.cs
@@ -283,27 +283,6 @@ namespace System.Tests
             Assert.Equal(1, closedGenericAttributes.Length);
             Assert.Equal(typeof(GenericAttribute<TGenericParameter>[]), closedGenericAttributes.GetType());
         }
-
-        [Fact]
-        public static void GetCustomAttributesBehaviorMemberInfoReturnsStringArray()
-        {
-            FieldInfo field = new CustomFieldInfo(new[] { "a" });
-            Assert.Throws<InvalidCastException>(() => Attribute.GetCustomAttributes(field));
-        }
-
-        [Fact]
-        public static void GetCustomAttributesBehaviorMemberInfoReturnsAttributeInObjectArray()
-        {
-            FieldInfo field = new CustomFieldInfo(new object[] { new TestAttribute(0) });
-            Assert.Throws<InvalidCastException>(() => Attribute.GetCustomAttributes(field));
-        }
-
-        [Fact]
-        public static void GetCustomAttributesBehaviorMemberInfoReturnsStringAndAttributeInObjectArray()
-        {
-            FieldInfo field = new CustomFieldInfo(new object[] { "a", new TestAttribute(0) });
-            Assert.Throws<InvalidCastException>(() => Attribute.GetCustomAttributes(field));
-        }
     }
 
     public static class GetCustomAttribute
@@ -936,34 +915,5 @@ namespace System.Tests
 
         [GenericAttribute<DateTime?>]
         public event Action Event;
-    }
-
-    public class CustomFieldInfo : FieldInfo
-    {
-        private readonly object[] _customAttributes;
-
-        public CustomFieldInfo(object[] customAttributes)
-        {
-            this._customAttributes = customAttributes;
-        }
-
-        public override FieldAttributes Attributes => default;
-        public override RuntimeFieldHandle FieldHandle => default;
-        public override Type FieldType => typeof(object);
-        public override Type DeclaringType => null;
-        public override string Name => "custom";
-        public override Type ReflectedType => null;
-
-        public override object[] GetCustomAttributes(bool inherit) => this._customAttributes;
-
-        public override object[] GetCustomAttributes(Type attributeType, bool inherit) => this._customAttributes;
-
-        public override object GetValue(object obj) => null;
-
-        public override bool IsDefined(Type attributeType, bool inherit) => false;
-
-        public override void SetValue(object obj, object value, BindingFlags invokeAttr, Binder binder, System.Globalization.CultureInfo culture)
-        {
-        }
     }
 }

--- a/src/libraries/System.Runtime/tests/System/Attributes.cs
+++ b/src/libraries/System.Runtime/tests/System/Attributes.cs
@@ -20,8 +20,6 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Xunit;
 
-[assembly: System.Tests.GenericAttribute<System.Type>]
-[module: System.Tests.GenericAttribute<bool>]
 [module: Debuggable(true, false)]
 namespace System.Tests
 {
@@ -223,22 +221,6 @@ namespace System.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/56887)", TestRuntimes.Mono)]
-        public static void GetCustomAttributesWorksWithOpenAndClosedGenericTypesForAssembly()
-        {
-            Assembly assembly = Assembly.GetExecutingAssembly();
-            GenericAttributesTestHelper<Type>(t => Attribute.GetCustomAttributes(assembly, t));
-        }
-
-        [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/56887)", TestRuntimes.Mono)]
-        public static void GetCustomAttributesWorksWithOpenAndClosedGenericTypesForModule()
-        {
-            Module module = typeof(HasGenericAttribute).Module;
-            GenericAttributesTestHelper<bool>(t => Attribute.GetCustomAttributes(module, t));
-        }
-
-        [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/56887)", TestRuntimes.Mono)]
         public static void GetCustomAttributesWorksWithOpenAndClosedGenericTypesForType()
         {
             GenericAttributesTestHelper<string>(t => Attribute.GetCustomAttributes(typeof(HasGenericAttribute), t));
@@ -335,8 +317,7 @@ namespace System.Tests
             // [TestAttributes.FooAttribute()]
             // [TestAttributes.ComplicatedAttribute((Int32)1, Stuff = 2)]
             // [System.Diagnostics.DebuggableAttribute((Boolean)True, (Boolean)False)]
-            // [System.Tests.GenericAttribute<bool>]
-            Assert.Equal(5, customAttributes.Count);
+            Assert.Equal(4, customAttributes.Count);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/Attributes.cs
+++ b/src/libraries/System.Runtime/tests/System/Attributes.cs
@@ -536,6 +536,7 @@ namespace System.Tests
 
         // reproduces https://github.com/dotnet/runtime/issues/64335
         [Fact]
+        [SkipOnMono("Mono throws on open generic type passed to GetCustomAttributes")]
         public static void GetCustomAttributesDoesNotReturnNullForOpenGenericType()
         {
             Attribute[] openGenericAttributes = Attribute.GetCustomAttributes(typeof(HasGenericAttribute), typeof(GenericAttribute<>));
@@ -548,6 +549,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [SkipOnMono("Mono throws NullReferenceException internally if ICustomAttributeProvider.GetCustomAttributes returns null")]
         public static void GetCustomAttributesReturnsAttributeArrayForMisbehavingCustomMemberInfo()
         {
             FieldInfo fieldWithNullAttributes = new CustomFieldInfo(null!);

--- a/src/tests/reflection/GenericAttribute/GenericAttributeMetadata.cs
+++ b/src/tests/reflection/GenericAttribute/GenericAttributeMetadata.cs
@@ -17,6 +17,8 @@ using System.Runtime.CompilerServices;
 [assembly: MultiAttribute<bool>()]
 [assembly: MultiAttribute<bool>(true)]
 
+[module: SingleAttribute<long>()]
+
 [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = false)]
 public class SingleAttribute<T> : Attribute
 {

--- a/src/tests/reflection/GenericAttribute/GenericAttributeTests.cs
+++ b/src/tests/reflection/GenericAttribute/GenericAttributeTests.cs
@@ -17,8 +17,8 @@ class Program
         Assert(((ICustomAttributeProvider)assembly).IsDefined(typeof(SingleAttribute<int>), true));
         Assert(CustomAttributeExtensions.IsDefined(assembly, typeof(SingleAttribute<bool>)));
         Assert(((ICustomAttributeProvider)assembly).IsDefined(typeof(SingleAttribute<bool>), true));
-        Assert(!CustomAttributeExtensions.GetCustomAttributes(assembly, typeof(SingleAttribute<>), false).GetEnumerator().MoveNext());
-        Assert(!CustomAttributeExtensions.GetCustomAttributes(assembly, typeof(SingleAttribute<>), true).GetEnumerator().MoveNext());
+        Assert(!CustomAttributeExtensions.GetCustomAttributes(assembly, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());
+        Assert(!CustomAttributeExtensions.GetCustomAttributes(assembly, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());
 
         TypeInfo programTypeInfo = typeof(Class).GetTypeInfo();
         Assert(CustomAttributeExtensions.GetCustomAttribute<SingleAttribute<int>>(programTypeInfo) != null);
@@ -157,10 +157,10 @@ class Program
 
         Module module = programTypeInfo.Module;
         AssertAny(CustomAttributeExtensions.GetCustomAttributes(module), a => a is SingleAttribute<long>);
-        Assert(CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<long>), false).GetEnumerator().MoveNext());
-        Assert(CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<long>), false).GetEnumerator().MoveNext());
-        Assert(!CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<>), false).GetEnumerator().MoveNext());
-        Assert(!CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<>), true).GetEnumerator().MoveNext());	
+        Assert(CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<long>)).GetEnumerator().MoveNext());
+        Assert(CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<long>)).GetEnumerator().MoveNext());
+        Assert(!CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());
+        Assert(!CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());	
 
         // Test coverage for CustomAttributeData api surface
         var a1_data = CustomAttributeData.GetCustomAttributes(programTypeInfo);

--- a/src/tests/reflection/GenericAttribute/GenericAttributeTests.cs
+++ b/src/tests/reflection/GenericAttribute/GenericAttributeTests.cs
@@ -8,7 +8,6 @@ class Program
 {
     static int Main(string[] args)
     {
-/* Re-enable once the fix to https://github.com/dotnet/msbuild/issues/6734 propagates to this repo.
         Assembly assembly = typeof(Class).GetTypeInfo().Assembly;
         Assert(CustomAttributeExtensions.GetCustomAttribute<SingleAttribute<int>>(assembly) != null);
         Assert(((ICustomAttributeProvider)assembly).GetCustomAttributes(typeof(SingleAttribute<int>), true) != null);
@@ -18,8 +17,8 @@ class Program
         Assert(((ICustomAttributeProvider)assembly).IsDefined(typeof(SingleAttribute<int>), true));
         Assert(CustomAttributeExtensions.IsDefined(assembly, typeof(SingleAttribute<bool>)));
         Assert(((ICustomAttributeProvider)assembly).IsDefined(typeof(SingleAttribute<bool>), true));
-
-*/
+        Assert(!CustomAttributeExtensions.GetCustomAttributes(assembly, typeof(SingleAttribute<>), false).GetEnumerator().MoveNext());
+        Assert(!CustomAttributeExtensions.GetCustomAttributes(assembly, typeof(SingleAttribute<>), true).GetEnumerator().MoveNext());
 
         TypeInfo programTypeInfo = typeof(Class).GetTypeInfo();
         Assert(CustomAttributeExtensions.GetCustomAttribute<SingleAttribute<int>>(programTypeInfo) != null);
@@ -155,6 +154,13 @@ class Program
         Assert(!CustomAttributeExtensions.GetCustomAttributes(programTypeInfo, typeof(MultiAttribute<>), false).GetEnumerator().MoveNext());
         Assert(!CustomAttributeExtensions.GetCustomAttributes(programTypeInfo, typeof(MultiAttribute<>), true).GetEnumerator().MoveNext());
         Assert(!((ICustomAttributeProvider)programTypeInfo).GetCustomAttributes(typeof(MultiAttribute<>), true).GetEnumerator().MoveNext());
+
+        Module module = programTypeInfo.Module;
+        AssertAny(CustomAttributeExtensions.GetCustomAttributes(module), a => a is SingleAttribute<long>);
+        Assert(CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<long>), false).GetEnumerator().MoveNext());
+        Assert(CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<long>), false).GetEnumerator().MoveNext());
+        Assert(!CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<>), false).GetEnumerator().MoveNext());
+        Assert(!CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<>), true).GetEnumerator().MoveNext());	
 
         // Test coverage for CustomAttributeData api surface
         var a1_data = CustomAttributeData.GetCustomAttributes(programTypeInfo);

--- a/src/tests/reflection/GenericAttribute/GenericAttributeTests.cs
+++ b/src/tests/reflection/GenericAttribute/GenericAttributeTests.cs
@@ -22,6 +22,13 @@ class Program
         Assert(!CustomAttributeExtensions.GetCustomAttributes(assembly, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());
 */
 
+        // Module module = programTypeInfo.Module;
+        // AssertAny(CustomAttributeExtensions.GetCustomAttributes(module), a => a is SingleAttribute<long>);
+        // Assert(CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<long>)).GetEnumerator().MoveNext());
+        // Assert(CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<long>)).GetEnumerator().MoveNext());
+        // Assert(!CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());
+        // Assert(!CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());	
+
         TypeInfo programTypeInfo = typeof(Class).GetTypeInfo();
         Assert(CustomAttributeExtensions.GetCustomAttribute<SingleAttribute<int>>(programTypeInfo) != null);
         Assert(((ICustomAttributeProvider)programTypeInfo).GetCustomAttributes(typeof(SingleAttribute<int>), true) != null);
@@ -156,13 +163,6 @@ class Program
         Assert(!CustomAttributeExtensions.GetCustomAttributes(programTypeInfo, typeof(MultiAttribute<>), false).GetEnumerator().MoveNext());
         Assert(!CustomAttributeExtensions.GetCustomAttributes(programTypeInfo, typeof(MultiAttribute<>), true).GetEnumerator().MoveNext());
         Assert(!((ICustomAttributeProvider)programTypeInfo).GetCustomAttributes(typeof(MultiAttribute<>), true).GetEnumerator().MoveNext());
-
-        Module module = programTypeInfo.Module;
-        AssertAny(CustomAttributeExtensions.GetCustomAttributes(module), a => a is SingleAttribute<long>);
-        Assert(CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<long>)).GetEnumerator().MoveNext());
-        Assert(CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<long>)).GetEnumerator().MoveNext());
-        Assert(!CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());
-        Assert(!CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());	
 
         // Test coverage for CustomAttributeData api surface
         var a1_data = CustomAttributeData.GetCustomAttributes(programTypeInfo);

--- a/src/tests/reflection/GenericAttribute/GenericAttributeTests.cs
+++ b/src/tests/reflection/GenericAttribute/GenericAttributeTests.cs
@@ -152,8 +152,8 @@ class Program
         AssertAny(b10, a => (a as MultiAttribute<Type>)?.Value == typeof(Class));
         AssertAny(b10, a => (a as MultiAttribute<Type>)?.Value == typeof(Class.Derive));
 
-        Assert(CustomAttributeExtensions.GetCustomAttributes(programTypeInfo, typeof(MultiAttribute<>), false) == null);
-        Assert(CustomAttributeExtensions.GetCustomAttributes(programTypeInfo, typeof(MultiAttribute<>), true) == null);
+        Assert(!CustomAttributeExtensions.GetCustomAttributes(programTypeInfo, typeof(MultiAttribute<>), false).GetEnumerator().MoveNext());
+        Assert(!CustomAttributeExtensions.GetCustomAttributes(programTypeInfo, typeof(MultiAttribute<>), true).GetEnumerator().MoveNext());
         Assert(!((ICustomAttributeProvider)programTypeInfo).GetCustomAttributes(typeof(MultiAttribute<>), true).GetEnumerator().MoveNext());
 
         // Test coverage for CustomAttributeData api surface

--- a/src/tests/reflection/GenericAttribute/GenericAttributeTests.cs
+++ b/src/tests/reflection/GenericAttribute/GenericAttributeTests.cs
@@ -8,6 +8,7 @@ class Program
 {
     static int Main(string[] args)
     {
+/* Re-enable once the fix to https://github.com/dotnet/msbuild/issues/6734 propagates to this repo.
         Assembly assembly = typeof(Class).GetTypeInfo().Assembly;
         Assert(CustomAttributeExtensions.GetCustomAttribute<SingleAttribute<int>>(assembly) != null);
         Assert(((ICustomAttributeProvider)assembly).GetCustomAttributes(typeof(SingleAttribute<int>), true) != null);
@@ -19,6 +20,7 @@ class Program
         Assert(((ICustomAttributeProvider)assembly).IsDefined(typeof(SingleAttribute<bool>), true));
         Assert(!CustomAttributeExtensions.GetCustomAttributes(assembly, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());
         Assert(!CustomAttributeExtensions.GetCustomAttributes(assembly, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());
+*/
 
         TypeInfo programTypeInfo = typeof(Class).GetTypeInfo();
         Assert(CustomAttributeExtensions.GetCustomAttribute<SingleAttribute<int>>(programTypeInfo) != null);


### PR DESCRIPTION
Fix #64335