### PR TITLE
Change SslStream's internal adapter interface to use static abstract interface methods

### DIFF
--- a/src/libraries/System.Net.Security/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Security/src/Resources/Strings.resx
@@ -135,7 +135,7 @@
     <value>The connection was closed</value>
   </data>
   <data name="net_io_invalidnestedcall" xml:space="preserve">
-    <value> The {0} method cannot be called when another {1} operation is pending.</value>
+    <value> This method may not be called when another {0} operation is pending.</value>
   </data>
   <data name="net_io_invalidendcall" xml:space="preserve">
     <value>{0} can only be called once for each asynchronous operation.</value>

--- a/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
@@ -341,12 +341,12 @@ namespace System.Net.Security
             return ReadAsync<AsyncReadWriteAdapter>(buffer, cancellationToken);
         }
 
-        private async ValueTask<int> ReadAsync<TIOAdapter>(Memory<byte> buffer, CancellationToken cancellationToken, [CallerMemberName] string? callerName = null)
+        private async ValueTask<int> ReadAsync<TIOAdapter>(Memory<byte> buffer, CancellationToken cancellationToken)
             where TIOAdapter : IReadWriteAdapter
         {
             if (Interlocked.Exchange(ref _readInProgress, 1) == 1)
             {
-                throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, callerName, "read"));
+                throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, "read"));
             }
 
             try
@@ -492,7 +492,7 @@ namespace System.Net.Security
         {
             if (Interlocked.Exchange(ref _writeInProgress, 1) == 1)
             {
-                throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, nameof(Write), "write"));
+                throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, "write"));
             }
 
             try
@@ -704,7 +704,7 @@ namespace System.Net.Security
             }
         }
 
-        private async Task AuthenticateAsync<TIOAdapter>(CancellationToken cancellationToken, [CallerMemberName] string? callerName = null)
+        private async Task AuthenticateAsync<TIOAdapter>(CancellationToken cancellationToken)
             where TIOAdapter : IReadWriteAdapter
         {
             Debug.Assert(_context != null);
@@ -712,7 +712,7 @@ namespace System.Net.Security
             ThrowIfFailed(authSuccessCheck: false);
             if (Interlocked.Exchange(ref _authInProgress, 1) == 1)
             {
-                throw new InvalidOperationException(SR.Format(SR.net_io_invalidnestedcall, callerName, "authenticate"));
+                throw new InvalidOperationException(SR.Format(SR.net_io_invalidnestedcall, "authenticate"));
             }
 
             try

--- a/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
@@ -134,7 +134,7 @@ namespace System.Net.Security
         public virtual void AuthenticateAsServer(NetworkCredential credential, ExtendedProtectionPolicy? policy, ProtectionLevel requiredProtectionLevel, TokenImpersonationLevel requiredImpersonationLevel)
         {
             ValidateCreateContext(DefaultPackage, credential, string.Empty, policy, requiredProtectionLevel, requiredImpersonationLevel);
-            AuthenticateAsync(new SyncReadWriteAdapter(InnerStream)).GetAwaiter().GetResult();
+            AuthenticateAsync<SyncReadWriteAdapter>(default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         public virtual IAsyncResult BeginAuthenticateAsServer(AsyncCallback? asyncCallback, object? asyncState) =>
@@ -172,7 +172,7 @@ namespace System.Net.Security
             NetworkCredential credential, ChannelBinding? binding, string targetName, ProtectionLevel requiredProtectionLevel, TokenImpersonationLevel allowedImpersonationLevel)
         {
             ValidateCreateContext(DefaultPackage, isServer: false, credential, targetName, binding, requiredProtectionLevel, allowedImpersonationLevel);
-            AuthenticateAsync(new SyncReadWriteAdapter(InnerStream)).GetAwaiter().GetResult();
+            AuthenticateAsync<SyncReadWriteAdapter>(default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         public virtual Task AuthenticateAsClientAsync() =>
@@ -195,7 +195,7 @@ namespace System.Net.Security
             TokenImpersonationLevel allowedImpersonationLevel)
         {
             ValidateCreateContext(DefaultPackage, isServer: false, credential, targetName, binding, requiredProtectionLevel, allowedImpersonationLevel);
-            return AuthenticateAsync(new AsyncReadWriteAdapter(InnerStream, cancellationToken: default));
+            return AuthenticateAsync<AsyncReadWriteAdapter>(default(CancellationToken));
         }
 
         public virtual Task AuthenticateAsServerAsync() =>
@@ -211,7 +211,7 @@ namespace System.Net.Security
             NetworkCredential credential, ExtendedProtectionPolicy? policy, ProtectionLevel requiredProtectionLevel, TokenImpersonationLevel requiredImpersonationLevel)
         {
             ValidateCreateContext(DefaultPackage, credential, string.Empty, policy, requiredProtectionLevel, requiredImpersonationLevel);
-            return AuthenticateAsync(new AsyncReadWriteAdapter(InnerStream, cancellationToken: default));
+            return AuthenticateAsync<AsyncReadWriteAdapter>(default(CancellationToken));
         }
 
         public override bool IsAuthenticated => IsAuthenticatedCore;
@@ -312,7 +312,7 @@ namespace System.Net.Security
                 return InnerStream.Read(buffer, offset, count);
             }
 
-            ValueTask<int> vt = ReadAsync(new SyncReadWriteAdapter(InnerStream), new Memory<byte>(buffer, offset, count));
+            ValueTask<int> vt = ReadAsync<SyncReadWriteAdapter>(new Memory<byte>(buffer, offset, count), default(CancellationToken));
             Debug.Assert(vt.IsCompleted, "Should have completed synchroously with sync adapter");
             return vt.GetAwaiter().GetResult();
         }
@@ -327,7 +327,7 @@ namespace System.Net.Security
                 return InnerStream.ReadAsync(buffer, offset, count, cancellationToken);
             }
 
-            return ReadAsync(new AsyncReadWriteAdapter(InnerStream, cancellationToken), new Memory<byte>(buffer, offset, count)).AsTask();
+            return ReadAsync<AsyncReadWriteAdapter>(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
         }
 
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
@@ -338,10 +338,11 @@ namespace System.Net.Security
                 return InnerStream.ReadAsync(buffer, cancellationToken);
             }
 
-            return ReadAsync(new AsyncReadWriteAdapter(InnerStream, cancellationToken), buffer);
+            return ReadAsync<AsyncReadWriteAdapter>(buffer, cancellationToken);
         }
 
-        private async ValueTask<int> ReadAsync<TAdapter>(TAdapter adapter, Memory<byte> buffer, [CallerMemberName] string? callerName = null) where TAdapter : IReadWriteAdapter
+        private async ValueTask<int> ReadAsync<TIOAdapter>(Memory<byte> buffer, CancellationToken cancellationToken, [CallerMemberName] string? callerName = null)
+            where TIOAdapter : IReadWriteAdapter
         {
             if (Interlocked.Exchange(ref _readInProgress, 1) == 1)
             {
@@ -364,7 +365,7 @@ namespace System.Net.Security
 
                 while (true)
                 {
-                    int readBytes = await ReadAllAsync(adapter, _readHeader, allowZeroRead: true).ConfigureAwait(false);
+                    int readBytes = await ReadAllAsync(InnerStream, _readHeader, allowZeroRead: true, cancellationToken).ConfigureAwait(false);
                     if (readBytes == 0)
                     {
                         return 0;
@@ -389,7 +390,7 @@ namespace System.Net.Security
                         _readBuffer = new byte[readBytes];
                     }
 
-                    readBytes = await ReadAllAsync(adapter, new Memory<byte>(_readBuffer, 0, readBytes), allowZeroRead: false).ConfigureAwait(false);
+                    readBytes = await ReadAllAsync(InnerStream, new Memory<byte>(_readBuffer, 0, readBytes), allowZeroRead: false, cancellationToken).ConfigureAwait(false);
 
                     // Decrypt into internal buffer, change "readBytes" to count now _Decrypted Bytes_
                     // Decrypted data start from zero offset, the size can be shrunk after decryption.
@@ -421,13 +422,13 @@ namespace System.Net.Security
                 _readInProgress = 0;
             }
 
-            static async ValueTask<int> ReadAllAsync(TAdapter adapter, Memory<byte> buffer, bool allowZeroRead)
+            static async ValueTask<int> ReadAllAsync(Stream stream, Memory<byte> buffer, bool allowZeroRead, CancellationToken cancellationToken)
             {
                 int read = 0;
 
                 do
                 {
-                    int bytes = await adapter.ReadAsync(buffer).ConfigureAwait(false);
+                    int bytes = await TIOAdapter.ReadAsync(stream, buffer, cancellationToken).ConfigureAwait(false);
                     if (bytes == 0)
                     {
                         if (read != 0 || !allowZeroRead)
@@ -457,7 +458,7 @@ namespace System.Net.Security
                 return;
             }
 
-            WriteAsync(new SyncReadWriteAdapter(InnerStream), new ReadOnlyMemory<byte>(buffer, offset, count)).GetAwaiter().GetResult();
+            WriteAsync<SyncReadWriteAdapter>(new ReadOnlyMemory<byte>(buffer, offset, count), default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <returns>A <see cref="Task"/> that represents the asynchronous read operation.</returns>
@@ -471,7 +472,7 @@ namespace System.Net.Security
                 return InnerStream.WriteAsync(buffer, offset, count, cancellationToken);
             }
 
-            return WriteAsync(new AsyncReadWriteAdapter(InnerStream, cancellationToken), new ReadOnlyMemory<byte>(buffer, offset, count));
+            return WriteAsync<AsyncReadWriteAdapter>(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken);
         }
 
         /// <returns>A <see cref="ValueTask"/> that represents the asynchronous read operation.</returns>
@@ -483,10 +484,11 @@ namespace System.Net.Security
                 return InnerStream.WriteAsync(buffer, cancellationToken);
             }
 
-            return new ValueTask(WriteAsync(new AsyncReadWriteAdapter(InnerStream, cancellationToken), buffer));
+            return new ValueTask(WriteAsync<AsyncReadWriteAdapter>(buffer, cancellationToken));
         }
 
-        private async Task WriteAsync<TAdapter>(TAdapter adapter, ReadOnlyMemory<byte> buffer) where TAdapter : IReadWriteAdapter
+        private async Task WriteAsync<TIOAdapter>(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+            where TIOAdapter : IReadWriteAdapter
         {
             if (Interlocked.Exchange(ref _writeInProgress, 1) == 1)
             {
@@ -508,7 +510,7 @@ namespace System.Net.Security
                         throw new IOException(SR.net_io_encrypt, e);
                     }
 
-                    await adapter.WriteAsync(_writeBuffer, 0, encryptedBytes).ConfigureAwait(false);
+                    await TIOAdapter.WriteAsync(InnerStream, _writeBuffer, 0, encryptedBytes, cancellationToken).ConfigureAwait(false);
                     buffer = buffer.Slice(chunkBytes);
                 }
             }
@@ -702,7 +704,8 @@ namespace System.Net.Security
             }
         }
 
-        private async Task AuthenticateAsync<TAdapter>(TAdapter adapter, [CallerMemberName] string? callerName = null) where TAdapter : IReadWriteAdapter
+        private async Task AuthenticateAsync<TIOAdapter>(CancellationToken cancellationToken, [CallerMemberName] string? callerName = null)
+            where TIOAdapter : IReadWriteAdapter
         {
             Debug.Assert(_context != null);
 
@@ -715,8 +718,8 @@ namespace System.Net.Security
             try
             {
                 await (_context.IsServer ?
-                    ReceiveBlobAsync(adapter) : // server should listen for a client blob
-                    SendBlobAsync(adapter, message: null)).ConfigureAwait(false); // client should send the first blob
+                    ReceiveBlobAsync<TIOAdapter>(cancellationToken) : // server should listen for a client blob
+                    SendBlobAsync<TIOAdapter>(message: null, cancellationToken)).ConfigureAwait(false); // client should send the first blob
             }
             catch (Exception e)
             {
@@ -751,7 +754,8 @@ namespace System.Net.Security
         }
 
         // Client authentication starts here, but server also loops through this method.
-        private async Task SendBlobAsync<TAdapter>(TAdapter adapter, byte[]? message) where TAdapter : IReadWriteAdapter
+        private async Task SendBlobAsync<TIOAdapter>(byte[]? message, CancellationToken cancellationToken)
+            where TIOAdapter : IReadWriteAdapter
         {
             Debug.Assert(_context != null);
 
@@ -764,7 +768,7 @@ namespace System.Net.Security
             if (exception != null)
             {
                 // Signal remote side on a failed attempt.
-                await SendAuthResetSignalAndThrowAsync(adapter, message!, exception).ConfigureAwait(false);
+                await SendAuthResetSignalAndThrowAsync<TIOAdapter>(message!, exception, cancellationToken).ConfigureAwait(false);
                 Debug.Fail("Unreachable");
             }
 
@@ -782,7 +786,7 @@ namespace System.Net.Security
                         statusCode = (int)((uint)statusCode >> 8);
                     }
 
-                    await SendAuthResetSignalAndThrowAsync(adapter, message, exception).ConfigureAwait(false);
+                    await SendAuthResetSignalAndThrowAsync<TIOAdapter>(message, exception, cancellationToken).ConfigureAwait(false);
                     Debug.Fail("Unreachable");
                 }
 
@@ -798,7 +802,7 @@ namespace System.Net.Security
                         statusCode = (int)((uint)statusCode >> 8);
                     }
 
-                    await SendAuthResetSignalAndThrowAsync(adapter, message, exception).ConfigureAwait(false);
+                    await SendAuthResetSignalAndThrowAsync<TIOAdapter>(message, exception, cancellationToken).ConfigureAwait(false);
                     Debug.Fail("Unreachable");
                 }
 
@@ -816,7 +820,7 @@ namespace System.Net.Security
                         statusCode = (int)((uint)statusCode >> 8);
                     }
 
-                    await SendAuthResetSignalAndThrowAsync(adapter, message, exception).ConfigureAwait(false);
+                    await SendAuthResetSignalAndThrowAsync<TIOAdapter>(message, exception, cancellationToken).ConfigureAwait(false);
                     Debug.Fail("Unreachable");
                 }
 
@@ -840,7 +844,7 @@ namespace System.Net.Security
             if (message != null)
             {
                 //even if we are completed, there could be a blob for sending.
-                await _framer!.WriteMessageAsync(adapter, message).ConfigureAwait(false);
+                await _framer!.WriteMessageAsync<TIOAdapter>(InnerStream, message, cancellationToken).ConfigureAwait(false);
             }
 
             if (HandshakeComplete && _remoteOk)
@@ -849,15 +853,16 @@ namespace System.Net.Security
                 return;
             }
 
-            await ReceiveBlobAsync(adapter).ConfigureAwait(false);
+            await ReceiveBlobAsync<TIOAdapter>(cancellationToken).ConfigureAwait(false);
         }
 
         // Server authentication starts here, but client also loops through this method.
-        private async Task ReceiveBlobAsync<TAdapter>(TAdapter adapter) where TAdapter : IReadWriteAdapter
+        private async Task ReceiveBlobAsync<TIOAdapter>(CancellationToken cancellationToken)
+            where TIOAdapter : IReadWriteAdapter
         {
             Debug.Assert(_framer != null);
 
-            byte[]? message = await _framer.ReadMessageAsync(adapter).ConfigureAwait(false);
+            byte[]? message = await _framer.ReadMessageAsync<TIOAdapter>(InnerStream, cancellationToken).ConfigureAwait(false);
             if (message == null)
             {
                 // This is an EOF otherwise we would get at least *empty* message but not a null one.
@@ -903,12 +908,13 @@ namespace System.Net.Security
             }
 
             // Not yet done, get a new blob and send it if any.
-            await SendBlobAsync(adapter, message).ConfigureAwait(false);
+            await SendBlobAsync<TIOAdapter>(message, cancellationToken).ConfigureAwait(false);
         }
 
         //  This is to reset auth state on the remote side.
         //  If this write succeeds we will allow auth retrying.
-        private async Task SendAuthResetSignalAndThrowAsync<TAdapter>(TAdapter adapter, byte[] message, Exception exception) where TAdapter : IReadWriteAdapter
+        private async Task SendAuthResetSignalAndThrowAsync<TIOAdapter>(byte[] message, Exception exception, CancellationToken cancellationToken)
+            where TIOAdapter : IReadWriteAdapter
         {
             _framer!.WriteHeader.MessageId = FrameHeader.HandshakeErrId;
 
@@ -922,7 +928,7 @@ namespace System.Net.Security
                 exception = new AuthenticationException(SR.net_auth_SSPI, exception);
             }
 
-            await _framer.WriteMessageAsync(adapter, message).ConfigureAwait(false);
+            await _framer.WriteMessageAsync<TIOAdapter>(InnerStream, message, cancellationToken).ConfigureAwait(false);
 
             _canRetryAuthentication = true;
             ExceptionDispatchInfo.Throw(exception);

--- a/src/libraries/System.Net.Security/src/System/Net/Security/ReadWriteAdapter.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/ReadWriteAdapter.cs
@@ -17,7 +17,7 @@ namespace System.Net.Security
     }
 #pragma warning restore CA2252
 
-    internal sealed class AsyncReadWriteAdapter : IReadWriteAdapter
+    internal readonly struct AsyncReadWriteAdapter : IReadWriteAdapter
     {
         public static ValueTask<int> ReadAsync(Stream stream, Memory<byte> buffer, CancellationToken cancellationToken) =>
             stream.ReadAsync(buffer, cancellationToken);
@@ -30,7 +30,7 @@ namespace System.Net.Security
         public static Task WaitAsync(TaskCompletionSource<bool> waiter) => waiter.Task;
     }
 
-    internal sealed class SyncReadWriteAdapter : IReadWriteAdapter
+    internal readonly struct SyncReadWriteAdapter : IReadWriteAdapter
     {
         public static ValueTask<int> ReadAsync(Stream stream, Memory<byte> buffer, CancellationToken cancellationToken) =>
             new ValueTask<int>(stream.Read(buffer.Span));

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -172,8 +172,8 @@ namespace System.Net.Security
             else
             {
                 return isAsync ?
-                    ForceAuthenticationAsync(new AsyncReadWriteAdapter(InnerStream, cancellationToken), _context!.IsServer, null, isApm) :
-                    ForceAuthenticationAsync(new SyncReadWriteAdapter(InnerStream), _context!.IsServer, null);
+                    ForceAuthenticationAsync<AsyncReadWriteAdapter>(_context!.IsServer, null, isApm, cancellationToken) :
+                    ForceAuthenticationAsync<SyncReadWriteAdapter>(_context!.IsServer, null, isApm: false, cancellationToken);
             }
         }
 
@@ -185,8 +185,8 @@ namespace System.Net.Security
             try
             {
                 Task task = isAsync?
-                    ForceAuthenticationAsync(new AsyncReadWriteAdapter(InnerStream, cancellationToken), _context!.IsServer, null, isApm) :
-                    ForceAuthenticationAsync(new SyncReadWriteAdapter(InnerStream), _context!.IsServer, null);
+                    ForceAuthenticationAsync<AsyncReadWriteAdapter>(_context!.IsServer, null, isApm, cancellationToken) :
+                    ForceAuthenticationAsync<SyncReadWriteAdapter>(_context!.IsServer, null, isApm: false, cancellationToken);
 
                 await task.ConfigureAwait(false);
 
@@ -206,12 +206,12 @@ namespace System.Net.Security
         //
         // This is used to reply on re-handshake when received SEC_I_RENEGOTIATE on Read().
         //
-        private async Task ReplyOnReAuthenticationAsync<TIOAdapter>(TIOAdapter adapter, byte[]? buffer)
+        private async Task ReplyOnReAuthenticationAsync<TIOAdapter>(byte[]? buffer, CancellationToken cancellationToken)
             where TIOAdapter : IReadWriteAdapter
         {
             try
             {
-                await ForceAuthenticationAsync(adapter, receiveFirst: false, buffer).ConfigureAwait(false);
+                await ForceAuthenticationAsync<TIOAdapter>(receiveFirst: false, buffer, isApm: false, cancellationToken).ConfigureAwait(false);
             }
             finally
             {
@@ -221,7 +221,7 @@ namespace System.Net.Security
         }
 
         // This will initiate renegotiation or PHA for Tls1.3
-        private async Task RenegotiateAsync<TIOAdapter>(TIOAdapter adapter)
+        private async Task RenegotiateAsync<TIOAdapter>(CancellationToken cancellationToken)
             where TIOAdapter : IReadWriteAdapter
         {
             if (Interlocked.Exchange(ref _nestedAuth, 1) == 1)
@@ -253,10 +253,10 @@ namespace System.Net.Security
 
                 SecurityStatusPal status = _context!.Renegotiate(out byte[]? nextmsg);
 
-                if (nextmsg is {} && nextmsg.Length > 0)
+                if (nextmsg is { Length: > 0 })
                 {
-                    await adapter.WriteAsync(nextmsg, 0, nextmsg.Length).ConfigureAwait(false);
-                    await adapter.FlushAsync().ConfigureAwait(false);
+                    await TIOAdapter.WriteAsync(InnerStream, nextmsg, 0, nextmsg.Length, cancellationToken).ConfigureAwait(false);
+                    await TIOAdapter.FlushAsync(InnerStream, cancellationToken).ConfigureAwait(false);
                 }
 
                 if (status.ErrorCode != SecurityStatusPalErrorCode.OK)
@@ -274,11 +274,11 @@ namespace System.Net.Security
 
                 ProtocolToken message = null!;
                 do {
-                    message = await ReceiveBlobAsync(adapter).ConfigureAwait(false);
+                    message = await ReceiveBlobAsync<TIOAdapter>(cancellationToken).ConfigureAwait(false);
                     if (message.Size > 0)
                     {
-                        await adapter.WriteAsync(message.Payload!, 0, message.Size).ConfigureAwait(false);
-                        await adapter.FlushAsync().ConfigureAwait(false);
+                        await TIOAdapter.WriteAsync(InnerStream, message.Payload!, 0, message.Size, cancellationToken).ConfigureAwait(false);
+                        await TIOAdapter.FlushAsync(InnerStream, cancellationToken).ConfigureAwait(false);
                     }
                 } while (message.Status.ErrorCode == SecurityStatusPalErrorCode.ContinueNeeded);
 
@@ -299,8 +299,8 @@ namespace System.Net.Security
         }
 
         // reAuthenticationData is only used on Windows in case of renegotiation.
-        private async Task ForceAuthenticationAsync<TIOAdapter>(TIOAdapter adapter, bool receiveFirst, byte[]? reAuthenticationData, bool isApm = false)
-             where TIOAdapter : IReadWriteAdapter
+        private async Task ForceAuthenticationAsync<TIOAdapter>(bool receiveFirst, byte[]? reAuthenticationData, bool isApm, CancellationToken cancellationToken)
+            where TIOAdapter : IReadWriteAdapter
         {
             ProtocolToken message;
             bool handshakeCompleted = false;
@@ -316,14 +316,13 @@ namespace System.Net.Security
 
             try
             {
-
                 if (!receiveFirst)
                 {
                     message = _context!.NextMessage(reAuthenticationData);
                     if (message.Size > 0)
                     {
-                        await adapter.WriteAsync(message.Payload!, 0, message.Size).ConfigureAwait(false);
-                        await adapter.FlushAsync().ConfigureAwait(false);
+                        await TIOAdapter.WriteAsync(InnerStream, message.Payload!, 0, message.Size, cancellationToken).ConfigureAwait(false);
+                        await TIOAdapter.FlushAsync(InnerStream, cancellationToken).ConfigureAwait(false);
                         if (NetEventSource.Log.IsEnabled())
                             NetEventSource.Log.SentFrame(this, message.Payload);
                     }
@@ -347,7 +346,7 @@ namespace System.Net.Security
 
                 while (!handshakeCompleted)
                 {
-                    message = await ReceiveBlobAsync(adapter).ConfigureAwait(false);
+                    message = await ReceiveBlobAsync<TIOAdapter>(cancellationToken).ConfigureAwait(false);
 
                     byte[]? payload = null;
                     int size = 0;
@@ -366,8 +365,8 @@ namespace System.Net.Security
                     if (payload != null && size > 0)
                     {
                         // If there is message send it out even if call failed. It may contain TLS Alert.
-                        await adapter.WriteAsync(payload!, 0, size).ConfigureAwait(false);
-                        await adapter.FlushAsync().ConfigureAwait(false);
+                        await TIOAdapter.WriteAsync(InnerStream, payload!, 0, size, cancellationToken).ConfigureAwait(false);
+                        await TIOAdapter.FlushAsync(InnerStream, cancellationToken).ConfigureAwait(false);
 
                         if (NetEventSource.Log.IsEnabled())
                             NetEventSource.Log.SentFrame(this, payload);
@@ -416,10 +415,10 @@ namespace System.Net.Security
 
         }
 
-        private async ValueTask<ProtocolToken> ReceiveBlobAsync<TIOAdapter>(TIOAdapter adapter)
-                 where TIOAdapter : IReadWriteAdapter
+        private async ValueTask<ProtocolToken> ReceiveBlobAsync<TIOAdapter>(CancellationToken cancellationToken)
+            where TIOAdapter : IReadWriteAdapter
         {
-            int frameSize = await EnsureFullTlsFrameAsync(adapter).ConfigureAwait(false);
+            int frameSize = await EnsureFullTlsFrameAsync<TIOAdapter>(cancellationToken).ConfigureAwait(false);
 
             if (frameSize == 0)
             {
@@ -462,7 +461,7 @@ namespace System.Net.Security
                             {
                                 SslServerAuthenticationOptions userOptions =
                                     await _sslAuthenticationOptions.ServerOptionDelegate(this, new SslClientHelloInfo(_sslAuthenticationOptions.TargetHost, _lastFrame.SupportedVersions),
-                                                                                        _sslAuthenticationOptions.UserState, adapter.CancellationToken).ConfigureAwait(false);
+                                        _sslAuthenticationOptions.UserState, cancellationToken).ConfigureAwait(false);
                                 _sslAuthenticationOptions.UpdateOptions(userOptions);
                             }
                         }
@@ -598,19 +597,19 @@ namespace System.Net.Security
             }
         }
 
-        private async ValueTask WriteAsyncChunked<TIOAdapter>(TIOAdapter writeAdapter, ReadOnlyMemory<byte> buffer)
-            where TIOAdapter : struct, IReadWriteAdapter
+        private async ValueTask WriteAsyncChunked<TIOAdapter>(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+            where TIOAdapter : IReadWriteAdapter
         {
             do
             {
                 int chunkBytes = Math.Min(buffer.Length, MaxDataSize);
-                await WriteSingleChunk(writeAdapter, buffer.Slice(0, chunkBytes)).ConfigureAwait(false);
+                await WriteSingleChunk<TIOAdapter>(buffer.Slice(0, chunkBytes), cancellationToken).ConfigureAwait(false);
                 buffer = buffer.Slice(chunkBytes);
             } while (buffer.Length != 0);
         }
 
-        private ValueTask WriteSingleChunk<TIOAdapter>(TIOAdapter writeAdapter, ReadOnlyMemory<byte> buffer)
-            where TIOAdapter : struct, IReadWriteAdapter
+        private ValueTask WriteSingleChunk<TIOAdapter>(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+            where TIOAdapter : IReadWriteAdapter
         {
             byte[] rentedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length + FrameOverhead);
             byte[] outBuffer = rentedBuffer;
@@ -630,7 +629,7 @@ namespace System.Net.Security
                 TaskCompletionSource<bool>? waiter = _handshakeWaiter;
                 if (waiter != null)
                 {
-                    Task waiterTask = writeAdapter.WaitAsync(waiter);
+                    Task waiterTask = TIOAdapter.WaitAsync(waiter);
                     // We finished synchronously waiting for renegotiation. We can try again immediately.
                     if (waiterTask.IsCompletedSuccessfully)
                     {
@@ -638,7 +637,7 @@ namespace System.Net.Security
                     }
 
                     // We need to wait asynchronously as well as for the write when EncryptData is finished.
-                    return WaitAndWriteAsync(writeAdapter, buffer, waiterTask, rentedBuffer);
+                    return WaitAndWriteAsync(buffer, waiterTask, rentedBuffer, cancellationToken);
                 }
             }
 
@@ -648,7 +647,7 @@ namespace System.Net.Security
                 return ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new IOException(SR.net_io_encrypt, SslStreamPal.GetException(status))));
             }
 
-            ValueTask t = writeAdapter.WriteAsync(outBuffer, 0, encryptedBytes);
+            ValueTask t = TIOAdapter.WriteAsync(InnerStream, outBuffer, 0, encryptedBytes, cancellationToken);
             if (t.IsCompletedSuccessfully)
             {
                 ArrayPool<byte>.Shared.Return(rentedBuffer);
@@ -659,7 +658,7 @@ namespace System.Net.Security
                 return CompleteWriteAsync(t, rentedBuffer);
             }
 
-            async ValueTask WaitAndWriteAsync(TIOAdapter writeAdapter, ReadOnlyMemory<byte> buffer, Task waitTask, byte[] rentedBuffer)
+            async ValueTask WaitAndWriteAsync(ReadOnlyMemory<byte> buffer, Task waitTask, byte[] rentedBuffer, CancellationToken cancellationToken)
             {
                 byte[]? bufferToReturn = rentedBuffer;
                 byte[] outBuffer = rentedBuffer;
@@ -678,11 +677,11 @@ namespace System.Net.Security
 
                         // Call WriteSingleChunk() recursively to avoid code duplication.
                         // This should be extremely rare in cases when second renegotiation happens concurrently with Write.
-                        await WriteSingleChunk(writeAdapter, buffer).ConfigureAwait(false);
+                        await WriteSingleChunk<TIOAdapter>(buffer, cancellationToken).ConfigureAwait(false);
                     }
                     else if (status.ErrorCode == SecurityStatusPalErrorCode.OK)
                     {
-                        await writeAdapter.WriteAsync(outBuffer, 0, encryptedBytes).ConfigureAwait(false);
+                        await TIOAdapter.WriteAsync(InnerStream, outBuffer, 0, encryptedBytes, cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
@@ -698,7 +697,7 @@ namespace System.Net.Security
                 }
             }
 
-            async ValueTask CompleteWriteAsync(ValueTask writeTask, byte[] bufferToReturn)
+            static async ValueTask CompleteWriteAsync(ValueTask writeTask, byte[] bufferToReturn)
             {
                 try
                 {
@@ -737,7 +736,7 @@ namespace System.Net.Security
         }
 
 
-        private async ValueTask<int> EnsureFullTlsFrameAsync<TIOAdapter>(TIOAdapter adapter)
+        private async ValueTask<int> EnsureFullTlsFrameAsync<TIOAdapter>(CancellationToken cancellationToken)
             where TIOAdapter : IReadWriteAdapter
         {
             int frameSize;
@@ -752,7 +751,7 @@ namespace System.Net.Security
                 Debug.Assert(_buffer.AvailableLength > 0, "_buffer.AvailableBytes > 0");
 
                 // We either don't have full frame or we don't have enough data to even determine the size.
-                int bytesRead = await adapter.ReadAsync(_buffer.AvailableMemory).ConfigureAwait(false);
+                int bytesRead = await TIOAdapter.ReadAsync(InnerStream, _buffer.AvailableMemory, cancellationToken).ConfigureAwait(false);
                 if (bytesRead == 0)
                 {
                     if (_buffer.EncryptedLength != 0)
@@ -816,7 +815,7 @@ namespace System.Net.Security
             return status;
         }
 
-        private async ValueTask<int> ReadAsyncInternal<TIOAdapter>(TIOAdapter adapter, Memory<byte> buffer)
+        private async ValueTask<int> ReadAsyncInternal<TIOAdapter>(Memory<byte> buffer, CancellationToken cancellationToken)
             where TIOAdapter : IReadWriteAdapter
         {
             if (Interlocked.Exchange(ref _nestedRead, 1) == 1)
@@ -859,7 +858,7 @@ namespace System.Net.Security
                     // until data is actually available from the underlying stream.
                     // Note that if the underlying stream does not supporting blocking on zero byte reads, then this will
                     // complete immediately and won't save any memory, but will still function correctly.
-                    await adapter.ReadAsync(Memory<byte>.Empty).ConfigureAwait(false);
+                    await TIOAdapter.ReadAsync(InnerStream, Memory<byte>.Empty, cancellationToken).ConfigureAwait(false);
                 }
 
                 Debug.Assert(_buffer.DecryptedLength == 0);
@@ -868,7 +867,7 @@ namespace System.Net.Security
 
                 while (true)
                 {
-                    payloadBytes = await EnsureFullTlsFrameAsync(adapter).ConfigureAwait(false);
+                    payloadBytes = await EnsureFullTlsFrameAsync<TIOAdapter>(cancellationToken).ConfigureAwait(false);
                     if (payloadBytes == 0)
                     {
                         _receivedEOF = true;
@@ -897,7 +896,7 @@ namespace System.Net.Security
                             {
                                 throw new IOException(SR.net_ssl_io_renego);
                             }
-                            await ReplyOnReAuthenticationAsync(adapter, extraBuffer).ConfigureAwait(false);
+                            await ReplyOnReAuthenticationAsync<TIOAdapter>(extraBuffer, cancellationToken).ConfigureAwait(false);
                             // Loop on read.
                             continue;
                         }
@@ -951,7 +950,7 @@ namespace System.Net.Security
             }
             catch (Exception e)
             {
-                if (e is IOException || (e is OperationCanceledException && adapter.CancellationToken.IsCancellationRequested))
+                if (e is IOException || (e is OperationCanceledException && cancellationToken.IsCancellationRequested))
                 {
                     throw;
                 }
@@ -965,8 +964,8 @@ namespace System.Net.Security
             }
         }
 
-        private async ValueTask WriteAsyncInternal<TIOAdapter>(TIOAdapter writeAdapter, ReadOnlyMemory<byte> buffer)
-            where TIOAdapter : struct, IReadWriteAdapter
+        private async ValueTask WriteAsyncInternal<TIOAdapter>(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+            where TIOAdapter : IReadWriteAdapter
         {
             ThrowIfExceptionalOrNotAuthenticatedOrShutdown();
 
@@ -984,13 +983,13 @@ namespace System.Net.Security
             try
             {
                 ValueTask t = buffer.Length < MaxDataSize ?
-                    WriteSingleChunk(writeAdapter, buffer) :
-                    WriteAsyncChunked(writeAdapter, buffer);
+                    WriteSingleChunk<TIOAdapter>(buffer, cancellationToken) :
+                    WriteAsyncChunked<TIOAdapter>(buffer, cancellationToken);
                 await t.ConfigureAwait(false);
             }
             catch (Exception e)
             {
-                if (e is IOException || (e is OperationCanceledException && writeAdapter.CancellationToken.IsCancellationRequested))
+                if (e is IOException || (e is OperationCanceledException && cancellationToken.IsCancellationRequested))
                 {
                     throw;
                 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -472,7 +472,7 @@ namespace System.Net.Security
 
             ValidateCreateContext(sslClientAuthenticationOptions, _userCertificateValidationCallback, _certSelectionDelegate);
 
-            return ProcessAuthenticationAsync(isAsync: true, isApm: false, cancellationToken);
+            return ProcessAuthenticationAsync(isAsync: true, cancellationToken);
         }
 
         private Task AuthenticateAsClientApm(SslClientAuthenticationOptions sslClientAuthenticationOptions, CancellationToken cancellationToken = default)
@@ -482,7 +482,7 @@ namespace System.Net.Security
 
             ValidateCreateContext(sslClientAuthenticationOptions, _userCertificateValidationCallback, _certSelectionDelegate);
 
-            return ProcessAuthenticationAsync(isAsync: true, isApm: true, cancellationToken);
+            return ProcessAuthenticationAsync(isAsync: true, cancellationToken);
         }
 
         public virtual Task AuthenticateAsServerAsync(X509Certificate serverCertificate) =>
@@ -520,7 +520,7 @@ namespace System.Net.Security
             SetAndVerifyValidationCallback(sslServerAuthenticationOptions.RemoteCertificateValidationCallback);
             ValidateCreateContext(CreateAuthenticationOptions(sslServerAuthenticationOptions));
 
-            return ProcessAuthenticationAsync(isAsync: true, isApm: false, cancellationToken);
+            return ProcessAuthenticationAsync(isAsync: true, cancellationToken);
         }
 
         private Task AuthenticateAsServerApm(SslServerAuthenticationOptions sslServerAuthenticationOptions, CancellationToken cancellationToken = default)
@@ -528,13 +528,13 @@ namespace System.Net.Security
             SetAndVerifyValidationCallback(sslServerAuthenticationOptions.RemoteCertificateValidationCallback);
             ValidateCreateContext(CreateAuthenticationOptions(sslServerAuthenticationOptions));
 
-            return ProcessAuthenticationAsync(isAsync: true, isApm: true, cancellationToken);
+            return ProcessAuthenticationAsync(isAsync: true, cancellationToken);
         }
 
         public Task AuthenticateAsServerAsync(ServerOptionsSelectionCallback optionsCallback, object? state, CancellationToken cancellationToken = default)
         {
             ValidateCreateContext(new SslAuthenticationOptions(optionsCallback, state, _userCertificateValidationCallback));
-            return ProcessAuthenticationAsync(isAsync: true, isApm: false, cancellationToken);
+            return ProcessAuthenticationAsync(isAsync: true, cancellationToken);
         }
 
         public virtual Task ShutdownAsync()
@@ -831,7 +831,7 @@ namespace System.Net.Security
             ThrowIfExceptionalOrNotAuthenticated();
             if (Interlocked.Exchange(ref _nestedRead, 1) == 1)
             {
-                throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, "ReadByte", "read"));
+                throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, "read"));
             }
 
             // If there's any data in the buffer, take one byte, and we're done.

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -50,7 +50,6 @@ namespace System.Net.Security
         internal LocalCertSelectionCallback? _certSelectionDelegate;
         internal EncryptionPolicy _encryptionPolicy;
 
-        private readonly Stream _innerStream;
         private SecureChannel? _context;
 
         private ExceptionDispatchInfo? _exception;
@@ -221,8 +220,6 @@ namespace System.Net.Security
             _userCertificateSelectionCallback = userCertificateSelectionCallback;
             _encryptionPolicy = encryptionPolicy;
             _certSelectionDelegate = userCertificateSelectionCallback == null ? null : new LocalCertSelectionCallback(UserCertSelectionCallbackWrapper);
-
-            _innerStream = innerStream;
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Log.SslStreamCtor(this, innerStream);
         }
@@ -802,7 +799,7 @@ namespace System.Net.Security
                 throw new InvalidOperationException(SR.net_ssl_certificate_exist);
             }
 
-            return RenegotiateAsync(new AsyncReadWriteAdapter(InnerStream, cancellationToken));
+            return RenegotiateAsync<AsyncReadWriteAdapter>(cancellationToken);
         }
 
         protected override void Dispose(bool disposing)
@@ -869,7 +866,7 @@ namespace System.Net.Security
         {
             ThrowIfExceptionalOrNotAuthenticated();
             ValidateBufferArguments(buffer, offset, count);
-            ValueTask<int> vt = ReadAsyncInternal(new SyncReadWriteAdapter(InnerStream), new Memory<byte>(buffer, offset, count));
+            ValueTask<int> vt = ReadAsyncInternal<SyncReadWriteAdapter>(new Memory<byte>(buffer, offset, count), default(CancellationToken));
             Debug.Assert(vt.IsCompleted, "Sync operation must have completed synchronously");
             return vt.GetAwaiter().GetResult();
         }
@@ -881,7 +878,7 @@ namespace System.Net.Security
             ThrowIfExceptionalOrNotAuthenticated();
             ValidateBufferArguments(buffer, offset, count);
 
-            ValueTask vt = WriteAsyncInternal(new SyncReadWriteAdapter(InnerStream), new ReadOnlyMemory<byte>(buffer, offset, count));
+            ValueTask vt = WriteAsyncInternal<SyncReadWriteAdapter>(new ReadOnlyMemory<byte>(buffer, offset, count), default(CancellationToken));
             Debug.Assert(vt.IsCompleted, "Sync operation must have completed synchronously");
             vt.GetAwaiter().GetResult();
         }
@@ -914,26 +911,26 @@ namespace System.Net.Security
         {
             ThrowIfExceptionalOrNotAuthenticated();
             ValidateBufferArguments(buffer, offset, count);
-            return WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            return WriteAsyncInternal<AsyncReadWriteAdapter>(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
         }
 
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
             ThrowIfExceptionalOrNotAuthenticated();
-            return WriteAsyncInternal(new AsyncReadWriteAdapter(InnerStream, cancellationToken), buffer);
+            return WriteAsyncInternal<AsyncReadWriteAdapter>(buffer, cancellationToken);
         }
 
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ThrowIfExceptionalOrNotAuthenticated();
             ValidateBufferArguments(buffer, offset, count);
-            return ReadAsyncInternal(new AsyncReadWriteAdapter(InnerStream, cancellationToken), new Memory<byte>(buffer, offset, count)).AsTask();
+            return ReadAsyncInternal<AsyncReadWriteAdapter>(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
         }
 
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             ThrowIfExceptionalOrNotAuthenticated();
-            return ReadAsyncInternal(new AsyncReadWriteAdapter(InnerStream, cancellationToken), buffer);
+            return ReadAsyncInternal<AsyncReadWriteAdapter>(buffer, cancellationToken);
         }
 
         private void ThrowIfExceptional()

--- a/src/libraries/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
@@ -37,10 +37,11 @@ namespace System.Net.Security
             _sslAuthenticationOptions = new FakeOptions() { TargetHost = sslAuthenticationOptions.TargetHost };
         }
 
-        private ValueTask WriteAsyncInternal<TWriteAdapter>(TWriteAdapter writeAdapter, ReadOnlyMemory<byte> buffer)
-            where TWriteAdapter : struct, IReadWriteAdapter => default;
+        private ValueTask WriteAsyncInternal<TWriteAdapter>(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+            where TWriteAdapter : IReadWriteAdapter => default;
 
-        private ValueTask<int> ReadAsyncInternal<TReadAdapter>(TReadAdapter adapter, Memory<byte> buffer) => default;
+        private ValueTask<int> ReadAsyncInternal<TReadAdapter>(Memory<byte> buffer, CancellationToken cancellationToken)
+            where TReadAdapter : IReadWriteAdapter => default;
 
         private bool RemoteCertRequired => default;
 
@@ -51,12 +52,12 @@ namespace System.Net.Security
         // This method assumes that a SSPI context is already in a good shape.
         // For example it is either a fresh context or already authenticated context that needs renegotiation.
         //
-        private Task ProcessAuthenticationAsync(bool isAsync = false, bool isApm = false, CancellationToken cancellationToken = default)
+        private Task ProcessAuthenticationAsync(bool isAsync = false, CancellationToken cancellationToken = default)
         {
             return Task.Run(() => { });
         }
 
-        private Task RenegotiateAsync(AsyncReadWriteAdapter adapter) => throw new PlatformNotSupportedException();
+        private Task RenegotiateAsync<AsyncReadWriteAdapter>(CancellationToken cancellationToken) => throw new PlatformNotSupportedException();
 
         private void ReturnReadBufferIfEmpty()
         {


### PR DESCRIPTION
Passing around the adapter instance was working around the lack of static abstract interface methods.  Now that we have the latter, we can get rid of the former, and pass around just the data that's needed.  This will make some of the state machines smaller, as we're now just accessing InnerStream rather than passing the stream around as part of the adapter. I also removed the isApm argument that was adding complication and expense purely to add a method name into an exception message thrown when the type is misused, but a) that information is already available in the resulting exception's stack trace, and b) it adds expense by increasing the size of the async method state machines.

cc: @wfurt, @tannergooding 