### PR TITLE
Improve regex optimizations around repetitions of the same character

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/RegexReductionTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexReductionTests.cs
@@ -124,6 +124,16 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("aa+", "a{2,}")]
         [InlineData("aa?", "a{1,2}")]
         [InlineData("aa{1,3}", "a{2,4}")]
+        [InlineData("aaa+b", "aa(?>a+)b")]
+        [InlineData("a+aab", "(?>a{3,})b")]
+        [InlineData("a{3}b", "aaab")]
+        [InlineData("a{2}ab", "aaab")]
+        [InlineData("aa{2}b", "aaab")]
+        [InlineData("ca{3}b", "caaab")]
+        [InlineData("caa{2}b", "caaab")]
+        [InlineData("ca{2}ab", "caaab")]
+        [InlineData("ca{2}", "caa")]
+        [InlineData(@"ca{2}\w", @"caa\w")]
         // Two atomic one loops
         [InlineData("(?>a*)(?>a*)", "(?>a*)")]
         [InlineData("(?>a*)(?>(?:a*))", "(?>a*)")]
@@ -476,7 +486,6 @@ namespace System.Text.RegularExpressions.Tests
 
         [Theory]
         // Not coalescing loops
-        [InlineData("aa", "a{2}")]
         [InlineData("a[^a]", "a{2}")]
         [InlineData("[^a]a", "[^a]{2}")]
         [InlineData("a*b*", "a*")]


### PR DESCRIPTION
- For concatenations, we currently do two passes over its nodes: one that coalesces adjacent characters into strings, and one that coalesces adjacent loops.  This swaps the order so that we first coalesce adjacent loops.  We want to coalesce loops first so that we prioritize associating a One with an adjacent loop rather than with an adjacent string.  This is primarily beneficial later on for auto-atomicity.  Consider `a+ab` composed of a loop, a One 'a', and a One 'b'.  We're either going to make that into a loop `a{2,}` followed by `b` or into a loop `a+` followed by the multi `ab`.  We want to do the former, as then when we apply auto-atomicity to the `a{2,}`, we'll see that it's followed by something non-overlapping ('b'), and make the loop atomic.  In constrast, if we joined the `a` and `b`, then auto-atomicity for the `a+` would see it's followed by an `a` and it wouldn't be upgraded.
- Currently, the adjacent loop coalescing logic joins two individual One nodes with the same Ch value into a repeater.  That's actually a deoptimization, so this stops doing so.  We'd rather have `aa` be evaluated as a Multi of two characters rather than as an `a{2}` repeater, as we're able to apply better optimizations with multis, e.g. taking advantage of StartsWith for matching.
- Also in the adjacent loop logic, we're already checking for a loop followed by a one but we're not checking for a loop followed by a multi.  For the same auto-atomicity benefits discussed earlier, we want to shift any adjacent text from a multi following a loop back into the loop, as it makes it more likely we'll then be able to upgrade that loop to atomic. (We could also add logic for a multi followed by a loop, but the benefits there are less obvious.)
- When creating repeaters, we're actually better off creating multis, for the same reasons outlined earlier.  But we don't want to create massive strings in the super rare case where large repeaters for single chars are used, so we only do so up to a limit.
- When emitting generated code for a One repeater, which might be used to implement the required portion of other loops, emit it as a multi match for short enough repetitions.

Fixes https://github.com/dotnet/runtime/issues/64991