### PR TITLE
[tests] Extend partial disablement of SkippingHiddenFiles

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/SpecialDirectoryTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/SpecialDirectoryTests.cs
@@ -61,7 +61,7 @@ namespace System.IO.Tests.Enumeration
             // Files that begin with periods are considered hidden on Unix
             string[] paths = GetNames(TestDirectory, new EnumerationOptions { ReturnSpecialDirectories = true, AttributesToSkip = 0 });
 
-            if (!PlatformDetection.IsWindows10Version22000OrGreater)
+            if (!PlatformDetection.IsWindows10Version20348OrGreater)
             {
                 // Sometimes this is not returned - presumably an OS bug.
                 // This occurs often on Windows 11, very rarely otherwise.


### PR DESCRIPTION
```
System.IO.Tests.Enumeration.SpecialDirectoryTests_Enumerable.SkippingHiddenFiles [FAIL]
      Assert.Contains() Failure
      Not found: .
      In value:  String[] [".."]
```
was hit on Windows Server 2022. Extending the condition applied to Windows 11 to include Windows Server 2022. 
https://github.com/dotnet/runtime/issues/33148