### PR TITLE
Enable build of arm64 RPM packages

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -86,9 +86,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>78eaf78761027d225030be2b28aaf4e8bf392929</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="7.0.0-beta.22110.7">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="7.0.0-beta.22114.8">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>78eaf78761027d225030be2b28aaf4e8bf392929</Sha>
+      <Sha>0ffa6d40b8174b06d44814f2c76539be4cdadff9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="7.0.0-beta.22110.7">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -65,7 +65,7 @@
     <MicrosoftDotNetXUnitExtensionsVersion>7.0.0-beta.22110.7</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.22110.7</MicrosoftDotNetXUnitConsoleRunnerVersion>
     <MicrosoftDotNetBuildTasksArchivesVersion>7.0.0-beta.22110.7</MicrosoftDotNetBuildTasksArchivesVersion>
-    <MicrosoftDotNetBuildTasksInstallersVersion>7.0.0-beta.22110.7</MicrosoftDotNetBuildTasksInstallersVersion>
+    <MicrosoftDotNetBuildTasksInstallersVersion>7.0.0-beta.22114.8</MicrosoftDotNetBuildTasksInstallersVersion>
     <MicrosoftDotNetBuildTasksPackagingVersion>7.0.0-beta.22110.7</MicrosoftDotNetBuildTasksPackagingVersion>
     <MicrosoftDotNetBuildTasksTargetFrameworkVersion>7.0.0-beta.22111.10</MicrosoftDotNetBuildTasksTargetFrameworkVersion>
     <MicrosoftDotNetBuildTasksTemplatingVersion>7.0.0-beta.22110.7</MicrosoftDotNetBuildTasksTemplatingVersion>

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -423,18 +423,20 @@ jobs:
       displayName: Disk Usage after Build
 
   # Only in glibc leg, we produce RPMs and Debs
-  - ${{ if and(eq(parameters.runtimeFlavor, 'coreclr'), eq(parameters.platform, 'Linux_x64'), eq(parameters.osSubgroup, ''), eq(parameters.pgoType, ''))}}:
+  - ${{ if and(eq(parameters.runtimeFlavor, 'coreclr'), or(eq(parameters.platform, 'Linux_x64'), eq(parameters.platform, 'Linux_arm64')), eq(parameters.osSubgroup, ''), eq(parameters.pgoType, ''))}}:
     - ${{ each packageBuild in parameters.packageDistroList }}:
       # This leg's RID matches the build image. Build its distro-dependent packages, as well as
       # the distro-independent installers. (There's no particular reason to build the distro-
       # independent installers on this leg, but we need to do it somewhere.)
-      - template: steps/build-linux-package.yml
-        parameters:
-          packageType: ${{ packageBuild.packageType }}
-          image: ${{ packageBuild.image }}
-          packageStepDescription: Runtime Deps, Runtime, Framework Packs installers
-          subsetArg: $(installersSubsetArg)
-          packagingArgs: ${{ packageBuild.packagingArgs }}
+      # Currently, Linux_arm64 supports 'rpm' type only.
+      - ${{ if or(not(eq(parameters.platform, 'Linux_arm64')), eq(packageBuild.packageType, 'rpm')) }}:
+        - template: steps/build-linux-package.yml
+          parameters:
+            packageType: ${{ packageBuild.packageType }}
+            image: ${{ packageBuild.image }}
+            packageStepDescription: Runtime Deps, Runtime, Framework Packs installers
+            subsetArg: $(installersSubsetArg)
+            packagingArgs: ${{ packageBuild.packagingArgs }}
 
   - ${{ if ne(parameters.container, '') }}:
     # Files may be owned by root because builds don't set user ID. Later build steps run 'find' in


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/64755

This PR enables build of arm64 RPM packages. It includes an update in Arcade's Installers infra, and the change in Installer pipeline.