### PR TITLE
Revisit `PatternContext<TFrame>.PushDataFrame` nullable annotation

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/ref/Microsoft.Extensions.FileSystemGlobbing.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/ref/Microsoft.Extensions.FileSystemGlobbing.cs
@@ -247,14 +247,14 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts
         public override void Declare(System.Action<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment, bool> onDeclare) { }
         public override bool Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory) { throw null; }
     }
-    public abstract partial class PatternContext<TFrame> : Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext
+    public abstract partial class PatternContext<TFrame> : Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext where TFrame : struct
     {
-        protected TFrame? Frame;
+        protected TFrame Frame;
         protected PatternContext() { }
         public virtual void Declare(System.Action<Microsoft.Extensions.FileSystemGlobbing.Internal.IPathSegment, bool> declare) { }
         protected bool IsStackEmpty() { throw null; }
         public virtual void PopDirectory() { }
-        protected void PushDataFrame(TFrame? frame) { }
+        protected void PushDataFrame(TFrame frame) { }
         public abstract void PushDirectory(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory);
         public abstract bool Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase directory);
         public abstract Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult Test(Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase file);

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/PatternContexts/PatternContext.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/PatternContexts/PatternContext.cs
@@ -7,10 +7,10 @@ using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 
 namespace Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts
 {
-    public abstract class PatternContext<TFrame> : IPatternContext
+    public abstract class PatternContext<TFrame> : IPatternContext where TFrame : struct
     {
-        private Stack<TFrame?> _stack = new();
-        protected TFrame? Frame;
+        private Stack<TFrame> _stack = new();
+        protected TFrame Frame;
 
         public virtual void Declare(Action<IPathSegment, bool> declare) { }
 
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts
             Frame = _stack.Pop();
         }
 
-        protected void PushDataFrame(TFrame? frame)
+        protected void PushDataFrame(TFrame frame)
         {
             _stack.Push(Frame);
             Frame = frame;


### PR DESCRIPTION
Fixes: #65590 

`where TFrame : struct` needs to be added here, right? Otherwise there's a possibility of `protected TFrame Frame;` being `null` and therefore `null` being pushed.