### PR TITLE
Ad-Hoc codesign on macOS-arm64 for crossgen2 binaries

### DIFF
--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -51,7 +51,7 @@
     </PropertyGroup>
 
     <!-- Ad-hoc code-signing for crossgen2 binaries for macOS-arm64 -->
-    <Exec Condition="$([MSBuild]::IsOSPlatform('OSX')) and '$(_hostArch)' == 'arm64'"
+    <Exec Condition="'$(Configuration)' == 'Checked' and $([MSBuild]::IsOSPlatform('OSX')) and '$(_hostArch)' == 'arm64'"
           Command="codesign -f -s - %(CrossGen2DllFiles.Identity)" />
   </Target>
 

--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -49,6 +49,10 @@
       <CoreLibPerfMapPath Condition="$(BuildPerfMap)">$([MSBuild]::NormalizePath('$(BinDir)', '$(CoreLibAssemblyName).ni.r2rmap'))</CoreLibPerfMapPath>
       <MergedMibcPath>$([MSBuild]::NormalizePath('$(BinDir)', 'StandardOptimizationData.mibc'))</MergedMibcPath>
     </PropertyGroup>
+
+    <!-- Ad-hoc code-signing for crossgen2 binaries for macOS-arm64 -->
+    <Exec Condition="$([MSBuild]::IsOSPlatform('OSX')) and '$(_hostArch)' == 'arm64'"
+          Command="codesign -f -s - %(CrossGen2DllFiles.Identity)" />
   </Target>
 
   <Target Name="CreateMergedMibcFile"


### PR DESCRIPTION
This fixes super annoying issue https://github.com/dotnet/runtime/issues/65228 on macOS M1 where we randomly hit
![image](https://user-images.githubusercontent.com/523221/154946217-103cc291-c88e-4779-a69b-dab6a178e0b1.png)
when we rebuild Clr (I know @AndyAyersMS hit it too recently)

I am not sure I don't brake official package signing with this PR so it needs some review
Don't know who to ping, so pinging those who touched other codesign related files @agocke @janvorli @am11 