### PR TITLE
Remove or move some expensive low-value testing

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -637,27 +637,6 @@ jobs:
         creator: dotnet-bot
         testRunNamePrefixSuffix: Mono_$(_BuildConfig)
 
-# Build and test libraries under single-file publishing
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Release
-    platforms:
-    - windows_x64
-    - Linux_x64
-    jobParameters:
-      testGroup: innerloop
-      isSingleFile: true
-      nameSuffix: SingleFile
-      buildArgs: -s clr+libs+libs.tests -c $(_BuildConfig) /p:TestSingleFile=true /p:ArchiveTests=true
-      timeoutInMinutes: 120
-      # extra steps, run tests
-      extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-      extraStepsParameters:
-        creator: dotnet-bot
-        testRunNamePrefixSuffix: SingleFile_$(_BuildConfig)
-
 #
 # Build Mono and Installer on LLVMJIT mode
 #

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -161,21 +161,6 @@ jobs:
       testGroup: innerloop
 
 #
-# Build PGO CoreCLR release
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-    buildConfig: release
-    platforms:
-    - windows_x64
-    - windows_x86
-    - Linux_x64
-    jobParameters:
-      testGroup: innerloop
-      pgoType: 'PGO'
-
-#
 # Build CoreCLR Formatting Job
 # Only when CoreCLR is changed, and only in the 'main' branch (no release branches;
 # both Rolling and PR builds).
@@ -1024,22 +1009,6 @@ jobs:
     jobParameters:
       liveRuntimeBuildConfig: release
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-
-#
-# PGO Build
-#
-- template: /eng/pipelines/installer/installer-matrix.yml
-  parameters:
-    buildConfig: Release
-    jobParameters:
-      isOfficialBuild: ${{ variables.isOfficialBuild }}
-      liveRuntimeBuildConfig: release
-      liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-      pgoType: 'PGO'
-    platforms:
-    - windows_x64
-    - windows_x86
-    - Linux_x64
 
 #
 # CoreCLR Test builds using live libraries release build


### PR DESCRIPTION
There are two sets of runs we do right now that aren't very valuable.

Single-file is mainly testing API compatiblity and the analyzer has mostly solved that. NativeAOT also now verifies this.

PGO is still important, but very stable and only needs to run in the official runs during publishing.