### PR TITLE
Fix an incorrect assert

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -3375,7 +3375,11 @@ void CodeGen::genStructPutArgUnroll(GenTreePutArgStk* putArgNode)
 #endif
 
     unsigned size = putArgNode->GetStackByteSize();
+#ifdef TARGET_X86
     assert((XMM_REGSIZE_BYTES <= size) && (size <= CPBLK_UNROLL_LIMIT));
+#else  // !TARGET_X86
+    assert(size <= CPBLK_UNROLL_LIMIT);
+#endif // !TARGET_X86
 
     if (src->AsOp()->gtOp1->isUsedFromReg())
     {
@@ -3399,7 +3403,7 @@ void CodeGen::genStructPutArgUnroll(GenTreePutArgStk* putArgNode)
 #ifdef TARGET_X86
     longTmpReg = xmmTmpReg;
 #else
-    longTmpReg             = intTmpReg;
+    longTmpReg = intTmpReg;
 #endif
 
     // Let's use SSE2 to be able to do 16 byte at a time with loads and stores.


### PR DESCRIPTION
We only require "greater than" on x86. [Ref](https://github.com/dotnet/runtime/blob/3deadcfc767074093899765821172edcac10f76b/src/coreclr/jit/lowerxarch.cpp#L603-L636).

No test added because the code was (and is) correct for the non-x86 case, just the assert condition was faulty.

Fixes https://github.com/dotnet/runtime/pull/64805#issuecomment-1044518626.