### PR TITLE
Cleanup some XML tests

### DIFF
--- a/src/libraries/Common/tests/System/Xml/ModuleCore/ctestexception.cs
+++ b/src/libraries/Common/tests/System/Xml/ModuleCore/ctestexception.cs
@@ -58,24 +58,24 @@ namespace OLEDB.Test.ModuleCore
         public object Expected;
 
         //Constructor
-        public CTestException(string message)
+        public CTestException(string message!!)
             : this(CTestBase.TEST_FAIL, message)
         {
         }
 
-        public CTestException(int result, string message)
+        public CTestException(int result, string message!!)
             : this(result, message, false, true, null)
         {
         }
 
-        public CTestException(int result, string message, object actual, object expected, Exception inner)
+        public CTestException(int result, string message!!, object actual, object expected, Exception inner)
             : base(message, inner)
         {
             //Note: iResult is the variation result (i.e.: TEST_PASS, TEST_FAIL, etc...)
             //Setup the exception
             Result = result;
-            Actual = actual;
-            Expected = expected;
+            Actual = actual ?? "";
+            Expected = expected ?? "";
         }
 
         public override string Message

--- a/src/libraries/Common/tests/System/Xml/XmlCoreTest/CustomWriter.cs
+++ b/src/libraries/Common/tests/System/Xml/XmlCoreTest/CustomWriter.cs
@@ -157,6 +157,11 @@ namespace XmlCoreTest.Common
             }
         }
 
+        public override void Close()
+        {
+            Dispose(disposing:true);
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (disposing)

--- a/src/libraries/Common/tests/System/Xml/XmlCoreTest/FilePathUtil.cs
+++ b/src/libraries/Common/tests/System/Xml/XmlCoreTest/FilePathUtil.cs
@@ -111,8 +111,7 @@ namespace XmlCoreTest.Common
             return resultPath.ToString();
         }
 
-        private static MyDict<string, Stream> s_XmlFileInMemoryCache = null;
-        private static MyDict<string, Stream> s_XmlFileInMemoryCacheBackup = null;
+        private static MyDict<string, MemoryStream> s_XmlFileInMemoryCache = null;
 
         private static readonly object s_XmlFileMemoryCacheLock = new object();
         static void initXmlFileCacheIfNotYet()
@@ -121,35 +120,20 @@ namespace XmlCoreTest.Common
             {
                 if (s_XmlFileInMemoryCache == null)
                 {
-                    s_XmlFileInMemoryCache = new MyDict<string, Stream>();
-                    s_XmlFileInMemoryCacheBackup = new MyDict<string, Stream>();
+                    s_XmlFileInMemoryCache = new MyDict<string, MemoryStream>();
 
-                    foreach (var file in GetDataFiles())
+                    foreach (Tuple<string, byte[]> file in GetDataFiles())
                     {
-                        addBytes(file.Item1, file.Item2);
+                        var ms = new MemoryStream(file.Item2);
+                        s_XmlFileInMemoryCache[NormalizeFilePath(file.Item1)] = ms;
                     }
                 }
             }
         }
 
-        public static void cacheXml(string filename, string content)
-        {
-            initXmlFileCacheIfNotYet();
-            MemoryStream ms = new MemoryStream();
-            StreamWriter sw = new StreamWriter(ms);
-            sw.Write(content);
-            sw.Flush();
-            s_XmlFileInMemoryCache[NormalizeFilePath(filename)] = ms;
-
-            MemoryStream msbak = new MemoryStream();
-            ms.Position = 0;
-            ms.CopyTo(msbak);
-            s_XmlFileInMemoryCacheBackup[NormalizeFilePath(filename)] = msbak;
-        }
-
         public static Stream getStreamDirect(string filename)
         {
-            foreach (var file in GetDataFiles())
+            foreach (Tuple<string, byte[]> file in GetDataFiles())
             {
                 if (file.Item1 == filename)
                 {
@@ -171,51 +155,23 @@ namespace XmlCoreTest.Common
 
             lock (s_XmlFileMemoryCacheLock)
             {
-                Stream s = s_XmlFileInMemoryCache[normalizedFileName];
+                MemoryStream ms = s_XmlFileInMemoryCache[normalizedFileName];
 
-                if (s == null)
+                if (ms == null)
                 {
                     throw new FileNotFoundException("File Not Found: " + filename);
                 }
 
-                if (s.CanSeek)
-                {
-                    s.Position = 0;
-                    return s;
-                }
-                else
-                {
-                    Stream msbak = s_XmlFileInMemoryCacheBackup[normalizedFileName];
-                    MemoryStream msnew = new MemoryStream();
-                    msbak.Position = 0;
-                    msbak.CopyTo(msnew);
-
-                    s_XmlFileInMemoryCache[normalizedFileName] = msnew;
-                    msnew.Position = 0;
-                    return msnew;
-                }
-            }
-        }
-
-        public static void addBytes(string filename, byte[] bytes)
-        {
-            if (null == filename)
-                return;
-
-            initXmlFileCacheIfNotYet();
-
-            lock (s_XmlFileMemoryCacheLock)
-            {
-                var ms = new MemoryStream(bytes);
-                s_XmlFileInMemoryCache[NormalizeFilePath(filename)] = ms;
-                MemoryStream msbak = new MemoryStream();
+                // Always give out a new stream, so there's no concern about concurrent use
+                MemoryStream msnew = new MemoryStream();
                 ms.Position = 0;
-                ms.CopyTo(msbak);
-                s_XmlFileInMemoryCacheBackup[NormalizeFilePath(filename)] = msbak;
+                ms.CopyTo(msnew);
+                msnew.Position = 0;
+                return msnew;
             }
         }
 
-        public static void addStream(string filename, Stream s)
+        public static void addStream(string filename, MemoryStream s!!)
         {
             if (null == filename)
                 return;
@@ -224,12 +180,8 @@ namespace XmlCoreTest.Common
 
             lock (s_XmlFileMemoryCacheLock)
             {
+                // overwrite any existing
                 s_XmlFileInMemoryCache[NormalizeFilePath(filename)] = s;
-
-                MemoryStream msbak = new MemoryStream();
-                s.Position = 0;
-                s.CopyTo(msbak);
-                s_XmlFileInMemoryCacheBackup[NormalizeFilePath(filename)] = msbak;
             }
         }
 

--- a/src/libraries/Common/tests/System/Xml/XmlCoreTest/WriterFactory.cs
+++ b/src/libraries/Common/tests/System/Xml/XmlCoreTest/WriterFactory.cs
@@ -60,7 +60,7 @@ namespace XmlCoreTest.Common
 
         private XmlWriterSettings _wSettings = null;
         private XmlWriter _xmlWriter = null;
-        private Stream _writerStream = null;
+        private MemoryStream _writerStream = null;
 
         XmlWriter CreateWriterImpl()
         {

--- a/src/libraries/Common/tests/System/Xml/XmlCoreTest/WriterFactory.cs
+++ b/src/libraries/Common/tests/System/Xml/XmlCoreTest/WriterFactory.cs
@@ -90,9 +90,8 @@ namespace XmlCoreTest.Common
                     _wSettings.CloseOutput = false;
                     if (_overrideAsync)
                         _wSettings.Async = _async;
-
+                    _xmlWriter = new CustomWriter(_writerStream, _wSettings);
                     FilePathUtil.addStream(_fileName, _writerStream);
-                    _xmlWriter = new CustomWriter(_fileName, _wSettings);
                     break;
                 case WriterType.UTF8WriterIndent:
                     _writerStream = new MemoryStream();

--- a/src/libraries/System.Private.Xml/tests/Readers/NameTable/TestFiles.cs
+++ b/src/libraries/System.Private.Xml/tests/Readers/NameTable/TestFiles.cs
@@ -79,7 +79,7 @@ namespace System.Xml.Tests
         public static void CreateGenericTestFile(string strFileName)
         {
             MemoryStream ms = new MemoryStream();
-            TextWriter tw = new StreamWriter(ms);
+            using var tw = new StreamWriter(ms, encoding:null, bufferSize:-1, leaveOpen:true);
 
             tw.WriteLine("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>");
             tw.WriteLine("<!-- comment1 -->");
@@ -170,7 +170,6 @@ namespace System.Xml.Tests
             tw.WriteLine("<CHARS_COMMENT1>xxx<!-- comment1-->zzz</CHARS_COMMENT1>");
             tw.WriteLine("<CHARS_COMMENT2><!-- comment1-->zzz</CHARS_COMMENT2>");
             tw.WriteLine("<CHARS_COMMENT3>xxx<!-- comment1--></CHARS_COMMENT3>");
-            tw.Flush();
             tw.WriteLine("<ISDEFAULT />");
             tw.WriteLine("<ISDEFAULT a1='a1value' />");
             tw.WriteLine("<BOOLEAN1>true</BOOLEAN1>");
@@ -202,7 +201,6 @@ namespace System.Xml.Tests
             tw.WriteLine("<GRPDESCR>twin brothers, and sons to Aegeon and Aemilia.</GRPDESCR>");
             tw.WriteLine("</PGROUP>");
             tw.WriteLine("<PGROUP>");
-            tw.Flush();
             tw.WriteLine("<XMLLANG0 xml:lang=\"en-US\">What color e1foo is it?</XMLLANG0>");
             tw.Write("<XMLLANG1 xml:lang=\"en-GB\">What color is it?<a><b><c>Language Test</c><PERSONA>DROMIO OF EPHESUS</PERSONA></b></a></XMLLANG1>");
             tw.WriteLine("<NOXMLLANG />");
@@ -269,28 +267,26 @@ namespace System.Xml.Tests
 
 
             tw.Write("</PLAY>");
-            tw.Flush();
+
             FilePathUtil.addStream(strFileName, ms);
         }
 
         public static void CreateBigElementTestFile(string strFileName)
         {
             MemoryStream ms = new MemoryStream();
-            TextWriter tw = new StreamWriter(ms);
+            using var tw = new StreamWriter(ms, encoding:null, bufferSize:-1, leaveOpen:true);
 
             string str = new string('Z', (1 << 20) - 1);
             tw.WriteLine("<Root>");
             tw.Write("<");
             tw.Write(str);
             tw.WriteLine("X />");
-            tw.Flush();
 
             tw.Write("<");
             tw.Write(str);
             tw.WriteLine("Y />");
             tw.WriteLine("</Root>");
 
-            tw.Flush();
             FilePathUtil.addStream(strFileName, ms);
         }
     }

--- a/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/TCFullEndElement.cs
+++ b/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/TCFullEndElement.cs
@@ -6352,12 +6352,12 @@ namespace System.Xml.Tests
                 [XmlWriterInlineData]
                 public void var_1(XmlWriterUtils utils)
                 {
-                    using (XmlWriter writer = utils.CreateWriter())
-                    {
-                        writer.WriteStartElement("Root");
-                        writer.WriteStartElement("Nesting");
-                        writer.WriteStartElement("SomeDeep");
-                    }
+                    XmlWriter writer = utils.CreateWriter();
+                    writer.WriteStartElement("Root");
+                    writer.WriteStartElement("Nesting");
+                    writer.WriteStartElement("SomeDeep");
+                    writer.Close();
+
                     Assert.True(utils.CompareReader("<Root><Nesting><SomeDeep /></Nesting></Root>"));
                 }
 

--- a/src/libraries/System.Private.Xml/tests/XmlReaderLib/TestFiles.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlReaderLib/TestFiles.cs
@@ -291,42 +291,42 @@ namespace System.Xml.Tests
 
         public static void CreateByteTestFile(string strFileName)
         {
-            Stream s = new MemoryStream();
-            TextWriter tw = new StreamWriter(s);
+            var s = new MemoryStream();
+            using var tw = new StreamWriter(s, encoding:null, bufferSize:-1, leaveOpen:true);
+
             tw.WriteLine("x");
-            tw.Flush();
+
             FilePathUtil.addStream(strFileName, s);
         }
 
         public static void CreateUTF8EncodedTestFile(string strFileName, Encoding encode)
         {
-            Stream strm = new MemoryStream();
-            TextWriter tw = new StreamWriter(strm, encode);
+            var s = new MemoryStream();
+            using var tw = new StreamWriter(s, encode, bufferSize:-1, leaveOpen:true);
 
             tw.WriteLine("<root>");
             tw.Write("\u00A9");
             tw.WriteLine("</root>");
 
-            tw.Flush();
-            FilePathUtil.addStream(strFileName, strm);
+            FilePathUtil.addStream(strFileName, s);
         }
 
         public static void CreateEncodedTestFile(string strFileName, Encoding encode)
         {
-            Stream strm = new MemoryStream();
-            TextWriter tw = new StreamWriter(strm, encode);
+            var s = new MemoryStream();
+            using var tw = new StreamWriter(s, encode, bufferSize:-1, leaveOpen:true);
 
             tw.WriteLine("<root>");
             tw.WriteLine("</root>");
 
-            tw.Flush();
-            FilePathUtil.addStream(strFileName, strm);
+            FilePathUtil.addStream(strFileName, s);
         }
 
         public static void CreateWhitespaceHandlingTestFile(string strFileName)
         {
-            Stream s = new MemoryStream();
-            TextWriter tw = new StreamWriter(s);
+            var s = new MemoryStream();
+            using var tw = new StreamWriter(s, encoding:null, bufferSize:-1, leaveOpen:true);
+
             tw.WriteLine("<!DOCTYPE dt [");
             tw.WriteLine("<!ELEMENT WHITESPACE1 (#PCDATA)*>");
             tw.WriteLine("<!ELEMENT WHITESPACE2 (#PCDATA)*>");
@@ -337,7 +337,7 @@ namespace System.Xml.Tests
             tw.WriteLine("<WHITESPACE2> <ELEM /> </WHITESPACE2>");
             tw.WriteLine("<WHITESPACE3>\t<ELEM />\t</WHITESPACE3>");
             tw.WriteLine("</doc>");
-            tw.Flush();
+
             FilePathUtil.addStream(strFileName, s);
         }
 
@@ -350,8 +350,9 @@ namespace System.Xml.Tests
         }
         public static void CreateGenericTestFile(string strFileName)
         {
-            Stream s = new MemoryStream();
-            TextWriter tw = new StreamWriter(s);
+            var s = new MemoryStream();
+            using var tw = new StreamWriter(s, encoding:null, bufferSize:-1, leaveOpen:true);
+
             tw.WriteLine("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>");
             tw.WriteLine("<!-- comment1 -->");
             tw.WriteLine("<?PI1_First processing instruction?>");
@@ -425,7 +426,6 @@ namespace System.Xml.Tests
             tw.WriteLine("<CHARS_COMMENT1>xxx<!-- comment1-->zzz</CHARS_COMMENT1>");
             tw.WriteLine("<CHARS_COMMENT2><!-- comment1-->zzz</CHARS_COMMENT2>");
             tw.WriteLine("<CHARS_COMMENT3>xxx<!-- comment1--></CHARS_COMMENT3>");
-            tw.Flush();
             tw.WriteLine("<ISDEFAULT />");
             tw.WriteLine("<ISDEFAULT a1='a1value' />");
             tw.WriteLine("<BOOLEAN1>true</BOOLEAN1>");
@@ -457,7 +457,6 @@ namespace System.Xml.Tests
             tw.WriteLine("<GRPDESCR>twin brothers, and sons to Aegeon and Aemilia.</GRPDESCR>");
             tw.WriteLine("</PGROUP>");
             tw.WriteLine("<PGROUP>");
-            tw.Flush();
             tw.WriteLine("<XMLLANG0 xml:lang=\"en-US\">What color NO_REFERENCEe1; is it?</XMLLANG0>");
             tw.Write("<XMLLANG1 xml:lang=\"en-GB\">What color is it?<a><b><c>Language Test</c><PERSONA>DROMIO OF EPHESUS</PERSONA></b></a></XMLLANG1>");
             tw.WriteLine("<NOXMLLANG />");
@@ -523,7 +522,6 @@ namespace System.Xml.Tests
             tw.WriteLine("<VALIDXMLLANG3 xml:lang=\"a b-cd\" />");
 
             tw.Write("</PLAY>");
-            tw.Flush();
             FilePathUtil.addStream(strFileName, s);
         }
 
@@ -561,17 +559,18 @@ namespace System.Xml.Tests
 
         public static void CreateInvalidNamespaceTestFile(string strFileName)
         {
-            Stream s = new MemoryStream();
-            TextWriter tw = new StreamWriter(s);
+            var s = new MemoryStream();
+            using var tw = new StreamWriter(s, encoding:null, bufferSize:-1, leaveOpen:true);
+
             tw.WriteLine("<NAMESPACE0 xmlns:bar=\"1\"><bar1:check>Namespace=1</bar1:check></NAMESPACE0>");
-            tw.Flush();
+
             FilePathUtil.addStream(strFileName, s);
         }
 
         public static void CreateNamespaceTestFile(string strFileName)
         {
-            Stream s = new MemoryStream();
-            TextWriter tw = new StreamWriter(s);
+            var s = new MemoryStream();
+            using var tw = new StreamWriter(s, encoding:null, bufferSize:-1, leaveOpen:true);
 
             tw.WriteLine("<DOCNAMESPACE>");
             tw.WriteLine("<NAMESPACE0 xmlns:bar=\"1\"><bar:check>Namespace=1</bar:check></NAMESPACE0>");
@@ -585,14 +584,15 @@ namespace System.Xml.Tests
             tw.WriteLine("<a13 a:check=\"Namespace=13\" xmlns:a=\"13\" /><check14 xmlns=\"14\">Namespace=14</check14></NAMESPACE3>");
             tw.WriteLine("<NONAMESPACE>Namespace=\"\"</NONAMESPACE>");
             tw.WriteLine("</DOCNAMESPACE>");
-            tw.Flush();
+
             FilePathUtil.addStream(strFileName, s);
         }
 
         public static void CreateXmlLangTestFile(string strFileName)
         {
-            Stream s = new MemoryStream();
-            TextWriter tw = new StreamWriter(s);
+            var s = new MemoryStream();
+            using var tw = new StreamWriter(s, encoding:null, bufferSize:-1, leaveOpen:true);
+
             tw.WriteLine("<PGROUP>");
             tw.WriteLine("<PERSONA>DROMIO OF EPHESUS</PERSONA>");
             tw.WriteLine("<PERSONA>DROMIO OF SYRACUSE</PERSONA>");
@@ -603,14 +603,14 @@ namespace System.Xml.Tests
             tw.WriteLine("<XMLLANG2 xml:lang=\"en-US\">What color is it?<TITLE><!-- this is a comment--></TITLE><XMLLANG1 xml:lang=\"en-GB\">Testing language<XMLLANG0 xml:lang=\"en-US\">What color is it?</XMLLANG0>haha </XMLLANG1>hihihi</XMLLANG2>");
             tw.WriteLine("<DONEXMLLANG />");
             tw.WriteLine("</PGROUP>");
-            tw.Flush();
+
             FilePathUtil.addStream(strFileName, s);
         }
 
         public static void CreateXmlSpaceTestFile(string strFileName)
         {
-            Stream s = new MemoryStream();
-            TextWriter tw = new StreamWriter(s);
+            var s = new MemoryStream();
+            using var tw = new StreamWriter(s, encoding:null, bufferSize:-1, leaveOpen:true);
 
             tw.WriteLine("<PGROUP>");
             tw.WriteLine("<PERSONA>DROMIO OF EPHESUS</PERSONA>");
@@ -622,18 +622,18 @@ namespace System.Xml.Tests
             tw.WriteLine("<XMLSPACE2A xml:space=\'default\'>&lt; <XMLSPACE3 xml:space=\'preserve\'>  &lt; &gt; <XMLSPACE4 xml:space=\'default\'>  &lt; &gt;  </XMLSPACE4> test </XMLSPACE3> &gt;</XMLSPACE2A>");
             tw.WriteLine("<GRPDESCR>twin brothers, and attendants on the two Antipholuses.</GRPDESCR>");
             tw.WriteLine("</PGROUP>");
-            tw.Flush();
+
             FilePathUtil.addStream(strFileName, s);
         }
 
         public static void CreateJunkTestFile(string strFileName)
         {
-            Stream s = new MemoryStream();
-            TextWriter tw = new StreamWriter(s);
+            var s = new MemoryStream();
+            using var tw = new StreamWriter(s, encoding:null, bufferSize:-1, leaveOpen:true);
 
             string str = new string('Z', (1 << 20) - 1);
             tw.Write(str);
-            tw.Flush();
+
             FilePathUtil.addStream(strFileName, s);
         }
 
@@ -661,8 +661,10 @@ namespace System.Xml.Tests
             {
                 WriteToBuffer(ref WTextOnly, ref WTextOnlylen, System.BitConverter.GetBytes(strBase64[i]));
             }
-            MemoryStream mems = new MemoryStream();
-            XmlWriter w = XmlWriter.Create(mems, null);
+
+            var mems = new MemoryStream();
+            using var w = XmlWriter.Create(mems, new XmlWriterSettings { CloseOutput = false });
+
             w.WriteStartDocument();
             w.WriteStartElement("Root");
             w.WriteStartElement("ElemAll");
@@ -697,7 +699,7 @@ namespace System.Xml.Tests
             w.WriteRaw("D2BAa<MIX></MIX>AQID");
             w.WriteEndElement();
             w.WriteEndElement();
-            w.Flush();
+
             FilePathUtil.addStream(strFileName, mems);
         }
 
@@ -725,14 +727,14 @@ namespace System.Xml.Tests
             {
                 WriteToBuffer(ref WTextOnly, ref WTextOnlylen, System.BitConverter.GetBytes(strBinHex[i]));
             }
-            MemoryStream mems = new MemoryStream();
 
-            XmlWriter w = XmlWriter.Create(mems);
+            var mems = new MemoryStream();
+            using var w = XmlWriter.Create(mems, new XmlWriterSettings { CloseOutput = false });
+
             w.WriteStartElement("Root");
             w.WriteStartElement("ElemAll");
             w.WriteBinHex(Wbinhex, 0, (int)Wbinhexlen);
             w.WriteEndElement();
-            w.Flush();
 
             w.WriteStartElement("ElemEmpty");
             w.WriteString(string.Empty);
@@ -759,68 +761,67 @@ namespace System.Xml.Tests
             w.WriteElementString("ElemErr", "a&A2A3");
 
             w.WriteEndElement();
-            w.Flush();
+
             FilePathUtil.addStream(strFileName, mems);
         }
 
         public static void CreateBigElementTestFile(string strFileName)
         {
-            Stream s = new MemoryStream();
-            TextWriter tw = new StreamWriter(s);
+            var s = new MemoryStream();
+            using var tw = new StreamWriter(s, encoding:null, bufferSize:-1, leaveOpen:true);
 
             string str = new string('Z', (1 << 20) - 1);
             tw.WriteLine("<Root>");
             tw.Write("<");
             tw.Write(str);
             tw.WriteLine("X />");
-            tw.Flush();
 
             tw.Write("<");
             tw.Write(str);
             tw.WriteLine("Y />");
             tw.WriteLine("</Root>");
 
-            tw.Flush();
             FilePathUtil.addStream(strFileName, s);
         }
         public static void CreateXSLTStyleSheetWCopyTestFile(string strFileName)
         {
-            Stream s = new MemoryStream();
-            TextWriter tw = new StreamWriter(s);
+            var s = new MemoryStream();
+            using var tw = new StreamWriter(s, encoding:null, bufferSize:-1, leaveOpen:true);
+
             tw.WriteLine("<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">");
             tw.WriteLine("<xsl:template match=\"/\">");
             tw.WriteLine("<xsl:copy-of select=\"/\" />");
             tw.WriteLine("</xsl:template>");
             tw.WriteLine("</xsl:stylesheet>");
-            tw.Flush();
+
             FilePathUtil.addStream(strFileName, s);
         }
 
         public static void CreateConstructorTestFile(string strFileName)
         {
-            Stream s = new MemoryStream();
-            TextWriter tw = new StreamWriter(s);
+            var s = new MemoryStream();
+            using var tw = new StreamWriter(s, encoding:null, bufferSize:-1, leaveOpen:true);
 
             tw.WriteLine("<?xml version=\"1.0\"?>");
             tw.WriteLine("<ROOT>");
             tw.WriteLine("<ATTRIBUTE3 a1='a1value' a2='a2value' a3='a3value' />");
             tw.Write("</ROOT>");
-            tw.Flush();
+
             FilePathUtil.addStream(strFileName, s);
         }
 
         public static void CreateLineNumberTestFile(string strFileName)
         {
-            Stream s = new MemoryStream();
-            TextWriter tw = new StreamWriter(s);
+            var s = new MemoryStream();
+            using var tw = new StreamWriter(s, encoding:null, bufferSize:-1, leaveOpen:true);
 
             FilePathUtil.addStream(strFileName, s);
         }
 
         public static void CreateLbNormalizationTestFile(string strFileName)
         {
-            Stream s = new MemoryStream();
-            TextWriter tw = new StreamWriter(s);
+            var s = new MemoryStream();
+            using var tw = new StreamWriter(s, encoding:null, bufferSize:-1, leaveOpen:true);
 
             FilePathUtil.addStream(strFileName, s);
         }


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/65235 ... hopefully.

The XML tests are very old, and thus messy. Making significant changes is a non goal and I'm not certain what caused this failure.

In separated commit order

* fixed cases where a MemoryStream would get disposed at an arbitrary point by a wrapping StreamWriter, causing ODE. Instead, deterministically dispose the wrapper, without closing the inner stream. Remove redundant flushes. I don't believe this is the cause of the test failure.
* cleaned up the elaborate static cache of MemoryStreams, since it was locking around accessing the cache, but generally handing out the same streams to all comers. Potentially could have caused the test failure seen, if two threads are meddling with the offset of the stream, and copying is happening during: the copy could end up with nulls. The complexity of these tests is such that I can't reason whether this could happen. Instead, always clone to a new stream before handing it out.
* fixed the test exception to not crash in some failure cases, especially as it happens on a threadpool thread
* fixed a test to test what it claims to test per its comment
* fixed a case where a test expected to receive the same stream from the cache that it inserted - broken by the 2nd change