### PR TITLE
Checking CI build for segmenting diagnostics eventpipe tests for Android

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -137,7 +137,6 @@
     <NETStandardLibraryRefVersion>2.1.0</NETStandardLibraryRefVersion>
     <NetStandardLibraryVersion>2.0.3</NetStandardLibraryVersion>
     <MicrosoftDiagnosticsToolsRuntimeClientVersion>1.0.4-preview6.19326.1</MicrosoftDiagnosticsToolsRuntimeClientVersion>
-    <MicrosoftDiagnosticsNETCoreClientVersion>0.2.61701</MicrosoftDiagnosticsNETCoreClientVersion>
     <DNNEVersion>1.0.27</DNNEVersion>
     <MicrosoftBuildVersion>16.10.0</MicrosoftBuildVersion>
     <MicrosoftBuildTasksCoreVersion>$(MicrosoftBuildVersion)</MicrosoftBuildTasksCoreVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -137,6 +137,7 @@
     <NETStandardLibraryRefVersion>2.1.0</NETStandardLibraryRefVersion>
     <NetStandardLibraryVersion>2.0.3</NetStandardLibraryVersion>
     <MicrosoftDiagnosticsToolsRuntimeClientVersion>1.0.4-preview6.19326.1</MicrosoftDiagnosticsToolsRuntimeClientVersion>
+    <MicrosoftDiagnosticsNETCoreClientVersion>0.2.61701</MicrosoftDiagnosticsNETCoreClientVersion>
     <DNNEVersion>1.0.27</DNNEVersion>
     <MicrosoftBuildVersion>16.10.0</MicrosoftBuildVersion>
     <MicrosoftBuildTasksCoreVersion>$(MicrosoftBuildVersion)</MicrosoftBuildTasksCoreVersion>

--- a/src/tests/Common/test_dependencies/test_dependencies.csproj
+++ b/src/tests/Common/test_dependencies/test_dependencies.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tools.RuntimeClient" Version="$(MicrosoftDiagnosticsToolsRuntimeClientVersion)" />
-    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="$(MicrosoftDiagnosticsNETCoreClientVersion)" />
   </ItemGroup>
 
   <Target Name="Build" DependsOnTargets="$(TraversalBuildDependsOn)" />

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -71,6 +71,7 @@
 
     <TestBuildMode Condition="'$(__TestBuildMode)' != ''">$(__TestBuildMode)</TestBuildMode>
     <RuntimeFlavor Condition="'$(__RuntimeFlavor)' != ''">$(__RuntimeFlavor)</RuntimeFlavor>
+    <RuntimeFlavor Condition="'$(RuntimeFlavor)' == ''">coreclr</RuntimeFlavor>
 
     <RestoreDefaultOptimizationDataPackage Condition="'$(RestoreDefaultOptimizationDataPackage)' == ''">false</RestoreDefaultOptimizationDataPackage>
     <PortableBuild Condition="'$(PortableBuild)' == ''">true</PortableBuild>

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -194,5 +194,12 @@
     <TestFramework>GeneratedRunner</TestFramework>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- On Linux arm coreclr, the updated tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj project
+         does not yet work for several eventpipe runtime tests. We segment those tests with the following property and symbol -->
+    <UseUpdatedNETCoreClient Condition="!('$(TargetOS)' == 'Linux' And '$(TargetArchitecture)' == 'arm' And '$(RuntimeFlavor)' == 'coreclr')">true</UseUpdatedNETCoreClient>
+    <DefineConstants Condition="'$(UseUpdatedNETCoreClient)' == 'true'">$(DefineConstants);UPDATED_NETCORE_CLIENT</DefineConstants>
+  </PropertyGroup>
+
   <Import Project="$(RepositoryEngineeringDir)testing\tests.props"  Condition="'$(IsTestsCommonProject)' != 'true'" />
 </Project>

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -194,12 +194,5 @@
     <TestFramework>GeneratedRunner</TestFramework>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- On Linux arm coreclr, the updated tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj project
-         does not yet work for several eventpipe runtime tests. We segment those tests with the following property and symbol -->
-    <UseUpdatedNETCoreClient Condition="!('$(TargetOS)' == 'Linux' And '$(TargetArchitecture)' == 'arm' And '$(RuntimeFlavor)' == 'coreclr')">true</UseUpdatedNETCoreClient>
-    <DefineConstants Condition="'$(UseUpdatedNETCoreClient)' == 'true'">$(DefineConstants);UPDATED_NETCORE_CLIENT</DefineConstants>
-  </PropertyGroup>
-
   <Import Project="$(RepositoryEngineeringDir)testing\tests.props"  Condition="'$(IsTestsCommonProject)' != 'true'" />
 </Project>

--- a/src/tests/JIT/Directed/debugging/debuginfo/tester.cs
+++ b/src/tests/JIT/Directed/debugging/debuginfo/tester.cs
@@ -8,7 +8,7 @@ using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using Microsoft.Diagnostics.Tools.RuntimeClient;
+using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Parsers;
 using Microsoft.Diagnostics.Tracing.Parsers.Clr;
@@ -23,18 +23,17 @@ public unsafe class DebugInfoTest
         var keywords =
             ClrTraceEventParser.Keywords.Jit | ClrTraceEventParser.Keywords.JittedMethodILToNativeMap;
 
-        var dotnetRuntimeProvider = new List<Provider>
+        var dotnetRuntimeProvider = new List<EventPipeProvider>
         {
-            new Provider("Microsoft-Windows-DotNETRuntime", eventLevel: EventLevel.Verbose, keywords: (ulong)keywords)
+            new EventPipeProvider("Microsoft-Windows-DotNETRuntime", eventLevel: EventLevel.Verbose, keywords: (long)keywords)
         };
-
-        var config = new SessionConfiguration(1024, EventPipeSerializationFormat.NetTrace, dotnetRuntimeProvider);
 
         return
             IpcTraceTest.RunAndValidateEventCounts(
                 new Dictionary<string, ExpectedEventCount>(),
                 JitMethods,
-                config,
+                dotnetRuntimeProvider,
+                1024,
                 ValidateMappings);
     }
 

--- a/src/tests/JIT/Directed/debugging/debuginfo/tester.cs
+++ b/src/tests/JIT/Directed/debugging/debuginfo/tester.cs
@@ -28,6 +28,7 @@ public unsafe class DebugInfoTest
             ClrTraceEventParser.Keywords.Jit | ClrTraceEventParser.Keywords.JittedMethodILToNativeMap;
 
 #if UPDATED_NETCORE_CLIENT
+        Console.WriteLine($"NONLEGACY NETCORE.CLIENT");
         var dotnetRuntimeProvider = new List<EventPipeProvider>
         {
             new EventPipeProvider("Microsoft-Windows-DotNETRuntime", eventLevel: EventLevel.Verbose, keywords: (long)keywords)
@@ -41,6 +42,7 @@ public unsafe class DebugInfoTest
                 1024,
                 ValidateMappings);
 #else
+        Console.WriteLine($"LEGACY TOOLS.RUNTIMECLIENT");
         var dotnetRuntimeProvider = new List<Provider>
         {
             new Provider("Microsoft-Windows-DotNETRuntime", eventLevel: EventLevel.Verbose, keywords: (ulong)keywords)

--- a/src/tests/JIT/Directed/debugging/debuginfo/tester.csproj
+++ b/src/tests/JIT/Directed/debugging/debuginfo/tester.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="tests_r.ilproj" Aliases="tests_r" />
     <ProjectReference Include="attribute.csproj" />
     <ProjectReference Include="../../../../tracing/eventpipe/common/common.csproj" />
+    <ProjectReference Include="../../../../tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Directed/debugging/debuginfo/tester.csproj
+++ b/src/tests/JIT/Directed/debugging/debuginfo/tester.csproj
@@ -7,6 +7,12 @@
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- On Linux arm coreclr, the updated tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj project
+         does not yet work for several eventpipe runtime tests. We segment those tests with the following property and symbol -->
+    <UseUpdatedNETCoreClient Condition="!('$(TargetOS)' == 'Linux' And '$(TargetArchitecture)' == 'arm' And '$(RuntimeFlavor)' == 'coreclr')">true</UseUpdatedNETCoreClient>
+    <DefineConstants Condition="'$(UseUpdatedNETCoreClient)' == 'true'">$(DefineConstants);UPDATED_NETCORE_CLIENT</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="tests_d.ilproj" Aliases="tests_d" />
     <ProjectReference Include="tests_r.ilproj" Aliases="tests_r" />

--- a/src/tests/JIT/Directed/debugging/debuginfo/tester.csproj
+++ b/src/tests/JIT/Directed/debugging/debuginfo/tester.csproj
@@ -12,7 +12,7 @@
     <ProjectReference Include="tests_r.ilproj" Aliases="tests_r" />
     <ProjectReference Include="attribute.csproj" />
     <ProjectReference Include="../../../../tracing/eventpipe/common/common.csproj" />
-    <ProjectReference Include="../../../../tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
+    <ProjectReference Condition="'$(UseUpdatedNETCoreClient)' == 'true'" Include="../../../../tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
 </Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3622,9 +3622,6 @@
         <ExcludeList Include = "$(XunitTestBinBase)/tracing/eventpipe/complus_config/name_config_with_pid/**">
             <Issue>https://github.com/dotnet/runtime/issues/54974</Issue>
         </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/tracing/eventpipe/**">
-            <Issue>Need to update with Microsoft.Diagnostics.NETCore.Client port https://github.com/dotnet/runtime/pull/64358</Issue>
-        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/Interop/UnmanagedCallConv/UnmanagedCallConvTest/**">
             <Issue>https://github.com/dotnet/runtime/issues/53077</Issue>
         </ExcludeList>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3637,6 +3637,21 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_461649/DevDiv_461649/**">
             <Issue>https://github.com/dotnet/runtime/issues/53353</Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/tracing/eventpipe/diagnosticport/**">
+            <Issue>Cannot run multiple apps on Android for subprocesses</Issue>
+        </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/tracing/eventpipe/pauseonstart/**">
+            <Issue>Cannot run multiple apps on Android for subprocesses</Issue>
+        </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/tracing/eventpipe/processenvironment/**">
+            <Issue>Cannot run multiple apps on Android for subprocesses</Issue>
+        </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/tracing/eventpipe/reverse/**">
+            <Issue>Cannot run multiple apps on Android for subprocesses</Issue>
+        </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/tracing/eventpipe/reverseouter/**">
+            <Issue>Cannot run multiple apps on Android for subprocesses</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <ItemGroup Condition=" $(TargetOS) == 'Android' And '$(TargetArchitecture)' == 'arm64' " >

--- a/src/tests/profiler/common/profiler_common.csproj
+++ b/src/tests/profiler/common/profiler_common.csproj
@@ -10,5 +10,6 @@
     <Compile Include="DiagnosticsIPCWorkaround.cs" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="$(TestSourceDir)tracing/eventpipe/common/common.csproj" />
+    <ProjectReference Include="$(TestSourceDir)tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/eventpipe/eventpipe.csproj
+++ b/src/tests/profiler/eventpipe/eventpipe.csproj
@@ -17,5 +17,6 @@
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="../common/profiler_common.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+    <ProjectReference Include="$(TestSourceDir)tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/eventpipe/reverse_startup.csproj
+++ b/src/tests/profiler/eventpipe/reverse_startup.csproj
@@ -18,5 +18,6 @@
     <ProjectReference Include="../common/profiler_common.csproj" />
     <ProjectReference Include="$(TestSourceDir)tracing/eventpipe/common/common.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+    <ProjectReference Include="$(TestSourceDir)tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/tracing/eventpipe/bigevent/bigevent.cs
+++ b/src/tests/tracing/eventpipe/bigevent/bigevent.cs
@@ -50,6 +50,7 @@ namespace Tracing.Tests.BigEventsValidation
             // This test tries to send a big event (>100KB) and checks that the app does not crash
             // See https://github.com/dotnet/runtime/issues/50515 for the regression issue
 #if (UPDATED_NETCORE_CLIENT == true)
+            Console.WriteLine($"NONLEGACY NETCORE.CLIENT");
             var providers = new List<EventPipeProvider>()
             {
                 new EventPipeProvider("BigEventSource", EventLevel.Verbose)
@@ -57,6 +58,7 @@ namespace Tracing.Tests.BigEventsValidation
 
             return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024, _Verify);
 #else
+            Console.WriteLine($"LEGACY TOOLS.RUNTIMECLIENT");
             var providers = new List<Provider>()
             {
                 new Provider("BigEventSource")

--- a/src/tests/tracing/eventpipe/bigevent/bigevent.csproj
+++ b/src/tests/tracing/eventpipe/bigevent/bigevent.csproj
@@ -11,5 +11,6 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />
+    <ProjectReference Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/tracing/eventpipe/bigevent/bigevent.csproj
+++ b/src/tests/tracing/eventpipe/bigevent/bigevent.csproj
@@ -8,6 +8,12 @@
     <!-- GCStress timeout: https://github.com/dotnet/runtime/issues/51133 -->
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'OSX'">true</GCStressIncompatible>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- On Linux arm coreclr, the updated tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj project
+         does not yet work for several eventpipe runtime tests. We segment those tests with the following property and symbol -->
+    <UseUpdatedNETCoreClient Condition="!('$(TargetOS)' == 'Linux' And '$(TargetArchitecture)' == 'arm' And '$(RuntimeFlavor)' == 'coreclr')">true</UseUpdatedNETCoreClient>
+    <DefineConstants Condition="'$(UseUpdatedNETCoreClient)' == 'true'">$(DefineConstants);UPDATED_NETCORE_CLIENT</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />

--- a/src/tests/tracing/eventpipe/bigevent/bigevent.csproj
+++ b/src/tests/tracing/eventpipe/bigevent/bigevent.csproj
@@ -11,6 +11,6 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />
-    <ProjectReference Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
+    <ProjectReference Condition="'$(UseUpdatedNETCoreClient)' == 'true'" Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/tracing/eventpipe/buffersize/buffersize.cs
+++ b/src/tests/tracing/eventpipe/buffersize/buffersize.cs
@@ -32,6 +32,7 @@ namespace Tracing.Tests.BufferValidation
             // This tests the resilience of message sending with
             // smaller buffers, specifically 1MB and 4MB
 #if (UPDATED_NETCORE_CLIENT == true)
+            Console.WriteLine($"NONLEGACY NETCORE.CLIENT");
             var providers = new List<EventPipeProvider>()
             {
                 new EventPipeProvider("MyEventSource", EventLevel.Verbose)
@@ -49,6 +50,7 @@ namespace Tracing.Tests.BufferValidation
 
             return 100;
 #else
+            Console.WriteLine($"LEGACY TOOLS.RUNTIMECLIENT");
             var providers = new List<Provider>()
             {
                 new Provider("MyEventSource")

--- a/src/tests/tracing/eventpipe/buffersize/buffersize.cs
+++ b/src/tests/tracing/eventpipe/buffersize/buffersize.cs
@@ -10,7 +10,11 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Tracing.Tests.Common;
+#if (UPDATED_NETCORE_CLIENT == true)
 using Microsoft.Diagnostics.NETCore.Client;
+#else
+using Microsoft.Diagnostics.Tools.RuntimeClient;
+#endif
 
 namespace Tracing.Tests.BufferValidation
 {
@@ -27,7 +31,7 @@ namespace Tracing.Tests.BufferValidation
         {
             // This tests the resilience of message sending with
             // smaller buffers, specifically 1MB and 4MB
-
+#if (UPDATED_NETCORE_CLIENT == true)
             var providers = new List<EventPipeProvider>()
             {
                 new EventPipeProvider("MyEventSource", EventLevel.Verbose)
@@ -44,6 +48,26 @@ namespace Tracing.Tests.BufferValidation
             }
 
             return 100;
+#else
+            var providers = new List<Provider>()
+            {
+                new Provider("MyEventSource")
+            };
+
+            var tests = new int[] { 0, 2 }
+                .Select(x => (uint)Math.Pow(2, x))
+                .Select(bufferSize => new SessionConfiguration(circularBufferSizeMB: bufferSize, format: EventPipeSerializationFormat.NetTrace, providers: providers))
+                .Select<SessionConfiguration, Func<int>>(configuration => () => IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, configuration));
+
+            foreach (var test in tests)
+            {
+                var ret = test();
+                if (ret < 0)
+                    return ret;
+            }
+
+            return 100;
+#endif
         }
 
         private static Dictionary<string, ExpectedEventCount> _expectedEventCounts = new Dictionary<string, ExpectedEventCount>()

--- a/src/tests/tracing/eventpipe/buffersize/buffersize.csproj
+++ b/src/tests/tracing/eventpipe/buffersize/buffersize.csproj
@@ -10,5 +10,6 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />
+    <ProjectReference Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/tracing/eventpipe/buffersize/buffersize.csproj
+++ b/src/tests/tracing/eventpipe/buffersize/buffersize.csproj
@@ -7,6 +7,12 @@
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- On Linux arm coreclr, the updated tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj project
+         does not yet work for several eventpipe runtime tests. We segment those tests with the following property and symbol -->
+    <UseUpdatedNETCoreClient Condition="!('$(TargetOS)' == 'Linux' And '$(TargetArchitecture)' == 'arm' And '$(RuntimeFlavor)' == 'coreclr')">true</UseUpdatedNETCoreClient>
+    <DefineConstants Condition="'$(UseUpdatedNETCoreClient)' == 'true'">$(DefineConstants);UPDATED_NETCORE_CLIENT</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />

--- a/src/tests/tracing/eventpipe/buffersize/buffersize.csproj
+++ b/src/tests/tracing/eventpipe/buffersize/buffersize.csproj
@@ -10,6 +10,6 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />
-    <ProjectReference Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
+    <ProjectReference Condition="'$(UseUpdatedNETCoreClient)' == 'true'" Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
+++ b/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
@@ -264,12 +264,12 @@ namespace Tracing.Tests.Common
                         {
                             source.Process();
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             Logger.logger.Log($"Exception thrown while reading; dumping culprit stream to disk...");
                             eventPipeStream.DumpStreamToDisk();
                             // rethrow it to fail the test
-                            throw e;
+                            throw;
                         }
                         Logger.logger.Log("Stopping stream processing");
                         Logger.logger.Log($"Dropped {source.EventsLost} events");

--- a/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
+++ b/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
@@ -204,6 +204,10 @@ namespace Tracing.Tests.Common
             object threadSync = new object(); // for locking eventpipeSession access
             Func<int> optionalTraceValidationCallback = null;
             DiagnosticsClient client = new DiagnosticsClient(processId);
+#if DIAGNOSTICS_RUNTIME
+            if (OperatingSystem.IsAndroid())
+                client = new DiagnosticsClient(new IpcEndpointConfig("127.0.0.1:9000", IpcEndpointConfig.TransportType.TcpSocket, IpcEndpointConfig.PortType.Listen));
+#endif
             var readerTask = new Task(() =>
             {
                 Logger.logger.Log("Connecting to EventPipe...");

--- a/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
+++ b/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
@@ -2,18 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Collections.Concurrent;
-using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.NETCore.Client;
-using System.Runtime.InteropServices;
-using System.Linq;
-using System.Text.RegularExpressions;
+using Microsoft.Diagnostics.Tracing;
 
 namespace Tracing.Tests.Common
 {
@@ -101,7 +101,6 @@ namespace Tracing.Tests.Common
         // and don't care about the number of events sent
         private Dictionary<string, ExpectedEventCount> _expectedEventCounts;
         private Dictionary<string, int> _actualEventCounts = new Dictionary<string, int>();
-        private int _droppedEvents = 0;
 
         // A function to be called with the EventPipeEventSource _before_
         // the call to `source.Process()`.  The function should return another
@@ -238,7 +237,6 @@ namespace Tracing.Tests.Common
                                         Logger.logger.Log("Saw sentinel event");
                                     sentinelEventReceived.Set();
                                 }
-
                                 else if (_actualEventCounts.TryGetValue(eventData.ProviderName, out _))
                                 {
                                     _actualEventCounts[eventData.ProviderName]++;
@@ -295,7 +293,7 @@ namespace Tracing.Tests.Common
             _eventGeneratingAction();
             Logger.logger.Log("Stopping event generating action");
 
-            var stopTask = Task.Run(() => 
+            var stopTask = Task.Run(() =>
             {
                 Logger.logger.Log("Sending StopTracing command...");
                 lock (threadSync) // eventpipeSession
@@ -337,7 +335,7 @@ namespace Tracing.Tests.Common
         }
 
         // Ensure that we have a clean environment for running the test.
-        // Specifically check that we don't have more than one match for 
+        // Specifically check that we don't have more than one match for
         // Diagnostic IPC sockets in the TempPath.  These can be left behind
         // by bugs, catastrophic test failures, etc. from previous testing.
         // The tmp directory is only cleared on reboot, so it is possible to

--- a/src/tests/tracing/eventpipe/common/IpcTraceTest.legacy.cs
+++ b/src/tests/tracing/eventpipe/common/IpcTraceTest.legacy.cs
@@ -1,0 +1,417 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tools.RuntimeClient;
+using System.Runtime.InteropServices;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Tracing.Tests.Common
+{
+    public class Logger
+    {
+        public static Logger logger = new Logger();
+        private TextWriter _log;
+        private Stopwatch _sw;
+        public Logger(TextWriter log = null)
+        {
+            _log = log ?? Console.Out;
+            _sw = new Stopwatch();
+        }
+
+        public void Log(string message)
+        {
+            if (!_sw.IsRunning)
+                _sw.Start();
+            _log.WriteLine($"{_sw.Elapsed.TotalSeconds,5:f1}s: {message}");
+        }
+    }
+
+    public class ExpectedEventCount
+    {
+        // The acceptable percent error on the expected value
+        // represented as a floating point value in [0,1].
+        public float Error { get; private set; }
+
+        // The expected count of events. A value of -1 indicates
+        // that count does not matter, and we are simply testing
+        // that the provider exists in the trace.
+        public int Count { get; private set; }
+
+        public ExpectedEventCount(int count, float error = 0.0f)
+        {
+            Count = count;
+            Error = error;
+        }
+
+        public bool Validate(int actualValue)
+        {
+            return Count == -1 || CheckErrorBounds(actualValue);
+        }
+
+        public bool CheckErrorBounds(int actualValue)
+        {
+            return Math.Abs(actualValue - Count) <= (Count * Error);
+        }
+
+        public static implicit operator ExpectedEventCount(int i)
+        {
+            return new ExpectedEventCount(i);
+        }
+
+        public override string ToString()
+        {
+            return $"{Count} +- {Count * Error}";
+        }
+    }
+
+    // This event source is used by the test infra to
+    // to insure that providers have finished being enabled
+    // for the session being observed. Since the client API
+    // returns the pipe for reading _before_ it finishes
+    // enabling the providers to write to that session,
+    // we need to guarantee that our providers are on before
+    // sending events. This is a _unique_ problem I imagine
+    // should _only_ affect scenarios like these tests
+    // where the reading and sending of events are required
+    // to synchronize.
+    public sealed class SentinelEventSource : EventSource
+    {
+        private SentinelEventSource() {}
+        public static SentinelEventSource Log = new SentinelEventSource();
+        public void SentinelEvent() { WriteEvent(1, "SentinelEvent"); }
+    }
+
+    public static class SessionConfigurationExtensions
+    {
+        public static SessionConfiguration InjectSentinel(this SessionConfiguration sessionConfiguration)
+        {
+            var newProviderList = new List<Provider>(sessionConfiguration.Providers);
+            newProviderList.Add(new Provider("SentinelEventSource"));
+            return new SessionConfiguration(sessionConfiguration.CircularBufferSizeInMB, sessionConfiguration.Format, newProviderList.AsReadOnly());
+        }
+    }
+
+    public class IpcTraceTest
+    {
+        // This Action is executed while the trace is being collected.
+        private Action _eventGeneratingAction;
+
+        // A dictionary of event providers to number of events.
+        // A count of -1 indicates that you are only testing for the presence of the provider
+        // and don't care about the number of events sent
+        private Dictionary<string, ExpectedEventCount> _expectedEventCounts;
+        private Dictionary<string, int> _actualEventCounts = new Dictionary<string, int>();
+        private SessionConfiguration _sessionConfiguration;
+
+        // A function to be called with the EventPipeEventSource _before_
+        // the call to `source.Process()`.  The function should return another
+        // function that will be called to check whether the optional test was validated.
+        // Example in situ: providervalidation.cs
+        private Func<EventPipeEventSource, Func<int>> _optionalTraceValidator;
+
+        IpcTraceTest(
+            Dictionary<string, ExpectedEventCount> expectedEventCounts,
+            Action eventGeneratingAction,
+            SessionConfiguration? sessionConfiguration = null,
+            Func<EventPipeEventSource, Func<int>> optionalTraceValidator = null)
+        {
+            _eventGeneratingAction = eventGeneratingAction;
+            _expectedEventCounts = expectedEventCounts;
+            _sessionConfiguration = sessionConfiguration?.InjectSentinel() ?? new SessionConfiguration(
+                circularBufferSizeMB: 1000,
+                format: EventPipeSerializationFormat.NetTrace,
+                providers: new List<Provider> { 
+                    new Provider("Microsoft-Windows-DotNETRuntime"),
+                    new Provider("SentinelEventSource")
+                });
+            _optionalTraceValidator = optionalTraceValidator;
+        }
+
+        private int Fail(string message = "")
+        {
+            Logger.logger.Log("Test FAILED!");
+            Logger.logger.Log(message);
+            Logger.logger.Log("Configuration:");
+            Logger.logger.Log("{");
+            Logger.logger.Log($"\tbufferSize: {_sessionConfiguration.CircularBufferSizeInMB},");
+            Logger.logger.Log("\tproviders: [");
+            foreach (var provider in _sessionConfiguration.Providers)
+            {
+                Logger.logger.Log($"\t\t{provider.ToString()},");
+            }
+            Logger.logger.Log("\t]");
+            Logger.logger.Log("}\n");
+            Logger.logger.Log("Expected:");
+            Logger.logger.Log("{");
+            foreach (var (k, v) in _expectedEventCounts)
+            {
+                Logger.logger.Log($"\t\"{k}\" = {v}");
+            }
+            Logger.logger.Log("}\n");
+
+            Logger.logger.Log("Actual:");
+            Logger.logger.Log("{");
+            foreach (var (k, v) in _actualEventCounts)
+            {
+                Logger.logger.Log($"\t\"{k}\" = {v}");
+            }
+            Logger.logger.Log("}");
+
+            return -1;
+        }
+
+        private int Validate()
+        {
+            // FIXME: This is a bandaid fix for a deadlock in EventPipeEventSource caused by
+            // the lazy caching in the Regex library.  The caching creates a ConcurrentDictionary
+            // and because it is the first one in the process, it creates an EventSource which
+            // results in a deadlock over a lock in EventPipe.  These lines should be removed once the
+            // underlying issue is fixed by forcing these events to try to be written _before_ we shutdown.
+            //
+            // see: https://github.com/dotnet/runtime/pull/1794 for details on the issue
+            //
+            var emptyConcurrentDictionary = new ConcurrentDictionary<string, string>();
+            emptyConcurrentDictionary["foo"] = "bar";
+            var __count = emptyConcurrentDictionary.Count;
+
+            var isClean = IpcTraceTest.EnsureCleanEnvironment();
+            if (!isClean)
+                return -1;
+            // CollectTracing returns before EventPipe::Enable has returned, so the
+            // the sources we want to listen for may not have been enabled yet.
+            // We'll use this sentinel EventSource to check if Enable has finished
+            ManualResetEvent sentinelEventReceived = new ManualResetEvent(false);
+            var sentinelTask = new Task(() =>
+            {
+                Logger.logger.Log("Started sending sentinel events...");
+                while (!sentinelEventReceived.WaitOne(50))
+                {
+                    SentinelEventSource.Log.SentinelEvent();
+                }
+                Logger.logger.Log("Stopped sending sentinel events");
+            });
+            sentinelTask.Start();
+
+            int processId = Process.GetCurrentProcess().Id;
+            object threadSync = new object(); // for locking eventpipeSessionId access
+            ulong eventpipeSessionId = 0;
+            Func<int> optionalTraceValidationCallback = null;
+            var readerTask = new Task(() =>
+            {
+                Logger.logger.Log("Connecting to EventPipe...");
+                using (var eventPipeStream = new StreamProxy(EventPipeClient.CollectTracing(processId, _sessionConfiguration, out var sessionId)))
+                {
+                    if (sessionId == 0)
+                    {
+                        Logger.logger.Log("Failed to connect to EventPipe!");
+                        throw new ApplicationException("Failed to connect to EventPipe");
+                    }
+                    Logger.logger.Log($"Connected to EventPipe with sessionID '0x{sessionId:x}'");
+
+                    lock (threadSync)
+                    {
+                        eventpipeSessionId = sessionId;
+                    }
+
+                    Logger.logger.Log("Creating EventPipeEventSource...");
+                    using (EventPipeEventSource source = new EventPipeEventSource(eventPipeStream))
+                    {
+                        Logger.logger.Log("EventPipeEventSource created");
+
+                        source.Dynamic.All += (eventData) =>
+                        {
+                            try
+                            {
+                                if (eventData.ProviderName == "SentinelEventSource")
+                                {
+                                    if (!sentinelEventReceived.WaitOne(0))
+                                        Logger.logger.Log("Saw sentinel event");
+                                    sentinelEventReceived.Set();
+                                }
+
+                                else if (_actualEventCounts.TryGetValue(eventData.ProviderName, out _))
+                                {
+                                    _actualEventCounts[eventData.ProviderName]++;
+                                }
+                                else
+                                {
+                                    Logger.logger.Log($"Saw new provider '{eventData.ProviderName}'");
+                                    _actualEventCounts[eventData.ProviderName] = 1;
+                                }
+                            }
+                            catch (Exception e)
+                            {
+                                Logger.logger.Log("Exception in Dynamic.All callback " + e.ToString());
+                            }
+                        };
+                        Logger.logger.Log("Dynamic.All callback registered");
+
+                        if (_optionalTraceValidator != null)
+                        {
+                            Logger.logger.Log("Running optional trace validator");
+                            optionalTraceValidationCallback = _optionalTraceValidator(source);
+                            Logger.logger.Log("Finished running optional trace validator");
+                        }
+
+                        Logger.logger.Log("Starting stream processing...");
+                        try
+                        {
+                            source.Process();
+                        }
+                        catch (Exception e)
+                        {
+                            Logger.logger.Log($"Exception thrown while reading; dumping culprit stream to disk...");
+                            eventPipeStream.DumpStreamToDisk();
+                            // rethrow it to fail the test
+                            throw e;
+                        }
+                        Logger.logger.Log("Stopping stream processing");
+                        Logger.logger.Log($"Dropped {source.EventsLost} events");
+                    }
+                }
+            });
+
+            var waitSentinelEventTask = new Task(() => {
+                sentinelEventReceived.WaitOne();
+            });
+
+            readerTask.Start();
+            waitSentinelEventTask.Start();
+
+            // Will throw if the reader task throws any exceptions before signaling sentinelEventReceived.
+            Task.WaitAny(readerTask, waitSentinelEventTask);
+
+            Logger.logger.Log("Starting event generating action...");
+            _eventGeneratingAction();
+            Logger.logger.Log("Stopping event generating action");
+
+            var stopTask = Task.Run(() => 
+            {
+                Logger.logger.Log("Sending StopTracing command...");
+                lock (threadSync) // eventpipeSessionId
+                {
+                    EventPipeClient.StopTracing(processId, eventpipeSessionId);
+                }
+                Logger.logger.Log("Finished StopTracing command");
+            });
+
+            // Should throw if the reader task throws any exceptions
+            Task.WaitAll(readerTask, stopTask);
+            Logger.logger.Log("Reader task finished");
+
+            foreach (var (provider, expectedCount) in _expectedEventCounts)
+            {
+                if (_actualEventCounts.TryGetValue(provider, out var actualCount))
+                {
+                    if (!expectedCount.Validate(actualCount))
+                    {
+                        return Fail($"Event count mismatch for provider \"{provider}\": expected {expectedCount}, but saw {actualCount}");
+                    }
+                }
+                else
+                {
+                    return Fail($"No events for provider \"{provider}\"");
+                }
+            }
+
+            if (optionalTraceValidationCallback != null)
+            {
+                Logger.logger.Log("Validating optional callback...");
+                // reader thread should be dead now, no need to lock
+                return optionalTraceValidationCallback();
+            }
+            else
+            {
+                return 100;
+            }
+        }
+
+        // Ensure that we have a clean environment for running the test.
+        // Specifically check that we don't have more than one match for 
+        // Diagnostic IPC sockets in the TempPath.  These can be left behind
+        // by bugs, catastrophic test failures, etc. from previous testing.
+        // The tmp directory is only cleared on reboot, so it is possible to
+        // run into these zombie pipes if there are failures over time.
+        // Note: Windows has some guarantees about named pipes not living longer
+        // the process that created them, so we don't need to check on that platform.
+        static public bool EnsureCleanEnvironment()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                Func<(IEnumerable<IGrouping<int,FileInfo>>, List<int>)> getPidsAndSockets = () =>
+                {
+                    IEnumerable<IGrouping<int,FileInfo>> currentIpcs = Directory.GetFiles(Path.GetTempPath(), "dotnet-diagnostic*")
+                        .Select(filename => new { pid = int.Parse(Regex.Match(filename, @"dotnet-diagnostic-(?<pid>\d+)").Groups["pid"].Value), fileInfo = new FileInfo(filename) })
+                        .GroupBy(fileInfos => fileInfos.pid, fileInfos => fileInfos.fileInfo);
+                    List<int> currentPids = System.Diagnostics.Process.GetProcesses().Select(pid => pid.Id).ToList();
+                    return (currentIpcs, currentPids);
+                };
+
+                var (currentIpcs, currentPids) = getPidsAndSockets();
+
+                foreach (var ipc in currentIpcs)
+                {
+                    if (!currentPids.Contains(ipc.Key))
+                    {
+                        foreach (FileInfo fi in ipc)
+                        {
+                            Logger.logger.Log($"Attempting to delete the zombied pipe: {fi.FullName}");
+                            fi.Delete();
+                            Logger.logger.Log($"Deleted");
+                        }
+                    }
+                    else
+                    {
+                        if (ipc.Count() > 1)
+                        {
+                            // delete zombied pipes except newest which is owned
+                            var duplicates = ipc.OrderBy(fileInfo => fileInfo.CreationTime.Ticks).SkipLast(1);
+                            foreach (FileInfo fi in duplicates)
+                            {
+                                Logger.logger.Log($"Attempting to delete the zombied pipe: {fi.FullName}");
+                                fi.Delete();
+                            }
+                        }
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        public static int RunAndValidateEventCounts(
+            Dictionary<string, ExpectedEventCount> expectedEventCounts,
+            Action eventGeneratingAction,
+            SessionConfiguration? sessionConfiguration = null,
+            Func<EventPipeEventSource, Func<int>> optionalTraceValidator = null)
+        {
+            Logger.logger.Log("==TEST STARTING==");
+            var test = new IpcTraceTest(expectedEventCounts, eventGeneratingAction, sessionConfiguration, optionalTraceValidator);
+            try
+            {
+                var ret = test.Validate();
+                if (ret == 100)
+                    Logger.logger.Log("==TEST FINISHED: PASSED!==");
+                else
+                    Logger.logger.Log("==TEST FINISHED: FAILED!==");
+                return ret;
+            }
+            catch (Exception e)
+            {
+                Logger.logger.Log(e.ToString());
+                Logger.logger.Log("==TEST FINISHED: FAILED!==");
+                return -1;
+            }
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/AssemblyInfo.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+#if DIAGNOSTICS_RUNTIME
+// As of https://github.com/dotnet/runtime/pull/64358, InternalsVisibleTo MSBuild Item does not seem to work in Dotnet/Runtime like it does on Dotnet/Diagnostics
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("common")]
+#endif

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/BinaryWriterExtensions.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/BinaryWriterExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal static class BinaryWriterExtensions
+    {
+        public static void WriteString(this BinaryWriter @this, string value)
+        {
+            if (@this == null)
+                throw new ArgumentNullException(nameof(@this));
+
+            @this.Write(value != null ? (value.Length + 1) : 0);
+            if (value != null)
+                @this.Write(Encoding.Unicode.GetBytes(value + '\0'));
+        }
+
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -1,0 +1,590 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    /// <summary>
+    /// This is a top-level class that contains methods to send various diagnostics command to the runtime.
+    /// </summary>
+    public sealed class DiagnosticsClient
+    {
+        private readonly IpcEndpoint _endpoint;
+
+        public DiagnosticsClient(int processId) :
+            this(new PidIpcEndpoint(processId))
+        {
+        }
+
+        internal DiagnosticsClient(IpcEndpointConfig config) :
+            this(new DiagnosticPortIpcEndpoint(config))
+        {
+        }
+
+        internal DiagnosticsClient(IpcEndpoint endpoint)
+        {
+            _endpoint = endpoint;
+        }
+
+        /// <summary>
+        /// Wait for an available diagnostic endpoint to the runtime instance.
+        /// </summary>
+        /// <param name="timeout">The amount of time to wait before cancelling the wait for the connection.</param>
+        internal void WaitForConnection(TimeSpan timeout)
+        {
+            _endpoint.WaitForConnection(timeout);
+        }
+
+        /// <summary>
+        /// Wait for an available diagnostic endpoint to the runtime instance.
+        /// </summary>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        /// <returns>
+        /// A task the completes when a diagnostic endpoint to the runtime instance becomes available.
+        /// </returns>
+        internal Task WaitForConnectionAsync(CancellationToken token)
+        {
+            return _endpoint.WaitForConnectionAsync(token);
+        }
+
+        /// <summary>
+        /// Start tracing the application and return an EventPipeSession object
+        /// </summary>
+        /// <param name="providers">An IEnumerable containing the list of Providers to turn on.</param>
+        /// <param name="requestRundown">If true, request rundown events from the runtime</param>
+        /// <param name="circularBufferMB">The size of the runtime's buffer for collecting events in MB</param>
+        /// <returns>
+        /// An EventPipeSession object representing the EventPipe session that just started.
+        /// </returns> 
+        public EventPipeSession StartEventPipeSession(IEnumerable<EventPipeProvider> providers, bool requestRundown = true, int circularBufferMB = 256)
+        {
+            return EventPipeSession.Start(_endpoint, providers, requestRundown, circularBufferMB);
+        }
+
+        /// <summary>
+        /// Start tracing the application and return an EventPipeSession object
+        /// </summary>
+        /// <param name="provider">An EventPipeProvider to turn on.</param>
+        /// <param name="requestRundown">If true, request rundown events from the runtime</param>
+        /// <param name="circularBufferMB">The size of the runtime's buffer for collecting events in MB</param>
+        /// <returns>
+        /// An EventPipeSession object representing the EventPipe session that just started.
+        /// </returns> 
+        public EventPipeSession StartEventPipeSession(EventPipeProvider provider, bool requestRundown = true, int circularBufferMB = 256)
+        {
+            return EventPipeSession.Start(_endpoint, new[] { provider }, requestRundown, circularBufferMB);
+        }
+
+        /// <summary>
+        /// Start tracing the application and return an EventPipeSession object
+        /// </summary>
+        /// <param name="providers">An IEnumerable containing the list of Providers to turn on.</param>
+        /// <param name="requestRundown">If true, request rundown events from the runtime</param>
+        /// <param name="circularBufferMB">The size of the runtime's buffer for collecting events in MB</param>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        /// <returns>
+        /// An EventPipeSession object representing the EventPipe session that just started.
+        /// </returns> 
+        internal Task<EventPipeSession> StartEventPipeSessionAsync(IEnumerable<EventPipeProvider> providers, bool requestRundown, int circularBufferMB, CancellationToken token)
+        {
+            return EventPipeSession.StartAsync(_endpoint, providers, requestRundown, circularBufferMB, token);
+        }
+
+        /// <summary>
+        /// Start tracing the application and return an EventPipeSession object
+        /// </summary>
+        /// <param name="provider">An EventPipeProvider to turn on.</param>
+        /// <param name="requestRundown">If true, request rundown events from the runtime</param>
+        /// <param name="circularBufferMB">The size of the runtime's buffer for collecting events in MB</param>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        /// <returns>
+        /// An EventPipeSession object representing the EventPipe session that just started.
+        /// </returns>
+        internal Task<EventPipeSession> StartEventPipeSessionAsync(EventPipeProvider provider, bool requestRundown, int circularBufferMB, CancellationToken token)
+        {
+            return EventPipeSession.StartAsync(_endpoint, new[] { provider }, requestRundown, circularBufferMB, token);
+        }
+
+        /// <summary>
+        /// Trigger a core dump generation.
+        /// </summary> 
+        /// <param name="dumpType">Type of the dump to be generated</param>
+        /// <param name="dumpPath">Full path to the dump to be generated. By default it is /tmp/coredump.{pid}</param>
+        /// <param name="logDumpGeneration">When set to true, display the dump generation debug log to the console.</param>
+        public void WriteDump(DumpType dumpType, string dumpPath, bool logDumpGeneration = false)
+        {
+            IpcMessage request = CreateWriteDumpMessage(dumpType, dumpPath, logDumpGeneration);
+            IpcMessage response = IpcClient.SendMessage(_endpoint, request);
+            ValidateResponseMessage(response, nameof(WriteDump));
+        }
+
+        /// <summary>
+        /// Trigger a core dump generation.
+        /// </summary> 
+        /// <param name="dumpType">Type of the dump to be generated</param>
+        /// <param name="dumpPath">Full path to the dump to be generated. By default it is /tmp/coredump.{pid}</param>
+        /// <param name="flags">logging and crash report flags. On runtimes less than 6.0, only LoggingEnabled is supported.</param>
+        public void WriteDump(DumpType dumpType, string dumpPath, WriteDumpFlags flags)
+        {
+            IpcMessage request = CreateWriteDumpMessage2(dumpType, dumpPath, flags);
+            IpcMessage response = IpcClient.SendMessage(_endpoint, request);
+            if (!ValidateResponseMessage(response, nameof(WriteDump), ValidateResponseOptions.UnknownCommandReturnsFalse))
+            {
+                if ((flags & ~WriteDumpFlags.LoggingEnabled) != 0)
+                {
+                    throw new ArgumentException($"Only {nameof(WriteDumpFlags.LoggingEnabled)} flag is supported by this runtime version", nameof(flags));
+                }
+                WriteDump(dumpType, dumpPath, logDumpGeneration: (flags & WriteDumpFlags.LoggingEnabled) != 0);
+            }
+        }
+
+        /// <summary>
+        /// Trigger a core dump generation.
+        /// </summary> 
+        /// <param name="dumpType">Type of the dump to be generated</param>
+        /// <param name="dumpPath">Full path to the dump to be generated. By default it is /tmp/coredump.{pid}</param>
+        /// <param name="logDumpGeneration">When set to true, display the dump generation debug log to the console.</param>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        public async Task WriteDumpAsync(DumpType dumpType, string dumpPath, bool logDumpGeneration, CancellationToken token)
+        {
+            IpcMessage request = CreateWriteDumpMessage(dumpType, dumpPath, logDumpGeneration);
+            IpcMessage response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
+            ValidateResponseMessage(response, nameof(WriteDumpAsync));
+        }
+
+        /// <summary>
+        /// Trigger a core dump generation.
+        /// </summary> 
+        /// <param name="dumpType">Type of the dump to be generated</param>
+        /// <param name="dumpPath">Full path to the dump to be generated. By default it is /tmp/coredump.{pid}</param>
+        /// <param name="flags">logging and crash report flags. On runtimes less than 6.0, only LoggingEnabled is supported.</param>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        public async Task WriteDumpAsync(DumpType dumpType, string dumpPath, WriteDumpFlags flags, CancellationToken token)
+        {
+            IpcMessage request = CreateWriteDumpMessage2(dumpType, dumpPath, flags);
+            IpcMessage response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
+            if (!ValidateResponseMessage(response, nameof(WriteDumpAsync), ValidateResponseOptions.UnknownCommandReturnsFalse))
+            {
+                if ((flags & ~WriteDumpFlags.LoggingEnabled) != 0)
+                {
+                    throw new ArgumentException($"Only {nameof(WriteDumpFlags.LoggingEnabled)} flag is supported by this runtime version", nameof(flags));
+                }
+                await WriteDumpAsync(dumpType, dumpPath, logDumpGeneration: (flags & WriteDumpFlags.LoggingEnabled) != 0, token);
+            }
+        }
+
+        /// <summary>
+        /// Attach a profiler.
+        /// </summary>
+        /// <param name="attachTimeout">Timeout for attaching the profiler</param>
+        /// <param name="profilerGuid">Guid for the profiler to be attached</param>
+        /// <param name="profilerPath">Path to the profiler to be attached</param>
+        /// <param name="additionalData">Additional data to be passed to the profiler</param>
+        public void AttachProfiler(TimeSpan attachTimeout, Guid profilerGuid, string profilerPath, byte[] additionalData = null)
+        {
+            IpcMessage request = CreateAttachProfilerMessage(attachTimeout, profilerGuid, profilerPath, additionalData);
+            IpcMessage response = IpcClient.SendMessage(_endpoint, request);
+            ValidateResponseMessage(response, nameof(AttachProfiler));
+
+            // The call to set up the pipe and send the message operates on a different timeout than attachTimeout, which is for the runtime.
+            // We should eventually have a configurable timeout for the message passing, potentially either separately from the 
+            // runtime timeout or respect attachTimeout as one total duration.
+        }
+
+        internal async Task AttachProfilerAsync(TimeSpan attachTimeout, Guid profilerGuid, string profilerPath, byte[] additionalData, CancellationToken token)
+        {
+            IpcMessage request = CreateAttachProfilerMessage(attachTimeout, profilerGuid, profilerPath, additionalData);
+            IpcMessage response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
+            ValidateResponseMessage(response, nameof(AttachProfilerAsync));
+        }
+
+        /// <summary>
+        /// Set a profiler as the startup profiler. It is only valid to issue this command
+        /// while the runtime is paused at startup.
+        /// </summary>
+        /// <param name="profilerGuid">Guid for the profiler to be attached</param>
+        /// <param name="profilerPath">Path to the profiler to be attached</param>
+        public void SetStartupProfiler(Guid profilerGuid, string profilerPath)
+        {
+            IpcMessage request = CreateSetStartupProfilerMessage(profilerGuid, profilerPath);
+            IpcMessage response = IpcClient.SendMessage(_endpoint, request);
+            ValidateResponseMessage(response, nameof(SetStartupProfiler), ValidateResponseOptions.InvalidArgumentIsRequiresSuspension);
+        }
+
+        internal async Task SetStartupProfilerAsync(Guid profilerGuid, string profilerPath, CancellationToken token)
+        {
+            IpcMessage request = CreateSetStartupProfilerMessage(profilerGuid, profilerPath);
+            IpcMessage response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
+            ValidateResponseMessage(response, nameof(SetStartupProfilerAsync), ValidateResponseOptions.InvalidArgumentIsRequiresSuspension);
+        }
+
+        /// <summary>
+        /// Tell the runtime to resume execution after being paused at startup.
+        /// </summary>
+        public void ResumeRuntime()
+        {
+            IpcMessage request = CreateResumeRuntimeMessage();
+            IpcMessage response = IpcClient.SendMessage(_endpoint, request);
+            ValidateResponseMessage(response, nameof(ResumeRuntime));
+        }
+
+        internal async Task ResumeRuntimeAsync(CancellationToken token)
+        {
+            IpcMessage request = CreateResumeRuntimeMessage();
+            IpcMessage response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
+            ValidateResponseMessage(response, nameof(ResumeRuntimeAsync));
+        }
+
+        /// <summary>
+        /// Set an environment variable in the target process.
+        /// </summary>
+        /// <param name="name">The name of the environment variable to set.</param>
+        /// <param name="value">The value of the environment variable to set.</param>
+        public void SetEnvironmentVariable(string name, string value)
+        {
+            IpcMessage request = CreateSetEnvironmentVariableMessage(name, value);
+            IpcMessage response = IpcClient.SendMessage(_endpoint, request);
+            ValidateResponseMessage(response, nameof(SetEnvironmentVariable));
+        }
+
+        internal async Task SetEnvironmentVariableAsync(string name, string value, CancellationToken token)
+        {
+            IpcMessage request = CreateSetEnvironmentVariableMessage(name, value);
+            IpcMessage response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
+            ValidateResponseMessage(response, nameof(SetEnvironmentVariableAsync));
+        }
+
+        /// <summary>
+        /// Gets all environement variables and their values from the target process.
+        /// </summary>
+        /// <returns>A dictionary containing all of the environment variables defined in the target process.</returns>
+        public Dictionary<string, string> GetProcessEnvironment()
+        {
+            IpcMessage message = CreateProcessEnvironmentMessage();
+            using IpcResponse response = IpcClient.SendMessageGetContinuation(_endpoint, message);
+            ValidateResponseMessage(response.Message, nameof(GetProcessEnvironmentAsync));
+
+            ProcessEnvironmentHelper helper = ProcessEnvironmentHelper.Parse(response.Message.Payload);
+            return helper.ReadEnvironment(response.Continuation);
+        }
+
+        internal async Task<Dictionary<string, string>> GetProcessEnvironmentAsync(CancellationToken token)
+        {
+            IpcMessage message = CreateProcessEnvironmentMessage();
+            using IpcResponse response = await IpcClient.SendMessageGetContinuationAsync(_endpoint, message, token).ConfigureAwait(false);
+            ValidateResponseMessage(response.Message, nameof(GetProcessEnvironmentAsync));
+
+            ProcessEnvironmentHelper helper = ProcessEnvironmentHelper.Parse(response.Message.Payload);
+            return await helper.ReadEnvironmentAsync(response.Continuation, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Get all the active processes that can be attached to.
+        /// </summary>
+        /// <returns>
+        /// IEnumerable of all the active process IDs.
+        /// </returns>
+        public static IEnumerable<int> GetPublishedProcesses()
+        {
+            static IEnumerable<int> GetAllPublishedProcesses()
+            {
+                foreach (var port in Directory.GetFiles(PidIpcEndpoint.IpcRootPath))
+                {
+                    var fileName = new FileInfo(port).Name;
+                    var match = Regex.Match(fileName, PidIpcEndpoint.DiagnosticsPortPattern);
+                    if (!match.Success) continue;
+                    var group = match.Groups[1].Value;
+                    if (!int.TryParse(group, NumberStyles.Integer, CultureInfo.InvariantCulture, out var processId))
+                        continue;
+
+                    yield return processId;
+                }
+            }
+
+            return GetAllPublishedProcesses().Distinct();
+        }
+
+        internal ProcessInfo GetProcessInfo()
+        {
+            // Attempt to get ProcessInfo v2
+            ProcessInfo processInfo = TryGetProcessInfo2();
+            if (null != processInfo)
+            {
+                return processInfo;
+            }
+
+            IpcMessage request = CreateProcessInfoMessage();
+            using IpcResponse response = IpcClient.SendMessageGetContinuation(_endpoint, request);
+            return GetProcessInfoFromResponse(response, nameof(GetProcessInfo));
+        }
+
+        internal async Task<ProcessInfo> GetProcessInfoAsync(CancellationToken token)
+        {
+            // Attempt to get ProcessInfo v2
+            ProcessInfo processInfo = await TryGetProcessInfo2Async(token);
+            if (null != processInfo)
+            {
+                return processInfo;
+            }
+
+            IpcMessage request = CreateProcessInfoMessage();
+            using IpcResponse response = await IpcClient.SendMessageGetContinuationAsync(_endpoint, request, token).ConfigureAwait(false);
+            return GetProcessInfoFromResponse(response, nameof(GetProcessInfoAsync));
+        }
+
+        private ProcessInfo TryGetProcessInfo2()
+        {
+            IpcMessage request = CreateProcessInfo2Message();
+            using IpcResponse response2 = IpcClient.SendMessageGetContinuation(_endpoint, request);
+            return TryGetProcessInfo2FromResponse(response2, nameof(GetProcessInfo));
+        }
+
+        private async Task<ProcessInfo> TryGetProcessInfo2Async(CancellationToken token)
+        {
+            IpcMessage request = CreateProcessInfo2Message();
+            using IpcResponse response2 = await IpcClient.SendMessageGetContinuationAsync(_endpoint, request, token).ConfigureAwait(false);
+            return TryGetProcessInfo2FromResponse(response2, nameof(GetProcessInfoAsync));
+        }
+
+        private static byte[] SerializePayload<T>(T arg)
+        {
+            using (var stream = new MemoryStream())
+            using (var writer = new BinaryWriter(stream))
+            {
+                SerializePayloadArgument(arg, writer);
+
+                writer.Flush();
+                return stream.ToArray();
+            }
+        }
+
+        private static byte[] SerializePayload<T1, T2>(T1 arg1, T2 arg2)
+        {
+            using (var stream = new MemoryStream())
+            using (var writer = new BinaryWriter(stream))
+            {
+                SerializePayloadArgument(arg1, writer);
+                SerializePayloadArgument(arg2, writer);
+
+                writer.Flush();
+                return stream.ToArray();
+            }
+        }
+
+        private static byte[] SerializePayload<T1, T2, T3>(T1 arg1, T2 arg2, T3 arg3)
+        {
+            using (var stream = new MemoryStream())
+            using (var writer = new BinaryWriter(stream))
+            {
+                SerializePayloadArgument(arg1, writer);
+                SerializePayloadArgument(arg2, writer);
+                SerializePayloadArgument(arg3, writer);
+
+                writer.Flush();
+                return stream.ToArray();
+            }
+        }
+
+        private static byte[] SerializePayload<T1, T2, T3, T4>(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        {
+            using (var stream = new MemoryStream())
+            using (var writer = new BinaryWriter(stream))
+            {
+                SerializePayloadArgument(arg1, writer);
+                SerializePayloadArgument(arg2, writer);
+                SerializePayloadArgument(arg3, writer);
+                SerializePayloadArgument(arg4, writer);
+
+                writer.Flush();
+                return stream.ToArray();
+            }
+        }
+
+        private static void SerializePayloadArgument<T>(T obj, BinaryWriter writer)
+        {
+            if (typeof(T) == typeof(string))
+            {
+                writer.WriteString((string)((object)obj));
+            }
+            else if (typeof(T) == typeof(int))
+            {
+                writer.Write((int)((object)obj));
+            }
+            else if (typeof(T) == typeof(uint))
+            {
+                writer.Write((uint)((object)obj));
+            }
+            else if (typeof(T) == typeof(bool))
+            {
+                bool bValue = (bool)((object)obj);
+                uint uiValue = bValue ? (uint)1 : 0;
+                writer.Write(uiValue);
+            }
+            else if (typeof(T) == typeof(Guid))
+            {
+                Guid guidVal = (Guid)((object)obj);
+                writer.Write(guidVal.ToByteArray());
+            }
+            else if (typeof(T) == typeof(byte[]))
+            {
+                byte[] byteArray = (byte[])((object)obj);
+                uint length = byteArray == null ? 0U : (uint)byteArray.Length;
+                writer.Write(length);
+
+                if (length > 0)
+                {
+                    writer.Write(byteArray);
+                }
+            }
+            else
+            {
+                throw new ArgumentException($"Type {obj.GetType()} is not supported in SerializePayloadArgument, please add it.");
+            }
+        }
+
+        private static IpcMessage CreateAttachProfilerMessage(TimeSpan attachTimeout, Guid profilerGuid, string profilerPath, byte[] additionalData)
+        {
+            if (profilerGuid == null || profilerGuid == Guid.Empty)
+            {
+                throw new ArgumentException($"{nameof(profilerGuid)} must be a valid Guid");
+            }
+
+            if (String.IsNullOrEmpty(profilerPath))
+            {
+                throw new ArgumentException($"{nameof(profilerPath)} must be non-null");
+            }
+
+            byte[] serializedConfiguration = SerializePayload((uint)attachTimeout.TotalSeconds, profilerGuid, profilerPath, additionalData);
+            return new IpcMessage(DiagnosticsServerCommandSet.Profiler, (byte)ProfilerCommandId.AttachProfiler, serializedConfiguration);
+        }
+
+        private static IpcMessage CreateProcessEnvironmentMessage()
+        {
+            return new IpcMessage(DiagnosticsServerCommandSet.Process, (byte)ProcessCommandId.GetProcessEnvironment);
+        }
+
+        private static IpcMessage CreateProcessInfoMessage()
+        {
+            return new IpcMessage(DiagnosticsServerCommandSet.Process, (byte)ProcessCommandId.GetProcessInfo);
+        }
+
+        private static IpcMessage CreateProcessInfo2Message()
+        {
+            return new IpcMessage(DiagnosticsServerCommandSet.Process, (byte)ProcessCommandId.GetProcessInfo2);
+        }
+
+        private static IpcMessage CreateResumeRuntimeMessage()
+        {
+            return new IpcMessage(DiagnosticsServerCommandSet.Process, (byte)ProcessCommandId.ResumeRuntime);
+        }
+
+        private static IpcMessage CreateSetEnvironmentVariableMessage(string name, string value)
+        {
+            if (String.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException($"{nameof(name)} must be non-null.");
+            }
+
+            byte[] serializedConfiguration = SerializePayload(name, value);
+            return new IpcMessage(DiagnosticsServerCommandSet.Process, (byte)ProcessCommandId.SetEnvironmentVariable, serializedConfiguration);
+        }
+
+        private static IpcMessage CreateSetStartupProfilerMessage(Guid profilerGuid, string profilerPath)
+        {
+            if (profilerGuid == null || profilerGuid == Guid.Empty)
+            {
+                throw new ArgumentException($"{nameof(profilerGuid)} must be a valid Guid");
+            }
+
+            if (String.IsNullOrEmpty(profilerPath))
+            {
+                throw new ArgumentException($"{nameof(profilerPath)} must be non-null");
+            }
+
+            byte[] serializedConfiguration = SerializePayload(profilerGuid, profilerPath);
+            return new IpcMessage(DiagnosticsServerCommandSet.Profiler, (byte)ProfilerCommandId.StartupProfiler, serializedConfiguration);
+        }
+
+        private static IpcMessage CreateWriteDumpMessage(DumpType dumpType, string dumpPath, bool logDumpGeneration)
+        {
+            if (string.IsNullOrEmpty(dumpPath))
+                throw new ArgumentNullException($"{nameof(dumpPath)} required");
+
+            byte[] payload = SerializePayload(dumpPath, (uint)dumpType, logDumpGeneration);
+            return new IpcMessage(DiagnosticsServerCommandSet.Dump, (byte)DumpCommandId.GenerateCoreDump, payload);
+        }
+
+        private static IpcMessage CreateWriteDumpMessage2(DumpType dumpType, string dumpPath, WriteDumpFlags flags)
+        {
+            if (string.IsNullOrEmpty(dumpPath))
+                throw new ArgumentNullException($"{nameof(dumpPath)} required");
+
+            byte[] payload = SerializePayload(dumpPath, (uint)dumpType, (uint)flags);
+            return new IpcMessage(DiagnosticsServerCommandSet.Dump, (byte)DumpCommandId.GenerateCoreDump2, payload);
+        }
+
+        private static ProcessInfo GetProcessInfoFromResponse(IpcResponse response, string operationName)
+        {
+            ValidateResponseMessage(response.Message, operationName);
+
+            return ProcessInfo.ParseV1(response.Message.Payload);
+        }
+
+        private static ProcessInfo TryGetProcessInfo2FromResponse(IpcResponse response, string operationName)
+        {
+            if (!ValidateResponseMessage(response.Message, operationName, ValidateResponseOptions.UnknownCommandReturnsFalse))
+            {
+                return null;
+            }
+
+            return ProcessInfo.ParseV2(response.Message.Payload);
+        }
+
+        internal static bool ValidateResponseMessage(IpcMessage responseMessage, string operationName, ValidateResponseOptions options = ValidateResponseOptions.None)
+        {
+            switch ((DiagnosticsServerResponseId)responseMessage.Header.CommandId)
+            {
+                case DiagnosticsServerResponseId.Error:
+                    uint hr = BitConverter.ToUInt32(responseMessage.Payload, 0);
+                    switch (hr)
+                    {
+                        case (uint)DiagnosticsIpcError.UnknownCommand:
+                            if (options.HasFlag(ValidateResponseOptions.UnknownCommandReturnsFalse))
+                            {
+                                return false;
+                            }
+                            throw new UnsupportedCommandException($"{operationName} failed - Command is not supported.");
+                        case (uint)DiagnosticsIpcError.ProfilerAlreadyActive:
+                            throw new ProfilerAlreadyActiveException($"{operationName} failed - A profiler is already loaded.");
+                        case (uint)DiagnosticsIpcError.InvalidArgument:
+                            if (options.HasFlag(ValidateResponseOptions.InvalidArgumentIsRequiresSuspension))
+                            {
+                                throw new ServerErrorException($"{operationName} failed - The runtime must be suspended for this command.");
+                            }
+                            throw new UnsupportedCommandException($"{operationName} failed - Invalid command argument.");
+                    }
+                    throw new ServerErrorException($"{operationName} failed - HRESULT: 0x{hr:X8}");
+                case DiagnosticsServerResponseId.OK:
+                    return true;
+                default:
+                    throw new ServerErrorException($"{operationName} failed - Server responded with unknown response.");
+            }
+        }
+
+        [Flags]
+        internal enum ValidateResponseOptions
+        {
+            None = 0x0,
+            UnknownCommandReturnsFalse = 0x1,
+            InvalidArgumentIsRequiresSuspension = 0x2,
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClientExceptions.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClientExceptions.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    public class DiagnosticsClientException : Exception
+    {
+        public DiagnosticsClientException(string msg) : base(msg) {}
+    }
+
+    // When a certian command is not supported by either the library or the target process' runtime
+    public class UnsupportedProtocolException : DiagnosticsClientException
+    {
+        public UnsupportedProtocolException(string msg) : base(msg) {}
+    }
+
+    // When the runtime is no longer availble for attaching.
+    public class ServerNotAvailableException : DiagnosticsClientException
+    {
+        public ServerNotAvailableException(string msg) : base(msg) {}
+    }
+
+    // When the runtime responded with an error
+    public class ServerErrorException : DiagnosticsClientException
+    {
+        public ServerErrorException(string msg): base(msg) {}
+    }
+
+    // When the runtime doesn't support the command
+    public class UnsupportedCommandException : ServerErrorException
+    {
+        public UnsupportedCommandException(string msg): base(msg) {}
+    }
+
+    // When the runtime already has loaded profiler
+    public class ProfilerAlreadyActiveException : ServerErrorException
+    {
+        public ProfilerAlreadyActiveException(string msg): base(msg) {}
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DumpType.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DumpType.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    public enum DumpType
+    {
+        Normal = 1,
+        WithHeap = 2,
+        Triage = 3,
+        Full = 4
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeProvider.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeProvider.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    public sealed class EventPipeProvider
+    {
+        public EventPipeProvider(string name, EventLevel eventLevel, long keywords = 0xF00000000000, IDictionary<string, string> arguments = null)
+        {
+            Name = name;
+            EventLevel = eventLevel;
+            Keywords = keywords;
+            Arguments = arguments;
+        }
+
+        public long Keywords { get; }
+
+        public EventLevel EventLevel { get; }
+
+        public string Name { get; }
+
+        public IDictionary<string, string> Arguments { get; }
+
+        public override string ToString()
+        {
+            return $"{Name}:0x{Keywords:X16}:{(uint)EventLevel}{(Arguments == null ? "" : $":{GetArgumentString()}")}";
+        }
+        
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+            
+            return this == (EventPipeProvider)obj;
+        }
+
+        public override int GetHashCode()
+        {
+            int hash = 0;
+            hash ^= this.Name.GetHashCode();
+            hash ^= this.Keywords.GetHashCode();
+            hash ^= this.EventLevel.GetHashCode();
+            hash ^= GetArgumentString().GetHashCode();
+            return hash;
+        }
+
+        public static bool operator ==(EventPipeProvider left, EventPipeProvider right)
+        {
+            return left.ToString() == right.ToString();
+        }
+
+        public static bool operator !=(EventPipeProvider left, EventPipeProvider right)
+        {
+            return !(left == right);    
+        }
+
+        internal string GetArgumentString()
+        {
+            if (Arguments == null)
+            {
+                return "";
+            }
+            return string.Join(";", Arguments.Select(a => {
+                var escapedKey = a.Key.Contains(";") || a.Key.Contains("=") ? $"\"{a.Key}\"" : a.Key;
+                var escapedValue = a.Value.Contains(";") || a.Value.Contains("=") ? $"\"{a.Value}\"" : a.Value;
+                return $"{escapedKey}={escapedValue}";
+            }));
+        }
+
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSession.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSession.cs
@@ -1,0 +1,156 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    public class EventPipeSession : IDisposable
+    {
+        private long _sessionId;
+        private IpcEndpoint _endpoint;
+        private bool _disposedValue = false; // To detect redundant calls
+        private bool _stopped = false; // To detect redundant calls
+        private readonly IpcResponse _response;
+
+        private EventPipeSession(IpcEndpoint endpoint, IpcResponse response, long sessionId)
+        {
+            _endpoint = endpoint;
+            _response = response;
+            _sessionId = sessionId;
+        }
+
+        public Stream EventStream => _response.Continuation;
+
+        internal static EventPipeSession Start(IpcEndpoint endpoint, IEnumerable<EventPipeProvider> providers, bool requestRundown, int circularBufferMB)
+        {
+            IpcMessage requestMessage = CreateStartMessage(providers, requestRundown, circularBufferMB);
+            IpcResponse? response = IpcClient.SendMessageGetContinuation(endpoint, requestMessage);
+            return CreateSessionFromResponse(endpoint, ref response, nameof(Start));
+        }
+
+        internal static async Task<EventPipeSession> StartAsync(IpcEndpoint endpoint, IEnumerable<EventPipeProvider> providers, bool requestRundown, int circularBufferMB, CancellationToken cancellationToken)
+        {
+            IpcMessage requestMessage = CreateStartMessage(providers, requestRundown, circularBufferMB);
+            IpcResponse? response = await IpcClient.SendMessageGetContinuationAsync(endpoint, requestMessage, cancellationToken).ConfigureAwait(false);
+            return CreateSessionFromResponse(endpoint, ref response, nameof(StartAsync));
+        }
+
+        ///<summary>
+        /// Stops the given session
+        ///</summary>
+        public void Stop()
+        {
+            if (TryCreateStopMessage(out IpcMessage requestMessage))
+            {
+                try
+                {
+                    IpcMessage response = IpcClient.SendMessage(_endpoint, requestMessage);
+
+                    DiagnosticsClient.ValidateResponseMessage(response, nameof(Stop));
+                }
+                // On non-abrupt exits (i.e. the target process has already exited and pipe is gone, sending Stop command will fail).
+                catch (IOException)
+                {
+                    throw new ServerNotAvailableException("Could not send Stop command. The target process may have exited.");
+                }
+            }
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            if (TryCreateStopMessage(out IpcMessage requestMessage))
+            {
+                try
+                {
+                    IpcMessage response = await IpcClient.SendMessageAsync(_endpoint, requestMessage, cancellationToken).ConfigureAwait(false);
+
+                    DiagnosticsClient.ValidateResponseMessage(response, nameof(StopAsync));
+                }
+                // On non-abrupt exits (i.e. the target process has already exited and pipe is gone, sending Stop command will fail).
+                catch (IOException)
+                {
+                    throw new ServerNotAvailableException("Could not send Stop command. The target process may have exited.");
+                }
+            }
+        }
+
+        private static IpcMessage CreateStartMessage(IEnumerable<EventPipeProvider> providers, bool requestRundown, int circularBufferMB)
+        {
+            var config = new EventPipeSessionConfiguration(circularBufferMB, EventPipeSerializationFormat.NetTrace, providers, requestRundown);
+            return new IpcMessage(DiagnosticsServerCommandSet.EventPipe, (byte)EventPipeCommandId.CollectTracing2, config.SerializeV2());
+        }
+
+        private static EventPipeSession CreateSessionFromResponse(IpcEndpoint endpoint, ref IpcResponse? response, string operationName)
+        {
+            try
+            {
+                DiagnosticsClient.ValidateResponseMessage(response.Value.Message, operationName);
+
+                long sessionId = BitConverter.ToInt64(response.Value.Message.Payload, 0);
+
+                var session = new EventPipeSession(endpoint, response.Value, sessionId);
+                response = null;
+                return session;
+            }
+            finally
+            {
+                response?.Dispose();
+            }
+        }
+
+        private bool TryCreateStopMessage(out IpcMessage stopMessage)
+        {
+            Debug.Assert(_sessionId > 0);
+
+            // Do not issue another Stop command if it has already been issued for this session instance.
+            if (_stopped)
+            {
+                stopMessage = null;
+                return false;
+            }
+            else
+            {
+                _stopped = true;
+            }
+
+            byte[] payload = BitConverter.GetBytes(_sessionId);
+
+            stopMessage = new IpcMessage(DiagnosticsServerCommandSet.EventPipe, (byte)EventPipeCommandId.StopTracing, payload);
+
+            return true;
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            // If session being disposed hasn't been stopped, attempt to stop it first
+            if (!_stopped)
+            {
+                try
+                {
+                    Stop();
+                }
+                catch {} // swallow any exceptions that may be thrown from Stop.
+            }
+
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    _response.Dispose();
+                }
+                _disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSessionConfiguration.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSessionConfiguration.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal enum EventPipeSerializationFormat
+    {
+        NetPerf,
+        NetTrace
+    }
+
+    internal class EventPipeSessionConfiguration
+    {
+        public EventPipeSessionConfiguration(int circularBufferSizeMB, EventPipeSerializationFormat format, IEnumerable<EventPipeProvider> providers, bool requestRundown=true)
+        {
+            if (circularBufferSizeMB == 0)
+                throw new ArgumentException($"Buffer size cannot be zero.");
+            if (format != EventPipeSerializationFormat.NetPerf && format != EventPipeSerializationFormat.NetTrace)
+                throw new ArgumentException("Unrecognized format");
+            if (providers == null)
+                throw new ArgumentNullException(nameof(providers));
+
+            CircularBufferSizeInMB = circularBufferSizeMB;
+            Format = format;
+            RequestRundown = requestRundown;
+            _providers = new List<EventPipeProvider>(providers);
+        }
+
+        public bool RequestRundown { get; }
+        public int CircularBufferSizeInMB { get; }
+        public EventPipeSerializationFormat Format { get; }
+
+        public IReadOnlyCollection<EventPipeProvider> Providers => _providers.AsReadOnly();
+
+        private readonly List<EventPipeProvider> _providers;
+
+        public byte[] SerializeV2()
+        {
+            byte[] serializedData = null;
+            using (var stream = new MemoryStream())
+            using (var writer = new BinaryWriter(stream))
+            {
+                writer.Write(CircularBufferSizeInMB);
+                writer.Write((uint)Format);
+                writer.Write(RequestRundown);
+
+                writer.Write(Providers.Count);
+                foreach (var provider in Providers)
+                {
+                    writer.Write(provider.Keywords);
+                    writer.Write((uint)provider.EventLevel);
+
+                    writer.WriteString(provider.Name);
+                    writer.WriteString(provider.GetArgumentString());
+                }
+
+                writer.Flush();
+                serializedData = stream.ToArray();
+            }
+
+            return serializedData;
+        }
+
+
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/WriteDumpFlags.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/WriteDumpFlags.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    public enum WriteDumpFlags
+    {
+        None = 0x00,
+        LoggingEnabled = 0x01,
+        VerboseLoggingEnabled = 0x02,
+        CrashReportEnabled = 0x04
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ExposedSocketNetworkStream.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ExposedSocketNetworkStream.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Sockets;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal sealed class ExposedSocketNetworkStream :
+        NetworkStream
+    {
+        public ExposedSocketNetworkStream(Socket socket, bool ownsSocket)
+            : base(socket, ownsSocket)
+        {
+        }
+
+        public new Socket Socket => base.Socket;
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcAdvertise.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcAdvertise.cs
@@ -1,0 +1,114 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    /**
+     * ==ADVERTISE PROTOCOL==
+     * Before standard IPC Protocol communication can occur on a client-mode connection
+     * the runtime must advertise itself over the connection. ALL SUBSEQUENT COMMUNICATION 
+     * IS STANDARD DIAGNOSTICS IPC PROTOCOL COMMUNICATION.
+     * 
+     * The flow for Advertise is a one-way burst of 34 bytes consisting of
+     * 8 bytes  - "ADVR_V1\0" (ASCII chars + null byte)
+     * 16 bytes - CLR Instance Cookie (little-endian)
+     * 8 bytes  - PID (little-endian)
+     * 2 bytes  - future
+     */
+
+    internal sealed class IpcAdvertise
+    {
+        private static byte[] Magic_V1 => Encoding.ASCII.GetBytes("ADVR_V1" + '\0');
+        private static readonly int IpcAdvertiseV1SizeInBytes = Magic_V1.Length + 16 + 8 + 2; // 34 bytes
+
+        private IpcAdvertise(byte[] magic, Guid cookie, UInt64 pid, UInt16 future)
+        {
+            Future = future;
+            Magic = magic;
+            ProcessId = pid;
+            RuntimeInstanceCookie = cookie;
+        }
+
+        public static int V1SizeInBytes { get; } = IpcAdvertiseV1SizeInBytes;
+
+        public static async Task<IpcAdvertise> ParseAsync(Stream stream, CancellationToken token)
+        {
+            byte[] buffer = new byte[IpcAdvertiseV1SizeInBytes];
+
+            int totalRead = 0;
+            do
+            {
+                int read = await stream.ReadAsync(buffer, totalRead, buffer.Length - totalRead, token).ConfigureAwait(false);
+                if (0 == read)
+                {
+                    throw new EndOfStreamException();
+                }
+                totalRead += read;
+            }
+            while (totalRead < buffer.Length);
+
+            int index = 0;
+            byte[] magic = new byte[Magic_V1.Length];
+            Array.Copy(buffer, magic, Magic_V1.Length);
+            index += Magic_V1.Length;
+
+            if (!Magic_V1.SequenceEqual(magic))
+            {
+                throw new Exception("Invalid advertise message from client connection");
+            }
+
+            byte[] cookieBuffer = new byte[16];
+            Array.Copy(buffer, index, cookieBuffer, 0, 16);
+            Guid cookie = new Guid(cookieBuffer);
+            index += 16;
+
+            UInt64 pid = BitConverter.ToUInt64(buffer, index);
+            index += 8;
+
+            UInt16 future = BitConverter.ToUInt16(buffer, index);
+            index += 2;
+
+            // FUTURE: switch on incoming magic and change if version ever increments
+            return new IpcAdvertise(magic, cookie, pid, future);
+        }
+
+        public static async Task SerializeAsync(Stream stream, Guid runtimeInstanceCookie, ulong processId, CancellationToken token)
+        {
+            int index = 0;
+            byte[] buffer = new byte[IpcAdvertiseV1SizeInBytes];
+
+            Array.Copy(Magic_V1, buffer, Magic_V1.Length);
+            index += Magic_V1.Length;
+
+            byte[] cookieBuffer = runtimeInstanceCookie.ToByteArray();
+            Array.Copy(cookieBuffer, 0, buffer, index, cookieBuffer.Length);
+            index += cookieBuffer.Length;
+
+            Array.Copy(BitConverter.GetBytes(processId), 0, buffer, index, sizeof(ulong));
+            index += sizeof(ulong);
+
+            short future = 0;
+            Array.Copy(BitConverter.GetBytes(future), 0, buffer, index, sizeof(short));
+            index += sizeof(short);
+
+            await stream.WriteAsync(buffer, 0, index).ConfigureAwait(false);
+        }
+
+        public override string ToString()
+        {
+            return $"{{ Magic={Magic}; ClrInstanceId={RuntimeInstanceCookie}; ProcessId={ProcessId}; Future={Future} }}";
+        }
+
+        private UInt16 Future { get; } = 0;
+        public byte[] Magic { get; } = Magic_V1;
+        public UInt64 ProcessId { get; } = 0;
+        public Guid RuntimeInstanceCookie { get; } = Guid.Empty;
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs
@@ -1,0 +1,122 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal class IpcClient
+    {
+        // The amount of time to wait for a stream to be available for consumption by the Connect method.
+        // Normally expect the runtime to respond quickly but resource constrained machines may take longer.
+        internal static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Sends a single DiagnosticsIpc Message to the dotnet process associated with the <paramref name="endpoint"/>.
+        /// </summary>
+        /// <param name="endpoint">An endpoint that provides a diagnostics connection to a runtime instance.</param>
+        /// <param name="message">The DiagnosticsIpc Message to be sent</param>
+        /// <returns>An <see cref="IpcMessage"/> that is the response message.</returns>
+        public static IpcMessage SendMessage(IpcEndpoint endpoint, IpcMessage message)
+        {
+            using IpcResponse response = SendMessageGetContinuation(endpoint, message);
+            return response.Message;
+        }
+
+        /// <summary>
+        /// Sends a single DiagnosticsIpc Message to the dotnet process associated with the <paramref name="endpoint"/>.
+        /// </summary>
+        /// <param name="endpoint">An endpoint that provides a diagnostics connection to a runtime instance.</param>
+        /// <param name="message">The DiagnosticsIpc Message to be sent</param>
+        /// <returns>An <see cref="IpcResponse"/> containing the response message and continuation stream.</returns>
+        public static IpcResponse SendMessageGetContinuation(IpcEndpoint endpoint, IpcMessage message)
+        {
+            Stream stream = null;
+            try
+            {
+                stream = endpoint.Connect(ConnectTimeout);
+
+                Write(stream, message);
+
+                IpcMessage response = Read(stream);
+
+                return new IpcResponse(response, Release(ref stream));
+            }
+            finally
+            {
+                stream?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Sends a single DiagnosticsIpc Message to the dotnet process associated with the <paramref name="endpoint"/>.
+        /// </summary>
+        /// <param name="endpoint">An endpoint that provides a diagnostics connection to a runtime instance.</param>
+        /// <param name="message">The DiagnosticsIpc Message to be sent</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>An <see cref="IpcMessage"/> that is the response message.</returns>
+        public static async Task<IpcMessage> SendMessageAsync(IpcEndpoint endpoint, IpcMessage message, CancellationToken cancellationToken)
+        {
+            using IpcResponse response = await SendMessageGetContinuationAsync(endpoint, message, cancellationToken).ConfigureAwait(false);
+            return response.Message;
+        }
+
+        /// <summary>
+        /// Sends a single DiagnosticsIpc Message to the dotnet process associated with the <paramref name="endpoint"/>.
+        /// </summary>
+        /// <param name="endpoint">An endpoint that provides a diagnostics connection to a runtime instance.</param>
+        /// <param name="message">The DiagnosticsIpc Message to be sent</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>An <see cref="IpcResponse"/> containing the response message and continuation stream.</returns>
+        public static async Task<IpcResponse> SendMessageGetContinuationAsync(IpcEndpoint endpoint, IpcMessage message, CancellationToken cancellationToken)
+        {
+            Stream stream = null;
+            try
+            {
+                stream = await endpoint.ConnectAsync(cancellationToken).ConfigureAwait(false);
+
+                await WriteAsync(stream, message, cancellationToken).ConfigureAwait(false);
+
+                IpcMessage response = await ReadAsync(stream, cancellationToken).ConfigureAwait(false);
+
+                return new IpcResponse(response, Release(ref stream));
+            }
+            finally
+            {
+                stream?.Dispose();
+            }
+        }
+
+        private static void Write(Stream stream, IpcMessage message)
+        {
+            byte[] buffer = message.Serialize();
+            stream.Write(buffer, 0, buffer.Length);
+        }
+
+        private static Task WriteAsync(Stream stream, IpcMessage message, CancellationToken cancellationToken)
+        {
+            byte[] buffer = message.Serialize();
+            return stream.WriteAsync(buffer, 0, buffer.Length, cancellationToken);
+        }
+
+        private static IpcMessage Read(Stream stream)
+        {
+            return IpcMessage.Parse(stream);
+        }
+
+        private static Task<IpcMessage> ReadAsync(Stream stream, CancellationToken cancellationToken)
+        {
+            return IpcMessage.ParseAsync(stream, cancellationToken);
+        }
+
+        private static Stream Release(ref Stream stream1)
+        {
+            Stream intermediate = stream1;
+            stream1 = null;
+            return intermediate;
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal enum DiagnosticsServerCommandSet : byte
+    {
+        Dump           = 0x01,
+        EventPipe      = 0x02,
+        Profiler       = 0x03,
+        Process        = 0x04,
+
+        Server         = 0xFF,
+    }
+
+    internal enum DiagnosticsServerResponseId : byte
+    {
+        OK            = 0x00,
+        // future
+        Error         = 0xFF,
+    }
+
+    internal enum EventPipeCommandId : byte
+    {
+        StopTracing     = 0x01,
+        CollectTracing  = 0x02,
+        CollectTracing2 = 0x03,
+    }
+
+    internal enum DumpCommandId : byte
+    {
+        GenerateCoreDump = 0x01,
+        GenerateCoreDump2 = 0x02,
+    }
+
+    internal enum ProfilerCommandId : byte
+    {
+        AttachProfiler = 0x01,
+        StartupProfiler = 0x02,
+    }
+
+    internal enum ProcessCommandId : byte
+    {
+        GetProcessInfo = 0x00,
+        ResumeRuntime  = 0x01,
+        GetProcessEnvironment = 0x02,
+        SetEnvironmentVariable = 0x03,
+        GetProcessInfo2 = 0x04
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcEndpointConfig.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcEndpointConfig.cs
@@ -1,0 +1,181 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal class IpcEndpointConfig
+    {
+        public enum PortType
+        {
+            Connect,
+            Listen
+        }
+
+        public enum TransportType
+        {
+            NamedPipe,
+            UnixDomainSocket
+        }
+
+        PortType _portType;
+
+        TransportType _transportType;
+
+        public string Address { get; }
+
+        public bool IsConnectConfig => _portType == PortType.Connect;
+
+        public bool IsListenConfig => _portType == PortType.Listen;
+
+        public TransportType Transport => _transportType;
+
+        const string NamedPipeSchema = "namedpipe";
+        const string UnixDomainSocketSchema = "uds";
+        const string NamedPipeDefaultIPCRoot = @"\\.\pipe\";
+        const string NamedPipeSchemaDefaultIPCRootPath = "/pipe/";
+
+        public IpcEndpointConfig(string address, TransportType transportType, PortType portType)
+        {
+            if (string.IsNullOrEmpty(address))
+                throw new ArgumentException("Address is null or empty.");
+
+            switch (transportType)
+            {
+                case TransportType.NamedPipe:
+                {
+                    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        throw new PlatformNotSupportedException($"{NamedPipeSchema} is only supported on Windows.");
+                    break;
+                }
+                case TransportType.UnixDomainSocket:
+                {
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        throw new PlatformNotSupportedException($"{UnixDomainSocketSchema} is not supported on Windows, use {NamedPipeSchema}.");
+                    break;
+                }
+                default:
+                {
+                    throw new NotSupportedException($"{transportType} not supported.");
+                }
+            }
+
+            Address = address;
+            _transportType = transportType;
+            _portType = portType;
+        }
+
+        // Config format: [Address],[PortType]
+        //
+        // Address in UnixDomainSocket formats:
+        // myport => myport
+        // uds:myport => myport
+        // /User/mrx/myport.sock => /User/mrx/myport.sock
+        // uds:/User/mrx/myport.sock => /User/mrx/myport.sock
+        // uds://authority/User/mrx/myport.sock => /User/mrx/myport.sock
+        // uds:///User/mrx/myport.sock => /User/mrx/myport.sock
+        //
+        // Address in NamedPipe formats:
+        // myport => myport
+        // namedpipe:myport => myport
+        // \\.\pipe\myport => myport (dropping \\.\pipe\ is inline with implemented namedpipe client/server)
+        // namedpipe://./pipe/myport => myport (dropping authority and /pipe/ is inline with implemented namedpipe client/server)
+        // namedpipe:/pipe/myport  => myport (dropping /pipe/ is inline with implemented namedpipe client/server)
+        // namedpipe://authority/myport => myport
+        // namedpipe:///myport => myport
+        //
+        // PortType: Listen|Connect, default Listen.
+        public static bool TryParse(string config, out IpcEndpointConfig result)
+        {
+            try
+            {
+                result = Parse(config);
+            }
+            catch(Exception)
+            {
+                result = null;
+            }
+            return result != null;
+        }
+
+        public static IpcEndpointConfig Parse(string config)
+        {
+            if (string.IsNullOrEmpty(config))
+                throw new FormatException("Missing IPC endpoint config.");
+
+            string address = "";
+            PortType portType = PortType.Connect;
+            TransportType transportType = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? TransportType.NamedPipe : TransportType.UnixDomainSocket;
+
+            if (!string.IsNullOrEmpty(config))
+            {
+                var parts = config.Split(',');
+                if (parts.Length > 2)
+                    throw new FormatException($"Unknow IPC endpoint config format, {config}.");
+
+                if (string.IsNullOrEmpty(parts[0]))
+                    throw new FormatException($"Missing IPC endpoint config address, {config}.");
+
+                portType = PortType.Listen;
+                address = parts[0];
+
+                if (parts.Length == 2)
+                {
+                    if (string.Equals(parts[1], "connect", StringComparison.OrdinalIgnoreCase))
+                    {
+                        portType = PortType.Connect;
+                    }
+                    else if (string.Equals(parts[1], "listen", StringComparison.OrdinalIgnoreCase))
+                    {
+                        portType = PortType.Listen;
+                    }
+                    else
+                    {
+                        throw new FormatException($"Unknow IPC endpoint config keyword, {parts[1]} in {config}.");
+                    }
+                }
+            }
+
+            if (Uri.TryCreate(address, UriKind.Absolute, out Uri parsedAddress))
+            {
+                if (string.Equals(parsedAddress.Scheme, NamedPipeSchema, StringComparison.OrdinalIgnoreCase))
+                {
+                    transportType = TransportType.NamedPipe;
+                    address = parsedAddress.AbsolutePath;
+                }
+                else if (string.Equals(parsedAddress.Scheme, UnixDomainSocketSchema, StringComparison.OrdinalIgnoreCase))
+                {
+                    transportType = TransportType.UnixDomainSocket;
+                    address = parsedAddress.AbsolutePath;
+                }
+                else if (string.Equals(parsedAddress.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
+                {
+                    address = parsedAddress.AbsolutePath;
+                }
+                else if (!string.IsNullOrEmpty(parsedAddress.Scheme))
+                {
+                    throw new FormatException($"{parsedAddress.Scheme} not supported.");
+                }
+            }
+            else
+            {
+                if (address.StartsWith(NamedPipeDefaultIPCRoot, StringComparison.OrdinalIgnoreCase))
+                    transportType = TransportType.NamedPipe;
+            }
+
+            if (transportType == TransportType.NamedPipe)
+            {
+                if (address.StartsWith(NamedPipeDefaultIPCRoot, StringComparison.OrdinalIgnoreCase))
+                    address = address.Substring(NamedPipeDefaultIPCRoot.Length);
+                else if (address.StartsWith(NamedPipeSchemaDefaultIPCRootPath, StringComparison.OrdinalIgnoreCase))
+                    address = address.Substring(NamedPipeSchemaDefaultIPCRootPath.Length);
+                else if (address.StartsWith("/", StringComparison.OrdinalIgnoreCase))
+                    address = address.Substring("/".Length);
+            }
+
+            return new IpcEndpointConfig(address, transportType, portType);
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcEndpointConfig.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcEndpointConfig.cs
@@ -17,13 +17,17 @@ namespace Microsoft.Diagnostics.NETCore.Client
         public enum TransportType
         {
             NamedPipe,
-            UnixDomainSocket
+            UnixDomainSocket,
+#if DIAGNOSTICS_RUNTIME
+            TcpSocket
+#endif
         }
 
         PortType _portType;
 
         TransportType _transportType;
 
+        // For TcpSocket TransportType, the address format will be <hostname_or_ip>:<port>
         public string Address { get; }
 
         public bool IsConnectConfig => _portType == PortType.Connect;
@@ -56,6 +60,12 @@ namespace Microsoft.Diagnostics.NETCore.Client
                         throw new PlatformNotSupportedException($"{UnixDomainSocketSchema} is not supported on Windows, use {NamedPipeSchema}.");
                     break;
                 }
+#if DIAGNOSTICS_RUNTIME
+                case TransportType.TcpSocket:
+                {
+                    break;
+                }
+#endif
                 default:
                 {
                     throw new NotSupportedException($"{transportType} not supported.");

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcHeader.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcHeader.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal class IpcHeader
+    {
+        IpcHeader() { }
+
+        public IpcHeader(DiagnosticsServerCommandSet commandSet, byte commandId)
+        {
+            CommandSet = (byte)commandSet;
+            CommandId = commandId;
+        }
+
+        // the number of bytes for the DiagnosticsIpc::IpcHeader type in native code
+        public static readonly UInt16 HeaderSizeInBytes = 20;
+        private static readonly UInt16 MagicSizeInBytes = 14;
+
+        public byte[] Magic = DotnetIpcV1; // byte[14] in native code
+        public UInt16 Size = HeaderSizeInBytes;
+        public byte CommandSet;
+        public byte CommandId;
+        public UInt16 Reserved = 0x0000;
+
+
+        // Helper expression to quickly get V1 magic string for comparison
+        // should be 14 bytes long
+        public static byte[] DotnetIpcV1 => Encoding.ASCII.GetBytes("DOTNET_IPC_V1" + '\0');
+
+        public byte[] Serialize()
+        {
+            using (var stream = new MemoryStream())
+            using (var writer = new BinaryWriter(stream))
+            {
+                writer.Write(Magic);
+                Debug.Assert(Magic.Length == MagicSizeInBytes);
+                writer.Write(Size);
+                writer.Write(CommandSet);
+                writer.Write(CommandId);
+                writer.Write((UInt16)0x0000);
+                writer.Flush();
+                return stream.ToArray();
+            }
+        }
+
+        public static IpcHeader Parse(BinaryReader reader)
+        {
+            IpcHeader header = new IpcHeader
+            {
+                Magic = reader.ReadBytes(14),
+                Size = reader.ReadUInt16(),
+                CommandSet = reader.ReadByte(),
+                CommandId = reader.ReadByte(),
+                Reserved = reader.ReadUInt16()
+            };
+
+            return header;
+        }
+
+        public static async Task<IpcHeader> ParseAsync(Stream stream, CancellationToken cancellationToken)
+        {
+            byte[] buffer = await stream.ReadBytesAsync(HeaderSizeInBytes, cancellationToken).ConfigureAwait(false);
+            using MemoryStream bufferStream = new MemoryStream(buffer);
+            using BinaryReader bufferReader = new BinaryReader(bufferStream);
+            IpcHeader header = Parse(bufferReader);
+            Debug.Assert(bufferStream.Position == bufferStream.Length);
+            return header;
+        }
+
+        override public string ToString()
+        {
+            return $"{{ Magic={Magic}; Size={Size}; CommandSet={CommandSet}; CommandId={CommandId}; Reserved={Reserved} }}";
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcMessage.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcMessage.cs
@@ -1,0 +1,130 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    /// <summary>
+    /// Errors (HRESULT) returned for DiagnosticsServerCommandId.Error responses.
+    /// </summary>
+    internal enum DiagnosticsIpcError : uint
+    {
+        InvalidArgument       = 0x80070057,
+        ProfilerAlreadyActive = 0x8013136A,
+        BadEncoding           = 0x80131384,
+        UnknownCommand        = 0x80131385,
+        UnknownMagic          = 0x80131386,
+        UnknownError          = 0x80131387,
+    }
+
+    /// <summary>
+    /// Different diagnostic message types that are handled by the runtime.
+    /// </summary>
+    internal enum DiagnosticsMessageType : uint
+    {
+        /// <summary>
+        /// Initiates core dump generation 
+        /// </summary>
+        GenerateCoreDump = 1,
+        /// <summary>
+        /// Starts an EventPipe session that writes events to a file when the session is stopped or the application exits.
+        /// </summary>
+        StartEventPipeTracing = 1024,
+        /// <summary>
+        /// Stops an EventPipe session.
+        /// </summary>
+        StopEventPipeTracing = 1025,
+        /// <summary>
+        /// Starts an EventPipe session that sends events out-of-proc through IPC.
+        /// </summary>
+        CollectEventPipeTracing = 1026,
+        /// <summary>
+        /// Attaches a profiler to an existing process
+        /// </summary>
+        AttachProfiler = 2048,
+    }
+
+
+    /// <summary>
+    /// Message header used to send commands to the .NET Core runtime through IPC.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct MessageHeader
+    {
+        /// <summary>
+        /// Request type.
+        /// </summary>
+        public DiagnosticsMessageType RequestType;
+
+        /// <summary>
+        /// Remote process Id.
+        /// </summary>
+        public uint Pid;
+    }
+
+
+    internal class IpcMessage
+    {
+        public IpcMessage()
+        { }
+
+        public IpcMessage(IpcHeader header, byte[] payload = null)
+        {
+            Payload = payload ?? Array.Empty<byte>();
+            Header = header;
+        }
+
+        public IpcMessage(DiagnosticsServerCommandSet commandSet, byte commandId, byte[] payload = null)
+        : this(new IpcHeader(commandSet, commandId), payload)
+        {
+        }
+
+        public byte[] Payload { get; private set; } = null;
+        public IpcHeader Header { get; private set; } = default;
+
+        public byte[] Serialize()
+        { 
+            byte[] serializedData = null;
+            // Verify things will fit in the size capacity
+            Header.Size = checked((UInt16)(IpcHeader.HeaderSizeInBytes + Payload.Length));
+            byte[] headerBytes = Header.Serialize();
+
+            using (var stream = new MemoryStream())
+            using (var writer = new BinaryWriter(stream))
+            {
+                writer.Write(headerBytes);
+                writer.Write(Payload);
+                writer.Flush();
+                serializedData = stream.ToArray();
+            }
+
+            return serializedData;
+        }
+
+        public static IpcMessage Parse(Stream stream)
+        {
+            IpcMessage message = new IpcMessage();
+            using (var reader = new BinaryReader(stream, Encoding.UTF8, true))
+            {
+                message.Header = IpcHeader.Parse(reader);
+                message.Payload = reader.ReadBytes(message.Header.Size - IpcHeader.HeaderSizeInBytes);
+                return message;
+            }
+        }
+
+        public static async Task<IpcMessage> ParseAsync(Stream stream, CancellationToken cancellationToken)
+        {
+            IpcMessage message = new IpcMessage();
+            message.Header = await IpcHeader.ParseAsync(stream, cancellationToken).ConfigureAwait(false);
+            message.Payload = await stream.ReadBytesAsync(message.Header.Size - IpcHeader.HeaderSizeInBytes, cancellationToken).ConfigureAwait(false);
+            return message;
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcResponse.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcResponse.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal struct IpcResponse : IDisposable
+    {
+        public readonly IpcMessage Message;
+
+        public readonly Stream Continuation;
+
+        public IpcResponse(IpcMessage message, Stream continuation)
+        {
+            Message = message;
+            Continuation = continuation;
+        }
+
+        public void Dispose()
+        {
+            Continuation?.Dispose();
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcServerTransport.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcServerTransport.cs
@@ -1,0 +1,287 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal abstract class IpcServerTransport : IDisposable
+    {
+        private IIpcServerTransportCallbackInternal _callback;
+        private bool _disposed;
+
+        public static IpcServerTransport Create(string address, int maxConnections, bool enableTcpIpProtocol, IIpcServerTransportCallbackInternal transportCallback = null)
+        {
+            if (!enableTcpIpProtocol || !IpcTcpSocketEndPoint.IsTcpIpEndPoint(address))
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    return new IpcWindowsNamedPipeServerTransport(address, maxConnections, transportCallback);
+                }
+                else
+                {
+                    return new IpcUnixDomainSocketServerTransport(address, maxConnections, transportCallback);
+                }
+            }
+            else
+            {
+                return new IpcTcpSocketServerTransport(address, maxConnections, transportCallback);
+            }
+        }
+
+        protected IpcServerTransport(IIpcServerTransportCallbackInternal transportCallback = null)
+        {
+            _callback = transportCallback;
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                Dispose(disposing: true);
+
+                _disposed = true;
+            }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+        }
+
+        public abstract Task<Stream> AcceptAsync(CancellationToken token);
+
+        public static int MaxAllowedConnections {
+            get
+            {
+                return -1;
+            }
+        }
+
+        protected void VerifyNotDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(this.GetType().Name);
+            }
+        }
+
+        internal void SetCallback(IIpcServerTransportCallbackInternal callback)
+        {
+            _callback = callback;
+        }
+
+        protected void OnCreateNewServer(EndPoint localEP)
+        {
+            _callback?.CreatedNewServer(localEP);
+        }
+    }
+
+    internal sealed class IpcWindowsNamedPipeServerTransport : IpcServerTransport
+    {
+        private const string PipePrefix = @"\\.\pipe\";
+
+        private NamedPipeServerStream _stream;
+
+        private readonly CancellationTokenSource _cancellation = new CancellationTokenSource();
+        private readonly string _pipeName;
+        private readonly int _maxInstances;
+
+        public IpcWindowsNamedPipeServerTransport(string pipeName, int maxInstances, IIpcServerTransportCallbackInternal transportCallback = null)
+            : base(transportCallback)
+        {
+            _maxInstances = maxInstances != MaxAllowedConnections ? maxInstances : NamedPipeServerStream.MaxAllowedServerInstances;
+            _pipeName = pipeName.StartsWith(PipePrefix) ? pipeName.Substring(PipePrefix.Length) : pipeName;
+            _stream = CreateNewNamedPipeServer(_pipeName, _maxInstances);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _cancellation.Cancel();
+
+                _stream.Dispose();
+
+                _cancellation.Dispose();
+            }
+        }
+
+        public override async Task<Stream> AcceptAsync(CancellationToken token)
+        {
+            VerifyNotDisposed();
+
+            using var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(token, _cancellation.Token);
+            try
+            {
+                // Connect client to named pipe server stream.
+                await _stream.WaitForConnectionAsync(linkedSource.Token).ConfigureAwait(false);
+
+                // Transfer ownership of connected named pipe.
+                var connectedStream = _stream;
+
+                // Setup new named pipe server stream used in upcomming accept calls.
+                _stream = CreateNewNamedPipeServer(_pipeName, _maxInstances);
+
+                return connectedStream;
+            }
+            catch (Exception)
+            {
+                // Keep named pipe server stream when getting any kind of cancel request.
+                // Cancel happens when complete transport is about to disposed or caller
+                // cancels out specific accept call, no need to recycle named pipe server stream.
+                // In all other exception scenarios named pipe server stream will be re-created.
+                if (!linkedSource.IsCancellationRequested)
+                {
+                    _stream.Dispose();
+                    _stream = CreateNewNamedPipeServer(_pipeName, _maxInstances);
+                }
+                throw;
+            }
+        }
+
+        private NamedPipeServerStream CreateNewNamedPipeServer(string pipeName, int maxInstances)
+        {
+            var stream = new NamedPipeServerStream(pipeName, PipeDirection.InOut, maxInstances, PipeTransmissionMode.Byte, PipeOptions.Asynchronous, 16 * 1024, 16 * 1024);
+            OnCreateNewServer(null);
+            return stream;
+        }
+    }
+
+    internal abstract class IpcSocketServerTransport : IpcServerTransport
+    {
+        private readonly CancellationTokenSource _cancellation = new CancellationTokenSource();
+        protected IpcSocket _socket;
+
+        protected IpcSocketServerTransport(IIpcServerTransportCallbackInternal transportCallback = null)
+            : base(transportCallback)
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _cancellation.Cancel();
+
+                try
+                {
+                    _socket.Shutdown(SocketShutdown.Both);
+                }
+                catch { }
+                finally
+                {
+                    _socket.Close(0);
+                }
+                _socket.Dispose();
+
+                _cancellation.Dispose();
+            }
+        }
+
+        public override async Task<Stream> AcceptAsync(CancellationToken token)
+        {
+            VerifyNotDisposed();
+
+            using var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(token, _cancellation.Token);
+            try
+            {
+                // Accept next client socket.
+                var socket = await _socket.AcceptAsync(linkedSource.Token).ConfigureAwait(false);
+
+                // Configure client socket based on transport type.
+                OnAccept(socket);
+
+                return new ExposedSocketNetworkStream(socket, ownsSocket: true);
+            }
+            catch (Exception)
+            {
+                // Keep server socket when getting any kind of cancel request.
+                // Cancel happens when complete transport is about to disposed or caller
+                // cancels out specific accept call, no need to recycle server socket.
+                // In all other exception scenarios server socket will be re-created.
+                if (!linkedSource.IsCancellationRequested)
+                {
+                    _socket = CreateNewSocketServer();
+                }
+                throw;
+            }
+        }
+
+        internal abstract bool OnAccept(Socket socket);
+
+        internal abstract IpcSocket CreateNewSocketServer();
+    }
+
+    internal sealed class IpcTcpSocketServerTransport : IpcSocketServerTransport
+    {
+        private readonly int _backlog;
+        private readonly IpcTcpSocketEndPoint _endPoint;
+
+        public IpcTcpSocketServerTransport(string address, int backlog, IIpcServerTransportCallbackInternal transportCallback = null)
+            : base(transportCallback)
+        {
+            _endPoint = new IpcTcpSocketEndPoint(address);
+            _backlog = backlog != MaxAllowedConnections ? backlog : 100;
+            _socket = CreateNewSocketServer();
+        }
+
+        internal override bool OnAccept(Socket socket)
+        {
+            socket.NoDelay = true;
+            return true;
+        }
+
+        internal override IpcSocket CreateNewSocketServer()
+        {
+            var socket = new IpcSocket(SocketType.Stream, ProtocolType.Tcp);
+            if (_endPoint.DualMode)
+                socket.DualMode = _endPoint.DualMode;
+            socket.Bind(_endPoint);
+            socket.Listen(_backlog);
+            socket.LingerState.Enabled = false;
+            OnCreateNewServer(socket.LocalEndPoint);
+            return socket;
+        }
+    }
+
+    internal sealed class IpcUnixDomainSocketServerTransport : IpcSocketServerTransport
+    {
+        private readonly int _backlog;
+        private readonly IpcUnixDomainSocketEndPoint _endPoint;
+
+        public IpcUnixDomainSocketServerTransport(string path, int backlog, IIpcServerTransportCallbackInternal transportCallback = null)
+            : base(transportCallback)
+        {
+            _backlog = backlog != MaxAllowedConnections ? backlog : (int)SocketOptionName.MaxConnections;
+            _endPoint = new IpcUnixDomainSocketEndPoint(path);
+            _socket = CreateNewSocketServer();
+        }
+
+        internal override bool OnAccept(Socket socket)
+        {
+            return true;
+        }
+
+        internal override IpcSocket CreateNewSocketServer()
+        {
+            var socket = new IpcUnixDomainSocket();
+            socket.Bind(_endPoint);
+            socket.Listen(_backlog);
+            socket.LingerState.Enabled = false;
+            OnCreateNewServer(null);
+            return socket;
+        }
+    }
+
+    internal interface IIpcServerTransportCallbackInternal
+    {
+        void CreatedNewServer(EndPoint localEP);
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcSocket.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcSocket.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal class IpcSocket : Socket
+    {
+        public IpcSocket(SocketType socketType, ProtocolType protocolType)
+            : base(socketType, protocolType)
+        {
+        }
+
+        public IpcSocket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
+            : base(addressFamily, socketType, protocolType)
+        {
+        }
+
+        public async Task<Socket> AcceptAsync(CancellationToken token)
+        {
+            using (token.Register(() => Close(0)))
+            {
+                try
+                {
+                    return await Task.Factory.FromAsync(BeginAccept, EndAccept, this).ConfigureAwait(false);
+                }
+                // When the socket is closed, the FromAsync logic will try to call EndAccept on the socket,
+                // but that will throw an ObjectDisposedException. Only catch the exception if due to cancellation.
+                catch (ObjectDisposedException) when (token.IsCancellationRequested)
+                {
+                    // First check if the cancellation token caused the closing of the socket,
+                    // then rethrow the exception if it did not.
+                    token.ThrowIfCancellationRequested();
+
+                    Debug.Fail("Token should have thrown cancellation exception.");
+                    return null;
+                }
+            }
+        }
+
+        public virtual void Connect(EndPoint remoteEP, TimeSpan timeout)
+        {
+            IAsyncResult result = BeginConnect(remoteEP, null, null);
+
+            if (result.AsyncWaitHandle.WaitOne(timeout))
+            {
+                EndConnect(result);
+            }
+            else
+            {
+                Close(0);
+                throw new TimeoutException();
+            }
+        }
+
+        public async Task ConnectAsync(EndPoint remoteEP, CancellationToken token)
+        {
+            using (token.Register(() => Close(0)))
+            {
+                try
+                {
+                    Func<AsyncCallback, object, IAsyncResult> beginConnect = (callback, state) =>
+                    {
+                        return BeginConnect(remoteEP, callback, state);
+                    };
+                    await Task.Factory.FromAsync(beginConnect, EndConnect, this).ConfigureAwait(false);
+                }
+                // When the socket is closed, the FromAsync logic will try to call EndAccept on the socket,
+                // but that will throw an ObjectDisposedException. Only catch the exception if due to cancellation.
+                catch (ObjectDisposedException) when (token.IsCancellationRequested)
+                {
+                    // First check if the cancellation token caused the closing of the socket,
+                    // then rethrow the exception if it did not.
+                    token.ThrowIfCancellationRequested();
+                }
+            }
+        }
+
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcSocket.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcSocket.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
         {
         }
 
+// .NET 6 implements this method directly on Socket, but for earlier runtimes we need a polyfill
+#if !NET6_0
         public async Task<Socket> AcceptAsync(CancellationToken token)
         {
             using (token.Register(() => Close(0)))
@@ -43,6 +45,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 }
             }
         }
+#endif
 
         public virtual void Connect(EndPoint remoteEP, TimeSpan timeout)
         {
@@ -59,6 +62,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
             }
         }
 
+// .NET 6 implements this method directly on Socket, but for earlier runtimes we need a polyfill
+#if !NET6_0
         public async Task ConnectAsync(EndPoint remoteEP, CancellationToken token)
         {
             using (token.Register(() => Close(0)))
@@ -81,6 +86,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 }
             }
         }
-
+#endif
     }
 }

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTcpSocketEndPoint.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTcpSocketEndPoint.cs
@@ -1,0 +1,153 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal sealed class IpcTcpSocketEndPoint
+    {
+        public bool DualMode { get; }
+        public IPEndPoint EndPoint { get; }
+
+        public static bool IsTcpIpEndPoint(string endPoint)
+        {
+            bool result = true;
+
+            try
+            {
+                ParseTcpIpEndPoint(endPoint, out _, out _);
+            }
+            catch(Exception)
+            {
+                result = false;
+            }
+
+            return result;
+        }
+
+        public static string NormalizeTcpIpEndPoint(string endPoint)
+        {
+            ParseTcpIpEndPoint(endPoint, out string host, out int port);
+            return string.Format("{0}:{1}", host, port);
+        }
+
+        public IpcTcpSocketEndPoint(string endPoint)
+        {
+            ParseTcpIpEndPoint(endPoint, out string host, out int port);
+            EndPoint = CreateEndPoint(host, port);
+            DualMode = string.CompareOrdinal(host, "*") == 0;
+        }
+
+        public static implicit operator EndPoint(IpcTcpSocketEndPoint endPoint) => endPoint.EndPoint;
+
+        private static void ParseTcpIpEndPoint(string endPoint, out string host, out int port)
+        {
+            host = "";
+            port = -1;
+
+            bool usesWildcardHost = false;
+            string uriToParse= "";
+
+            if (endPoint.Contains("://"))
+            {
+                // Host can contain wildcard (*) that is a reserved charachter in URI's.
+                // Replace with dummy localhost representation just for parsing purpose.
+                if (endPoint.IndexOf("//*", StringComparison.Ordinal) != -1)
+                {
+                    usesWildcardHost = true;
+                    uriToParse = endPoint.Replace("//*", "//localhost");
+                }
+                else
+                {
+                    uriToParse = endPoint;
+                }
+            }
+
+            try
+            {
+                if (!string.IsNullOrEmpty(uriToParse) && Uri.TryCreate(uriToParse, UriKind.RelativeOrAbsolute, out Uri uri))
+                {
+                    if (string.Compare(uri.Scheme, Uri.UriSchemeNetTcp, StringComparison.OrdinalIgnoreCase) != 0 &&
+                        string.Compare(uri.Scheme, "tcp", StringComparison.OrdinalIgnoreCase) != 0)
+                    {
+                        throw new ArgumentException(string.Format("Unsupported Uri schema, \"{0}\"", uri.Scheme));
+                    }
+
+                    host = usesWildcardHost ? "*" : uri.Host;
+                    port = uri.IsDefaultPort ? 0 : uri.Port;
+                }
+            }
+            catch (InvalidOperationException)
+            {
+            }
+
+            if (string.IsNullOrEmpty(host) || port == -1)
+            {
+                string[] segments = endPoint.Split(':');
+                if (segments.Length > 2)
+                {
+                    host = string.Join(":", segments, 0, segments.Length - 1);
+                    port = int.Parse(segments[segments.Length - 1]);
+                }
+                else if (segments.Length == 2)
+                {
+                    host = segments[0];
+                    port = int.Parse(segments[1]);
+                }
+
+                if (string.CompareOrdinal(host, "*") != 0)
+                {
+                    if (!IPAddress.TryParse(host, out _))
+                    {
+                        if (!Uri.TryCreate(Uri.UriSchemeNetTcp + "://" + host + ":" + port, UriKind.RelativeOrAbsolute, out _))
+                        {
+                            host = "";
+                            port = -1;
+                        }
+                    }
+                }
+            }
+
+            if (string.IsNullOrEmpty(host) || port == -1)
+            {
+                throw new ArgumentException(string.Format("Could not parse {0} into host, port", endPoint));
+            }
+        }
+
+        private static IPEndPoint CreateEndPoint(string host, int port)
+        {
+            IPAddress ipAddress = null;
+            try
+            {
+                if (string.CompareOrdinal(host, "*") == 0)
+                {
+                    if (Socket.OSSupportsIPv6)
+                    {
+                        ipAddress = IPAddress.IPv6Any;
+                    }
+                    else
+                    {
+                        ipAddress = IPAddress.Any;
+                    }
+                }
+                else if (!IPAddress.TryParse(host, out ipAddress))
+                {
+                    var hostEntry = Dns.GetHostEntry(host);
+                    if (hostEntry.AddressList.Length > 0)
+                        ipAddress = hostEntry.AddressList[0];
+                }
+            }
+            catch(Exception)
+            {
+            }
+
+            if (ipAddress == null)
+                throw new ArgumentException(string.Format("Could not resolve {0} into an IP address", host));
+
+            return new IPEndPoint(ipAddress, port);
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
+using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Threading;
@@ -68,6 +69,15 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 socket.Connect(new IpcUnixDomainSocketEndPoint(config.Address), timeout);
                 return new ExposedSocketNetworkStream(socket, ownsSocket: true);
             }
+#if DIAGNOSTICS_RUNTIME
+            else if (config.Transport == IpcEndpointConfig.TransportType.TcpSocket)
+            {
+                var tcpClient = new TcpClient ();
+                var endPoint = new IpcTcpSocketEndPoint(config.Address);
+                tcpClient.Connect(endPoint.EndPoint);
+                return tcpClient.GetStream();
+            }
+#endif
             else
             {
                 throw new ArgumentException($"Unsupported IpcEndpointConfig transport type {config.Transport}");

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
@@ -1,0 +1,317 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal abstract class IpcEndpoint
+    {
+        /// <summary>
+        /// Connects to the underlying IPC transport and opens a read/write-able Stream
+        /// </summary>
+        /// <param name="timeout">The amount of time to block attempting to connect</param>
+        /// <returns>A stream used for writing and reading data to and from the target .NET process</returns>
+        public abstract Stream Connect(TimeSpan timeout);
+
+        /// <summary>
+        /// Connects to the underlying IPC transport and opens a read/write-able Stream
+        /// </summary>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        /// <returns>
+        /// A task that completes with a stream used for writing and reading data to and from the target .NET process.
+        /// </returns>
+        public abstract Task<Stream> ConnectAsync(CancellationToken token);
+
+        /// <summary>
+        /// Wait for an available diagnostic endpoint to the runtime instance.
+        /// </summary>
+        /// <param name="timeout">The amount of time to wait before cancelling the wait for the connection.</param>
+        public abstract void WaitForConnection(TimeSpan timeout);
+
+        /// <summary>
+        /// Wait for an available diagnostic endpoint to the runtime instance.
+        /// </summary>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        /// <returns>
+        /// A task that completes when a diagnostic endpoint to the runtime instance becomes available.
+        /// </returns>
+        public abstract Task WaitForConnectionAsync(CancellationToken token);
+    }
+
+    internal class IpcEndpointHelper
+    {
+        public static Stream Connect(IpcEndpointConfig config, TimeSpan timeout)
+        {
+            if (config.Transport == IpcEndpointConfig.TransportType.NamedPipe)
+            {
+                var namedPipe = new NamedPipeClientStream(
+                    ".",
+                    config.Address,
+                    PipeDirection.InOut,
+                    PipeOptions.None,
+                    TokenImpersonationLevel.Impersonation);
+                namedPipe.Connect((int)timeout.TotalMilliseconds);
+                return namedPipe;
+            }
+            else if (config.Transport == IpcEndpointConfig.TransportType.UnixDomainSocket)
+            {
+                var socket = new IpcUnixDomainSocket();
+                socket.Connect(new IpcUnixDomainSocketEndPoint(config.Address), timeout);
+                return new ExposedSocketNetworkStream(socket, ownsSocket: true);
+            }
+            else
+            {
+                throw new ArgumentException($"Unsupported IpcEndpointConfig transport type {config.Transport}");
+            }
+        }
+
+        public static async Task<Stream> ConnectAsync(IpcEndpointConfig config, CancellationToken token)
+        {
+            if (config.Transport == IpcEndpointConfig.TransportType.NamedPipe)
+            {
+                var namedPipe = new NamedPipeClientStream(
+                    ".",
+                    config.Address,
+                    PipeDirection.InOut,
+                    PipeOptions.Asynchronous,
+                    TokenImpersonationLevel.Impersonation);
+
+                // Pass non-infinite timeout in order to cause internal connection algorithm
+                // to check the CancellationToken periodically. Otherwise, if the named pipe
+                // is waited using WaitNamedPipe with an infinite timeout, then the
+                // CancellationToken cannot be observed.
+                await namedPipe.ConnectAsync(int.MaxValue, token).ConfigureAwait(false);
+                
+                return namedPipe;
+            }
+            else if (config.Transport == IpcEndpointConfig.TransportType.UnixDomainSocket)
+            {
+                var socket = new IpcUnixDomainSocket();
+                await socket.ConnectAsync(new IpcUnixDomainSocketEndPoint(config.Address), token).ConfigureAwait(false);
+                return new ExposedSocketNetworkStream(socket, ownsSocket: true);
+            }
+            else
+            {
+                throw new ArgumentException($"Unsupported IpcEndpointConfig transport type {config.Transport}");
+            }
+        }
+    }
+
+    internal class ServerIpcEndpoint : IpcEndpoint
+    {
+        private readonly Guid _runtimeId;
+        private readonly ReversedDiagnosticsServer _server;
+
+        public ServerIpcEndpoint(ReversedDiagnosticsServer server, Guid runtimeId)
+        {
+            _runtimeId = runtimeId;
+            _server = server;
+        }
+
+        /// <remarks>
+        /// This will block until the diagnostic stream is provided. This block can happen if
+        /// the stream is acquired previously and the runtime instance has not yet reconnected
+        /// to the reversed diagnostics server.
+        /// </remarks>
+        public override Stream Connect(TimeSpan timeout)
+        {
+            return _server.Connect(_runtimeId, timeout);
+        }
+
+        public override Task<Stream> ConnectAsync(CancellationToken token)
+        {
+            return _server.ConnectAsync(_runtimeId, token);
+        }
+
+        public override void WaitForConnection(TimeSpan timeout)
+        {
+            _server.WaitForConnection(_runtimeId, timeout);
+        }
+
+        public override Task WaitForConnectionAsync(CancellationToken token)
+        {
+            return _server.WaitForConnectionAsync(_runtimeId, token);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ServerIpcEndpoint);
+        }
+
+        public bool Equals(ServerIpcEndpoint other)
+        {
+            return other != null && other._runtimeId == _runtimeId && other._server == _server;
+        }
+
+        public override int GetHashCode()
+        {
+            return _runtimeId.GetHashCode() ^ _server.GetHashCode();
+        }
+    }
+
+    internal class DiagnosticPortIpcEndpoint : IpcEndpoint
+    {
+        IpcEndpointConfig _config;
+
+        public DiagnosticPortIpcEndpoint(string diagnosticPort)
+        {
+            _config = IpcEndpointConfig.Parse(diagnosticPort);
+        }
+
+        public DiagnosticPortIpcEndpoint(IpcEndpointConfig config)
+        {
+            _config = config;
+        }
+
+        public override Stream Connect(TimeSpan timeout)
+        {
+            return IpcEndpointHelper.Connect(_config, timeout);
+        }
+
+        public override async Task<Stream> ConnectAsync(CancellationToken token)
+        {
+            return await IpcEndpointHelper.ConnectAsync(_config, token).ConfigureAwait(false);
+        }
+
+        public override void WaitForConnection(TimeSpan timeout)
+        {
+            using var _ = Connect(timeout);
+        }
+
+        public override async Task WaitForConnectionAsync(CancellationToken token)
+        {
+            using var _ = await ConnectAsync(token).ConfigureAwait(false);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as DiagnosticPortIpcEndpoint);
+        }
+
+        public bool Equals(DiagnosticPortIpcEndpoint other)
+        {
+            return other != null && other._config == _config;
+        }
+
+        public override int GetHashCode()
+        {
+            return _config.GetHashCode();
+        }
+    }
+
+    internal class PidIpcEndpoint : IpcEndpoint
+    {
+        public static string IpcRootPath { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"\\.\pipe\" : Path.GetTempPath();
+        public static string DiagnosticsPortPattern { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"^dotnet-diagnostic-(\d+)$" : @"^dotnet-diagnostic-(\d+)-(\d+)-socket$";
+
+        int _pid;
+
+        IpcEndpointConfig _config;
+
+        /// <summary>
+        /// Creates a reference to a .NET process's IPC Transport
+        /// using the default rules for a given pid
+        /// </summary>
+        /// <param name="pid">The pid of the target process</param>
+        /// <returns>A reference to the IPC Transport</returns>
+        public PidIpcEndpoint(int pid)
+        {
+            _pid = pid;
+        }
+
+        public override Stream Connect(TimeSpan timeout)
+        {
+            string address = GetDefaultAddress();
+            _config = IpcEndpointConfig.Parse(address + ",connect");
+            return IpcEndpointHelper.Connect(_config, timeout);
+        }
+
+        public override async Task<Stream> ConnectAsync(CancellationToken token)
+        {
+            string address = GetDefaultAddress();
+            _config = IpcEndpointConfig.Parse(address + ",connect");
+            return await IpcEndpointHelper.ConnectAsync(_config, token).ConfigureAwait(false);
+        }
+
+        public override void WaitForConnection(TimeSpan timeout)
+        {
+            using var _ = Connect(timeout);
+        }
+
+        public override async Task WaitForConnectionAsync(CancellationToken token)
+        {
+            using var _ = await ConnectAsync(token).ConfigureAwait(false);
+        }
+
+        private string GetDefaultAddress()
+        {
+            try
+            {
+                var process = Process.GetProcessById(_pid);
+            }
+            catch (ArgumentException)
+            {
+                throw new ServerNotAvailableException($"Process {_pid} is not running.");
+            }
+            catch (InvalidOperationException)
+            {
+                throw new ServerNotAvailableException($"Process {_pid} seems to be elevated.");
+            }
+
+            if (!TryGetDefaultAddress(_pid, out string transportName))
+            {
+                throw new ServerNotAvailableException($"Process {_pid} not running compatible .NET runtime.");
+            }
+
+            return transportName;
+        }
+
+        private static bool TryGetDefaultAddress(int pid, out string defaultAddress)
+        {
+            defaultAddress = null;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                defaultAddress = $"dotnet-diagnostic-{pid}";
+            }
+            else
+            {
+                try
+                {
+                    defaultAddress = Directory.GetFiles(IpcRootPath, $"dotnet-diagnostic-{pid}-*-socket") // Try best match.
+                        .OrderByDescending(f => new FileInfo(f).LastWriteTime)
+                        .FirstOrDefault();
+                }
+                catch (InvalidOperationException)
+                {
+                }
+            }
+
+            return !string.IsNullOrEmpty(defaultAddress);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as PidIpcEndpoint);
+        }
+
+        public bool Equals(PidIpcEndpoint other)
+        {
+            return other != null && other._pid == _pid;
+        }
+
+        public override int GetHashCode()
+        {
+            return _pid.GetHashCode();
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcUnixDomainSocket.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcUnixDomainSocket.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal sealed class IpcUnixDomainSocket : IpcSocket
+    {
+        private bool _ownsSocketFile;
+        private string _path;
+
+        internal IpcUnixDomainSocket()
+            : base(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified)
+        {
+        }
+
+        public void Bind(IpcUnixDomainSocketEndPoint localEP)
+        {
+            base.Bind(localEP);
+            _path = localEP.Path;
+            _ownsSocketFile = true;
+        }
+
+        public override void Connect(EndPoint localEP, TimeSpan timeout)
+        {
+            base.Connect(localEP, timeout);
+            _ownsSocketFile = false;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (_ownsSocketFile && !string.IsNullOrEmpty(_path) && File.Exists(_path))
+                {
+                    File.Delete(_path);
+                }
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcUnixDomainSocketEndPoint.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcUnixDomainSocketEndPoint.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal sealed class IpcUnixDomainSocketEndPoint
+    {
+        public string Path { get; }
+        public EndPoint EndPoint { get; }
+
+        public IpcUnixDomainSocketEndPoint(string endPoint)
+        {
+            Path = endPoint;
+            EndPoint = CreateEndPoint(endPoint);
+        }
+
+        public static implicit operator EndPoint(IpcUnixDomainSocketEndPoint endPoint) => endPoint.EndPoint;
+
+        private static EndPoint CreateEndPoint(string endPoint)
+        {
+#if NETCOREAPP
+            return new UnixDomainSocketEndPoint(endPoint);
+#elif NETSTANDARD2_0
+            // UnixDomainSocketEndPoint is not part of .NET Standard 2.0
+            var type = typeof(Socket).Assembly.GetType("System.Net.Sockets.UnixDomainSocketEndPoint")
+                        ?? Type.GetType("System.Net.Sockets.UnixDomainSocketEndPoint, System.Core");
+            if (type == null)
+            {
+                throw new PlatformNotSupportedException("Current process is not running a compatible .NET runtime.");
+            }
+            var ctor = type.GetConstructor(new[] { typeof(string) });
+            return (EndPoint)ctor.Invoke(new object[] { endPoint });
+#endif
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ProcessEnvironment.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ProcessEnvironment.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal class ProcessEnvironmentHelper
+    {
+        private const int CopyBufferSize = (16 << 10) /* 16KiB */;
+
+        private ProcessEnvironmentHelper() {}
+        public static ProcessEnvironmentHelper Parse(byte[] payload)
+        {
+            ProcessEnvironmentHelper helper = new ProcessEnvironmentHelper();
+
+            helper.ExpectedSizeInBytes = BitConverter.ToUInt32(payload, 0);
+            helper.Future = BitConverter.ToUInt16(payload, 4);
+
+            return helper;
+        }
+
+        public Dictionary<string, string> ReadEnvironment(Stream continuation)
+        {
+            using var memoryStream = new MemoryStream();
+            continuation.CopyTo(memoryStream, CopyBufferSize);
+            return ReadEnvironmentCore(memoryStream);
+        }
+
+        public async Task<Dictionary<string,string>> ReadEnvironmentAsync(Stream continuation, CancellationToken token = default(CancellationToken))
+        {
+            using var memoryStream = new MemoryStream();
+            await continuation.CopyToAsync(memoryStream, CopyBufferSize, token);
+            return ReadEnvironmentCore(memoryStream);
+        }
+
+        private Dictionary<string, string> ReadEnvironmentCore(MemoryStream stream)
+        {
+            stream.Seek(0, SeekOrigin.Begin);
+            byte[] envBlock = stream.ToArray();
+
+            if (envBlock.Length != (long)ExpectedSizeInBytes)
+                throw new ApplicationException($"ProcessEnvironment continuation length did not match expected length. Expected: {ExpectedSizeInBytes} bytes, Received: {envBlock.Length} bytes");
+
+            var env = new Dictionary<string, string>();
+            int cursor = 0;
+            UInt32 nElements = BitConverter.ToUInt32(envBlock, cursor);
+            cursor += sizeof(UInt32);
+            while (cursor < envBlock.Length)
+            {
+                string pair = IpcHelpers.ReadString(envBlock, ref cursor);
+                int equalsIdx = pair.IndexOf('=');
+                env[pair.Substring(0, equalsIdx)] = equalsIdx != pair.Length - 1 ? pair.Substring(equalsIdx + 1) : "";
+            }
+
+            return env;
+        }
+
+
+        private UInt32 ExpectedSizeInBytes { get; set; }
+        private UInt16 Future { get; set; }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ProcessInfo.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ProcessInfo.cs
@@ -1,0 +1,91 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Text;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    /**
+     * ==ProcessInfo==
+     * The response payload to issuing the GetProcessInfo command.
+     * 
+     * 8 bytes  - PID (little-endian)
+     * 16 bytes - CLR Runtime Instance Cookie (little-endian)
+     * # bytes  - Command line string length and data
+     * # bytes  - Operating system string length and data
+     * # bytes  - Process architecture string length and data
+     * 
+     * ==ProcessInfo2==
+     * The response payload to issuing the GetProcessInfo2 command.
+     * 
+     * 8 bytes  - PID (little-endian)
+     * 16 bytes - CLR Runtime Instance Cookie (little-endian)
+     * # bytes  - Command line string length and data
+     * # bytes  - Operating system string length and data
+     * # bytes  - Process architecture string length and data
+     * # bytes  - Managed entrypoint assembly name
+     * # bytes  - CLR product version string (may include prerelease labels)
+     * 
+     * 
+     * The "string length and data" fields are variable length:
+     * 4 bytes            - Length of string data in UTF-16 characters
+     * (2 * length) bytes - The data of the string encoded using Unicode
+     *                      (includes null terminating character)
+     */
+
+    internal class ProcessInfo
+    {
+        private static readonly int GuidSizeInBytes = 16;
+
+        /// <summary>
+        /// Parses a ProcessInfo payload.
+        /// </summary>
+        internal static ProcessInfo ParseV1(byte[] payload)
+        {
+            int index = 0;
+            return ParseCommon(payload, ref index);
+        }
+
+        /// <summary>
+        /// Parses a ProcessInfo2 payload.
+        /// </summary>
+        internal static ProcessInfo ParseV2(byte[] payload)
+        {
+            int index = 0;
+            ProcessInfo processInfo = ParseCommon(payload, ref index);
+
+            processInfo.ManagedEntrypointAssemblyName = IpcHelpers.ReadString(payload, ref index);
+            processInfo.ClrProductVersionString = IpcHelpers.ReadString(payload, ref index);
+
+            return processInfo;
+        }
+
+        private static ProcessInfo ParseCommon(byte[] payload, ref int index)
+        {
+            ProcessInfo processInfo = new ProcessInfo();
+
+            processInfo.ProcessId = BitConverter.ToUInt64(payload, index);
+            index += sizeof(UInt64);
+
+            byte[] cookieBuffer = new byte[GuidSizeInBytes];
+            Array.Copy(payload, index, cookieBuffer, 0, GuidSizeInBytes);
+            processInfo.RuntimeInstanceCookie = new Guid(cookieBuffer);
+            index += GuidSizeInBytes;
+
+            processInfo.CommandLine = IpcHelpers.ReadString(payload, ref index);
+            processInfo.OperatingSystem = IpcHelpers.ReadString(payload, ref index);
+            processInfo.ProcessArchitecture = IpcHelpers.ReadString(payload, ref index);
+
+            return processInfo;
+        }
+
+        public UInt64 ProcessId { get; private set; }
+        public Guid RuntimeInstanceCookie { get; private set; }
+        public string CommandLine { get; private set; }
+        public string OperatingSystem { get; private set; }
+        public string ProcessArchitecture { get; private set; }
+        public string ManagedEntrypointAssemblyName { get; private set; }
+        public string ClrProductVersionString { get; private set; }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterFactory.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterFactory.cs
@@ -1,0 +1,1412 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Security.Principal;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal class RuntimeTimeoutException : TimeoutException
+    {
+        public RuntimeTimeoutException(int TimeoutMs)
+            : base(string.Format("No new runtime endpoints connected, waited {0} ms", TimeoutMs))
+        { }
+    }
+
+    internal class BackendStreamTimeoutException : TimeoutException
+    {
+        public BackendStreamTimeoutException(int TimeoutMs)
+            : base(string.Format("No new back end streams available, waited {0} ms", TimeoutMs))
+        { }
+    }
+
+    /// <summary>
+    /// Base class representing a Diagnostics Server router factory.
+    /// </summary>
+    internal class DiagnosticsServerRouterFactory
+    {
+        int IsStreamConnectedTimeoutMs { get; set; } = 500;
+
+        public virtual string IpcAddress { get; }
+
+        public virtual string TcpAddress { get; }
+
+        public virtual ILogger Logger { get; }
+
+        public virtual Task Start(CancellationToken token)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual Task Stop()
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual void Reset()
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual Task<Router> CreateRouterAsync(CancellationToken token)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected bool IsStreamConnected(Stream stream, CancellationToken token)
+        {
+            bool connected = true;
+
+            if (stream is NamedPipeServerStream || stream is NamedPipeClientStream)
+            {
+                PipeStream pipeStream = stream as PipeStream;
+
+                // PeekNamedPipe will return false if the pipe is disconnected/broken.
+                connected = NativeMethods.PeekNamedPipe(
+                    pipeStream.SafePipeHandle,
+                    null,
+                    0,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    IntPtr.Zero);
+            }
+            else if (stream is ExposedSocketNetworkStream networkStream)
+            {
+                bool blockingState = networkStream.Socket.Blocking;
+                try
+                {
+                    // Check connection read state by peek one byte. Will return 0 in case connection is closed.
+                    // A closed connection could also raise exception, but then socket connected state should
+                    // be set to false.
+                    networkStream.Socket.Blocking = false;
+                    if (networkStream.Socket.Receive(new byte[1], 0, 1, System.Net.Sockets.SocketFlags.Peek) == 0)
+                        connected = false;
+
+                    // Check connection write state by sending non-blocking zero-byte data.
+                    // A closed connection should raise exception, but then socket connected state should
+                    // be set to false.
+                    if (connected)
+                        networkStream.Socket.Send(Array.Empty<byte>(), 0, System.Net.Sockets.SocketFlags.None);
+                }
+                catch (Exception)
+                {
+                    connected = networkStream.Socket.Connected;
+                }
+                finally
+                {
+                    networkStream.Socket.Blocking = blockingState;
+                }
+            }
+            else
+            {
+                connected = false;
+            }
+
+            return connected;
+        }
+
+        protected async Task IsStreamConnectedAsync(Stream stream, CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                // Check if tcp stream connection is still available.
+                if (!IsStreamConnected(stream, token))
+                {
+                    throw new EndOfStreamException();
+                }
+
+                try
+                {
+                    // Wait before rechecking connection.
+                    await Task.Delay(IsStreamConnectedTimeoutMs, token).ConfigureAwait(false);
+                }
+                catch { }
+            }
+        }
+
+        protected bool IsCompletedSuccessfully(Task t)
+        {
+#if NETCOREAPP2_0_OR_GREATER
+            return t.IsCompletedSuccessfully;
+#else
+            return t.IsCompleted && !t.IsCanceled && !t.IsFaulted;
+#endif
+        }
+    }
+
+    /// <summary>
+    /// This class represent a TCP/IP server endpoint used when building up router instances.
+    /// </summary>
+    internal class TcpServerRouterFactory : IIpcServerTransportCallbackInternal
+    {
+        protected readonly ILogger _logger;
+
+        string _tcpServerAddress;
+
+        ReversedDiagnosticsServer _tcpServer;
+        IpcEndpointInfo _tcpServerEndpointInfo;
+
+        bool _auto_shutdown;
+
+        int RuntimeTimeoutMs { get; set; } = 60000;
+        int TcpServerTimeoutMs { get; set; } = 5000;
+
+        public Guid RuntimeInstanceId
+        {
+            get { return _tcpServerEndpointInfo.RuntimeInstanceCookie; }
+        }
+
+        public int RuntimeProcessId
+        {
+            get { return _tcpServerEndpointInfo.ProcessId; }
+        }
+
+        public string TcpServerAddress
+        {
+            get { return _tcpServerAddress; }
+        }
+
+        public delegate TcpServerRouterFactory CreateInstanceDelegate(string tcpServer, int runtimeTimeoutMs, ILogger logger);
+
+        public static TcpServerRouterFactory CreateDefaultInstance(string tcpServer, int runtimeTimeoutMs, ILogger logger)
+        {
+            return new TcpServerRouterFactory(tcpServer, runtimeTimeoutMs, logger);
+        }
+
+        public TcpServerRouterFactory(string tcpServer, int runtimeTimeoutMs, ILogger logger)
+        {
+            _logger = logger;
+
+            _tcpServerAddress = IpcTcpSocketEndPoint.NormalizeTcpIpEndPoint(string.IsNullOrEmpty(tcpServer) ? "127.0.0.1:0" : tcpServer);
+
+            _auto_shutdown = runtimeTimeoutMs != Timeout.Infinite;
+            if (runtimeTimeoutMs != Timeout.Infinite)
+                RuntimeTimeoutMs = runtimeTimeoutMs;
+
+            _tcpServer = new ReversedDiagnosticsServer(_tcpServerAddress, enableTcpIpProtocol : true);
+            _tcpServerEndpointInfo = new IpcEndpointInfo();
+            _tcpServer.TransportCallback = this;
+        }
+
+        public virtual void Start()
+        {
+            _tcpServer.Start();
+        }
+
+        public virtual async Task Stop()
+        {
+            await _tcpServer.DisposeAsync().ConfigureAwait(false);
+        }
+
+        public void Reset()
+        {
+            if (_tcpServerEndpointInfo.Endpoint != null)
+            {
+                _tcpServer.RemoveConnection(_tcpServerEndpointInfo.RuntimeInstanceCookie);
+                _tcpServerEndpointInfo = new IpcEndpointInfo();
+            }
+        }
+
+        public async Task<Stream> AcceptTcpStreamAsync(CancellationToken token)
+        {
+            Stream tcpServerStream;
+
+            _logger?.LogDebug($"Waiting for a new tcp connection at endpoint \"{_tcpServerAddress}\".");
+
+            if (_tcpServerEndpointInfo.Endpoint == null)
+            {
+                using var acceptTimeoutTokenSource = new CancellationTokenSource();
+                using var acceptTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token, acceptTimeoutTokenSource.Token);
+
+                try
+                {
+                    // If no new runtime instance connects, timeout.
+                    acceptTimeoutTokenSource.CancelAfter(RuntimeTimeoutMs);
+                    _tcpServerEndpointInfo = await _tcpServer.AcceptAsync(acceptTokenSource.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    if (acceptTimeoutTokenSource.IsCancellationRequested)
+                    {
+                        _logger?.LogDebug("No runtime instance connected before timeout.");
+
+                        if (_auto_shutdown)
+                            throw new RuntimeTimeoutException(RuntimeTimeoutMs);
+                    }
+
+                    throw;
+                }
+            }
+
+            using var connectTimeoutTokenSource = new CancellationTokenSource();
+            using var connectTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token, connectTimeoutTokenSource.Token);
+
+            try
+            {
+                // Get next connected tcp stream. Should timeout if no endpoint appears within timeout.
+                // If that happens we need to remove endpoint since it might indicate a unresponsive runtime.
+                connectTimeoutTokenSource.CancelAfter(TcpServerTimeoutMs);
+                tcpServerStream = await _tcpServerEndpointInfo.Endpoint.ConnectAsync(connectTokenSource.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                if (connectTimeoutTokenSource.IsCancellationRequested)
+                {
+                    _logger?.LogDebug("No tcp stream connected before timeout.");
+                    throw new BackendStreamTimeoutException(TcpServerTimeoutMs);
+                }
+
+                throw;
+            }
+
+            if (tcpServerStream != null)
+                _logger?.LogDebug($"Successfully connected tcp stream, runtime id={RuntimeInstanceId}, runtime pid={RuntimeProcessId}.");
+
+            return tcpServerStream;
+        }
+
+        public void CreatedNewServer(EndPoint localEP)
+        {
+            if (localEP is IPEndPoint ipEP)
+                _tcpServerAddress = _tcpServerAddress.Replace(":0", string.Format(":{0}", ipEP.Port));
+        }
+    }
+
+    /// <summary>
+    /// This class represent a TCP/IP client endpoint used when building up router instances.
+    /// </summary>
+    internal class TcpClientRouterFactory
+    {
+        protected readonly ILogger _logger;
+
+        protected readonly string _tcpClientAddress;
+
+        protected bool _auto_shutdown;
+
+        protected int TcpClientTimeoutMs { get; set; } = Timeout.Infinite;
+
+        protected int TcpClientRetryTimeoutMs { get; set; } = 500;
+
+        public delegate TcpClientRouterFactory CreateInstanceDelegate(string tcpClient, int runtimeTimeoutMs, ILogger logger);
+
+        public static TcpClientRouterFactory CreateDefaultInstance(string tcpClient, int runtimeTimeoutMs, ILogger logger)
+        {
+            return new TcpClientRouterFactory(tcpClient, runtimeTimeoutMs, logger);
+        }
+
+        public string TcpClientAddress {
+            get { return _tcpClientAddress; }
+        }
+
+        public TcpClientRouterFactory(string tcpClient, int runtimeTimeoutMs, ILogger logger)
+        {
+            _logger = logger;
+            _tcpClientAddress = IpcTcpSocketEndPoint.NormalizeTcpIpEndPoint(string.IsNullOrEmpty(tcpClient) ? "127.0.0.1:" + string.Format("{0}", 56000 + (Process.GetCurrentProcess().Id % 1000)) : tcpClient);
+            _auto_shutdown = runtimeTimeoutMs != Timeout.Infinite;
+            if (runtimeTimeoutMs != Timeout.Infinite)
+                TcpClientTimeoutMs = runtimeTimeoutMs;
+        }
+
+        public virtual async Task<Stream> ConnectTcpStreamAsync(CancellationToken token)
+        {
+            return await ConnectTcpStreamAsyncInternal(token, _auto_shutdown).ConfigureAwait(false);
+        }
+
+        public virtual async Task<Stream> ConnectTcpStreamAsync(CancellationToken token, bool retry)
+        {
+            return await ConnectTcpStreamAsyncInternal(token, retry).ConfigureAwait(false);
+        }
+
+        public virtual void Start()
+        {
+        }
+
+        public virtual void Stop()
+        {
+        }
+
+        async Task<Stream> ConnectTcpStreamAsyncInternal(CancellationToken token, bool retry)
+        {
+            Stream tcpClientStream = null;
+
+            _logger?.LogDebug($"Connecting new tcp endpoint \"{_tcpClientAddress}\".");
+
+            IpcTcpSocketEndPoint clientTcpEndPoint = new IpcTcpSocketEndPoint(_tcpClientAddress);
+            Socket clientSocket = null;
+
+            using var connectTimeoutTokenSource = new CancellationTokenSource();
+            using var connectTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token, connectTimeoutTokenSource.Token);
+
+            connectTimeoutTokenSource.CancelAfter(TcpClientTimeoutMs);
+
+            do
+            {
+                clientSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+
+                try
+                {
+                    await ConnectAsyncInternal(clientSocket, clientTcpEndPoint, connectTokenSource.Token).ConfigureAwait(false);
+                    retry = false;
+                }
+                catch (Exception)
+                {
+                    clientSocket?.Dispose();
+
+                    if (connectTimeoutTokenSource.IsCancellationRequested)
+                    {
+                        _logger?.LogDebug("No tcp stream connected, timing out.");
+
+                        if (_auto_shutdown)
+                            throw new RuntimeTimeoutException(TcpClientTimeoutMs);
+
+                        throw new TimeoutException();
+                    }
+
+                    // If we are not doing retries when runtime is unavailable, fail right away, this will
+                    // break any accepted IPC connections, making sure client is notified and could reconnect.
+                    // If not, retry until succeed or time out.
+                    if (!retry)
+                    {
+                        _logger?.LogTrace($"Failed connecting {_tcpClientAddress}.");
+                        throw;
+                    }
+
+                    _logger?.LogTrace($"Failed connecting {_tcpClientAddress}, wait {TcpClientRetryTimeoutMs} ms before retrying.");
+
+                    // If we get an error (without hitting timeout above), most likely due to unavailable listener.
+                    // Delay execution to prevent to rapid retry attempts.
+                    await Task.Delay(TcpClientRetryTimeoutMs, token).ConfigureAwait(false);
+                }
+            }
+            while (retry);
+
+            tcpClientStream = new ExposedSocketNetworkStream(clientSocket, ownsSocket: true);
+            _logger?.LogDebug("Successfully connected tcp stream.");
+
+            return tcpClientStream;
+        }
+
+        async Task ConnectAsyncInternal(Socket clientSocket, EndPoint remoteEP, CancellationToken token)
+        {
+            using (token.Register(() => clientSocket.Close(0)))
+            {
+                try
+                {
+                    Func<AsyncCallback, object, IAsyncResult> beginConnect = (callback, state) =>
+                    {
+                        return clientSocket.BeginConnect(remoteEP, callback, state);
+                    };
+                    await Task.Factory.FromAsync(beginConnect, clientSocket.EndConnect, this).ConfigureAwait(false);
+                }
+                // When the socket is closed, the FromAsync logic will try to call EndAccept on the socket,
+                // but that will throw an ObjectDisposedException. Only catch the exception if due to cancellation.
+                catch (ObjectDisposedException) when (token.IsCancellationRequested)
+                {
+                    // First check if the cancellation token caused the closing of the socket,
+                    // then rethrow the exception if it did not.
+                    token.ThrowIfCancellationRequested();
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// This class represent a IPC server endpoint used when building up router instances.
+    /// </summary>
+    internal class IpcServerRouterFactory
+    {
+        readonly ILogger _logger;
+
+        readonly string _ipcServerPath;
+
+        IpcServerTransport _ipcServer;
+
+        int IpcServerTimeoutMs { get; set; } = Timeout.Infinite;
+
+        public string IpcServerPath {
+            get { return _ipcServerPath; }
+        }
+
+        public IpcServerRouterFactory(string ipcServer, ILogger logger)
+        {
+            if (string.IsNullOrEmpty(ipcServer))
+                throw new ArgumentException("Missing IPC server path.");
+
+            _logger = logger;
+            _ipcServerPath = ipcServer;
+
+            _ipcServer = IpcServerTransport.Create(_ipcServerPath, IpcServerTransport.MaxAllowedConnections, false);
+        }
+
+        public void Start()
+        {
+        }
+
+        public void Stop()
+        {
+            _ipcServer?.Dispose();
+        }
+
+        public async Task<Stream> AcceptIpcStreamAsync(CancellationToken token)
+        {
+            Stream ipcServerStream = null;
+
+            _logger?.LogDebug($"Waiting for new ipc connection at endpoint \"{_ipcServerPath}\".");
+
+
+            using var connectTimeoutTokenSource = new CancellationTokenSource();
+            using var connectTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token, connectTimeoutTokenSource.Token);
+
+            try
+            {
+                connectTimeoutTokenSource.CancelAfter(IpcServerTimeoutMs);
+                ipcServerStream = await _ipcServer.AcceptAsync(connectTokenSource.Token).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                ipcServerStream?.Dispose();
+
+                if (connectTimeoutTokenSource.IsCancellationRequested)
+                {
+                    _logger?.LogDebug("No ipc stream connected, timing out.");
+                    throw new TimeoutException();
+                }
+
+                throw;
+            }
+
+            if (ipcServerStream != null)
+                _logger?.LogDebug("Successfully connected ipc stream.");
+
+            return ipcServerStream;
+        }
+    }
+
+    /// <summary>
+    /// This class represent a IPC client endpoint used when building up router instances.
+    /// </summary>
+    internal class IpcClientRouterFactory
+    {
+        readonly ILogger _logger;
+
+        readonly string _ipcClientPath;
+
+        int IpcClientTimeoutMs { get; set; } = Timeout.Infinite;
+
+        int IpcClientRetryTimeoutMs { get; set; } = 500;
+
+        public string IpcClientPath {
+            get { return _ipcClientPath; }
+        }
+
+        public IpcClientRouterFactory(string ipcClient, ILogger logger)
+        {
+            _logger = logger;
+            _ipcClientPath = ipcClient;
+        }
+
+        public async Task<Stream> ConnectIpcStreamAsync(CancellationToken token)
+        {
+            Stream ipcClientStream = null;
+
+            _logger?.LogDebug($"Connecting new ipc endpoint \"{_ipcClientPath}\".");
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var namedPipe = new NamedPipeClientStream(
+                    ".",
+                    _ipcClientPath,
+                    PipeDirection.InOut,
+                    PipeOptions.Asynchronous,
+                    TokenImpersonationLevel.Impersonation);
+
+                try
+                {
+                    await namedPipe.ConnectAsync(IpcClientTimeoutMs, token).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    namedPipe?.Dispose();
+
+                    if (ex is TimeoutException)
+                        _logger?.LogDebug("No ipc stream connected, timing out.");
+
+                    throw;
+                }
+
+                ipcClientStream = namedPipe;
+            }
+            else
+            {
+                bool retry = false;
+                IpcUnixDomainSocket unixDomainSocket;
+
+                using var connectTimeoutTokenSource = new CancellationTokenSource();
+                using var connectTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token, connectTimeoutTokenSource.Token);
+
+                connectTimeoutTokenSource.CancelAfter(IpcClientTimeoutMs);
+
+                do
+                {
+                    unixDomainSocket = new IpcUnixDomainSocket();
+
+                    try
+                    {
+                        await unixDomainSocket.ConnectAsync(new IpcUnixDomainSocketEndPoint(_ipcClientPath), token).ConfigureAwait(false);
+                        retry = false;
+                    }
+                    catch (Exception)
+                    {
+                        unixDomainSocket?.Dispose();
+
+                        if (connectTimeoutTokenSource.IsCancellationRequested)
+                        {
+                            _logger?.LogDebug("No ipc stream connected, timing out.");
+                            throw new TimeoutException();
+                        }
+
+                        _logger?.LogTrace($"Failed connecting {_ipcClientPath}, wait {IpcClientRetryTimeoutMs} ms before retrying.");
+
+                        // If we get an error (without hitting timeout above), most likely due to unavailable listener.
+                        // Delay execution to prevent to rapid retry attempts.
+                        await Task.Delay(IpcClientRetryTimeoutMs, token).ConfigureAwait(false);
+
+                        retry = true;
+                    }
+                }
+                while (retry);
+
+                ipcClientStream = new ExposedSocketNetworkStream(unixDomainSocket, ownsSocket: true);
+            }
+
+            if (ipcClientStream != null)
+                _logger?.LogDebug("Successfully connected ipc stream.");
+
+            return ipcClientStream;
+        }
+    }
+
+    /// <summary>
+    /// This class creates IPC Server - TCP Server router instances.
+    /// Supports NamedPipes/UnixDomainSocket server and TCP/IP server.
+    /// </summary>
+    internal class IpcServerTcpServerRouterFactory : DiagnosticsServerRouterFactory
+    {
+        ILogger _logger;
+        TcpServerRouterFactory _tcpServerRouterFactory;
+        IpcServerRouterFactory _ipcServerRouterFactory;
+
+        public IpcServerTcpServerRouterFactory(string ipcServer, string tcpServer, int runtimeTimeoutMs, TcpServerRouterFactory.CreateInstanceDelegate factory, ILogger logger)
+        {
+            _logger = logger;
+            _tcpServerRouterFactory = factory(tcpServer, runtimeTimeoutMs, logger);
+            _ipcServerRouterFactory = new IpcServerRouterFactory(ipcServer, logger);
+        }
+
+        public override string IpcAddress
+        {
+            get
+            {
+                return _ipcServerRouterFactory.IpcServerPath;
+            }
+        }
+
+        public override string TcpAddress
+        {
+            get
+            {
+                return _tcpServerRouterFactory.TcpServerAddress;
+            }
+        }
+
+        public override ILogger Logger
+        {
+            get
+            {
+                return _logger;
+            }
+        }
+
+        public override Task Start(CancellationToken token)
+        {
+            _tcpServerRouterFactory.Start();
+            _ipcServerRouterFactory.Start();
+
+            _logger?.LogInformation($"Starting IPC server ({_ipcServerRouterFactory.IpcServerPath}) <--> TCP server ({_tcpServerRouterFactory.TcpServerAddress}) router.");
+
+            return Task.CompletedTask;
+        }
+
+        public override Task Stop()
+        {
+            _logger?.LogInformation($"Stopping IPC server ({_ipcServerRouterFactory.IpcServerPath}) <--> TCP server ({_tcpServerRouterFactory.TcpServerAddress}) router.");
+            _ipcServerRouterFactory.Stop();
+            return _tcpServerRouterFactory.Stop();
+        }
+
+        public override void Reset()
+        {
+            _tcpServerRouterFactory.Reset();
+        }
+
+        public override async Task<Router> CreateRouterAsync(CancellationToken token)
+        {
+            Stream tcpServerStream = null;
+            Stream ipcServerStream = null;
+
+            _logger?.LogDebug($"Trying to create new router instance.");
+
+            try
+            {
+                using CancellationTokenSource cancelRouter = CancellationTokenSource.CreateLinkedTokenSource(token);
+
+                // Get new tcp server endpoint.
+                using var tcpServerStreamTask = _tcpServerRouterFactory.AcceptTcpStreamAsync(cancelRouter.Token);
+
+                // Get new ipc server endpoint.
+                using var ipcServerStreamTask = _ipcServerRouterFactory.AcceptIpcStreamAsync(cancelRouter.Token);
+
+                await Task.WhenAny(ipcServerStreamTask, tcpServerStreamTask).ConfigureAwait(false);
+
+                if (IsCompletedSuccessfully(ipcServerStreamTask) && IsCompletedSuccessfully(tcpServerStreamTask))
+                {
+                    ipcServerStream = ipcServerStreamTask.Result;
+                    tcpServerStream = tcpServerStreamTask.Result;
+                }
+                else if (IsCompletedSuccessfully(ipcServerStreamTask))
+                {
+                    ipcServerStream = ipcServerStreamTask.Result;
+
+                    // We have a valid ipc stream and a pending tcp accept. Wait for completion
+                    // or disconnect of ipc stream.
+                    using var checkIpcStreamTask = IsStreamConnectedAsync(ipcServerStream, cancelRouter.Token);
+
+                    // Wait for at least completion of one task.
+                    await Task.WhenAny(tcpServerStreamTask, checkIpcStreamTask).ConfigureAwait(false);
+
+                    // Cancel out any pending tasks not yet completed.
+                    cancelRouter.Cancel();
+
+                    try
+                    {
+                        await Task.WhenAll(tcpServerStreamTask, checkIpcStreamTask).ConfigureAwait(false);
+                    }
+                    catch (Exception)
+                    {
+                        // Check if we have an accepted tcp stream.
+                        if (IsCompletedSuccessfully(tcpServerStreamTask))
+                            tcpServerStreamTask.Result?.Dispose();
+
+                        if (checkIpcStreamTask.IsFaulted)
+                        {
+                            _logger?.LogInformation("Broken ipc connection detected, aborting tcp connection.");
+                            checkIpcStreamTask.GetAwaiter().GetResult();
+                        }
+
+                        throw;
+                    }
+
+                    tcpServerStream = tcpServerStreamTask.Result;
+                }
+                else if (IsCompletedSuccessfully(tcpServerStreamTask))
+                {
+                    tcpServerStream = tcpServerStreamTask.Result;
+
+                    // We have a valid tcp stream and a pending ipc accept. Wait for completion
+                    // or disconnect of tcp stream.
+                    using var checkTcpStreamTask = IsStreamConnectedAsync(tcpServerStream, cancelRouter.Token);
+
+                    // Wait for at least completion of one task.
+                    await Task.WhenAny(ipcServerStreamTask, checkTcpStreamTask).ConfigureAwait(false);
+
+                    // Cancel out any pending tasks not yet completed.
+                    cancelRouter.Cancel();
+
+                    try
+                    {
+                        await Task.WhenAll(ipcServerStreamTask, checkTcpStreamTask).ConfigureAwait(false);
+                    }
+                    catch (Exception)
+                    {
+                        // Check if we have an accepted ipc stream.
+                        if (IsCompletedSuccessfully(ipcServerStreamTask))
+                            ipcServerStreamTask.Result?.Dispose();
+
+                        if (checkTcpStreamTask.IsFaulted)
+                        {
+                            _logger?.LogInformation("Broken tcp connection detected, aborting ipc connection.");
+                            checkTcpStreamTask.GetAwaiter().GetResult();
+                        }
+
+                        throw;
+                    }
+
+                    ipcServerStream = ipcServerStreamTask.Result;
+                }
+                else
+                {
+                    // Error case, cancel out. wait and throw exception.
+                    cancelRouter.Cancel();
+                    try
+                    {
+                        await Task.WhenAll(ipcServerStreamTask, tcpServerStreamTask).ConfigureAwait(false);
+                    }
+                    catch (Exception)
+                    {
+                        // Check if we have an ipc stream.
+                        if (IsCompletedSuccessfully(ipcServerStreamTask))
+                            ipcServerStreamTask.Result?.Dispose();
+                        throw;
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                _logger?.LogDebug("Failed creating new router instance.");
+
+                // Cleanup and rethrow.
+                ipcServerStream?.Dispose();
+                tcpServerStream?.Dispose();
+
+                throw;
+            }
+
+            // Create new router.
+            _logger?.LogDebug("New router instance successfully created.");
+
+            return new Router(ipcServerStream, tcpServerStream, _logger);
+        }
+    }
+
+    /// <summary>
+    /// This class creates IPC Server - TCP Client router instances.
+    /// Supports NamedPipes/UnixDomainSocket server and TCP/IP client.
+    /// </summary>
+    internal class IpcServerTcpClientRouterFactory : DiagnosticsServerRouterFactory
+    {
+        ILogger _logger;
+        IpcServerRouterFactory _ipcServerRouterFactory;
+        TcpClientRouterFactory _tcpClientRouterFactory;
+
+        public IpcServerTcpClientRouterFactory(string ipcServer, string tcpClient, int runtimeTimeoutMs, TcpClientRouterFactory.CreateInstanceDelegate factory, ILogger logger)
+        {
+            _logger = logger;
+            _ipcServerRouterFactory = new IpcServerRouterFactory(ipcServer, logger);
+            _tcpClientRouterFactory = factory(tcpClient, runtimeTimeoutMs, logger);
+        }
+
+        public override string IpcAddress
+        {
+            get
+            {
+                return _ipcServerRouterFactory.IpcServerPath;
+            }
+        }
+
+        public override string TcpAddress
+        {
+            get
+            {
+                return _tcpClientRouterFactory.TcpClientAddress;
+            }
+        }
+
+        public override ILogger Logger
+        {
+            get
+            {
+                return _logger;
+            }
+        }
+
+        public override Task Start(CancellationToken token)
+        {
+            _ipcServerRouterFactory.Start();
+            _tcpClientRouterFactory.Start();
+            _logger?.LogInformation($"Starting IPC server ({_ipcServerRouterFactory.IpcServerPath}) <--> TCP client ({_tcpClientRouterFactory.TcpClientAddress}) router.");
+
+            return Task.CompletedTask;
+        }
+
+        public override Task Stop()
+        {
+            _logger?.LogInformation($"Stopping IPC server ({_ipcServerRouterFactory.IpcServerPath}) <--> TCP client ({_tcpClientRouterFactory.TcpClientAddress}) router.");
+            _tcpClientRouterFactory.Stop();
+            _ipcServerRouterFactory.Stop();
+            return Task.CompletedTask;
+        }
+
+        public override async Task<Router> CreateRouterAsync(CancellationToken token)
+        {
+            Stream tcpClientStream = null;
+            Stream ipcServerStream = null;
+
+            _logger?.LogDebug("Trying to create a new router instance.");
+
+            try
+            {
+                using CancellationTokenSource cancelRouter = CancellationTokenSource.CreateLinkedTokenSource(token);
+
+                // Get new server endpoint.
+                ipcServerStream = await _ipcServerRouterFactory.AcceptIpcStreamAsync(cancelRouter.Token).ConfigureAwait(false);
+
+                // Get new client endpoint.
+                using var tcpClientStreamTask = _tcpClientRouterFactory.ConnectTcpStreamAsync(cancelRouter.Token);
+
+                // We have a valid ipc stream and a pending tcp stream. Wait for completion
+                // or disconnect of ipc stream.
+                using var checkIpcStreamTask = IsStreamConnectedAsync(ipcServerStream, cancelRouter.Token);
+
+                // Wait for at least completion of one task.
+                await Task.WhenAny(tcpClientStreamTask, checkIpcStreamTask).ConfigureAwait(false);
+
+                // Cancel out any pending tasks not yet completed.
+                cancelRouter.Cancel();
+
+                try
+                {
+                    await Task.WhenAll(tcpClientStreamTask, checkIpcStreamTask).ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    // Check if we have an accepted tcp stream.
+                    if (IsCompletedSuccessfully(tcpClientStreamTask))
+                        tcpClientStreamTask.Result?.Dispose();
+
+                    if (checkIpcStreamTask.IsFaulted)
+                    {
+                        _logger?.LogInformation("Broken ipc connection detected, aborting tcp connection.");
+                        checkIpcStreamTask.GetAwaiter().GetResult();
+                    }
+
+                    throw;
+                }
+
+                tcpClientStream = tcpClientStreamTask.Result;
+            }
+            catch (Exception)
+            {
+                _logger?.LogDebug("Failed creating new router instance.");
+
+                // Cleanup and rethrow.
+                ipcServerStream?.Dispose();
+                tcpClientStream?.Dispose();
+
+                throw;
+            }
+
+            // Create new router.
+            _logger?.LogDebug("New router instance successfully created.");
+
+            return new Router(ipcServerStream, tcpClientStream, _logger);
+        }
+    }
+
+    /// <summary>
+    /// This class creates IPC Client - TCP Server router instances.
+    /// Supports NamedPipes/UnixDomainSocket client and TCP/IP server.
+    /// </summary>
+    internal class IpcClientTcpServerRouterFactory : DiagnosticsServerRouterFactory
+    {
+        ILogger _logger;
+        IpcClientRouterFactory _ipcClientRouterFactory;
+        TcpServerRouterFactory _tcpServerRouterFactory;
+
+        public IpcClientTcpServerRouterFactory(string ipcClient, string tcpServer, int runtimeTimeoutMs, TcpServerRouterFactory.CreateInstanceDelegate factory, ILogger logger)
+        {
+            _logger = logger;
+            _ipcClientRouterFactory = new IpcClientRouterFactory(ipcClient, logger);
+            _tcpServerRouterFactory = factory(tcpServer, runtimeTimeoutMs, logger);
+        }
+
+        public override string IpcAddress
+        {
+            get
+            {
+                return _ipcClientRouterFactory.IpcClientPath;
+            }
+        }
+
+        public override string TcpAddress
+        {
+            get
+            {
+                return _tcpServerRouterFactory.TcpServerAddress;
+            }
+        }
+
+        public override ILogger Logger
+        {
+            get
+            {
+                return _logger;
+            }
+        }
+
+        public override Task Start(CancellationToken token)
+        {
+            if (string.IsNullOrEmpty(_ipcClientRouterFactory.IpcClientPath))
+                throw new ArgumentException("No IPC client path specified.");
+
+            _tcpServerRouterFactory.Start();
+
+            _logger?.LogInformation($"Starting IPC client ({_ipcClientRouterFactory.IpcClientPath}) <--> TCP server ({_tcpServerRouterFactory.TcpServerAddress}) router.");
+
+            return Task.CompletedTask;
+        }
+
+        public override Task Stop()
+        {
+            _logger?.LogInformation($"Stopping IPC client ({_ipcClientRouterFactory.IpcClientPath}) <--> TCP server ({_tcpServerRouterFactory.TcpServerAddress}) router.");
+            return _tcpServerRouterFactory.Stop();
+        }
+
+        public override void Reset()
+        {
+            _tcpServerRouterFactory.Reset();
+        }
+
+        public override async Task<Router> CreateRouterAsync(CancellationToken token)
+        {
+            Stream tcpServerStream = null;
+            Stream ipcClientStream = null;
+
+            _logger?.LogDebug("Trying to create a new router instance.");
+
+            try
+            {
+                using CancellationTokenSource cancelRouter = CancellationTokenSource.CreateLinkedTokenSource(token);
+
+                // Get new server endpoint.
+                tcpServerStream = await _tcpServerRouterFactory.AcceptTcpStreamAsync(cancelRouter.Token).ConfigureAwait(false);
+
+                // Get new client endpoint.
+                using var ipcClientStreamTask = _ipcClientRouterFactory.ConnectIpcStreamAsync(cancelRouter.Token);
+
+                // We have a valid tcp stream and a pending ipc stream. Wait for completion
+                // or disconnect of tcp stream.
+                using var checkTcpStreamTask = IsStreamConnectedAsync(tcpServerStream, cancelRouter.Token);
+
+                // Wait for at least completion of one task.
+                await Task.WhenAny(ipcClientStreamTask, checkTcpStreamTask).ConfigureAwait(false);
+
+                // Cancel out any pending tasks not yet completed.
+                cancelRouter.Cancel();
+
+                try
+                {
+                    await Task.WhenAll(ipcClientStreamTask, checkTcpStreamTask).ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    // Check if we have an accepted ipc stream.
+                    if (IsCompletedSuccessfully(ipcClientStreamTask))
+                        ipcClientStreamTask.Result?.Dispose();
+
+                    if (checkTcpStreamTask.IsFaulted)
+                    {
+                        _logger?.LogInformation("Broken tcp connection detected, aborting ipc connection.");
+                        checkTcpStreamTask.GetAwaiter().GetResult();
+                    }
+
+                    throw;
+                }
+
+                ipcClientStream = ipcClientStreamTask.Result;
+
+                try
+                {
+                    // TcpServer consumes advertise message, needs to be replayed back to ipc client.
+                    await IpcAdvertise.SerializeAsync(ipcClientStream, _tcpServerRouterFactory.RuntimeInstanceId, (ulong)_tcpServerRouterFactory.RuntimeProcessId, token).ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    _logger?.LogDebug("Failed sending advertise message.");
+                    throw;
+                }
+            }
+            catch (Exception)
+            {
+                _logger?.LogDebug("Failed creating new router instance.");
+
+                // Cleanup and rethrow.
+                tcpServerStream?.Dispose();
+                ipcClientStream?.Dispose();
+
+                throw;
+            }
+
+            // Create new router.
+            _logger?.LogDebug("New router instance successfully created.");
+
+            return new Router(ipcClientStream, tcpServerStream, _logger, (ulong)IpcAdvertise.V1SizeInBytes);
+        }
+    }
+
+    /// <summary>
+    /// This class creates IPC Client - TCP Client router instances.
+    /// Supports NamedPipes/UnixDomainSocket client and TCP/IP client.
+    /// </summary>
+    internal class IpcClientTcpClientRouterFactory : DiagnosticsServerRouterFactory
+    {
+        Guid _runtimeInstanceId;
+        ulong _runtimeProcessId;
+        ILogger _logger;
+        IpcClientRouterFactory _ipcClientRouterFactory;
+        TcpClientRouterFactory _tcpClientRouterFactory;
+
+        public IpcClientTcpClientRouterFactory(string ipcClient, string tcpClient, int runtimeTimeoutMs, TcpClientRouterFactory.CreateInstanceDelegate factory, ILogger logger)
+        {
+            _runtimeInstanceId = Guid.Empty;
+            _runtimeProcessId = 0;
+            _logger = logger;
+            _ipcClientRouterFactory = new IpcClientRouterFactory(ipcClient, logger);
+            _tcpClientRouterFactory = factory(tcpClient, runtimeTimeoutMs, logger);
+        }
+
+        public override string IpcAddress {
+            get
+            {
+                return _ipcClientRouterFactory.IpcClientPath;
+            }
+        }
+
+        public override string TcpAddress {
+            get
+            {
+                return _tcpClientRouterFactory.TcpClientAddress;
+            }
+        }
+
+        public override ILogger Logger {
+            get
+            {
+                return _logger;
+            }
+        }
+
+        public override Task Start(CancellationToken token)
+        {
+            _tcpClientRouterFactory.Start();
+            _logger?.LogInformation($"Starting IPC client ({_ipcClientRouterFactory.IpcClientPath}) <--> TCP client ({_tcpClientRouterFactory.TcpClientAddress}) router.");
+
+            var requestRuntimeInfo = new Task(() =>
+            {
+                try
+                {
+                    _logger?.LogDebug($"Requesting runtime process information.");
+
+                    // Get new tcp client endpoint.
+                    using var tcpClientStream = _tcpClientRouterFactory.ConnectTcpStreamAsync(token).Result;
+
+                    // Request process info.
+                    IpcMessage message = new IpcMessage(DiagnosticsServerCommandSet.Process, (byte)ProcessCommandId.GetProcessInfo);
+                
+                    byte[] buffer = message.Serialize();
+                    tcpClientStream.Write(buffer, 0, buffer.Length);
+
+                    var response = IpcMessage.Parse(tcpClientStream);
+                    if ((DiagnosticsServerResponseId)response.Header.CommandId == DiagnosticsServerResponseId.OK)
+                    {
+                        var info = ProcessInfo.ParseV1(response.Payload);
+
+                        _runtimeProcessId = info.ProcessId;
+                        _runtimeInstanceId = info.RuntimeInstanceCookie;
+
+                        _logger?.LogDebug($"Retrieved runtime process information, pid={_runtimeProcessId}, cookie={_runtimeInstanceId}.");
+                    }
+                    else
+                    {
+                        throw new ServerErrorException("Failed to retrieve runtime process info.");
+                    }
+                }
+                catch (Exception)
+                {
+                    _runtimeProcessId = (ulong)Process.GetCurrentProcess().Id;
+                    _runtimeInstanceId = Guid.NewGuid();
+                    _logger?.LogWarning($"Failed to retrieve runtime process info, fallback to current process information, pid={_runtimeProcessId}, cookie={_runtimeInstanceId}.");
+                }
+            });
+
+            requestRuntimeInfo.Start();
+            return requestRuntimeInfo;
+        }
+
+        public override Task Stop()
+        {
+            _logger?.LogInformation($"Stopping IPC client ({_ipcClientRouterFactory.IpcClientPath}) <--> TCP client ({_tcpClientRouterFactory.TcpClientAddress}) router.");
+            _tcpClientRouterFactory.Stop();
+            return Task.CompletedTask;
+        }
+
+        public override async Task<Router> CreateRouterAsync(CancellationToken token)
+        {
+            Stream tcpClientStream = null;
+            Stream ipcClientStream = null;
+
+            _logger?.LogDebug("Trying to create a new router instance.");
+
+            try
+            {
+                using CancellationTokenSource cancelRouter = CancellationTokenSource.CreateLinkedTokenSource(token);
+
+                // Get new tcp client endpoint.
+                tcpClientStream = await _tcpClientRouterFactory.ConnectTcpStreamAsync(cancelRouter.Token, true).ConfigureAwait(false);
+
+                // Get new ipc client endpoint.
+                using var ipcClientStreamTask = _ipcClientRouterFactory.ConnectIpcStreamAsync(cancelRouter.Token);
+
+                // We have a valid tcp stream and a pending ipc stream. Wait for completion
+                // or disconnect of tcp stream.
+                using var checkTcpStreamTask = IsStreamConnectedAsync(tcpClientStream, cancelRouter.Token);
+
+                // Wait for at least completion of one task.
+                await Task.WhenAny(ipcClientStreamTask, checkTcpStreamTask).ConfigureAwait(false);
+
+                // Cancel out any pending tasks not yet completed.
+                cancelRouter.Cancel();
+
+                try
+                {
+                    await Task.WhenAll(ipcClientStreamTask, checkTcpStreamTask).ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    // Check if we have an accepted ipc stream.
+                    if (IsCompletedSuccessfully(ipcClientStreamTask))
+                        ipcClientStreamTask.Result?.Dispose();
+
+                    if (checkTcpStreamTask.IsFaulted)
+                    {
+                        _logger?.LogInformation("Broken tcp connection detected, aborting ipc connection.");
+                        checkTcpStreamTask.GetAwaiter().GetResult();
+                    }
+
+                    throw;
+                }
+
+                ipcClientStream = ipcClientStreamTask.Result;
+
+                try
+                {
+                    await IpcAdvertise.SerializeAsync(ipcClientStream, _runtimeInstanceId, _runtimeProcessId, token).ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    _logger?.LogDebug("Failed sending advertise message.");
+                    throw;
+                }
+            }
+            catch (Exception)
+            {
+                _logger?.LogDebug("Failed creating new router instance.");
+
+                // Cleanup and rethrow.
+                tcpClientStream?.Dispose();
+                ipcClientStream?.Dispose();
+
+                throw;
+            }
+
+            // Create new router.
+            _logger?.LogDebug("New router instance successfully created.");
+
+            return new Router(ipcClientStream, tcpClientStream, _logger, (ulong)IpcAdvertise.V1SizeInBytes);
+        }
+    }
+
+    internal class Router : IDisposable
+    {
+        readonly ILogger _logger;
+
+        Stream _frontendStream = null;
+        Stream _backendStream = null;
+
+        Task _backendReadFrontendWriteTask = null;
+        Task _frontendReadBackendWriteTask = null;
+
+        CancellationTokenSource _cancelRouterTokenSource = null;
+
+        bool _disposed = false;
+
+        ulong _backendToFrontendByteTransfer;
+        ulong _frontendToBackendByteTransfer;
+
+        static int s_routerInstanceCount;
+
+        public TaskCompletionSource<bool> RouterTaskCompleted { get; }
+
+        public Router(Stream frontendStream, Stream backendStream, ILogger logger, ulong initBackendToFrontendByteTransfer = 0, ulong initFrontendToBackendByteTransfer = 0)
+        {
+            _logger = logger;
+
+            _frontendStream = frontendStream;
+            _backendStream = backendStream;
+
+            _cancelRouterTokenSource = new CancellationTokenSource();
+
+            RouterTaskCompleted = new TaskCompletionSource<bool>();
+
+            _backendToFrontendByteTransfer = initBackendToFrontendByteTransfer;
+            _frontendToBackendByteTransfer = initFrontendToBackendByteTransfer;
+
+            Interlocked.Increment(ref s_routerInstanceCount);
+        }
+
+        public void Start()
+        {
+            if (_backendReadFrontendWriteTask != null || _frontendReadBackendWriteTask != null || _disposed)
+                throw new InvalidOperationException();
+
+            _backendReadFrontendWriteTask = BackendReadFrontendWrite(_cancelRouterTokenSource.Token);
+            _frontendReadBackendWriteTask = FrontendReadBackendWrite(_cancelRouterTokenSource.Token);
+        }
+
+        public async void Stop()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(nameof(Router));
+
+            _cancelRouterTokenSource.Cancel();
+
+            List<Task> runningTasks = new List<Task>();
+
+            if (_backendReadFrontendWriteTask != null)
+                runningTasks.Add(_backendReadFrontendWriteTask);
+
+            if (_frontendReadBackendWriteTask != null)
+                runningTasks.Add(_frontendReadBackendWriteTask);
+
+            await Task.WhenAll(runningTasks.ToArray()).ConfigureAwait(false);
+
+            _backendReadFrontendWriteTask?.Dispose();
+            _frontendReadBackendWriteTask?.Dispose();
+
+            RouterTaskCompleted?.TrySetResult(true);
+
+            _backendReadFrontendWriteTask = null;
+            _frontendReadBackendWriteTask = null;
+        }
+
+        public bool IsRunning {
+            get
+            {
+                if (_backendReadFrontendWriteTask == null || _frontendReadBackendWriteTask == null || _disposed)
+                    return false;
+
+                return !_backendReadFrontendWriteTask.IsCompleted && !_frontendReadBackendWriteTask.IsCompleted;
+            }
+        }
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                Stop();
+
+                _cancelRouterTokenSource.Dispose();
+
+                _backendStream?.Dispose();
+                _frontendStream?.Dispose();
+
+                _disposed = true;
+
+                Interlocked.Decrement(ref s_routerInstanceCount);
+
+                _logger?.LogTrace($"Diposed stats: Back End->Front End {_backendToFrontendByteTransfer} bytes, Front End->Back End {_frontendToBackendByteTransfer} bytes.");
+                _logger?.LogTrace($"Active instances: {s_routerInstanceCount}");
+            }
+        }
+
+        async Task BackendReadFrontendWrite(CancellationToken token)
+        {
+            try
+            {
+                byte[] buffer = new byte[1024];
+                while (!token.IsCancellationRequested)
+                {
+                    _logger?.LogTrace("Start reading bytes from back end.");
+
+                    int bytesRead = await _backendStream.ReadAsync(buffer, 0, buffer.Length, token).ConfigureAwait(false);
+
+                    _logger?.LogTrace($"Read {bytesRead} bytes from back end.");
+
+                    // Check for end of stream indicating that remote end disconnected.
+                    if (bytesRead == 0)
+                    {
+                        _logger?.LogTrace("Back end disconnected.");
+                        break;
+                    }
+
+                    _backendToFrontendByteTransfer += (ulong)bytesRead;
+
+                    _logger?.LogTrace($"Start writing {bytesRead} bytes to front end.");
+
+                    await _frontendStream.WriteAsync(buffer, 0, bytesRead, token).ConfigureAwait(false);
+                    await _frontendStream.FlushAsync().ConfigureAwait(false);
+
+                    _logger?.LogTrace($"Wrote {bytesRead} bytes to front end.");
+                }
+            }
+            catch (Exception)
+            {
+                // Completing task will trigger dispose of instance and cleanup.
+                // Faliure mainly consists of closed/disposed streams and cancelation requests.
+                // Just make sure task gets complete, nothing more needs to be in response to these exceptions.
+                _logger?.LogTrace("Failed stream operation. Completing task.");
+            }
+
+            RouterTaskCompleted?.TrySetResult(true);
+        }
+
+        async Task FrontendReadBackendWrite(CancellationToken token)
+        {
+            try
+            {
+                byte[] buffer = new byte[1024];
+                while (!token.IsCancellationRequested)
+                {
+                    _logger?.LogTrace("Start reading bytes from front end.");
+
+                    int bytesRead = await _frontendStream.ReadAsync(buffer, 0, buffer.Length, token).ConfigureAwait(false);
+
+                    _logger?.LogTrace($"Read {bytesRead} bytes from front end.");
+
+                    // Check for end of stream indicating that remote end disconnected.
+                    if (bytesRead == 0)
+                    {
+                        _logger?.LogTrace("Front end disconnected.");
+                        break;
+                    }
+
+                    _frontendToBackendByteTransfer += (ulong)bytesRead;
+
+                    _logger?.LogTrace($"Start writing {bytesRead} bytes to back end.");
+
+                    await _backendStream.WriteAsync(buffer, 0, bytesRead, token).ConfigureAwait(false);
+                    await _backendStream.FlushAsync().ConfigureAwait(false);
+
+                    _logger?.LogTrace($"Wrote {bytesRead} bytes to back end.");
+                }
+            }
+            catch (Exception)
+            {
+                // Completing task will trigger dispose of instance and cleanup.
+                // Faliure mainly consists of closed/disposed streams and cancelation requests.
+                // Just make sure task gets complete, nothing more needs to be in response to these exceptions.
+                _logger?.LogTrace("Failed stream operation. Completing task.");
+            }
+
+            RouterTaskCompleted?.TrySetResult(true);
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterRunner.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterRunner.cs
@@ -1,0 +1,166 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    /// <summary>
+    /// Class used to run different flavours of Diagnostics Server routers.
+    /// </summary>
+    internal class DiagnosticsServerRouterRunner
+    {
+        internal interface Callbacks
+        {
+            void OnRouterStarted(string tcpAddress);
+            void OnRouterStopped();
+        }
+
+        public static async Task<int> runIpcClientTcpServerRouter(CancellationToken token, string ipcClient, string tcpServer, int runtimeTimeoutMs, TcpServerRouterFactory.CreateInstanceDelegate tcpServerRouterFactory, ILogger logger, Callbacks callbacks)
+        {
+            return await runRouter(token, new IpcClientTcpServerRouterFactory(ipcClient, tcpServer, runtimeTimeoutMs, tcpServerRouterFactory, logger), callbacks).ConfigureAwait(false);
+        }
+
+        public static async Task<int> runIpcServerTcpServerRouter(CancellationToken token, string ipcServer, string tcpServer, int runtimeTimeoutMs, TcpServerRouterFactory.CreateInstanceDelegate tcpServerRouterFactory, ILogger logger, Callbacks callbacks)
+        {
+            return await runRouter(token, new IpcServerTcpServerRouterFactory(ipcServer, tcpServer, runtimeTimeoutMs, tcpServerRouterFactory, logger), callbacks).ConfigureAwait(false);
+        }
+
+        public static async Task<int> runIpcServerTcpClientRouter(CancellationToken token, string ipcServer, string tcpClient, int runtimeTimeoutMs, TcpClientRouterFactory.CreateInstanceDelegate tcpClientRouterFactory, ILogger logger, Callbacks callbacks)
+        {
+            return await runRouter(token, new IpcServerTcpClientRouterFactory(ipcServer, tcpClient, runtimeTimeoutMs, tcpClientRouterFactory, logger), callbacks).ConfigureAwait(false);
+        }
+
+        public static async Task<int> runIpcClientTcpClientRouter(CancellationToken token, string ipcClient, string tcpClient, int runtimeTimeoutMs, TcpClientRouterFactory.CreateInstanceDelegate tcpClientRouterFactory, ILogger logger, Callbacks callbacks)
+        {
+            return await runRouter(token, new IpcClientTcpClientRouterFactory(ipcClient, tcpClient, runtimeTimeoutMs, tcpClientRouterFactory, logger), callbacks).ConfigureAwait(false);
+        }
+
+        public static bool isLoopbackOnly(string address)
+        {
+            bool isLooback = false;
+
+            try
+            {
+                var value = new IpcTcpSocketEndPoint(address);
+                isLooback = IPAddress.IsLoopback(value.EndPoint.Address);
+            }
+            catch { }
+
+            return isLooback;
+        }
+
+        async static Task<int> runRouter(CancellationToken token, DiagnosticsServerRouterFactory routerFactory, Callbacks callbacks)
+        {
+            List<Task> runningTasks = new List<Task>();
+            List<Router> runningRouters = new List<Router>();
+
+            try
+            {
+                await routerFactory.Start(token);
+                if (!token.IsCancellationRequested)
+                    callbacks?.OnRouterStarted(routerFactory.TcpAddress);
+
+                while (!token.IsCancellationRequested)
+                {
+                    Task<Router> routerTask = null;
+                    Router router = null;
+
+                    try
+                    {
+                        routerTask = routerFactory.CreateRouterAsync(token);
+
+                        do
+                        {
+                            // Search list and clean up dead router instances before continue waiting on new instances.
+                            runningRouters.RemoveAll(IsRouterDead);
+
+                            runningTasks.Clear();
+                            foreach (var runningRouter in runningRouters)
+                                runningTasks.Add(runningRouter.RouterTaskCompleted.Task);
+                            runningTasks.Add(routerTask);
+                        }
+                        while (await Task.WhenAny(runningTasks.ToArray()).ConfigureAwait(false) != routerTask);
+
+                        if (routerTask.IsFaulted || routerTask.IsCanceled)
+                        {
+                            //Throw original exception.
+                            routerTask.GetAwaiter().GetResult();
+                        }
+
+                        if (routerTask.IsCompleted)
+                        {
+                            router = routerTask.Result;
+                            router.Start();
+
+                            // Add to list of running router instances.
+                            runningRouters.Add(router);
+                            router = null;
+                        }
+
+                        routerTask.Dispose();
+                        routerTask = null;
+                    }
+                    catch (Exception ex)
+                    {
+                        router?.Dispose();
+                        router = null;
+
+                        routerTask?.Dispose();
+                        routerTask = null;
+
+                        // Timing out on accepting new streams could mean that either the frontend holds an open connection
+                        // alive (but currently not using it), or we have a dead backend. If there are no running
+                        // routers we assume a dead backend. Reset current backend endpoint and see if we get
+                        // reconnect using same or different runtime instance.
+                        if (ex is BackendStreamTimeoutException && runningRouters.Count == 0)
+                        {
+                            routerFactory.Logger?.LogDebug("No backend stream available before timeout.");
+                            routerFactory.Reset();
+                        }
+
+                        // Timing out on accepting a new runtime connection means there is no runtime alive.
+                        // Shutdown router to prevent instances to outlive runtime process (if auto shutdown is enabled).
+                        if (ex is RuntimeTimeoutException)
+                        {
+                            routerFactory.Logger?.LogInformation("No runtime connected before timeout.");
+                            routerFactory.Logger?.LogInformation("Starting automatic shutdown.");
+                            throw;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                routerFactory.Logger?.LogInformation($"Shutting down due to error: {ex.Message}");
+            }
+            finally
+            {
+                if (token.IsCancellationRequested)
+                    routerFactory.Logger?.LogInformation("Shutting down due to cancelation request.");
+
+                runningRouters.RemoveAll(IsRouterDead);
+                runningRouters.Clear();
+
+                await routerFactory?.Stop();
+                callbacks?.OnRouterStopped();
+
+                routerFactory.Logger?.LogInformation("Router stopped.");
+            }
+            return 0;
+        }
+
+        static bool IsRouterDead(Router router)
+        {
+            bool isRunning = router.IsRunning && !router.RouterTaskCompleted.Task.IsCompleted;
+            if (!isRunning)
+                router.Dispose();
+            return !isRunning;
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/HandleableCollection.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/HandleableCollection.cs
@@ -1,0 +1,279 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    /// <summary>
+    /// A collection of objects that allows for observability and mutability using handlers.
+    /// </summary>
+    internal class HandleableCollection<T> : IEnumerable<T>, IDisposable
+    {
+        public delegate bool Handler(T item, out bool removeItem);
+
+        /// <summary>
+        /// Accepts the first item it encounters and requests that the item is removed from the collection.
+        /// </summary>
+        private static readonly Handler DefaultHandler = (T item, out bool removeItem) => { removeItem = true; return true; };
+
+        private readonly List<T> _items = new List<T>();
+        private readonly List<Tuple<TaskCompletionSource<T>, Handler>> _handlers = new List<Tuple<TaskCompletionSource<T>, Handler>>();
+
+        private bool _disposed = false;
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the underlying collection.
+        /// </summary>
+        /// <remarks>
+        /// The returned enumerator is over a copy of the underlying collection so that there are no concurrency issues.
+        /// </remarks>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            IList<T> copy;
+            lock (_items)
+            {
+                VerifyNotDisposed();
+                copy = _items.ToList();
+            }
+            return copy.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the underlying collection.
+        /// </summary>
+        /// <remarks>
+        /// The returned enumerator is over a copy of the underlying collection so that there are no concurrency issues.
+        /// </remarks>
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        {
+            IList<T> copy;
+            lock (_items)
+            {
+                VerifyNotDisposed();
+                copy = _items.ToList();
+            }
+            return copy.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Disposes the <see cref="HandleableCollection{T}"/> by clearing all items and handlers.
+        /// </summary>
+        /// <remarks>
+        /// All pending handlers with throw <see cref="ObjectDisposedException"/>.
+        /// </remarks>
+        public void Dispose()
+        {
+            lock (_items)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+                _disposed = true;
+            }
+
+            RemoveAndDisposeItems();
+
+            foreach (Tuple<TaskCompletionSource<T>, Handler> tuple in _handlers)
+            {
+                tuple.Item1.TrySetException(new ObjectDisposedException(nameof(HandleableCollection<T>)));
+            }
+            _handlers.Clear();
+        }
+
+        /// <summary>
+        /// Adds an item so that it may be observed by a handler.
+        /// </summary>
+        /// <param name="item">Item to add to the collection.</param>
+        /// <remarks>
+        /// The item may be immediately consumed if a handler removes the item, thus it may
+        /// not be stored into the underlying list.
+        /// </remarks>
+        public void Add(in T item)
+        {
+            lock (_items)
+            {
+                VerifyNotDisposed();
+
+                bool handledValue = false;
+                for (int i = 0; !handledValue && i < _handlers.Count; i++)
+                {
+                    Tuple<TaskCompletionSource<T>, Handler> handler = _handlers[i];
+
+                    if (TryHandler(item, handler.Item2, handler.Item1, out handledValue))
+                    {
+                        _handlers.RemoveAt(i);
+                        i--;
+                    }
+                }
+
+                if (!handledValue)
+                {
+                    _items.Add(item);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns the first item offered to the handler
+        /// or waits for a future item if no item is immediately available.
+        /// </summary>
+        /// <param name="timeout">The amount of time to wait before cancelling the handler.</param>
+        /// <returns>The first item offered to the handler.</returns>
+        public T Handle(TimeSpan timeout) => Handle(DefaultHandler, timeout);
+
+        /// <summary>
+        /// Returns the item on which the handler completes or waits for future items
+        /// if the handler does not immediately complete.
+        /// </summary>
+        /// <param name="handler">The handler that determines on which item to complete.</param>
+        /// <param name="timeout">The amount of time to wait before cancelling the handler.</param>
+        /// <returns>The item on which the handler completes.</returns>
+        public T Handle(Handler handler, TimeSpan timeout)
+        {
+            using var cancellation = new CancellationTokenSource(timeout);
+
+            var completionSource = new TaskCompletionSource<T>();
+            using var _ = cancellation.Token.Register(
+                () => completionSource.TrySetException(new TimeoutException()));
+
+            RunOrQueueHandler(handler, completionSource);
+
+            try
+            {
+                return completionSource.Task.Result;
+            }
+            catch (AggregateException ex)
+            {
+                throw ex.GetBaseException();
+            }
+        }
+
+        /// <summary>
+        /// Returns the first item offered to the handler
+        /// or waits for a future item if no item is immediately available.
+        /// </summary>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that completes with the first item offered to the handler.</returns>
+        public Task<T> HandleAsync(CancellationToken token) => HandleAsync(DefaultHandler, token);
+
+        /// <summary>
+        /// Returns the item on which the handler completes and waits for future items
+        /// if the handler does not immediately complete.
+        /// </summary>
+        /// <param name="handler">The handler that determines on which item to complete.</param>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that completes with the item on which the handler completes.</returns>
+        public async Task<T> HandleAsync(Handler handler, CancellationToken token)
+        {
+            var completionSource = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var _ = token.Register(() => completionSource.TrySetCanceled(token));
+
+            RunOrQueueHandler(handler, completionSource);
+
+            return await completionSource.Task.ConfigureAwait(false);
+        }
+
+        private void RunOrQueueHandler(Handler handler, TaskCompletionSource<T> completionSource)
+        {
+            lock (_items)
+            {
+                VerifyNotDisposed();
+
+                OnHandlerBegin();
+
+                bool stopHandling = false;
+                for (int i = 0; !stopHandling && i < _items.Count; i++)
+                {
+                    T item = _items[i];
+
+                    stopHandling = TryHandler(item, handler, completionSource, out bool removeItem);
+
+                    if (removeItem)
+                    {
+                        _items.RemoveAt(i);
+                        i--;
+                    }
+                }
+
+                if (!stopHandling)
+                {
+                    _handlers.Add(Tuple.Create(completionSource, handler));
+                }
+            }
+        }
+
+        private static bool TryHandler(in T item, Handler handler, TaskCompletionSource<T> completionSource, out bool removeItem)
+        {
+            removeItem = false;
+            if (completionSource.Task.IsCompleted)
+            {
+                return true;
+            }
+
+            bool stopHandling = false;
+            try
+            {
+                stopHandling = handler(item, out removeItem);
+            }
+            catch (Exception ex)
+            {
+                completionSource.TrySetException(ex);
+                return true;
+            }
+
+            if (stopHandling)
+            {
+                completionSource.TrySetResult(item);
+            }
+
+            return stopHandling;
+        }
+
+        /// <summary>
+        /// Clears all items from the collection.
+        /// </summary>
+        public void ClearItems()
+        {
+            lock (_items)
+            {
+                VerifyNotDisposed();
+
+                RemoveAndDisposeItems();
+            }
+        }
+
+        private void RemoveAndDisposeItems()
+        {
+            foreach (T item in _items)
+            {
+                if (item is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+            }
+            _items.Clear();
+        }
+
+        private void VerifyNotDisposed()
+        {
+            Debug.Assert(Monitor.IsEntered(_items));
+
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(HandleableCollection<T>));
+            }
+        }
+
+        protected virtual void OnHandlerBegin()
+        {
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/IpcHelpers.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/IpcHelpers.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal static class IpcHelpers
+    {
+        public static string ReadString(byte[] buffer, ref int index)
+        {
+            // Length of the string of UTF-16 characters
+            int length = (int)BitConverter.ToUInt32(buffer, index);
+            index += sizeof(UInt32);
+
+            int size = (int)length * sizeof(char);
+            // The string contains an ending null character; remove it before returning the value
+            string value = Encoding.Unicode.GetString(buffer, index, size).Substring(0, length - 1);
+            index += size;
+            return value;
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
@@ -13,6 +13,11 @@
     <IsShipping>true</IsShipping>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(GitHubRepositoryName)' == 'runtime'">
+    <DefineConstants>$(DefineConstants);DIAGNOSTICS_RUNTIME</DefineConstants>
+    <NoWarn>CS1591,CS8073,CS0162</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
@@ -28,5 +33,9 @@
     <!-- Temporary until Diagnostic Apis are finalized-->
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.WebApi" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.NETCore.Client.UnitTests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Condition="'$(GitHubRepositoryName)' == 'runtime'" Include="**/*.cs" />
   </ItemGroup>
 </Project>

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <RootNamespace>Microsoft.Diagnostics.NETCore.Client</RootNamespace>
+    <Description>.NET Core Diagnostics Client Library</Description>
+    <VersionPrefix>0.2.0</VersionPrefix>
+    <IsPackable>true</IsPackable>
+    <PackageTags>Diagnostic</PackageTags>
+    <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IsShipping>true</IsShipping>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="dotnet-counters" />
+    <InternalsVisibleTo Include="dotnet-dsrouter" />
+    <InternalsVisibleTo Include="dotnet-monitor" />
+    <InternalsVisibleTo Include="dotnet-trace" />
+    <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring" />
+    <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.EventPipe" />
+    <!-- Temporary until Diagnostic Apis are finalized-->
+    <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.WebApi" />
+    <InternalsVisibleTo Include="Microsoft.Diagnostics.NETCore.Client.UnitTests" />
+  </ItemGroup>
+</Project>

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/NativeMethods.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/NativeMethods.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal class NativeMethods
+    {
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool PeekNamedPipe(
+            SafePipeHandle hNamedPipe,
+            byte[] lpBuffer,
+            int bufferSize,
+            IntPtr lpBytesRead,
+            IntPtr lpTotalBytesAvail,
+            IntPtr lpBytesLeftThisMessage
+            );
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/ReversedServer/IpcEndpointInfo.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/ReversedServer/IpcEndpointInfo.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    /// <summary>
+    /// Represents a runtine instance connection to a reversed diagnostics server.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    internal struct IpcEndpointInfo
+    {
+        internal IpcEndpointInfo(IpcEndpoint endpoint, int processId, Guid runtimeInstanceCookie)
+        {
+            Endpoint = endpoint;
+            ProcessId = processId;
+            RuntimeInstanceCookie = runtimeInstanceCookie;
+        }
+
+        /// <summary>
+        /// An endpoint used to retrieve diagnostic information from the associated runtime instance.
+        /// </summary>
+        public IpcEndpoint Endpoint { get; }
+
+        /// <summary>
+        /// The identifier of the process that is unique within its process namespace.
+        /// </summary>
+        public int ProcessId { get; }
+
+        /// <summary>
+        /// The unique identifier of the runtime instance.
+        /// </summary>
+        public Guid RuntimeInstanceCookie { get; }
+
+        internal string DebuggerDisplay => FormattableString.Invariant($"PID={ProcessId}, Cookie={RuntimeInstanceCookie}");
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/ReversedServer/ReversedDiagnosticsServer.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/ReversedServer/ReversedDiagnosticsServer.cs
@@ -1,0 +1,375 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    /// <summary>
+    /// Establishes server endpoint for runtime instances to connect when
+    /// configured to provide diagnostic endpoints in reverse mode.
+    /// </summary>
+    internal sealed class ReversedDiagnosticsServer : IAsyncDisposable
+    {
+        // The amount of time to allow parsing of the advertise data before cancelling. This allows the server to
+        // remain responsive in case the advertise data is incomplete and the stream is not closed.
+        private static readonly TimeSpan ParseAdvertiseTimeout = TimeSpan.FromMilliseconds(250);
+
+        private readonly CancellationTokenSource _disposalSource = new CancellationTokenSource();
+        private readonly HandleableCollection<IpcEndpointInfo> _endpointInfos = new HandleableCollection<IpcEndpointInfo>();
+        private readonly ConcurrentDictionary<Guid, HandleableCollection<Stream>> _streamCollections = new ConcurrentDictionary<Guid, HandleableCollection<Stream>>();
+        private readonly string _address;
+
+        private bool _disposed = false;
+        private Task _listenTask;
+        private bool _enableTcpIpProtocol = false;
+
+        /// <summary>
+        /// Constructs the <see cref="ReversedDiagnosticsServer"/> instance with an endpoint bound
+        /// to the location specified by <paramref name="address"/>.
+        /// </summary>
+        /// <param name="address">
+        /// The server endpoint.
+        /// On Windows, this can be a full pipe path or the name without the "\\.\pipe\" prefix.
+        /// On all other systems, this must be the full file path of the socket.
+        /// </param>
+        public ReversedDiagnosticsServer(string address)
+        {
+            _address = address;
+        }
+
+        /// <summary>
+        /// Constructs the <see cref="ReversedDiagnosticsServer"/> instance with an endpoint bound
+        /// to the location specified by <paramref name="address"/>.
+        /// </summary>
+        /// <param name="address">
+        /// The server endpoint.
+        /// On Windows, this can be a full pipe path or the name without the "\\.\pipe\" prefix.
+        /// On all other systems, this must be the full file path of the socket.
+        /// When TcpIp is enabled, this can also be host:port of the listening socket.
+        /// </param>
+        /// <param name="enableTcpIpProtocol">
+        /// Add TcpIp as a supported protocol for ReversedDiagnosticServer. When enabled, address will
+        /// be analyzed and if on format host:port, ReversedDiagnosticServer will try to bind
+        /// a TcpIp listener to host and port.
+        ///
+        /// </param>
+        public ReversedDiagnosticsServer(string address, bool enableTcpIpProtocol)
+        {
+            _address = address;
+            _enableTcpIpProtocol = enableTcpIpProtocol;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (!_disposed)
+            {
+                _disposalSource.Cancel();
+
+                if (null != _listenTask)
+                {
+                    try
+                    {
+                        await _listenTask.ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.Fail(ex.Message);
+                    }
+                }
+
+                _endpointInfos.Dispose();
+
+                foreach (HandleableCollection<Stream> streamCollection in _streamCollections.Values)
+                {
+                    streamCollection.Dispose();
+                }
+
+                _streamCollections.Clear();
+
+                _disposalSource.Dispose();
+
+                _disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Starts listening at the address for new connections.
+        /// </summary>
+        public void Start()
+        {
+            Start(MaxAllowedConnections);
+        }
+
+        /// <summary>
+        /// Starts listening at the address for new connections.
+        /// </summary>
+        /// <param name="maxConnections">The maximum number of connections the server will support.</param>
+        public void Start(int maxConnections)
+        {
+            VerifyNotDisposed();
+
+            if (IsStarted)
+            {
+                throw new InvalidOperationException(nameof(ReversedDiagnosticsServer.Start) + " method can only be called once.");
+            }
+
+            _listenTask = ListenAsync(maxConnections, _disposalSource.Token);
+            if (_listenTask.IsFaulted)
+                _listenTask.Wait(); // Rethrow aggregated exception.
+        }
+
+        /// <summary>
+        /// Gets endpoint information when a new runtime instance connects to the server.
+        /// </summary>
+        /// <param name="timeout">The amount of time to wait before cancelling the accept operation.</param>
+        /// <returns>An <see cref="IpcEndpointInfo"/> value that contains information about the new runtime instance connection.</returns>
+        public IpcEndpointInfo Accept(TimeSpan timeout)
+        {
+            VerifyNotDisposed();
+            VerifyIsStarted();
+
+            return _endpointInfos.Handle(timeout);
+        }
+
+        /// <summary>
+        /// Gets endpoint information when a new runtime instance connects to the server.
+        /// </summary>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that completes with a <see cref="IpcEndpointInfo"/> value that contains information about the new runtime instance connection.</returns>
+        public Task<IpcEndpointInfo> AcceptAsync(CancellationToken token)
+        {
+            VerifyNotDisposed();
+            VerifyIsStarted();
+
+            return _endpointInfos.HandleAsync(token);
+        }
+
+        /// <summary>
+        /// Removes endpoint information from the server so that it is no longer tracked.
+        /// </summary>
+        /// <param name="runtimeCookie">The runtime instance cookie that corresponds to the endpoint to be removed.</param>
+        /// <returns>True if the endpoint existed and was removed; otherwise false.</returns>
+        public bool RemoveConnection(Guid runtimeCookie)
+        {
+            VerifyNotDisposed();
+            VerifyIsStarted();
+
+            if (_streamCollections.TryRemove(runtimeCookie, out HandleableCollection<Stream> streamCollection))
+            {
+                streamCollection.Dispose();
+                return true;
+            }
+            return false;
+        }
+
+        private void VerifyNotDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(ReversedDiagnosticsServer));
+            }
+        }
+
+        private void VerifyIsStarted()
+        {
+            if (!IsStarted)
+            {
+                throw new InvalidOperationException(nameof(ReversedDiagnosticsServer.Start) + " method must be called before invoking this operation.");
+            }
+        }
+
+        /// <summary>
+        /// Listens at the address for new connections.
+        /// </summary>
+        /// <param name="maxConnections">The maximum number of connections the server will support.</param>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that completes when the server is no longer listening at the address.</returns>
+        private async Task ListenAsync(int maxConnections, CancellationToken token)
+        {
+            // This disposal shuts down the transport in case an exception is thrown.
+            using var transport = IpcServerTransport.Create(_address, maxConnections, _enableTcpIpProtocol, TransportCallback);
+            // This disposal shuts down the transport in case of cancellation; causes the transport
+            // to not recreate the server stream before the AcceptAsync call observes the cancellation.
+            using var _ = token.Register(() => transport.Dispose());
+
+            while (!token.IsCancellationRequested)
+            {
+                Stream stream = null;
+                IpcAdvertise advertise = null;
+                try
+                {
+                    stream = await transport.AcceptAsync(token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                catch (Exception)
+                {
+                    // The advertise data could be incomplete if the runtime shuts down before completely writing
+                    // the information. Catch the exception and continue waiting for a new connection.
+                }
+
+                if (null != stream)
+                {
+                    // Cancel parsing of advertise data after timeout period to
+                    // mitigate runtimes that write partial data and do not close the stream (avoid waiting forever).
+                    using var parseCancellationSource = new CancellationTokenSource();
+                    using var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(token, parseCancellationSource.Token);
+                    try
+                    {
+                        parseCancellationSource.CancelAfter(ParseAdvertiseTimeout);
+
+                        advertise = await IpcAdvertise.ParseAsync(stream, linkedSource.Token).ConfigureAwait(false);
+                    }
+                    catch (Exception)
+                    {
+                        stream.Dispose();
+                    }
+                }
+
+                if (null != advertise)
+                {
+                    Guid runtimeCookie = advertise.RuntimeInstanceCookie;
+                    int pid = unchecked((int)advertise.ProcessId);
+
+                    // The valueFactory parameter of the GetOrAdd overload that uses Func<TKey, TValue> valueFactory
+                    // does not execute the factory under a lock thus it is not thread-safe. Create the collection and
+                    // use a thread-safe version of GetOrAdd; use equality comparison on the result to determine if
+                    // the new collection was added to the dictionary or if an existing one was returned.
+                    var newStreamCollection = new HandleableCollection<Stream>();
+                    var streamCollection = _streamCollections.GetOrAdd(runtimeCookie, newStreamCollection);
+
+                    try
+                    {
+                        streamCollection.ClearItems();
+                        streamCollection.Add(stream);
+
+                        if (newStreamCollection == streamCollection)
+                        {
+                            ServerIpcEndpoint endpoint = new ServerIpcEndpoint(this, runtimeCookie);
+                            _endpointInfos.Add(new IpcEndpointInfo(endpoint, pid, runtimeCookie));
+                        }
+                        else
+                        {
+                            newStreamCollection.Dispose();
+                        }
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // The stream collection could be disposed by RemoveConnection which would cause an
+                        // ObjectDisposedException to be thrown if trying to clear/add the stream.
+                        stream.Dispose();
+                    }
+                }
+            }
+        }
+
+        private HandleableCollection<Stream> GetStreams(Guid runtimeCookie)
+        {
+            return _streamCollections.GetOrAdd(runtimeCookie, _ => new HandleableCollection<Stream>());
+        }
+
+        internal Stream Connect(Guid runtimeInstanceCookie, TimeSpan timeout)
+        {
+            VerifyNotDisposed();
+            VerifyIsStarted();
+
+            return GetStreams(runtimeInstanceCookie).Handle(timeout);
+        }
+
+        internal Task<Stream> ConnectAsync(Guid runtimeInstanceCookie, CancellationToken token)
+        {
+            VerifyNotDisposed();
+            VerifyIsStarted();
+
+            return GetStreams(runtimeInstanceCookie).HandleAsync(token);
+        }
+
+        internal void WaitForConnection(Guid runtimeInstanceCookie, TimeSpan timeout)
+        {
+            VerifyNotDisposed();
+            VerifyIsStarted();
+
+            GetStreams(runtimeInstanceCookie).Handle(WaitForConnectionHandler, timeout);
+        }
+
+        internal async Task WaitForConnectionAsync(Guid runtimeInstanceCookie, CancellationToken token)
+        {
+            VerifyNotDisposed();
+            VerifyIsStarted();
+
+            await GetStreams(runtimeInstanceCookie).HandleAsync(WaitForConnectionHandler, token).ConfigureAwait(false);
+        }
+
+        private static bool WaitForConnectionHandler(Stream item, out bool removeItem)
+        {
+            if (!TestStream(item))
+            {
+                item?.Dispose();
+                removeItem = true;
+                return false;
+            }
+
+            removeItem = false;
+            return true;
+        }
+
+        private static bool TestStream(Stream stream)
+        {
+            if (null == stream)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            if (stream is ExposedSocketNetworkStream networkStream)
+            {
+                // Update Connected state of socket by sending non-blocking zero-byte data.
+                Socket socket = networkStream.Socket;
+                bool blocking = socket.Blocking;
+                try
+                {
+                    socket.Blocking = false;
+                    socket.Send(Array.Empty<byte>(), 0, SocketFlags.None);
+                }
+                catch (Exception)
+                {
+                }
+                finally
+                {
+                    socket.Blocking = blocking;
+                }
+                return socket.Connected;
+            }
+            else if (stream is PipeStream pipeStream)
+            {
+                Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Pipe stream should only be used on Windows.");
+
+                // PeekNamedPipe will return false if the pipe is disconnected/broken.
+                return NativeMethods.PeekNamedPipe(
+                    pipeStream.SafePipeHandle,
+                    null,
+                    0,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    IntPtr.Zero);
+            }
+
+            return false;
+        }
+
+        private bool IsStarted => null != _listenTask;
+
+        public static int MaxAllowedConnections = IpcServerTransport.MaxAllowedConnections;
+
+        internal IIpcServerTransportCallbackInternal TransportCallback { get; set; }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/StreamExtensions.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/StreamExtensions.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal static class StreamExtensions
+    {
+        public static async Task<byte[]> ReadBytesAsync(this Stream stream, int length, CancellationToken cancellationToken)
+        {
+            byte[] buffer = new byte[length];
+
+            int totalRead = 0;
+            int remaining = length;
+            while (remaining > 0)
+            {
+                int read = await stream.ReadAsync(buffer, totalRead, remaining, cancellationToken);
+                if (0 == read)
+                {
+                    throw new EndOfStreamException();
+                }
+
+                remaining -= read;
+                totalRead += read;
+            }
+
+            return buffer;
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/common/common.csproj
+++ b/src/tests/tracing/eventpipe/common/common.csproj
@@ -6,10 +6,17 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(GitHubRepositoryName)' == 'runtime'">
+    <DefineConstants>$(DefineConstants);DIAGNOSTICS_RUNTIME</DefineConstants>
+    <NoWarn>CS1591,CS8073,CS0162</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="IpcTraceTest.cs" />
-    <Compile Include="StreamProxy.cs" />
-    <Compile Include="Reverse.cs" />
     <Compile Include="IpcUtils.cs" />
+    <Compile Include="Reverse.cs" />
+    <Compile Include="StreamProxy.cs" />
+    <ProjectReference Include="Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/tracing/eventpipe/common/common.csproj
+++ b/src/tests/tracing/eventpipe/common/common.csproj
@@ -12,6 +12,13 @@
     <NoWarn>CS1591,CS8073,CS0162</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- On Linux arm coreclr, the updated tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj project
+         does not yet work for several eventpipe runtime tests. We segment those tests with the following property and symbol -->
+    <UseUpdatedNETCoreClient Condition="!('$(TargetOS)' == 'Linux' And '$(TargetArchitecture)' == 'arm' And '$(RuntimeFlavor)' == 'coreclr')">true</UseUpdatedNETCoreClient>
+    <DefineConstants Condition="'$(UseUpdatedNETCoreClient)' == 'true'">$(DefineConstants);UPDATED_NETCORE_CLIENT</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Condition="'$(UseUpdatedNETCoreClient)' == 'true'" Include="IpcTraceTest.cs" />
     <Compile Condition="'$(UseUpdatedNETCoreClient)' != 'true'" Include="IpcTraceTest.legacy.cs" />

--- a/src/tests/tracing/eventpipe/common/common.csproj
+++ b/src/tests/tracing/eventpipe/common/common.csproj
@@ -13,10 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="IpcTraceTest.cs" />
+    <Compile Condition="'$(UseUpdatedNETCoreClient)' == 'true'" Include="IpcTraceTest.cs" />
+    <Compile Condition="'$(UseUpdatedNETCoreClient)' != 'true'" Include="IpcTraceTest.legacy.cs" />
     <Compile Include="IpcUtils.cs" />
     <Compile Include="Reverse.cs" />
     <Compile Include="StreamProxy.cs" />
-    <ProjectReference Include="Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
+    <ProjectReference Condition="'$(UseUpdatedNETCoreClient)' == 'true'" Include="Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/tracing/eventpipe/eventsourceerror/eventsourceerror.cs
+++ b/src/tests/tracing/eventpipe/eventsourceerror/eventsourceerror.cs
@@ -8,10 +8,10 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
-using Microsoft.Diagnostics.Tools.RuntimeClient;
 using Microsoft.Diagnostics.Tracing;
 using Tracing.Tests.Common;
 using Microsoft.Diagnostics.Tracing.Parsers.Clr;
+using Microsoft.Diagnostics.NETCore.Client;
 
 namespace Tracing.Tests.EventSourceError
 {
@@ -22,7 +22,6 @@ namespace Tracing.Tests.EventSourceError
     {
         public IllegalTypesEventSource()
         {
-
         }
 
         [Event(1, Level = EventLevel.LogAlways)]
@@ -50,13 +49,12 @@ namespace Tracing.Tests.EventSourceError
             // This test validates that if an EventSource generates an error
             // during construction it gets emitted over EventPipe
 
-            List<Provider> providers = new List<Provider>
+            var providers = new List<EventPipeProvider>
             {
-                new Provider("IllegalTypesEventSource")
+                new EventPipeProvider("IllegalTypesEventSource", EventLevel.Verbose)
             };
 
-            var configuration = new SessionConfiguration(circularBufferSizeMB: 1024, format: EventPipeSerializationFormat.NetTrace,  providers: providers);
-            return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, configuration, _DoesRundownContainMethodEvents);
+            return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024, _DoesRundownContainMethodEvents);
         }
 
         private static Dictionary<string, ExpectedEventCount> _expectedEventCounts = new Dictionary<string, ExpectedEventCount>()

--- a/src/tests/tracing/eventpipe/eventsourceerror/eventsourceerror.cs
+++ b/src/tests/tracing/eventpipe/eventsourceerror/eventsourceerror.cs
@@ -53,6 +53,7 @@ namespace Tracing.Tests.EventSourceError
             // This test validates that if an EventSource generates an error
             // during construction it gets emitted over EventPipe
 #if (UPDATED_NETCORE_CLIENT == true)
+            Console.WriteLine($"NONLEGACY NETCORE.CLIENT");
             var providers = new List<EventPipeProvider>
             {
                 new EventPipeProvider("IllegalTypesEventSource", EventLevel.Verbose)
@@ -60,6 +61,7 @@ namespace Tracing.Tests.EventSourceError
 
             return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024, _DoesRundownContainMethodEvents);
 #else
+            Console.WriteLine($"LEGACY TOOLS.RUNTIMECLIENT");
             List<Provider> providers = new List<Provider>
             {
                 new Provider("IllegalTypesEventSource")

--- a/src/tests/tracing/eventpipe/eventsourceerror/eventsourceerror.cs
+++ b/src/tests/tracing/eventpipe/eventsourceerror/eventsourceerror.cs
@@ -11,7 +11,11 @@ using System.Collections.Generic;
 using Microsoft.Diagnostics.Tracing;
 using Tracing.Tests.Common;
 using Microsoft.Diagnostics.Tracing.Parsers.Clr;
+#if (UPDATED_NETCORE_CLIENT == true)
 using Microsoft.Diagnostics.NETCore.Client;
+#else
+using Microsoft.Diagnostics.Tools.RuntimeClient;
+#endif
 
 namespace Tracing.Tests.EventSourceError
 {
@@ -48,13 +52,22 @@ namespace Tracing.Tests.EventSourceError
         {
             // This test validates that if an EventSource generates an error
             // during construction it gets emitted over EventPipe
-
+#if (UPDATED_NETCORE_CLIENT == true)
             var providers = new List<EventPipeProvider>
             {
                 new EventPipeProvider("IllegalTypesEventSource", EventLevel.Verbose)
             };
 
             return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024, _DoesRundownContainMethodEvents);
+#else
+            List<Provider> providers = new List<Provider>
+            {
+                new Provider("IllegalTypesEventSource")
+            };
+
+            var configuration = new SessionConfiguration(circularBufferSizeMB: 1024, format: EventPipeSerializationFormat.NetTrace,  providers: providers);
+            return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, configuration, _DoesRundownContainMethodEvents);
+#endif
         }
 
         private static Dictionary<string, ExpectedEventCount> _expectedEventCounts = new Dictionary<string, ExpectedEventCount>()

--- a/src/tests/tracing/eventpipe/eventsourceerror/eventsourceerror.csproj
+++ b/src/tests/tracing/eventpipe/eventsourceerror/eventsourceerror.csproj
@@ -10,5 +10,6 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />
+    <ProjectReference Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/tracing/eventpipe/eventsourceerror/eventsourceerror.csproj
+++ b/src/tests/tracing/eventpipe/eventsourceerror/eventsourceerror.csproj
@@ -7,6 +7,12 @@
     <GCStressIncompatible>true</GCStressIncompatible>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- On Linux arm coreclr, the updated tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj project
+         does not yet work for several eventpipe runtime tests. We segment those tests with the following property and symbol -->
+    <UseUpdatedNETCoreClient Condition="!('$(TargetOS)' == 'Linux' And '$(TargetArchitecture)' == 'arm' And '$(RuntimeFlavor)' == 'coreclr')">true</UseUpdatedNETCoreClient>
+    <DefineConstants Condition="'$(UseUpdatedNETCoreClient)' == 'true'">$(DefineConstants);UPDATED_NETCORE_CLIENT</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />

--- a/src/tests/tracing/eventpipe/eventsourceerror/eventsourceerror.csproj
+++ b/src/tests/tracing/eventpipe/eventsourceerror/eventsourceerror.csproj
@@ -10,6 +10,6 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />
-    <ProjectReference Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
+    <ProjectReference Condition="'$(UseUpdatedNETCoreClient)' == 'true'" Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/tracing/eventpipe/gcdump/gcdump.cs
+++ b/src/tests/tracing/eventpipe/gcdump/gcdump.cs
@@ -33,13 +33,12 @@ namespace Tracing.Tests.EventSourceError
             // This test validates that if an EventSource generates an error
             // during construction it gets emitted over EventPipe
 
-            List<Provider> providers = new List<Provider>
+            List<EventPipeProvider> providers = new List<EventPipeProvider>
             {
-                new Provider("Microsoft-Windows-DotNETRuntime", eventLevel: EventLevel.Verbose, keywords: (ulong)ClrTraceEventParser.Keywords.GCHeapSnapshot)
+                new EventPipeProvider("Microsoft-Windows-DotNETRuntime", eventLevel: EventLevel.Verbose, keywords: (long)ClrTraceEventParser.Keywords.GCHeapSnapshot)
             };
 
-            var configuration = new SessionConfiguration(circularBufferSizeMB: 1024, format: EventPipeSerializationFormat.NetTrace,  providers: providers);
-            return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, configuration, _DoesRundownContainMethodEvents);
+            return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024, _DoesRundownContainMethodEvents);
         }
 
         private static Dictionary<string, ExpectedEventCount> _expectedEventCounts = new Dictionary<string, ExpectedEventCount>()

--- a/src/tests/tracing/eventpipe/gcdump/gcdump.cs
+++ b/src/tests/tracing/eventpipe/gcdump/gcdump.cs
@@ -36,6 +36,7 @@ namespace Tracing.Tests.EventSourceError
             // This test validates that if an EventSource generates an error
             // during construction it gets emitted over EventPipe
 #if (UPDATED_NETCORE_CLIENT == true)
+            Console.WriteLine($"NONLEGACY NETCORE.CLIENT");
             List<EventPipeProvider> providers = new List<EventPipeProvider>
             {
                 new EventPipeProvider("Microsoft-Windows-DotNETRuntime", eventLevel: EventLevel.Verbose, keywords: (long)ClrTraceEventParser.Keywords.GCHeapSnapshot)
@@ -43,6 +44,7 @@ namespace Tracing.Tests.EventSourceError
 
             return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024, _DoesRundownContainMethodEvents);
 #else
+            Console.WriteLine($"LEGACY TOOLS.RUNTIMECLIENT");
             List<Provider> providers = new List<Provider>
             {
                 new Provider("Microsoft-Windows-DotNETRuntime", eventLevel: EventLevel.Verbose, keywords: (ulong)ClrTraceEventParser.Keywords.GCHeapSnapshot)

--- a/src/tests/tracing/eventpipe/gcdump/gcdump.cs
+++ b/src/tests/tracing/eventpipe/gcdump/gcdump.cs
@@ -8,8 +8,11 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+#if (UPDATED_NETCORE_CLIENT == true)
 using Microsoft.Diagnostics.NETCore.Client;
+#else
 using Microsoft.Diagnostics.Tools.RuntimeClient;
+#endif
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Parsers;
 using Tracing.Tests.Common;
@@ -17,7 +20,7 @@ using Microsoft.Diagnostics.Tracing.Parsers.Clr;
 
 namespace Tracing.Tests.EventSourceError
 {
-    // Regression test for https://github.com/dotnet/runtime/issues/38639 
+    // Regression test for https://github.com/dotnet/runtime/issues/38639
     public class GCDumpTest
     {
         private static int _bulkTypeCount = 0;
@@ -32,13 +35,22 @@ namespace Tracing.Tests.EventSourceError
         {
             // This test validates that if an EventSource generates an error
             // during construction it gets emitted over EventPipe
-
+#if (UPDATED_NETCORE_CLIENT == true)
             List<EventPipeProvider> providers = new List<EventPipeProvider>
             {
                 new EventPipeProvider("Microsoft-Windows-DotNETRuntime", eventLevel: EventLevel.Verbose, keywords: (long)ClrTraceEventParser.Keywords.GCHeapSnapshot)
             };
 
             return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024, _DoesRundownContainMethodEvents);
+#else
+            List<Provider> providers = new List<Provider>
+            {
+                new Provider("Microsoft-Windows-DotNETRuntime", eventLevel: EventLevel.Verbose, keywords: (ulong)ClrTraceEventParser.Keywords.GCHeapSnapshot)
+            };
+
+            var configuration = new SessionConfiguration(circularBufferSizeMB: 1024, format: EventPipeSerializationFormat.NetTrace,  providers: providers);
+            return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, configuration, _DoesRundownContainMethodEvents);
+#endif
         }
 
         private static Dictionary<string, ExpectedEventCount> _expectedEventCounts = new Dictionary<string, ExpectedEventCount>()
@@ -78,7 +90,7 @@ namespace Tracing.Tests.EventSourceError
                 _bulkRootStaticVarCount += data.Count;
             };
 
-            return () => 
+            return () =>
             {
                 // Hopefully it is low enough to be resilient to changes in the runtime
                 // and high enough to catch issues. There should be between hundreds and thousands

--- a/src/tests/tracing/eventpipe/gcdump/gcdump.csproj
+++ b/src/tests/tracing/eventpipe/gcdump/gcdump.csproj
@@ -10,5 +10,6 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />
+    <ProjectReference Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/tracing/eventpipe/gcdump/gcdump.csproj
+++ b/src/tests/tracing/eventpipe/gcdump/gcdump.csproj
@@ -7,6 +7,12 @@
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- On Linux arm coreclr, the updated tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj project
+         does not yet work for several eventpipe runtime tests. We segment those tests with the following property and symbol -->
+    <UseUpdatedNETCoreClient Condition="!('$(TargetOS)' == 'Linux' And '$(TargetArchitecture)' == 'arm' And '$(RuntimeFlavor)' == 'coreclr')">true</UseUpdatedNETCoreClient>
+    <DefineConstants Condition="'$(UseUpdatedNETCoreClient)' == 'true'">$(DefineConstants);UPDATED_NETCORE_CLIENT</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />

--- a/src/tests/tracing/eventpipe/gcdump/gcdump.csproj
+++ b/src/tests/tracing/eventpipe/gcdump/gcdump.csproj
@@ -10,6 +10,6 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />
-    <ProjectReference Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
+    <ProjectReference Condition="'$(UseUpdatedNETCoreClient)' == 'true'" Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/tracing/eventpipe/processinfo/processinfo.cs
+++ b/src/tests/tracing/eventpipe/processinfo/processinfo.cs
@@ -149,7 +149,9 @@ namespace Tracing.Tests.ProcessInfoValidation
             string currentProcessCommandLine = $"{currentProcess.MainModule.FileName} {System.Reflection.Assembly.GetExecutingAssembly().Location}";
             string receivedCommandLine = NormalizeCommandLine(commandLine);
 
-            Utils.Assert(currentProcessCommandLine.Equals(receivedCommandLine, StringComparison.OrdinalIgnoreCase), $"CommandLine must match current process. Expected: {currentProcessCommandLine}, Received: {receivedCommandLine} (original: {commandLine})");
+            // ActiveIssue https://github.com/dotnet/runtime/issues/62729
+            if (!OperatingSystem.IsAndroid())
+                Utils.Assert(currentProcessCommandLine.Equals(receivedCommandLine, StringComparison.OrdinalIgnoreCase), $"CommandLine must match current process. Expected: {currentProcessCommandLine}, Received: {receivedCommandLine} (original: {commandLine})");
 
             // VALIDATE OS
             start = end;
@@ -177,6 +179,10 @@ namespace Tracing.Tests.ProcessInfoValidation
             else if (OperatingSystem.IsLinux())
             {
                 expectedOSValue = "Linux";
+            }
+            else if (OperatingSystem.IsAndroid())
+            {
+                expectedOSValue = "Android";
             }
             else
             {

--- a/src/tests/tracing/eventpipe/processinfo2/processinfo2.cs
+++ b/src/tests/tracing/eventpipe/processinfo2/processinfo2.cs
@@ -150,7 +150,9 @@ namespace Tracing.Tests.ProcessInfoValidation
             string currentProcessCommandLine = $"{currentProcess.MainModule.FileName} {System.Reflection.Assembly.GetExecutingAssembly().Location}";
             string receivedCommandLine = NormalizeCommandLine(commandLine);
 
-            Utils.Assert(currentProcessCommandLine.Equals(receivedCommandLine, StringComparison.OrdinalIgnoreCase), $"CommandLine must match current process. Expected: {currentProcessCommandLine}, Received: {receivedCommandLine} (original: {commandLine})");
+            // ActiveIssue https://github.com/dotnet/runtime/issues/62729
+            if (!OperatingSystem.IsAndroid())
+                Utils.Assert(currentProcessCommandLine.Equals(receivedCommandLine, StringComparison.OrdinalIgnoreCase), $"CommandLine must match current process. Expected: {currentProcessCommandLine}, Received: {receivedCommandLine} (original: {commandLine})");
 
             // VALIDATE OS
             start = end;
@@ -178,6 +180,10 @@ namespace Tracing.Tests.ProcessInfoValidation
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 expectedOSValue = "Linux";
+            }
+            else if (OperatingSystem.IsAndroid())
+            {
+                expectedOSValue = "Android";
             }
             else
             {

--- a/src/tests/tracing/eventpipe/providervalidation/providervalidation.cs
+++ b/src/tests/tracing/eventpipe/providervalidation/providervalidation.cs
@@ -8,9 +8,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
-using Microsoft.Diagnostics.Tools.RuntimeClient;
 using Microsoft.Diagnostics.Tracing;
 using Tracing.Tests.Common;
+using Microsoft.Diagnostics.NETCore.Client;
 
 namespace Tracing.Tests.ProviderValidation
 {
@@ -29,15 +29,13 @@ namespace Tracing.Tests.ProviderValidation
             // and that providers turned on that generate events are being written to
             // the stream.
 
-            var providers = new List<Provider>()
+            var providers = new List<EventPipeProvider>()
             {
-                new Provider("MyEventSource"),
-                new Provider("Microsoft-DotNETCore-SampleProfiler")
+                new EventPipeProvider("MyEventSource", EventLevel.Verbose),
+                new EventPipeProvider("Microsoft-DotNETCore-SampleProfiler", EventLevel.Verbose)
             };
 
-            var config = new SessionConfiguration(circularBufferSizeMB: (uint)Math.Pow(2, 10), format: EventPipeSerializationFormat.NetTrace,  providers: providers);
-
-            var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, config);
+            var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024);
             if (ret < 0)
                 return ret;
             else

--- a/src/tests/tracing/eventpipe/providervalidation/providervalidation.cs
+++ b/src/tests/tracing/eventpipe/providervalidation/providervalidation.cs
@@ -33,6 +33,7 @@ namespace Tracing.Tests.ProviderValidation
             // and that providers turned on that generate events are being written to
             // the stream.
 #if (UPDATED_NETCORE_CLIENT == true)
+            Console.WriteLine($"NONLEGACY NETCORE.CLIENT");
             var providers = new List<EventPipeProvider>()
             {
                 new EventPipeProvider("MyEventSource", EventLevel.Verbose),
@@ -41,6 +42,7 @@ namespace Tracing.Tests.ProviderValidation
 
             var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024);
 #else
+            Console.WriteLine($"LEGACY TOOLS.RUNTIMECLIENT");
             var providers = new List<Provider>()
             {
                 new Provider("MyEventSource"),

--- a/src/tests/tracing/eventpipe/providervalidation/providervalidation.cs
+++ b/src/tests/tracing/eventpipe/providervalidation/providervalidation.cs
@@ -10,7 +10,11 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using Microsoft.Diagnostics.Tracing;
 using Tracing.Tests.Common;
+#if (UPDATED_NETCORE_CLIENT == true)
 using Microsoft.Diagnostics.NETCore.Client;
+#else
+using Microsoft.Diagnostics.Tools.RuntimeClient;
+#endif
 
 namespace Tracing.Tests.ProviderValidation
 {
@@ -28,7 +32,7 @@ namespace Tracing.Tests.ProviderValidation
             // This test validates that the rundown events are present
             // and that providers turned on that generate events are being written to
             // the stream.
-
+#if (UPDATED_NETCORE_CLIENT == true)
             var providers = new List<EventPipeProvider>()
             {
                 new EventPipeProvider("MyEventSource", EventLevel.Verbose),
@@ -36,6 +40,17 @@ namespace Tracing.Tests.ProviderValidation
             };
 
             var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024);
+#else
+            var providers = new List<Provider>()
+            {
+                new Provider("MyEventSource"),
+                new Provider("Microsoft-DotNETCore-SampleProfiler")
+            };
+
+            var config = new SessionConfiguration(circularBufferSizeMB: (uint)Math.Pow(2, 10), format: EventPipeSerializationFormat.NetTrace,  providers: providers);
+
+            var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, config);
+#endif
             if (ret < 0)
                 return ret;
             else
@@ -49,7 +64,7 @@ namespace Tracing.Tests.ProviderValidation
             { "Microsoft-DotNETCore-SampleProfiler", -1 }
         };
 
-        private static Action _eventGeneratingAction = () => 
+        private static Action _eventGeneratingAction = () =>
         {
             for (int i = 0; i < 100_000; i++)
             {

--- a/src/tests/tracing/eventpipe/providervalidation/providervalidation.csproj
+++ b/src/tests/tracing/eventpipe/providervalidation/providervalidation.csproj
@@ -10,5 +10,6 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />
+    <ProjectReference Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/tracing/eventpipe/providervalidation/providervalidation.csproj
+++ b/src/tests/tracing/eventpipe/providervalidation/providervalidation.csproj
@@ -7,6 +7,12 @@
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- On Linux arm coreclr, the updated tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj project
+         does not yet work for several eventpipe runtime tests. We segment those tests with the following property and symbol -->
+    <UseUpdatedNETCoreClient Condition="!('$(TargetOS)' == 'Linux' And '$(TargetArchitecture)' == 'arm' And '$(RuntimeFlavor)' == 'coreclr')">true</UseUpdatedNETCoreClient>
+    <DefineConstants Condition="'$(UseUpdatedNETCoreClient)' == 'true'">$(DefineConstants);UPDATED_NETCORE_CLIENT</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />

--- a/src/tests/tracing/eventpipe/providervalidation/providervalidation.csproj
+++ b/src/tests/tracing/eventpipe/providervalidation/providervalidation.csproj
@@ -10,6 +10,6 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />
-    <ProjectReference Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
+    <ProjectReference Condition="'$(UseUpdatedNETCoreClient)' == 'true'" Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.cs
+++ b/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.cs
@@ -8,9 +8,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
-using Microsoft.Diagnostics.Tools.RuntimeClient;
 using Microsoft.Diagnostics.Tracing;
 using Tracing.Tests.Common;
+using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing.Parsers.Clr;
 
 namespace Tracing.Tests.RundownValidation
@@ -24,13 +24,12 @@ namespace Tracing.Tests.RundownValidation
             // and that the rundown contains the necessary events to get
             // symbols in a nettrace file.
 
-            var providers = new List<Provider>()
+            var providers = new List<EventPipeProvider>()
             {
-                new Provider("Microsoft-DotNETCore-SampleProfiler")
+                new EventPipeProvider("Microsoft-DotNETCore-SampleProfiler", EventLevel.Verbose)
             };
 
-            var configuration = new SessionConfiguration(circularBufferSizeMB: 1024, format: EventPipeSerializationFormat.NetTrace,  providers: providers);
-            return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, configuration, _DoesRundownContainMethodEvents);
+            return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024, _DoesRundownContainMethodEvents);
         }
 
         private static Dictionary<string, ExpectedEventCount> _expectedEventCounts = new Dictionary<string, ExpectedEventCount>()

--- a/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.cs
+++ b/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.cs
@@ -28,6 +28,7 @@ namespace Tracing.Tests.RundownValidation
             // and that the rundown contains the necessary events to get
             // symbols in a nettrace file.
 #if (UPDATED_NETCORE_CLIENT == true)
+            Console.WriteLine($"NONLEGACY NETCORE.CLIENT");
             var providers = new List<EventPipeProvider>()
             {
                 new EventPipeProvider("Microsoft-DotNETCore-SampleProfiler", EventLevel.Verbose)
@@ -35,6 +36,7 @@ namespace Tracing.Tests.RundownValidation
 
             return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024, _DoesRundownContainMethodEvents);
 #else
+            Console.WriteLine($"LEGACY TOOLS.RUNTIMECLIENT");
             var providers = new List<Provider>()
             {
                 new Provider("Microsoft-DotNETCore-SampleProfiler")

--- a/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.cs
+++ b/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.cs
@@ -10,7 +10,11 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using Microsoft.Diagnostics.Tracing;
 using Tracing.Tests.Common;
+#if (UPDATED_NETCORE_CLIENT == true)
 using Microsoft.Diagnostics.NETCore.Client;
+#else
+using Microsoft.Diagnostics.Tools.RuntimeClient;
+#endif
 using Microsoft.Diagnostics.Tracing.Parsers.Clr;
 
 namespace Tracing.Tests.RundownValidation
@@ -23,13 +27,22 @@ namespace Tracing.Tests.RundownValidation
             // This test validates that the rundown events are present
             // and that the rundown contains the necessary events to get
             // symbols in a nettrace file.
-
+#if (UPDATED_NETCORE_CLIENT == true)
             var providers = new List<EventPipeProvider>()
             {
                 new EventPipeProvider("Microsoft-DotNETCore-SampleProfiler", EventLevel.Verbose)
             };
 
             return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024, _DoesRundownContainMethodEvents);
+#else
+            var providers = new List<Provider>()
+            {
+                new Provider("Microsoft-DotNETCore-SampleProfiler")
+            };
+
+            var configuration = new SessionConfiguration(circularBufferSizeMB: 1024, format: EventPipeSerializationFormat.NetTrace,  providers: providers);
+            return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, configuration, _DoesRundownContainMethodEvents);
+#endif
         }
 
         private static Dictionary<string, ExpectedEventCount> _expectedEventCounts = new Dictionary<string, ExpectedEventCount>()

--- a/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.csproj
+++ b/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.csproj
@@ -5,7 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- The test launches a secondary process and process launch creates
-    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    an infinite event loop in the SocketAsyncEngine on Linux. Since
     runincontext loads even framework assemblies into the unloadable
     context, locals in this loop prevent unloading -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
@@ -15,5 +15,6 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />
+    <ProjectReference Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.csproj
+++ b/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.csproj
@@ -12,6 +12,12 @@
     <!-- Times out -->
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'OSX'">true</GCStressIncompatible>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- On Linux arm coreclr, the updated tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj project
+         does not yet work for several eventpipe runtime tests. We segment those tests with the following property and symbol -->
+    <UseUpdatedNETCoreClient Condition="!('$(TargetOS)' == 'Linux' And '$(TargetArchitecture)' == 'arm' And '$(RuntimeFlavor)' == 'coreclr')">true</UseUpdatedNETCoreClient>
+    <DefineConstants Condition="'$(UseUpdatedNETCoreClient)' == 'true'">$(DefineConstants);UPDATED_NETCORE_CLIENT</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.csproj
+++ b/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.csproj
@@ -12,9 +12,10 @@
     <!-- Times out -->
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'OSX'">true</GCStressIncompatible>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />
-    <ProjectReference Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
+    <ProjectReference Condition="'$(UseUpdatedNETCoreClient)' == 'true'" Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
If we go the route of segmenting a portion of eventpipe tests noted in https://github.com/dotnet/runtime/pull/64358
will rebase the main PR with these commits.
For now, I wanted to check CI lanes with the segmentation changes