### PR TITLE
Improved handling of Antimirov mode in Nonbacktracking Regex engine

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/CharKind.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/CharKind.cs
@@ -11,8 +11,8 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <summary>All characters other than those in the four other kinds.</summary>
         internal const uint General = 0;
 
-        /// <summary>Start or Stop of input (bit 0 is 1)</summary>
-        internal const uint StartStop = 1;
+        /// <summary>Beginning or End of input (bit 0 is 1)</summary>
+        internal const uint BeginningEnd = 1;
 
         /// <summary>New line character (\n) (bit 1 is 1)</summary>
         internal const uint Newline = 2;
@@ -37,7 +37,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
         internal static string DescribePrev(uint i) => i switch
         {
-            StartStop => @"\A",
+            BeginningEnd => @"\A",
             Newline => @"\n",
             NewLineS => @"\A\n",
             WordLetter => @"\w",

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DfaMatchingState.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DfaMatchingState.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Net;
-using System.Threading;
 
 namespace System.Text.RegularExpressions.Symbolic
 {
@@ -25,9 +24,6 @@ namespace System.Text.RegularExpressions.Symbolic
         internal int Id { get; set; }
 
         internal bool IsInitialState { get; set; }
-
-        /// <summary>State is lazy</summary>
-        internal bool IsLazy => Node._info.IsLazy;
 
         /// <summary>This is a deadend state</summary>
         internal bool IsDeadend => Node.IsNothing;
@@ -85,7 +81,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 // If the previous state was the start state, mark this as the very FIRST \n.
                 // Essentially, this looks the same as the very last \n and is used to nullify
                 // rev(\Z) in the conext of a reversed automaton.
-                nextCharKind = PrevCharKind == CharKind.StartStop ?
+                nextCharKind = PrevCharKind == CharKind.BeginningEnd ?
                     CharKind.NewLineS :
                     CharKind.Newline;
             }
@@ -122,7 +118,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// </summary>
         /// <param name="minterm">minterm corresponding to some input character or False corresponding to last \n</param>
         /// <returns>an enumeration of the transitions as pairs of the target state and a list of effects to be applied</returns>
-        internal List<(DfaMatchingState<T> derivative, List<DerivativeEffect> effects)> AntimirovEagerNextWithEffects(T minterm)
+        internal List<(DfaMatchingState<T> derivative, List<DerivativeEffect> effects)> NfaEagerNextWithEffects(T minterm)
         {
             uint nextCharKind = GetNextCharKind(ref minterm);
 
@@ -147,7 +143,7 @@ namespace System.Text.RegularExpressions.Symbolic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool IsNullable(uint nextCharKind)
         {
-            Debug.Assert(nextCharKind is 0 or CharKind.StartStop or CharKind.Newline or CharKind.WordLetter or CharKind.NewLineS);
+            Debug.Assert(nextCharKind is 0 or CharKind.BeginningEnd or CharKind.Newline or CharKind.WordLetter or CharKind.NewLineS);
             uint context = CharKind.Context(PrevCharKind, nextCharKind);
             return Node.IsNullableFor(context);
         }
@@ -182,131 +178,5 @@ namespace System.Text.RegularExpressions.Symbolic
             }
         }
 #endif
-    }
-
-    /// <summary>Encapsulates either a DFA state in Brzozowski mode or an NFA state set in Antimirov mode. Used by reference only.</summary>
-    internal struct CurrentState<T> where T : notnull
-    {
-        // TBD: Consider SparseIntMap instead of HashSet
-        // TBD: OrderedOr
-
-        // _dfaMatchingState == null means Antimirov mode
-        private DfaMatchingState<T>? _dfaMatchingState;
-
-        private readonly SymbolicRegexBuilder<T> _builder;
-
-        // used in Antimirov mode only
-        private readonly HashSet<int> _nfaStates = new();
-        private readonly List<int> _nfaStatesList = new();
-
-        public CurrentState(DfaMatchingState<T> dfaMatchingState)
-        {
-            _builder = dfaMatchingState.Node._builder;
-            if (_builder._antimirov)
-            {
-                // Create NFA state set if the builder is in Antimirov mode
-                Debug.Assert(dfaMatchingState.Node.Kind == SymbolicRegexKind.Or && dfaMatchingState.Node._alts is not null);
-                foreach (SymbolicRegexNode<T> member in dfaMatchingState.Node._alts)
-                {
-                    // Create (possibly new) NFA states for all the members
-                    // add their IDs to the current set of NFA states and into the list
-                    int nfaState = _builder.MkNfaState(member, dfaMatchingState.PrevCharKind);
-                    if (_nfaStates.Add(nfaState))
-                        // the list maintains the original order in which states are added but avoids duplicates
-                        // TBD: OrderedOr may need to rely on that order
-                        _nfaStatesList.Add(nfaState);
-                }
-                // Antimirov mode
-                _dfaMatchingState = null;
-            }
-            else
-                // Brzozowski mode
-                _dfaMatchingState = dfaMatchingState;
-        }
-        public bool StartsWithLineAnchor
-        {
-            get
-            {
-                if (_dfaMatchingState is null)
-                {
-                    // in Antimirov mode check if some underlying core state starts with line anchor
-                    for (int i = 0; i < _nfaStatesList.Count; i++)
-                        if (_builder.GetCoreState(_nfaStatesList[i]).StartsWithLineAnchor)
-                            return true;
-                    return false;
-                }
-                else
-                {
-                    // Brzozowski mode
-                    return _dfaMatchingState.StartsWithLineAnchor;
-                }
-            }
-        }
-        public bool IsNullable(uint nextCharKind)
-        {
-            if (_dfaMatchingState is null)
-            {
-                // in Antimirov mode check if some underlying core state is nullable
-                for (int i = 0; i < _nfaStatesList.Count; i++)
-                    if (_builder.GetCoreState(_nfaStatesList[i]).IsNullable(nextCharKind))
-                        return true;
-                return false;
-            }
-            else
-            {
-                return _dfaMatchingState.IsNullable(nextCharKind);
-            }
-        }
-
-        /// <summary>In Antimirov mode an empty set of states means that it is a deadend</summary>
-        public bool IsDeadend => (_dfaMatchingState is null ? _nfaStates.Count == 0 : _dfaMatchingState.IsDeadend);
-        /// <summary>In Antimirov mode an empty set of states means that it is nothing</summary>
-        public bool IsNothing => (_dfaMatchingState is null ? _nfaStates.Count == 0 : _dfaMatchingState.IsNothing);
-        /// <summary>In Antimirov mode there are no watchdogs</summary>
-        public int WatchDog => (_dfaMatchingState is null ? -1 : _dfaMatchingState.WatchDog);
-        /// <summary>In Antimirov mode a set of states does not qualify as an initial state</summary>
-        public bool IsInitialState => (_dfaMatchingState is null ? false : _dfaMatchingState.IsInitialState);
-
-        /// <summary>
-        /// Take the transition to the next state. This may cause a shift from  Brzozowski to Antimirov mode.
-        /// </summary>
-        public static void TakeTransition(ref CurrentState<T> state, int mintermId, T minterm)
-        {
-            if (state._dfaMatchingState is null)
-            {
-                // take a snapshot of the current set of nfa states
-                int[] sourceStates = state._nfaStatesList.ToArray();
-
-                // transition into the new set of target nfa states
-                state._nfaStates.Clear();
-                state._nfaStatesList.Clear();
-                for (int i = 0; i < sourceStates.Length; i++)
-                {
-                    int source = sourceStates[i];
-                    // Calculate the offset into the nfa transition table
-                    int nfaoffset = (source << state._builder._mintermsCount) | mintermId;
-                    List<int> targets = Volatile.Read(ref state._builder._antimirovDelta[nfaoffset]) ?? state._builder.CreateNewNfaTransition(source, mintermId, minterm, nfaoffset);
-                    for (int j = 0; j < targets.Count; j++)
-                        if (state._nfaStates.Add(targets[j]))
-                            state._nfaStatesList.Add(targets[j]);
-                }
-            }
-            else
-            {
-                Debug.Assert(state._builder._delta is not null);
-
-                int offset = (state._dfaMatchingState.Id << state._builder._mintermsCount) | mintermId;
-                state._dfaMatchingState = Volatile.Read(ref state._builder._delta[offset]) ?? state._builder.CreateNewTransition(state._dfaMatchingState, minterm, offset);
-
-                if (state._builder._antimirov)
-                {
-                    // CreateNewTransition switched from Brzozowski to Antimirov mode
-                    // update the state representation accordingly
-                    // TBD: OrderedOr
-                    Debug.Assert(state._dfaMatchingState.Node.Kind == SymbolicRegexKind.Or);
-                    state = new CurrentState<T>(state._dfaMatchingState);
-                }
-            }
-        }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Dgml/RegexAutomaton.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Dgml/RegexAutomaton.cs
@@ -23,8 +23,8 @@ namespace System.Text.RegularExpressions.Symbolic.DGML
         {
             _builder = srm._builder;
             uint startId = inReverse ?
-                (srm._reversePattern._info.StartsWithLineAnchor ? CharKind.StartStop : 0) :
-                (srm._pattern._info.StartsWithLineAnchor ? CharKind.StartStop : 0);
+                (srm._reversePattern._info.StartsWithLineAnchor ? CharKind.BeginningEnd : 0) :
+                (srm._pattern._info.StartsWithLineAnchor ? CharKind.BeginningEnd : 0);
 
             //inReverse only matters if Ar contains some line anchor
             _q0 = _builder.CreateState(inReverse ? srm._reversePattern : (addDotStar ? srm._dotStarredPattern : srm._pattern), startId);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Dgml/RegexAutomaton.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Dgml/RegexAutomaton.cs
@@ -17,7 +17,7 @@ namespace System.Text.RegularExpressions.Symbolic.DGML
         private readonly HashSet<int> _stateSet = new();
         private readonly List<Move<(SymbolicRegexNode<T>?, T)>> _moves = new();
         private readonly SymbolicRegexBuilder<T> _builder;
-        private SymbolicNFA<T>? _nfa;
+        private readonly SymbolicNFA<T>? _nfa;
 
         internal RegexAutomaton(SymbolicRegexMatcher<T> srm, int bound, bool addDotStar, bool inReverse, bool asNFA)
         {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/MintermClassifier.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/MintermClassifier.cs
@@ -94,7 +94,7 @@ namespace System.Text.RegularExpressions.Symbolic
         public int GetMintermID(int c)
         {
             int[] ascii = _ascii;
-            return (uint)c < ascii.Length ? ascii[c] : _nonAscii.Find(c);
+            return (uint)c < (uint)ascii.Length ? ascii[c] : _nonAscii.Find(c);
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeConverter.cs
@@ -138,7 +138,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     {
                         captureNum = node.M;
                     }
-                    return _builder.CreateCapture(ConvertToSymbolicRegexNode(node.Child(0), tryCreateFixedLengthMarker: false), captureNum);
+                    return _builder.CreateCapture(ConvertToSymbolicRegexNode(node.Child(0), tryCreateFixedLengthMarker), captureNum);
 
                 case RegexNodeKind.Empty:
                 case RegexNodeKind.UpdateBumpalong: // UpdateBumpalong is a directive relevant only to backtracking and can be ignored just like Empty

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -6,12 +6,13 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace System.Text.RegularExpressions.Symbolic
 {
     /// <summary>Represents a regex matching engine that performs regex matching using symbolic derivatives.</summary>
-    internal interface ISymbolicRegexMatcher
+    internal abstract class SymbolicRegexMatcher
     {
 #if DEBUG
         /// <summary>Unwind the regex of the matcher and save the resulting state graph in DGML</summary>
@@ -23,7 +24,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <param name="writer">dgml output is written here</param>
         /// <param name="maxLabelLength">maximum length of labels in nodes anything over that length is indicated with .. </param>
         /// <param name="asNFA">if true creates NFA instead of DFA</param>
-        void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, bool onlyDFAinfo, int maxLabelLength, bool asNFA);
+        public abstract void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, bool onlyDFAinfo, int maxLabelLength, bool asNFA);
 
         /// <summary>
         /// Generates up to k random strings matched by the regex
@@ -32,57 +33,44 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <param name="randomseed">random seed for the generator, 0 means no random seed</param>
         /// <param name="negative">if true then generate inputs that do not match</param>
         /// <returns></returns>
-        IEnumerable<string> GenerateRandomMembers(int k, int randomseed, bool negative);
+        public abstract IEnumerable<string> GenerateRandomMembers(int k, int randomseed, bool negative);
 #endif
     }
 
     /// <summary>Represents a regex matching engine that performs regex matching using symbolic derivatives.</summary>
     /// <typeparam name="TSetType">Character set type.</typeparam>
-    internal sealed class SymbolicRegexMatcher<TSetType> : ISymbolicRegexMatcher where TSetType : notnull
+    internal sealed class SymbolicRegexMatcher<TSetType> : SymbolicRegexMatcher where TSetType : notnull
     {
-        /// <summary>Maximum number of states before switching over to Antimirov mode.</summary>
+        /// <summary>Maximum number of built states before switching over to NFA mode.</summary>
         /// <remarks>
-        /// "Brzozowski" is by default used for state graphs that represent the DFA nodes for the regex.
-        /// In this mode, for the singular state we're currently in, we can evaluate the next character and determine
-        /// the singular next state to be in. Some regular expressions, however, can result in really, really large DFA
-        /// state graphs.  Instead of falling over with large representations, after this (somewhat arbitrary) threshold,
-        /// the implementation switches to "Antimirov" mode.  In this mode, which can be thought of as NFA-based instead
-        /// of DFA-based, we can be in any number of states at the same time, represented as a <see cref="SymbolicRegexNode{S}"/>
-        /// that's the union of all such states; transitioning based on the next character is then handled by finding
-        /// all possible states we might transition to from each of the states in the current set, and producing a new set
-        /// that's the union of all of those.  The matching engine switches dynamically from Brzozowski to Antimirov once
-        /// it trips over this threshold in the size of the state graph, which may be produced lazily.
+        /// By default, all matching starts out using DFAs, where every state transitions to one and only one
+        /// state for any minterm (each character maps to one minterm).  Some regular expressions, however, can result
+        /// in really, really large DFA state graphs, much too big to actually store.  Instead of failing when we
+        /// encounter such state graphs, at some point we instead switch from processing as a DFA to processing as
+        /// an NFA.  As an NFA, we instead track all of the states we're in at any given point, and transitioning
+        /// from one "state" to the next really means for every constituent state that composes our current "state",
+        /// we find all possible states that transitioning out of each of them could result in, and the union of
+        /// all of those is our new "state".  This constant represents the size of the graph after which we start
+        /// processing as an NFA instead of as a DFA.  This processing doesn't change immediately, however. All
+        /// processing starts out in DFA mode, even if we've previously triggered NFA mode for the same regex.
+        /// We switch over into NFA mode the first time a given traversal (match operation) results in us needing
+        /// to create a new node and the graph is already or newly beyond this threshold.
         /// </remarks>
-        internal const int AntimirovThreshold = 10_000;
-
-        /// <summary>Wiggle room around the exact size of the state graph before we switch to Antimirov.</summary>
-        /// <remarks>
-        /// The inner loop of the matching engine wants to be as streamlined as possible, and in Brzozowski mode
-        /// having to check at every iteration whether we need to switch to Antimirov is a perf bottleneck.  As such,
-        /// the inner loop is allowed to run for up to this many transitions without regard for the size of the
-        /// graph, which could cause <see cref="AntimirovThreshold"/> to be exceeded by this limit.  Once
-        /// we've hit <see cref="AntimirovThresholdLeeway"/> number of transitions in the inner loop, we
-        /// force ourselves back out to the outerloop, where we can check the graph size and other things like timeouts.
-        /// </remarks>
-        private const int AntimirovThresholdLeeway = 1_000;
+        internal const int NfaThreshold = 10_000;
 
         /// <summary>Sentinel value used internally by the matcher to indicate no match exists.</summary>
         private const int NoMatchExists = -2;
 
         /// <summary>Builder used to create <see cref="SymbolicRegexNode{S}"/>s while matching.</summary>
         /// <remarks>
-        /// The builder servers two purposes:
-        /// 1. For Brzozowski, we build up the DFA state space lazily, which means we need to be able to
-        ///    produce new <see cref="SymbolicRegexNode{S}"/>s as we match.
-        /// 2. For Antimirov, currently the list of states we're currently in is represented as a <see cref="SymbolicRegexNode{S}"/>
-        ///    that's a union of all current states.  Augmenting that list requires building new nodes.
-        /// The builder maintains a cache of nodes, and requests for it to make new ones might return existing ones from the cache.
-        /// The separation of a matcher and a builder is somewhat arbitrary; they could potentially be combined.
+        /// The builder is used to build up the DFA state space lazily, which means we need to be able to
+        /// produce new <see cref="SymbolicRegexNode{S}"/>s as we match.  Once in NFA mode, we also use
+        /// the builder to produce new NFA states.  The builder maintains a cache of all DFA and NFA states.
         /// </remarks>
         internal readonly SymbolicRegexBuilder<TSetType> _builder;
 
-        /// <summary>Maps each character into a partition id in the range 0..K-1.</summary>
-        private readonly MintermClassifier _partitions;
+        /// <summary>Maps every character to its corresponding minterm ID.</summary>
+        private readonly MintermClassifier _mintermClassifier;
 
         /// <summary><see cref="_pattern"/> prefixed with [0-0xFFFF]*</summary>
         /// <remarks>
@@ -141,10 +129,12 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <summary>Number of capture groups.</summary>
         private readonly int _capsize;
 
-        /// <summary>Fixed-length of any match, if there is one.</summary>
+        /// <summary>Fixed-length of any possible match.</summary>
+        /// <remarks>This will be null if matches may be of varying lengths or if a fixed-length couldn't otherwise be computed.</remarks>
         private readonly int? _fixedMatchLength;
 
-        /// <summary>This determines whether the matcher uses the special capturing NFA simulation mode.</summary>
+        /// <summary>Gets whether the regular expression contains captures (beyond the implicit root-level capture).</summary>
+        /// <remarks>This determines whether the matcher uses the special capturing NFA simulation mode.</remarks>
         internal bool HasSubcaptures => _capsize > 1;
 
         /// <summary>Get the minterm of <paramref name="c"/>.</summary>
@@ -153,11 +143,11 @@ namespace System.Text.RegularExpressions.Symbolic
         private TSetType GetMinterm(int c)
         {
             Debug.Assert(_builder._minterms is not null);
-            return _builder._minterms[_partitions.GetMintermID(c)];
+            return _builder._minterms[_mintermClassifier.GetMintermID(c)];
         }
 
         /// <summary>Constructs matcher for given symbolic regex.</summary>
-        internal SymbolicRegexMatcher(SymbolicRegexNode<TSetType> sr, RegexCode code, BDD[] minterms, TimeSpan matchTimeout, CultureInfo culture)
+        internal SymbolicRegexMatcher(SymbolicRegexNode<TSetType> sr, RegexCode code, BDD[] minterms, TimeSpan matchTimeout)
         {
             Debug.Assert(sr._builder._solver is BV64Algebra or BVAlgebra or CharSetSolver, $"Unsupported algebra: {sr._builder._solver}");
 
@@ -165,7 +155,7 @@ namespace System.Text.RegularExpressions.Symbolic
             _builder = sr._builder;
             _checkTimeout = Regex.InfiniteMatchTimeout != matchTimeout;
             _timeout = (int)(matchTimeout.TotalMilliseconds + 0.5); // Round up, so it will be at least 1ms
-            _partitions = _builder._solver switch
+            _mintermClassifier = _builder._solver switch
             {
                 BV64Algebra bv64 => bv64._classifier,
                 BVAlgebra bv => bv._classifier,
@@ -252,62 +242,696 @@ namespace System.Text.RegularExpressions.Symbolic
         }
 
         /// <summary>
-        /// Per thread data to be held by the regex runner and passed into every call to FindMatch. This is used to
-        /// avoid repeated memory allocation.
+        /// Create a PerThreadData with the appropriate parts initialized for this matcher's pattern.
         /// </summary>
-        internal sealed class PerThreadData
-        {
-            /// <summary>Maps used for the capturing third phase.</summary>
-            public readonly SparseIntMap<Registers>? Current, Next;
-            /// <summary>Registers used for the capturing third phase.</summary>
-            public readonly Registers InitialRegisters;
+        internal PerThreadData CreatePerThreadData() => new PerThreadData(_builder, _capsize);
 
-            public PerThreadData(int capsize)
+        /// <summary>Compute the target state for the source state and input[i] character and transition to it.</summary>
+        /// <param name="builder">The associated builder.</param>
+        /// <param name="input">The input text.</param>
+        /// <param name="i">The index into <paramref name="input"/> at which the target character lives.</param>
+        /// <param name="state">The current state being transitioned from. Upon return it's the new state if the transition succeeded.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool TryTakeTransition<TStateHandler>(SymbolicRegexBuilder<TSetType> builder, ReadOnlySpan<char> input, int i, ref CurrentState state)
+            where TStateHandler : struct, IStateHandler
+        {
+            int c = input[i];
+
+            int mintermId = c == '\n' && i == input.Length - 1 && TStateHandler.StartsWithLineAnchor(ref state) ?
+                builder._minterms!.Length : // mintermId = minterms.Length represents \Z (last \n)
+                _mintermClassifier.GetMintermID(c);
+
+            return TStateHandler.TakeTransition(builder, ref state, mintermId);
+        }
+
+        private List<(DfaMatchingState<TSetType>, List<DerivativeEffect>)> CreateNewCapturingTransitions(DfaMatchingState<TSetType> state, TSetType minterm, int offset)
+        {
+            Debug.Assert(_builder._capturingDelta is not null);
+            lock (this)
             {
-                // Only create data used for capturing mode if there are subcaptures
-                if (capsize > 1)
+                // Get the next state if it exists.  The caller should have already tried and found it null (not yet created),
+                // but in the interim another thread could have created it.
+                List<(DfaMatchingState<TSetType>, List<DerivativeEffect>)>? p = _builder._capturingDelta[offset];
+                if (p is null)
                 {
-                    Current = new();
-                    Next = new();
-                    InitialRegisters = new Registers(new int[capsize], new int[capsize]);
+                    // Build the new state and store it into the array.
+                    p = state.NfaEagerNextWithEffects(minterm);
+                    Volatile.Write(ref _builder._capturingDelta[offset], p);
                 }
+
+                return p;
             }
         }
 
-        /// <summary>
-        /// Create a PerThreadData with the appropriate parts initialized for this matcher's pattern.
-        /// </summary>
-        internal PerThreadData CreatePerThreadData() => new PerThreadData(_capsize);
-
-        /// <summary>Compute the target state for the source state and input[i] character.</summary>
-        /// <param name="input">input span</param>
-        /// <param name="i">The index into <paramref name="input"/> at which the target character lives.</param>
-        /// <param name="state">passed in as the source state and upon return is set to the new target state</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void Delta(ReadOnlySpan<char> input, int i, ref CurrentState<TSetType> state)
+        private void DoCheckTimeout(int timeoutOccursAt)
         {
-            TSetType[]? minterms = _builder._minterms;
-            Debug.Assert(minterms is not null);
+            // This logic is identical to RegexRunner.DoCheckTimeout, with the exception of check skipping. RegexRunner calls
+            // DoCheckTimeout potentially on every iteration of a loop, whereas this calls it only once per transition.
+            int currentMillis = Environment.TickCount;
+            if (currentMillis >= timeoutOccursAt && (0 <= timeoutOccursAt || 0 >= currentMillis))
+            {
+                throw new RegexMatchTimeoutException(string.Empty, string.Empty, TimeSpan.FromMilliseconds(_timeout));
+            }
+        }
 
-            int c = input[i];
+        /// <summary>Find a match.</summary>
+        /// <param name="isMatch">Whether to return once we know there's a match without determining where exactly it matched.</param>
+        /// <param name="input">The input span</param>
+        /// <param name="startat">The position to start search in the input span.</param>
+        /// <param name="perThreadData">Per thread data reused between calls.</param>
+        public SymbolicMatch FindMatch(bool isMatch, ReadOnlySpan<char> input, int startat, PerThreadData perThreadData)
+        {
+            Debug.Assert(startat >= 0 && startat <= input.Length, $"{nameof(startat)} == {startat}, {nameof(input.Length)} == {input.Length}");
+            Debug.Assert(perThreadData is not null);
 
-            int mintermId = c == '\n' && i == input.Length - 1 && state.StartsWithLineAnchor ?
-                minterms.Length : // mintermId = minterms.Length represents \Z (last \n)
-                _partitions.GetMintermID(c);
+            // If we need to perform timeout checks, store the absolute timeout value.
+            int timeoutOccursAt = 0;
+            if (_checkTimeout)
+            {
+                // Using Environment.TickCount for efficiency instead of Stopwatch -- as in the non-DFA case.
+                timeoutOccursAt = Environment.TickCount + (int)(_timeout + 0.5);
+            }
 
-            TSetType minterm = (uint)mintermId < (uint)minterms.Length ?
-                minterms[mintermId] :
-                _builder._solver.False; // minterm=False represents \Z
+            // If we're starting at the end of the input, we don't need to do any work other than
+            // determine whether an empty match is valid, i.e. whether the pattern is "nullable"
+            // given the kinds of characters at and just before the end.
+            if (startat == input.Length)
+            {
+                // TODO https://github.com/dotnet/runtime/issues/65606: Handle capture groups.
+                uint prevKind = GetCharKind(input, startat - 1);
+                uint nextKind = GetCharKind(input, startat);
+                return _pattern.IsNullableFor(CharKind.Context(prevKind, nextKind)) ?
+                    new SymbolicMatch(startat, 0) :
+                    SymbolicMatch.NoMatch;
+            }
 
-            CurrentState<TSetType>.TakeTransition(ref state, mintermId, minterm);
+            // Phase 1:
+            // Determine whether there is a match by finding the first final state position.  This only tells
+            // us whether there is a match but needn't give us the longest possible match. This may return -1 as
+            // a legitimate value when the initial state is nullable and startat == 0. It returns NoMatchExists (-2)
+            // when there is no match.  As an example, consider the pattern a{5,10}b* run against an input
+            // of aaaaaaaaaaaaaaabbbc: phase 1 will find the position of the first b: aaaaaaaaaaaaaaab.
+            int i = FindFinalStatePosition(input, startat, timeoutOccursAt, out int matchStartLowBoundary, out int matchStartLengthMarker, perThreadData);
+
+            // If there wasn't a match, we're done.
+            if (i == NoMatchExists)
+            {
+                return SymbolicMatch.NoMatch;
+            }
+
+            // A match exists. If we don't need further details, because IsMatch was used (and thus we don't
+            // need the exact bounds of the match, captures, etc.), we're done.
+            if (isMatch)
+            {
+                return SymbolicMatch.QuickMatch;
+            }
+
+            // Phase 2:
+            // Match backwards through the input matching against the reverse of the pattern, looking for the earliest
+            // start position.  That tells us the actual starting position of the match.  We can skip this phase if we
+            // recorded a fixed-length marker for the portion of the pattern that matched, as we can then jump that
+            // exact number of positions backwards.  Continuing the previous example, phase 2 will walk backwards from
+            // that first b until it finds the 6th a: aaaaaaaaaab.
+            int matchStart;
+            if (matchStartLengthMarker >= 0)
+            {
+                matchStart = i - matchStartLengthMarker + 1;
+            }
+            else
+            {
+                Debug.Assert(i >= startat - 1);
+                matchStart = i < startat ?
+                    startat :
+                    FindStartPosition(input, i, matchStartLowBoundary, perThreadData);
+            }
+
+            // Phase 3:
+            // Match again, this time from the computed start position, to find the latest end position.  That start
+            // and end then represent the bounds of the match.  If the pattern has subcaptures (captures other than
+            // the top-level capture for the whole match), we need to do more work to compute their exact bounds, so we
+            // take a faster path if captures aren't required.  Further, if captures aren't needed, and if any possible
+            // match of the whole pattern is a fixed length, we can skip this phase as well, just using that fixed-length
+            // to compute the ending position based on the starting position.  Continuing the previous example, phase 3
+            // will walk forwards from the 6th a until it finds the end of the match: aaaaaaaaaabbb.
+            if (!HasSubcaptures)
+            {
+                if (_fixedMatchLength.HasValue)
+                {
+                    return new SymbolicMatch(matchStart, _fixedMatchLength.GetValueOrDefault());
+                }
+
+                int matchEnd = FindEndPosition(input, matchStart, perThreadData);
+                return new SymbolicMatch(matchStart, matchEnd + 1 - matchStart);
+            }
+            else
+            {
+                int matchEnd = FindEndPositionCapturing(input, matchStart, out Registers endRegisters, perThreadData);
+                return new SymbolicMatch(matchStart, matchEnd + 1 - matchStart, endRegisters.CaptureStarts, endRegisters.CaptureEnds);
+            }
+        }
+
+        /// <summary>Phase 3 of matching. From a found starting position, find the ending position of the match using the original pattern.</summary>
+        /// <remarks>
+        /// The ending position is known to exist; this function just needs to determine exactly what it is.
+        /// We need to find the longest possible match and thus the latest valid ending position.
+        /// </remarks>
+        /// <param name="input">The input text.</param>
+        /// <param name="i">The starting position of the match.</param>
+        /// <param name="perThreadData">Per thread data reused between calls.</param>
+        /// <returns>The found ending position of the match.</returns>
+        private int FindEndPosition(ReadOnlySpan<char> input, int i, PerThreadData perThreadData)
+        {
+            // Get the starting state based on the current context.
+            DfaMatchingState<TSetType> dfaStartState = _initialStates[GetCharKind(input, i - 1)];
+
+            // If the starting state is nullable (accepts the empty string), then it's a valid
+            // match and we need to record the position as a possible end, but keep going looking
+            // for a better one.
+            int end = input.Length; // invalid sentinel value
+            if (dfaStartState.IsNullable(GetCharKind(input, i)))
+            {
+                // Empty match exists because the initial state is accepting.
+                end = i - 1;
+            }
+
+            if ((uint)i < (uint)input.Length)
+            {
+                // Iterate from the starting state until we've found the best ending state.
+                SymbolicRegexBuilder<TSetType> builder = dfaStartState.Node._builder;
+                var currentState = new CurrentState(dfaStartState);
+                while (true)
+                {
+                    // Run the DFA or NFA traversal backwards from the current point using the current state.
+                    bool done = currentState.NfaState is not null ?
+                        FindEndPositionDeltas<NfaStateHandler>(builder, input, ref i, ref currentState, ref end) :
+                        FindEndPositionDeltas<DfaStateHandler>(builder, input, ref i, ref currentState, ref end);
+
+                    // If we successfully found the ending position, we're done.
+                    if (done || (uint)i >= (uint)input.Length)
+                    {
+                        break;
+                    }
+
+                    // We exited out of the inner processing loop, but we didn't hit a dead end or run out
+                    // of input, and that should only happen if we failed to transition from one state to
+                    // the next, which should only happen if we were in DFA mode and we tried to create
+                    // a new state and exceeded the graph size.  Upgrade to NFA mode and continue;
+                    Debug.Assert(currentState.DfaState is not null);
+                    NfaMatchingState nfaState = perThreadData.NfaState;
+                    nfaState.InitializeFrom(currentState.DfaState);
+                    currentState = new CurrentState(nfaState);
+                }
+            }
+
+            // Return the found ending position.
+            Debug.Assert(end < input.Length, "Expected to find an ending position but didn't");
+            return end;
         }
 
         /// <summary>
-        /// Stores additional data for tracking capture start and end positions.
+        /// Workhorse inner loop for <see cref="FindEndPosition"/>.  Consumes the <paramref name="input"/> character by character,
+        /// starting at <paramref name="i"/>, for each character transitioning from one state in the DFA or NFA graph to the next state,
+        /// lazily building out the graph as needed.
+        /// </summary>
+        private bool FindEndPositionDeltas<TStateHandler>(SymbolicRegexBuilder<TSetType> builder, ReadOnlySpan<char> input, ref int i, ref CurrentState currentState, ref int endingIndex)
+            where TStateHandler : struct, IStateHandler
+        {
+            // To avoid frequent reads/writes to ref values, make and operate on local copies, which we then copy back once before returning.
+            int pos = i;
+            CurrentState state = currentState;
+
+            // Repeatedly read the next character from the input and use it to transition the current state to the next.
+            // We're looking for the furthest final state we can find.
+            while ((uint)pos < (uint)input.Length && TryTakeTransition<TStateHandler>(builder, input, pos, ref state))
+            {
+                if (TStateHandler.IsNullable(ref state, GetCharKind(input, pos + 1)))
+                {
+                    // If the new state accepts the empty string, we found an ending state. Record the position.
+                    endingIndex = pos;
+                }
+                else if (TStateHandler.IsDeadend(ref state))
+                {
+                    // If the new state is a dead end, the match ended the last time endingIndex was updated.
+                    currentState = state;
+                    i = pos;
+                    return true;
+                }
+
+                // We successfully transitioned to the next state and consumed the current character,
+                // so move along to the next.
+                pos++;
+            }
+
+            // We either ran out of input, in which case we successfully recorded an ending index,
+            // or we failed to transition to the next state due to the graph becoming too large.
+            currentState = state;
+            i = pos;
+            return false;
+        }
+
+        /// <summary>Find match end position using the original pattern, end position is known to exist. This version also produces captures.</summary>
+        /// <param name="input">input span</param>
+        /// <param name="i">inclusive start position</param>
+        /// <param name="resultRegisters">out parameter for the final register values, which indicate capture starts and ends</param>
+        /// <param name="perThreadData">Per thread data reused between calls.</param>
+        /// <returns>the match end position</returns>
+        private int FindEndPositionCapturing(ReadOnlySpan<char> input, int i, out Registers resultRegisters, PerThreadData perThreadData)
+        {
+            int i_end = input.Length;
+            Registers endRegisters = default;
+            DfaMatchingState<TSetType>? endState = null;
+
+            // Pick the correct start state based on previous character kind.
+            DfaMatchingState<TSetType> initialState = _initialStates[GetCharKind(input, i - 1)];
+
+            Registers initialRegisters = perThreadData.InitialRegisters;
+
+            // Initialize registers with -1, which means "not seen yet"
+            Array.Fill(initialRegisters.CaptureStarts, -1);
+            Array.Fill(initialRegisters.CaptureEnds, -1);
+
+            if (initialState.IsNullable(GetCharKind(input, i)))
+            {
+                // Empty match exists because the initial state is accepting.
+                i_end = i - 1;
+                endRegisters.Assign(initialRegisters);
+                endState = initialState;
+            }
+
+            // Use two maps from state IDs to register values for the current and next set of states.
+            // Note that these maps use insertion order, which is used to maintain priorities between states in a way
+            // that matches the order the backtracking engines visit paths.
+            Debug.Assert(perThreadData.Current is not null && perThreadData.Next is not null);
+            SparseIntMap<Registers> current = perThreadData.Current, next = perThreadData.Next;
+            current.Clear();
+            next.Clear();
+            current.Add(initialState.Id, initialRegisters);
+
+            SymbolicRegexBuilder<TSetType> builder = _builder;
+
+            while ((uint)i < (uint)input.Length)
+            {
+                Debug.Assert(next.Count == 0);
+
+                int c = input[i];
+                int normalMintermId = _mintermClassifier.GetMintermID(c);
+
+                foreach ((int sourceId, Registers sourceRegisters) in current.Values)
+                {
+                    Debug.Assert(builder._capturingStateArray is not null);
+                    DfaMatchingState<TSetType> sourceState = builder._capturingStateArray[sourceId];
+
+                    // Find the minterm, handling the special case for the last \n
+                    int mintermId = c == '\n' && i == input.Length - 1 && sourceState.StartsWithLineAnchor ?
+                        builder._minterms!.Length :
+                        normalMintermId; // mintermId = minterms.Length represents \Z (last \n)
+                    TSetType minterm = builder.GetMinterm(mintermId);
+
+                    // Get or create the transitions
+                    int offset = (sourceId << builder._mintermsLog) | mintermId;
+                    Debug.Assert(builder._capturingDelta is not null);
+                    List<(DfaMatchingState<TSetType>, List<DerivativeEffect>)>? transitions =
+                        builder._capturingDelta[offset] ??
+                        CreateNewCapturingTransitions(sourceState, minterm, offset);
+
+                    // Take the transitions in their prioritized order
+                    for (int j = 0; j < transitions.Count; ++j)
+                    {
+                        (DfaMatchingState<TSetType> targetState, List<DerivativeEffect> effects) = transitions[j];
+                        if (targetState.IsDeadend)
+                            continue;
+
+                        // Try to add the state and handle the case where it didn't exist before. If the state already
+                        // exists, then the transition can be safely ignored, as the existing state was generated by a
+                        // higher priority transition.
+                        if (next.Add(targetState.Id, out int index))
+                        {
+                            // Avoid copying the registers on the last transition from this state, reusing the registers instead
+                            Registers newRegisters = j != transitions.Count - 1 ? sourceRegisters.Clone() : sourceRegisters;
+                            newRegisters.ApplyEffects(effects, i);
+                            next.Update(index, targetState.Id, newRegisters);
+                            if (targetState.IsNullable(GetCharKind(input, i + 1)))
+                            {
+                                // Accepting state has been reached. Record the position.
+                                i_end = i;
+                                endRegisters.Assign(newRegisters);
+                                endState = targetState;
+                                // No lower priority transitions from this or other source states are taken because the
+                                // backtracking engines would return the match ending here.
+                                goto BreakNullable;
+                            }
+                        }
+                    }
+                }
+
+            BreakNullable:
+                if (next.Count == 0)
+                {
+                    // If all states died out some nullable state must have been seen before
+                    break;
+                }
+
+                // Swap the state sets and prepare for the next character
+                SparseIntMap<Registers> tmp = current;
+                current = next;
+                next = tmp;
+                next.Clear();
+                i++;
+            }
+
+            Debug.Assert(i_end != input.Length && endState is not null);
+            // Apply effects for finishing at the stored end state
+            endState.Node.ApplyEffects(effect => endRegisters.ApplyEffect(effect, i_end + 1),
+                CharKind.Context(endState.PrevCharKind, GetCharKind(input, i_end + 1)));
+            resultRegisters = endRegisters;
+            return i_end;
+        }
+
+        /// <summary>
+        /// Phase 2 of matching. From a found ending position, walk in reverse through the input using the reverse pattern to find the
+        /// start position of match.
         /// </summary>
         /// <remarks>
-        /// The NFA simulation based third phase has one of these for each current state in the current set of live states.
+        /// The start position is known to exist; this function just needs to determine exactly what it is.
+        /// We need to find the earliest (lowest index) starting position that's not earlier than <paramref name="matchStartBoundary"/>.
         /// </remarks>
+        /// <param name="input">The input text.</param>
+        /// <param name="i">The ending position to walk backwards from. <paramref name="i"/> points at the last character of the match.</param>
+        /// <param name="matchStartBoundary">The initial starting location discovered in phase 1, a point we must not walk earlier than.</param>
+        /// <param name="perThreadData">Per thread data reused between calls.</param>
+        /// <returns>The found starting position for the match.</returns>
+        private int FindStartPosition(ReadOnlySpan<char> input, int i, int matchStartBoundary, PerThreadData perThreadData)
+        {
+            Debug.Assert(i >= 0, $"{nameof(i)} == {i}");
+            Debug.Assert(matchStartBoundary >= 0 && matchStartBoundary < input.Length, $"{nameof(matchStartBoundary)} == {matchStartBoundary}");
+            Debug.Assert(i >= matchStartBoundary, $"Expected {i} >= {matchStartBoundary}.");
+
+            // Get the starting state for the reverse pattern. This depends on previous character (which, because we're
+            // going backwards, is character number i + 1).
+            var currentState = new CurrentState(_reverseInitialStates[GetCharKind(input, i + 1)]);
+
+            // If the initial state is nullable, meaning it accepts the empty string, then we've already discovered
+            // a valid starting position, and we just need to keep looking for an earlier one in case there is one.
+            int lastStart = -1; // invalid sentinel value
+            if (currentState.DfaState!.IsNullable(GetCharKind(input, i)))
+            {
+                lastStart = i + 1;
+            }
+
+            // Walk backwards to the furthest accepting state of the reverse pattern but no earlier than matchStartBoundary.
+            SymbolicRegexBuilder<TSetType> builder = currentState.DfaState.Node._builder;
+            while (true)
+            {
+                // Run the DFA or NFA traversal backwards from the current point using the current state.
+                bool done = currentState.NfaState is not null ?
+                    FindStartPositionDeltas<NfaStateHandler>(builder, input, ref i, matchStartBoundary, ref currentState, ref lastStart) :
+                    FindStartPositionDeltas<DfaStateHandler>(builder, input, ref i, matchStartBoundary, ref currentState, ref lastStart);
+
+                // If we found the starting position, we're done.
+                if (done)
+                {
+                    break;
+                }
+
+                // We didn't find the starting position but we did exit out of the backwards traversal.  That should only happen
+                // if we were unable to transition, which should only happen if we were in DFA mode and exceeded our graph size.
+                // Upgrade to NFA mode and continue.
+                Debug.Assert(i >= matchStartBoundary);
+                Debug.Assert(currentState.DfaState is not null);
+                NfaMatchingState nfaState = perThreadData.NfaState;
+                nfaState.InitializeFrom(currentState.DfaState);
+                currentState = new CurrentState(nfaState);
+            }
+
+            Debug.Assert(lastStart != -1, "We expected to find a starting position but didn't.");
+            return lastStart;
+        }
+
+        /// <summary>
+        /// Workhorse inner loop for <see cref="FindStartPosition"/>.  Consumes the <paramref name="input"/> character by character in reverse,
+        /// starting at <paramref name="i"/>, for each character transitioning from one state in the DFA or NFA graph to the next state,
+        /// lazily building out the graph as needed.
+        /// </summary>
+        private bool FindStartPositionDeltas<TStateHandler>(SymbolicRegexBuilder<TSetType> builder, ReadOnlySpan<char> input, ref int i, int startThreshold, ref CurrentState currentState, ref int lastStart)
+            where TStateHandler : struct, IStateHandler
+        {
+            // To avoid frequent reads/writes to ref values, make and operate on local copies, which we then copy back once before returning.
+            int pos = i;
+            CurrentState state = currentState;
+
+            // Loop backwards through each character in the input, transitioning from state to state for each.
+            while (TryTakeTransition<TStateHandler>(builder, input, pos, ref state))
+            {
+                // We successfully transitioned.  If the new state is a dead end, we're done, as we must have already seen
+                // and recorded a larger lastStart value that was the earliest valid starting position.
+                if (TStateHandler.IsDeadend(ref state))
+                {
+                    Debug.Assert(lastStart != -1);
+                    currentState = state;
+                    i = pos;
+                    return true;
+                }
+
+                // If the new state accepts the empty string, we found a valid starting position.  Record it and keep going,
+                // since we're looking for the earliest one to occur within bounds.
+                if (TStateHandler.IsNullable(ref state, GetCharKind(input, pos - 1)))
+                {
+                    lastStart = pos;
+                }
+
+                // Since we successfully transitioned, update our current index to match the fact that we consumed the previous character in the input.
+                pos--;
+
+                // If doing so now puts us below the start threshold, bail; we should have already found a valid starting location.
+                if (pos < startThreshold)
+                {
+                    Debug.Assert(lastStart != -1);
+                    currentState = state;
+                    i = pos;
+                    return true;
+                }
+            }
+
+            // Unable to transition further.
+            currentState = state;
+            i = pos;
+            return false;
+        }
+
+        /// <summary>Performs the initial Phase 1 match to find the first final state encountered.</summary>
+        /// <param name="input">The input text.</param>
+        /// <param name="i">The starting position in <paramref name="input"/>.</param>
+        /// <param name="timeoutOccursAt">The time at which timeout occurs, if timeouts are being checked.</param>
+        /// <param name="initialStateIndex">The last position the initial state of <see cref="_dotStarredPattern"/> was visited.</param>
+        /// <param name="matchLength">Length of the match if there's a match; otherwise, -1.</param>
+        /// <param name="perThreadData">Per thread data reused between calls.</param>
+        /// <returns>The index into input that matches the final state, or NoMatchExists if no match exists. It returns -1 when i=0 and the initial state is nullable.</returns>
+        private int FindFinalStatePosition(ReadOnlySpan<char> input, int i, int timeoutOccursAt, out int initialStateIndex, out int matchLength, PerThreadData perThreadData)
+        {
+            matchLength = -1;
+            initialStateIndex = i;
+
+            // Start with the start state of the dot-star pattern, which in general depends on the previous character kind in the input in order to handle anchors.
+            // If the starting state is a dead end, then no match exists.
+            var currentState = new CurrentState(_dotstarredInitialStates[GetCharKind(input, i - 1)]);
+            if (currentState.DfaState!.IsNothing)
+            {
+                // This can happen, for example, when the original regex starts with a beginning anchor but the previous char kind is not Beginning.
+                return NoMatchExists;
+            }
+
+            // If the starting state accepts the empty string in this context (factoring in anchors), we're done.
+            if (currentState.DfaState.IsNullable(GetCharKind(input, i)))
+            {
+                // The initial state is nullable in this context so at least an empty match exists.
+                // The last position of the match is i - 1 because the match is empty.
+                // This value is -1 if i == 0.
+                return i - 1;
+            }
+
+            // Otherwise, start searching from the current position until the end of the input.
+            if ((uint)i < (uint)input.Length)
+            {
+                SymbolicRegexBuilder<TSetType> builder = currentState.DfaState.Node._builder;
+                while (true)
+                {
+                    // If we're at an initial state, try to search ahead for the next possible match location
+                    // using any find optimizations that may have previously been computed.
+                    if (currentState.DfaState is { IsInitialState: true })
+                    {
+                        // i is the most recent position in the input when the dot-star pattern is in the initial state
+                        initialStateIndex = i;
+
+                        if (_findOpts is RegexFindOptimizations findOpts)
+                        {
+                            // Find the first position i that matches with some likely character.
+                            if (!findOpts.TryFindNextStartingPosition(input, ref i, 0, 0, input.Length))
+                            {
+                                // no match was found
+                                return NoMatchExists;
+                            }
+
+                            initialStateIndex = i;
+
+                            // Update the starting state based on where TryFindNextStartingPosition moved us to.
+                            // As with the initial starting state, if it's a dead end, no match exists.
+                            currentState = new CurrentState(_dotstarredInitialStates[GetCharKind(input, i - 1)]);
+                            if (currentState.DfaState!.IsNothing)
+                            {
+                                return NoMatchExists;
+                            }
+                        }
+                    }
+
+                    // Now run the DFA or NFA traversal from the current point using the current state.
+                    int finalStatePosition;
+                    int findResult = currentState.NfaState is not null ?
+                        FindFinalStatePositionDeltas<NfaStateHandler>(builder, input, ref i, ref currentState, ref matchLength, out finalStatePosition) :
+                        FindFinalStatePositionDeltas<DfaStateHandler>(builder, input, ref i, ref currentState, ref matchLength, out finalStatePosition);
+
+                    // If we reached a final or deadend state, we're done.
+                    if (findResult > 0)
+                    {
+                        return finalStatePosition;
+                    }
+
+                    // We're not at an end state, so we either ran out of input (in which case no match exists), hit an initial state (in which case
+                    // we want to loop around to apply our initial state processing logic and optimizations), or failed to transition (which should
+                    // only happen if we were in DFA mode and need to switch over to NFA mode).  If we exited because we hit an initial state,
+                    // find result will be 0, otherwise negative.
+                    if (findResult < 0)
+                    {
+                        if ((uint)i >= (uint)input.Length)
+                        {
+                            // We ran out of input. No match.
+                            break;
+                        }
+
+                        // We failed to transition. Upgrade to DFA mode.
+                        Debug.Assert(currentState.DfaState is not null);
+                        NfaMatchingState nfaState = perThreadData.NfaState;
+                        nfaState.InitializeFrom(currentState.DfaState);
+                        currentState = new CurrentState(nfaState);
+                    }
+
+                    // Check for a timeout before continuing.
+                    if (_checkTimeout)
+                    {
+                        DoCheckTimeout(timeoutOccursAt);
+                    }
+                }
+            }
+
+            // No match was found.
+            return NoMatchExists;
+        }
+
+        /// <summary>
+        /// Workhorse inner loop for <see cref="FindFinalStatePosition"/>.  Consumes the <paramref name="input"/> character by character,
+        /// starting at <paramref name="i"/>, for each character transitioning from one state in the DFA or NFA graph to the next state,
+        /// lazily building out the graph as needed.
+        /// </summary>
+        /// <remarks>
+        /// The <typeparamref name="TStateHandler"/> supplies the actual transitioning logic, controlling whether processing is
+        /// performed in DFA mode or in NFA mode.  However, it expects <paramref name="currentState"/> to be configured to match,
+        /// so for example if <typeparamref name="TStateHandler"/> is a <see cref="DfaStateHandler"/>, it expects the <paramref name="currentState"/>'s
+        /// <see cref="CurrentState.DfaState"/> to be non-null and its <see cref="CurrentState.NfaState"/> to be null; vice versa for
+        /// <see cref="NfaStateHandler"/>.
+        /// </remarks>
+        /// <returns>
+        /// A positive value if iteration completed because it reached a nullable or deadend state.
+        /// 0 if iteration completed because we reached an initial state.
+        /// A negative value if iteration completed because we ran out of input or we failed to transition.
+        /// </returns>
+        private int FindFinalStatePositionDeltas<TStateHandler>(SymbolicRegexBuilder<TSetType> builder, ReadOnlySpan<char> input, ref int i, ref CurrentState currentState, ref int matchLength, out int finalStatePosition)
+            where TStateHandler : struct, IStateHandler
+        {
+            // To avoid frequent reads/writes to ref values, make and operate on local copies, which we then copy back once before returning.
+            int pos = i;
+            CurrentState state = currentState;
+
+            // Loop through each character in the input, transitioning from state to state for each.
+            while ((uint)pos < (uint)input.Length && TryTakeTransition<TStateHandler>(builder, input, pos, ref state))
+            {
+                // We successfully transitioned for the character at index i.  If the new state is nullable for
+                // the next character, meaning it accepts the empty string, we found a final state and are done!
+                if (TStateHandler.IsNullable(ref state, GetCharKind(input, pos + 1)))
+                {
+                    // Check whether there's a fixed-length marker for the current state.  If there is, we can
+                    // use that length to optimize subsequent matching phases.
+                    matchLength = TStateHandler.FixedLength(ref state);
+                    currentState = state;
+                    i = pos;
+                    finalStatePosition = pos;
+                    return 1;
+                }
+
+                // If the new state is a dead end, such that we didn't match and we can't transition anywhere
+                // else, then no match exists.
+                if (TStateHandler.IsDeadend(ref state))
+                {
+                    currentState = state;
+                    i = pos;
+                    finalStatePosition = NoMatchExists;
+                    return 1;
+                }
+
+                // We successfully transitioned, so update our current input index to match.
+                pos++;
+
+                // Now that currentState and our position are coherent, check if currentState represents an initial state.
+                // If it does, we exit out in order to allow our find optimizations to kick in to hopefully more quickly
+                // find the next possible starting location.
+                if (TStateHandler.IsInitialState(ref state))
+                {
+                    currentState = state;
+                    i = pos;
+                    finalStatePosition = 0;
+                    return 0;
+                }
+            }
+
+            currentState = state;
+            i = pos;
+            finalStatePosition = 0;
+            return -1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private uint GetCharKind(ReadOnlySpan<char> input, int i)
+        {
+            return !_pattern._info.ContainsSomeAnchor ?
+                CharKind.General : // The previous character kind is irrelevant when anchors are not used.
+                GetCharKindWithAnchor(input, i);
+
+            uint GetCharKindWithAnchor(ReadOnlySpan<char> input, int i)
+            {
+                Debug.Assert(_asciiCharKinds is not null);
+
+                if ((uint)i >= (uint)input.Length)
+                {
+                    return CharKind.BeginningEnd;
+                }
+
+                char nextChar = input[i];
+                if (nextChar == '\n')
+                {
+                    return
+                        _builder._newLinePredicate.Equals(_builder._solver.False) ? 0 : // ignore \n
+                        i == 0 || i == input.Length - 1 ? CharKind.NewLineS : // very first or very last \n. Detection of very first \n is needed for rev(\Z).
+                        CharKind.Newline;
+                }
+
+                uint[] asciiCharKinds = _asciiCharKinds;
+                return
+                    nextChar < (uint)asciiCharKinds.Length ? asciiCharKinds[nextChar] :
+                    _builder._solver.And(GetMinterm(nextChar), _builder._wordLetterPredicateForAnchors).Equals(_builder._solver.False) ? 0 : //apply the wordletter predicate to compute the kind of the next character
+                    CharKind.WordLetter;
+            }
+        }
+
+        /// <summary>Stores additional data for tracking capture start and end positions.</summary>
+        /// <remarks>The NFA simulation based third phase has one of these for each current state in the current set of live states.</remarks>
         internal struct Registers
         {
             public Registers(int[] captureStarts, int[] captureEnds)
@@ -379,541 +1003,277 @@ namespace System.Text.RegularExpressions.Symbolic
             }
         }
 
-        private List<(DfaMatchingState<TSetType>, List<DerivativeEffect>)> CreateNewCapturingTransitions(DfaMatchingState<TSetType> state, TSetType minterm, int offset)
+        /// <summary>
+        /// Per thread data to be held by the regex runner and passed into every call to FindMatch. This is used to
+        /// avoid repeated memory allocation.
+        /// </summary>
+        internal sealed class PerThreadData
         {
-            Debug.Assert(_builder._capturingDelta is not null);
-            lock (this)
-            {
-                // check if meanwhile delta[offset] has become defined possibly by another thread
-                List<(DfaMatchingState<TSetType>, List<DerivativeEffect>)> p = _builder._capturingDelta[offset];
-                if (p is null)
-                {
-                    // this is the only place in code where the Next method is called in the matcher
-                    p = state.AntimirovEagerNextWithEffects(minterm);
-                    Volatile.Write(ref _builder._capturingDelta[offset], p);
-                }
+            public readonly NfaMatchingState NfaState;
+            /// <summary>Maps used for the capturing third phase.</summary>
+            public readonly SparseIntMap<Registers>? Current, Next;
+            /// <summary>Registers used for the capturing third phase.</summary>
+            public readonly Registers InitialRegisters;
 
-                return p;
+            public PerThreadData(SymbolicRegexBuilder<TSetType> builder, int capsize)
+            {
+                NfaState = new NfaMatchingState(builder);
+
+                // Only create data used for capturing mode if there are subcaptures
+                if (capsize > 1)
+                {
+                    Current = new();
+                    Next = new();
+                    InitialRegisters = new Registers(new int[capsize], new int[capsize]);
+                }
             }
         }
 
-        private void DoCheckTimeout(int timeoutOccursAt)
+        /// <summary>Stores the state that represents a current state in NFA mode.</summary>
+        /// <remarks>The entire state is composed of a list of individual states.</remarks>
+        internal sealed class NfaMatchingState
         {
-            // This logic is identical to RegexRunner.DoCheckTimeout, with the exception of check skipping. RegexRunner calls
-            // DoCheckTimeout potentially on every iteration of a loop, whereas this calls it only once per transition.
-            int currentMillis = Environment.TickCount;
-            if (currentMillis >= timeoutOccursAt && (0 <= timeoutOccursAt || 0 >= currentMillis))
+            /// <summary>The associated builder used to lazily add new DFA or NFA nodes to the graph.</summary>
+            public readonly SymbolicRegexBuilder<TSetType> Builder;
+
+            /// <summary>Ordered set used to store the current NFA states.</summary>
+            /// <remarks>The value is unused.  The type is used purely for its keys.</remarks>
+            public SparseIntMap<int> NfaStateSet = new();
+            /// <summary>Scratch set to swap with <see cref="NfaStateSet"/> on each transition.</summary>
+            /// <remarks>
+            /// On each transition, <see cref="NfaStateSetScratch"/> is cleared and filled with the next
+            /// states computed from the current states in <see cref="NfaStateSet"/>, and then the sets
+            /// are swapped so the scratch becomes the current and the current becomes the scratch.
+            /// </remarks>
+            public SparseIntMap<int> NfaStateSetScratch = new();
+
+            /// <summary>Create the instance.</summary>
+            /// <remarks>New instances should only be created once per runner.</remarks>
+            public NfaMatchingState(SymbolicRegexBuilder<TSetType> builder) => Builder = builder;
+
+            /// <summary>Resets this NFA state to represent the supplied DFA state.</summary>
+            /// <param name="dfaMatchingState">The DFA state to use to initialize the NFA state.</param>
+            public void InitializeFrom(DfaMatchingState<TSetType> dfaMatchingState)
             {
-                throw new RegexMatchTimeoutException(string.Empty, string.Empty, TimeSpan.FromMilliseconds(_timeout));
+                NfaStateSet.Clear();
+
+                // If the DFA state is a union of multiple DFA states, loop through all of them
+                // adding an NFA state for each.
+                if (dfaMatchingState.Node.Kind is SymbolicRegexNodeKind.Or)
+                {
+                    Debug.Assert(dfaMatchingState.Node._alts is not null);
+                    foreach (SymbolicRegexNode<TSetType> node in dfaMatchingState.Node._alts)
+                    {
+                        // Create (possibly new) NFA states for all the members.
+                        // Add their IDs to the current set of NFA states and into the list.
+                        int nfaState = Builder.CreateNfaState(node, dfaMatchingState.PrevCharKind);
+                        NfaStateSet.Add(nfaState, out _);
+                    }
+                }
+                else
+                {
+                    // Otherwise, just add an NFA state for the singular DFA state.
+                    SymbolicRegexNode<TSetType> node = dfaMatchingState.Node;
+                    int nfaState = Builder.CreateNfaState(node, dfaMatchingState.PrevCharKind);
+                    NfaStateSet.Add(nfaState, out _);
+                }
             }
         }
 
-        /// <summary>Find a match.</summary>
-        /// <param name="isMatch">Whether to return once we know there's a match without determining where exactly it matched.</param>
-        /// <param name="input">The input span</param>
-        /// <param name="startat">The position to start search in the input span.</param>
-        /// <param name="perThreadData">Per thread data reused between calls.</param>
-        public SymbolicMatch FindMatch(bool isMatch, ReadOnlySpan<char> input, int startat, PerThreadData perThreadData)
+        /// <summary>Represents a current state in a DFA or NFA graph walk while processing a regular expression.</summary>
+        /// <remarks>This is a discriminated union between a DFA state and an NFA state. One and only one will be non-null.</remarks>
+        private struct CurrentState
         {
-            // If we need to perform timeout checks, store the absolute timeout value.
-            int timeoutOccursAt = 0;
-            if (_checkTimeout)
+            /// <summary>Initializes the state as a DFA state.</summary>
+            public CurrentState(DfaMatchingState<TSetType> dfaState)
             {
-                // Using Environment.TickCount for efficiency instead of Stopwatch -- as in the non-DFA case.
-                timeoutOccursAt = Environment.TickCount + (int)(_timeout + 0.5);
+                DfaState = dfaState;
+                NfaState = null;
             }
 
-            // If we're starting at the end of the input, we don't need to do any work other than
-            // determine whether an empty match is valid, i.e. whether the pattern is "nullable"
-            // given the kinds of characters at and just before the end.
-            if (startat == input.Length)
+            /// <summary>Initializes the state as an NFA state.</summary>
+            public CurrentState(NfaMatchingState nfaState)
             {
-                uint prevKind = GetCharKind(input, startat - 1);
-                uint nextKind = GetCharKind(input, startat);
-                return _pattern.IsNullableFor(CharKind.Context(prevKind, nextKind)) ?
-                    new SymbolicMatch(startat, 0) :
-                    SymbolicMatch.NoMatch;
+                DfaState = null;
+                NfaState = nfaState;
             }
 
-            // Phase 1:
-            // Determine whether there is a match by finding the first final state position.  This only tells
-            // us whether there is a match but needn't give us the longest possible match. This may return -1 as
-            // a legitimate value when the initial state is nullable and startat == 0. It returns NoMatchExists (-2)
-            // when there is no match.  As an example, consider the pattern a{5,10}b* run against an input
-            // of aaaaaaaaaaaaaaabbbc: phase 1 will find the position of the first b: aaaaaaaaaaaaaaab.
-            int i = FindFinalStatePosition(input, startat, timeoutOccursAt, out int matchStartLowBoundary, out int matchStartLengthMarker);
-
-            // If there wasn't a match, we're done.
-            if (i == NoMatchExists)
-            {
-                return SymbolicMatch.NoMatch;
-            }
-
-            // A match exists. If we don't need further details, because IsMatch was used (and thus we don't
-            // need the exact bounds of the match, captures, etc.), we're done.
-            if (isMatch)
-            {
-                return SymbolicMatch.QuickMatch;
-            }
-
-            // Phase 2:
-            // Match backwards through the input matching against the reverse of the pattern, looking for the earliest
-            // start position.  That tells us the actual starting position of the match.  We can skip this phase if we
-            // recorded a fixed-length marker for the portion of the pattern that matched, as we can then jump that
-            // exact number of positions backwards.  Continuing the previous example, phase 2 will walk backwards from
-            // that first b until it finds the 6th a: aaaaaaaaaab.
-            int matchStart;
-            if (matchStartLengthMarker >= 0)
-            {
-                matchStart = i - matchStartLengthMarker + 1;
-            }
-            else
-            {
-                Debug.Assert(i >= startat - 1);
-                matchStart = i < startat ?
-                    startat :
-                    FindStartPosition(input, i, matchStartLowBoundary);
-            }
-
-            // Phase 3:
-            // Match again, this time from the computed start position, to find the latest end position.  That start
-            // and end then represent the bounds of the match.  If the pattern has subcaptures (captures other than
-            // the top-level capture for the whole match), we need to do more work to compute their exact bounds, so we
-            // take a faster path if captures aren't required.  Further, if captures aren't needed, and if any possible
-            // match of the whole pattern is a fixed length, we can skip this phase as well, just using that fixed-length
-            // to compute the ending position based on the starting position.  Continuing the previous example, phase 3
-            // will walk forwards from the 6th a until it finds the end of the match: aaaaaaaaaabbb.
-            if (!HasSubcaptures)
-            {
-                if (_fixedMatchLength.HasValue)
-                {
-                    return new SymbolicMatch(matchStart, _fixedMatchLength.GetValueOrDefault());
-                }
-
-                int matchEnd = FindEndPosition(input, matchStart);
-                return new SymbolicMatch(matchStart, matchEnd + 1 - matchStart);
-            }
-            else
-            {
-                int matchEnd = FindEndPositionCapturing(input, matchStart, out Registers endRegisters, perThreadData);
-                return new SymbolicMatch(matchStart, matchEnd + 1 - matchStart, endRegisters.CaptureStarts, endRegisters.CaptureEnds);
-            }
+            /// <summary>The DFA state.</summary>
+            public DfaMatchingState<TSetType>? DfaState;
+            /// <summary>The NFA state.</summary>
+            public NfaMatchingState? NfaState;
         }
 
-        /// <summary>Find match end position using the original pattern, end position is known to exist.</summary>
-        /// <param name="input">input span</param>
-        /// <param name="i">inclusive start position</param>
-        /// <returns>the match end position</returns>
-        private int FindEndPosition(ReadOnlySpan<char> input, int i)
+        /// <summary>Represents a set of routines for operating over a <see cref="CurrentState"/>.</summary>
+        private interface IStateHandler
         {
-            int i_end = input.Length;
-            // reset to Brzozowski mode
-            _builder._antimirov = false;
-
-            // Pick the correct start state based on previous character kind.
-            uint prevCharKind = GetCharKind(input, i - 1);
-            CurrentState<TSetType> state = new CurrentState<TSetType>(_initialStates[prevCharKind]);
-
-            if (state.IsNullable(GetCharKind(input, i)))
-            {
-                // Empty match exists because the initial state is accepting.
-                i_end = i - 1;
-            }
-
-            while (i < input.Length)
-            {
-                int j = Math.Min(input.Length, i + AntimirovThresholdLeeway);
-                bool done = FindEndPositionDeltas(input, ref i, j, ref state, ref i_end);
-
-                if (done)
-                {
-                    break;
-                }
-            }
-
-            Debug.Assert(i_end < input.Length);
-            return i_end;
+#pragma warning disable CA2252 // This API requires opting into preview features
+            public static abstract bool StartsWithLineAnchor(ref CurrentState state);
+            public static abstract bool IsNullable(ref CurrentState state, uint nextCharKind);
+            public static abstract bool IsDeadend(ref CurrentState state);
+            public static abstract int FixedLength(ref CurrentState state);
+            public static abstract bool IsInitialState(ref CurrentState state);
+            public static abstract bool TakeTransition(SymbolicRegexBuilder<TSetType> builder, ref CurrentState state, int mintermId);
+#pragma warning restore CA2252 // This API requires opting into preview features
         }
 
-        /// <summary>Inner loop for FindEndPosition parameterized by an ITransition type.</summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool FindEndPositionDeltas(ReadOnlySpan<char> input, ref int i, int j, ref CurrentState<TSetType> q, ref int i_end)
+        /// <summary>An <see cref="IStateHandler"/> for operating over <see cref="CurrentState"/> instances configured as DFA states.</summary>
+        private readonly struct DfaStateHandler : IStateHandler
         {
-            do
-            {
-                Delta(input, i, ref q);
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool StartsWithLineAnchor(ref CurrentState state) => state.DfaState!.StartsWithLineAnchor;
 
-                if (q.IsNullable(GetCharKind(input, i + 1)))
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool IsNullable(ref CurrentState state, uint nextCharKind) => state.DfaState!.IsNullable(nextCharKind);
+
+            /// <summary>Gets whether this is a dead-end state, meaning there are no transitions possible out of the state.</summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool IsDeadend(ref CurrentState state) => state.DfaState!.IsDeadend;
+
+            /// <summary>Gets the length of any fixed-length marker that exists for this state, or -1 if there is none.</summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static int FixedLength(ref CurrentState state) => state.DfaState!.FixedLength;
+
+            /// <summary>Gets whether this is an initial state.</summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool IsInitialState(ref CurrentState state) => state.DfaState!.IsInitialState;
+
+            /// <summary>Take the transition to the next DFA state.</summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool TakeTransition(SymbolicRegexBuilder<TSetType> builder, ref CurrentState state, int mintermId)
+            {
+                Debug.Assert(state.DfaState is not null, $"Expected non-null {nameof(state.DfaState)}.");
+                Debug.Assert(state.NfaState is null, $"Expected null {nameof(state.NfaState)}.");
+                Debug.Assert(builder._delta is not null);
+
+                // Get the current state.
+                DfaMatchingState<TSetType> dfaMatchingState = state.DfaState!;
+
+                // Use the mintermId for the character being read to look up which state to transition to.
+                // If that state has already been materialized, move to it, and we're done. If that state
+                // hasn't been materialized, try to create it; if we can, move to it, and we're done.
+                int dfaOffset = (dfaMatchingState.Id << builder._mintermsLog) | mintermId;
+                DfaMatchingState<TSetType>? nextState = builder._delta[dfaOffset];
+                if (nextState is not null || builder.TryCreateNewTransition(dfaMatchingState, mintermId, dfaOffset, checkThreshold: true, out nextState))
                 {
-                    // Accepting state has been reached. Record the position.
-                    i_end = i;
-                }
-                else if (q.IsDeadend)
-                {
-                    // Non-accepting sink state (deadend) has been reached in the original pattern.
-                    // So the match ended when the last i_end was updated.
+                    // There was an existing state for this transition or we were able to create one.  Move to it and
+                    // return that we're still operating as a DFA and can keep going.
+                    state.DfaState = nextState;
                     return true;
                 }
 
-                i++;
+                return false;
             }
-            while (i < j);
-
-            return false;
         }
 
-        /// <summary>Find match end position using the original pattern, end position is known to exist. This version also produces captures.</summary>
-        /// <param name="input">input span</param>
-        /// <param name="i">inclusive start position</param>
-        /// <param name="resultRegisters">out parameter for the final register values, which indicate capture starts and ends</param>
-        /// <param name="perThreadData">Per thread data reused between calls.</param>
-        /// <returns>the match end position</returns>
-        private int FindEndPositionCapturing(ReadOnlySpan<char> input, int i, out Registers resultRegisters, PerThreadData perThreadData)
+        /// <summary>An <see cref="IStateHandler"/> for operating over <see cref="CurrentState"/> instances configured as NFA states.</summary>
+        private readonly struct NfaStateHandler : IStateHandler
         {
-            int i_end = input.Length;
-            Registers endRegisters = default(Registers);
-            DfaMatchingState<TSetType>? endState = null;
-
-            // Reset to Brzozowski mode
-            _builder._antimirov = false;
-
-            // Pick the correct start state based on previous character kind.
-            uint prevCharKind = GetCharKind(input, i - 1);
-            DfaMatchingState<TSetType> state = _initialStates[prevCharKind];
-
-            Registers initialRegisters = perThreadData.InitialRegisters;
-            // Initialize registers with -1, which means "not seen yet"
-            Array.Fill(initialRegisters.CaptureStarts, -1);
-            Array.Fill(initialRegisters.CaptureEnds, -1);
-
-            if (state.IsNullable(GetCharKind(input, i)))
+            /// <summary>Check if any underlying core state starts with a line anchor.</summary>
+            public static bool StartsWithLineAnchor(ref CurrentState state)
             {
-                // Empty match exists because the initial state is accepting.
-                i_end = i - 1;
-                endRegisters.Assign(initialRegisters);
-                endState = state;
+                SymbolicRegexBuilder<TSetType> builder = state.NfaState!.Builder;
+                foreach (ref KeyValuePair<int, int> nfaState in CollectionsMarshal.AsSpan(state.NfaState!.NfaStateSet.Values))
+                {
+                    if (builder.GetCoreState(nfaState.Key).StartsWithLineAnchor)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
             }
 
-            // Use two maps from state IDs to register values for the current and next set of states.
-            // Note that these maps use insertion order, which is used to maintain priorities between states in a way
-            // that matches the order the backtracking engines visit paths.
-            Debug.Assert(perThreadData.Current is not null && perThreadData.Next is not null);
-            SparseIntMap<Registers> current = perThreadData.Current, next = perThreadData.Next;
-            current.Clear();
-            next.Clear();
-            current.Add(state.Id, initialRegisters);
-
-            while ((uint)i < (uint)input.Length)
+            /// <summary>Check if any underlying core state is nullable.</summary>
+            public static bool IsNullable(ref CurrentState state, uint nextCharKind)
             {
-                Debug.Assert(next.Count == 0);
-
-                TSetType[]? minterms = _builder._minterms;
-                Debug.Assert(minterms is not null);
-
-                int c = input[i];
-                int normalMintermId = _partitions.GetMintermID(c);
-
-                foreach ((int sourceId, SymbolicRegexMatcher<TSetType>.Registers sourceRegisters) in current.Values)
+                SymbolicRegexBuilder<TSetType> builder = state.NfaState!.Builder;
+                foreach (ref KeyValuePair<int, int> nfaState in CollectionsMarshal.AsSpan(state.NfaState!.NfaStateSet.Values))
                 {
-                    Debug.Assert(_builder._capturingStateArray is not null);
-                    DfaMatchingState<TSetType> sourceState = _builder._capturingStateArray[sourceId];
-
-                    // Find the minterm, handling the special case for the last \n
-                    int mintermId = c == '\n' && i == input.Length - 1 && sourceState.StartsWithLineAnchor ?
-                        minterms.Length : normalMintermId; // mintermId = minterms.Length represents \Z (last \n)
-                    TSetType minterm = (uint)mintermId < (uint)minterms.Length ?
-                        minterms[mintermId] :
-                        _builder._solver.False; // minterm=False represents \Z
-
-                    // Get or create the transitions
-                    int offset = (sourceId << _builder._mintermsCount) | mintermId;
-                    Debug.Assert(_builder._capturingDelta is not null);
-                    List<(DfaMatchingState<TSetType>, List<DerivativeEffect>)>? transitions = Volatile.Read(ref _builder._capturingDelta[offset])
-                        ?? CreateNewCapturingTransitions(sourceState, minterm, offset);
-
-                    // Take the transitions in their prioritized order
-                    for (int j = 0; j < transitions.Count; ++j)
+                    if (builder.GetCoreState(nfaState.Key).IsNullable(nextCharKind))
                     {
-                        (DfaMatchingState<TSetType> targetState, List<DerivativeEffect> effects) = transitions[j];
-                        if (targetState.IsDeadend)
-                            continue;
+                        return true;
+                    }
+                }
 
-                        // Try to add the state and handle the case where it didn't exist before. If the state already
-                        // exists, then the transition can be safely ignored, as the existing state was generated by a
-                        // higher priority transition.
-                        if (next.Add(targetState.Id, out int index))
+                return false;
+            }
+
+            /// <summary>Gets whether this is a dead-end state, meaning there are no transitions possible out of the state.</summary>
+            /// <remarks>In NFA mode, an empty set of states means that it is a dead end.</remarks>
+            public static bool IsDeadend(ref CurrentState state) => state.NfaState!.NfaStateSet.Count == 0;
+
+            /// <summary>Gets the length of any fixed-length marker that exists for this state, or -1 if there is none.</summary>
+            /// <summary>In NFA mode, there are no fixed-length markers.</summary>
+            public static int FixedLength(ref CurrentState state) => -1;
+
+            /// <summary>Gets whether this is an initial state.</summary>
+            /// <summary>In NFA mode, no set of states qualifies as an initial state.</summary>
+            public static bool IsInitialState(ref CurrentState state) => false;
+
+            /// <summary>Take the transition to the next NFA state.</summary>
+            public static bool TakeTransition(SymbolicRegexBuilder<TSetType> builder, ref CurrentState state, int mintermId)
+            {
+                Debug.Assert(state.DfaState is null, $"Expected null {nameof(state.DfaState)}.");
+                Debug.Assert(state.NfaState is not null, $"Expected non-null {nameof(state.NfaState)}.");
+
+                NfaMatchingState nfaState = state.NfaState!;
+
+                // Grab the sets, swapping the current active states set with the scratch set.
+                SparseIntMap<int> nextStates = nfaState.NfaStateSetScratch;
+                SparseIntMap<int> sourceStates = nfaState.NfaStateSet;
+                nfaState.NfaStateSet = nextStates;
+                nfaState.NfaStateSetScratch = sourceStates;
+
+                // Compute the set of all unique next states from the current source states and the mintermId.
+                nextStates.Clear();
+                if (sourceStates.Count == 1)
+                {
+                    // We have a single source state.  We know its next states are already deduped,
+                    // so we can just add them directly to the destination states list.
+                    foreach (int nextState in GetNextStates(sourceStates.Values[0].Key, mintermId, builder))
+                    {
+                        nextStates.Add(nextState, out _);
+                    }
+                }
+                else
+                {
+                    // We have multiple source states, so we need to potentially dedup across each of
+                    // their next states.  For each source state, get its next states, adding each into
+                    // our set (which exists purely for deduping purposes), and if we successfully added
+                    // to the set, then add the known-unique state to the destination list.
+                    foreach (ref KeyValuePair<int, int> sourceState in CollectionsMarshal.AsSpan(sourceStates.Values))
+                    {
+                        foreach (int nextState in GetNextStates(sourceState.Key, mintermId, builder))
                         {
-                            // Avoid copying the registers on the last transition from this state, reusing the registers instead
-                            Registers newRegisters = j != transitions.Count - 1 ? sourceRegisters.Clone() : sourceRegisters;
-                            newRegisters.ApplyEffects(effects, i);
-                            next.Update(index, targetState.Id, newRegisters);
-                            if (targetState.IsNullable(GetCharKind(input, i + 1)))
-                            {
-                                // Accepting state has been reached. Record the position.
-                                i_end = i;
-                                endRegisters.Assign(newRegisters);
-                                endState = targetState;
-                                // No lower priority transitions from this or other source states are taken because the
-                                // backtracking engines would return the match ending here.
-                                goto BreakNullable;
-                            }
+                            nextStates.Add(nextState, out _);
                         }
                     }
                 }
 
-            BreakNullable:
-                if (next.Count == 0)
+                return true;
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                static int[] GetNextStates(int sourceState, int mintermId, SymbolicRegexBuilder<TSetType> builder)
                 {
-                    // If all states died out some nullable state must have been seen before
-                    goto FINISH;
+                    // Calculate the offset into the NFA transition table.
+                    int nfaOffset = (sourceState << builder._mintermsLog) | mintermId;
+
+                    // Get the next NFA state.
+                    return builder._nfaDelta[nfaOffset] ?? builder.CreateNewNfaTransition(sourceState, mintermId, nfaOffset);
                 }
-
-                // Swap the state sets and prepare for the next character
-                SparseIntMap<SymbolicRegexMatcher<TSetType>.Registers> tmp = current;
-                current = next;
-                next = tmp;
-                next.Clear();
-                i++;
-            }
-
-        FINISH:
-            Debug.Assert(i_end != input.Length && endState is not null);
-            // Apply effects for finishing at the stored end state
-            endState.Node.ApplyEffects(effect => endRegisters.ApplyEffect(effect, i_end + 1),
-                CharKind.Context(endState.PrevCharKind, GetCharKind(input, i_end + 1)));
-            resultRegisters = endRegisters;
-            return i_end;
-        }
-
-        /// <summary>Walk back in reverse using the reverse pattern to find the start position of match, start position is known to exist.</summary>
-        /// <param name="input">the input span</param>
-        /// <param name="i">position to start walking back from, i points at the last character of the match</param>
-        /// <param name="match_start_boundary">do not pass this boundary when walking back</param>
-        /// <returns></returns>
-        private int FindStartPosition(ReadOnlySpan<char> input, int i, int match_start_boundary)
-        {
-            // Fetch the correct start state for the reverse pattern.
-            // This depends on previous character --- which, because going backwards, is character number i+1.
-            uint prevKind = GetCharKind(input, i + 1);
-            // reset to Brzozowski mode
-            _builder._antimirov = false;
-
-            CurrentState<TSetType> q = new CurrentState<TSetType>(_reverseInitialStates[prevKind]);
-
-            if (i == -1)
-            {
-                Debug.Assert(q.IsNullable(GetCharKind(input, i)), "we reached the beginning of the input, thus the state q must be accepting");
-                return 0;
-            }
-
-            int last_start = -1;
-            if (q.IsNullable(GetCharKind(input, i)))
-            {
-                // The whole prefix of the reverse pattern was in reverse a prefix of the original pattern,
-                // for example when the original pattern is concrete word such as "abc"
-                last_start = i + 1;
-            }
-
-            // Walk back to the accepting state of the reverse pattern
-            while (i >= match_start_boundary)
-            {
-                int j = Math.Max(match_start_boundary, i - AntimirovThresholdLeeway);
-                bool done = FindStartPositionDeltas(input, ref i, j, ref q, ref last_start);
-
-                if (done)
-                {
-                    break;
-                }
-            }
-
-            Debug.Assert(last_start != -1);
-            return last_start;
-        }
-
-        // Inner loop for FindStartPosition parameterized by an ITransition type.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool FindStartPositionDeltas(ReadOnlySpan<char> input, ref int i, int j, ref CurrentState<TSetType> q, ref int last_start)
-        {
-            do
-            {
-                Delta(input, i, ref q);
-
-                // Reached a deadend state, thus the earliest match start point must have occurred already.
-                if (q.IsNothing)
-                {
-                    return true;
-                }
-
-                if (q.IsNullable(GetCharKind(input, i - 1)))
-                {
-                    // Earliest start point so far. This must happen at some point
-                    // or else the dot-star pattern would not have reached a final state after match_start_boundary.
-                    last_start = i;
-                }
-
-                i -= 1;
-            }
-            while (i > j);
-
-            return false;
-        }
-
-        /// <summary>Returns NoMatchExists if no match exists. Returns -1 when i=0 and the initial state is nullable.</summary>
-        /// <param name="input">given input span</param>
-        /// <param name="i">start position</param>
-        /// <param name="timeoutOccursAt">The time at which timeout occurs, if timeouts are being checked.</param>
-        /// <param name="initialStateIndex">last position the initial state of <see cref="_dotStarredPattern"/> was visited</param>
-        /// <param name="matchLength">length of match when positive</param>
-        private int FindFinalStatePosition(ReadOnlySpan<char> input, int i, int timeoutOccursAt, out int initialStateIndex, out int matchLength)
-        {
-            // Get the correct start state of the dot-star pattern, which in general depends on the previous character kind in the input.
-            uint prevCharKindId = GetCharKind(input, i - 1);
-
-            CurrentState<TSetType> q = new CurrentState<TSetType>(_dotstarredInitialStates[prevCharKindId]);
-            initialStateIndex = i;
-
-            if (q.IsNothing)
-            {
-                // If q is nothing then it is a deadend from the beginning this happens for example when the original
-                // regex started with start anchor and prevCharKindId is not Start
-                matchLength = -1;
-                return NoMatchExists;
-            }
-
-            if (q.IsNullable(GetCharKind(input, i)))
-            {
-                // The initial state is nullable in this context so at least an empty match exists.
-                // The last position of the match is i-1 because the match is empty.
-                // This value is -1 if i == 0.
-                matchLength = -1;
-                return i - 1;
-            }
-
-            matchLength = -1;
-
-            // Search for a match end position within input[i..k-1]
-            while (i < input.Length)
-            {
-                if (q.IsInitialState)
-                {
-                    // i_q0_A1 is the most recent position in the input when the dot-star pattern is in the initial state
-                    initialStateIndex = i;
-
-                    if (_findOpts is RegexFindOptimizations findOpts)
-                    {
-                        // Find the first position i that matches with some likely character.
-                        if (!findOpts.TryFindNextStartingPosition(input, ref i, 0, 0, input.Length))
-                        {
-                            // no match was found
-                            return NoMatchExists;
-                        }
-
-                        initialStateIndex = i;
-
-                        // the start state must be updated
-                        // to reflect the kind of the previous character
-                        // when anchors are not used, q will remain the same state
-                        q = new CurrentState<TSetType>(_dotstarredInitialStates[GetCharKind(input, i - 1)]);
-                        if (q.IsNothing)
-                        {
-                            return NoMatchExists;
-                        }
-                    }
-                }
-
-                int result;
-                int j = Math.Min(input.Length, i + AntimirovThresholdLeeway);
-                bool done = FindFinalStatePositionDeltas(input, j, ref i, ref q, ref matchLength, out result);
-
-                if (done)
-                {
-                    return result;
-                }
-
-                if (_checkTimeout)
-                {
-                    DoCheckTimeout(timeoutOccursAt);
-                }
-            }
-
-            //no match was found
-            return NoMatchExists;
-        }
-
-        /// <summary>Inner loop for FindFinalStatePosition parameterized by an ITransition type.</summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool FindFinalStatePositionDeltas(ReadOnlySpan<char> input, int j, ref int i, ref CurrentState<TSetType> q, ref int watchdog, out int result)
-        {
-            do
-            {
-                // Make the transition based on input[i].
-                Delta(input, i, ref q);
-
-                if (q.IsNullable(GetCharKind(input, i + 1)))
-                {
-                    matchLength = q.FixedLength;
-                    result = i;
-                    return true;
-                }
-
-                if (q.IsNothing)
-                {
-                    // q is a deadend state so any further search is meaningless
-                    result = NoMatchExists;
-                    return true;
-                }
-
-                // continue from the next character
-                i++;
-            }
-            while (i < j && !q.IsInitialState);
-
-            result = 0;
-            return false;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private uint GetCharKind(ReadOnlySpan<char> input, int i)
-        {
-            return !_pattern._info.ContainsSomeAnchor ?
-                CharKind.General : // The previous character kind is irrelevant when anchors are not used.
-                GetCharKindWithAnchor(input, i);
-
-            uint GetCharKindWithAnchor(ReadOnlySpan<char> input, int i)
-            {
-                Debug.Assert(_asciiCharKinds is not null);
-
-                if ((uint)i >= (uint)input.Length)
-                {
-                    return CharKind.StartStop;
-                }
-
-                char nextChar = input[i];
-                if (nextChar == '\n')
-                {
-                    return
-                        _builder._newLinePredicate.Equals(_builder._solver.False) ? 0 : // ignore \n
-                        i == 0 || i == input.Length - 1 ? CharKind.NewLineS : // very first or very last \n. Detection of very first \n is needed for rev(\Z).
-                        CharKind.Newline;
-                }
-
-                uint[] asciiCharKinds = _asciiCharKinds;
-                return
-                    nextChar < (uint)asciiCharKinds.Length ? asciiCharKinds[nextChar] :
-                    _builder._solver.And(GetMinterm(nextChar), _builder._wordLetterPredicateForAnchors).Equals(_builder._solver.False) ? 0 : //apply the wordletter predicate to compute the kind of the next character
-                    CharKind.WordLetter;
             }
         }
 
 #if DEBUG
-        public void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, bool onlyDFAinfo, int maxLabelLength, bool asNFA)
+        public override void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, bool onlyDFAinfo, int maxLabelLength, bool asNFA)
         {
             var graph = new DGML.RegexAutomaton<TSetType>(this, bound, addDotStar, inReverse, asNFA);
             var dgml = new DGML.DgmlWriter(writer, hideStateInfo, maxLabelLength, onlyDFAinfo);
             dgml.Write(graph);
         }
 
-        public IEnumerable<string> GenerateRandomMembers(int k, int randomseed, bool negative) =>
+        public override IEnumerable<string> GenerateRandomMembers(int k, int randomseed, bool negative) =>
             new SymbolicRegexSampler<TSetType>(_pattern, randomseed, negative).GenerateRandomMembers(k);
 #endif
     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -1990,7 +1990,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     {
                         Debug.Assert(_left is not null);
                         SymbolicRegexNode<S> body = _left.IgnoreOrOrderAndLazyness();
-                        return body == _left && !IsLazy?
+                        return body == _left && !IsLazy ?
                             this :
                             CreateLoop(_builder, body, _lower, _upper, isLazy: false);
                     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSampler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSampler.cs
@@ -47,7 +47,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 // Initially there is no previous character
                 // Here one could also consider previous characters for example for \b, \B, and ^ anchors
                 // and initialize input_so_far accordingly
-                uint prevCharKind = CharKind.StartStop;
+                uint prevCharKind = CharKind.BeginningEnd;
 
                 // This flag is set to false in the unlikely situation that generation ends up in a dead-end
                 bool generationSucceeded = true;
@@ -68,7 +68,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     if (CanBeFinal(states))
                     {
                         // Unconditionally final state or end of the input due to \Z anchor for example
-                        if (IsFinal(states) || IsFinal(states, CharKind.Context(prevCharKind, CharKind.StartStop)))
+                        if (IsFinal(states) || IsFinal(states, CharKind.Context(prevCharKind, CharKind.BeginningEnd)))
                         {
                             possible_endings.Add("");
                         }

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -1790,8 +1790,9 @@ namespace System.Text.RegularExpressions.Tests
 
         public static IEnumerable<object[]> StressTestAntimirovMode_TestData()
         {
-            yield return new object[] { "a.{20}$", "a01234567890123456789", 21 };
-            yield return new object[] { "(a.{20}|a.{10})bc$", "a01234567890123456789bc", 23 };
+            yield return new object[] { "(?:a|aa|[abc]?[ab]?[abcd]).{20}$", "aaa01234567890123456789", 23 };
+            yield return new object[] { "(?:a|AA|BCD).{20}$", "a01234567890123456789", 21 };
+            yield return new object[] { "(?:a.{20}|a.{10})bc$", "a01234567890123456789bc", 23 };
         }
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -1788,7 +1788,7 @@ namespace System.Text.RegularExpressions.Tests
             Assert.True(re.Match(fullinput).Success);
         }
 
-        public static IEnumerable<object[]> StressTestAntimirovMode_TestData()
+        public static IEnumerable<object[]> StressTestNfaMode_TestData()
         {
             yield return new object[] { "(?:a|aa|[abc]?[ab]?[abcd]).{20}$", "aaa01234567890123456789", 23 };
             yield return new object[] { "(?:a|AA|BCD).{20}$", "a01234567890123456789", 21 };
@@ -1796,13 +1796,13 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         /// <summary>
-        /// Causes NonBacktracking engine to switch to Antimirov mode internally.
-        /// Antimirov mode is otherwise never triggered by typical cases.
+        /// Causes NonBacktracking engine to switch to NFA mode internally.
+        /// NFA mode is otherwise never triggered by typical cases.
         /// </summary>
         [Theory]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Doesn't support NonBacktracking")]
-        [MemberData(nameof(StressTestAntimirovMode_TestData))]
-        public async Task StressTestAntimirovMode(string pattern, string input_suffix, int expected_matchlength)
+        [MemberData(nameof(StressTestNfaMode_TestData))]
+        public async Task StressTestNfaMode(string pattern, string input_suffix, int expected_matchlength)
         {
             Random random = new Random(0);
             byte[] buffer = new byte[50_000];


### PR DESCRIPTION
Refactored how current state is represented by encapsulating it in a new struct `CurrentState` that is passed by reference in the `Delta` and `TakeTransition` methods and hides whether the state is `DfaMatchingState` or a set of NFA states that have now their own transition function `_antimirovDelta` maintained by the `SymbolicRegexBuilder`. Use of `CurrentState` should not incur any overhead over how `DfaMatchingState` was used before. Further improvements in the implementation of `CurrentState` might be possible using `SparseIntMap`, currently `List` and `HashSet` are being used.

The update should improve Antimorov mode performance, but was also useful for code cleanup in general.

Moved several methods from `SymbolicRegexMatcher` to `SymbolicRegexBuilder` where they belong more naturally. Removed `ITransition` interface and the associated Brzozowski and Antimirov structs as they are no longer needed.

Updated some unit tests to actually cause Antimirov mode to be triggered. Some new optimizations had caused the mode not to be triggered any more (e.g. for the regex  a.{20}$ where the index was advanced immediately to the 20th character from the end). (I will add some unit test to cover `Watchdog`, that has become dormant for seemingly similar reasons.)

Some code of `CreateNewNfaTransition` concering nondeterministic behavior from a single NFA state is currently not detected because derivatives do not introduce `Or` any more in many cases but rather `OrderedOr` so the important case 
`if (coretarget.Node.Kind == SymbolicRegexKind.Or)` in  `CreateNewNfaTransition` 
is currently never triggered and all `OrderedOr` nodes are treated as single states thus sidestepping the Antimirov mode.

**TODO: Getting rid of `Or`, or rather renaming `OrderedOr` to `Or` (and getting rid of the unordered semantics, the current mixture of `Or` and `OrderedOr` is a temporary headache). This will also make the `SymbolicRegexNode` AST more lightweight**

Fixes https://github.com/dotnet/runtime/issues/60918