### PR TITLE
Convert non-blittable delegate usage in System.DirectoryServices to function pointers.

### DIFF
--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DirectoryServer.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DirectoryServer.cs
@@ -293,15 +293,14 @@ namespace System.DirectoryServices.ActiveDirectory
 
         internal DirectoryContext Context => context;
 
-        internal void CheckConsistencyHelper(IntPtr dsHandle, SafeLibraryHandle libHandle)
+        internal unsafe void CheckConsistencyHelper(IntPtr dsHandle, SafeLibraryHandle libHandle)
         {
             // call DsReplicaConsistencyCheck
-            IntPtr functionPtr = global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaConsistencyCheck");
-            if (functionPtr == (IntPtr)0)
+            var replicaConsistencyCheck = (delegate* unmanaged<IntPtr, int, int, int>)global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaConsistencyCheck");
+            if (replicaConsistencyCheck == null)
             {
                 throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
             }
-            UnsafeNativeMethods.DsReplicaConsistencyCheck replicaConsistencyCheck = (UnsafeNativeMethods.DsReplicaConsistencyCheck)Marshal.GetDelegateForFunctionPointer(functionPtr, typeof(UnsafeNativeMethods.DsReplicaConsistencyCheck));
 
             int result = replicaConsistencyCheck(dsHandle, 0, 0);
 
@@ -309,47 +308,52 @@ namespace System.DirectoryServices.ActiveDirectory
                 throw ExceptionHelper.GetExceptionFromErrorCode(result, Name);
         }
 
-        internal IntPtr GetReplicationInfoHelper(IntPtr dsHandle, int type, int secondaryType, string? partition, ref bool advanced, int context, SafeLibraryHandle libHandle)
+        internal unsafe IntPtr GetReplicationInfoHelper(IntPtr dsHandle, int type, int secondaryType, string? partition, ref bool advanced, int context, SafeLibraryHandle libHandle)
         {
             IntPtr info = (IntPtr)0;
             int result = 0;
             bool needToTryAgain = true;
-            IntPtr functionPtr;
 
             // first try to use the DsReplicaGetInfo2W API which does not exist on win2k machine
             // call DsReplicaGetInfo2W
-            functionPtr = global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaGetInfo2W");
-            if (functionPtr == (IntPtr)0)
+            var dsReplicaGetInfo2W = (delegate* unmanaged<IntPtr, int, char*, IntPtr, char*, char*, int, int, IntPtr*, int>)global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaGetInfo2W");
+            if (dsReplicaGetInfo2W == null)
             {
                 // a win2k machine which does not have it.
-                functionPtr = global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaGetInfoW");
-                if (functionPtr == (IntPtr)0)
+                var dsReplicaGetInfoW = (delegate* unmanaged<IntPtr, int, char*, IntPtr, IntPtr*, int>)global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaGetInfoW");
+                if (dsReplicaGetInfoW == null)
                 {
                     throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
                 }
-                UnsafeNativeMethods.DsReplicaGetInfoW dsReplicaGetInfoW = (UnsafeNativeMethods.DsReplicaGetInfoW)Marshal.GetDelegateForFunctionPointer(functionPtr, typeof(UnsafeNativeMethods.DsReplicaGetInfoW));
-                result = dsReplicaGetInfoW(dsHandle, secondaryType, partition, (IntPtr)0, ref info);
+                fixed (char* partitionPtr = partition)
+                {
+                    result = dsReplicaGetInfoW(dsHandle, secondaryType, partitionPtr, (IntPtr)0, &info);
+                }
                 advanced = false;
                 needToTryAgain = false;
             }
             else
             {
-                UnsafeNativeMethods.DsReplicaGetInfo2W dsReplicaGetInfo2W = (UnsafeNativeMethods.DsReplicaGetInfo2W)Marshal.GetDelegateForFunctionPointer(functionPtr, typeof(UnsafeNativeMethods.DsReplicaGetInfo2W));
-                result = dsReplicaGetInfo2W(dsHandle, type, partition, (IntPtr)0, null, null, 0, context, ref info);
+                fixed (char* partitionPtr = partition)
+                {
+                    result = dsReplicaGetInfo2W(dsHandle, type, partitionPtr, (IntPtr)0, null, null, 0, context, &info);
+                }
             }
 
             // check the result
             if (needToTryAgain && result == DS_REPL_NOTSUPPORTED)
             {
                 // this is the case that client is xp/win2k3, dc is win2k
-                functionPtr = global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaGetInfoW");
-                if (functionPtr == (IntPtr)0)
+                var dsReplicaGetInfoW = (delegate* unmanaged<IntPtr, int, char*, IntPtr, IntPtr*, int>)global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaGetInfoW");
+                if (dsReplicaGetInfoW == null)
                 {
                     throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
                 }
-                UnsafeNativeMethods.DsReplicaGetInfoW dsReplicaGetInfoW = (UnsafeNativeMethods.DsReplicaGetInfoW)Marshal.GetDelegateForFunctionPointer(functionPtr, typeof(UnsafeNativeMethods.DsReplicaGetInfoW));
 
-                result = dsReplicaGetInfoW(dsHandle, secondaryType, partition, (IntPtr)0, ref info);
+                fixed (char* partitionPtr = partition)
+                {
+                    result = dsReplicaGetInfoW(dsHandle, secondaryType, partitionPtr, (IntPtr)0, &info);
+                }
                 advanced = false;
             }
 
@@ -634,7 +638,7 @@ namespace System.DirectoryServices.ActiveDirectory
             }
         }
 
-        internal void SyncReplicaAllHelper(IntPtr handle, SyncReplicaFromAllServersCallback syncAllFunctionPointer, string partition, SyncFromAllServersOptions option, SyncUpdateCallback? callback, SafeLibraryHandle libHandle)
+        internal unsafe void SyncReplicaAllHelper(IntPtr handle, SyncReplicaFromAllServersCallback syncAllCallback, string partition, SyncFromAllServersOptions option, SyncUpdateCallback? callback, SafeLibraryHandle libHandle)
         {
             IntPtr errorInfo = (IntPtr)0;
 
@@ -643,14 +647,19 @@ namespace System.DirectoryServices.ActiveDirectory
 
             // we want to return the dn instead of DNS guid
             // call DsReplicaSyncAllW
-            IntPtr functionPtr = global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaSyncAllW");
-            if (functionPtr == (IntPtr)0)
+            var dsReplicaSyncAllW = (delegate* unmanaged<IntPtr, char*, int, IntPtr, IntPtr, IntPtr*, int>)global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaSyncAllW");
+            if (dsReplicaSyncAllW == null)
             {
                 throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
             }
-            UnsafeNativeMethods.DsReplicaSyncAllW dsReplicaSyncAllW = (UnsafeNativeMethods.DsReplicaSyncAllW)Marshal.GetDelegateForFunctionPointer(functionPtr, typeof(UnsafeNativeMethods.DsReplicaSyncAllW));
 
-            int result = dsReplicaSyncAllW(handle, partition, (int)option | DS_REPSYNCALL_ID_SERVERS_BY_DN, syncAllFunctionPointer, (IntPtr)0, ref errorInfo);
+            int result;
+            fixed (char* partitionPtr = partition)
+            {
+                IntPtr syncAllFunctionPointer = Marshal.GetFunctionPointerForDelegate(syncAllCallback);
+                result = dsReplicaSyncAllW(handle, partitionPtr, (int)option | DS_REPSYNCALL_ID_SERVERS_BY_DN, syncAllFunctionPointer, (IntPtr)0, &errorInfo);
+                GC.KeepAlive(syncAllCallback);
+            }
 
             try
             {
@@ -678,23 +687,21 @@ namespace System.DirectoryServices.ActiveDirectory
             }
         }
 
-        private void FreeReplicaInfo(DS_REPL_INFO_TYPE type, IntPtr value, SafeLibraryHandle libHandle)
+        private unsafe void FreeReplicaInfo(DS_REPL_INFO_TYPE type, IntPtr value, SafeLibraryHandle libHandle)
         {
             if (value != (IntPtr)0)
             {
                 // call DsReplicaFreeInfo
-                IntPtr functionPtr = global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaFreeInfo");
-                if (functionPtr == (IntPtr)0)
+                var dsReplicaFreeInfo = (delegate* unmanaged<int, IntPtr, int>)global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaFreeInfo");
+                if (dsReplicaFreeInfo == null)
                 {
                     throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
                 }
-                UnsafeNativeMethods.DsReplicaFreeInfo dsReplicaFreeInfo = (UnsafeNativeMethods.DsReplicaFreeInfo)Marshal.GetDelegateForFunctionPointer(functionPtr, typeof(UnsafeNativeMethods.DsReplicaFreeInfo));
-
                 dsReplicaFreeInfo((int)type, value);
             }
         }
 
-        internal void SyncReplicaHelper(IntPtr dsHandle, bool isADAM, string partition, string? sourceServer, int option, SafeLibraryHandle libHandle)
+        internal unsafe void SyncReplicaHelper(IntPtr dsHandle, bool isADAM, string partition, string? sourceServer, int option, SafeLibraryHandle libHandle)
         {
             int structSize = Marshal.SizeOf(typeof(Guid));
             IntPtr unmanagedGuid = (IntPtr)0;
@@ -723,30 +730,32 @@ namespace System.DirectoryServices.ActiveDirectory
                 }
 
                 // call DsReplicaSyncW
-                IntPtr functionPtr = global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaSyncW");
-                if (functionPtr == (IntPtr)0)
+                var dsReplicaSyncW = (delegate* unmanaged<IntPtr, char*, IntPtr, int, int>)global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaSyncW");
+                if (dsReplicaSyncW == null)
                 {
                     throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
                 }
-                UnsafeNativeMethods.DsReplicaSyncW dsReplicaSyncW = (UnsafeNativeMethods.DsReplicaSyncW)Marshal.GetDelegateForFunctionPointer(functionPtr, typeof(UnsafeNativeMethods.DsReplicaSyncW));
 
-                int result = dsReplicaSyncW(dsHandle, partition, unmanagedGuid, (int)option);
-
-                // check the result
-                if (result != 0)
+                fixed (char* partitionPtr = partition)
                 {
-                    if (!Partitions.Contains(partition))
-                        throw new ArgumentException(SR.ServerNotAReplica, nameof(partition));
+                    int result = dsReplicaSyncW(dsHandle, partitionPtr, unmanagedGuid, (int)option);
 
-                    string? serverDownName = null;
-                    // this is the error returned when the server that we want to sync from is down
-                    if (result == ExceptionHelper.RPC_S_SERVER_UNAVAILABLE)
-                        serverDownName = sourceServer;
-                    // this is the error returned when the server that we want to get synced is down
-                    else if (result == ExceptionHelper.RPC_S_CALL_FAILED)
-                        serverDownName = Name;
+                    // check the result
+                    if (result != 0)
+                    {
+                        if (!Partitions.Contains(partition))
+                            throw new ArgumentException(SR.ServerNotAReplica, nameof(partition));
 
-                    throw ExceptionHelper.GetExceptionFromErrorCode(result, serverDownName);
+                        string? serverDownName = null;
+                        // this is the error returned when the server that we want to sync from is down
+                        if (result == ExceptionHelper.RPC_S_SERVER_UNAVAILABLE)
+                            serverDownName = sourceServer;
+                        // this is the error returned when the server that we want to get synced is down
+                        else if (result == ExceptionHelper.RPC_S_CALL_FAILED)
+                            serverDownName = Name;
+
+                        throw ExceptionHelper.GetExceptionFromErrorCode(result, serverDownName);
+                    }
                 }
             }
             finally

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Forest.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Forest.cs
@@ -869,7 +869,7 @@ namespace System.DirectoryServices.ActiveDirectory
             return new DomainController(dcContext, dcName);
         }
 
-        private ArrayList GetSites()
+        private unsafe ArrayList GetSites()
         {
             ArrayList sites = new ArrayList();
             int result = 0;
@@ -884,14 +884,17 @@ namespace System.DirectoryServices.ActiveDirectory
 
                 // Get the sites within the forest
                 // call DsListSites
-                IntPtr functionPtr = global::Interop.Kernel32.GetProcAddress(DirectoryContext.ADHandle, "DsListSitesW");
-                if (functionPtr == (IntPtr)0)
+                /*DWORD DsListSites(
+                    HANDLE hDs,
+                    PDS_NAME_RESULT* ppSites
+                    );*/
+                var dsListSites = (delegate* unmanaged<IntPtr, IntPtr*, int>)global::Interop.Kernel32.GetProcAddress(DirectoryContext.ADHandle, "DsListSitesW");
+                if (dsListSites == null)
                 {
                     throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
                 }
-                NativeMethods.DsListSites dsListSites = (NativeMethods.DsListSites)Marshal.GetDelegateForFunctionPointer(functionPtr, typeof(NativeMethods.DsListSites));
 
-                result = dsListSites(dsHandle, out sitesPtr);
+                result = dsListSites(dsHandle, &sitesPtr);
                 if (result == 0)
                 {
                     try
@@ -921,12 +924,11 @@ namespace System.DirectoryServices.ActiveDirectory
                         if (sitesPtr != IntPtr.Zero)
                         {
                             // call DsFreeNameResultW
-                            functionPtr = global::Interop.Kernel32.GetProcAddress(DirectoryContext.ADHandle, "DsFreeNameResultW");
-                            if (functionPtr == (IntPtr)0)
+                            var dsFreeNameResultW = (delegate* unmanaged<IntPtr, void>)global::Interop.Kernel32.GetProcAddress(DirectoryContext.ADHandle, "DsFreeNameResultW");
+                            if (dsFreeNameResultW == null)
                             {
                                 throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
                             }
-                            UnsafeNativeMethods.DsFreeNameResultW dsFreeNameResultW = (UnsafeNativeMethods.DsFreeNameResultW)Marshal.GetDelegateForFunctionPointer(functionPtr, typeof(UnsafeNativeMethods.DsFreeNameResultW));
                             dsFreeNameResultW(sitesPtr);
                         }
                     }

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/NativeMethods.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/NativeMethods.cs
@@ -364,87 +364,10 @@ namespace System.DirectoryServices.ActiveDirectory
         internal static partial int NetApiBufferFree(
             IntPtr buffer);
 
-        /*DWORD DsMakePasswordCredentials(
-            LPTSTR User,
-            LPTSTR Domain,
-            LPTSTR Password,
-            RPC_AUTH_IDENTITY_HANDLE* pAuthIdentity
-            );*/
-
-        internal delegate int DsMakePasswordCredentials(
-      [MarshalAs(UnmanagedType.LPWStr)] string? user,
-      [MarshalAs(UnmanagedType.LPWStr)] string? domain,
-      [MarshalAs(UnmanagedType.LPWStr)] string? password,
-      [Out] out IntPtr authIdentity);
-
-        /*VOID DsFreePasswordCredentials(
-            RPC_AUTH_IDENTITY_HANDLE AuthIdentity
-            );*/
-        internal delegate void DsFreePasswordCredentials(
-            [In] IntPtr authIdentity);
-
-        /*DWORD DsBindWithCred(
-            TCHAR* DomainController,
-            TCHAR* DnsDomainName,
-            RPC_AUTH_IDENTITY_HANDLE AuthIdentity,
-            HANDLE* phDS
-            );*/
-        internal delegate int DsBindWithCred(
-            [MarshalAs(UnmanagedType.LPWStr)] string? domainController,
-            [MarshalAs(UnmanagedType.LPWStr)] string? dnsDomainName,
-            [In] IntPtr authIdentity,
-            [Out] out IntPtr handle);
-
-        /*DWORD DsUnBind(
-            HANDLE* phDS
-            );*/
-        internal delegate int DsUnBind(
-            [In] ref IntPtr handle);
-
-        /*DWORD DsGetDomainControllerInfo(
-            HANDLE hDs,
-            LPTSTR DomainName,
-            DWORD InfoLevel,
-            DWORD* pcOut,
-            VOID** ppInfo
-            );*/
-        internal delegate int DsGetDomainControllerInfo(
-            [In] IntPtr handle,
-            [MarshalAs(UnmanagedType.LPWStr)] string domainName,
-            [In] int infoLevel,
-            [Out] out int dcCount,
-            [Out] out IntPtr dcInfo);
-
         internal const int DsDomainControllerInfoLevel2 = 2;
         internal const int DsDomainControllerInfoLevel3 = 3;
 
-        /*VOID DsFreeDomainControllerInfo(
-            DWORD InfoLevel,
-            DWORD cInfo,
-            VOID* pInfo
-            );*/
-        internal delegate void DsFreeDomainControllerInfo(
-            [In] int infoLevel,
-            [In] int dcInfoListCount,
-            [In] IntPtr dcInfoList);
-
         internal const int DsNameNoError = 0;
-
-        /*DWORD DsListSites(
-            HANDLE hDs,
-            PDS_NAME_RESULT* ppSites
-            );*/
-        internal delegate int DsListSites(
-            [In] IntPtr dsHandle,
-            [Out] out IntPtr sites);
-
-        /*DWORD DsListRoles(
-            HANDLE hDs,
-            PDS_NAME_RESULTW* ppRoles
-            );*/
-        internal delegate int DsListRoles(
-            [In] IntPtr dsHandle,
-            [Out] out IntPtr roles);
 
         internal const int DnsSrvData = 33;
         internal const int DnsQueryBypassCache = 8;
@@ -474,24 +397,6 @@ namespace System.DirectoryServices.ActiveDirectory
         internal static partial void DnsRecordListFree(
             IntPtr dnsResultList,
             bool dnsFreeType);
-
-        /*DWORD DsCrackNames(
-            HANDLE hDS,
-            DS_NAME_FLAGS flags,
-            DS_NAME_FORMAT formatOffered,
-            DS_NAME_FORMAT formatDesired,
-            DWORD cNames,
-            LPTSTR* rpNames,
-            PDS_NAME_RESULT* ppResult
-            );*/
-        internal delegate int DsCrackNames(
-            [In] IntPtr hDS,
-            [In] int flags,
-            [In] int formatOffered,
-            [In] int formatDesired,
-            [In] int nameCount,
-            [In] IntPtr names,
-            [Out] out IntPtr results);
 
         /*NTSTATUS LsaConnectUntrusted(
               PHANDLE LsaHandle

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/UnsafeNativeMethods.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/UnsafeNativeMethods.cs
@@ -574,18 +574,6 @@ namespace System.DirectoryServices.ActiveDirectory
 
     internal static partial class UnsafeNativeMethods
     {
-        public delegate int DsReplicaConsistencyCheck([In]IntPtr handle, int taskID, int flags);
-
-        public delegate int DsReplicaGetInfo2W(IntPtr handle, int type, [MarshalAs(UnmanagedType.LPWStr)] string? objectPath, IntPtr sourceGUID, string? attributeName, string? value, int flag, int context, ref IntPtr info);
-
-        public delegate int DsReplicaGetInfoW(IntPtr handle, int type, [MarshalAs(UnmanagedType.LPWStr)] string? objectPath, IntPtr sourceGUID, ref IntPtr info);
-
-        public delegate int DsReplicaFreeInfo(int type, IntPtr value);
-
-        public delegate int DsReplicaSyncW(IntPtr handle, [MarshalAs(UnmanagedType.LPWStr)] string partition, IntPtr uuid, int option);
-
-        public delegate int DsReplicaSyncAllW(IntPtr handle, [MarshalAs(UnmanagedType.LPWStr)] string partition, int flags, SyncReplicaFromAllServersCallback callback, IntPtr data, ref IntPtr error);
-
         [GeneratedDllImport(global::Interop.Libraries.Activeds, EntryPoint = "ADsEncodeBinaryData", CharSet = CharSet.Unicode)]
         public static partial int ADsEncodeBinaryData(byte[] data, int length, ref IntPtr result);
 
@@ -594,10 +582,6 @@ namespace System.DirectoryServices.ActiveDirectory
 
         [GeneratedDllImport(global::Interop.Libraries.Netapi32, EntryPoint = "DsGetSiteNameW", CharSet = CharSet.Unicode)]
         public static partial int DsGetSiteName(string? dcName, ref IntPtr ptr);
-
-        public delegate int DsListDomainsInSiteW(IntPtr handle, [MarshalAs(UnmanagedType.LPWStr)] string site, ref IntPtr info);
-
-        public delegate void DsFreeNameResultW(IntPtr result);
 
         [GeneratedDllImport(global::Interop.Libraries.Netapi32, EntryPoint = "DsEnumerateDomainTrustsW", CharSet = CharSet.Unicode)]
         public static partial int DsEnumerateDomainTrustsW(string serverName, int flags, out IntPtr domains, out int count);


### PR DESCRIPTION
All of the delegates used very simple marshalling and they were all used in one or two places immediately after a GetProcAddress call for them, so it seemed like it was worthwhile to go all the way to function pointers instead of just manually pinning the parameters and still allocating delegates.

Fixes #65259

@danmoseley is there a particular CI pipeline I can trigger to validate that the failing tests are passing now?

cc: @dotnet/interop-contrib 