### PR TITLE
Add reminder for package authoring

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/servicing_pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/servicing_pull_request_template.md
@@ -21,3 +21,8 @@ main PR <!-- Link to PR if any that fixed this in the main branch. -->
 # Risk
 
 <!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
+
+# Package authoring signed off?
+
+
+IMPORTANT: If this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -57,3 +57,5 @@ jobs:
           ## Testing
 
           ## Risk
+
+          IMPORTANT: If this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.


### PR DESCRIPTION
The backport bot makes it easy to overlook the requirement to add package authoring when code ships in its own package.

Add some reminders.