### PR TITLE
Roll out automated issue cleanup

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -5399,7 +5399,7 @@
         {
           "name": "addReply",
           "parameters": {
-            "comment": "Due to lack of recent activity, this issue has been marked as a candidate for backlog cleanup.  It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will undo this process.\n\nThis process is part of the experimental [issue cleanup initiative](https://github.com/dotnet/runtime/issues/60288) we are currently trialing in a limited number of areas. Please share any feedback you might have in the linked issue."
+            "comment": "Due to lack of recent activity, this issue has been marked as a candidate for backlog cleanup.  It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will undo this process.\n\nThis process is part of the experimental [issue cleanup initiative](https://github.com/dotnet/runtime/issues/60288) we are currently trialing. Please share any feedback you might have in the linked issue."
           }
         },
         {

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -5384,7 +5384,7 @@
           {
             "name": "labelAdded",
             "parameters": {
-              "label": "no-recent-activity"
+              "label": "backlog-cleanup-candidate"
             }
           }
         ]
@@ -5394,12 +5394,106 @@
         "issues",
         "project_card"
       ],
-      "taskName": "Issue cleanup notification",
+      "taskName": "Manual Issue Cleanup",
       "actions": [
         {
           "name": "addReply",
           "parameters": {
             "comment": "Due to lack of recent activity, this issue has been marked as a candidate for backlog cleanup.  It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will undo this process.\n\nThis process is part of the experimental [issue cleanup initiative](https://github.com/dotnet/runtime/issues/60288) we are currently trialing in a limited number of areas. Please share any feedback you might have in the linked issue."
+          }
+        },
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "no-recent-activity"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 1,
+          "hours": [],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 2,
+          "hours": [],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 3,
+          "hours": [],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 4,
+          "hours": [],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 5,
+          "hours": [],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 6,
+          "hours": [],
+          "timezoneOffset": 0
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 1827
+          }
+        },
+        {
+          "name": "isIssue",
+          "parameters": {}
+        },
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "noLabel",
+          "parameters": {
+            "label": "backlog-cleanup-candidate"
+          }
+        }
+      ],
+      "taskName": "Automated Issue cleanup",
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "backlog-cleanup-candidate"
+          }
+        },
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Due to lack of recent activity, this issue has been marked as a candidate for backlog cleanup.  It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will undo this process.\n\nThis process is part of the experimental [issue cleanup initiative](https://github.com/dotnet/runtime/issues/60288) we are currently trialing in a limited number of areas. Please share any feedback you might have in the linked issue."
+          }
+        },
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "no-recent-activity"
           }
         }
       ]

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -5487,7 +5487,7 @@
         {
           "name": "addReply",
           "parameters": {
-            "comment": "Due to lack of recent activity, this issue has been marked as a candidate for backlog cleanup.  It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will undo this process.\n\nThis process is part of the experimental [issue cleanup initiative](https://github.com/dotnet/runtime/issues/60288) we are currently trialing in a limited number of areas. Please share any feedback you might have in the linked issue."
+            "comment": "Due to lack of recent activity, this issue has been marked as a candidate for backlog cleanup.  It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will undo this process.\n\nThis process is part of the experimental [issue cleanup initiative](https://github.com/dotnet/runtime/issues/60288) we are currently trialing. Please share any feedback you might have in the linked issue."
           }
         },
         {


### PR DESCRIPTION
Makes the following changes to our existing [issue cleanup automation](https://github.com/dotnet/runtime/issues/60288):

* Adds a scheduled search rule that automatically marks issues for cleanup that have been inactive for over 5 years. Currently this only impacts [12 issues in our backlogs](https://github.com/dotnet/runtime/issues?q=is%3Aissue+is%3Aopen+updated%3A%3C%3D2017-02-18+) with potential for [impacting ~100 issues over the coming year](https://github.com/dotnet/runtime/issues?q=is%3Aissue+is%3Aopen+updated%3A%3C%3D2018-02-18+). This is a conservative threshold intended to minimize the amount of generated noise, we can make adjustments to it in the future.
* Uses a dedicated [`backlog-cleanup-candidate` label](https://github.com/dotnet/runtime/labels/backlog-cleanup-candidate) for marking issues (replacing the more widely used `no-recent-activity`). `no-recent-activity` can be removed by automation so it's harder to track issues that have been marked for cleanup in the past.

Contributes to #60288.