### PR TITLE
Don't report ZR reg to GC

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9756,7 +9756,7 @@ bool Compiler::lvaIsOSRLocal(unsigned varNum)
 //
 var_types Compiler::gtTypeForNullCheck(GenTree* tree)
 {
-    if (varTypeIsIntegralOrI(tree))
+    if (varTypeIsIntegral(tree))
     {
 #if defined(TARGET_XARCH)
         // Just an optimization for XARCH - smaller mov


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/65175 (regressed by https://github.com/dotnet/runtime/pull/64683)

`varTypeIsIntegralOrI` name is quite confusing 😞 it sounds more like it checks whether a type is an integer on native integer (e.g. `TYP_I_IMPL`) but in reality TYP_REF and TYP_BYREF gc types also bypass it

The fix avoids propagating TYP_REF/TYP_BYREF for nullchecks