### PR TITLE
Remove OpenSSL error queue checking in SslInitializer

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.Initialization.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.Initialization.cs
@@ -24,11 +24,6 @@ internal static partial class Interop
 
             //Call ssl specific initializer
             Ssl.EnsureLibSslInitialized();
-            if (Interop.Crypto.ErrPeekLastError() != 0)
-            {
-                // It is going to be wrapped in a type load exception but will have the error information
-                throw Interop.Crypto.CreateOpenSslCryptographicException();
-            }
         }
 #endif
 


### PR DESCRIPTION
Fixes #64492

as noted by @bartonjs in https://github.com/dotnet/runtime/issues/64492#issuecomment-1031773207, nothing in the `CryptoNative_EnsureLibSslInitialized` puts any errors in the error queue, so it is not necessary to check it after finishing.

In 6.0, there is a possibility that if a previous crypto operation left an error in the OpenSSL error queue then `SslInitializer` would be prevented from completing correctly (See discussion of the original issue for more details.), this has probably been greatly reduced or even fixed by #65148 for 7.0, but backporting change made in this PR to 6.0 should be less risky and just as effective.