### PR TITLE
Don't mark prefldinit4 as requiring process isolation

### DIFF
--- a/src/tests/JIT/Methodical/cctor/simple/prefldinit4_il_d.ilproj
+++ b/src/tests/JIT/Methodical/cctor/simple/prefldinit4_il_d.ilproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/cctor/simple/prefldinit4_il_r.ilproj
+++ b/src/tests/JIT/Methodical/cctor/simple/prefldinit4_il_r.ilproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>


### PR DESCRIPTION
Turns out this particular test doesn't actually need process
isolation, I overzealously marked it as such in a previous wave
just because it's a static initialization test. This lets us
postpone dealing with out-of-process ilproj tests to a later
phase.

Thanks

Tomas

/cc @dotnet/jit-contrib 