### PR TITLE
add test for lazy file system entries properties evaluation

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/SymbolicLinksTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/SymbolicLinksTests.cs
@@ -138,5 +138,12 @@ namespace System.IO.Tests.Enumeration
                 Assert.Throws<IOException>(() => Directory.GetFiles(testDirectory.FullName, "*", options).Count());
             }
         }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]
+        public void PropertiesArePopulatedLazily()
+        {
+            Assert.True(Directory.EnumerateFileSystemEntries("/dev/fd").Count() >= 0);
+        }
     }
 }


### PR DESCRIPTION
The bug reported in #65254 has been fixed by @tmds in #60214. Let's just add a test that ensures that it's not coming back