### PR TITLE
Gracefully emit a diagnostic when the GeneratedDllImport attribute didn't parse quite right and we don't have a valid AttributeData object

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
@@ -359,18 +359,34 @@ namespace Microsoft.Interop
                         continue;
                     case nameof(GeneratedDllImportData.CharSet):
                         userDefinedValues |= DllImportMember.CharSet;
+                        if (namedArg.Value.Value is not CharSet)
+                        {
+                            return null;
+                        }
                         charSet = (CharSet)namedArg.Value.Value!;
                         break;
                     case nameof(GeneratedDllImportData.EntryPoint):
                         userDefinedValues |= DllImportMember.EntryPoint;
+                        if (namedArg.Value.Value is not string)
+                        {
+                            return null;
+                        }
                         entryPoint = (string)namedArg.Value.Value!;
                         break;
                     case nameof(GeneratedDllImportData.ExactSpelling):
                         userDefinedValues |= DllImportMember.ExactSpelling;
+                        if (namedArg.Value.Value is not bool)
+                        {
+                            return null;
+                        }
                         exactSpelling = (bool)namedArg.Value.Value!;
                         break;
                     case nameof(GeneratedDllImportData.SetLastError):
                         userDefinedValues |= DllImportMember.SetLastError;
+                        if (namedArg.Value.Value is not bool)
+                        {
+                            return null;
+                        }
                         setLastError = (bool)namedArg.Value.Value!;
                         break;
                 }
@@ -432,7 +448,7 @@ namespace Microsoft.Interop
             if (stubDllImportData is null)
             {
                 generatorDiagnostics.ReportConfigurationNotSupported(generatedDllImportAttr!, "Invalid syntax");
-                stubDllImportData = new GeneratedDllImportData("");
+                stubDllImportData = new GeneratedDllImportData("INVALID_CSHARP_SYNTAX");
             }
 
             if (lcidConversionAttr is not null)

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
@@ -359,10 +359,12 @@ namespace Microsoft.Interop
                         continue;
                     case nameof(GeneratedDllImportData.CharSet):
                         userDefinedValues |= DllImportMember.CharSet;
-                        if (namedArg.Value.Value is not CharSet)
+                        // TypedConstant's Value property only contains primitive values.
+                        if (namedArg.Value.Value is not int)
                         {
                             return null;
                         }
+                        // A boxed primitive can be unboxed to an enum with the same underlying type.
                         charSet = (CharSet)namedArg.Value.Value!;
                         break;
                     case nameof(GeneratedDllImportData.EntryPoint):

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CodeSnippets.cs
@@ -1422,5 +1422,33 @@ partial struct Basic
     public static partial ref readonly {typeName} RefReadonlyReturn();
 }}";
 
+        public static string PartialPropertyName => @"
+using System.Runtime.InteropServices;
+
+partial struct Basic
+{
+    [GeneratedDllImport(""DoesNotExist"", SetLa)]
+    public static partial void Method();
+}
+";
+        public static string InvalidConstantForModuleName => @"
+using System.Runtime.InteropServices;
+
+partial struct Basic
+{
+    [GeneratedDllImport(DoesNotExist)]
+    public static partial void Method();
+}
+";
+        public static string IncorrectAttributeFieldType => @"
+using System.Runtime.InteropServices;
+
+partial struct Basic
+{
+    [GeneratedDllImport(""DoesNotExist"", SetLastError = ""Foo"")]
+    public static partial void Method();
+}
+";
+
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CompileFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CompileFails.cs
@@ -136,6 +136,9 @@ namespace DllImportGenerator.UnitTests
         {
             yield return new object[] { CodeSnippets.RecursiveImplicitlyBlittableStruct, 0, 1 };
             yield return new object[] { CodeSnippets.MutuallyRecursiveImplicitlyBlittableStruct, 0, 2 };
+            yield return new object[] { CodeSnippets.PartialPropertyName, 1, 2 };
+            yield return new object[] { CodeSnippets.InvalidConstantForModuleName, 1, 1 };
+            yield return new object[] { CodeSnippets.IncorrectAttributeFieldType, 1, 1 };
         }
 
         [ConditionalTheory]


### PR DESCRIPTION
I ran into a scenario where this was useful while working on #65343 so I figured I'd put up a WIP PR.

Contributes to #65008