### PR TITLE
Fix scheduled search in issue cleanup automation

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -5420,37 +5420,72 @@
       "frequency": [
         {
           "weekDay": 0,
-          "hours": [],
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
           "timezoneOffset": 0
         },
         {
           "weekDay": 1,
-          "hours": [],
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
           "timezoneOffset": 0
         },
         {
           "weekDay": 2,
-          "hours": [],
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
           "timezoneOffset": 0
         },
         {
           "weekDay": 3,
-          "hours": [],
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
           "timezoneOffset": 0
         },
         {
           "weekDay": 4,
-          "hours": [],
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
           "timezoneOffset": 0
         },
         {
           "weekDay": 5,
-          "hours": [],
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
           "timezoneOffset": 0
         },
         {
           "weekDay": 6,
-          "hours": [],
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
           "timezoneOffset": 0
         }
       ],


### PR DESCRIPTION
It turns out that the automated issue cleanup rule I introduced in #65576 has not been configured properly: it does not set a frequency. Setting to 4 times a day to be consistent with the other scheduled searches we already have in place.