### PR TITLE
Host test error format

### DIFF
--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/DependencyResolutionCommandResultExtensions.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/DependencyResolutionCommandResultExtensions.cs
@@ -6,7 +6,6 @@ using FluentAssertions.Execution;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using TestUtils.Assertions;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
 {

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/DependencyResolutionCommandResultExtensions.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/DependencyResolutionCommandResultExtensions.cs
@@ -6,6 +6,7 @@ using FluentAssertions.Execution;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using TestUtils.Assertions;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
 {
@@ -22,7 +23,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             foreach (string value in values)
             {
                 Execute.Assertion.ForCondition(propertyValue != null && propertyValue.Contains(value))
-                    .FailWith("The property {0} doesn't contain expected value: {1}\n{2}\n{3}", propertyName, value, propertyValue, assertion.GetDiagnosticsInfo());
+                    .FailWithPreformatted($"The property {propertyName} doesn't contain expected value: '{value}'{Environment.NewLine}" +
+                        $"{propertyName}='{propertyValue}'" +
+                        $"{assertion.GetDiagnosticsInfo()}");
             }
 
             return new AndConstraint<CommandResultAssertions>(assertion);
@@ -35,7 +38,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             foreach (string value in values)
             {
                 Execute.Assertion.ForCondition(propertyValue != null && !propertyValue.Contains(value))
-                    .FailWith("The property {0} contains unexpected value: {1}\n{2}\n{3}", propertyName, value, propertyValue, assertion.GetDiagnosticsInfo());
+                    .FailWithPreformatted($"The property {propertyName} contains unexpected value: '{value}'{Environment.NewLine}" +
+                        $"{propertyName}='{propertyValue}'" +
+                        $"{assertion.GetDiagnosticsInfo()}");
             }
 
             return new AndConstraint<CommandResultAssertions>(assertion);
@@ -80,7 +85,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             foreach (string value in values)
             {
                 Execute.Assertion.ForCondition(propertyValue != null && propertyValue.Contains(value))
-                    .FailWith("The resolved {0} doesn't contain expected value: {1}\n{2}\n{3}", propertyName, value, propertyValue, assertion.GetDiagnosticsInfo());
+                    .FailWithPreformatted($"The resolved {propertyName} doesn't contain expected value: '{value}'{Environment.NewLine}" +
+                        $"{propertyName}='{propertyValue}'" +
+                        $"{assertion.GetDiagnosticsInfo()}");
             }
 
             return new AndConstraint<CommandResultAssertions>(assertion);
@@ -96,7 +103,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             foreach (string value in values)
             {
                 Execute.Assertion.ForCondition(propertyValue != null && !propertyValue.Contains(value))
-                    .FailWith("The resolved {0} contains unexpected value: {1}\n{2}\n{3}", propertyName, value, propertyValue, assertion.GetDiagnosticsInfo());
+                    .FailWithPreformatted($"The resolved {propertyName} contains unexpected value: '{value}'{Environment.NewLine}" +
+                        $"{propertyName}='{propertyValue}'" +
+                        $"{assertion.GetDiagnosticsInfo()}");
             }
 
             return new AndConstraint<CommandResultAssertions>(assertion);

--- a/src/installer/tests/TestUtils/Assertions/AssertionScopeExtensions.cs
+++ b/src/installer/tests/TestUtils/Assertions/AssertionScopeExtensions.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions.Execution;
+
+namespace TestUtils.Assertions
+{
+    public static class AssertionScopeExtensions
+    {
+        public static Continuation FailWithPreformatted(this AssertionScope assertionScope, string message)
+        {
+            if (!assertionScope.Succeeded)
+            {
+                assertionScope.AddFailure(message);
+            }
+
+            return new Continuation(assertionScope, assertionScope.Succeeded);
+        }
+    }
+}

--- a/src/installer/tests/TestUtils/Assertions/AssertionScopeExtensions.cs
+++ b/src/installer/tests/TestUtils/Assertions/AssertionScopeExtensions.cs
@@ -3,7 +3,7 @@
 
 using FluentAssertions.Execution;
 
-namespace TestUtils.Assertions
+namespace Microsoft.DotNet.CoreSetup.Test
 {
     public static class AssertionScopeExtensions
     {

--- a/src/installer/tests/TestUtils/Assertions/CommandResultAssertions.cs
+++ b/src/installer/tests/TestUtils/Assertions/CommandResultAssertions.cs
@@ -6,7 +6,6 @@ using System.Text.RegularExpressions;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.DotNet.Cli.Build.Framework;
-using TestUtils.Assertions;
 
 namespace Microsoft.DotNet.CoreSetup.Test
 {

--- a/src/installer/tests/TestUtils/Assertions/CommandResultAssertions.cs
+++ b/src/installer/tests/TestUtils/Assertions/CommandResultAssertions.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.DotNet.Cli.Build.Framework;
+using TestUtils.Assertions;
 
 namespace Microsoft.DotNet.CoreSetup.Test
 {
@@ -21,105 +22,105 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public AndConstraint<CommandResultAssertions> ExitWith(int expectedExitCode)
         {
             Execute.Assertion.ForCondition(Result.ExitCode == expectedExitCode)
-                .FailWith("Expected command to exit with {0} but it did not.{1}", expectedExitCode, GetDiagnosticsInfo());
+                .FailWithPreformatted($"Expected command to exit with {expectedExitCode} but it did not.{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> Pass()
         {
             Execute.Assertion.ForCondition(Result.ExitCode == 0)
-                .FailWith("Expected command to pass but it did not.{0}", GetDiagnosticsInfo());
+                .FailWithPreformatted($"Expected command to pass but it did not.{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> Fail()
         {
             Execute.Assertion.ForCondition(Result.ExitCode != 0)
-                .FailWith("Expected command to fail but it did not.{0}", GetDiagnosticsInfo());
+                .FailWithPreformatted($"Expected command to fail but it did not.{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> HaveStdOut()
         {
             Execute.Assertion.ForCondition(!string.IsNullOrEmpty(Result.StdOut))
-                .FailWith("Command did not output anything to stdout{0}", GetDiagnosticsInfo());
+                .FailWithPreformatted($"Command did not output anything to stdout{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> HaveStdOut(string expectedOutput)
         {
             Execute.Assertion.ForCondition(Result.StdOut.Equals(expectedOutput, StringComparison.Ordinal))
-                .FailWith("Command did not output with Expected Output. Expected: {0}{1}", expectedOutput, GetDiagnosticsInfo());
+                .FailWithPreformatted($"Command did not output with Expected Output. Expected: '{expectedOutput}'{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> HaveStdOutContaining(string pattern)
         {
             Execute.Assertion.ForCondition(Result.StdOut.Contains(pattern))
-                .FailWith("The command output did not contain expected result: {0}{1}", pattern, GetDiagnosticsInfo());
+                .FailWithPreformatted($"The command output did not contain expected result: '{pattern}'{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> NotHaveStdOutContaining(string pattern)
         {
             Execute.Assertion.ForCondition(!Result.StdOut.Contains(pattern))
-                .FailWith("The command output contained a result it should not have contained: {0}{1}", pattern, GetDiagnosticsInfo());
+                .FailWithPreformatted($"The command output contained a result it should not have contained: '{pattern}'{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> HaveStdOutMatching(string pattern, RegexOptions options = RegexOptions.None)
         {
             Execute.Assertion.ForCondition(Regex.Match(Result.StdOut, pattern, options).Success)
-                .FailWith("Matching the command output failed. Pattern: {0}{1}", pattern, GetDiagnosticsInfo());
+                .FailWithPreformatted($"Matching the command output failed. Pattern: '{pattern}'{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> HaveStdErr()
         {
             Execute.Assertion.ForCondition(!string.IsNullOrEmpty(Result.StdErr))
-                .FailWith("Command did not output anything to stderr.{0}", GetDiagnosticsInfo());
+                .FailWithPreformatted($"Command did not output anything to stderr.{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> HaveStdErrContaining(string pattern)
         {
             Execute.Assertion.ForCondition(Result.StdErr.Contains(pattern))
-                .FailWith("The command error output did not contain expected result: {0}{1}", pattern, GetDiagnosticsInfo());
+                .FailWithPreformatted($"The command error output did not contain expected result: '{pattern}'{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> NotHaveStdErrContaining(string pattern)
         {
             Execute.Assertion.ForCondition(!Result.StdErr.Contains(pattern))
-                .FailWith("The command error output contained a result it should not have contained: {0}{1}", pattern, GetDiagnosticsInfo());
+                .FailWithPreformatted($"The command error output contained a result it should not have contained: '{pattern}'{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> HaveStdErrMatching(string pattern, RegexOptions options = RegexOptions.None)
         {
             Execute.Assertion.ForCondition(Regex.Match(Result.StdErr, pattern, options).Success)
-                .FailWith("Matching the command error output failed. Pattern: {0}{1}", pattern, GetDiagnosticsInfo());
+                .FailWithPreformatted($"Matching the command error output failed. Pattern: '{pattern}'{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> NotHaveStdOut()
         {
             Execute.Assertion.ForCondition(string.IsNullOrEmpty(Result.StdOut))
-                .FailWith("Expected command to not output to stdout but it was not:{0}", GetDiagnosticsInfo());
+                .FailWithPreformatted($"Expected command to not output to stdout but it was not:{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> NotHaveStdErr()
         {
             Execute.Assertion.ForCondition(string.IsNullOrEmpty(Result.StdErr))
-                .FailWith("Expected command to not output to stderr but it was not:{0}", GetDiagnosticsInfo());
+                .FailWithPreformatted($"Expected command to not output to stderr but it was not:{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> FileExists(string path)
         {
             Execute.Assertion.ForCondition(System.IO.File.Exists(path))
-                .FailWith("The command did not write the expected file: {0}{1}", path, GetDiagnosticsInfo());
+                .FailWithPreformatted($"The command did not write the expected file: '{path}'{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
@@ -127,7 +128,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         {
             string fileContent = System.IO.File.ReadAllText(path);
             Execute.Assertion.ForCondition(fileContent.Contains(pattern))
-                .FailWith("The command did not write the expected result '{0}' to the file: {1}{2}\nfile content: {3}", pattern, path, GetDiagnosticsInfo(), fileContent);
+                .FailWithPreformatted($"The command did not write the expected result '{pattern}' to the file: '{path}'{GetDiagnosticsInfo()}{Environment.NewLine}file content: >>{fileContent}<<");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
@@ -135,7 +136,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         {
             string fileContent = System.IO.File.ReadAllText(path);
             Execute.Assertion.ForCondition(!fileContent.Contains(pattern))
-                .FailWith("The command did not write the expected result '{1}' to the file: {1}{2}\nfile content: {3}", pattern, path, GetDiagnosticsInfo(), fileContent);
+                .FailWithPreformatted($"The command did not write the expected result '{pattern}' to the file: '{path}'{GetDiagnosticsInfo()}{Environment.NewLine}file content: >>{fileContent}<<");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 

--- a/src/installer/tests/TestUtils/Assertions/DirectoryInfoAssertions.cs
+++ b/src/installer/tests/TestUtils/Assertions/DirectoryInfoAssertions.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using TestUtils.Assertions;
 
 namespace Microsoft.DotNet.CoreSetup.Test
 {

--- a/src/installer/tests/TestUtils/Assertions/DirectoryInfoAssertions.cs
+++ b/src/installer/tests/TestUtils/Assertions/DirectoryInfoAssertions.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using TestUtils.Assertions;
 
 namespace Microsoft.DotNet.CoreSetup.Test
 {
@@ -24,7 +25,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public AndConstraint<DirectoryInfoAssertions> Exist()
         {
             Execute.Assertion.ForCondition(_dirInfo.Exists)
-                .FailWith("Expected directory {0} does not exist.", _dirInfo.FullName);
+                .FailWithPreformatted($"Expected directory '{_dirInfo.FullName}' does not exist.");
             return new AndConstraint<DirectoryInfoAssertions>(this);
         }
 
@@ -32,7 +33,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         {
             var file = _dirInfo.EnumerateFiles(expectedFile, SearchOption.TopDirectoryOnly).SingleOrDefault();
             Execute.Assertion.ForCondition(file != null)
-                .FailWith("Expected File {0} cannot be found in directory {1}.", expectedFile, _dirInfo.FullName);
+                .FailWithPreformatted($"Expected File '{expectedFile}' cannot be found in directory '{_dirInfo.FullName}.");
             return new AndConstraint<DirectoryInfoAssertions>(this);
         }
 
@@ -40,7 +41,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         {
             var file = _dirInfo.EnumerateFiles(expectedFile, SearchOption.TopDirectoryOnly).SingleOrDefault();
             Execute.Assertion.ForCondition(file == null)
-                .FailWith("File {0} should not be found in directory {1}.", expectedFile, _dirInfo.FullName);
+                .FailWithPreformatted($"File '{expectedFile}' should not be found in directory '{_dirInfo.FullName}'.");
             return new AndConstraint<DirectoryInfoAssertions>(this);
         }
 
@@ -68,7 +69,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         {
             var dir = _dirInfo.EnumerateDirectories(expectedDir, SearchOption.TopDirectoryOnly).SingleOrDefault();
             Execute.Assertion.ForCondition(dir != null)
-                .FailWith("Expected directory {0} cannot be found inside directory {1}.", expectedDir, _dirInfo.FullName);
+                .FailWithPreformatted($"Expected directory '{expectedDir}' cannot be found inside directory '{_dirInfo.FullName}'.");
 
             return new AndConstraint<DirectoryInfoAssertions>(new DirectoryInfoAssertions(dir));
         }
@@ -77,7 +78,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         {
             var dir = _dirInfo.EnumerateDirectories(expectedDir, SearchOption.TopDirectoryOnly).SingleOrDefault();
             Execute.Assertion.ForCondition(dir == null)
-                .FailWith("Directory {0} should not be found in found inside directory {1}.", expectedDir, _dirInfo.FullName);
+                .FailWithPreformatted($"Directory '{expectedDir}' should not be found in found inside directory '{_dirInfo.FullName}'.");
 
             return new AndConstraint<DirectoryInfoAssertions>(new DirectoryInfoAssertions(dir));
         }
@@ -90,10 +91,10 @@ namespace Microsoft.DotNet.CoreSetup.Test
             var nl = Environment.NewLine;
 
             Execute.Assertion.ForCondition(!missingFiles.Any())
-                .FailWith($"Following files cannot be found inside directory {_dirInfo.FullName} {nl} {string.Join(nl, missingFiles)}");
+                .FailWithPreformatted($"Following files cannot be found inside directory {_dirInfo.FullName} {nl} {string.Join(nl, missingFiles)}");
 
             Execute.Assertion.ForCondition(!extraFiles.Any())
-                .FailWith($"Following extra files are found inside directory {_dirInfo.FullName} {nl} {string.Join(nl, extraFiles)}");
+                .FailWithPreformatted($"Following extra files are found inside directory {_dirInfo.FullName} {nl} {string.Join(nl, extraFiles)}");
 
             return new AndConstraint<DirectoryInfoAssertions>(this);
         }
@@ -104,7 +105,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             DateTime writeTime = _dirInfo.LastWriteTimeUtc;
 
             Execute.Assertion.ForCondition(writeTime <= timeUtc)
-                .FailWith("Directory {0} should not be modified after {1}, but is modified at {2}.", _dirInfo.FullName, timeUtc, writeTime);
+                .FailWithPreformatted($"Directory '{_dirInfo.FullName}' should not be modified after {timeUtc}, but is modified at {writeTime}.");
 
             return new AndConstraint<DirectoryInfoAssertions>(this);
         }


### PR DESCRIPTION
The host tests use FluentAssertions which has its own implementation of string formatting, for things like `FailWith("Some {0}", "message\r\nline")`. Instead of taking the string replacement as-is, it formats it by wrapping it in double quotes and replaces newlines with escaped values, so the above would output:
```
Some "message\r\nline"
```

This makes the test output quite hard to read without formatting it back (by unescaping the newlines).

Unfortunately FluentAssertions tries hard to always run the value through its own formatter. So even if we preformat everything and instead call `FailWith($"Some {"message\r\nline"})` it only works sometimes. The string is still parsed and the parser may fail if it finds for example only an open `{` without a closing one. This makes it nest to useless as we would have to make sure to somehow escape everything we feed in.

So this change introduces a new extension method `FailWithPreformatted` which circumvents the automatic formatting and uses the underlying `AddFailure` method which will not format anything.