### PR TITLE
Fix liveness for dead non-removable partial definitions

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5319,7 +5319,8 @@ public:
                            LclVarDsc*       varDsc,
                            VARSET_VALARG_TP life,
                            bool*            doAgain,
-                           bool* pStmtInfoDirty DEBUGARG(bool* treeModf));
+                           bool*            pStmtInfoDirty,
+                           bool* pStoreRemoved DEBUGARG(bool* treeModf));
 
     void fgInterBlockLocalVarLiveness();
 

--- a/src/tests/JIT/Directed/lifetime/PartialDefLiveness.cs
+++ b/src/tests/JIT/Directed/lifetime/PartialDefLiveness.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+// Here we are testing that SSA and liveness agree on whether a dead
+// partial store constitues a use (it does, in our model).
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+class PartialDefLiveness
+{
+    public static int Main()
+    {
+        // Just making sure we'll not hit any asserts in SSA.
+        Problem();
+        return 100;
+    }
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Problem()
+    {
+        Unsafe.SkipInit(out EnormousStruct a);
+        // We expect liveness to fail to remove this dead store.
+        a.Field = 1;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = ushort.MaxValue + 1 + sizeof(int))]
+    struct EnormousStruct
+    {
+        [FieldOffset(ushort.MaxValue + 1)]
+        public int Field;
+    }
+}

--- a/src/tests/JIT/Directed/lifetime/PartialDefLiveness.csproj
+++ b/src/tests/JIT/Directed/lifetime/PartialDefLiveness.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
It is the case that in our SSA model "partial defs" are considered uses.

However, liveness was not considering them as such in one particular case: when a dead partial store wasn't removed. The consequence of this is that SSA would miss pushing a definition for the "use" portion of the partial def.

This change fixes that.

Notably, back-end liveness does not need to pessimize itself like that because we don't have SSA in the backend.

We're expecting text-only diffs that were hitting the case in the test, but in a non-fatal fashion.

Ref: https://github.com/dotnet/runtime/pull/64130#discussion_r810427937.