### PR TITLE
Fix PGO jobs on official builds

### DIFF
--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -317,7 +317,7 @@ jobs:
           SecretsFilter: 'dotnetfeed-storage-access-key-1,microsoft-symbol-server-pat,symweb-symbol-server-pat'
 
     # Save packages using the prepare-signed-artifacts format.
-    - ${{ if and(eq(parameters.isOfficialBuild, true), ne(parameters.testGroup, 'clrTools')) }}:
+    - ${{ if and(eq(parameters.isOfficialBuild, true), ne(parameters.testGroup, 'clrTools'), eq(parameters.pgoType, '')) }}:
       - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
         parameters:
           name: ${{ parameters.platform }}

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -383,7 +383,7 @@ stages:
       - Linux_x64
       jobParameters:
         isOfficialBuild: ${{ variables.isOfficialBuild }}
-        signBinaries: ${{ variables.isOfficialBuild }}
+        signBinaries: false
         testGroup: innerloop
         pgoType: 'PGO'
 

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -382,6 +382,8 @@ stages:
       - windows_x86
       - Linux_x64
       jobParameters:
+        isOfficialBuild: ${{ variables.isOfficialBuild }}
+        signBinaries: ${{ variables.isOfficialBuild }}
         testGroup: innerloop
         pgoType: 'PGO'
 


### PR DESCRIPTION
After https://github.com/dotnet/runtime/pull/65603 the official build failed because we missed passing in the `isOfficialBuild` variable on the PGO jobs.

Test official build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1624977&view=results