### PR TITLE
Resolve System.Net.Security.Tests.LoggingTest SkipTestException failure

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.DotNet.XUnitExtensions;
@@ -25,27 +24,27 @@ namespace System.Net.Security.Tests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "X509 certificate store is not supported on iOS or tvOS.")] // Match SslStream_StreamToStream_Authentication_Success
         public void EventSource_EventsRaisedAsExpected()
         {
-            if (PlatformDetection.IsWindows10Version22000OrGreater)
+            RemoteExecutor.Invoke(async () =>
             {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/58927")]
-                throw new SkipTestException("Unstable on Windows 11");
-            }
-
-            RemoteExecutor.Invoke(() =>
-            {
-                using (var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.Security", EventLevel.Verbose))
+                try
                 {
+                    using var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.Security", EventLevel.Verbose);
                     var events = new ConcurrentQueue<EventWrittenEventArgs>();
-                    listener.RunWithCallback(events.Enqueue, () =>
+                    await listener.RunWithCallbackAsync(events.Enqueue, async () =>
                     {
                         // Invoke tests that'll cause some events to be generated
                         var test = new SslStreamStreamToStreamTest_Async();
-                        test.SslStream_StreamToStream_Authentication_Success().GetAwaiter().GetResult();
+                        await test.SslStream_StreamToStream_Authentication_Success();
                     });
                     Assert.DoesNotContain(events, ev => ev.EventId == 0); // errors from the EventSource itself
                     Assert.InRange(events.Count, 1, int.MaxValue);
+                }
+                catch (SkipTestException)
+                {
+                    // Don't throw inside RemoteExecutor if SslStream_StreamToStream_Authentication_Success chose to skip the test
                 }
             }).Dispose();
         }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -72,7 +72,6 @@ namespace System.Net.Security.Tests
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "X509 certificate store is not supported on iOS or tvOS.")]
         public async Task SslStream_StreamToStream_Authentication_Success(X509Certificate serverCert = null, X509Certificate clientCert = null)
         {
-
             if (PlatformDetection.IsWindows10Version20348OrGreater)
             {
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/58927")]


### PR DESCRIPTION
Fixes #65279

I removed the `SkipTestException` check from the `EventSource` test, letting it delegate to the inner test.

After this and #65105, there is only one other test ([`EventSource_UnsuccessfulHandshake_LogsStartFailureStop`](https://github.com/dotnet/runtime/blob/e4fb7303f7be173f5434d711d42b4bba706d0ad0/src/libraries/System.Net.Security/tests/FunctionalTests/TelemetryTest.cs#L100)) using an existing test inside `RemoteExecutor`. But [that test](https://github.com/dotnet/runtime/blob/e4fb7303f7be173f5434d711d42b4bba706d0ad0/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs#L119) doesn't seem like it would ever become flaky / disabled on any OS.