### PR TITLE
Explicitly check for TTL expiration when using Ping utility

### DIFF
--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
@@ -90,16 +90,30 @@ namespace System.Net.NetworkInformation
                     return CreatePingReply(IPStatus.TimedOut);
                 }
 
-                if ((p.ExitCode == 1 || p.ExitCode == 2) &&
-                    options?.Ttl == null) // we can't distinguish between not reached and TTL expired without checking stdout
-                {
-                    // Throw timeout for known failure return codes from ping functions.
-                    return CreatePingReply(IPStatus.TimedOut);
-                }
-
                 try
                 {
-                    string output = await p.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
+                    string? output = null;
+                    // Throw timeout for known failure return codes from ping functions.
+                    if (p.ExitCode == 1 || p.ExitCode == 2)
+                    {
+                        if (options?.Ttl != null)
+                        {
+                            // TTL exceeded may have occured
+                            output = await p.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
+                            if (output.Contains("Time to live exceeded", StringComparison.Ordinal))
+                            {
+                                // look for address in "From 172.21.64.1 icmp_seq=1 Time to live exceeded"
+                                int addressStart = output.IndexOf("From ", StringComparison.Ordinal) + 5;
+                                int addressLength = output.IndexOf(' ', addressStart) - addressStart;
+                                address = IPAddress.Parse(output.AsSpan(addressStart, addressLength));
+                                return CreatePingReply(IPStatus.TimeExceeded, address);
+                            }
+                        }
+
+                        return CreatePingReply(IPStatus.TimedOut);
+                    }
+
+                    output ??= await p.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
                     return ParsePingUtilityOutput(address, output);
                 }
                 catch (Exception)
@@ -112,26 +126,12 @@ namespace System.Net.NetworkInformation
 
         private PingReply ParsePingUtilityOutput(IPAddress address, string output)
         {
-            long rtt = 0;
-            IPStatus status;
-            if (output.Contains("Time to live exceeded", StringComparison.Ordinal))
-            {
-                // look for address in "From 172.21.64.1 icmp_seq=1 Time to live exceeded"
-                int addressStart = output.IndexOf("From ", StringComparison.Ordinal) + 5;
-                int addressLength = output.IndexOf(' ', addressStart) - addressStart;
-                address = IPAddress.Parse(output.AsSpan(addressStart, addressLength));
-                status = IPStatus.TimeExceeded;
-            }
-            else // expect success
-            {
-                rtt = UnixCommandLinePing.ParseRoundTripTime(output);
-                status = IPStatus.Success;
-            }
+            long rtt = UnixCommandLinePing.ParseRoundTripTime(output);
 
             return new PingReply(
                 address,
                 null, // Ping utility cannot accommodate these, return null to indicate they were ignored.
-                status,
+                IPStatus.Success,
                 rtt,
                 Array.Empty<byte>()); // Ping utility doesn't deliver this info.
         }

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
@@ -340,7 +340,7 @@ namespace System.Net.NetworkInformation
             }
         }
 
-        private static PingReply CreatePingReply(IPStatus status, IPAddress? address = null, int rtt = 0)
+        private static PingReply CreatePingReply(IPStatus status, IPAddress? address = null, long rtt = 0)
         {
             // Documentation indicates that you should only pay attention to the IPStatus value when
             // its value is not "Success", but the rest of these values match that of the Windows implementation.

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
@@ -32,10 +32,10 @@ namespace System.Net.NetworkInformation
             bool sendIpHeader = ipv4 && options != null && SendIpHeader;
             int totalLength = 0;
 
-             if (sendIpHeader)
-             {
+            if (sendIpHeader)
+            {
                 iph.VersionAndLength = 0x45;
-                totalLength = sizeof(IpHeader) + checked(sizeof(IcmpHeader) +  buffer.Length);
+                totalLength = sizeof(IpHeader) + checked(sizeof(IcmpHeader) + buffer.Length);
                 // On OSX this strangely must be host byte order.
                 iph.TotalLength = OperatingSystem.IsFreeBSD() ? (ushort)IPAddress.HostToNetworkOrder((short)totalLength) : (ushort)totalLength;
                 iph.Protocol = 1; // ICMP
@@ -46,7 +46,7 @@ namespace System.Net.NetworkInformation
 #pragma warning restore 618
                 // No need to fill in SourceAddress or checksum.
                 // If left blank, kernel will fill it in - at least on OSX.
-             }
+            }
 
             return new SocketConfig(
                 new IPEndPoint(address, 0), timeout, options,
@@ -340,11 +340,11 @@ namespace System.Net.NetworkInformation
             }
         }
 
-        private static PingReply CreatePingReply(IPStatus status)
+        private static PingReply CreatePingReply(IPStatus status, IPAddress? address = null, int rtt = 0)
         {
             // Documentation indicates that you should only pay attention to the IPStatus value when
             // its value is not "Success", but the rest of these values match that of the Windows implementation.
-            return new PingReply(new IPAddress(0), null, status, 0, Array.Empty<byte>());
+            return new PingReply(address ?? new IPAddress(0), null, status, rtt, Array.Empty<byte>());
         }
 
 #if DEBUG


### PR DESCRIPTION
Fixes issue #65065

For some reason, TTL expiration went through the same path as timout expiration. This PR adds code which explicitly checks if TTL occured.
