### PR TITLE
Separate capturing from normal states in NonBacktracking

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DfaMatchingState.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DfaMatchingState.cs
@@ -111,7 +111,7 @@ namespace System.Text.RegularExpressions.Symbolic
             // nextCharKind will be the PrevCharKind of the target state
             // use an existing state instead if one exists already
             // otherwise create a new new id for it
-            return Node._builder.MkState(derivative, nextCharKind);
+            return Node._builder.MkState(derivative, nextCharKind, capturing: false);
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 // nextCharKind will be the PrevCharKind of the target state
                 // use an existing state instead if one exists already
                 // otherwise create a new new id for it
-                yield return (Node._builder.MkState(derivative, nextCharKind), effects);
+                yield return (Node._builder.MkState(derivative, nextCharKind, capturing: true), effects);
             }
         }
 


### PR DESCRIPTION
This should address issue https://github.com/dotnet/runtime/issues/65289 where a long literal string pattern caused an out-of-memory error. The capturing support added in PR https://github.com/dotnet/runtime/pull/65129 effectively doubled memory usage by adding a second capturing-enabled transition array that grew in lockstep with the original one. This PR splits capturing states into a separately indexed set of states, which allows the two transition arrays to grow separately.

Edit: that branch name should say nonbacktracking.