### PR TITLE
Disable R2R code for all associated components of a composite image

### DIFF
--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -4615,16 +4615,16 @@ void Module::RunEagerFixups()
     {
         // For composite images, multiple modules may request initializing eager fixups
         // from multiple threads so we need to lock their resolution.
-        if (compositeNativeImage->EagerFixupsHaveRun())
-        {
-            return;
-        }
         CrstHolder compositeEagerFixups(compositeNativeImage->EagerFixupsLock());
         if (compositeNativeImage->EagerFixupsHaveRun())
         {
+            if (compositeNativeImage->ReadyToRunCodeDisabled())
+                GetReadyToRunInfo()->DisableAllR2RCode();
             return;
         }
         RunEagerFixupsUnlocked();
+        if (GetReadyToRunInfo()->ReadyToRunCodeDisabled())
+            compositeNativeImage->DisableAllR2RCode();
         compositeNativeImage->SetEagerFixupsHaveRun();
     }
     else

--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -59,6 +59,7 @@ NativeImage::NativeImage(AssemblyBinder *pAssemblyBinder, PEImageLayout *pImageL
     m_pImageLayout = pImageLayout;
     m_fileName = imageFileName;
     m_eagerFixupsHaveRun = false;
+    m_readyToRunCodeDisabled = false;
 }
 
 void NativeImage::Initialize(READYTORUN_HEADER *pHeader, LoaderAllocator *pLoaderAllocator, AllocMemTracker *pamTracker)

--- a/src/coreclr/vm/nativeimage.h
+++ b/src/coreclr/vm/nativeimage.h
@@ -90,6 +90,7 @@ private:
     
     Crst m_eagerFixupsLock;
     bool m_eagerFixupsHaveRun;
+    bool m_readyToRunCodeDisabled;
 
 private:
     NativeImage(AssemblyBinder *pAssemblyBinder, PEImageLayout *peImageLayout, LPCUTF8 imageFileName);
@@ -125,6 +126,18 @@ public:
     PTR_READYTORUN_CORE_HEADER GetComponentAssemblyHeader(LPCUTF8 assemblySimpleName);
 
     void CheckAssemblyMvid(Assembly *assembly) const;
+
+    void DisableAllR2RCode()
+    {
+        LIMITED_METHOD_CONTRACT;
+        m_readyToRunCodeDisabled = true;
+    }
+
+    bool ReadyToRunCodeDisabled()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_readyToRunCodeDisabled;
+    }
 
 private:
     IMDInternalImport *LoadManifestMetadata();

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -823,7 +823,7 @@ bool ReadyToRunInfo::GetPgoInstrumentationData(MethodDesc * pMD, BYTE** pAllocat
         return false;
 
     // If R2R code is disabled for this module, simply behave as if it is never found
-    if (m_readyToRunCodeDisabled)
+    if (ReadyToRunCodeDisabled())
         return false;
 
     if (m_pgoInstrumentationDataHashtable.IsNull())
@@ -890,7 +890,7 @@ PCODE ReadyToRunInfo::GetEntryPoint(MethodDesc * pMD, PrepareCodeConfig* pConfig
         goto done;
 
     // If R2R code is disabled for this module, simply behave as if it is never found
-    if (m_readyToRunCodeDisabled)
+    if (ReadyToRunCodeDisabled())
         goto done;
 
     ETW::MethodLog::GetR2RGetEntryPointStart(pMD);
@@ -1077,7 +1077,7 @@ BOOL ReadyToRunInfo::MethodIterator::Next()
     }
     CONTRACTL_END;
 
-    if (m_pInfo->m_readyToRunCodeDisabled)
+    if (m_pInfo->ReadyToRunCodeDisabled())
         return FALSE;
 
     // Enumerate non-generic methods

--- a/src/coreclr/vm/readytoruninfo.h
+++ b/src/coreclr/vm/readytoruninfo.h
@@ -66,7 +66,7 @@ class ReadyToRunInfo
     PTR_CORCOMPILE_IMPORT_SECTION   m_pImportSections;
     DWORD                           m_nImportSections;
 
-    bool                            m_readyToRunCodeDisabled;
+    bool                            m_readyToRunCodeDisabled; // Is 
 
     NativeFormat::NativeReader      m_nativeReader;
     NativeFormat::NativeArray       m_methodDefEntryPoints;
@@ -125,7 +125,13 @@ public:
     void DisableAllR2RCode()
     {
         LIMITED_METHOD_CONTRACT;
-        m_readyToRunCodeDisabled = TRUE;
+        m_readyToRunCodeDisabled = true;
+    }
+
+    bool ReadyToRunCodeDisabled()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_readyToRunCodeDisabled;
     }
 
     BOOL HasNonShareablePInvokeStubs()


### PR DESCRIPTION
- When loading a composite image, capture the detail that the composite image code cannot be used into the NativeImage structure, and flow that data into all associated ReadyToRunInfo structures.

Fixes #61471