### PR TITLE
Suppress warnings in NativeAOT smoke tests

### DIFF
--- a/src/tests/nativeaot/SmokeTests/ComWrappers/ComWrappers.csproj
+++ b/src/tests/nativeaot/SmokeTests/ComWrappers/ComWrappers.csproj
@@ -3,6 +3,10 @@
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+
+    <!-- Shouldn't need this: https://github.com/dotnet/linker/issues/2618 -->
+    <NoWarn>$(NoWarn);IL2050</NoWarn>
+
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ComWrappers.cs" />

--- a/src/tests/nativeaot/SmokeTests/DeadCodeElimination/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/DeadCodeElimination/DeadCodeElimination.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -150,6 +151,8 @@ class Program
         }
     }
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+        Justification = "That's the point")]
     private static bool IsTypePresent(Type testType, string typeName) => testType.GetNestedType(typeName, BindingFlags.NonPublic | BindingFlags.Public) != null;
 
     private static void ThrowIfPresent(Type testType, string typeName)

--- a/src/tests/nativeaot/SmokeTests/DynamicGenerics/DynamicGenerics.csproj
+++ b/src/tests/nativeaot/SmokeTests/DynamicGenerics/DynamicGenerics.csproj
@@ -5,6 +5,10 @@
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
+    <!-- There's just too many of these warnings -->
+    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
+    <NoWarn>$(NoWarn);IL3050</NoWarn>
+
     <!-- Look for MULTIMODULE_BUILD #define for the more specific incompatible parts -->
     <CLRTestTargetUnsupported Condition="'$(IlcMultiModule)' == 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/nativeaot/SmokeTests/FeatureSwitches/FeatureSwitches.cs
+++ b/src/tests/nativeaot/SmokeTests/FeatureSwitches/FeatureSwitches.cs
@@ -149,6 +149,8 @@ class Program
         }
     }
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+        Justification = "That's the point")]
     private static bool IsTypePresent(Type testType, string typeName) => testType.GetNestedType(typeName, BindingFlags.NonPublic | BindingFlags.Public) != null;
 
     private static void ThrowIfPresent(Type testType, string typeName)

--- a/src/tests/nativeaot/SmokeTests/Generics/Generics.csproj
+++ b/src/tests/nativeaot/SmokeTests/Generics/Generics.csproj
@@ -4,6 +4,11 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- There's just too many of these warnings -->
+    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
+    <NoWarn>$(NoWarn);IL3050;IL3054</NoWarn>
+
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Generics.cs" />

--- a/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.csproj
+++ b/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.csproj
@@ -3,6 +3,9 @@
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
+    <!-- Correctness of interop for abstract delegates cannot be guaranteed after native compilation -->
+    <NoWarn>$(NoWarn);IL3055</NoWarn>
+
     <!-- Look for MULTIMODULE_BUILD #define for the more specific incompatible parts -->
     <CLRTestTargetUnsupported Condition="'$(IlcMultiModule)' == 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime;
 using System.Runtime.InteropServices;
 
@@ -871,6 +872,8 @@ class TestGCInteraction
 
 static class Assert
 {
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+        Justification = "Yep, we don't want to keep the cctor if it wasn't kept")]
     private static bool HasCctor(Type type)
     {
         return type.GetConstructor(BindingFlags.NonPublic | BindingFlags.Static, null, Type.EmptyTypes, null) != null;

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.csproj
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.csproj
@@ -6,6 +6,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);REFLECTION_FROM_USAGE</DefineConstants>
 
+    <!-- There's just too many of these warnings -->
+    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
+    <NoWarn>$(NoWarn);IL3050</NoWarn>
+
     <!-- Look for MULTIMODULE_BUILD #define for the more specific incompatible parts -->
     <CLRTestTargetUnsupported Condition="'$(IlcMultiModule)' == 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection_ReflectedOnly.csproj
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection_ReflectedOnly.csproj
@@ -5,6 +5,10 @@
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
+    <!-- There's just too many of these warnings -->
+    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
+    <NoWarn>$(NoWarn);IL3050</NoWarn>
+
     <!-- Look for MULTIMODULE_BUILD #define for the more specific incompatible parts -->
     <CLRTestTargetUnsupported Condition="'$(IlcMultiModule)' == 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>


### PR DESCRIPTION
Building the nativeaot tests produces a wall of warning text, making it difficult to find things like compiler failures and RyuJIT asserts.