### PR TITLE
Disable core dumps when running libraries tests on macOS

### DIFF
--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -132,7 +132,13 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
   # files already in /cores/ at this point. This is being done to prevent
   # inadvertently flooding the CI machines with dumps.
   if [[ ! -d "/cores" || ! "$(ls -A /cores)" ]]; then
-    ulimit -c unlimited
+    # Disabling core dumps on macOS. System dumps are large (even for very small
+    # programs) and not configurable. As a result, if a single PR build causes a
+    # lot of tests to crash, we can take out the entire queue.
+    # See discussions in:
+    #   https://github.com/dotnet/core-eng/issues/15333
+    #   https://github.com/dotnet/core-eng/issues/15597
+    ulimit -c 0
   fi
 
 elif [[ "$(uname -s)" == "Linux" ]]; then


### PR DESCRIPTION
We had a single PR - with a real bug crashing all the tests - take out the whole queue. Disabling core dumps for test runs on macOS entirely until we have some better story.

cc @dotnet/area-infrastructure-libraries @danmoseley @stephentoub 