### PR TITLE
[release/6.0] Build a new version of System.Runtime.Experimental with the correct assembly version

### DIFF
--- a/src/libraries/System.Runtime.Experimental/ref/System.Runtime.Experimental.csproj
+++ b/src/libraries/System.Runtime.Experimental/ref/System.Runtime.Experimental.csproj
@@ -17,7 +17,8 @@
     <BuildOutputTargetFolder>ref</BuildOutputTargetFolder>
     <DefineConstants>$(DefineConstants);FEATURE_GENERIC_MATH</DefineConstants>
     <IsPackable>true</IsPackable>
-    <ServicingVersion>1</ServicingVersion>
+    <ServicingVersion>2</ServicingVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageDescription>Exposes new experimental APIs from System.Runtime</PackageDescription>
     <PackageId>$(MSBuildProjectName)</PackageId>
     <!-- TODO: Remove when the package shipped with NET6. -->


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/65018

We already merged the fix to generate the correct assembly version for this package in: https://github.com/dotnet/runtime/commit/826c3d7a522202f05cc8653781794c4937637018