### PR TITLE
[Android] Fix leftover direct invocation of clock_nanosleep

### DIFF
--- a/src/mono/mono/mini/mini-posix.c
+++ b/src/mono/mono/mini/mini-posix.c
@@ -509,7 +509,8 @@ clock_sleep_ns_abs (guint64 ns_abs)
 	then.tv_nsec = ns_abs % 1000000000;
 
 	do {
-		ret = clock_nanosleep (sampling_clock, TIMER_ABSTIME, &then, NULL);
+		ret = g_clock_nanosleep (sampling_clock, TIMER_ABSTIME, &then, NULL);
+
 		if (ret != 0 && ret != EINTR)
 			g_error ("%s: clock_nanosleep () returned %d", __func__, ret);
 	} while (ret == EINTR && mono_atomic_load_i32 (&sampling_thread_running));


### PR DESCRIPTION
This is a follow-up of #64679 

I realized that one invocation of `clock_nanosleep` wasn't replaced with `g_clock_nanosleep`.