### PR TITLE
FIX | Adds support for Shim gss api on Linux to delay loading libgssapi_krb…

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
@@ -16,6 +16,9 @@ internal static partial class Interop
             IntPtr bufferPtr,
             ulong length);
 
+        [DllImport(Interop.Libraries.NetSecurityNative, EntryPoint = "NetSecurityNative_EnsureGssInitialized")]
+        private static extern int EnsureGssInitialized();
+
         [GeneratedDllImport(Interop.Libraries.NetSecurityNative, EntryPoint="NetSecurityNative_DisplayMinorStatus")]
         internal static partial Status DisplayMinorStatus(
             out Status minorStatus,
@@ -168,6 +171,18 @@ internal static partial class Interop
             Debug.Assert(count >= 0 && count <= inputBytes.Length, "count must be valid");
 
             return Unwrap(out minorStatus, contextHandle, inputBytes, offset, count, ref outBuffer);
+        }
+
+        // This constructor is added to address the issue with net6 regarding 
+        // Shim gss api on Linux to delay loading libgssapi_krb5.so
+        // issue https://github.com/dotnet/SqlClient/issues/1390
+        // dotnet runtime issue https://github.com/dotnet/runtime/pull/55037
+        static NetSecurityNative()
+        {
+            if (Environment.Version.Major >= 6)
+            {
+                EnsureGssInitialized();
+            }
         }
     }
 }


### PR DESCRIPTION
Ports [dotnet/sqlclient#1411](https://github.com/dotnet/SqlClient/pull/1411) to add shim gss api on Linux following changes in [dotnet/runtime#55037](https://github.com/dotnet/runtime/pull/55037)

Tracked by issue https://github.com/dotnet/SqlClient/issues/1390

### Summary
When working with Kerberos authentication on Unix with recent changes in Net6 users fail to get a connection from Sql server. There is no exception thrown as well. It just crashes.

### Customer Impact
This will prevent users from upgrading to Net6 while using Kerberos authentication in Unix.

### Testing
Adding tests require some special setup on CI pipelines to install Net6 TFS and enabled Kerberos authentication.