### PR TITLE
Use SSA def descriptors in copy propagation

### DIFF
--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -294,6 +294,7 @@ void Compiler::optCopyPropPushDef(GenTreeOp*           asg,
     if ((gsShadowVarInfo != nullptr) && lvaGetDesc(lclNum)->lvIsParam &&
         (gsShadowVarInfo[lclNum].shadowCopy != BAD_VAR_NUM))
     {
+        assert(!curSsaName->Lookup(lclNum));
         return;
     }
 
@@ -308,9 +309,11 @@ void Compiler::optCopyPropPushDef(GenTreeOp*           asg,
     else
     {
         assert((lclNode->gtFlags & GTF_VAR_DEF) != 0);
+        ssaDefNum = GetSsaNumForLocalVarDef(lclNode);
+
         // This will be "RESERVED_SSA_NUM" for promoted struct fields assigned using the parent struct.
         // TODO-CQ: fix this.
-        ssaDefNum = GetSsaNumForLocalVarDef(lclNode);
+        assert((ssaDefNum != SsaConfig::RESERVED_SSA_NUM) || lvaGetDesc(lclNode)->CanBeReplacedWithItsField(this));
     }
 
     // The default is "not available".

--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -26,7 +26,7 @@
  * of the graph originating from the block. Refer SSA renaming for any additional info.
  * "curSsaName" tracks the currently live definitions.
  */
-void Compiler::optBlockCopyPropPopStacks(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName)
+void Compiler::optBlockCopyPropPopStacks(BasicBlock* block, LclNumToLiveDefsMap* curSsaName)
 {
     for (Statement* const stmt : block->Statements())
     {
@@ -42,7 +42,7 @@ void Compiler::optBlockCopyPropPopStacks(BasicBlock* block, LclNumToGenTreePtrSt
                     continue;
                 }
 
-                GenTreePtrStack* stack = nullptr;
+                CopyPropSsaDefStack* stack = nullptr;
                 curSsaName->Lookup(lclNum, &stack);
                 stack->Pop();
                 if (stack->Empty())
@@ -55,12 +55,12 @@ void Compiler::optBlockCopyPropPopStacks(BasicBlock* block, LclNumToGenTreePtrSt
 }
 
 #ifdef DEBUG
-void Compiler::optDumpCopyPropStack(LclNumToGenTreePtrStack* curSsaName)
+void Compiler::optDumpCopyPropStack(LclNumToLiveDefsMap* curSsaName)
 {
     JITDUMP("{ ");
-    for (LclNumToGenTreePtrStack::KeyIterator iter = curSsaName->Begin(); !iter.Equal(curSsaName->End()); ++iter)
+    for (LclNumToLiveDefsMap::KeyIterator iter = curSsaName->Begin(); !iter.Equal(curSsaName->End()); ++iter)
     {
-        GenTreeLclVarCommon* lclVar    = iter.GetValue()->Top()->AsLclVarCommon();
+        GenTreeLclVarCommon* lclVar    = iter.GetValue()->Top().GetDefNode()->AsLclVarCommon();
         unsigned             ssaLclNum = optIsSsaLocal(lclVar);
         assert(ssaLclNum != BAD_VAR_NUM);
 
@@ -82,7 +82,7 @@ void Compiler::optDumpCopyPropStack(LclNumToGenTreePtrStack* curSsaName)
  * Given the "lclVar" and "copyVar" compute if the copy prop will be beneficial.
  *
  */
-int Compiler::optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc, bool preferOp2)
+int Compiler::optCopyProp_LclVarScore(const LclVarDsc* lclVarDsc, const LclVarDsc* copyVarDsc, bool preferOp2)
 {
     int score = 0;
 
@@ -126,16 +126,17 @@ int Compiler::optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDs
 //    tree        -  The local tree to perform copy propagation on
 //    lclNum      -  The local number of said tree
 //    curSsaName  -  The map from lclNum to its recently live definitions as a stack
-
-void Compiler::optCopyProp(Statement*               stmt,
-                           GenTreeLclVarCommon*     tree,
-                           unsigned                 lclNum,
-                           LclNumToGenTreePtrStack* curSsaName)
+//
+void Compiler::optCopyProp(Statement* stmt, GenTreeLclVarCommon* tree, unsigned lclNum, LclNumToLiveDefsMap* curSsaName)
 {
     assert((lclNum != BAD_VAR_NUM) && (optIsSsaLocal(tree) == lclNum) && ((tree->gtFlags & GTF_VAR_DEF) == 0));
-    assert(tree->gtVNPair.GetConservative() != ValueNumStore::NoVN);
+    assert(tree->gtVNPair.BothDefined());
 
-    for (LclNumToGenTreePtrStack::KeyIterator iter = curSsaName->Begin(); !iter.Equal(curSsaName->End()); ++iter)
+    LclVarDsc* varDsc   = lvaGetDesc(lclNum);
+    ValueNum   lclDefVN = varDsc->GetPerSsaData(tree->GetSsaNum())->m_vnPair.GetConservative();
+    assert(lclDefVN != ValueNumStore::NoVN);
+
+    for (LclNumToLiveDefsMap::KeyIterator iter = curSsaName->Begin(); !iter.Equal(curSsaName->End()); ++iter)
     {
         unsigned newLclNum = iter.Get();
 
@@ -145,35 +146,30 @@ void Compiler::optCopyProp(Statement*               stmt,
             continue;
         }
 
-        LclVarDsc* varDsc        = lvaGetDesc(lclNum);
-        LclVarDsc* newLclVarDsc  = lvaGetDesc(newLclNum);
-        GenTree*   newLclDefNode = iter.GetValue()->Top(); // Note that this "def" node can actually be a use (for
-                                                           // parameters and other use-before-def locals).
+        CopyPropSsaDef newLclDef    = iter.GetValue()->Top();
+        LclSsaVarDsc*  newLclSsaDef = newLclDef.GetSsaDef();
+
+        // Likewise, nothing to do if the most recent def is not available.
+        if (newLclSsaDef == nullptr)
+        {
+            continue;
+        }
+
+        ValueNum newLclDefVN = newLclSsaDef->m_vnPair.GetConservative();
+        assert(newLclDefVN != ValueNumStore::NoVN);
+
+        if (newLclDefVN != lclDefVN)
+        {
+            continue;
+        }
 
         // Do not copy propagate if the old and new lclVar have different 'doNotEnregister' settings.
         // This is primarily to avoid copy propagating to IND(ADDR(LCL_VAR)) where the replacement lclVar
         // is not marked 'lvDoNotEnregister'.
         // However, in addition, it may not be profitable to propagate a 'doNotEnregister' lclVar to an
         // existing use of an enregisterable lclVar.
+        LclVarDsc* newLclVarDsc = lvaGetDesc(newLclNum);
         if (varDsc->lvDoNotEnregister != newLclVarDsc->lvDoNotEnregister)
-        {
-            continue;
-        }
-
-        if ((gsShadowVarInfo != nullptr) && newLclVarDsc->lvIsParam &&
-            (gsShadowVarInfo[newLclNum].shadowCopy != BAD_VAR_NUM))
-        {
-            continue;
-        }
-
-        ValueNum newLclDefVN = GetUseAsgDefVNOrTreeVN(newLclDefNode);
-        if (newLclDefVN == ValueNumStore::NoVN)
-        {
-            continue;
-        }
-
-        ValueNum lclDefVN = varDsc->GetPerSsaData(tree->GetSsaNum())->m_vnPair.GetConservative();
-        if (newLclDefVN != lclDefVN)
         {
             continue;
         }
@@ -182,6 +178,7 @@ void Compiler::optCopyProp(Statement*               stmt,
         {
             continue;
         }
+
         // Check whether the newLclNum is live before being substituted. Otherwise, we could end
         // up in a situation where there must've been a phi node that got pruned because the variable
         // is not live anymore. For example,
@@ -197,26 +194,11 @@ void Compiler::optCopyProp(Statement*               stmt,
         // 'c' with 'x.'
 
         // We compute liveness only on tracked variables. And all SSA locals are tracked.
-        assert(lvaGetDesc(newLclNum)->lvTracked);
+        assert(newLclVarDsc->lvTracked);
 
         // Because of this dependence on live variable analysis, CopyProp phase is immediately
         // after Liveness, SSA and VN.
         if ((newLclNum != info.compThisArg) && !VarSetOps::IsMember(this, compCurLife, newLclVarDsc->lvVarIndex))
-        {
-            continue;
-        }
-
-        unsigned newSsaNum = SsaConfig::RESERVED_SSA_NUM;
-        if (newLclDefNode->gtFlags & GTF_VAR_DEF)
-        {
-            newSsaNum = GetSsaNumForLocalVarDef(newLclDefNode);
-        }
-        else // parameters, this pointer etc.
-        {
-            newSsaNum = newLclDefNode->AsLclVarCommon()->GetSsaNum();
-        }
-
-        if (newSsaNum == SsaConfig::RESERVED_SSA_NUM)
         {
             continue;
         }
@@ -238,11 +220,14 @@ void Compiler::optCopyProp(Statement*               stmt,
             JITDUMP("VN based copy assertion for ");
             printTreeID(tree);
             printf(" V%02d " FMT_VN " by ", lclNum, lclDefVN);
-            printTreeID(newLclDefNode);
+            printTreeID(newLclDef.GetDefNode());
             printf(" V%02d " FMT_VN ".\n", newLclNum, newLclDefVN);
             DISPNODE(tree);
         }
 #endif
+
+        unsigned newSsaNum = newLclVarDsc->GetSsaNumForSsaDef(newLclSsaDef);
+        assert(newSsaNum != SsaConfig::RESERVED_SSA_NUM);
 
         tree->AsLclVarCommon()->SetLclNum(newLclNum);
         tree->AsLclVarCommon()->SetSsaNum(newSsaNum);
@@ -289,6 +274,71 @@ unsigned Compiler::optIsSsaLocal(GenTreeLclVarCommon* lclNode)
 }
 
 //------------------------------------------------------------------------------
+// optCopyPropPushDef: Push the new live SSA def on the stack for "lclNode".
+//
+// Arguments:
+//    asg        - The assignment node for this def (will be "nullptr" for "use" defs)
+//    lclNode    - The local tree representing "the def" (that can actually be a use)
+//    lclNum     - The local's number (see "optIsSsaLocal")
+//    curSsaName - The map of local numbers to stacks of their defs
+//
+void Compiler::optCopyPropPushDef(GenTreeOp*           asg,
+                                  GenTreeLclVarCommon* lclNode,
+                                  unsigned             lclNum,
+                                  LclNumToLiveDefsMap* curSsaName)
+{
+    assert((lclNum != BAD_VAR_NUM) && (lclNum == optIsSsaLocal(lclNode)));
+
+    // Shadowed parameters are special: they will (at most) have one use, that is one on the RHS of an
+    // assignment to their shadow, and we must not substitute them anywhere. So we'll not push any defs.
+    if ((gsShadowVarInfo != nullptr) && lvaGetDesc(lclNum)->lvIsParam &&
+        (gsShadowVarInfo[lclNum].shadowCopy != BAD_VAR_NUM))
+    {
+        return;
+    }
+
+    unsigned ssaDefNum = SsaConfig::RESERVED_SSA_NUM;
+    if (asg == nullptr)
+    {
+        // Parameters, this pointer etc.
+        assert((lclNode->gtFlags & GTF_VAR_DEF) == 0);
+        assert(lclNode->GetSsaNum() == SsaConfig::FIRST_SSA_NUM);
+        ssaDefNum = lclNode->GetSsaNum();
+    }
+    else
+    {
+        assert((lclNode->gtFlags & GTF_VAR_DEF) != 0);
+        // This will be "RESERVED_SSA_NUM" for promoted struct fields assigned using the parent struct.
+        // TODO-CQ: fix this.
+        ssaDefNum = GetSsaNumForLocalVarDef(lclNode);
+    }
+
+    // The default is "not available".
+    LclSsaVarDsc* ssaDef = nullptr;
+    if (ssaDefNum != SsaConfig::RESERVED_SSA_NUM)
+    {
+        // This code preserves previous behavior. In principle, "ssaDefVN" should
+        // always be obtained directly from the SSA def descriptor and be valid.
+        ValueNum ssaDefVN = GetUseAsgDefVNOrTreeVN(lclNode);
+        assert(ssaDefVN != ValueNumStore::NoVN);
+
+        if (ssaDefVN != ValueNumStore::VNForVoid())
+        {
+            ssaDef = lvaGetDesc(lclNum)->GetPerSsaData(ssaDefNum);
+        }
+    }
+
+    CopyPropSsaDefStack* defStack;
+    if (!curSsaName->Lookup(lclNum, &defStack))
+    {
+        defStack = new (curSsaName->GetAllocator()) CopyPropSsaDefStack(curSsaName->GetAllocator());
+        curSsaName->Set(lclNum, defStack);
+    }
+
+    defStack->Push(CopyPropSsaDef(ssaDef, lclNode));
+}
+
+//------------------------------------------------------------------------------
 // optBlockCopyProp : Perform copy propagation using currently live definitions on the current block's
 //                    variables. Also as new definitions are encountered update the "curSsaName" which
 //                    tracks the currently live definitions.
@@ -296,8 +346,8 @@ unsigned Compiler::optIsSsaLocal(GenTreeLclVarCommon* lclNode)
 // Arguments:
 //    block       -  Block the tree belongs to
 //    curSsaName  -  The map from lclNum to its recently live definitions as a stack
-
-void Compiler::optBlockCopyProp(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName)
+//
+void Compiler::optBlockCopyProp(BasicBlock* block, LclNumToLiveDefsMap* curSsaName)
 {
 #ifdef DEBUG
     JITDUMP("Copy Assertion for " FMT_BB "\n", block->bbNum);
@@ -333,13 +383,7 @@ void Compiler::optBlockCopyProp(BasicBlock* block, LclNumToGenTreePtrStack* curS
                     continue;
                 }
 
-                GenTreePtrStack* stack;
-                if (!curSsaName->Lookup(lclNum, &stack))
-                {
-                    stack = new (curSsaName->GetAllocator()) GenTreePtrStack(curSsaName->GetAllocator());
-                }
-                stack->Push(lclDefNode);
-                curSsaName->Set(lclNum, stack, LclNumToGenTreePtrStack::Overwrite);
+                optCopyPropPushDef(tree->AsOp(), lclDefNode, lclNum, curSsaName);
             }
             // TODO-CQ: propagate on LCL_FLDs too.
             else if (tree->OperIs(GT_LCL_VAR) && ((tree->gtFlags & GTF_VAR_DEF) == 0))
@@ -351,19 +395,11 @@ void Compiler::optBlockCopyProp(BasicBlock* block, LclNumToGenTreePtrStack* curS
                     continue;
                 }
 
-                // If we encounter first use of a param or this pointer add it as a live definition.
-                // Since they are always live, we'll do it only once.
-                if (lvaGetDesc(lclNum)->lvIsParam || (lclNum == info.compThisArg))
+                // If we encounter first use of a param or this pointer add it as a
+                // live definition. Since they are always live, we'll do it only once.
+                if ((lvaGetDesc(lclNum)->lvIsParam || (lclNum == info.compThisArg)) && !curSsaName->Lookup(lclNum))
                 {
-                    GenTreePtrStack* stack;
-                    if (!curSsaName->Lookup(lclNum, &stack))
-                    {
-                        assert(tree->AsLclVarCommon()->GetSsaNum() == SsaConfig::FIRST_SSA_NUM);
-
-                        stack = new (curSsaName->GetAllocator()) GenTreePtrStack(curSsaName->GetAllocator());
-                        stack->Push(tree);
-                        curSsaName->Set(lclNum, stack);
-                    }
+                    optCopyPropPushDef(nullptr, tree->AsLclVarCommon(), lclNum, curSsaName);
                 }
 
                 // TODO-Review: EH successor/predecessor iteration seems broken.
@@ -422,7 +458,7 @@ void Compiler::optVnCopyProp()
     class CopyPropDomTreeVisitor : public DomTreeVisitor<CopyPropDomTreeVisitor>
     {
         // The map from lclNum to its recently live definitions as a stack.
-        LclNumToGenTreePtrStack m_curSsaName;
+        LclNumToLiveDefsMap m_curSsaName;
 
     public:
         CopyPropDomTreeVisitor(Compiler* compiler)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12841,7 +12841,7 @@ DONE_MORPHING_CHILDREN:
                 // Perform the transform ADDR(COMMA(x, ..., z)) == COMMA(x, ..., ADDR(z)).
                 // (Be sure to mark "z" as an l-value...)
 
-                GenTreePtrStack commas(getAllocator(CMK_ArrayStack));
+                ArrayStack<GenTree*> commas(getAllocator(CMK_ArrayStack));
                 for (GenTree* comma = op1; comma != nullptr && comma->gtOper == GT_COMMA; comma = comma->gtGetOp2())
                 {
                     commas.Push(comma);

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -467,7 +467,7 @@ GenTree* MorphInitBlockHelper::MorphCommaBlock(Compiler* comp, GenTreeOp* firstC
 {
     assert(firstComma->OperIs(GT_COMMA));
 
-    Compiler::GenTreePtrStack commas(comp->getAllocator(CMK_ArrayStack));
+    ArrayStack<GenTree*> commas(comp->getAllocator(CMK_ArrayStack));
     for (GenTree* currComma = firstComma; currComma != nullptr && currComma->OperIs(GT_COMMA);
          currComma          = currComma->gtGetOp2())
     {


### PR DESCRIPTION
The next round of copy propagation improvements: push SSA defs on the stacks instead of nodes and optimize the main loop.

The main benefit is performance: my PIN tells me this change reduces the number of instruction retired by `~0.40%` when replaying `benchmarks.run`.

Additionally, the way this change is structured will allows easily replicating previous behavior once the LHS locals no longer have meaningful VNs.

There some small [diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1609409&view=ms.vss-build-web.run-extensions-tab) with this change, they're caused by the slightly different rebalancing order of the hash table as we no longer "overwrite" the stack pointer when pushing a def and don't push defs for shadowed locals.