### PR TITLE
Improve PipeWriterTests.CompleteWithLargeWriteThrows

### DIFF
--- a/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
@@ -232,7 +232,7 @@ namespace System.IO.Pipelines.Tests
         public async Task CompleteWithLargeWriteThrows()
         {
             var completeDelay = TimeSpan.FromMilliseconds(10);
-            var testTimeout = TimeSpan.FromMilliseconds(100);
+            var testTimeout = TimeSpan.FromMilliseconds(10000);
             var pipe = new Pipe();
             pipe.Reader.Complete();
 
@@ -247,13 +247,13 @@ namespace System.IO.Pipelines.Tests
             {
                 var testStartTime = DateTime.UtcNow;
                 var buffer = new byte[10000000];
-                int i = 0;
+                ulong i = 0;
                 while (true)
                 {
                     await pipe.Writer.WriteAsync(buffer);
 
-                    // abort test if we're executing for more than the testTimeout (check every 1000th iteration)
-                    if (i++ % 1000 == 0 && DateTime.UtcNow - testStartTime > testTimeout)
+                    // abort test if we're executing for more than the testTimeout (check every 10000th iteration)
+                    if (i++ % 10000 == 0 && DateTime.UtcNow - testStartTime > testTimeout)
                         break;
                 }
             });

--- a/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
@@ -228,33 +228,34 @@ namespace System.IO.Pipelines.Tests
             pipe.Reader.Complete();
         }
 
-        [Fact]
-        [SkipOnPlatform(TestPlatforms.Browser, "allocates too much memory")]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CompleteWithLargeWriteThrows()
         {
+            var completeDelay = TimeSpan.FromMilliseconds(10);
             var pipe = new Pipe();
             pipe.Reader.Complete();
 
             var task = Task.Run(async () =>
             {
-                await Task.Delay(10);
+                await Task.Delay(completeDelay);
                 pipe.Writer.Complete();
             });
 
-            try
+            // Complete while writing
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
-                for (int i = 0; i < 1000; i++)
+                var testStartTime = DateTime.UtcNow;
+                var buffer = new byte[10000000];
+                int i = 0;
+                while (true)
                 {
-                    var buffer = new byte[10000000];
                     await pipe.Writer.WriteAsync(buffer);
-                }
-            }
-            catch (InvalidOperationException)
-            {
-                // Complete while writing
-            }
 
-            await task;
+                    // abort test if we're executing for more than 10 times the completeDelay (check every 1000th iteration)
+                    if (i++ % 1000 == 0 && DateTime.UtcNow - testStartTime > completeDelay * 10)
+                        break;
+                }
+            });
         }
 
         [Fact]

--- a/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
@@ -232,6 +232,7 @@ namespace System.IO.Pipelines.Tests
         public async Task CompleteWithLargeWriteThrows()
         {
             var completeDelay = TimeSpan.FromMilliseconds(10);
+            var testTimeout = TimeSpan.FromMilliseconds(100);
             var pipe = new Pipe();
             pipe.Reader.Complete();
 
@@ -251,8 +252,8 @@ namespace System.IO.Pipelines.Tests
                 {
                     await pipe.Writer.WriteAsync(buffer);
 
-                    // abort test if we're executing for more than 10 times the completeDelay (check every 1000th iteration)
-                    if (i++ % 1000 == 0 && DateTime.UtcNow - testStartTime > completeDelay * 10)
+                    // abort test if we're executing for more than the testTimeout (check every 1000th iteration)
+                    if (i++ % 1000 == 0 && DateTime.UtcNow - testStartTime > testTimeout)
                         break;
                 }
             });


### PR DESCRIPTION
Allocate the buffer outside of the loop so we don't hit OOM issues.

While looking at the test I noticed that it actually had a bug too:
Nothing was asserting that we indeed throw an InvalidOperationException when the writer is completed. Adding `Assert.ThrowsAsync` revealed that the current loop iteration count was too low to hit the exception reliably
within the 10ms delay so instead check for the execution time.

Fixes https://github.com/dotnet/runtime/issues/64930