### PR TITLE
Added tests for changing a list size being iterated on (#65608)

### DIFF
--- a/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.Find.cs
+++ b/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.Find.cs
@@ -290,18 +290,21 @@ namespace System.Collections.Tests
         [Fact]
         public void Find_ListSizeCanBeChanged()
         {
+            var expected = new List<int>() { 1, 2, 3, 2, 3, 4, 3, 4, 4 };
+
             var list = new List<int>() { 1, 2, 3 };
-            var results = list.FindAll(i =>
+
+            list.Find(i =>
             {
                 if (i < 4)
                 {
                     list.Add(i + 1);
                 }
 
-                return true;
+                return false;
             });
 
-            Assert.Equal(list, results);
+            Assert.Equal(list, expected);
         }
 
         #endregion
@@ -1001,8 +1004,11 @@ namespace System.Collections.Tests
         [Fact]
         public void FindAll_ListSizeCanBeChanged()
         {
+            var expected = new List<int>() { 1, 2, 3, 2, 3, 4, 3, 4, 4 };
+
             var list = new List<int>() { 1, 2, 3 };
-            var results = list.FindAll(i =>
+
+            list.FindAll(i =>
             {
                 if (i < 4)
                 {
@@ -1012,7 +1018,7 @@ namespace System.Collections.Tests
                 return true;
             });
 
-            Assert.Equal(list, results);
+            Assert.Equal(list, expected);
         }
 
         #endregion

--- a/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.Find.cs
+++ b/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.Find.cs
@@ -290,11 +290,11 @@ namespace System.Collections.Tests
         [Fact]
         public void Find_ListSizeCanBeChanged()
         {
-            var expected = new List<int>() { 1, 2, 3, 2, 3, 4, 3, 4, 4 };
+            List<int> expectedList = new List<int>() { 1, 2, 3, 2, 3, 4, 3, 4, 4 };
 
-            var list = new List<int>() { 1, 2, 3 };
+            List<int> list = new List<int>() { 1, 2, 3 };
 
-            list.Find(i =>
+            int result = list.Find(i =>
             {
                 if (i < 4)
                 {
@@ -304,7 +304,8 @@ namespace System.Collections.Tests
                 return false;
             });
 
-            Assert.Equal(list, expected);
+            Assert.Equal(0, result);
+            Assert.Equal(expectedList, list);
         }
 
         #endregion
@@ -1004,11 +1005,10 @@ namespace System.Collections.Tests
         [Fact]
         public void FindAll_ListSizeCanBeChanged()
         {
-            var expected = new List<int>() { 1, 2, 3, 2, 3, 4, 3, 4, 4 };
+            List<int> list = new List<int>() { 1, 2, 3 };
+            List<int> expectedList = new List<int>() { 1, 2, 3, 2, 3, 4, 3, 4, 4 };
 
-            var list = new List<int>() { 1, 2, 3 };
-
-            list.FindAll(i =>
+            List<int> result = list.FindAll(i =>
             {
                 if (i < 4)
                 {
@@ -1018,7 +1018,8 @@ namespace System.Collections.Tests
                 return true;
             });
 
-            Assert.Equal(list, expected);
+            Assert.Equal(expectedList, result);
+            Assert.Equal(expectedList, list);
         }
 
         #endregion

--- a/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.Find.cs
+++ b/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.Find.cs
@@ -287,6 +287,23 @@ namespace System.Collections.Tests
             }
         }
 
+        [Fact]
+        public void Find_ListSizeCanBeChanged()
+        {
+            var list = new List<int>() { 1, 2, 3 };
+            var results = list.FindAll(i =>
+            {
+                if (i < 4)
+                {
+                    list.Add(i + 1);
+                }
+
+                return true;
+            });
+
+            Assert.Equal(list, results);
+        }
+
         #endregion
 
         #region FindLast
@@ -979,6 +996,23 @@ namespace System.Collections.Tests
 
             //[] Verify FindAll returns an empty List if the match returns false on every item
             VerifyList(list.FindAll(_alwaysFalseDelegate), new List<T>());
+        }
+
+        [Fact]
+        public void FindAll_ListSizeCanBeChanged()
+        {
+            var list = new List<int>() { 1, 2, 3 };
+            var results = list.FindAll(i =>
+            {
+                if (i < 4)
+                {
+                    list.Add(i + 1);
+                }
+
+                return true;
+            });
+
+            Assert.Equal(list, results);
         }
 
         #endregion

--- a/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.Misc.cs
+++ b/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.Misc.cs
@@ -1103,9 +1103,10 @@ namespace System.Collections.Tests
         [Fact]
         public static void TrueForAll_ListSizeCanBeChanged()
         {
-            var list = new List<int>() { 1, 2, 3 };
-            var results = new List<int> { 1, 2, 3, 2, 3, 4, 3, 4, 4 };
-            list.TrueForAll(i =>
+            List<int> list = new List<int>() { 1, 2, 3 };
+            List<int> expectedList = new List<int> { 1, 2, 3, 2, 3, 4, 3, 4, 4 };
+
+            bool result = list.TrueForAll(i =>
             {
                 if (i < 4)
                 {
@@ -1115,7 +1116,8 @@ namespace System.Collections.Tests
                 return true;
             });
 
-            Assert.Equal(list, results);
+            Assert.True(result);
+            Assert.Equal(expectedList, list);
         }
     }
 }

--- a/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.Misc.cs
+++ b/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.Misc.cs
@@ -1099,5 +1099,23 @@ namespace System.Collections.Tests
             intDriver.TrueForAll_VerifyExceptions(intArray);
             stringDriver.TrueForAll_VerifyExceptions(stringArray);
         }
+
+        [Fact]
+        public static void TrueForAll_ListSizeCanBeChanged()
+        {
+            var list = new List<int>() { 1, 2, 3 };
+            var results = new List<int> { 1, 2, 3, 2, 3, 4, 3, 4, 4 };
+            list.TrueForAll(i =>
+            {
+                if (i < 4)
+                {
+                    list.Add(i + 1);
+                }
+
+                return true;
+            });
+
+            Assert.Equal(list, results);
+        }
     }
 }


### PR DESCRIPTION
If I understand everything right then the concern is that we don't have tests to cover the list size change while the list is being iterated on. 
So I added some simple tests to make sure that the "InvalidOperationExceptions" is thrown when the size is changing.
Please feel free to let me know if I missed something.
