### PR TITLE
Fix minor random bias

### DIFF
--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/TrustHelper.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/TrustHelper.cs
@@ -55,7 +55,7 @@ namespace System.DirectoryServices.ActiveDirectory
         internal const int TRUST_TYPE_MIT = 0x00000003;
         private const int ERROR_ALREADY_EXISTS = 183;
         private const int ERROR_INVALID_LEVEL = 124;
-        private static readonly char[] s_punctuations = "!@#$%^&*()_-+=[{]};:>|./?".ToCharArray();
+        private const string PasswordCharacterSet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()_-+=[{]};:>|./?";
 
         internal static bool GetTrustedDomainInfoStatus(DirectoryContext context, string? sourceName, string targetName, TRUST_ATTRIBUTE attribute, bool isForest)
         {
@@ -947,30 +947,61 @@ namespace System.DirectoryServices.ActiveDirectory
 
         internal static string CreateTrustPassword()
         {
-            string password = string.Empty;
-            byte[] buf = new byte[PASSWORD_LENGTH];
+#if NETCOREAPP3_0_OR_GREATER
+            return string.Create<object?>(PASSWORD_LENGTH, null, static (destination, _) =>
+            {
+                for (int i = 0; i < destination.Length; i++)
+                {
+                    destination[i] = PasswordCharacterSet[RandomNumberGenerator.GetInt32(PasswordCharacterSet.Length)];
+                }
+            });
+#else
             char[] cBuf = new char[PASSWORD_LENGTH];
 
-            using (RandomNumberGenerator RNG = RandomNumberGenerator.Create())
+            using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
             {
-                RNG.GetBytes(buf);
-                for (int iter = 0; iter < PASSWORD_LENGTH; iter++)
+                for (int i = 0; i < PASSWORD_LENGTH; i++)
                 {
-                    int i = (int)(buf[iter] % 87);
-                    if (i < 10)
-                        cBuf[iter] = (char)('0' + i);
-                    else if (i < 36)
-                        cBuf[iter] = (char)('A' + i - 10);
-                    else if (i < 62)
-                        cBuf[iter] = (char)('a' + i - 36);
-                    else
-                        cBuf[iter] = s_punctuations[i - 62];
+                    cBuf[i] = PasswordCharacterSet[GetRandomByte(rng, PasswordCharacterSet.Length)];
                 }
             }
 
-            password = new string(cBuf);
+            return new string(cBuf);
 
-            return password;
+            // This is a private copy of RandomNumberGenerator.GetInt32 that works
+            // on platforms that don't have it. Since this is for a private specific
+            // use, it can be simplified to assume some things about the ranges.
+            // We know the upper-bound is < 255, so we can avoid converting random
+            // bytes to integers and mask a single byte instead. We also know the
+            // lower-bound is 0.
+            static int GetRandomByte(RandomNumberGenerator rng, int toExclusive)
+            {
+                Debug.Assert(toExclusive > 0 && toExclusive < byte.MaxValue);
+
+                // The total possible range is [0, 255).
+                int range = toExclusive - 1;
+
+                // Create a mask for only the applicable bits.
+                int mask = range;
+                mask |= mask >> 1;
+                mask |= mask >> 2;
+                mask |= mask >> 4;
+                // Don't need >> 8 or >> 16 since it is known the range is less than 255.
+
+                byte[] randomByte = new byte[1];
+                int result;
+
+                do
+                {
+                    rng.GetBytes(randomByte);
+                    result = mask & randomByte[0];
+                }
+                while (result > range);
+
+                Debug.Assert(result < toExclusive);
+                return result;
+            }
+#endif
         }
 
         private static IntPtr GetTrustedDomainInfo(DirectoryContext targetContext, string? targetName, bool isForest)

--- a/src/libraries/System.DirectoryServices/tests/System.DirectoryServices.Tests.csproj
+++ b/src/libraries/System.DirectoryServices/tests/System.DirectoryServices.Tests.csproj
@@ -19,6 +19,7 @@
     <Compile Include="System\DirectoryServices\ActiveDirectory\DirectoryContextTests.cs" />
     <Compile Include="System\DirectoryServices\ActiveDirectory\ForestTests.cs" />
     <Compile Include="System\DirectoryServices\ActiveDirectory\ActiveDirectoryTests.cs" />
+    <Compile Include="System\DirectoryServices\ActiveDirectory\TrustHelperTests.cs" />
     <Compile Include="$(CommonTestPath)System\DirectoryServices\LdapConfiguration.cs"
              Link="Common\DirectoryServices\LdapConfiguration.cs" />
   </ItemGroup>

--- a/src/libraries/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/TrustHelperTests.cs
+++ b/src/libraries/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/TrustHelperTests.cs
@@ -30,7 +30,7 @@ namespace System.DirectoryServices.ActiveDirectory.Tests
                 // password is a 15 character length string from a 87 character set.
                 // log2(87)*15 is about 96, the odds of which we will generate a duplicate
                 // here are next to nothing.
-                Assert.True(passwords.Add(password), "password is a duplicate");
+                Assert.True(passwords.Add(password), "password is not a duplicate");
             }
         }
     }

--- a/src/libraries/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/TrustHelperTests.cs
+++ b/src/libraries/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/TrustHelperTests.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace System.DirectoryServices.ActiveDirectory.Tests
+{
+    public static class TrustHelperTests
+    {
+        [Fact]
+        public static void CreateTrustPassword_Random()
+        {
+            Type trustHelperType = typeof(Domain).Assembly.GetType(
+                "System.DirectoryServices.ActiveDirectory.TrustHelper",
+                throwOnError: true);
+            MethodInfo createTrustPasswordMethod = trustHelperType.GetMethod(
+                "CreateTrustPassword",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.NotNull(createTrustPasswordMethod);
+
+            HashSet<string> passwords = new HashSet<string>();
+
+            for (int i = 0; i < 100; i++)
+            {
+                string password = (string)createTrustPasswordMethod.Invoke(null, null);
+
+                // password is a 15 character length string from a 87 character set.
+                // log2(87)*15 is about 96, the odds of which we will generate a duplicate
+                // here are next to nothing.
+                Assert.True(passwords.Add(password), "password is a duplicate");
+            }
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
@@ -36,10 +36,6 @@ namespace System.Net.Http
         private const string Response = "response";
         private const string Stale = "stale";
 
-        // Define alphanumeric characters for cnonce
-        // 48='0', 65='A', 97='a'
-        private static readonly int[] s_alphaNumChooser = new int[] { 48, 65, 97 };
-
         public static async Task<string?> GetDigestTokenForCredential(NetworkCredential credential, HttpRequestMessage request, DigestResponse digestResponse)
         {
             StringBuilder sb = StringBuilderCache.Acquire();
@@ -210,19 +206,15 @@ namespace System.Net.Http
         private static string GetRandomAlphaNumericString()
         {
             const int Length = 16;
-            Span<byte> randomNumbers = stackalloc byte[Length * 2];
-            RandomNumberGenerator.Fill(randomNumbers);
+            const string CharacterSet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-            StringBuilder sb = StringBuilderCache.Acquire(Length);
-            for (int i = 0; i < randomNumbers.Length;)
+            return string.Create<object?>(Length, null, static (destination, _) =>
             {
-                // Get a random digit 0-9, a random alphabet in a-z, or a random alphabeta in A-Z
-                int rangeIndex = randomNumbers[i++] % 3;
-                int value = randomNumbers[i++] % (rangeIndex == 0 ? 10 : 26);
-                sb.Append((char)(s_alphaNumChooser[rangeIndex] + value));
-            }
-
-            return StringBuilderCache.GetStringAndRelease(sb);
+                for (int i = 0; i < destination.Length; i++)
+                {
+                    destination[i] = CharacterSet[RandomNumberGenerator.GetInt32(CharacterSet.Length)];
+                }
+            });
         }
 
         private static string ComputeHash(string data, string algorithm)

--- a/src/libraries/System.Net.Http/tests/UnitTests/DigestAuthenticationTests.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/DigestAuthenticationTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -103,6 +104,26 @@ namespace System.Net.Http.Tests
             }
             Assert.Equal(fieldCount, parameter.Split(',').Length);
             Assert.False(parameter.Trim().EndsWith(","));
+        }
+
+        [Fact]
+        public static void DigestResponse_CnonceRandom()
+        {
+            const BindingFlags Flags = BindingFlags.Static | BindingFlags.NonPublic;
+            MethodInfo mi = typeof(AuthenticationHelper).GetMethod("GetRandomAlphaNumericString", Flags);
+            Assert.NotNull(mi);
+
+            HashSet<string> cnonces = new HashSet<string>();
+
+            for (int i = 0; i < 100; i++)
+            {
+                string token = (string)mi.Invoke(null, null);
+
+                // cnonce is a 16 character length string from a 62 character set.
+                // log2(62)*16 is about 95, the odds of which we will generate a duplicate
+                // here are next to nothing.
+                Assert.True(cnonces.Add(token), "cnonce is a duplicate");
+            }
         }
     }
 }

--- a/src/libraries/System.Net.Http/tests/UnitTests/DigestAuthenticationTests.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/DigestAuthenticationTests.cs
@@ -122,7 +122,7 @@ namespace System.Net.Http.Tests
                 // cnonce is a 16 character length string from a 62 character set.
                 // log2(62)*16 is about 95, the odds of which we will generate a duplicate
                 // here are next to nothing.
-                Assert.True(cnonces.Add(token), "cnonce is a duplicate");
+                Assert.True(cnonces.Add(token), "cnonce is not a duplicate");
             }
         }
     }


### PR DESCRIPTION
This corrects two uses of RandomNumberGenerator that resulted in slight bias in their results. After some internal discussion it was determined that the bias did not weaken the randomness to the point where this needed to be treated as a vulnerability.

This also adds some tests just to make sure the random generation is not completely broken.