### PR TITLE
[interp] Use dynamic method's assembly when getting a native wrapper

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -3361,7 +3361,13 @@ mono_interp_get_native_func_wrapper (InterpMethod* imethod, MonoMethodSignature*
 	MonoMethodPInvoke iinfo;
 	memset (&iinfo, 0, sizeof (iinfo));
 
-	MonoMethod* m = mono_marshal_get_native_func_wrapper (m_class_get_image (imethod->method->klass), csignature, &iinfo, mspecs, code);
+	MonoMethod *method = imethod->method;
+	MonoImage *image = NULL;
+	if (imethod->method->dynamic)
+		image = ((MonoDynamicMethod*)method)->assembly->image;
+	else
+		image = m_class_get_image (method->klass);
+	MonoMethod* m = mono_marshal_get_native_func_wrapper (image, csignature, &iinfo, mspecs, code);
 
 	for (int i = csignature->param_count; i >= 0; i--)
 		if (mspecs [i])


### PR DESCRIPTION
The dynamic method `klass` is just System.Object, so its image is always corelib.  As a result, we incorrectly pick up the `DisableRuntimeMarshalling` attribute from CoreLib.

Fixes https://github.com/dotnet/runtime/issues/65304

The corresponding change to the JIT+AOT was done in
https://github.com/dotnet/runtime/pull/64279/commits/ac825ab0678f07bfd6c161e4ea4413af84df9293