### PR TITLE
Cleanup fp registers assignments from arm64 path

### DIFF
--- a/src/coreclr/pal/src/exception/seh-unwind.cpp
+++ b/src/coreclr/pal/src/exception/seh-unwind.cpp
@@ -115,46 +115,6 @@ enum
     ASSIGN_REG(R13)        \
     ASSIGN_REG(R14)        \
     ASSIGN_REG(R15)
-#elif (defined(HOST_UNIX) && defined(HOST_ARM64)) || (defined(HOST_WINDOWS) && defined(TARGET_ARM64))
-#define ASSIGN_UNWIND_REGS \
-    ASSIGN_REG(Pc)         \
-    ASSIGN_REG(Sp)         \
-    ASSIGN_REG(Fp)         \
-    ASSIGN_REG(Lr)         \
-    ASSIGN_REG(X19)        \
-    ASSIGN_REG(X20)        \
-    ASSIGN_REG(X21)        \
-    ASSIGN_REG(X22)        \
-    ASSIGN_REG(X23)        \
-    ASSIGN_REG(X24)        \
-    ASSIGN_REG(X25)        \
-    ASSIGN_REG(X26)        \
-    ASSIGN_REG(X27)        \
-    ASSIGN_REG(X28)        \
-    ASSIGN_FP_REG(8)       \
-    ASSIGN_FP_REG(9)       \
-    ASSIGN_FP_REG(10)       \
-    ASSIGN_FP_REG(11)       \
-    ASSIGN_FP_REG(12)       \
-    ASSIGN_FP_REG(13)       \
-    ASSIGN_FP_REG(14)       \
-    ASSIGN_FP_REG(15)       \
-    ASSIGN_FP_REG(16)       \
-    ASSIGN_FP_REG(17)       \
-    ASSIGN_FP_REG(18)       \
-    ASSIGN_FP_REG(19)       \
-    ASSIGN_FP_REG(20)       \
-    ASSIGN_FP_REG(21)       \
-    ASSIGN_FP_REG(22)       \
-    ASSIGN_FP_REG(23)       \
-    ASSIGN_FP_REG(24)       \
-    ASSIGN_FP_REG(25)       \
-    ASSIGN_FP_REG(26)       \
-    ASSIGN_FP_REG(27)       \
-    ASSIGN_FP_REG(28)       \
-    ASSIGN_FP_REG(29)       \
-    ASSIGN_FP_REG(30)       \
-    ASSIGN_FP_REG(31)
 #elif (defined(HOST_UNIX) && defined(HOST_X86)) || (defined(HOST_WINDOWS) && defined(TARGET_X86))
 #define ASSIGN_UNWIND_REGS \
     ASSIGN_REG(Eip)        \
@@ -198,14 +158,9 @@ enum
 
 static void WinContextToUnwindContext(CONTEXT *winContext, unw_context_t *unwContext)
 {
-#if (defined(HOST_UNIX) && defined(HOST_ARM64)) || (defined(HOST_WINDOWS) && defined(TARGET_ARM64))
-    fpsimd_context* fp = GetNativeSigSimdContext(unwContext);
-#define ASSIGN_FP_REG(fp, reg) if (fp) *(NEON128*) &fp->vregs[reg] = winContext->V[reg];
-#endif
 #define ASSIGN_REG(reg) MCREG_##reg(unwContext->uc_mcontext) = winContext->reg;
     ASSIGN_UNWIND_REGS
 #undef ASSIGN_REG
-#undef ASSIGN_FP_REG
 }
 #else // UNWIND_CONTEXT_IS_UCONTEXT_T
 static void WinContextToUnwindContext(CONTEXT *winContext, unw_context_t *unwContext)


### PR DESCRIPTION
This path does not compile (dead code), and it has a bug: `ASSIGN_FP_REG` requires two arguments while one is passed at call sites.

Ref:https://github.com/dotnet/runtime/pull/63596#discussion_r789512322