### PR TITLE
[wasm] Disable System.Text.RegularExpressions.Generators.Tests 

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -18,6 +18,9 @@
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\console-node-ts\Wasm.Console.Node.TS.Sample.csproj" />
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-webpack\Wasm.Browser.WebPack.Sample.csproj" />
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-nextjs\Wasm.Browser.NextJs.Sample.csproj" />
+
+    <!-- These tests are completely disabled on wasm -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Generators.Tests/System.Text.RegularExpressions.Generators.Tests.csproj" />
   </ItemGroup>
 
   <!-- Wasm aot on !windows -->


### PR DESCRIPTION
.. since they are explicitly skipped in the source, for wasm.

Fixes https://github.com/dotnet/runtime/issues/65210