### PR TITLE
[release/6.0] Backport Fix PerformanceCounter's when running with Globalization Invariant Mode

### DIFF
--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);netcoreapp3.1-windows;netcoreapp3.1;netstandard2.0;net461</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1847</NoWarn>
     <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>1</ServicingVersion>
     <PackageDescription>Provides the System.Diagnostics.PerformanceCounter class, which allows access to Windows performance counters.
 
 Commonly Used Types:

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -45,11 +45,11 @@ namespace System.Diagnostics
         private const string LanguageKeyword = "language";
         private const string DllName = "netfxperf.dll";
 
-        private const int EnglishLCID = 0x009;
-
         private static volatile string s_computerName;
         private static volatile string s_iniFilePath;
         private static volatile string s_symbolFilePath;
+
+        private static CultureInfo s_englishCulture;
 
         private PerformanceMonitor _performanceMonitor;
         private readonly string _machineName;
@@ -76,6 +76,25 @@ namespace System.Diagnostics
                     Interlocked.CompareExchange(ref s_internalSyncObject, o, null);
                 }
                 return s_internalSyncObject;
+            }
+        }
+
+        private static CultureInfo EnglishCulture
+        {
+            get
+            {
+                if (s_englishCulture is null)
+                {
+                    try
+                    {
+                        s_englishCulture = CultureInfo.GetCultureInfo("en");
+                    }
+                    catch
+                    {
+                        s_englishCulture = CultureInfo.InvariantCulture;
+                    }
+                }
+                return s_englishCulture;
             }
         }
 
@@ -277,11 +296,11 @@ namespace System.Diagnostics
 
         internal static bool CategoryExists(string machine, string category)
         {
-            PerformanceCounterLib library = GetPerformanceCounterLib(machine, new CultureInfo(EnglishLCID));
+            PerformanceCounterLib library = GetPerformanceCounterLib(machine, EnglishCulture);
             if (library.CategoryExists(category))
                 return true;
 
-            if (CultureInfo.CurrentCulture.Parent.LCID != EnglishLCID)
+            if (CultureInfo.CurrentCulture.Parent.Name != EnglishCulture.Name)
             {
                 CultureInfo culture = CultureInfo.CurrentCulture;
                 while (culture != CultureInfo.InvariantCulture)
@@ -349,11 +368,11 @@ namespace System.Diagnostics
 
         internal static bool CounterExists(string machine, string category, string counter)
         {
-            PerformanceCounterLib library = GetPerformanceCounterLib(machine, new CultureInfo(EnglishLCID));
+            PerformanceCounterLib library = GetPerformanceCounterLib(machine, EnglishCulture);
             bool categoryExists = false;
             bool counterExists = library.CounterExists(category, counter, ref categoryExists);
 
-            if (!categoryExists && CultureInfo.CurrentCulture.Parent.LCID != EnglishLCID)
+            if (!categoryExists && CultureInfo.CurrentCulture.Parent.Name != EnglishCulture.Name)
             {
                 CultureInfo culture = CultureInfo.CurrentCulture;
                 while (culture != CultureInfo.InvariantCulture)
@@ -753,7 +772,7 @@ namespace System.Diagnostics
                 culture = culture.Parent;
             }
 
-            library = GetPerformanceCounterLib(machineName, new CultureInfo(EnglishLCID));
+            library = GetPerformanceCounterLib(machineName, EnglishCulture);
             return library.GetCategories();
         }
 
@@ -772,7 +791,7 @@ namespace System.Diagnostics
 
             //First check the current culture for the category. This will allow
             //PerformanceCounterCategory.CategoryHelp to return localized strings.
-            if (CultureInfo.CurrentCulture.Parent.LCID != EnglishLCID)
+            if (CultureInfo.CurrentCulture.Parent.Name != EnglishCulture.Name)
             {
                 CultureInfo culture = CultureInfo.CurrentCulture;
 
@@ -788,7 +807,7 @@ namespace System.Diagnostics
 
             //We did not find the category walking up the culture hierarchy. Try looking
             // for the category in the default culture English.
-            library = GetPerformanceCounterLib(machine, new CultureInfo(EnglishLCID));
+            library = GetPerformanceCounterLib(machine, EnglishCulture);
             help = library.GetCategoryHelp(category);
 
             if (help == null)
@@ -808,9 +827,9 @@ namespace System.Diagnostics
 
         internal static CategorySample GetCategorySample(string machine, string category)
         {
-            PerformanceCounterLib library = GetPerformanceCounterLib(machine, new CultureInfo(EnglishLCID));
+            PerformanceCounterLib library = GetPerformanceCounterLib(machine, EnglishCulture);
             CategorySample sample = library.GetCategorySample(category);
-            if (sample == null && CultureInfo.CurrentCulture.Parent.LCID != EnglishLCID)
+            if (sample == null && CultureInfo.CurrentCulture.Parent.Name != EnglishCulture.Name)
             {
                 CultureInfo culture = CultureInfo.CurrentCulture;
                 while (culture != CultureInfo.InvariantCulture)
@@ -845,11 +864,11 @@ namespace System.Diagnostics
 
         internal static string[] GetCounters(string machine, string category)
         {
-            PerformanceCounterLib library = GetPerformanceCounterLib(machine, new CultureInfo(EnglishLCID));
+            PerformanceCounterLib library = GetPerformanceCounterLib(machine, EnglishCulture);
             bool categoryExists = false;
             string[] counters = library.GetCounters(category, ref categoryExists);
 
-            if (!categoryExists && CultureInfo.CurrentCulture.Parent.LCID != EnglishLCID)
+            if (!categoryExists && CultureInfo.CurrentCulture.Parent.Name != EnglishCulture.Name)
             {
                 CultureInfo culture = CultureInfo.CurrentCulture;
                 while (culture != CultureInfo.InvariantCulture)
@@ -910,7 +929,7 @@ namespace System.Diagnostics
 
             //First check the current culture for the counter. This will allow
             //PerformanceCounter.CounterHelp to return localized strings.
-            if (CultureInfo.CurrentCulture.Parent.LCID != EnglishLCID)
+            if (CultureInfo.CurrentCulture.Parent.Name != EnglishCulture.Name)
             {
                 CultureInfo culture = CultureInfo.CurrentCulture;
                 while (culture != CultureInfo.InvariantCulture)
@@ -925,7 +944,7 @@ namespace System.Diagnostics
 
             //We did not find the counter walking up the culture hierarchy. Try looking
             // for the counter in the default culture English.
-            library = GetPerformanceCounterLib(machine, new CultureInfo(EnglishLCID));
+            library = GetPerformanceCounterLib(machine, EnglishCulture);
             help = library.GetCounterHelp(category, counter, ref categoryExists);
 
             if (!categoryExists)
@@ -990,7 +1009,8 @@ namespace System.Diagnostics
 
         internal static PerformanceCounterLib GetPerformanceCounterLib(string machineName, CultureInfo culture)
         {
-            string lcidString = culture.LCID.ToString("X3", CultureInfo.InvariantCulture);
+            // EnglishCulture.LCID == 9 will be false only if running with Globalization Invariant Mode. Use "009" at that time as default English language identifier.
+            string lcidString = EnglishCulture.LCID == 9 ? culture.LCID.ToString("X3", CultureInfo.InvariantCulture) : "009";
 
             machineName = (machineName == "." ? ComputerName : machineName).ToLowerInvariant();
 
@@ -1135,11 +1155,11 @@ namespace System.Diagnostics
 
         internal static bool IsCustomCategory(string machine, string category)
         {
-            PerformanceCounterLib library = GetPerformanceCounterLib(machine, new CultureInfo(EnglishLCID));
+            PerformanceCounterLib library = GetPerformanceCounterLib(machine, EnglishCulture);
             if (library.IsCustomCategory(category))
                 return true;
 
-            if (CultureInfo.CurrentCulture.Parent.LCID != EnglishLCID)
+            if (CultureInfo.CurrentCulture.Parent.Name != EnglishCulture.Name)
             {
                 CultureInfo culture = CultureInfo.CurrentCulture;
                 while (culture != CultureInfo.InvariantCulture)
@@ -1174,10 +1194,10 @@ namespace System.Diagnostics
         {
             PerformanceCounterCategoryType categoryType = PerformanceCounterCategoryType.Unknown;
 
-            PerformanceCounterLib library = GetPerformanceCounterLib(machine, new CultureInfo(EnglishLCID));
+            PerformanceCounterLib library = GetPerformanceCounterLib(machine, EnglishCulture);
             if (!library.FindCustomCategory(category, out categoryType))
             {
-                if (CultureInfo.CurrentCulture.Parent.LCID != EnglishLCID)
+                if (CultureInfo.CurrentCulture.Parent.Name != EnglishCulture.Name)
                 {
                     CultureInfo culture = CultureInfo.CurrentCulture;
                     while (culture != CultureInfo.InvariantCulture)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/65502

Backport of #65414 to release/6.0

/cc @tarekgh

## Customer Impact
This is a migration to .NET 6.0 blocker for users who enable [Globalization Invariant Mode](https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md) on their app and try to use the performance counter library.
Performance counter library has old code which creating CultureInfo object using [LCID](https://docs.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo.lcid?view=net-6.0). LCID is an obsolete concept, and it is recommended to always create a culture with the language tag names instead. When enabling the Globalization Invariant Mode, we don't support creating cultures using LCID at all as we don't depend on the underlying OS at all. This will cause the code in the performance counter library to throw an exception. That means there is no way to use this library when enabling the invariant mode.

## Testing
This change is already merged in .NET 7.0 and passing all regression and CI tests. Also, I added a new test for testing the library when enabling the Globalization Invariant Mode.

## Risk
Low as the change scoped to the performance counter library which is supported on Windows only and all the changes is changing the creation of the culture using the LCID to use the culture name instead which should be exact result anyway but will avoid the exception. 