### PR TITLE
[wasm] Disable wasm aot tests hitting OOM on all platforms

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -23,14 +23,8 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Generators.Tests/System.Text.RegularExpressions.Generators.Tests.csproj" />
   </ItemGroup>
 
-  <!-- Wasm aot on !windows -->
-  <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(BuildAOTTestsOnHelix)' == 'true' and '$(RunDisabledWasmTests)' != 'true' and '$(RunAOTCompilation)' == 'true' and '$(BrowserHost)' != 'Windows'">
-    <!-- https://github.com/dotnet/runtime/issues/61756 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj" />
-  </ItemGroup>
-
-  <!-- Wasm aot on windows -->
-  <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(BuildAOTTestsOnHelix)' == 'true' and '$(RunDisabledWasmTests)' != 'true' and '$(RunAOTCompilation)' == 'true' and '$(BrowserHost)' == 'Windows'">
+  <!-- Wasm aot on all platforms -->
+  <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(BuildAOTTestsOnHelix)' == 'true' and '$(RunDisabledWasmTests)' != 'true' and '$(RunAOTCompilation)' == 'true'">
     <!-- https://github.com/dotnet/runtime/issues/61756 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj" />
 


### PR DESCRIPTION
This is bascially https://github.com/dotnet/runtime/pull/65413, but for all platforms instead of only Windows.

- https://github.com/dotnet/runtime/issues/65356 - OOM while linking
System.Text.Json.SourceGeneration.Roslyn3.11.Tests

- https://github.com/dotnet/runtime/issues/65411 - possible OOM when
compiling System.Text.Json.SourceGeneration.Roslyn4.0.Tests.dll.bc -> .o
System.Text.Json.SourceGeneration.Roslyn4.0.Tests

- https://github.com/dotnet/runtime/issues/61524 - OOM while linking
System.Text.Json.Tests