### PR TITLE
crossgen2: Report CORINFO_FLG_NOGCCHECK back for internal calls

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1118,10 +1118,10 @@ namespace Internal.JitInterface
                 result |= CorInfoFlag.CORINFO_FLG_INTRINSIC;
             }
 
-            // Internal calls (usually?) turn into fcalls that are not GC
-            // interruptible or hijackable. Be conservative here and always let
-            // JIT know that this method may not do GC checks so it should make
-            // sure to generate code that is GC aware.
+            // Internal calls typically turn into fcalls that do not always
+            // probe for GC. Be conservative here and always let JIT know that
+            // this method may not do GC checks so the JIT might need to make
+            // callers fully interruptible.
             if (method.IsInternalCall)
             {
                 result |= CorInfoFlag.CORINFO_FLG_NOGCCHECK;

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1118,6 +1118,15 @@ namespace Internal.JitInterface
                 result |= CorInfoFlag.CORINFO_FLG_INTRINSIC;
             }
 
+            // Internal calls (usually?) turn into fcalls that are not GC
+            // interruptible or hijackable. Be conservative here and always let
+            // JIT know that this method may not do GC checks so it should make
+            // sure to generate code that is GC aware.
+            if (method.IsInternalCall)
+            {
+                result |= CorInfoFlag.CORINFO_FLG_NOGCCHECK;
+            }
+
             return (uint)result;
         }
 


### PR DESCRIPTION
When there are loops or tailcalls in a function the JIT will check for
a dominating call that is a GC safepoint to figure out if the function
needs to be marked fully interruptible or not. Methods with the
InternalCall flag may turn into fcalls that are not hijackable and thus
not GC safepoints, so in this case JIT should still mark the function
fully interruptible, but was not doing so because crossgen2 was not
reporting this flag back.

Fix #64980