### PR TITLE
Ensure all expected paths are logged on test failure

### DIFF
--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
@@ -54,7 +54,7 @@ namespace System.IO.Tests
             if (expectedPaths is not null && !expectedPaths.Contains(fullPath))
             {
                 // Assert.Contains does not print a full content of collection which makes it hard to diagnose issues like #65601
-                throw new XunitException($"Expected path(s): {Environment.NewLine}"
+                throw new XunitException($"Expected path(s):{Environment.NewLine}"
                     + string.Join(Environment.NewLine, expectedPaths)
                     + $"{Environment.NewLine}Actual path: {fullPath}");
             }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
@@ -39,15 +39,28 @@ namespace System.IO.Tests
             FileSystemEventHandler changeHandler = (o, e) =>
             {
                 Assert.Equal(WatcherChangeTypes.Changed, e.ChangeType);
-                if (expectedPaths != null)
-                {
-                    Assert.Contains(Path.GetFullPath(e.FullPath), expectedPaths);
-                }
+                VerifyExpectedPath(expectedPaths, e);
                 eventOccurred.Set();
             };
 
             watcher.Changed += changeHandler;
             return (eventOccurred, changeHandler);
+        }
+
+        private static void VerifyExpectedPath(string[] expectedPaths, FileSystemEventArgs e, ITestOutputHelper output = null)
+        {
+            if (expectedPaths != null)
+            {
+                try
+                {
+                    Assert.Contains(Path.GetFullPath(e.FullPath), expectedPaths);
+                }
+                catch (Exception ex)
+                {
+                    output?.WriteLine(ex.ToString());
+                    throw;
+                }
+            }
         }
 
         /// <summary>
@@ -67,18 +80,7 @@ namespace System.IO.Tests
                 }
 
                 Assert.Equal(WatcherChangeTypes.Created, e.ChangeType);
-                if (expectedPaths != null)
-                {
-                    try
-                    {
-                        Assert.Contains(Path.GetFullPath(e.FullPath), expectedPaths);
-                    }
-                    catch (Exception ex)
-                    {
-                        _output?.WriteLine(ex.ToString());
-                        throw;
-                    }
-                }
+                VerifyExpectedPath(expectedPaths, e, _output);
 
                 eventOccurred.Set();
             };
@@ -102,18 +104,8 @@ namespace System.IO.Tests
                     Assert.Equal(WatcherChangeTypes.Deleted, e.ChangeType);
                 }
 
-                if (expectedPaths != null)
-                {
-                    try
-                    {
-                        Assert.Contains(Path.GetFullPath(e.FullPath), expectedPaths);
-                    }
-                    catch (Exception ex)
-                    {
-                        _output?.WriteLine(ex.ToString());
-                        throw;
-                    }
-                }
+                VerifyExpectedPath(expectedPaths, e, _output);
+
                 eventOccurred.Set();
             };
 
@@ -137,18 +129,8 @@ namespace System.IO.Tests
                     Assert.Equal(WatcherChangeTypes.Renamed, e.ChangeType);
                 }
 
-                if (expectedPaths != null)
-                {
-                    try
-                    {
-                        Assert.Contains(Path.GetFullPath(e.FullPath), expectedPaths);
-                    }
-                    catch (Exception ex)
-                    {
-                        _output?.WriteLine(ex.ToString());
-                        throw;
-                    }
-                }
+                VerifyExpectedPath(expectedPaths, e, _output);
+
                 eventOccurred.Set();
             };
 


### PR DESCRIPTION
The failure provided in #65601 is not very helpful:

```log
Not found: /var/folders/62/ftpn5pv523j8xsdw56s9jnp40000gs/T/Directory_Create_Tests_hsm4w3hg.os4/FileSystemWatcher_Directory_Create_InNestedDirectory_53_bb03705a/dir1
In value:  String[] ["/var/folders/62/ftpn5pv523j8xsdw56s9jnp40000gs/T/D"...]
```

Let's print all information in the exception message so we can move on with #65601 diagnostics.
