### PR TITLE
Disable component governance for musl runs

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -49,6 +49,10 @@ jobs:
     enablePublishTestResults: ${{ parameters.enablePublishTestResults }}
     testResultsFormat: ${{ parameters.testResultsFormat }}
 
+    # Component governance does not work on musl machines
+    ${{ if eq(parameters.osSubGroup, '_musl') }}:
+      disableComponentGovernance: true
+
     workspace:
       clean: all
     enableRichCodeNavigation: ${{ parameters.enableRichCodeNavigation }}
@@ -124,7 +128,7 @@ jobs:
         inputs:
           artifact: Mono_Offsets_${{monoCrossAOTTargetOS}}
           path: '$(Build.SourcesDirectory)/artifacts/obj/mono/offsetfiles'
-    
+
     - ${{ if eq(parameters.buildingOnSourceBuildImage, true) }}:
       - template: /eng/common/templates/steps/source-build.yml
         parameters:

--- a/eng/pipelines/common/templates/runtimes/xplat-job.yml
+++ b/eng/pipelines/common/templates/runtimes/xplat-job.yml
@@ -65,6 +65,10 @@ jobs:
     ${{ if eq(parameters.osGroup, 'windows') }}:
       agentOs: windows
 
+    # Component governance does not work on musl machines
+    ${{ if eq(parameters.osSubGroup, '_musl') }}:
+      disableComponentGovernance: true
+
     # Setting this results in the arcade job template including a step
     # that gathers asset manifests and publishes them to pipeline
     # storage. Only relevant for build jobs.

--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -40,6 +40,11 @@ jobs:
       condition: and(succeeded(), ${{ parameters.condition }})
       helixRepo: dotnet/runtime
       pool: ${{ parameters.pool }}
+
+      # Component governance does not work on musl machines
+      ${{ if eq(parameters.osSubGroup, '_musl') }}:
+        disableComponentGovernance: true
+
       variables:
         - _buildScriptFileName: build
 


### PR DESCRIPTION
Musl machines don't have the prereqs for component governance, so they always fail