### PR TITLE
[release/6.0] Make sure WinHttpHandler 6.0.1 is released

### DIFF
--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
@@ -9,6 +9,8 @@
 
 Commonly Used Types:
 System.Net.Http.WinHttpHandler</PackageDescription>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>1</ServicingVersion>
   </PropertyGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->


### PR DESCRIPTION
This addresses an overlook from #63346. We forgot to follow [the nuget servicing guideline](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md#how-to-service-a-library) so the bugfix was not released.

Fixes #60291

/cc @safern

## Customer Impact

This is follow up to PR #63346 which was approved and merged for 6.0.2, but missed nuget authoring -- as a result, the fix didn't really ship as part of 6.0.2.

#60291 is a bug in WinHttpHandler that prevents running/debugging gRPC code on .NET Framework using Visual Studio + IIS Express which is an important customer scenario for https://github.com/dotnet/core/issues/5713. It can probably also manifest in production environments with servers other than Kestrel.

## Testing

N/A

## Risk

Low.