### PR TITLE
Remove Unused Encoding on UriHelper

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriHelper.cs
@@ -4,15 +4,11 @@
 using System.Text;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Buffers;
 
 namespace System
 {
     internal static class UriHelper
     {
-        internal static readonly Encoding s_noFallbackCharUTF8 = Encoding.GetEncoding(
-            Encoding.UTF8.CodePage, new EncoderReplacementFallback(""), new DecoderReplacementFallback(""));
-
         // http://host/Path/Path/File?Query is the base of
         //      - http://host/Path/Path/File/ ...    (those "File" words may be different in semantic but anyway)
         //      - http://host/Path/Path/#Fragment


### PR DESCRIPTION
This field was a left-over artifact from conflicts between the commits:
- https://github.com/dotnet/runtime/commit/70c070e84c617de0700612d03c5886e548195bed
- https://github.com/dotnet/runtime/commit/e53e5430c199c210b7d6f7ce508fb5fabb5faeba

In profiling the startup of a Maui Android app, this initialization is pulling in UTF32 and Latin1 encodings. The profile indicates this accounts for 7ms (roughly 1%). Removing this unnecessary field eliminates 7ms in a Maui App's InitializeComponent.