### PR TITLE
Remove workarounds for missing "parameterless struct" C# feature

### DIFF
--- a/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.Linq.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.Linq.cs
@@ -80,7 +80,7 @@ namespace System.Collections.Generic
                 return result;
             }
 
-            var builder = new LargeArrayBuilder<T>(initialize: true);
+            var builder = new LargeArrayBuilder<T>(int.MaxValue);
             builder.AddRange(source);
             return builder.ToArray();
         }

--- a/src/libraries/Common/src/System/Collections/Generic/LargeArrayBuilder.SizeOpt.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/LargeArrayBuilder.SizeOpt.cs
@@ -15,13 +15,6 @@ namespace System.Collections.Generic
     {
         private ArrayBuilder<T> _builder; // mutable struct; do not make this readonly
 
-        public LargeArrayBuilder(bool initialize) : this()
-        {
-            // This is a workaround for C# not having parameterless struct constructors yet.
-            // Once it gets them, replace this with a parameterless constructor.
-            Debug.Assert(initialize);
-        }
-
         public int Count => _builder.Count;
 
         public void Add(T item) => _builder.Add(item);

--- a/src/libraries/Common/src/System/Collections/Generic/LargeArrayBuilder.SpeedOpt.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/LargeArrayBuilder.SpeedOpt.cs
@@ -23,18 +23,6 @@ namespace System.Collections.Generic
         private int _count;                 // Count of all of the items in this builder.
 
         /// <summary>
-        /// Constructs a new builder.
-        /// </summary>
-        /// <param name="initialize">Pass <c>true</c>.</param>
-        public LargeArrayBuilder(bool initialize)
-            : this(maxCapacity: int.MaxValue)
-        {
-            // This is a workaround for C# not having parameterless struct constructors yet.
-            // Once it gets them, replace this with a parameterless constructor.
-            Debug.Assert(initialize);
-        }
-
-        /// <summary>
         /// Constructs a new builder with the specified maximum capacity.
         /// </summary>
         /// <param name="maxCapacity">The maximum capacity this builder can have.</param>

--- a/src/libraries/Common/src/System/Collections/Generic/SparseArrayBuilder.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/SparseArrayBuilder.cs
@@ -71,15 +71,11 @@ namespace System.Collections.Generic
         /// <summary>
         /// Constructs a new builder.
         /// </summary>
-        /// <param name="initialize">Pass <c>true</c>.</param>
-        public SparseArrayBuilder(bool initialize)
-            : this()
+        public SparseArrayBuilder()
         {
-            // Once C# gains parameterless struct constructors, please
-            // remove this workaround.
-            Debug.Assert(initialize);
-
-            _builder = new LargeArrayBuilder<T>(initialize: true);
+            _markers = default(ArrayBuilder<Marker>);
+            _reservedCount = default(int);
+            _builder = new LargeArrayBuilder<T>(int.MaxValue);
         }
 
         /// <summary>

--- a/src/libraries/Common/tests/Tests/System/Collections/Generic/LargeArrayBuilderTests.cs
+++ b/src/libraries/Common/tests/Tests/System/Collections/Generic/LargeArrayBuilderTests.cs
@@ -14,7 +14,7 @@ namespace System.Collections.Generic.Tests
         [Fact]
         public void Constructor()
         {
-            var builder = new LargeArrayBuilder<T>(initialize: true);
+            var builder = new LargeArrayBuilder<T>(int.MaxValue);
 
             Assert.Equal(0, builder.Count);
             Assert.Same(Array.Empty<T>(), builder.ToArray());
@@ -24,8 +24,8 @@ namespace System.Collections.Generic.Tests
         [MemberData(nameof(EnumerableData))]
         public void AddCountAndToArray(IEnumerable<T> seed)
         {
-            var builder1 = new LargeArrayBuilder<T>(initialize: true);
-            var builder2 = new LargeArrayBuilder<T>(initialize: true);
+            var builder1 = new LargeArrayBuilder<T>(int.MaxValue);
+            var builder2 = new LargeArrayBuilder<T>(int.MaxValue);
 
             int count = 0;
             foreach (T item in seed)
@@ -63,7 +63,7 @@ namespace System.Collections.Generic.Tests
         [MemberData(nameof(EnumerableData))]
         public void AddRange(IEnumerable<T> seed)
         {
-            var builder = new LargeArrayBuilder<T>(initialize: true);
+            var builder = new LargeArrayBuilder<T>(int.MaxValue);
 
             // Call AddRange multiple times and verify contents w/ each iteration.
             for (int i = 1; i <= 10; i++)
@@ -81,7 +81,7 @@ namespace System.Collections.Generic.Tests
         {
             var array = new T[seed.Count()];
 
-            var builder = new LargeArrayBuilder<T>(initialize: true);
+            var builder = new LargeArrayBuilder<T>(int.MaxValue);
             builder.AddRange(seed);
             builder.CopyTo(array, index, count);
 

--- a/src/libraries/System.Linq/src/System/Linq/AppendPrepend.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/AppendPrepend.SpeedOpt.cs
@@ -23,7 +23,7 @@ namespace System.Linq
             {
                 Debug.Assert(GetCount(onlyIfCheap: true) == -1);
 
-                var builder = new LargeArrayBuilder<TSource>(initialize: true);
+                var builder = new LargeArrayBuilder<TSource>(int.MaxValue);
 
                 if (!_appending)
                 {
@@ -106,7 +106,7 @@ namespace System.Linq
             {
                 Debug.Assert(GetCount(onlyIfCheap: true) == -1);
 
-                var builder = new SparseArrayBuilder<TSource>(initialize: true);
+                var builder = new SparseArrayBuilder<TSource>();
 
                 if (_prepended != null)
                 {

--- a/src/libraries/System.Linq/src/System/Linq/Concat.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Concat.SpeedOpt.cs
@@ -38,7 +38,7 @@ namespace System.Linq
 
             public override TSource[] ToArray()
             {
-                var builder = new SparseArrayBuilder<TSource>(initialize: true);
+                var builder = new SparseArrayBuilder<TSource>();
 
                 bool reservedFirst = builder.ReserveOrAdd(_first);
                 bool reservedSecond = builder.ReserveOrAdd(_second);
@@ -102,7 +102,7 @@ namespace System.Linq
             {
                 Debug.Assert(!_hasOnlyCollections);
 
-                var builder = new SparseArrayBuilder<TSource>(initialize: true);
+                var builder = new SparseArrayBuilder<TSource>();
                 ArrayBuilder<int> deferredCopies = default;
 
                 for (int i = 0; ; i++)

--- a/src/libraries/System.Linq/src/System/Linq/Select.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Select.SpeedOpt.cs
@@ -22,7 +22,7 @@ namespace System.Linq
         {
             public TResult[] ToArray()
             {
-                var builder = new LargeArrayBuilder<TResult>(initialize: true);
+                var builder = new LargeArrayBuilder<TResult>(int.MaxValue);
 
                 foreach (TSource item in _source)
                 {
@@ -585,7 +585,7 @@ namespace System.Linq
             {
                 Debug.Assert(_source.GetCount(onlyIfCheap: true) == -1);
 
-                var builder = new LargeArrayBuilder<TResult>(initialize: true);
+                var builder = new LargeArrayBuilder<TResult>(int.MaxValue);
                 foreach (TSource input in _source)
                 {
                     builder.Add(_selector(input));

--- a/src/libraries/System.Linq/src/System/Linq/SelectMany.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/SelectMany.SpeedOpt.cs
@@ -31,7 +31,7 @@ namespace System.Linq
 
             public TResult[] ToArray()
             {
-                var builder = new SparseArrayBuilder<TResult>(initialize: true);
+                var builder = new SparseArrayBuilder<TResult>();
                 ArrayBuilder<IEnumerable<TResult>> deferredCopies = default;
 
                 foreach (TSource element in _source)

--- a/src/libraries/System.Linq/src/System/Linq/Where.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Where.SpeedOpt.cs
@@ -34,7 +34,7 @@ namespace System.Linq
 
             public TSource[] ToArray()
             {
-                var builder = new LargeArrayBuilder<TSource>(initialize: true);
+                var builder = new LargeArrayBuilder<TSource>(int.MaxValue);
 
                 foreach (TSource item in _source)
                 {
@@ -332,7 +332,7 @@ namespace System.Linq
 
             public TResult[] ToArray()
             {
-                var builder = new LargeArrayBuilder<TResult>(initialize: true);
+                var builder = new LargeArrayBuilder<TResult>(int.MaxValue);
 
                 foreach (TSource item in _source)
                 {


### PR DESCRIPTION
Fix #63120 