### PR TITLE
Optimize the Regex source generator's handling of `Compilation` objects.

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -37,7 +37,7 @@ namespace System.Text.RegularExpressions.Generator
         };
 
         /// <summary>Generates the code for one regular expression class.</summary>
-        private static (string, ImmutableArray<Diagnostic>) EmitRegexType(RegexType regexClass, Compilation compilation)
+        private static (string, ImmutableArray<Diagnostic>) EmitRegexType(RegexType regexClass, bool allowUnsafe)
         {
             var sb = new StringBuilder(1024);
             var writer = new IndentedTextWriter(new StringWriter(sb));
@@ -78,7 +78,7 @@ namespace System.Text.RegularExpressions.Generator
             generatedName += ComputeStringHash(generatedName).ToString("X");
 
             // Generate the regex type
-            ImmutableArray<Diagnostic> diagnostics = EmitRegexMethod(writer, regexClass.Method, generatedName, compilation);
+            ImmutableArray<Diagnostic> diagnostics = EmitRegexMethod(writer, regexClass.Method, generatedName, allowUnsafe);
 
             while (writer.Indent != 0)
             {
@@ -145,7 +145,7 @@ namespace System.Text.RegularExpressions.Generator
         }
 
         /// <summary>Generates the code for a regular expression method.</summary>
-        private static ImmutableArray<Diagnostic> EmitRegexMethod(IndentedTextWriter writer, RegexMethod rm, string id, Compilation compilation)
+        private static ImmutableArray<Diagnostic> EmitRegexMethod(IndentedTextWriter writer, RegexMethod rm, string id, bool allowUnsafe)
         {
             string patternExpression = Literal(rm.Pattern);
             string optionsExpression = Literal(rm.Options);
@@ -169,8 +169,6 @@ namespace System.Text.RegularExpressions.Generator
                 writer.WriteLine("}");
                 return ImmutableArray.Create(Diagnostic.Create(DiagnosticDescriptors.LimitedSourceGeneration, rm.MethodSyntax.GetLocation()));
             }
-
-            bool allowUnsafe = compilation.Options is CSharpCompilationOptions { AllowUnsafe: true };
 
             writer.WriteLine($"new {id}();");
             writer.WriteLine();

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
@@ -4,7 +4,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.DotnetRuntime.Extensions;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
@@ -25,31 +25,30 @@ namespace System.Text.RegularExpressions.Generator
     {
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
+            // To avoid invalidating the generator's output when anything from the compilation
+            // changes, we will extract from it the only thing we care about: whether unsafe
+            // code is allowed.
+            IncrementalValueProvider<bool> allowUnsafeProvider =
+                context.CompilationProvider
+                .Select((x, _) => x.Options is CSharpCompilationOptions { AllowUnsafe: true });
+
             // Contains one entry per regex method, either the generated code for that regex method,
             // a diagnostic to fail with, or null if no action should be taken for that regex.
             IncrementalValueProvider<ImmutableArray<object?>> codeOrDiagnostics =
                 context.SyntaxProvider
 
-                // Find all MethodDeclarationSyntax nodes attributed with RegexGenerator
-                .CreateSyntaxProvider(static (s, _) => IsSyntaxTargetForGeneration(s), static (ctx, _) => GetSemanticTargetForGeneration(ctx))
+                // Find all MethodDeclarationSyntax nodes attributed with RegexGenerator and gather the required information
+                .CreateSyntaxProvider(IsSyntaxTargetForGeneration, GetSemanticTargetForGeneration)
                 .Where(static m => m is not null)
 
-                // Pair each with the compilation
-                .Combine(context.CompilationProvider)
-
-                // Use a custom comparer that ignores the compilation. We want to avoid regenerating for regex methods
-                // that haven't been changed, but any change to a regex method will change the Compilation, so we ignore
-                // the Compilation for purposes of caching.
-                .WithComparer(new LambdaComparer<(MethodDeclarationSyntax?, Compilation)>(
-                    static (left, right) => EqualityComparer<MethodDeclarationSyntax>.Default.Equals(left.Item1, right.Item1),
-                    static o => o.Item1?.GetHashCode() ?? 0))
+                // Pair each with whether unsafe code is allowed
+                .Combine(allowUnsafeProvider)
 
                 // Get the resulting code string or error Diagnostic for each MethodDeclarationSyntax/Compilation pair
-                .Select((state, cancellationToken) =>
+                .Select((state, _) =>
                 {
-                    Debug.Assert(state.Item1 is not null);
-                    object? result = GetRegexTypeToEmit(state.Item2, state.Item1, cancellationToken);
-                    return result is RegexType regexType ? EmitRegexType(regexType, state.Item2) : result;
+                    Debug.Assert(state.Left is not null);
+                    return state.Left is RegexType regexType ? EmitRegexType(regexType, state.Right) : state.Left;
                 })
                 .Collect();
 
@@ -82,22 +81,6 @@ namespace System.Text.RegularExpressions.Generator
 
                 context.AddSource("RegexGenerator.g.cs", string.Join(Environment.NewLine, code));
             });
-        }
-
-        private sealed class LambdaComparer<T> : IEqualityComparer<T>
-        {
-            private readonly Func<T?, T?, bool> _equal;
-            private readonly Func<T?, int> _getHashCode;
-
-            public LambdaComparer(Func<T?, T?, bool> equal, Func<T?, int> getHashCode)
-            {
-                _equal = equal;
-                _getHashCode = getHashCode;
-            }
-
-            public bool Equals(T? x, T? y) => _equal(x, y);
-
-            public int GetHashCode(T obj) => _getHashCode(obj);
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
@@ -44,7 +44,8 @@ namespace System.Text.RegularExpressions.Generator
                 // Pair each with whether unsafe code is allowed
                 .Combine(allowUnsafeProvider)
 
-                // Get the resulting code string or error Diagnostic for each MethodDeclarationSyntax/Compilation pair
+                // Get the resulting code string or error Diagnostic for
+                // each MethodDeclarationSyntax/allow-unsafe-blocks pair
                 .Select((state, _) =>
                 {
                     Debug.Assert(state.Left is not null);

--- a/src/libraries/System.Text.RegularExpressions/gen/Stubs.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/Stubs.cs
@@ -84,8 +84,3 @@ namespace System.Text.RegularExpressions
         public const int WholeString = -4;
     }
 }
-
-namespace System.Runtime.CompilerServices
-{
-    internal static class IsExternalInit { }
-}

--- a/src/libraries/System.Text.RegularExpressions/gen/System.Text.RegularExpressions.Generator.csproj
+++ b/src/libraries/System.Text.RegularExpressions/gen/System.Text.RegularExpressions.Generator.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <!-- Common generator support -->
-    <Compile Include="$(CommonPath)Roslyn\GetBestTypeByMetadataName.cs" Link="Common\Roslyn\GetBestTypeByMetadataName.cs" />
+    <Compile Include="$(CommonPath)System\Runtime\CompilerServices\IsExternalInit.cs" Link="Common\System\Runtime\CompilerServices\IsExternalInit.cs" />
 
     <!-- Code included from System.Text.RegularExpressions -->
     <Compile Include="$(CommonPath)System\HexConverter.cs" Link="Production\HexConverter.cs" />

--- a/src/libraries/System.Text.RegularExpressions/gen/System.Text.RegularExpressions.Generator.csproj
+++ b/src/libraries/System.Text.RegularExpressions/gen/System.Text.RegularExpressions.Generator.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <!-- Common generator support -->
+    <Compile Include="$(CommonPath)Roslyn\GetBestTypeByMetadataName.cs" Link="Common\Roslyn\GetBestTypeByMetadataName.cs" />
     <Compile Include="$(CommonPath)System\Runtime\CompilerServices\IsExternalInit.cs" Link="Common\System\Runtime\CompilerServices\IsExternalInit.cs" />
 
     <!-- Code included from System.Text.RegularExpressions -->


### PR DESCRIPTION
This PR optimizes the Regex source generator's pipeline in a similar way to what was done in #64579.

The `Compilation` object was mostly removed from the pipeline, with its presence being restricted to an `IncrementalValueProvider<bool>` that contains whether unsafe code is allowed, which is seamlessly combined to the main pipeline without needing a custom comparer.

The `GetRegexTypeToEmit` method was merged with the `GetSemanticTargetForGeneration` method and moved earlier in the pipeline, according to feedback from the linked PR.