### PR TITLE
Move more things under S.S.Cryptography.

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/ExportTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/ExportTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
-using Internal.Cryptography;
 using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -60,8 +60,6 @@
     <Compile Include="CertificateCreation\DSAX509SignatureGenerator.cs" />
     <Compile Include="CertificateCreation\EccTestData.cs" />
     <Compile Include="CertificateCreation\ECDsaX509SignatureGeneratorTests.cs" />
-    <Compile Include="$(CommonPath)Internal\Cryptography\PemEnumerator.cs"
-             Link="Common\Internal\Cryptography\PemEnumerator.cs" />
     <Compile Include="CertificateCreation\PrivateKeyAssociationTests.cs" />
     <Compile Include="CertificateCreation\RSAPkcs1X509SignatureGeneratorTests.cs" />
     <Compile Include="CertificateCreation\RSAPssX509SignatureGeneratorTests.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -26,28 +26,10 @@
              Link="Common\DisableRuntimeMarshalling.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\AsymmetricAlgorithmHelpers.Der.cs"
              Link="Common\Internal\Cryptography\AsymmetricAlgorithmHelpers.Der.cs" />
-    <Compile Include="$(CommonPath)Internal\Cryptography\BasicSymmetricCipher.cs"
-             Link="Common\Internal\Cryptography\BasicSymmetricCipher.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\HashProvider.cs"
              Link="Common\Internal\Cryptography\HashProvider.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\Helpers.cs"
              Link="Common\Internal\Cryptography\Helpers.cs" />
-    <Compile Include="$(CommonPath)Internal\Cryptography\PemEnumerator.cs"
-             Link="Common\Internal\Cryptography\PemEnumerator.cs" />
-    <Compile Include="$(CommonPath)Internal\Cryptography\PemKeyHelpers.cs"
-             Link="Common\Internal\Cryptography\PemKeyHelpers.cs" />
-    <Compile Include="$(CommonPath)Internal\Cryptography\ILiteSymmetricCipher.cs"
-             Link="Common\Internal\Cryptography\ILiteSymmetricCipher.cs" />
-    <Compile Include="$(CommonPath)Internal\Cryptography\SymmetricPadding.cs"
-             Link="Common\Internal\Cryptography\SymmetricPadding.cs" />
-    <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoTransform.cs"
-             Link="Common\Internal\Cryptography\UniversalCryptoTransform.cs" />
-    <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoEncryptor.cs"
-             Link="Common\Internal\Cryptography\UniversalCryptoEncryptor.cs" />
-    <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoDecryptor.cs"
-             Link="Common\Internal\Cryptography\UniversalCryptoDecryptor.cs" />
-    <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoOneShot.cs"
-             Link="Common\Internal\Cryptography\UniversalCryptoOneShot.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeHandleCache.cs"
              Link="Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeX509ChainHandle.cs"
@@ -294,6 +276,7 @@
     <Compile Include="System\Security\Cryptography\AsymmetricSignatureDeformatter.cs" />
     <Compile Include="System\Security\Cryptography\AsymmetricSignatureFormatter.cs" />
     <Compile Include="System\Security\Cryptography\Base64Transforms.cs" />
+    <Compile Include="System\Security\Cryptography\BasicSymmetricCipher.cs" />
     <Compile Include="System\Security\Cryptography\ChaCha20Poly1305.cs" />
     <Compile Include="System\Security\Cryptography\CipherMode.cs" />
     <Compile Include="System\Security\Cryptography\CngAlgorithm.cs" />
@@ -357,6 +340,7 @@
     <Compile Include="System\Security\Cryptography\HMACSHA512.cs" />
     <Compile Include="System\Security\Cryptography\ICryptoTransform.cs" />
     <Compile Include="System\Security\Cryptography\ICspAsymmetricAlgorithm.cs" />
+    <Compile Include="System\Security\Cryptography\ILiteSymmetricCipher.cs" />
     <Compile Include="System\Security\Cryptography\IncrementalHash.cs" />
     <Compile Include="System\Security\Cryptography\KeyedHashAlgorithm.cs" />
     <Compile Include="System\Security\Cryptography\KeyNumber.cs" />
@@ -375,7 +359,9 @@
     <Compile Include="System\Security\Cryptography\PbeEncryptionAlgorithm.cs" />
     <Compile Include="System\Security\Cryptography\PbeParameters.cs" />
     <Compile Include="System\Security\Cryptography\PemEncoding.cs" />
+    <Compile Include="System\Security\Cryptography\PemEnumerator.cs" />
     <Compile Include="System\Security\Cryptography\PemFields.cs" />
+    <Compile Include="System\Security\Cryptography\PemKeyHelpers.cs" />
     <Compile Include="System\Security\Cryptography\PKCS1MaskGenerationMethod.cs" />
     <Compile Include="System\Security\Cryptography\RandomNumberGenerator.cs" />
     <Compile Include="System\Security\Cryptography\RandomNumberGeneratorImplementation.cs" />
@@ -414,8 +400,13 @@
     <Compile Include="System\Security\Cryptography\SHA512Managed.cs" />
     <Compile Include="System\Security\Cryptography\SignatureDescription.cs" />
     <Compile Include="System\Security\Cryptography\SymmetricAlgorithm.cs" />
+    <Compile Include="System\Security\Cryptography\SymmetricPadding.cs" />
     <Compile Include="System\Security\Cryptography\TripleDES.cs" />
     <Compile Include="System\Security\Cryptography\TripleDesImplementation.cs" />
+    <Compile Include="System\Security\Cryptography\UniversalCryptoTransform.cs" />
+    <Compile Include="System\Security\Cryptography\UniversalCryptoEncryptor.cs" />
+    <Compile Include="System\Security\Cryptography\UniversalCryptoDecryptor.cs" />
+    <Compile Include="System\Security\Cryptography\UniversalCryptoOneShot.cs" />
     <Compile Include="System\Security\Cryptography\XmlKeyHelper.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\CertificateExtensionsCommon.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\CertificatePal.cs" />
@@ -1331,10 +1322,6 @@
     <Compile Include="System\Security\Cryptography\X509Certificates\X509Pal.iOS.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows'">
-    <Compile Include="$(CommonPath)Internal\Cryptography\BasicSymmetricCipherBCrypt.cs"
-             Link="Common\Internal\Cryptography\BasicSymmetricCipherBCrypt.cs" />
-    <Compile Include="$(CommonPath)Internal\Cryptography\BasicSymmetricCipherLiteBCrypt.cs"
-             Link="Common\Internal\Cryptography\BasicSymmetricCipherLiteBCrypt.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\CngCommon.Hash.cs"
              Link="Common\Internal\Cryptography\CngCommon.Hash.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\CngCommon.SignVerify.cs"
@@ -1723,7 +1710,9 @@
     <Compile Include="System\Security\Cryptography\AesImplementation.Windows.cs" />
     <Compile Include="System\Security\Cryptography\AsnFormatter.Windows.cs" />
     <Compile Include="System\Security\Cryptography\BasicSymmetricCipherCsp.cs" />
+    <Compile Include="System\Security\Cryptography\BasicSymmetricCipherBCrypt.cs" />
     <Compile Include="System\Security\Cryptography\BasicSymmetricCipherNCrypt.cs" />
+    <Compile Include="System\Security\Cryptography\BasicSymmetricCipherLiteBCrypt.cs" />
     <Compile Include="System\Security\Cryptography\BasicSymmetricCipherLiteNCrypt.cs" />
     <Compile Include="System\Security\Cryptography\CapiHelper.DSA.Shared.cs" />
     <Compile Include="System\Security\Cryptography\CapiHelper.DSA.Windows.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/BasicSymmetricCipher.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/BasicSymmetricCipher.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Diagnostics;
-using System.Security.Cryptography;
 
-namespace Internal.Cryptography
+namespace System.Security.Cryptography
 {
     //
     // Represents a symmetric reusable cipher encryptor or decryptor. Underlying technology may be CNG or OpenSSL or anything else.

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/BasicSymmetricCipherBCrypt.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/BasicSymmetricCipherBCrypt.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Diagnostics;
-using System.Security.Cryptography;
+using Internal.Cryptography;
 using Internal.NativeCrypto;
 
-namespace Internal.Cryptography
+namespace System.Security.Cryptography
 {
     internal sealed class BasicSymmetricCipherBCrypt : BasicSymmetricCipher
     {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/BasicSymmetricCipherLiteBCrypt.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/BasicSymmetricCipherLiteBCrypt.cs
@@ -3,10 +3,9 @@
 
 using System;
 using System.Diagnostics;
-using System.Security.Cryptography;
 using Internal.NativeCrypto;
 
-namespace Internal.Cryptography
+namespace System.Security.Cryptography
 {
     internal sealed class BasicSymmetricCipherLiteBCrypt : ILiteSymmetricCipher
     {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ILiteSymmetricCipher.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ILiteSymmetricCipher.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics;
-using System.Security.Cryptography;
 
-namespace Internal.Cryptography
+namespace System.Security.Cryptography
 {
     internal interface ILiteSymmetricCipher : IDisposable
     {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/PemEnumerator.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/PemEnumerator.cs
@@ -5,7 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Security.Cryptography;
 
-namespace Internal.Cryptography
+namespace System.Security.Cryptography
 {
     internal readonly ref struct PemEnumerator
     {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/PemKeyHelpers.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/PemKeyHelpers.cs
@@ -5,7 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Security.Cryptography;
 
-namespace Internal.Cryptography
+namespace System.Security.Cryptography
 {
     internal static class PemKeyHelpers
     {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SymmetricPadding.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SymmetricPadding.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Diagnostics;
-using System.Security.Cryptography;
 
-namespace Internal.Cryptography
+namespace System.Security.Cryptography
 {
     internal static class SymmetricPadding
     {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/UniversalCryptoDecryptor.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/UniversalCryptoDecryptor.cs
@@ -4,8 +4,9 @@
 using System;
 using System.Diagnostics;
 using System.Security.Cryptography;
+using Internal.Cryptography;
 
-namespace Internal.Cryptography
+namespace System.Security.Cryptography
 {
     //
     // A cross-platform ICryptoTransform implementation for decryption.

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/UniversalCryptoEncryptor.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/UniversalCryptoEncryptor.cs
@@ -4,8 +4,9 @@
 using System;
 using System.Diagnostics;
 using System.Security.Cryptography;
+using Internal.Cryptography;
 
-namespace Internal.Cryptography
+namespace System.Security.Cryptography
 {
     //
     // A cross-platform ICryptoTransform implementation for encryption.

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/UniversalCryptoOneShot.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/UniversalCryptoOneShot.cs
@@ -4,8 +4,9 @@
 using System;
 using System.Diagnostics;
 using System.Security.Cryptography;
+using Internal.Cryptography;
 
-namespace Internal.Cryptography
+namespace System.Security.Cryptography
 {
     internal static class UniversalCryptoOneShot
     {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/UniversalCryptoTransform.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/UniversalCryptoTransform.cs
@@ -4,8 +4,9 @@
 using System;
 using System.Diagnostics;
 using System.Security.Cryptography;
+using Internal.Cryptography;
 
-namespace Internal.Cryptography
+namespace System.Security.Cryptography
 {
     //
     // The common base class for the cross-platform CreateEncryptor()/CreateDecryptor() implementations.


### PR DESCRIPTION
Some of the things in Internal.Cryptography can be moved under System.Security.Cryptography.

More can be moved eventually, but I started with this since it is blocking other cleanup I would like to do around the symmetric one-shots, which is to remove the per-platform implementations of `BasicSymmetricCipher` since that is all handled by the Lite cipher implementation now.