### PR TITLE
[WASM] Disable JIT/Methodical/NaN/r4nanconv_il_d and JIT/Methodical/NaN/r4nanconv_il_r

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3211,6 +3211,12 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/VT/callconv/jumps4_il_d/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/NaN/r4nanconv_il_d/**">
+            <Issue>https://github.com/dotnet/runtime/issues/65681</Issue>
+        </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/NaN/r4nanconv_il_r/**">
+            <Issue>https://github.com/dotnet/runtime/issues/65681</Issue>
+        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/NaN/r8nanconv_il_d/**">
             <Issue>needs triage</Issue>
         </ExcludeList>


### PR DESCRIPTION
This change is to disable `JIT/Methodical/NaN/r4nanconv_il_d` and `JIT/Methodical/NaN/r4nanconv_il_r` tests which have failed recently on the rolling build.

See https://github.com/dotnet/runtime/issues/65681