### PR TITLE
Don't binplace Microsoft.XmlSerializer.Generator

### DIFF
--- a/src/libraries/Microsoft.XmlSerializer.Generator/src/Microsoft.XmlSerializer.Generator.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/src/Microsoft.XmlSerializer.Generator.csproj
@@ -13,6 +13,8 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=858594</PackageProjectUrl>
     <PackageDescription>Creates an Xml serialization assembly for types contained in an assembly in order to improve the startup performance of Xml serialization when serializing or de-serializing objects of those types using XmlSerializer.</PackageDescription>
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
+    <!-- this assembly doesn't need to be binplaced -->
+    <EnableBinPlacing>false</EnableBinPlacing>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
It's not needed and avoids accidentally including this assembly in places where we don't want it.

/cc @ViktorHofer 