### PR TITLE
Propagate native references to merged project wrapper outputs

### DIFF
--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -117,9 +117,6 @@
       Condition="'$(IsMergedTestRunnerAssembly)' == 'true'"
       AfterTargets="Build"
       BeforeTargets="CopyNativeProjectBinaries">
-    <PropertyGroup>
-          <CopyMergedWrapperReferencesHasRun>true</CopyMergedWrapperReferencesHasRun>
-    </PropertyGroup>
     <ItemGroup>
       <MergedWrapperReferenceFolders Include="@(ProjectReference->'$([System.IO.Path]::GetFullPath('%(ProjectReference.Identity)/..', '$(OutDir)/..'))/%(ProjectReference.FileName)')" />
       <!-- For merged project wrappers, include native libraries in all project references -->

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -113,6 +113,24 @@
     <SkipImportILTargets Condition="'$(CLRTestBuildAllTargets)' != '' And '$(CLRTestNeedTarget)' != '$(CLRTestBuildAllTargets)'">true</SkipImportILTargets>
   </PropertyGroup>
 
+  <Target Name="CopyMergedWrapperReferences"
+      Condition="'$(IsMergedTestRunnerAssembly)' == 'true'"
+      AfterTargets="Build"
+      BeforeTargets="CopyNativeProjectBinaries">
+    <PropertyGroup>
+          <CopyMergedWrapperReferencesHasRun>true</CopyMergedWrapperReferencesHasRun>
+    </PropertyGroup>
+    <ItemGroup>
+      <MergedWrapperReferenceFolders Include="@(ProjectReference->'$([System.IO.Path]::GetFullPath('%(ProjectReference.Identity)/..', '$(OutDir)/..'))/%(ProjectReference.FileName)')" />
+      <!-- For merged project wrappers, include native libraries in all project references -->
+      <MergedWrapperReferenceFiles Include="%(MergedWrapperReferenceFolders.Identity)/$(LibPrefix)*$(LibSuffix)" />
+    </ItemGroup>
+    <Copy SourceFiles="@(MergedWrapperReferenceFiles)"
+        DestinationFiles="@(MergedWrapperReferenceFiles->'$(OutDir)/%(FileName)%(Extension)')" 
+        SkipUnchangedFiles="true"
+        />
+  </Target>
+
   <Target Name="CopyNativeProjectBinaries" Condition="'$(_CopyNativeProjectBinaries)' == 'true'">
     <ItemGroup Condition="'$(UseVisualStudioNativeBinariesLayout)' == 'true'">
       <NativeProjectBinaries Include="$(NativeProjectOutputFolder)\*.*" />


### PR DESCRIPTION
When building tests in merged mode, we need to copy the native
references along with the component test dlls to the output folder
to make them discoverable by the OS loader.

Thanks

Tomas