### PR TITLE
Use `push` for 8/12 byte struct args on x86

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1231,9 +1231,14 @@ protected:
     unsigned genMove2IfNeeded(unsigned size, regNumber tmpReg, GenTree* srcAddr, unsigned offset);
     unsigned genMove1IfNeeded(unsigned size, regNumber tmpReg, GenTree* srcAddr, unsigned offset);
     void genCodeForLoadOffset(instruction ins, emitAttr size, regNumber dst, GenTree* base, unsigned offset);
+    void genStoreRegToStackArg(var_types type, regNumber reg, int offset);
     void genStructPutArgRepMovs(GenTreePutArgStk* putArgStkNode);
     void genStructPutArgUnroll(GenTreePutArgStk* putArgStkNode);
-    void genStoreRegToStackArg(var_types type, regNumber reg, int offset);
+#ifdef TARGET_X86
+    void genStructPutArgPush(GenTreePutArgStk* putArgStkNode);
+#else
+    void genStructPutArgPartialRepMovs(GenTreePutArgStk* putArgStkNode);
+#endif
 #endif // FEATURE_PUT_STRUCT_ARG_STK
 
     void genCodeForStoreBlk(GenTreeBlk* storeBlkNode);

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -3466,7 +3466,7 @@ void CodeGen::genStructPutArgPush(GenTreePutArgStk* putArgNode)
 
     ClassLayout*   layout   = src->AsObj()->GetLayout();
     const unsigned byteSize = putArgNode->GetStackByteSize();
-    assert(byteSize % TARGET_POINTER_SIZE == 0);
+    assert((byteSize % TARGET_POINTER_SIZE == 0) && ((byteSize < XMM_REGSIZE_BYTES) || layout->HasGCPtr()));
     const unsigned numSlots = byteSize / TARGET_POINTER_SIZE;
     assert(putArgNode->gtNumSlots == numSlots);
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -10758,6 +10758,9 @@ void Compiler::gtDispTree(GenTree*     tree,
                     case GenTreePutArgStk::Kind::RepInstr:
                         printf(" (RepInstr)");
                         break;
+                    case GenTreePutArgStk::Kind::PartialRepInstr:
+                        printf(" (PartialRepInstr)");
+                        break;
                     case GenTreePutArgStk::Kind::Unroll:
                         printf(" (Unroll)");
                         break;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -6775,7 +6775,12 @@ public:
     // block node.
 
     enum class Kind : __int8{
-        Invalid, RepInstr, Unroll, Push, PushAllSlots,
+        Invalid,
+        RepInstr,
+        PartialRepInstr,
+        Unroll,
+        Push,
+        PushAllSlots,
     };
     Kind gtPutArgStkKind;
 #endif
@@ -6823,6 +6828,11 @@ public:
 #if defined(FEATURE_PUT_STRUCT_ARG_STK)
         DEBUG_ARG_SLOTS_ASSERT(m_byteSize == gtNumSlots * TARGET_POINTER_SIZE);
 #endif
+    }
+
+    GenTree*& Data()
+    {
+        return gtOp1;
     }
 
 #if FEATURE_FASTTAILCALL

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -6775,12 +6775,7 @@ public:
     // block node.
 
     enum class Kind : __int8{
-        Invalid,
-        RepInstr,
-        PartialRepInstr,
-        Unroll,
-        Push,
-        PushAllSlots,
+        Invalid, RepInstr, PartialRepInstr, Unroll, Push, PushAllSlots,
     };
     Kind gtPutArgStkKind;
 #endif

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -599,32 +599,30 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
 
     // TODO-X86-CQ: The helper call either is not supported on x86 or required more work
     // (I don't know which).
+    CLANG_FORMAT_COMMENT_ANCHOR;
 
-    if (size <= CPBLK_UNROLL_LIMIT && !layout->HasGCPtr())
+    if (!layout->HasGCPtr())
     {
-#ifdef TARGET_X86
-        if (size < XMM_REGSIZE_BYTES)
-        {
-            putArgStk->gtPutArgStkKind = GenTreePutArgStk::Kind::Push;
-        }
-        else
-#endif // TARGET_X86
+        if (size <= CPBLK_UNROLL_LIMIT)
         {
             putArgStk->gtPutArgStkKind = GenTreePutArgStk::Kind::Unroll;
         }
+        else
+        {
+            putArgStk->gtPutArgStkKind = GenTreePutArgStk::Kind::RepInstr;
+        }
     }
-#ifdef TARGET_X86
-    else if (layout->HasGCPtr())
+    else // There are GC pointers.
     {
+#ifdef TARGET_X86
         // On x86, we must use `push` to store GC references to the stack in order for the emitter to properly update
         // the function's GC info. These `putargstk` nodes will generate a sequence of `push` instructions.
         putArgStk->gtPutArgStkKind = GenTreePutArgStk::Kind::Push;
+#else // !TARGET_X86
+        putArgStk->gtPutArgStkKind = GenTreePutArgStk::Kind::PartialRepInstr;
+#endif // !TARGET_X86
     }
-#endif // TARGET_X86
-    else
-    {
-        putArgStk->gtPutArgStkKind = GenTreePutArgStk::Kind::RepInstr;
-    }
+
     // Always mark the OBJ and ADDR as contained trees by the putarg_stk. The codegen will deal with this tree.
     MakeSrcContained(putArgStk, src);
     if (haveLocalAddr)

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -599,11 +599,23 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
 
     // TODO-X86-CQ: The helper call either is not supported on x86 or required more work
     // (I don't know which).
-    CLANG_FORMAT_COMMENT_ANCHOR;
 
     if (!layout->HasGCPtr())
     {
-        if (size <= CPBLK_UNROLL_LIMIT)
+#ifdef TARGET_X86
+        if (size < XMM_REGSIZE_BYTES)
+        {
+            // Codegen for "Kind::Push" will always load bytes in TARGET_POINTER_SIZE
+            // chunks. As such, the correctness of this code depends on the fact that
+            // morph will copy any "mis-sized" (too small) non-local OBJs into a temp,
+            // thus preventing any possible out-of-bounds memory reads.
+            assert(((layout->GetSize() % TARGET_POINTER_SIZE) == 0) || src->OperIsLocalRead() ||
+                   (src->OperIsIndir() && src->AsIndir()->Addr()->IsLocalAddrExpr()));
+            putArgStk->gtPutArgStkKind = GenTreePutArgStk::Kind::Push;
+        }
+        else
+#endif // TARGET_X86
+            if (size <= CPBLK_UNROLL_LIMIT)
         {
             putArgStk->gtPutArgStkKind = GenTreePutArgStk::Kind::Unroll;
         }
@@ -618,7 +630,7 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
         // On x86, we must use `push` to store GC references to the stack in order for the emitter to properly update
         // the function's GC info. These `putargstk` nodes will generate a sequence of `push` instructions.
         putArgStk->gtPutArgStkKind = GenTreePutArgStk::Kind::Push;
-#else // !TARGET_X86
+#else  // !TARGET_X86
         putArgStk->gtPutArgStkKind = GenTreePutArgStk::Kind::PartialRepInstr;
 #endif // !TARGET_X86
     }

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -1579,14 +1579,6 @@ int LinearScan::BuildPutArgStk(GenTreePutArgStk* putArgStk)
     ssize_t size = putArgStk->GetStackByteSize();
     switch (putArgStk->gtPutArgStkKind)
     {
-        case GenTreePutArgStk::Kind::Push:
-            // Zero-diff quirk: remove.
-            if (size >= 8)
-            {
-                SetContainsAVXFlags();
-            }
-            break;
-
         case GenTreePutArgStk::Kind::Unroll:
             // If we have a remainder smaller than XMM_REGSIZE_BYTES, we need an integer temp reg.
             if ((size % XMM_REGSIZE_BYTES) != 0)
@@ -1615,6 +1607,11 @@ int LinearScan::BuildPutArgStk(GenTreePutArgStk* putArgStk)
             buildInternalIntRegisterDefForNode(putArgStk, RBM_RCX);
             buildInternalIntRegisterDefForNode(putArgStk, RBM_RSI);
             break;
+
+#ifdef TARGET_X86
+        case GenTreePutArgStk::Kind::Push:
+            break;
+#endif // TARGET_X86
 
         default:
             unreached();

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -1587,22 +1587,19 @@ int LinearScan::BuildPutArgStk(GenTreePutArgStk* putArgStk)
                 buildInternalIntRegisterDefForNode(putArgStk, regMask);
             }
 
-#ifdef TARGET_X86
-            if (size >= 8)
-#else  // !TARGET_X86
             if (size >= XMM_REGSIZE_BYTES)
-#endif // !TARGET_X86
             {
-                // If we have a buffer larger than or equal to XMM_REGSIZE_BYTES on x64/ux,
-                // or larger than or equal to 8 bytes on x86, reserve an XMM register to use it for a
-                // series of 16-byte loads and stores.
+                // If we have a buffer larger than or equal to XMM_REGSIZE_BYTES, reserve
+                // an XMM register to use it for a series of 16-byte loads and stores.
                 buildInternalFloatRegisterDefForNode(putArgStk, internalFloatRegCandidates());
                 SetContainsAVXFlags();
             }
             break;
 
         case GenTreePutArgStk::Kind::RepInstr:
+#ifndef TARGET_X86
         case GenTreePutArgStk::Kind::PartialRepInstr:
+#endif
             buildInternalIntRegisterDefForNode(putArgStk, RBM_RDI);
             buildInternalIntRegisterDefForNode(putArgStk, RBM_RCX);
             buildInternalIntRegisterDefForNode(putArgStk, RBM_RSI);


### PR DESCRIPTION
It is the case that currently for code like the following:
```cs
private static void Problem(StructWithIndex* p)
{
    CallForStructWithIndex(*p);
}

struct StructWithIndex
{
    public int Index;
    public int Value;
}
```
On x86 we generate the following:
```asm
       vmovq    xmm0, qword ptr [ecx]
       sub      esp, 8
       vmovq    qword ptr [esp], xmm0
       call     RyuJitReproduction.Program:CallForStructWithIndex(StructWithIndex)
```
While could generate:
```asm
       push     dword ptr [ecx+4]
       push     dword ptr [ecx]
```
Which is both a little faster (ah-hoc benchmarking on my machine shows ~10% improvement) and smaller. This change does just that, using `push [addr]` for 8 and 12 byte structs (the latter made the code simple).

To achieve that, some code refactoring was undertaken: we already had a path that did what we needed, but it was only used for structs with GC pointers. I deleted the double meaning of `Kind::Push` - for `TYP_STRUCT` it now means only one thing, that is `genStructPutArgPush`, while before this change it could also go down the "unroll" path (for the very specific cases of 8 and 12 byte structs that we are moving to using `push`es).

As a cleanup item, `PartialRepInstr` kind was added, to represent the algorithm we use for storing structs with GC pointers on x64 Unix.

There will be two types of diffs with this change: first the one showed above, second - removal of unnecessary `vzeroupper` instructions that were being generated because LSRA was allocating an unnecessary XMM register for `Kind::Push` `PUTARG_STK`s with GC pointers.

[Diffs](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-65387/win-x86.md) - x86 only ([no](https://dev.azure.com/dnceng/public/_build/results?buildId=1614490&view=ms.vss-build-web.run-extensions-tab) diffs on other targets as expected). All regressions are alignment artifacts.