### PR TITLE
Suppress some new trimmer warnings

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -2905,6 +2905,10 @@ namespace System
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2063:UnrecognizedReflectionPattern",
+            Justification = "Trimming makes sure that interfaces are fully preserved, so the Interfaces annotation is transitive." +
+                            "The cache doesn't carry the necessary annotation since it returns an array type," +
+                            "so the analysis complains that the returned value doesn't have the necessary annotation.")]
         public override Type? GetInterface(string fullname!!, bool ignoreCase)
         {
             BindingFlags bindingAttr = BindingFlags.Public | BindingFlags.NonPublic;

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -2903,12 +2903,12 @@ namespace System
             return match;
         }
 
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2063:UnrecognizedReflectionPattern",
             Justification = "Trimming makes sure that interfaces are fully preserved, so the Interfaces annotation is transitive." +
                             "The cache doesn't carry the necessary annotation since it returns an array type," +
                             "so the analysis complains that the returned value doesn't have the necessary annotation.")]
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
         public override Type? GetInterface(string fullname!!, bool ignoreCase)
         {
             BindingFlags bindingAttr = BindingFlags.Public | BindingFlags.NonPublic;

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AssociatedMetadataTypeTypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AssociatedMetadataTypeTypeDescriptor.cs
@@ -113,6 +113,16 @@ namespace System.ComponentModel.DataAnnotations
                 }
             }
 
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2063:UnrecognizedReflectionPattern",
+                Justification = "The cache is a dictionary which is hard to annotate. All values in the cache" +
+                                "have annotation All (since we only ever add attribute.MetadataClassType which has All)." +
+                                "But the call to TryGetValue doesn't carry the annotation so this warns when trying" +
+                                "to return value.")]
+            // Better "fix" for the missing annotation would be a local funcion
+            // `bool TryGetAssociatedMetadataTypeFromCache(Type type, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] out Type? associatedMetadataType)`
+            // With the suppression on it - since that would be much more localized.
+            // Unfortunately this currently doesn't work due to an issue in the trimmer
+            // https://github.com/dotnet/linker/issues/2632
             [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
             public static Type? GetAssociatedMetadataType(Type type)
             {

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/FormatterServices.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/FormatterServices.cs
@@ -16,8 +16,9 @@ namespace System.Runtime.Serialization
     {
         private static readonly ConcurrentDictionary<MemberHolder, MemberInfo[]> s_memberInfoTable = new ConcurrentDictionary<MemberHolder, MemberInfo[]>();
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
-            Justification = "The Type is annotated with All, which will preserve base type fields.")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2065:UnrecognizedReflectionPattern",
+            Justification = "The parentType is read from an array which currently can't be annotated," +
+                            "but the input type is annotated with All, so all of its base types are also All.")]
         private static FieldInfo[] InternalGetSerializableMembers(
             // currently the only way to preserve base, non-public fields is to use All
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)


### PR DESCRIPTION
The next update of linker will improve some data flow analysis and this uncovers more warnings in the libraries.
None of these warnings are a real problem, they're all basically inability to express the desired behavior with the current annotation system.

This change suppresses the new warnings.