### PR TITLE
JIT: Consider local var reads to be outstanding only if they are values

### DIFF
--- a/src/coreclr/jit/lir.cpp
+++ b/src/coreclr/jit/lir.cpp
@@ -1359,7 +1359,7 @@ public:
             }
 
             AliasSet::NodeInfo nodeInfo(compiler, node);
-            if (nodeInfo.IsLclVarRead() && !unusedDefs.Contains(node))
+            if (nodeInfo.IsLclVarRead() && node->IsValue() && !unusedDefs.Contains(node))
             {
                 jitstd::list<GenTree*>* reads;
                 if (!unusedLclVarReads.TryGetValue(nodeInfo.LclNum(), &reads))

--- a/src/coreclr/jit/lir.cpp
+++ b/src/coreclr/jit/lir.cpp
@@ -1387,9 +1387,8 @@ public:
                         unsigned writeEnd   = writeStart + genTypeSize(node->TypeGet());
                         if ((readEnd > writeStart) && (writeEnd > readStart))
                         {
-                            JITDUMP(
-                                "Write to local overlaps outstanding read (write: %u..%u, read: %u..%u)\n",
-                                writeStart, writeEnd, readStart, readEnd);
+                            JITDUMP("Write to local overlaps outstanding read (write: %u..%u, read: %u..%u)\n",
+                                    writeStart, writeEnd, readStart, readEnd);
 
                             LIR::Use use;
                             bool     found = const_cast<LIR::Range*>(range)->TryGetUse(read, &use);

--- a/src/coreclr/jit/lir.cpp
+++ b/src/coreclr/jit/lir.cpp
@@ -1388,7 +1388,7 @@ public:
                         if ((readEnd > writeStart) && (writeEnd > readStart))
                         {
                             JITDUMP(
-                                "Write to unaliased local overlaps outstanding read (write: %u..%u, read: %u..%u)\n",
+                                "Write to local overlaps outstanding read (write: %u..%u, read: %u..%u)\n",
                                 writeStart, writeEnd, readStart, readEnd);
 
                             LIR::Use use;


### PR DESCRIPTION
For unused indirs off of local variables we produce GT_NULLCHECK nodes
on arm64. The "CheckLclVarSemanticsHelper" class considers indirs off of
local vars to be local var reads and record these as outstanding in this
debug check, expecting to see a later use. However GT_NULLCHECK is not a
value so we never find such a use.

It is not clear that it is correct to consider an indir off of a local
var to be an outstanding read in general, but it seems that we currently
do not see cases that trip this check, so leaving it in for now.

Fix #65307