### PR TITLE
Disable System.Diagnostics.Tests.EventLogRecordTests.ExceptionOnce on Windows Server 2022

### DIFF
--- a/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogRecordTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogRecordTests.cs
@@ -91,7 +91,8 @@ namespace System.Diagnostics.Tests
         public void ExceptionOnce()
         {
             if (PlatformDetection.IsWindows7 ||  // Null events in PowerShell log
-                PlatformDetection.IsWindows10Version22000OrGreater) // ActiveIssue("https://github.com/dotnet/runtime/issues/58829")
+                PlatformDetection.IsWindows10Version22000OrGreater ||  // Windows 11 and Windows Server 2022:
+                PlatformDetection.IsWindows10Version20348OrGreater)    // ActiveIssue("https://github.com/dotnet/runtime/issues/58829")
                 return;
             var query = new EventLogQuery("Application", PathType.LogName, "*[System]") { ReverseDirection = true };
             var eventLog = new EventLogReader(query, Helpers.GetBookmark("Application", PathType.LogName));


### PR DESCRIPTION
`System.Diagnostics.Tests.EventLogRecordTests.ExceptionOnce` is failing the same way as in https://github.com/dotnet/runtime/issues/58829. It was disabled it on Windows 11 - disabling it on Windows Server 2022 as well to unblock that queue.

@dotnet/area-system-diagnostics-eventlog 