### PR TITLE
Make sure we have GCGenerationRanges events when using Generation-Aware analysis on Linux

### DIFF
--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -1729,7 +1729,7 @@ void GCToEEInterface::UpdateGCEventStatus(int currentPublicLevel, int currentPub
 
     // WARNING: To change an event's GC level, perfcollect script needs to be updated simultaneously to reflect it.
     BOOL keyword_gc_verbose = EventXplatEnabledGCJoin_V2() || EventPipeEventEnabledGCJoin_V2();
-    BOOL keyword_gc_informational = EventXplatEnabledGCStart() || EventPipeEventEnabledGCStart();
+    BOOL keyword_gc_informational = EventXplatEnabledGCStart() || EventPipeEventEnabledGCStart() || EventXplatEnabledGCGenerationRange() || EventPipeEventEnabledGCGenerationRange();
 
     BOOL keyword_gc_heapsurvival_and_movement_informational = EventXplatEnabledGCGenerationRange() || EventPipeEventEnabledGCGenerationRange();
     BOOL keyword_gchandle_informational = EventXplatEnabledSetGCHandle() || EventPipeEventEnabledSetGCHandle();

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -1729,7 +1729,7 @@ void GCToEEInterface::UpdateGCEventStatus(int currentPublicLevel, int currentPub
 
     // WARNING: To change an event's GC level, perfcollect script needs to be updated simultaneously to reflect it.
     BOOL keyword_gc_verbose = EventXplatEnabledGCJoin_V2() || EventPipeEventEnabledGCJoin_V2();
-    BOOL keyword_gc_informational = EventXplatEnabledGCStart() || EventPipeEventEnabledGCStart() || EventXplatEnabledGCGenerationRange() || EventPipeEventEnabledGCGenerationRange();
+    BOOL keyword_gc_informational = EventXplatEnabledGCStart() || EventPipeEventEnabledGCStart();
 
     BOOL keyword_gc_heapsurvival_and_movement_informational = EventXplatEnabledGCGenerationRange() || EventPipeEventEnabledGCGenerationRange();
     BOOL keyword_gchandle_informational = EventXplatEnabledSetGCHandle() || EventPipeEventEnabledSetGCHandle();
@@ -1738,7 +1738,8 @@ void GCToEEInterface::UpdateGCEventStatus(int currentPublicLevel, int currentPub
     BOOL prv_gcprv_informational = EventXplatEnabledBGCBegin() || EventPipeEventEnabledBGCBegin();
     BOOL prv_gcprv_verbose = EventXplatEnabledPinPlugAtGCTime() || EventPipeEventEnabledPinPlugAtGCTime();
 
-    int publicProviderLevel = keyword_gc_verbose ? GCEventLevel_Verbose : (keyword_gc_informational ? GCEventLevel_Information : GCEventLevel_None);
+    int publicProviderLevel = keyword_gc_verbose ? GCEventLevel_Verbose : 
+                                 ((keyword_gc_informational || keyword_gc_heapsurvival_and_movement_informational) ? GCEventLevel_Information : GCEventLevel_None);
     int publicProviderKeywords = (keyword_gc_informational ? GCEventKeyword_GC : GCEventKeyword_None) |
                                  (keyword_gchandle_informational ? GCEventKeyword_GCHandle : GCEventKeyword_None) |
                                  (keyword_gc_heapsurvival_and_movement_informational ? GCEventKeyword_GCHeapSurvivalAndMovement : GCEventKeyword_None);

--- a/src/coreclr/vm/genanalysis.cpp
+++ b/src/coreclr/vm/genanalysis.cpp
@@ -88,7 +88,7 @@ bool gcGenAnalysisDump = false;
     const uint64_t keyword                          = GCHeapAndTypeNamesKeyword|GCHeapSurvivalAndMovementKeyword|GCHeapDumpKeyword|TypeKeyword;
     pProviders[0].providerName = W("Microsoft-Windows-DotNETRuntime");
     pProviders[0].keywords = keyword;
-    pProviders[0].loggingLevel = (uint32_t)EP_EVENT_LEVEL_VERBOSE;
+    pProviders[0].loggingLevel = (uint32_t)EP_EVENT_LEVEL_INFORMATIONAL;
     pProviders[0].filterData = nullptr;
 
     EventPipeProviderConfigurationAdapter configAdapter(pProviders, providerCnt);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/64390

1. It appears that verbose logging level is not necessary - an experiment on Windows proved that information level produced exactly the same set of events for generation aware analysis, so I changed that.
2. GCGenerationRange events are informational, so if the event is on, we should make sure the level is at least informational.