### PR TITLE
Always dispose inner stream in StreamPipeWriter.Complete*

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -212,13 +212,18 @@ namespace System.IO.Pipelines
 
             _isCompleted = true;
 
-            FlushInternal(writeToStream: exception == null);
-
-            _internalTokenSource?.Dispose();
-
-            if (!_leaveOpen)
+            try
             {
-                InnerStream.Dispose();
+                FlushInternal(writeToStream: exception == null);
+            }
+            finally
+            {
+                _internalTokenSource?.Dispose();
+
+                if (!_leaveOpen)
+                {
+                    InnerStream.Dispose();
+                }
             }
         }
 
@@ -231,17 +236,22 @@ namespace System.IO.Pipelines
 
             _isCompleted = true;
 
-            await FlushAsyncInternal(writeToStream: exception == null, data: Memory<byte>.Empty).ConfigureAwait(false);
-
-            _internalTokenSource?.Dispose();
-
-            if (!_leaveOpen)
+            try
             {
+                await FlushAsyncInternal(writeToStream: exception == null, data: Memory<byte>.Empty).ConfigureAwait(false);
+            }
+            finally
+            {
+                _internalTokenSource?.Dispose();
+
+                if (!_leaveOpen)
+                {
 #if (!NETSTANDARD2_0 && !NETFRAMEWORK)
-                await InnerStream.DisposeAsync().ConfigureAwait(false);
+                    await InnerStream.DisposeAsync().ConfigureAwait(false);
 #else
-                InnerStream.Dispose();
+                    InnerStream.Dispose();
 #endif
+                }
             }
         }
 

--- a/src/libraries/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
@@ -458,6 +458,26 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
+        public void CompleteAlwaysCallsDispose()
+        {
+            var stream = new CountsDisposesStream();
+            PipeWriter writer = PipeWriter.Create(stream);
+            writer.Complete();
+
+            Assert.True(stream.DisposeCalled);
+        }
+
+        [Fact]
+        public async Task CompleteAsyncAlwaysCallsDisposeAsync()
+        {
+            var stream = new CountsDisposesStream();
+            PipeWriter writer = PipeWriter.Create(stream);
+            await writer.Complete();
+
+            Assert.True(stream.DisposeAsyncCalled);
+        }
+
+        [Fact]
         public void GetMemorySameAsTheMaxPoolSizeUsesThePool()
         {
             using (var pool = new DisposeTrackingBufferPool())
@@ -643,6 +663,25 @@ namespace System.IO.Pipelines.Tests
             public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
             {
                 throw new OperationCanceledException();
+            }
+#endif
+        }
+
+        private class CountsDisposesStream : ThrowsOperationCanceledExceptionStream
+        {
+            public bool DisposeCalled { get; set; }
+            public bool DisposeAsyncCalled { get; set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                DisposeCalled = true;
+            }
+
+#if (!NETSTANDARD2_0 && !NETFRAMEWORK)
+            public override ValueTask DisposeAsync()
+            {
+                DisposeAsyncCalled = true;
+                return default;
             }
 #endif
         }

--- a/src/libraries/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
@@ -473,7 +473,7 @@ namespace System.IO.Pipelines.Tests
         {
             var stream = new CountsDisposesStream();
             PipeWriter writer = PipeWriter.Create(stream);
-            await writer.Complete();
+            await writer.CompleteAsync();
 
             Assert.True(stream.DisposeAsyncCalled);
         }

--- a/src/libraries/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
@@ -467,6 +467,7 @@ namespace System.IO.Pipelines.Tests
             Assert.True(stream.DisposeCalled);
         }
 
+#if (!NETSTANDARD2_0 && !NETFRAMEWORK)
         [Fact]
         public async Task CompleteAsyncAlwaysCallsDisposeAsync()
         {
@@ -476,6 +477,7 @@ namespace System.IO.Pipelines.Tests
 
             Assert.True(stream.DisposeAsyncCalled);
         }
+#endif
 
         [Fact]
         public void GetMemorySameAsTheMaxPoolSizeUsesThePool()


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/64639