### PR TITLE
[crossgen2] Promote single byref aot.

### DIFF
--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -841,7 +841,7 @@ enum CorInfoFlag
     CORINFO_FLG_ARRAY                 = 0x00080000, // class is an array class (initialized differently)
     CORINFO_FLG_OVERLAPPING_FIELDS    = 0x00100000, // struct or class has fields that overlap (aka union)
     CORINFO_FLG_INTERFACE             = 0x00200000, // it is an interface
-    CORINFO_FLG_DONT_PROMOTE          = 0x00400000, // don't try to promote fields (used for types outside of AOT compilation version bubble)
+    CORINFO_FLG_DONT_DIG_FIELDS       = 0x00400000, // don't ask field info, AOT can't rely on it (used for types outside of AOT compilation version bubble)
     CORINFO_FLG_CUSTOMLAYOUT          = 0x00800000, // does this struct have custom layout?
     CORINFO_FLG_CONTAINS_GC_PTR       = 0x01000000, // does the class contain a gc ptr ?
     CORINFO_FLG_DELEGATE              = 0x02000000, // is this a subclass of delegate or multicast delegate ?

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4149,6 +4149,8 @@ public:
         void PromoteStructVar(unsigned lclNum);
         void SortStructFields();
 
+        bool CanConstructAndPromoteField(lvaStructPromotionInfo* structPromotionInfo);
+
         lvaStructFieldInfo GetFieldInfo(CORINFO_FIELD_HANDLE fieldHnd, BYTE ordinal);
         bool TryPromoteStructField(lvaStructFieldInfo& outerFieldInfo);
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4480,9 +4480,9 @@ inline static bool StructHasCustomLayout(DWORD attribs)
     return ((attribs & CORINFO_FLG_CUSTOMLAYOUT) != 0);
 }
 
-inline static bool StructHasNoPromotionFlagSet(DWORD attribs)
+inline static bool StructHasDontDigFieldsFlagSet(DWORD attribs)
 {
-    return ((attribs & CORINFO_FLG_DONT_PROMOTE) != 0);
+    return ((attribs & CORINFO_FLG_DONT_DIG_FIELDS) != 0);
 }
 
 //------------------------------------------------------------------------------

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1685,13 +1685,6 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
     structPromotionInfo.fieldCnt = (unsigned char)fieldCnt;
     DWORD typeFlags              = compHandle->getClassAttribs(typeHnd);
 
-    if (StructHasDontDigFieldsFlagSet(typeFlags))
-    {
-        // In AOT ReadyToRun compilation, don't try to promote fields of types
-        // outside of the current version bubble.
-        return false;
-    }
-
     bool overlappingFields = StructHasOverlappingFields(typeFlags);
     if (overlappingFields)
     {
@@ -1708,6 +1701,26 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
     // On ARM, we have a requirement on the struct alignment; see below.
     unsigned structAlignment = roundUp(compHandle->getClassAlignmentRequirement(typeHnd), TARGET_POINTER_SIZE);
 #endif // TARGET_ARM
+
+    // If we have "Custom Layout" then we might have an explicit Size attribute
+    // Managed C++ uses this for its structs, such C++ types will not contain GC pointers.
+    //
+    // The current VM implementation also incorrectly sets the CORINFO_FLG_CUSTOMLAYOUT
+    // whenever a managed value class contains any GC pointers.
+    // (See the comment for VMFLAG_NOT_TIGHTLY_PACKED in class.h)
+    //
+    // It is important to struct promote managed value classes that have GC pointers
+    // So we compute the correct value for "CustomLayout" here
+    //
+    if (StructHasCustomLayout(typeFlags) && ((typeFlags & CORINFO_FLG_CONTAINS_GC_PTR) == 0))
+    {
+        structPromotionInfo.customLayout = true;
+    }
+
+    if (StructHasDontDigFieldsFlagSet(typeFlags))
+    {
+        return CanConstructAndPromoteField(&structPromotionInfo);
+    }
 
     unsigned fieldsSize = 0;
 
@@ -1760,21 +1773,6 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
     noway_assert((containsGCpointers == false) ||
                  ((typeFlags & (CORINFO_FLG_CONTAINS_GC_PTR | CORINFO_FLG_BYREF_LIKE)) != 0));
 
-    // If we have "Custom Layout" then we might have an explicit Size attribute
-    // Managed C++ uses this for its structs, such C++ types will not contain GC pointers.
-    //
-    // The current VM implementation also incorrectly sets the CORINFO_FLG_CUSTOMLAYOUT
-    // whenever a managed value class contains any GC pointers.
-    // (See the comment for VMFLAG_NOT_TIGHTLY_PACKED in class.h)
-    //
-    // It is important to struct promote managed value classes that have GC pointers
-    // So we compute the correct value for "CustomLayout" here
-    //
-    if (StructHasCustomLayout(typeFlags) && ((typeFlags & CORINFO_FLG_CONTAINS_GC_PTR) == 0))
-    {
-        structPromotionInfo.customLayout = true;
-    }
-
     // Check if this promoted struct contains any holes.
     assert(!overlappingFields);
     if (fieldsSize != structSize)
@@ -1787,6 +1785,62 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
     // Cool, this struct is promotable.
 
     structPromotionInfo.canPromote = true;
+    return true;
+}
+
+//--------------------------------------------------------------------------------------------
+// CanConstructAndPromoteField - checks if we can construct field types without asking about them directly.
+//
+// Arguments:
+//   structPromotionInfo - struct promotion candidate information.
+//
+// Return value:
+//   true if we can figure out the fields from available knowledge.
+//
+// Notes:
+//   This is needed for AOT R2R compilation when we can't cross compilation bubble borders
+//   so we should not ask about fields that are not directly referenced. If we do VM will have
+//   to emit a type check for this field type but it does not have enough information about it.
+//   As a workaround for perfomance critical corner case: struct with 1 gcref, we try to construct
+//   the field information from indirect observations.
+//
+bool Compiler::StructPromotionHelper::CanConstructAndPromoteField(lvaStructPromotionInfo* structPromotionInfo)
+{
+    const CORINFO_CLASS_HANDLE typeHnd    = structPromotionInfo->typeHnd;
+    const COMP_HANDLE          compHandle = compiler->info.compCompHnd;
+    const DWORD                typeFlags  = compHandle->getClassAttribs(typeHnd);
+    if (structPromotionInfo->fieldCnt != 1)
+    {
+        // Can't find out values for several fields.
+        return false;
+    }
+    if ((typeFlags & CORINFO_FLG_CONTAINS_GC_PTR) == 0)
+    {
+        // Can't find out type of a non-gc field.
+        return false;
+    }
+
+    const unsigned structSize = compHandle->getClassSize(typeHnd);
+    if (structSize != TARGET_POINTER_SIZE)
+    {
+        return false;
+    }
+
+    assert(!structPromotionInfo->containsHoles);
+    assert(!structPromotionInfo->customLayout);
+    lvaStructFieldInfo& fldInfo = structPromotionInfo->fields[0];
+
+    fldInfo.fldHnd = compHandle->getFieldInClass(typeHnd, 0);
+
+    // We should not read it anymore.
+    fldInfo.fldTypeHnd = 0;
+
+    fldInfo.fldOffset  = 0;
+    fldInfo.fldOrdinal = 0;
+    fldInfo.fldSize    = TARGET_POINTER_SIZE;
+    fldInfo.fldType    = TYP_BYREF;
+
+    structPromotionInfo->canPromote = true;
     return true;
 }
 

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1685,7 +1685,7 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
     structPromotionInfo.fieldCnt = (unsigned char)fieldCnt;
     DWORD typeFlags              = compHandle->getClassAttribs(typeHnd);
 
-    if (StructHasNoPromotionFlagSet(typeFlags))
+    if (StructHasDontDigFieldsFlagSet(typeFlags))
     {
         // In AOT ReadyToRun compilation, don't try to promote fields of types
         // outside of the current version bubble.
@@ -2761,7 +2761,7 @@ void Compiler::makeExtraStructQueries(CORINFO_CLASS_HANDLE structHandle, int lev
     assert(structHandle != NO_CLASS_HANDLE);
     (void)typGetObjLayout(structHandle);
     DWORD typeFlags = info.compCompHnd->getClassAttribs(structHandle);
-    if (StructHasNoPromotionFlagSet(typeFlags))
+    if (StructHasDontDigFieldsFlagSet(typeFlags))
     {
         // In AOT ReadyToRun compilation, don't query fields of types
         // outside of the current version bubble.

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2028,7 +2028,7 @@ namespace Internal.JitInterface
             if (!_compilation.CompilationModuleGroup.VersionsWithType(type))
             {
                 // Prevent the JIT from drilling into types outside of the current versioning bubble
-                result |= CorInfoFlag.CORINFO_FLG_DONT_PROMOTE;
+                result |= CorInfoFlag.CORINFO_FLG_DONT_DIG_FIELDS;
                 result &= ~CorInfoFlag.CORINFO_FLG_BEFOREFIELDINIT;
             }
 #endif

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -594,7 +594,7 @@ namespace Internal.JitInterface
         CORINFO_FLG_ARRAY = 0x00080000, // class is an array class (initialized differently)
         CORINFO_FLG_OVERLAPPING_FIELDS = 0x00100000, // struct or class has fields that overlap (aka union)
         CORINFO_FLG_INTERFACE = 0x00200000, // it is an interface
-        CORINFO_FLG_DONT_PROMOTE = 0x00400000, // don't try to promote fieds of types outside of AOT compilation version bubble
+        CORINFO_FLG_DONT_DIG_FIELDS = 0x00400000, // don't try to ask about fieds outside of AOT compilation version bubble
         CORINFO_FLG_CUSTOMLAYOUT = 0x00800000, // does this struct have custom layout?
         CORINFO_FLG_CONTAINS_GC_PTR = 0x01000000, // does the class contain a gc ptr ?
         CORINFO_FLG_DELEGATE = 0x02000000, // is this a subclass of delegate or multicast delegate ?

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -594,7 +594,7 @@ namespace Internal.JitInterface
         CORINFO_FLG_ARRAY = 0x00080000, // class is an array class (initialized differently)
         CORINFO_FLG_OVERLAPPING_FIELDS = 0x00100000, // struct or class has fields that overlap (aka union)
         CORINFO_FLG_INTERFACE = 0x00200000, // it is an interface
-        CORINFO_FLG_DONT_DIG_FIELDS = 0x00400000, // don't try to ask about fieds outside of AOT compilation version bubble
+        CORINFO_FLG_DONT_DIG_FIELDS = 0x00400000, // don't try to ask about fields outside of AOT compilation version bubble
         CORINFO_FLG_CUSTOMLAYOUT = 0x00800000, // does this struct have custom layout?
         CORINFO_FLG_CONTAINS_GC_PTR = 0x01000000, // does the class contain a gc ptr ?
         CORINFO_FLG_DELEGATE = 0x02000000, // is this a subclass of delegate or multicast delegate ?


### PR DESCRIPTION
Allow crossgen2 jit to promote structs like:
```
struct Foo
{
  Object o;
}
```
even when we can't ask about 'o' during crossgen2 compilation.


Some positive diffs:
```
Crossgen CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for  default jit

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 37372723
Total bytes of diff: 37201427
Total bytes of delta: -171296 (-0.46 % of base)
Total relative delta: NaN
    diff is an improvement.
    relative diff is a regression.


Top file regressions (bytes):
         169 : System.Reflection.MetadataLoadContext.dasm (0.10% of base)
          40 : System.IO.IsolatedStorage.dasm (0.26% of base)
           6 : Microsoft.Extensions.Hosting.Systemd.dasm (0.17% of base)
           4 : System.Linq.Expressions.dasm (0.00% of base)
           2 : Microsoft.Extensions.DependencyInjection.dasm (0.00% of base)

Top file improvements (bytes):
      -72878 : Microsoft.CodeAnalysis.VisualBasic.dasm (-1.52% of base)
      -59359 : Microsoft.CodeAnalysis.CSharp.dasm (-1.53% of base)
      -13336 : Microsoft.CodeAnalysis.dasm (-1.06% of base)
       -3757 : Newtonsoft.Json.dasm (-0.66% of base)
       -3121 : FSharp.Core.dasm (-0.31% of base)
       -3117 : System.Linq.Parallel.dasm (-1.02% of base)
       -2777 : System.Net.Http.dasm (-0.49% of base)
       -1725 : System.Private.DataContractSerialization.dasm (-0.26% of base)
       -1272 : Newtonsoft.Json.Bson.dasm (-1.79% of base)
       -1228 : System.Reflection.Metadata.dasm (-0.38% of base)
       -1145 : System.Threading.Tasks.Dataflow.dasm (-0.85% of base)
        -924 : System.Security.Cryptography.Pkcs.dasm (-0.29% of base)
        -739 : System.Net.Sockets.dasm (-0.44% of base)
        -576 : System.Net.Security.dasm (-0.35% of base)
        -463 : System.Collections.Concurrent.dasm (-1.06% of base)
        -403 : System.Threading.Channels.dasm (-1.27% of base)
        -340 : System.Threading.Tasks.Parallel.dasm (-1.03% of base)
        -295 : System.Security.Cryptography.dasm (-0.05% of base)
        -282 : System.Net.Http.WinHttpHandler.dasm (-0.35% of base)
        -218 : System.Private.Xml.Linq.dasm (-0.19% of base)

81 total files with Code Size differences (76 improved, 5 regressed), 192 unchanged.
```

the wins look as expected, for example, `Microsoft.CodeAnalysis.VisualBasic.Symbols.OverriddenMembersResult`1:.ctor(System.Collections.Immutable.ImmutableArray`1[System.__Canon],System.Collections.Immutable.ImmutableArray`1[System.__Canon],System.Collections.Immutable.ImmutableArray`1[System.__Canon]):this (MethodHash=18164335)`:
before:
```
; Total bytes of code 71, prolog size 3, PerfScore 28.10, instruction count 21, allocated bytes for code 71 (MethodHash=18164335) for method Microsoft.CodeAnalysis.VisualBasic.Symbols.OverriddenMembersResult`1:.ctor(System.Collections.Immutable.ImmutableArray`1[System.__Canon],System.Collections.Immutable.ImmutableArray`1[System.__Canon],System.Collections.Immutable.ImmutableArray`1[System.__Canon]):this
G_M48330_IG01:        ; func=00, offs=000000H, size=0015H, bbWeight=1    PerfScore 6.25, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref, nogc <-- Prolog IG
                                                                                                                                                            
IN000b: 000000 push     rdi
IN000c: 000001 push     rsi
IN000d: 000002 push     rbx
IN000e: 000003 mov      qword ptr [V01 rsp+28H], rdx
IN000f: 000008 mov      qword ptr [V02 rsp+30H], r8
IN0010: 00000D mov      qword ptr [V03 rsp+38H], r9
IN0011: 000012 mov      rbx, rcx

G_M48330_IG02:        ; offs=000015H, size=002EH, bbWeight=1    PerfScore 12.25, gcrefRegs=00000008 {rbx}, byrefRegs=00000000 {}, BB01 [0000], byref

IN0001: 000015 lea      rdi, bword ptr [rbx+8]
IN0002: 000019 lea      rsi, bword ptr [V01 rsp+28H]
IN0003: 00001E call     [CORINFO_HELP_ASSIGN_BYREF]
IN0004: 000024 lea      rdi, bword ptr [rbx+16]
IN0005: 000028 lea      rsi, bword ptr [V02 rsp+30H]
IN0006: 00002D call     [CORINFO_HELP_ASSIGN_BYREF]
IN0007: 000033 lea      rdi, bword ptr [rbx+24]
IN0008: 000037 lea      rsi, bword ptr [V03 rsp+38H]
IN0009: 00003C call     [CORINFO_HELP_ASSIGN_BYREF]
IN000a: 000042 nop      

G_M48330_IG03:        ; offs=000043H, size=0004H, bbWeight=1    PerfScore 2.50, epilog, nogc, extend

IN0012: 000043 pop      rbx
IN0013: 000044 pop      rsi
IN0014: 000045 pop      rdi
IN0015: 000046 ret
```

after:
```
; Total bytes of code 13, prolog size 0, PerfScore 5.30, instruction count 4, allocated bytes for code 13 (MethodHash=18164335) for method Microsoft.CodeAnalysis.VisualBasic.Symbols.OverriddenMembersResult`1:.ctor(System.Collections.Immutable.ImmutableArray`1[System.__Canon],System.Collections.Immutable.ImmutableArray`1[System.__Canon],System.Collections.Immutable.ImmutableArray`1[System.__Canon]):this
G_M48330_IG01:        ; func=00, offs=000000H, size=0000H, bbWeight=1    PerfScore 0.00, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref, nogc <-- Prolog IG

G_M48330_IG02:        ; offs=000000H, size=000CH, bbWeight=1    PerfScore 3.00, gcrefRegs=00000002 {rcx}, byrefRegs=00000304 {rdx r8 r9}, BB01 [0000], byref       
           
IN0001: 000000 mov      bword ptr [rcx+8], rdx
IN0002: 000004 mov      bword ptr [rcx+16], r8
IN0003: 000008 mov      bword ptr [rcx+24], r9

G_M48330_IG03:        ; offs=00000CH, size=0001H, bbWeight=1    PerfScore 1.00, epilog, nogc, extend        
                                    
IN0004: 00000C ret 
```

the regression are caused by some tail calls that we now reject because of this condition: https://github.com/dotnet/runtime/blob/3e01d11fd1722450d326f90b4913f3831ce132bb/src/coreclr/jit/morph.cpp#L7364