### PR TITLE
Ensure that tls_destructionMonitor is initialized if a thread is attached to the runtime.

### DIFF
--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1844,9 +1844,6 @@ struct TlsDestructionMonitor
 
     ~TlsDestructionMonitor()
     {
-        // Don't destroy threads here if we're in shutdown (shutdown will
-        // clean up for us instead).
-
         if (m_activated)
         {
             Thread* thread = GetThreadNULLOk();

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1839,7 +1839,7 @@ struct TlsDestructionMonitor
 
     void SetThread(Thread* thread)
     {
-        _ASSERTE(m_thread == NULL || m_thread == thread);
+        _ASSERTE(thread == GetThreadNULLOk());
         m_thread = thread;
     }
 

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1835,12 +1835,20 @@ BOOL STDMETHODCALLTYPE EEDllMain( // TRUE on success, FALSE on error.
 
 struct TlsDestructionMonitor
 {
+    Thread* m_thread = nullptr;
+
+    void SetThread(Thread* thread)
+    {
+        _ASSERTE(m_thread == NULL || m_thread == thread);
+        m_thread = thread;
+    }
+
     ~TlsDestructionMonitor()
     {
         // Don't destroy threads here if we're in shutdown (shutdown will
         // clean up for us instead).
 
-        Thread* thread = GetThreadNULLOk();
+        Thread* thread = m_thread;
         if (thread)
         {
 #ifdef FEATURE_COMINTEROP
@@ -1870,6 +1878,11 @@ struct TlsDestructionMonitor
 // This thread local object is used to detect thread shutdown. Its destructor
 // is called when a thread is being shut down.
 thread_local TlsDestructionMonitor tls_destructionMonitor;
+
+void EnsureTlsDestructionMonitor(void* thread)
+{
+    tls_destructionMonitor.SetThread((Thread*)thread);
+}
 
 #ifdef DEBUGGING_SUPPORTED
 //

--- a/src/coreclr/vm/ceemain.h
+++ b/src/coreclr/vm/ceemain.h
@@ -45,7 +45,7 @@ void ForceEEShutdown(ShutdownCompleteAction sca = SCA_ExitProcessWhenShutdownCom
 // Notification of a DLL_THREAD_DETACH or a Thread Terminate.
 void ThreadDetaching();
 
-void EnsureTlsDestructionMonitor(void* thread);
+void EnsureTlsDestructionMonitor();
 
 void SetLatchedExitCode (INT32 code);
 INT32 GetLatchedExitCode (void);

--- a/src/coreclr/vm/ceemain.h
+++ b/src/coreclr/vm/ceemain.h
@@ -45,6 +45,8 @@ void ForceEEShutdown(ShutdownCompleteAction sca = SCA_ExitProcessWhenShutdownCom
 // Notification of a DLL_THREAD_DETACH or a Thread Terminate.
 void ThreadDetaching();
 
+void EnsureTlsDestructionMonitor(void* thread);
+
 void SetLatchedExitCode (INT32 code);
 INT32 GetLatchedExitCode (void);
 

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -376,7 +376,10 @@ void SetThread(Thread* t)
     LIMITED_METHOD_CONTRACT
 
     gCurrentThreadInfo.m_pThread = t;
-    EnsureTlsDestructionMonitor(t);
+    if (t != NULL)
+    {
+        EnsureTlsDestructionMonitor();
+    }
 }
 
 void SetAppDomain(AppDomain* ad)

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -376,6 +376,7 @@ void SetThread(Thread* t)
     LIMITED_METHOD_CONTRACT
 
     gCurrentThreadInfo.m_pThread = t;
+    EnsureTlsDestructionMonitor(t);
 }
 
 void SetAppDomain(AppDomain* ad)


### PR DESCRIPTION
Fixes:https://github.com/dotnet/runtime/issues/64509

I have verified that 
- the repro scenario does cause a slow but steady memory leak (dotnet 7.0 on Ubuntu)
- there is no leak after this fix is applied.
