### PR TITLE
Clear GC info when consuming GT_PUTARG_SPLIT nodes

### DIFF
--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -3190,7 +3190,9 @@ void CodeGen::genCall(GenTreeCall* call)
     }
 
 #ifdef DEBUG
-    // Killed registers should no longer contain any GC pointers.
+    // We should not have GC pointers in killed registers live around the call.
+    // GC info for arg registers were cleared when consuming arg nodes above
+    // and LSRA should ensure it for other trashed registers.
     regMaskTP killMask = RBM_CALLEE_TRASH;
     if (call->IsHelperCall())
     {

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -1807,7 +1807,6 @@ void CodeGen::genConsumePutStructArgStk(GenTreePutArgStk* putArgNode,
 #if FEATURE_ARG_SPLIT
 //------------------------------------------------------------------------
 // genConsumeArgRegSplit: Consume register(s) in Call node to set split struct argument.
-//                        Liveness update for the PutArgSplit node is not needed
 //
 // Arguments:
 //    putArgNode - the PUTARG_STK tree.
@@ -1822,8 +1821,7 @@ void CodeGen::genConsumeArgSplitStruct(GenTreePutArgSplit* putArgNode)
 
     genUnspillRegIfNeeded(putArgNode);
 
-    // Skip updating GC info
-    // GC info for all argument registers will be cleared in caller
+    gcInfo.gcMarkRegSetNpt(putArgNode->gtGetRegMask());
 
     genCheckConsumeNode(putArgNode);
 }

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -5280,7 +5280,9 @@ void CodeGen::genCall(GenTreeCall* call)
     }
 
 #ifdef DEBUG
-    // Killed registers should no longer contain any GC pointers.
+    // We should not have GC pointers in killed registers live around the call.
+    // GC info for arg registers were cleared when consuming arg nodes above
+    // and LSRA should ensure it for other trashed registers.
     regMaskTP killMask = RBM_CALLEE_TRASH;
     if (call->IsHelperCall())
     {


### PR DESCRIPTION
Fix #65395