### PR TITLE
[mono] Cache aotdata file in AOTCompiler task

### DIFF
--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -698,8 +698,10 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
         if (UseAotDataFile)
         {
             string aotDataFile = Path.ChangeExtension(assembly, ".aotdata");
-            aotArgs.Add($"data-outfile={aotDataFile}");
-            aotAssembly.SetMetadata("AotDataFile", aotDataFile);
+            ProxyFile proxyFile = _cache.NewFile(aotDataFile);
+            proxyFiles.Add(proxyFile);
+            aotArgs.Add($"data-outfile={proxyFile.TempFile}");
+            aotAssembly.SetMetadata("AotDataFile", proxyFile.TargetFile);
         }
 
         if (AotProfilePath?.Length > 0)


### PR DESCRIPTION
This change improves the inner devloop experience by making sure to cache the .aotdata file when it's generated. Otherwise, if you clean your artifacts directory and no aot changes have been made, it will not be generated again.  The result being an error when building an app.

I believe this mostly impacts iOS configurations.