### PR TITLE
[wasm] Replace active issue for browser platform with NodeJS only

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/tests/AbortTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/AbortTest.cs
@@ -17,7 +17,7 @@ namespace System.Net.WebSockets.Client.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/63673", TestPlatforms.Browser)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/63673", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJS))]
         public async Task Abort_ConnectAndAbort_ThrowsWebSocketExceptionWithmessage(Uri server)
         {
             using (var cws = new ClientWebSocket())

--- a/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.cs
@@ -170,7 +170,7 @@ namespace System.Net.WebSockets.Client.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/63681", TestPlatforms.Browser)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/63681", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJS))]
         public async Task ConnectAsync_PassNoSubProtocol_ServerRequires_ThrowsWebSocketException(Uri server)
         {
             const string AcceptedProtocol = "CustomProtocol";
@@ -257,7 +257,7 @@ namespace System.Net.WebSockets.Client.Tests
         }
 
         [ConditionalFact(nameof(WebSocketsSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/63672", TestPlatforms.Browser)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/63672", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJS))]
         public async Task ConnectAsync_CancellationRequestedBeforeConnect_ThrowsOperationCanceledException()
         {
             using (var clientSocket = new ClientWebSocket())
@@ -270,7 +270,7 @@ namespace System.Net.WebSockets.Client.Tests
         }
 
         [ConditionalFact(nameof(WebSocketsSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/63672", TestPlatforms.Browser)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/63672", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJS))]
         public async Task ConnectAsync_CancellationRequestedInflightConnect_ThrowsOperationCanceledException()
         {
             using (var clientSocket = new ClientWebSocket())
@@ -284,7 +284,7 @@ namespace System.Net.WebSockets.Client.Tests
 
         [ConditionalFact(nameof(WebSocketsSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34690", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/63671", TestPlatforms.Browser)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/63671", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJS))]
         public async Task ConnectAsync_CancellationRequestedAfterConnect_ThrowsOperationCanceledException()
         {
             var releaseServer = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/63441 I have disabled some tests for whole browser platform. 
Those tests don't work only on node, on browser they work.

This PR replaces disabling tests for browser platform with node only.