### PR TITLE
Only register composite R2R native image code range once

### DIFF
--- a/src/coreclr/inc/CrstTypes.def
+++ b/src/coreclr/inc/CrstTypes.def
@@ -206,6 +206,7 @@ Crst ExecutableAllocatorLock
 End
 
 Crst ExecuteManRangeLock
+    AcquiredAfter NativeImageEagerFixups
 End
 
 Crst FCall

--- a/src/coreclr/inc/crsttypes.h
+++ b/src/coreclr/inc/crsttypes.h
@@ -216,7 +216,7 @@ int g_rgCrstLevelMap[] =
     4,          // CrstModuleLookupTable
     0,          // CrstMulticoreJitHash
     13,         // CrstMulticoreJitManager
-    0,          // CrstNativeImageEagerFixups
+    3,          // CrstNativeImageEagerFixups
     0,          // CrstNativeImageLoad
     0,          // CrstNls
     0,          // CrstNotifyGdb

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -4703,6 +4703,14 @@ void Module::RunEagerFixupsUnlocked()
             }
         }
     }
+
+    TADDR base = dac_cast<TADDR>(pNativeImage->GetBase());
+
+    ExecutionManager::AddCodeRange(
+        base, base + (TADDR)pNativeImage->GetVirtualSize(),
+        ExecutionManager::GetReadyToRunJitManager(),
+        RangeSection::RANGE_SECTION_READYTORUN,
+        this /* pHeapListOrZapModule */);
 }
 #endif // !DACCESS_COMPILE
 

--- a/src/coreclr/vm/domainassembly.cpp
+++ b/src/coreclr/vm/domainassembly.cpp
@@ -532,14 +532,6 @@ void DomainAssembly::EagerFixups()
     {
         GetModule()->RunEagerFixups();
 
-        PEImageLayout * pLayout = GetModule()->GetReadyToRunInfo()->GetImage();
-
-        TADDR base = dac_cast<TADDR>(pLayout->GetBase());
-
-        ExecutionManager::AddCodeRange(base, base + (TADDR)pLayout->GetVirtualSize(),
-                                        ExecutionManager::GetReadyToRunJitManager(),
-                                         RangeSection::RANGE_SECTION_READYTORUN,
-                                         GetModule() /* (void *)pLayout */);
     }
 #endif // FEATURE_READYTORUN
 }


### PR DESCRIPTION
As David Wrighton noticed during an independent investigation,
today CoreCLR runtime logic ends up registering composite image
code range with the execution manager the number of times equal
to the number of component modules of the composite image
accessed at runtime, i.e. ultimately up to over 200 times in case
of the composite framework. This change fixes that by slightly
shuffling the initialization housekeeping chores.

Thanks

Tomas

Fixes: https://github.com/dotnet/runtime/issues/65481

/cc @dotnet/crossgen-contrib 