### PR TITLE
`ZeroObj` assertions

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7696,6 +7696,7 @@ public:
         O2K_CONST_INT,
         O2K_CONST_LONG,
         O2K_CONST_DOUBLE,
+        O2K_ZEROOBJ,
         O2K_SUBRANGE,
         O2K_COUNT
     };
@@ -7837,6 +7838,9 @@ public:
                     // exact match because of positive and negative zero.
                     return (memcmp(&op2.dconVal, &that->op2.dconVal, sizeof(double)) == 0);
 
+                case O2K_ZEROOBJ:
+                    return true;
+
                 case O2K_LCLVAR_COPY:
                     return (op2.lcl.lclNum == that->op2.lcl.lclNum) &&
                            (!vnBased || op2.lcl.ssaNum == that->op2.lcl.ssaNum) &&
@@ -7973,7 +7977,6 @@ public:
     bool optAssertionIsNonNull(GenTree*         op,
                                ASSERT_VALARG_TP assertions DEBUGARG(bool* pVnBased) DEBUGARG(AssertionIndex* pIndex));
 
-    // Used for Relop propagation.
     AssertionIndex optGlobalAssertionIsEqualOrNotEqual(ASSERT_VALARG_TP assertions, GenTree* op1, GenTree* op2);
     AssertionIndex optGlobalAssertionIsEqualOrNotEqualZero(ASSERT_VALARG_TP assertions, GenTree* op1);
     AssertionIndex optLocalAssertionIsEqualOrNotEqual(
@@ -7987,10 +7990,13 @@ public:
     GenTree* optConstantAssertionProp(AssertionDsc*        curAssertion,
                                       GenTreeLclVarCommon* tree,
                                       Statement* stmt DEBUGARG(AssertionIndex index));
+    bool optZeroObjAssertionProp(GenTree* tree, ASSERT_VALARG_TP assertions);
 
     // Assertion propagation functions.
     GenTree* optAssertionProp(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt, BasicBlock* block);
     GenTree* optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTreeLclVarCommon* tree, Statement* stmt);
+    GenTree* optAssertionProp_Asg(ASSERT_VALARG_TP assertions, GenTreeOp* asg, Statement* stmt);
+    GenTree* optAssertionProp_Return(ASSERT_VALARG_TP assertions, GenTreeUnOp* ret, Statement* stmt);
     GenTree* optAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt);
     GenTree* optAssertionProp_Cast(ASSERT_VALARG_TP assertions, GenTreeCast* cast, Statement* stmt);
     GenTree* optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCall* call, Statement* stmt);

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1481,6 +1481,8 @@ void GenTree::BashToConst(T value, var_types type /* = TYP_UNDEF */)
         type = typeOfValue;
     }
 
+    assert(type == genActualType(type));
+
     genTreeOps oper = GT_NONE;
     if (varTypeIsFloating(type))
     {
@@ -1492,7 +1494,6 @@ void GenTree::BashToConst(T value, var_types type /* = TYP_UNDEF */)
     }
 
     SetOperResetFlags(oper);
-
     gtType = type;
 
     switch (oper)


### PR DESCRIPTION
It is the case that the IR supports the "zero" node for structs in two positions: on the RHS of an assignment (`InitBlk` form) and under a return, in case the ABI return type is scalar.

Meanwhile, assertion propagation "blindly" replaced structs with zeroes, and so workarounds had to be applied in order for the IR to remain valid, in the form of the `NO_CSE` flag, applied either explicitly (multi-reg returns) or implicitly (`ADDR(LCL)` created by `impNormStructVal` for call args).

This was:

a) A CQ problem in cases where we forgot to clear the `NO_CSE` flag when the node's parent was updated, say after inlining.
b) A burden for enabling struct `LCL_VAR` arguments, as one had to remember to mark them `NO_CSE` in all situations.

This change fixes the problem by deleting propagation of zeroes for local uses, instead propagating them as part of their parents (`ASG`s and `RETURN`s).

This has the CQ benefits of not being affected by stale `NO_CSE`s and the drawback of not participating in the "chained" propagation, where we first copy-propagated something, and then zero-propagated into the new local as well. These cases seem rather rare, so I decided not to spend TP on fixing them by looking at the copy assertions in the new code.

This change also deletes the zero propagation code for `SIMD`s. It was only useful in cases we had a promoted `SIMD` field that was zero-inited via an `InitBlk` on the parent struct. That promotion code was (and is) creating nodes that look like integral constants, except they are of `TYP_SIMD`. We should delete that form and use proper `SIMD` zero nodes instead, and design the propagation story for them separately.

I have considered introducing a new flag for this, say `GTF_VAR_ZERO_STRUCT_PROP_ALLOWED`, to be set on nodes under parents that support "zero" operands, but it seemed like a less robust (if technically "easier") solution to me.

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1610301&view=ms.vss-build-web.run-extensions-tab).

Contributes to #51569.