### PR TITLE
Clean-up slngen related logic

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -21,7 +21,7 @@
       ]
     },
     "microsoft.visualstudio.slngen.tool": {
-      "version": "6.3.0",
+      "version": "8.1.6",
       "commands": [
         "slngen"
       ]

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -118,7 +118,7 @@
   <Import Project="$(RepositoryEngineeringDir)testing\runtimeConfiguration.targets" />
   <Import Project="$(RepositoryEngineeringDir)testing\runsettings.targets" Condition="'$(EnableRunSettingsSupport)' == 'true'" />
   <Import Project="$(RepositoryEngineeringDir)testing\coverage.targets" Condition="'$(EnableRunSettingsSupport)' == 'true' or '$(EnableCoverageSupport)' == 'true'" />
-  <Import Project="$(RepositoryEngineeringDir)slngen.targets" />
+  <Import Project="$(RepositoryEngineeringDir)slngen.targets" Condition="'$(IsSlnGen)' == 'true'" />
 
   <Import Project="$(RepositoryEngineeringDir)illink.targets" Condition="'$(IsSourceProject)' == 'true'" />
   <Import Project="$(RepositoryEngineeringDir)AvoidRestoreCycleOnSelfReference.targets" Condition="'$(AvoidRestoreCycleOnSelfReference)' == 'true'" />

--- a/src/libraries/slngen.proj
+++ b/src/libraries/slngen.proj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- By default glob all solutions: "src/libraries/*" unless a /p:SolutionName property is passed in. -->
     <SolutionFile Include="$(MSBuildThisFileDirectory)$([MSBuild]::ValueOrDefault('$(SolutionName)', '%2A'))\*.sln" />
   </ItemGroup>
 

--- a/src/libraries/slngen.proj
+++ b/src/libraries/slngen.proj
@@ -19,7 +19,7 @@
           DestinationFiles="%(SolutionFile.ProjFilePath)" />
     
     <!-- Invoke slngen -->
-    <Exec Command="$(RepoRoot)dotnet$(ScriptExt) slngen -p SlnGenMainProject=%(SolutionFile.Filename) --launch false --nologo &quot;%(SolutionFile.ProjFilePath)&quot;" />
+    <Exec Command="&quot;$(RepoRoot)dotnet$(ScriptExt)&quot; slngen -p SlnGenMainProject=%(SolutionFile.Filename) --launch false --nologo &quot;%(SolutionFile.ProjFilePath)&quot;" />
 
     <!-- Delete temporary template file -->
     <Delete Files="%(SolutionFile.ProjFilePath)" />

--- a/src/libraries/slngen.proj
+++ b/src/libraries/slngen.proj
@@ -1,15 +1,12 @@
-<!--
-  Targets that can be executed individually even though they are sequenced into build already:
-    - UpdateSolutionFile: Adds/updates solution files with slngen which includes dependencies.
--->
 <Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
+    <ScriptExt Condition="$([MSBuild]::IsOSPlatform('WINDOWS'))">.cmd</ScriptExt>
+    <ScriptExt Condition="!$([MSBuild]::IsOSPlatform('WINDOWS'))">.sh</ScriptExt>
     <ProjTemplatePath>$(RepositoryEngineeringDir)slngen.template.proj</ProjTemplatePath>
   </PropertyGroup>
 
   <ItemGroup>
-    <SolutionFile Include="$(MSBuildThisFileDirectory)*\*.sln" />
-    <SourceProject Include="$(MSBuildThisFileDirectory)*\src\*.*proj" />
+    <SolutionFile Include="$(MSBuildThisFileDirectory)$([MSBuild]::ValueOrDefault('$(SolutionName)', '%2A'))\*.sln" />
   </ItemGroup>
 
   <Target Name="UpdateSolutionFile"
@@ -22,7 +19,7 @@
           DestinationFiles="%(SolutionFile.ProjFilePath)" />
     
     <!-- Invoke slngen -->
-    <Exec Command="dotnet slngen -p SlnGenMainProject=%(SolutionFile.Filename) --launch false --nologo &quot;%(SolutionFile.ProjFilePath)&quot;" />
+    <Exec Command="$(RepoRoot)dotnet$(ScriptExt) slngen -p SlnGenMainProject=%(SolutionFile.Filename) --launch false --nologo &quot;%(SolutionFile.ProjFilePath)&quot;" />
 
     <!-- Delete temporary template file -->
     <Delete Files="%(SolutionFile.ProjFilePath)" />
@@ -31,8 +28,7 @@
   <Target Name="GetSolutionFiles">
     <ItemGroup>
       <!-- Add attributes that require a separate item mutation. -->
-      <SolutionFile ProjFilePath="%(RelativeDir)%(Filename).proj"
-                    NuGetConfigFilePath="%(RelativeDir)NuGet.config" />
+      <SolutionFile ProjFilePath="%(RelativeDir)%(Filename).proj" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/libraries/slngen.proj
+++ b/src/libraries/slngen.proj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- By default glob all solutions: "src/libraries/*" unless a /p:SolutionName property is passed in. -->
+    <!-- Unless a "/p:SolutionName" property is passed in, glob all solutions under src/libraries. -->
     <SolutionFile Include="$(MSBuildThisFileDirectory)$([MSBuild]::ValueOrDefault('$(SolutionName)', '%2A'))\*.sln" />
   </ItemGroup>
 


### PR DESCRIPTION
There was some dead code in the project file with the recent removal of the nuget.config update target. Also invoke slngen with the repo local SDK instead of depending on a global one being installed.