### PR TITLE
Fix PerformanceCounter's when running with Globalization Invariant Mode

### DIFF
--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -85,7 +85,14 @@ namespace System.Diagnostics
             {
                 if (s_englishCulture is null)
                 {
-                    try { s_englishCulture = CultureInfo.GetCultureInfo("en"); } catch { s_englishCulture = CultureInfo.InvariantCulture; }
+                    try
+                    {
+                        s_englishCulture = CultureInfo.GetCultureInfo("en");
+                    }
+                    catch
+                    {
+                        s_englishCulture = CultureInfo.InvariantCulture;
+                    }
                 }
                 return s_englishCulture;
             }

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -45,11 +45,11 @@ namespace System.Diagnostics
         private const string LanguageKeyword = "language";
         private const string DllName = "netfxperf.dll";
 
-        private const int EnglishLCID = 0x009;
-
         private static volatile string s_computerName;
         private static volatile string s_iniFilePath;
         private static volatile string s_symbolFilePath;
+
+        private static CultureInfo? s_englishCulture;
 
         private PerformanceMonitor _performanceMonitor;
         private readonly string _machineName;
@@ -76,6 +76,18 @@ namespace System.Diagnostics
                     Interlocked.CompareExchange(ref s_internalSyncObject, o, null);
                 }
                 return s_internalSyncObject;
+            }
+        }
+
+        private static CultureInfo EnglishCulture
+        {
+            get
+            {
+                if (s_englishCulture is null)
+                {
+                    try { s_englishCulture = CultureInfo.GetCultureInfo("en"); } catch { s_englishCulture = CultureInfo.InvariantCulture; }
+                }
+                return s_englishCulture;
             }
         }
 
@@ -275,11 +287,11 @@ namespace System.Diagnostics
 
         internal static bool CategoryExists(string machine, string category)
         {
-            PerformanceCounterLib library = GetPerformanceCounterLib(machine, new CultureInfo(EnglishLCID));
+            PerformanceCounterLib library = GetPerformanceCounterLib(machine, EnglishCulture);
             if (library.CategoryExists(category))
                 return true;
 
-            if (CultureInfo.CurrentCulture.Parent.LCID != EnglishLCID)
+            if (CultureInfo.CurrentCulture.Parent.Name != EnglishCulture.Name)
             {
                 CultureInfo culture = CultureInfo.CurrentCulture;
                 while (culture != CultureInfo.InvariantCulture)
@@ -347,11 +359,11 @@ namespace System.Diagnostics
 
         internal static bool CounterExists(string machine, string category, string counter)
         {
-            PerformanceCounterLib library = GetPerformanceCounterLib(machine, new CultureInfo(EnglishLCID));
+            PerformanceCounterLib library = GetPerformanceCounterLib(machine, EnglishCulture);
             bool categoryExists = false;
             bool counterExists = library.CounterExists(category, counter, ref categoryExists);
 
-            if (!categoryExists && CultureInfo.CurrentCulture.Parent.LCID != EnglishLCID)
+            if (!categoryExists && CultureInfo.CurrentCulture.Parent.Name != EnglishCulture.Name)
             {
                 CultureInfo culture = CultureInfo.CurrentCulture;
                 while (culture != CultureInfo.InvariantCulture)
@@ -755,7 +767,7 @@ namespace System.Diagnostics
                 culture = culture.Parent;
             }
 
-            library = GetPerformanceCounterLib(machineName, new CultureInfo(EnglishLCID));
+            library = GetPerformanceCounterLib(machineName, EnglishCulture);
             return library.GetCategories();
         }
 
@@ -774,7 +786,7 @@ namespace System.Diagnostics
 
             //First check the current culture for the category. This will allow
             //PerformanceCounterCategory.CategoryHelp to return localized strings.
-            if (CultureInfo.CurrentCulture.Parent.LCID != EnglishLCID)
+            if (CultureInfo.CurrentCulture.Parent.Name != EnglishCulture.Name)
             {
                 CultureInfo culture = CultureInfo.CurrentCulture;
 
@@ -790,7 +802,7 @@ namespace System.Diagnostics
 
             //We did not find the category walking up the culture hierarchy. Try looking
             // for the category in the default culture English.
-            library = GetPerformanceCounterLib(machine, new CultureInfo(EnglishLCID));
+            library = GetPerformanceCounterLib(machine, EnglishCulture);
             help = library.GetCategoryHelp(category);
 
             if (help == null)
@@ -810,9 +822,9 @@ namespace System.Diagnostics
 
         internal static CategorySample GetCategorySample(string machine, string category)
         {
-            PerformanceCounterLib library = GetPerformanceCounterLib(machine, new CultureInfo(EnglishLCID));
+            PerformanceCounterLib library = GetPerformanceCounterLib(machine, EnglishCulture);
             CategorySample sample = library.GetCategorySample(category);
-            if (sample == null && CultureInfo.CurrentCulture.Parent.LCID != EnglishLCID)
+            if (sample == null && CultureInfo.CurrentCulture.Parent.Name != EnglishCulture.Name)
             {
                 CultureInfo culture = CultureInfo.CurrentCulture;
                 while (culture != CultureInfo.InvariantCulture)
@@ -845,11 +857,11 @@ namespace System.Diagnostics
 
         internal static string[] GetCounters(string machine, string category)
         {
-            PerformanceCounterLib library = GetPerformanceCounterLib(machine, new CultureInfo(EnglishLCID));
+            PerformanceCounterLib library = GetPerformanceCounterLib(machine, EnglishCulture);
             bool categoryExists = false;
             string[] counters = library.GetCounters(category, ref categoryExists);
 
-            if (!categoryExists && CultureInfo.CurrentCulture.Parent.LCID != EnglishLCID)
+            if (!categoryExists && CultureInfo.CurrentCulture.Parent.Name != EnglishCulture.Name)
             {
                 CultureInfo culture = CultureInfo.CurrentCulture;
                 while (culture != CultureInfo.InvariantCulture)
@@ -910,7 +922,7 @@ namespace System.Diagnostics
 
             //First check the current culture for the counter. This will allow
             //PerformanceCounter.CounterHelp to return localized strings.
-            if (CultureInfo.CurrentCulture.Parent.LCID != EnglishLCID)
+            if (CultureInfo.CurrentCulture.Parent.Name != EnglishCulture.Name)
             {
                 CultureInfo culture = CultureInfo.CurrentCulture;
                 while (culture != CultureInfo.InvariantCulture)
@@ -925,7 +937,7 @@ namespace System.Diagnostics
 
             //We did not find the counter walking up the culture hierarchy. Try looking
             // for the counter in the default culture English.
-            library = GetPerformanceCounterLib(machine, new CultureInfo(EnglishLCID));
+            library = GetPerformanceCounterLib(machine, EnglishCulture);
             help = library.GetCounterHelp(category, counter, ref categoryExists);
 
             if (!categoryExists)
@@ -990,7 +1002,8 @@ namespace System.Diagnostics
 
         internal static PerformanceCounterLib GetPerformanceCounterLib(string machineName, CultureInfo culture)
         {
-            string lcidString = culture.LCID.ToString("X3", CultureInfo.InvariantCulture);
+            // EnglishCulture.LCID == 9 will be false only if running with Globalization Invariant Mode. Use "009" at that time as default English language identifier.
+            string lcidString = EnglishCulture.LCID == 9 ? culture.LCID.ToString("X3", CultureInfo.InvariantCulture) : "009";
 
             machineName = (machineName == "." ? ComputerName : machineName).ToLowerInvariant();
 
@@ -1135,11 +1148,11 @@ namespace System.Diagnostics
 
         internal static bool IsCustomCategory(string machine, string category)
         {
-            PerformanceCounterLib library = GetPerformanceCounterLib(machine, new CultureInfo(EnglishLCID));
+            PerformanceCounterLib library = GetPerformanceCounterLib(machine, EnglishCulture);
             if (library.IsCustomCategory(category))
                 return true;
 
-            if (CultureInfo.CurrentCulture.Parent.LCID != EnglishLCID)
+            if (CultureInfo.CurrentCulture.Parent.Name != EnglishCulture.Name)
             {
                 CultureInfo culture = CultureInfo.CurrentCulture;
                 while (culture != CultureInfo.InvariantCulture)
@@ -1170,10 +1183,10 @@ namespace System.Diagnostics
 
         internal static PerformanceCounterCategoryType GetCategoryType(string machine, string category)
         {
-            PerformanceCounterLib library = GetPerformanceCounterLib(machine, new CultureInfo(EnglishLCID));
+            PerformanceCounterLib library = GetPerformanceCounterLib(machine, EnglishCulture);
             if (!library.FindCustomCategory(category, out PerformanceCounterCategoryType categoryType))
             {
-                if (CultureInfo.CurrentCulture.Parent.LCID != EnglishLCID)
+                if (CultureInfo.CurrentCulture.Parent.Name != EnglishCulture.Name)
                 {
                     CultureInfo culture = CultureInfo.CurrentCulture;
                     while (culture != CultureInfo.InvariantCulture)

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterTests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections;
+using System.Globalization;
 using System.Collections.Specialized;
+using Microsoft.DotNet.RemoteExecutor;
 using System.Threading;
 using Xunit;
 
@@ -316,6 +318,32 @@ namespace System.Diagnostics.Tests
             }
 
             Helpers.DeleteCategory(categoryName);
+        }
+
+        private static bool CanRunInInvariantMode => RemoteExecutor.IsSupported && !PlatformDetection.IsNetFramework;
+
+        [ConditionalTheory(nameof(CanRunInInvariantMode))]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void RunWithGlobalizationInvariantModeTest(bool predefinedCultures)
+        {
+            ProcessStartInfo psi = new ProcessStartInfo() {  UseShellExecute = false };
+            psi.Environment.Add("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1");
+            psi.Environment.Add("DOTNET_SYSTEM_GLOBALIZATION_PREDEFINED_CULTURES_ONLY", predefinedCultures ? "1" : "0");
+            RemoteExecutor.Invoke(() =>
+            {
+                // Ensure we are running inside the Globalization invariant mode.
+                Assert.Equal("", CultureInfo.CurrentCulture.Name);
+
+                // This test ensure creating PerformanceCounter object while we are running with Globalization Invariant Mode.
+                // PerformanceCounter used to create cultures using LCID's which fail in Globalization Invariant Mode.
+                // This test ensure no failure should be encountered in this case.
+                using (PerformanceCounter counterSample = new PerformanceCounter("Processor", "Interrupts/sec", "0", "."))
+                {
+                    Assert.Equal("Processor", counterSample.CategoryName);
+                }
+            }, new RemoteInvokeOptions { StartInfo =  psi}).Dispose();
         }
 
         public static PerformanceCounter CreateCounterWithCategory(string categoryName, bool readOnly, PerformanceCounterCategoryType categoryType)


### PR DESCRIPTION
PerformanceCounter's was creating culture objects using LCID. When running with Globalization Invariant Mode, it is not allowed to create any culture using LCID. Also, if the switch `DOTNET_SYSTEM_GLOBALIZATION_PREDEFINED_CULTURES_ONLY` is set to true there, it will not allow creating any culture even using culture names except the Invariant culture. That means PerformanceCounter library will not be usable at all when enabling the Globalization Invariant Mode. 

The fix here is to allow running PerformanceCounter with the Globalization Invariant Mode and always report counters matching the English language at that time.