### PR TITLE
ILCompiler.Reflection.ReadyToRun shouldn't depend on type system

### DIFF
--- a/src/coreclr/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using Internal.TypeSystem;
 
 // If any of these constants change, update src/coreclr/inc/readytorun.h and
 // src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs with the new R2R minor version
@@ -339,11 +338,5 @@ namespace Internal.ReadyToRunConstants
         Float64 = 2,
         Vector64 = 3,
         Vector128 = 4,
-    }
-
-    public static class ReadyToRunRuntimeConstants
-    {
-        public const int READYTORUN_PInvokeTransitionFrameSizeInPointerUnits = 11;
-        public static int READYTORUN_ReversePInvokeTransitionFrameSizeInPointerUnits(TargetArchitecture target) => target == TargetArchitecture.X86 ? 5 : 2;
     }
 }

--- a/src/coreclr/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
@@ -339,4 +339,11 @@ namespace Internal.ReadyToRunConstants
         Vector64 = 3,
         Vector128 = 4,
     }
+
+    public static class ReadyToRunRuntimeConstants
+    {
+        public const int READYTORUN_PInvokeTransitionFrameSizeInPointerUnits = 11;
+        public const int READYTORUN_ReversePInvokeTransitionFrameSizeInPointerUnits_X86 = 5;
+        public const int READYTORUN_ReversePInvokeTransitionFrameSizeInPointerUnits_Universal = 2;
+    }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -2595,8 +2595,8 @@ namespace Internal.JitInterface
             throw new RequiresRuntimeJitException($"{MethodBeingCompiled} -> {nameof(canGetCookieForPInvokeCalliSig)}");
         }
 
-        private int SizeOfPInvokeTransitionFrame => ReadyToRunRuntimeConstants.READYTORUN_PInvokeTransitionFrameSizeInPointerUnits * _compilation.NodeFactory.Target.PointerSize;
-        private int SizeOfReversePInvokeTransitionFrame => ReadyToRunRuntimeConstants.READYTORUN_ReversePInvokeTransitionFrameSizeInPointerUnits(_compilation.NodeFactory.Target.Architecture) * _compilation.NodeFactory.Target.PointerSize;
+        private int SizeOfPInvokeTransitionFrame => 11 * _compilation.NodeFactory.Target.PointerSize;
+        private int SizeOfReversePInvokeTransitionFrame => (_compilation.NodeFactory.Target.Architecture == TargetArchitecture.X86 ? 5 : 2) * _compilation.NodeFactory.Target.PointerSize;
 
         private void setEHcount(uint cEH)
         {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -2595,8 +2595,17 @@ namespace Internal.JitInterface
             throw new RequiresRuntimeJitException($"{MethodBeingCompiled} -> {nameof(canGetCookieForPInvokeCalliSig)}");
         }
 
-        private int SizeOfPInvokeTransitionFrame => 11 * _compilation.NodeFactory.Target.PointerSize;
-        private int SizeOfReversePInvokeTransitionFrame => (_compilation.NodeFactory.Target.Architecture == TargetArchitecture.X86 ? 5 : 2) * _compilation.NodeFactory.Target.PointerSize;
+        private int SizeOfPInvokeTransitionFrame => ReadyToRunRuntimeConstants.READYTORUN_PInvokeTransitionFrameSizeInPointerUnits * PointerSize;
+        private int SizeOfReversePInvokeTransitionFrame
+        {
+            get
+            {
+                if (_compilation.NodeFactory.Target.Architecture == TargetArchitecture.X86)
+                    return ReadyToRunRuntimeConstants.READYTORUN_ReversePInvokeTransitionFrameSizeInPointerUnits_X86 * PointerSize;
+                else
+                    return ReadyToRunRuntimeConstants.READYTORUN_ReversePInvokeTransitionFrameSizeInPointerUnits_Universal * PointerSize;
+            }
+        }
 
         private void setEHcount(uint cEH)
         {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj
@@ -29,8 +29,4 @@
     <Compile Include="..\..\Common\Internal\Runtime\ReadyToRunInstructionSet.cs" Link="Common\ReadyToRunInstructionSet.cs" />
     <Compile Include="..\..\Common\Pgo\PgoFormat.cs" Link="Common\PgoFormat.cs" />
   </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\ILCompiler.TypeSystem\ILCompiler.TypeSystem.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -16,7 +16,6 @@ using System.Text;
 using Internal.CorConstants;
 using Internal.Runtime;
 using Internal.ReadyToRunConstants;
-using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
 
@@ -180,33 +179,6 @@ namespace ILCompiler.Reflection.ReadyToRun
         }
 
         /// <summary>
-        /// Conversion of the PE machine ID to TargetArchitecture used by TargetDetails.
-        /// </summary>
-        public TargetArchitecture TargetArchitecture
-        {
-            get
-            {
-                switch (Machine)
-                {
-                    case Machine.I386:
-                        return TargetArchitecture.X86;
-
-                    case Machine.Amd64:
-                        return TargetArchitecture.X64;
-
-                    case Machine.ArmThumb2:
-                        return TargetArchitecture.ARM;
-
-                    case Machine.Arm64:
-                        return TargetArchitecture.ARM64;
-
-                    default:
-                        throw new NotImplementedException(_machine.ToString());
-                }
-            }
-        }
-
-        /// <summary>
         /// Targeting operating system for the R2R executable
         /// </summary>
         public OperatingSystem OperatingSystem
@@ -215,36 +187,6 @@ namespace ILCompiler.Reflection.ReadyToRun
             {
                 EnsureHeader();
                 return _operatingSystem;
-            }
-        }
-
-        /// <summary>
-        /// Targeting operating system converted to the enumeration used by TargetDetails.
-        /// </summary>
-        public TargetOS TargetOperatingSystem
-        {
-            get
-            {
-                switch (OperatingSystem)
-                {
-                    case OperatingSystem.Windows:
-                        return TargetOS.Windows;
-
-                    case OperatingSystem.Linux:
-                        return TargetOS.Linux;
-
-                    case OperatingSystem.Apple:
-                        return TargetOS.OSX;
-
-                    case OperatingSystem.FreeBSD:
-                        return TargetOS.FreeBSD;
-
-                    case OperatingSystem.NetBSD:
-                        return TargetOS.FreeBSD;
-
-                    default:
-                        throw new NotImplementedException(OperatingSystem.ToString());
-                }
             }
         }
 


### PR DESCRIPTION
We don't want to ship it in the NuGet consumed by ILSpy.

~~I took the liberty of inlining the transition frame constants. It's the same kind of constant as the function pointer within the delegate (that we inline here:~~ https://github.com/dotnet/runtime/blob/1615de6ccc1290be168c1de290429489c489efde/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs#L358 ~~). Feel free to push back - we can come up with a scheme where this is in ReadyToRunConstants.cs, but without having to depend on the type system but it felt like extra complexity.~~