### PR TITLE
New Arcade Installers package with Mariner cm.2 change

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -86,9 +86,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>6d977266bcc193caedb60a27ae44d14d9a11a040</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="7.0.0-beta.22114.7">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="7.0.0-beta.22117.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>6d977266bcc193caedb60a27ae44d14d9a11a040</Sha>
+      <Sha>4f26404a6ca1061e385e53501954bd5edda20bf2</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="7.0.0-beta.22114.7">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -65,7 +65,7 @@
     <MicrosoftDotNetXUnitExtensionsVersion>7.0.0-beta.22114.7</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.22114.7</MicrosoftDotNetXUnitConsoleRunnerVersion>
     <MicrosoftDotNetBuildTasksArchivesVersion>7.0.0-beta.22114.7</MicrosoftDotNetBuildTasksArchivesVersion>
-    <MicrosoftDotNetBuildTasksInstallersVersion>7.0.0-beta.22114.7</MicrosoftDotNetBuildTasksInstallersVersion>
+    <MicrosoftDotNetBuildTasksInstallersVersion>7.0.0-beta.22117.1</MicrosoftDotNetBuildTasksInstallersVersion>
     <MicrosoftDotNetBuildTasksPackagingVersion>7.0.0-beta.22114.7</MicrosoftDotNetBuildTasksPackagingVersion>
     <MicrosoftDotNetBuildTasksTargetFrameworkVersion>7.0.0-beta.22114.7</MicrosoftDotNetBuildTasksTargetFrameworkVersion>
     <MicrosoftDotNetBuildTasksTemplatingVersion>7.0.0-beta.22114.7</MicrosoftDotNetBuildTasksTemplatingVersion>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/65541

Picks up new Arcade's Microsoft.DotNet.Build.Tasks.Installers that contains the change: https://github.com/dotnet/arcade/pull/8481
