### PR TITLE
Centralize regex tree analysis for atomic/capture/backtracking detection

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/System.Text.RegularExpressions.Generator.csproj
+++ b/src/libraries/System.Text.RegularExpressions/gen/System.Text.RegularExpressions.Generator.csproj
@@ -44,6 +44,7 @@
     <Compile Include="..\src\System\Text\RegularExpressions\RegexParser.cs" Link="Production\RegexParser.cs" />
     <Compile Include="..\src\System\Text\RegularExpressions\RegexPrefixAnalyzer.cs" Link="Production\RegexPrefixAnalyzer.cs" />
     <Compile Include="..\src\System\Text\RegularExpressions\RegexTree.cs" Link="Production\RegexTree.cs" />
+    <Compile Include="..\src\System\Text\RegularExpressions\RegexTreeAnalyzer.cs" Link="Production\RegexTreeAnalyzer.cs" />
     <Compile Include="..\src\System\Text\RegularExpressions\RegexWriter.cs" Link="Production\RegexWriter.cs" />
     <Compile Include="..\src\System\Collections\HashtableExtensions.cs" Link="Production\HashtableExtensions.cs" />
   </ItemGroup>

--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -44,6 +44,7 @@
     <Compile Include="System\Text\RegularExpressions\RegexRunner.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexRunnerFactory.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexTree.cs" />
+    <Compile Include="System\Text\RegularExpressions\RegexTreeAnalyzer.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexWriter.cs" />
     <Compile Include="System\Text\RegularExpressions\ThrowHelper.cs" />
     <!-- RegexOptions.Compiled -->

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -1051,7 +1051,6 @@ namespace System.Text.RegularExpressions
             // Skip the Capture node. We handle the implicit root capture specially.
             node = node.Child(0);
 
-
             // In some limited cases, FindFirstChar will only return true if it successfully matched the whole expression.
             // We can special case these to do essentially nothing in Go other than emit the capture.
             switch (node.Kind)
@@ -1126,8 +1125,13 @@ namespace System.Text.RegularExpressions
             int sliceStaticPos = 0;
             SliceInputSpan();
 
+            AnalysisResults analysis = RegexTreeAnalyzer.Analyze(_code);
+
+            // Check whether there are captures anywhere in the expression. If there isn't, we can skip all
+            // the boilerplate logic around uncapturing, as there won't be anything to uncapture.
+            bool expressionHasCaptures = analysis.MayContainCapture(node);
+
             // Emit the code for all nodes in the tree.
-            bool expressionHasCaptures = (node.Options & RegexNode.HasCapturesFlag) != 0;
             EmitNode(node);
 
             // Success:
@@ -1281,7 +1285,7 @@ namespace System.Text.RegularExpressions
                 // successfully prevent backtracking into this child node, we can emit better / cheaper code
                 // for an Alternate when it is atomic, so we still take it into account here.
                 Debug.Assert(node.Parent is not null);
-                bool isAtomic = node.IsAtomicByParent();
+                bool isAtomic = analysis.IsAtomicByAncestor(node);
 
                 // Label to jump to when any branch completes successfully.
                 Label matchLabel = DefineLabel();
@@ -1314,7 +1318,7 @@ namespace System.Text.RegularExpressions
                 // what they were at the start of the alternation.  Of course, if there are no captures
                 // anywhere in the regex, we don't have to do any of that.
                 LocalBuilder? startingCapturePos = null;
-                if (expressionHasCaptures && ((node.Options & RegexNode.HasCapturesFlag) != 0 || !isAtomic))
+                if (expressionHasCaptures && (analysis.MayContainCapture(node) || !isAtomic))
                 {
                     // startingCapturePos = base.Crawlpos();
                     startingCapturePos = DeclareInt32();
@@ -1541,7 +1545,7 @@ namespace System.Text.RegularExpressions
                 Debug.Assert(node.Kind is RegexNodeKind.BackreferenceConditional, $"Unexpected type: {node.Kind}");
                 Debug.Assert(node.ChildCount() == 2, $"Expected 2 children, found {node.ChildCount()}");
 
-                bool isAtomic = node.IsAtomicByParent();
+                bool isAtomic = analysis.IsAtomicByAncestor(node);
 
                 // We're branching in a complicated fashion.  Make sure sliceStaticPos is 0.
                 TransferSliceStaticPosToPos();
@@ -1687,7 +1691,7 @@ namespace System.Text.RegularExpressions
                 Debug.Assert(node.Kind is RegexNodeKind.ExpressionConditional, $"Unexpected type: {node.Kind}");
                 Debug.Assert(node.ChildCount() == 3, $"Expected 3 children, found {node.ChildCount()}");
 
-                bool isAtomic = node.IsAtomicByParent();
+                bool isAtomic = analysis.IsAtomicByAncestor(node);
 
                 // We're branching in a complicated fashion.  Make sure sliceStaticPos is 0.
                 TransferSliceStaticPosToPos();
@@ -1718,7 +1722,7 @@ namespace System.Text.RegularExpressions
 
                 // If the condition expression has captures, we'll need to uncapture them in the case of no match.
                 LocalBuilder? startingCapturePos = null;
-                if ((condition.Options & RegexNode.HasCapturesFlag) != 0)
+                if (analysis.MayContainCapture(condition))
                 {
                     // int startingCapturePos = base.Crawlpos();
                     startingCapturePos = DeclareInt32();
@@ -1869,7 +1873,7 @@ namespace System.Text.RegularExpressions
 
                 int capnum = RegexParser.MapCaptureNumber(node.M, _code!.Caps);
                 int uncapnum = RegexParser.MapCaptureNumber(node.N, _code.Caps);
-                bool isAtomic = node.IsAtomicByParent();
+                bool isAtomic = analysis.IsAtomicByAncestor(node);
 
                 // pos += sliceStaticPos;
                 // slice = slice.Slice(sliceStaticPos);
@@ -1920,8 +1924,21 @@ namespace System.Text.RegularExpressions
                     Call(s_transferCaptureMethod);
                 }
 
-                if (!isAtomic && (childBacktracks || node.IsInLoop()))
+                if (isAtomic || !childBacktracks)
                 {
+                    // If the capture is atomic and nothing can backtrack into it, we're done.
+                    // Similarly, even if the capture isn't atomic, if the captured expression
+                    // doesn't do any backtracking, we're done.
+                    doneLabel = originalDoneLabel;
+                }
+                else
+                {
+                    // We're not atomic and the child node backtracks.  When it does, we need
+                    // to ensure that the starting position for the capture is appropriately
+                    // reset to what it was initially (it could have changed as part of being
+                    // in a loop or similar).  So, we emit a backtracking section that
+                    // pushes/pops the starting position before falling through.
+
                     // if (stackpos + 1 >= base.runstack.Length) Array.Resize(ref base.runstack, base.runstack.Length * 2);
                     // base.runstack[stackpos++] = startingPos;
                     EmitStackResizeIfNeeded(1);
@@ -1950,10 +1967,6 @@ namespace System.Text.RegularExpressions
 
                     doneLabel = backtrack;
                     MarkLabel(backtrackingEnd);
-                }
-                else
-                {
-                    doneLabel = originalDoneLabel;
                 }
             }
 
@@ -2052,21 +2065,6 @@ namespace System.Text.RegularExpressions
 
                 doneLabel = originalDoneLabel;
             }
-
-            // TODO https://github.com/dotnet/runtime/issues/62451:
-            // Replace this with a more robust mechanism.
-            static bool PossiblyBacktracks(RegexNode node) => !(
-                // Certain nodes will never backtrack out of them
-                node.Kind is RegexNodeKind.Atomic or // atomic nodes by definition don't give up anything
-                             RegexNodeKind.Oneloopatomic or RegexNodeKind.Notoneloopatomic or RegexNodeKind.Setloopatomic or // same for atomic loops
-                             RegexNodeKind.One or RegexNodeKind.Notone or RegexNodeKind.Set or // individual characters don't backtrack
-                             RegexNodeKind.Multi or // multiple characters don't backtrack
-                             RegexNodeKind.Backreference or // backreferences don't backtrack
-                             RegexNodeKind.Beginning or RegexNodeKind.Bol or RegexNodeKind.Start or RegexNodeKind.End or RegexNodeKind.EndZ or RegexNodeKind.Eol or RegexNodeKind.Boundary or RegexNodeKind.NonBoundary or RegexNodeKind.ECMABoundary or RegexNodeKind.NonECMABoundary or // anchors don't backtrack
-                             RegexNodeKind.Nothing or RegexNodeKind.Empty or RegexNodeKind.UpdateBumpalong // empty/nothing don't do anything
-                // Fixed-size repeaters of single characters or atomic don't backtrack
-                || node.Kind is RegexNodeKind.Oneloop or RegexNodeKind.Notoneloop or RegexNodeKind.Setloop or RegexNodeKind.Onelazy or RegexNodeKind.Notonelazy or RegexNodeKind.Setlazy && node.M == node.N
-                );
 
             // Emits the code for the node.
             void EmitNode(RegexNode node, RegexNode? subsequent = null, bool emitLengthChecksIfRequired = true)
@@ -2690,7 +2688,7 @@ namespace System.Text.RegularExpressions
 
                 // If the whole thing was actually that repeater, we're done. Similarly, if this is actually an atomic
                 // lazy loop, nothing will ever backtrack into this node, so we never need to iterate more than the minimum.
-                if (node.M == node.N || node.IsAtomicByParent())
+                if (node.M == node.N || analysis.IsAtomicByAncestor(node))
                 {
                     return;
                 }
@@ -2917,7 +2915,7 @@ namespace System.Text.RegularExpressions
 
                 if (node.IsInLoop())
                 {
-                    // Store the capture's state
+                    // Store the loop's state
                     // base.runstack[stackpos++] = startingPos;
                     // base.runstack[stackpos++] = capturepos;
                     // base.runstack[stackpos++] = iterationCount;
@@ -2936,7 +2934,7 @@ namespace System.Text.RegularExpressions
                     Label backtrackingEnd = DefineLabel();
                     BrFar(backtrackingEnd);
 
-                    // Emit a backtracking section that restores the capture's state and then jumps to the previous done label
+                    // Emit a backtracking section that restores the loop's state and then jumps to the previous done label
                     Label backtrack = DefineLabel();
                     MarkLabel(backtrack);
 
@@ -2974,7 +2972,7 @@ namespace System.Text.RegularExpressions
                 int minIterations = node.M;
                 int maxIterations = node.N;
                 Label originalDoneLabel = doneLabel;
-                bool isAtomic = node.IsAtomicByParent();
+                bool isAtomic = analysis.IsAtomicByAncestor(node);
 
                 // If this is actually an atomic lazy loop, we need to output just the minimum number of iterations,
                 // as nothing will backtrack into the lazy loop to get it progress further.
@@ -2995,7 +2993,7 @@ namespace System.Text.RegularExpressions
 
                 // If this is actually a repeater and the child doesn't have any backtracking in it that might
                 // cause us to need to unwind already taken iterations, just output it as a repeater loop.
-                if (minIterations == maxIterations && !PossiblyBacktracks(node.Child(0)))
+                if (minIterations == maxIterations && !analysis.MayBacktrack(node.Child(0)))
                 {
                     EmitNonBacktrackingRepeater(node);
                     return;
@@ -3617,7 +3615,7 @@ namespace System.Text.RegularExpressions
                 Debug.Assert(node.M < int.MaxValue, $"Unexpected M={node.M}");
                 Debug.Assert(node.M == node.N, $"Unexpected M={node.M} == N={node.N}");
                 Debug.Assert(node.ChildCount() == 1, $"Expected 1 child, found {node.ChildCount()}");
-                Debug.Assert(!PossiblyBacktracks(node.Child(0)), $"Expected non-backtracking node {node.Kind}");
+                Debug.Assert(!analysis.MayBacktrack(node.Child(0)), $"Expected non-backtracking node {node.Kind}");
 
                 // Ensure every iteration of the loop sees a consistent value.
                 TransferSliceStaticPosToPos();
@@ -3658,11 +3656,11 @@ namespace System.Text.RegularExpressions
 
                 int minIterations = node.M;
                 int maxIterations = node.N;
-                bool isAtomic = node.IsAtomicByParent();
+                bool isAtomic = analysis.IsAtomicByAncestor(node);
 
                 // If this is actually a repeater and the child doesn't have any backtracking in it that might
                 // cause us to need to unwind already taken iterations, just output it as a repeater loop.
-                if (minIterations == maxIterations && !PossiblyBacktracks(node.Child(0)))
+                if (minIterations == maxIterations && !analysis.MayBacktrack(node.Child(0)))
                 {
                     EmitNonBacktrackingRepeater(node);
                     return;
@@ -3865,7 +3863,7 @@ namespace System.Text.RegularExpressions
 
                     if (node.IsInLoop())
                     {
-                        // Store the capture's state
+                        // Store the loop's state
                         EmitStackResizeIfNeeded(3);
                         EmitStackPush(() => Ldloc(startingPos));
                         EmitStackPush(() => Ldloc(iterationCount));
@@ -3875,7 +3873,7 @@ namespace System.Text.RegularExpressions
                         Label backtrackingEnd = DefineLabel();
                         BrFar(backtrackingEnd);
 
-                        // Emit a backtracking section that restores the capture's state and then jumps to the previous done label
+                        // Emit a backtracking section that restores the loop's state and then jumps to the previous done label
                         Label backtrack = DefineLabel();
                         MarkLabel(backtrack);
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
@@ -60,9 +60,5 @@ namespace System.Text.RegularExpressions
         /// the top-level match.
         /// </remarks>
         NonBacktracking         = 0x0400,
-
-        // RegexCompiler internally uses 0x80000000 for its own internal purposes.
-        // If such a value ever needs to be added publicly, RegexCompiler will need
-        // to be changed to avoid it.
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTreeAnalyzer.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTreeAnalyzer.cs
@@ -1,0 +1,169 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Threading;
+
+namespace System.Text.RegularExpressions
+{
+    /// <summary>Analyzes a <see cref="RegexTree"/> of <see cref="RegexNode"/>s to produce data on the tree structure, in particular in support of code generation.</summary>
+    internal static class RegexTreeAnalyzer
+    {
+        /// <summary>Analyzes a <see cref="RegexCode"/> to learn about the structure of the tree.</summary>
+        public static AnalysisResults Analyze(RegexCode code)
+        {
+            var results = new AnalysisResults(code);
+            results._complete = TryAnalyze(code.Tree.Root, results, isAtomicBySelfOrParent: true);
+            return results;
+
+            static bool TryAnalyze(RegexNode node, AnalysisResults results, bool isAtomicBySelfOrParent)
+            {
+                if (!StackHelper.TryEnsureSufficientExecutionStack())
+                {
+                    return false;
+                }
+
+                if (isAtomicBySelfOrParent)
+                {
+                    // We've been told by our parent that we should be considered atomic, so add ourselves
+                    // to the atomic collection.
+                    results._isAtomicByAncestor.Add(node);
+                }
+                else
+                {
+                    // Certain kinds of nodes incur backtracking logic themselves: add them to the backtracking collection.
+                    // We may later find that a node contains another that has backtracking; we'll add nodes based on that
+                    // after examining the children.
+                    switch (node.Kind)
+                    {
+                        case RegexNodeKind.Alternate:
+                        case RegexNodeKind.Loop or RegexNodeKind.Lazyloop when node.M != node.N:
+                        case RegexNodeKind.Oneloop or RegexNodeKind.Notoneloop or RegexNodeKind.Setloop or RegexNodeKind.Onelazy or RegexNodeKind.Notonelazy or RegexNodeKind.Setlazy when node.M != node.N:
+                            (results._mayBacktrack ??= new()).Add(node);
+                            break;
+                    }
+                }
+
+                // Update state for certain node types.
+                switch (node.Kind)
+                {
+                    // Some node types add atomicity around what they wrap.  Set isAtomicBySelfOrParent to true for such nodes
+                    // even if it was false upon entering the method.
+                    case RegexNodeKind.Atomic:
+                    case RegexNodeKind.NegativeLookaround:
+                    case RegexNodeKind.PositiveLookaround:
+                        isAtomicBySelfOrParent = true;
+                        break;
+
+                    // Track any nodes that are themselves captures.
+                    case RegexNodeKind.Capture:
+                        results._containsCapture.Add(node);
+                        break;
+                }
+
+                // Process each child.
+                int childCount = node.ChildCount();
+                for (int i = 0; i < childCount; i++)
+                {
+                    RegexNode child = node.Child(i);
+
+                    // Determine whether the child should be treated as atomic (whether anything
+                    // can backtrack into it), which is influenced by whether this node (the child's
+                    // parent) is considered atomic by itself or by its parent.
+                    bool treatChildAsAtomic = isAtomicBySelfOrParent && node.Kind switch
+                    {
+                        // If the parent is atomic, so is the child.  That's the whole purpose
+                        // of the Atomic node, and lookarounds are also implicitly atomic.
+                        RegexNodeKind.Atomic or RegexNodeKind.NegativeLookaround or RegexNodeKind.PositiveLookaround => true,
+
+                        // Each branch is considered independently, so any atomicity applied to the alternation also applies
+                        // to each individual branch.  This is true as well for conditionals.
+                        RegexNodeKind.Alternate or RegexNodeKind.BackreferenceConditional or RegexNodeKind.ExpressionConditional => true,
+
+                        // Captures don't impact atomicity: if the parent of a capture is atomic, the capture is also atomic.
+                        RegexNodeKind.Capture => true,
+
+                        // If the parent is a concatenation and this is the last node, any atomicity
+                        // applying to the concatenation applies to this node, too.
+                        RegexNodeKind.Concatenate => i == childCount - 1,
+
+                        // For loops with a max iteration count of 1, they themselves can be considered
+                        // atomic as can whatever they wrap, as they won't ever iterate more than once
+                        // and thus we don't need to worry about one iteration consuming input destined
+                        // for a subsequent iteration.
+                        RegexNodeKind.Loop or RegexNodeKind.Lazyloop when node.N == 1 => true,
+
+                        // For any other parent type, give up on trying to prove atomicity.
+                        _ => false,
+                    };
+
+                    // Now analyze the child.
+                    if (!TryAnalyze(child, results, treatChildAsAtomic))
+                    {
+                        return false;
+                    }
+
+                    // If the child contains captures, so too does this parent.
+                    if (results.MayContainCapture(child))
+                    {
+                        results._containsCapture.Add(node);
+                    }
+
+                    // If the child might require backtracking into it, so too might the parent,
+                    // unless the parent is itself considered atomic.
+                    if (!isAtomicBySelfOrParent && results.MayBacktrack(child))
+                    {
+                        (results._mayBacktrack ??= new()).Add(node);
+                    }
+                }
+
+                // Successfully analyzed the node.
+                return true;
+            }
+        }
+    }
+
+    /// <summary>Provides results of a tree analysis.</summary>
+    internal sealed class AnalysisResults
+    {
+        /// <summary>Indicates whether the whole tree was successfully processed.</summary>
+        /// <remarks>
+        /// If it wasn't successfully processed, we have to assume the "worst", e.g. if it's
+        /// false, we need to assume we didn't fully determine which nodes contain captures,
+        /// and thus we need to assume they all do and not discard logic necessary to support
+        /// captures.  It should be exceedingly rare that this is false.
+        /// </remarks>
+        internal bool _complete;
+
+        /// <summary>Set of nodes that are considered to be atomic based on themselves or their ancestry.</summary>
+        internal readonly HashSet<RegexNode> _isAtomicByAncestor = new(); // since the root is implicitly atomic, every tree will contain atomic-by-ancestor nodes
+        /// <summary>Set of nodes that directly or indirectly contain capture groups.</summary>
+        internal readonly HashSet<RegexNode> _containsCapture = new(); // the root is a capture, so this will always contain at least the root node
+        /// <summary>Set of nodes that directly or indirectly contain backtracking constructs that aren't hidden internaly by atomic constructs.</summary>
+        internal HashSet<RegexNode>? _mayBacktrack;
+
+        /// <summary>Initializes the instance.</summary>
+        /// <param name="code">The code being analyzed.</param>
+        internal AnalysisResults(RegexCode code) => Code = code;
+
+        /// <summary>Gets the code that was analyzed.</summary>
+        public RegexCode Code { get; }
+
+        /// <summary>Gets whether a node is considered atomic based on itself or its ancestry.</summary>
+        public bool IsAtomicByAncestor(RegexNode node) => _isAtomicByAncestor.Contains(node);
+
+        /// <summary>Gets whether a node directly or indirectly contains captures.</summary>
+        public bool MayContainCapture(RegexNode node) => !_complete || _containsCapture.Contains(node);
+
+        /// <summary>Gets whether a node is or directory or indirectly contains a backtracking construct that isn't hidden by an internal atomic construct.</summary>
+        /// <remarks>
+        /// In most code generation situations, we only need to know after we emit the child code whether
+        /// the child may backtrack, and that we can see with 100% certainty.  This method is useful in situations
+        /// where we need to predict without traversing the child at code generation time whether it may
+        /// incur backtracking.  This method may have (few) false positives, but won't have any false negatives,
+        /// meaning it might claim a node requires backtracking even if it doesn't, but it will always return
+        /// true for any node that requires backtracking.
+        /// </remarks>
+        public bool MayBacktrack(RegexNode node) => !_complete || (_mayBacktrack?.Contains(node) ?? false);
+    }
+}


### PR DESCRIPTION
We currently either guess at some of this state based on the immediate surrounding nodes (e.g. whether the immediate child backtracks) or we do potentially-expensive walks each time we need to check (e.g. walking all ancestors until root to determine whether a given node is to be considered atomic).  This changes the code to do a pass over the graph to compute the relevant information, which can then be used by the code generators any time they need to access that information.  The net effect of this is that in some cases where we were generating code to handle backtracking we'll no longer emit that code, we're not susceptible to O(N^2) behavior in some places we previously were for oddly shaped trees (e.g. a loop deeply nested inside of an atomic node), and things are a little bit cleaner.

Fixes https://github.com/dotnet/runtime/issues/62451
Note that the issue also talks about tracking not just which nodes contain captures, but which nodes are followed by captures, as that would allow us to avoid emitting uncapturing code for nodes in expressions that contain captures but where the captures were before that node in the graph.  However, having written the logic to track that, I realized it was both a little complicated and it doesn't really buy us all that much, so I decided not to go ahead with it.