### PR TITLE
Fix mono warnings on linux arm64

### DIFF
--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -505,7 +505,7 @@ if(GCC)
   set(WARNINGS_C "-Wmissing-prototypes -Wstrict-prototypes -Wnested-externs")
 
   if (CMAKE_C_COMPILER_ID MATCHES "Clang")
-    set(WARNINGS "${WARNINGS} -Qunused-arguments -Wno-tautological-compare -Wno-parentheses-equality -Wno-self-assign -Wno-return-stack-address -Wno-constant-logical-operand -Wno-zero-length-array")
+    set(WARNINGS "${WARNINGS} -Qunused-arguments -Wno-tautological-compare -Wno-parentheses-equality -Wno-self-assign -Wno-return-stack-address -Wno-constant-logical-operand -Wno-zero-length-array -Wno-asm-operand-widths")
   endif()
 
   set(WERROR "-Werror=return-type")

--- a/src/mono/mono/mini/exceptions-arm64.c
+++ b/src/mono/mono/mini/exceptions-arm64.c
@@ -550,7 +550,7 @@ mono_arch_handle_exception (void *ctx, gpointer obj)
 	UCONTEXT_REG_R0 (sigctx) = (gsize)obj;
 
 	gpointer addr = (gpointer)handle_signal_exception;
-	UCONTEXT_REG_SET_PC (sigctx, addr);
+	UCONTEXT_REG_SET_PC (sigctx, (guint64)addr);
 	host_mgreg_t sp = UCONTEXT_REG_SP (sigctx) - MONO_ARCH_REDZONE_SIZE;
 	UCONTEXT_REG_SET_SP (sigctx, sp);
 #endif

--- a/src/mono/mono/mini/mini-arm64-gsharedvt.c
+++ b/src/mono/mono/mini/mini-arm64-gsharedvt.c
@@ -139,7 +139,7 @@ mono_arch_get_gsharedvt_call_info (MonoMemoryManager *mem_manager, gpointer addr
 	int aindex, i;
 	gboolean var_ret = FALSE;
 	CallInfo *cinfo, *gcinfo;
-	MonoMethodSignature *sig, *gsig;
+	MonoMethodSignature *sig;
 	GPtrArray *map;
 
 	if (gsharedvt_in) {
@@ -163,12 +163,10 @@ mono_arch_get_gsharedvt_call_info (MonoMemoryManager *mem_manager, gpointer addr
 	/* sig/cinfo describes the normal call, while gsig/gcinfo describes the gsharedvt call */
 	if (gsharedvt_in) {
 		sig = caller_sig;
-		gsig = callee_sig;
 		cinfo = caller_cinfo;
 		gcinfo = callee_cinfo;
 	} else {
 		sig = callee_sig;
-		gsig = caller_sig;
 		cinfo = callee_cinfo;
 		gcinfo = caller_cinfo;
 	}


### PR DESCRIPTION
Noticed in https://dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_apis/build/builds/1609091/logs/608.