### PR TITLE
Cleanup CLRConfig

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/CLRConfig.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/CLRConfig.cs
@@ -6,48 +6,13 @@ using System.Runtime.InteropServices;
 
 namespace System
 {
-    // CLRConfig is mainly reading the config switch values. this is used when we cannot use the AppContext class
-    // one example, is using the context switch in the globalization code which require to read the switch very
-    // early even before the appdomain get initialized.
+    // CLRConfig is mainly reading the config switch values. this is used when we cannot use the AppContext class.
     // In general AppContext should be used instead of CLRConfig if there is no reason prevent that.
     internal static partial class CLRConfig
     {
         internal static bool GetBoolValue(string switchName, out bool exist)
         {
             return GetConfigBoolValue(switchName, out exist);
-        }
-
-        internal static bool GetBoolValueWithFallbacks(string switchName, string environmentName, bool defaultValue)
-        {
-            bool value = GetBoolValue(switchName, out bool exists);
-
-            if (exists)
-                return value;
-
-            // Calls to this API can be very early- we want to avoid using higher-level
-            // abstractions where reasonably possible.
-
-            Span<char> buffer = stackalloc char[32];
-            uint length = Interop.Kernel32.GetEnvironmentVariable(environmentName, ref buffer.GetPinnableReference(), (uint)buffer.Length);
-            switch (length)
-            {
-                case 1:
-                    if (buffer[0] == '0')
-                        return false;
-                    if (buffer[0] == '1')
-                        return true;
-                    break;
-                case 4:
-                    if (bool.IsTrueStringIgnoreCase(buffer.Slice(0, 4)))
-                        return true;
-                    break;
-                case 5:
-                    if (bool.IsFalseStringIgnoreCase(buffer.Slice(0, 5)))
-                        return false;
-                    break;
-            }
-
-            return defaultValue;
         }
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ClrConfig_GetConfigBoolValue", CharSet = CharSet.Unicode)]

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/AutoreleasePool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/AutoreleasePool.cs
@@ -13,7 +13,7 @@ namespace System.Threading
 #if CORECLR
             // In coreclr_initialize, we call ICLRRuntimeHost4->Start() which, among other things,
             // starts a finalizer thread for Objective-C's NSAutoreleasePool interop on macOS.
-            // Althoguh AppContext.Setup() is done during CreateAppDomainWithManager() call which
+            // Although AppContext.Setup() is done during CreateAppDomainWithManager() call which
             // is made in coreclr_initialize right after the host has started, there is a chance of
             // race between the call to CreateAppDomainWithManager in coreclr_initialize and the
             // finalizer thread starting, that will call into the changed managed code.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/AutoreleasePool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/AutoreleasePool.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 namespace System.Threading
 {
@@ -11,14 +10,19 @@ namespace System.Threading
         private static bool CheckEnableAutoreleasePool()
         {
             const string feature = "System.Threading.Thread.EnableAutoreleasePool";
-#if !CORECLR
-            return AppContextConfigHelper.GetBooleanConfig(feature, false);
-#else
-            bool isEnabled = CLRConfig.GetBoolValue(feature, out bool isSet);
-            if (!isSet)
-                return false;
+#if CORECLR
+            // In coreclr_initialize, we call ICLRRuntimeHost4->Start() which, among other things,
+            // starts a finalizer thread for Objective-C's NSAutoreleasePool interop on macOS.
+            // Althoguh AppContext.Setup() is done during CreateAppDomainWithManager() call which
+            // is made in coreclr_initialize right after the host has started, there is a chance of
+            // race between the call to CreateAppDomainWithManager in coreclr_initialize and the
+            // finalizer thread starting, that will call into the changed managed code.
+            //
+            // Therefore, we are using CLR configuration via QCall here, instead of AppContext.
 
-            return isEnabled;
+            return CLRConfig.GetBoolValue(feature, out bool isSet) && isSet;
+#else
+            return AppContextConfigHelper.GetBooleanConfig(feature, false);
 #endif
         }
 


### PR DESCRIPTION
`GetBoolValueWithFallbacks` is unused since https://github.com/dotnet/runtime/commit/d4dcde13c969ad20deb20c99e91880de44aac9cd.