### PR TITLE
[wasm] Disable aot tests failing due to OOM

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -286,6 +286,9 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj" />
     <!-- https://github.com/dotnet/runtime/issues/65012 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Channels\tests\System.Threading.Channels.Tests.csproj" />
+
+    <!-- https://github.com/dotnet/runtime/issues/65335 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections.Immutable\tests\System.Collections.Immutable.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(RunDisabledWasmTests)' != 'true'">

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -33,6 +33,15 @@
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(BuildAOTTestsOnHelix)' == 'true' and '$(RunDisabledWasmTests)' != 'true' and '$(RunAOTCompilation)' == 'true' and '$(BrowserHost)' == 'Windows'">
     <!-- https://github.com/dotnet/runtime/issues/61756 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj" />
+
+    <!-- https://github.com/dotnet/runtime/issues/65356 - OOM while linking -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.SourceGeneration.Tests\System.Text.Json.SourceGeneration.Roslyn3.11.Tests.csproj" />
+    <!-- https://github.com/dotnet/runtime/issues/65411 - possible OOM when compiling
+         System.Text.Json.SourceGeneration.Roslyn4.0.Tests.dll.bc -> .o -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.SourceGeneration.Tests\System.Text.Json.SourceGeneration.Roslyn4.0.Tests.csproj" />
+
+    <!-- https://github.com/dotnet/runtime/issues/61524 - OOM while linking -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests\System.Text.Json.Tests.csproj" />
   </ItemGroup>
 
   <!-- Projects that don't support code coverage measurement. -->


### PR DESCRIPTION
- https://github.com/dotnet/runtime/issues/65356 - OOM while linking
    `System.Text.Json.SourceGeneration.Roslyn3.11.Tests`

- https://github.com/dotnet/runtime/issues/65411 - possible OOM when
  compiling `System.Text.Json.SourceGeneration.Roslyn4.0.Tests.dll.bc` -> `.o`
     `System.Text.Json.SourceGeneration.Roslyn4.0.Tests`

- https://github.com/dotnet/runtime/issues/61524 - OOM while linking
    `System.Text.Json.Tests`

Also, disable `System.Collections.Immutable.Tests` failing due to #65335 