### PR TITLE
Respect single target framework values in slngen.targets

### DIFF
--- a/eng/slngen.targets
+++ b/eng/slngen.targets
@@ -8,7 +8,7 @@
     <!-- Don't include reference projects which compose the microsoft.netcore.app targeting pack (except the current leaf's reference project) as those are referenced by the source project via named references
          and hence don't need to be part of the solution file (only P2Ps need to).
          Include the reference project in the solution file if it targets more than just NetCoreAppCurrent as other frameworks like .NETFramework, .NETStandard or older .NETCoreApp ones require it. -->
-    <IncludeInSolutionFile Condition="'$(IsNETCoreAppRef)' == 'true' and '$(MSBuildProjectName)' != '$(SlnGenMainProject)' and '$(TargetFrameworks)' == '$(NetCoreAppCurrent)'">false</IncludeInSolutionFile>
+    <IncludeInSolutionFile Condition="'$(IsNETCoreAppRef)' == 'true' and '$(MSBuildProjectName)' != '$(SlnGenMainProject)' and '$(TargetFramework)' == '$(NetCoreAppCurrent)' and ('$(TargetFrameworks)' == '' or '$(TargetFrameworks)' == '$(NetCoreAppCurrent)')">false</IncludeInSolutionFile>
   </PropertyGroup>
   <ItemGroup>
     <SlnGenCustomProjectTypeGuid Include=".ilproj" ProjectTypeGuid="{9A19103F-16F7-4668-BE54-9A1E7A4F7556}" />


### PR DESCRIPTION
Now that projects have have single target framework values via the `<TargetFramework>` property, the slngen logic that excludes a reference project from a solution, if it isn't necessary to be included, must be updated.