### PR TITLE
Draft for Min/Max intrinsics xarch (#65625)

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -7400,6 +7400,20 @@ void CodeGen::genIntrinsic(GenTree* treeNode)
     // Handle intrinsics that can be implemented by target-specific instructions
     switch (treeNode->AsIntrinsic()->gtIntrinsicName)
     {
+#ifdef TARGET_XARCH
+
+        case NI_System_Math_Max:
+            genConsumeOperands(treeNode->AsOp());
+            GetEmitter()->emitIns_R_R_R(INS_maxss, emitActualTypeSize(treeNode), treeNode->GetRegNum(),
+                                        treeNode->gtGetOp1()->GetRegNum(), treeNode->gtGetOp2()->GetRegNum());
+            break;
+
+        case NI_System_Math_Min:
+            genConsumeOperands(treeNode->AsOp());
+            GetEmitter()->emitIns_R_R_R(INS_minss, emitActualTypeSize(treeNode), treeNode->GetRegNum(),
+                                        treeNode->gtGetOp1()->GetRegNum(), treeNode->gtGetOp2()->GetRegNum());
+            break;
+#endif
         case NI_System_Math_Abs:
             genSSE2BitwiseOp(treeNode);
             break;

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -7403,16 +7403,20 @@ void CodeGen::genIntrinsic(GenTree* treeNode)
 #ifdef TARGET_XARCH
 
         case NI_System_Math_Max:
+        {
             genConsumeOperands(treeNode->AsOp());
-            GetEmitter()->emitIns_R_R_R(INS_maxss, emitActualTypeSize(treeNode), treeNode->GetRegNum(),
-                                        treeNode->gtGetOp1()->GetRegNum(), treeNode->gtGetOp2()->GetRegNum());
+            GetEmitter()->emitIns_SIMD_R_R_R(INS_maxss, emitActualTypeSize(treeNode), treeNode->GetRegNum(),
+                                             treeNode->gtGetOp1()->GetRegNum(), treeNode->gtGetOp2()->GetRegNum());
             break;
-
+        }
         case NI_System_Math_Min:
+        {
             genConsumeOperands(treeNode->AsOp());
-            GetEmitter()->emitIns_R_R_R(INS_minss, emitActualTypeSize(treeNode), treeNode->GetRegNum(),
-                                        treeNode->gtGetOp1()->GetRegNum(), treeNode->gtGetOp2()->GetRegNum());
+            GetEmitter()->emitIns_SIMD_R_R_R(INS_minss, emitActualTypeSize(treeNode), treeNode->GetRegNum(),
+                                             treeNode->gtGetOp1()->GetRegNum(), treeNode->gtGetOp2()->GetRegNum());
+
             break;
+        }
 #endif
         case NI_System_Math_Abs:
             genSSE2BitwiseOp(treeNode);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4492,13 +4492,14 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
             case NI_System_Math_Log:
             case NI_System_Math_Log2:
             case NI_System_Math_Log10:
-#ifdef TARGET_ARM64
+#if defined TARGET_ARM64 || defined TARGET_XARCH
             // ARM64 has fmax/fmin which are IEEE754:2019 minimum/maximum compatible
             // TODO-XARCH-CQ: Enable this for XARCH when one of the arguments is a constant
             // so we can then emit maxss/minss and avoid NaN/-0.0 handling
             case NI_System_Math_Max:
             case NI_System_Math_Min:
 #endif
+
             case NI_System_Math_Pow:
             case NI_System_Math_Round:
             case NI_System_Math_Sin:
@@ -20541,6 +20542,8 @@ bool Compiler::IsTargetIntrinsic(NamedIntrinsic intrinsicName)
 
         case NI_System_Math_Abs:
         case NI_System_Math_Sqrt:
+        case NI_System_Math_Max:
+        case NI_System_Math_Min:
             return true;
 
         case NI_System_Math_Ceiling:


### PR DESCRIPTION
I made the changes using [#65584](https://github.com/dotnet/runtime/pull/65584) as a referrence. It works with HelloWorld'sh code, but I'm stuck with building it via build.cmd. It doesn't want to compile and I can't figure out why. 
I face the errors:
```
Assertion failed 'IsThreeOperandAVXInstruction(ins)' in 'System.MathF:Min(float,float):float' during 'Generate code' (IL size 13)
Assertion failed 'IsThreeOperandAVXInstruction(ins)' in 'System.Single:System.INumber<System.Single>.Min(float,float):float' during 'Generate code' (IL size 8)
```
![image](https://user-images.githubusercontent.com/18483133/155118455-a9f5ace6-1bb2-43e9-ad34-05a198ad2e1e.png)
@EgorBo Could you please help me to figure out what I implemented wrong?