### PR TITLE
Fix Queryable-to-Enumerable overload mapping logic

### DIFF
--- a/src/libraries/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
+++ b/src/libraries/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
@@ -292,25 +292,24 @@ namespace System.Linq
                 Debug.Assert(matchingMethods.Length > 1);
                 ParameterInfo[][] parameters = matchingMethods.Select(m => m.GetParameters()).ToArray();
 
-                // `IsLessDerivedThan` defines a partial order on method signatures; pick a maximal element using that order.
+                // `AreAssignableFrom` defines a partial order on method signatures; pick a maximal element using that order.
                 // It is assumed that `matchingMethods` is a small array, so a naive quadratic search is probably better than
                 // doing some variant of topological sorting.
 
                 for (int i = 0; i < matchingMethods.Length; i++)
                 {
-                    bool foundDerivedMethodSignature = false;
+                    bool isMaximal = true;
                     for (int j = 0; j < matchingMethods.Length; j++)
                     {
-                        if (i != j && IsLessDerivedThan(parameters[i], parameters[j]))
+                        if (i != j && AreAssignableFrom(parameters[i], parameters[j]))
                         {
-                            foundDerivedMethodSignature = true;
+                            isMaximal = false;
                             break;
                         }
                     }
 
-                    if (!foundDerivedMethodSignature)
+                    if (isMaximal)
                     {
-                        // Found a maximal element
                         return matchingMethods[i];
                     }
                 }
@@ -318,12 +317,12 @@ namespace System.Linq
                 Debug.Fail("Search should have found a maximal element");
                 throw new Exception();
 
-                static bool IsLessDerivedThan(ParameterInfo[] params1, ParameterInfo[] params2)
+                static bool AreAssignableFrom(ParameterInfo[] left, ParameterInfo[] right)
                 {
-                    Debug.Assert(params1.Length == params2.Length);
-                    for (int i = 0; i < params1.Length; i++)
+                    Debug.Assert(left.Length == right.Length);
+                    for (int i = 0; i < left.Length; i++)
                     {
-                        if (!params1[i].ParameterType.IsAssignableFrom(params2[i].ParameterType))
+                        if (!left[i].ParameterType.IsAssignableFrom(right[i].ParameterType))
                         {
                             return false;
                         }

--- a/src/libraries/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
+++ b/src/libraries/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
@@ -259,21 +259,77 @@ namespace System.Linq
             Justification = "Enumerable methods don't have trim annotations.")]
         private static MethodInfo FindEnumerableMethodForQueryable(string name, ReadOnlyCollection<Expression> args, params Type[]? typeArgs)
         {
-            if (s_seqMethods == null)
+            s_seqMethods ??= GetEnumerableStaticMethods(typeof(Enumerable)).ToLookup(m => m.Name);
+
+            MethodInfo[] matchingMethods = s_seqMethods[name]
+                .Where(m => ArgsMatch(m, args, typeArgs))
+                .Select(m => typeArgs == null ? m : m.MakeGenericMethod(typeArgs))
+                .ToArray();
+
+            Debug.Assert(matchingMethods.Length > 0, "All static methods with arguments on Queryable have equivalents on Enumerable.");
+
+            if (matchingMethods.Length > 1)
             {
-                s_seqMethods = GetEnumerableStaticMethods(typeof(Enumerable)).ToLookup(m => m.Name);
+                return DisambiguateMatches(matchingMethods);
             }
-            MethodInfo? mi = s_seqMethods[name].FirstOrDefault(m => ArgsMatch(m, args, typeArgs));
-            Debug.Assert(mi != null, "All static methods with arguments on Queryable have equivalents on Enumerable.");
-            if (typeArgs != null)
-                return mi.MakeGenericMethod(typeArgs);
-            return mi;
+
+            return matchingMethods[0];
 
             [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
                 Justification = "This method is intentionally hiding the Enumerable type from the trimmer so it doesn't preserve all Enumerable's methods. " +
                 "This is safe because all Queryable methods have a DynamicDependency to the corresponding Enumerable method.")]
             static MethodInfo[] GetEnumerableStaticMethods(Type type) =>
                 type.GetMethods(BindingFlags.Public | BindingFlags.Static);
+
+            // In certain cases, there might be ambiguities when resolving matching overloads, for example between
+            //   1. FirstOrDefault<object>(IEnumerable<object> source, Func<object, bool> predicate) and
+            //   2. FirstOrDefault<object>(IEnumerable<object> source, object defaultvalue).
+            // In such cases we disambiguate by picking a method with the most derived signature.
+            static MethodInfo DisambiguateMatches(MethodInfo[] matchingMethods)
+            {
+                Debug.Assert(matchingMethods.Length > 1);
+                ParameterInfo[][] parameters = matchingMethods.Select(m => m.GetParameters()).ToArray();
+
+                // `IsLessDerivedThan` defines a partial order on method signatures; pick a maximal element using that order.
+                // It is assumed that `matchingMethods` is a small array, so a naive quadratic search is probably better than
+                // doing some variant of topological sorting.
+
+                for (int i = 0; i < matchingMethods.Length; i++)
+                {
+                    bool foundDerivedMethodSignature = false;
+                    for (int j = 0; j < matchingMethods.Length; j++)
+                    {
+                        if (i != j && IsLessDerivedThan(parameters[i], parameters[j]))
+                        {
+                            foundDerivedMethodSignature = true;
+                            break;
+                        }
+                    }
+
+                    if (!foundDerivedMethodSignature)
+                    {
+                        // Found a maximal element
+                        return matchingMethods[i];
+                    }
+                }
+
+                Debug.Fail("Search should have found a maximal element");
+                throw new Exception();
+
+                static bool IsLessDerivedThan(ParameterInfo[] params1, ParameterInfo[] params2)
+                {
+                    Debug.Assert(params1.Length == params2.Length);
+                    for (int i = 0; i < params1.Length; i++)
+                    {
+                        if (!params1[i].ParameterType.IsAssignableFrom(params2[i].ParameterType))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+            }
         }
 
         [RequiresUnreferencedCode(Queryable.InMemoryQueryableExtensionMethodsRequiresUnreferencedCode)]

--- a/src/libraries/System.Linq.Queryable/tests/FirstOrDefaultTests.cs
+++ b/src/libraries/System.Linq.Queryable/tests/FirstOrDefaultTests.cs
@@ -129,5 +129,16 @@ namespace System.Linq.Tests
             var val = (new int[] { 0, 1, 2 }).AsQueryable().FirstOrDefault(n => n > 1);
             Assert.Equal(2, val);
         }
+
+        [Fact]
+        public void FirstOrDefault_OverloadResolution_Regression()
+        {
+            // Regression test for https://github.com/dotnet/runtime/issues/65419
+            object? result = new object[] { 1, "" }.AsQueryable().FirstOrDefault(x => x is string);
+            Assert.IsType<string>(result);
+
+            result = Array.Empty<object>().AsQueryable().FirstOrDefault(1);
+            Assert.IsType<int>(result);
+        }
     }
 }

--- a/src/libraries/System.Linq.Queryable/tests/LastOrDefaultTests.cs
+++ b/src/libraries/System.Linq.Queryable/tests/LastOrDefaultTests.cs
@@ -96,5 +96,16 @@ namespace System.Linq.Tests.LegacyTests
             var val = (new int[] { 0, 1, 2 }).AsQueryable().LastOrDefault(n => n > 1);
             Assert.Equal(2, val);
         }
+
+        [Fact]
+        public void LastOrDefault_OverloadResolution_Regression()
+        {
+            // Regression test for https://github.com/dotnet/runtime/issues/65419
+            object? result = new object[] { 1, "" }.AsQueryable().LastOrDefault(x => x is int);
+            Assert.IsType<int>(result);
+
+            result = Array.Empty<object>().AsQueryable().LastOrDefault(1);
+            Assert.IsType<int>(result);
+        }
     }
 }

--- a/src/libraries/System.Linq.Queryable/tests/SingleOrDefaultTests.cs
+++ b/src/libraries/System.Linq.Queryable/tests/SingleOrDefaultTests.cs
@@ -79,5 +79,16 @@ namespace System.Linq.Tests
             var val = (new int[] { 2 }).AsQueryable().SingleOrDefault(n => n > 1);
             Assert.Equal(2, val);
         }
+
+        [Fact]
+        public void SingleOrDefault_OverloadResolution_Regression()
+        {
+            // Regression test for https://github.com/dotnet/runtime/issues/65419
+            object? result = new object[] { 1, "" }.AsQueryable().SingleOrDefault(x => x is string);
+            Assert.IsType<string>(result);
+
+            result = Array.Empty<object>().AsQueryable().SingleOrDefault(1);
+            Assert.IsType<int>(result);
+        }
     }
 }


### PR DESCRIPTION
Fix #65419.

Should be considered for .NET 6 servicing.