### PR TITLE
add RID for Ubuntu 22.04

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtime.compatibility.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtime.compatibility.json
@@ -3752,18 +3752,18 @@
     "any",
     "base"
   ],
-  "linux-loongarch64": [
-    "linux-loongarch64",
-    "linux",
-    "unix-loongarch64",
-    "unix",
-    "any",
-    "base"
-  ],
   "linux-armv6": [
     "linux-armv6",
     "linux",
     "unix-armv6",
+    "unix",
+    "any",
+    "base"
+  ],
+  "linux-loongarch64": [
+    "linux-loongarch64",
+    "linux",
+    "unix-loongarch64",
     "unix",
     "any",
     "base"
@@ -8227,6 +8227,71 @@
     "any",
     "base"
   ],
+  "ubuntu.22.04": [
+    "ubuntu.22.04",
+    "ubuntu",
+    "debian",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "ubuntu.22.04-arm": [
+    "ubuntu.22.04-arm",
+    "ubuntu.22.04",
+    "ubuntu-arm",
+    "ubuntu",
+    "debian-arm",
+    "debian",
+    "linux-arm",
+    "linux",
+    "unix-arm",
+    "unix",
+    "any",
+    "base"
+  ],
+  "ubuntu.22.04-arm64": [
+    "ubuntu.22.04-arm64",
+    "ubuntu.22.04",
+    "ubuntu-arm64",
+    "ubuntu",
+    "debian-arm64",
+    "debian",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "ubuntu.22.04-x64": [
+    "ubuntu.22.04-x64",
+    "ubuntu.22.04",
+    "ubuntu-x64",
+    "ubuntu",
+    "debian-x64",
+    "debian",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "ubuntu.22.04-x86": [
+    "ubuntu.22.04-x86",
+    "ubuntu.22.04",
+    "ubuntu-x86",
+    "ubuntu",
+    "debian-x86",
+    "debian",
+    "linux-x86",
+    "linux",
+    "unix-x86",
+    "unix",
+    "any",
+    "base"
+  ],
   "unix": [
     "unix",
     "any",
@@ -8250,14 +8315,14 @@
     "any",
     "base"
   ],
-  "unix-loongarch64": [
-    "unix-loongarch64",
+  "unix-armv6": [
+    "unix-armv6",
     "unix",
     "any",
     "base"
   ],
-  "unix-armv6": [
-    "unix-armv6",
+  "unix-loongarch64": [
+    "unix-loongarch64",
     "unix",
     "any",
     "base"

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
@@ -1498,16 +1498,16 @@
         "unix-armel"
       ]
     },
-    "linux-loongarch64": {
-      "#import": [
-        "linux",
-        "unix-loongarch64"
-      ]
-    },
     "linux-armv6": {
       "#import": [
         "linux",
         "unix-armv6"
+      ]
+    },
+    "linux-loongarch64": {
+      "#import": [
+        "linux",
+        "unix-loongarch64"
       ]
     },
     "linux-mips64": {
@@ -3425,6 +3425,35 @@
         "ubuntu-x86"
       ]
     },
+    "ubuntu.22.04": {
+      "#import": [
+        "ubuntu"
+      ]
+    },
+    "ubuntu.22.04-arm": {
+      "#import": [
+        "ubuntu.22.04",
+        "ubuntu-arm"
+      ]
+    },
+    "ubuntu.22.04-arm64": {
+      "#import": [
+        "ubuntu.22.04",
+        "ubuntu-arm64"
+      ]
+    },
+    "ubuntu.22.04-x64": {
+      "#import": [
+        "ubuntu.22.04",
+        "ubuntu-x64"
+      ]
+    },
+    "ubuntu.22.04-x86": {
+      "#import": [
+        "ubuntu.22.04",
+        "ubuntu-x86"
+      ]
+    },
     "unix": {
       "#import": [
         "any"
@@ -3445,12 +3474,12 @@
         "unix"
       ]
     },
-    "unix-loongarch64": {
+    "unix-armv6": {
       "#import": [
         "unix"
       ]
     },
-    "unix-armv6": {
+    "unix-loongarch64": {
       "#import": [
         "unix"
       ]

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
@@ -250,7 +250,7 @@
     <RuntimeGroup Include="ubuntu">
       <Parent>debian</Parent>
       <Architectures>x64;x86;arm;arm64</Architectures>
-      <Versions>16.04;16.10;17.04;17.10;18.04;18.10;19.04;19.10;20.04;20.10;21.04;21.10</Versions>
+      <Versions>16.04;16.10;17.04;17.10;18.04;18.10;19.04;19.10;20.04;20.10;21.04;21.10;22.04</Versions>
       <TreatVersionsAsCompatible>false</TreatVersionsAsCompatible>
     </RuntimeGroup>
 


### PR DESCRIPTION
contributes to https://github.com/dotnet/core/issues/7038

This diff looks word but it seems to swap order of loongarch64 and armv6