### PR TITLE
Disable default marshalling for bool

### DIFF
--- a/docs/design/libraries/DllImportGenerator/Compatibility.md
+++ b/docs/design/libraries/DllImportGenerator/Compatibility.md
@@ -58,6 +58,12 @@ When marshalling as [ANSI](https://docs.microsoft.com/windows/win32/intl/code-pa
 
 The p/invoke source generator does not provide an equivalent to using `CharSet.Auto` in the built-in system. If platform-dependent behaviour is desired, it is left to the user to define different p/invokes with different marshalling configurations.
 
+### `bool` marshalling
+
+We have decided to use `System.Runtime.CompilerServices.DisableRuntimeMarshalling` to enable our custom value type marshalling support. As a result, when a value type that has a `bool` field is passed to native code through source-generated marshalling, the `bool` field is treated as a 1-byte value and is not normalized. Since this default is a little odd and unlikely to be the majority use case, we're going to generally take a stance that all `bool` marshalling must be explicitly specified via `MarshalAs` or other mechanisms.
+
+To aid in conversion from `DllImport` to source-generated marshalling, the code-fix will automatically apply a `[MarshalAs(UnmangedType.Bool)]` attribute to `bool` parameters and return values to ensure the marshalling rules are not changed by the code fix.
+
 ### Custom marshaller support
 
 Using a custom marshaller (i.e. [`ICustomMarshaler`](https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.icustommarshaler)) with the `UnmanagedType.CustomMarshaler` value on `MarshalAsAttribute` is not supported. This also implies `MarshalAsAttribute` fields: [`MarshalTypeRef`](https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.marshalasattribute.marshaltyperef), [`MarshalType`](https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.marshalasattribute.marshaltype), and [`MarshalCookie`](https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.marshalasattribute.marshalcookie) are unsupported.

--- a/src/coreclr/System.Private.CoreLib/src/System/CLRConfig.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/CLRConfig.cs
@@ -16,6 +16,7 @@ namespace System
         }
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ClrConfig_GetConfigBoolValue", StringMarshalling = StringMarshalling.Utf16)]
-        private static partial bool GetConfigBoolValue(string configSwitchName, out bool exist);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool GetConfigBoolValue(string configSwitchName, [MarshalAs(UnmanagedType.Bool)] out bool exist);
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Debugger.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Debugger.cs
@@ -52,6 +52,7 @@ namespace System.Diagnostics
         }
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "DebugDebugger_Launch")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool LaunchInternal();
 
         // Returns whether or not a debugger is attached to the process.

--- a/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipe.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipe.CoreCLR.cs
@@ -50,9 +50,11 @@ namespace System.Diagnostics.Tracing
         // These PInvokes are used as part of the EventPipeEventDispatcher.
         //
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_GetSessionInfo")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool GetSessionInfo(ulong sessionID, EventPipeSessionInfo* pSessionInfo);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_GetNextEvent")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool GetNextEvent(ulong sessionID, EventPipeEventInstanceData* pInstance);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_GetWaitHandle")]

--- a/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Eventing/NativeRuntimeEventSource.PortableThreadPool.NativeSinks.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Eventing/NativeRuntimeEventSource.PortableThreadPool.NativeSinks.CoreCLR.cs
@@ -52,7 +52,7 @@ namespace System.Diagnostics.Tracing
         internal static partial void LogThreadPoolIOEnqueue(
             IntPtr NativeOverlapped,
             IntPtr Overlapped,
-            bool MultiDequeues,
+            [MarshalAs(UnmanagedType.Bool)] bool MultiDequeues,
             ushort ClrInstanceID);
 
         [NonEvent]

--- a/src/coreclr/System.Private.CoreLib/src/System/GC.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/GC.cs
@@ -78,7 +78,7 @@ namespace System
         }
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_StartNoGCRegion")]
-        internal static partial int _StartNoGCRegion(long totalSize, bool lohSizeKnown, long lohSize, bool disallowFullBlockingGC);
+        internal static partial int _StartNoGCRegion(long totalSize, [MarshalAs(UnmanagedType.Bool)] bool lohSizeKnown, long lohSize, [MarshalAs(UnmanagedType.Bool)] bool disallowFullBlockingGC);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_EndNoGCRegion")]
         internal static partial int _EndNoGCRegion();

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -160,7 +160,7 @@ namespace System.Reflection.Emit
             FieldAttributes attributes);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetMethodIL")]
-        private static partial void SetMethodIL(QCallModule module, int tk, bool isInitLocals,
+        private static partial void SetMethodIL(QCallModule module, int tk, [MarshalAs(UnmanagedType.Bool)] bool isInitLocals,
             byte[]? body, int bodyLength,
             byte[] LocalSig, int sigLength,
             int maxStackSize,

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/LoaderAllocator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/LoaderAllocator.cs
@@ -26,6 +26,7 @@ namespace System.Reflection
         internal IntPtr m_nativeLoaderAllocator;
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "LoaderAllocator_Destroy")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool Destroy(IntPtr nativeLoaderAllocator);
 
         ~LoaderAllocatorScout()

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/MetadataUpdater.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/MetadataUpdater.cs
@@ -13,6 +13,7 @@ namespace System.Reflection.Metadata
         private static unsafe partial void ApplyUpdate(QCallAssembly assembly, byte* metadataDelta, int metadataDeltaLength, byte* ilDelta, int ilDeltaLength, byte* pdbDelta, int pdbDeltaLength);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_IsApplyUpdateSupported")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static unsafe partial bool IsApplyUpdateSupported();
 
         /// <summary>

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -69,6 +69,7 @@ namespace System.Reflection
         }
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetCodeBase")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool GetCodeBase(QCallAssembly assembly,
                                                StringHandleOnStack retString);
 
@@ -177,8 +178,8 @@ namespace System.Reflection
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetType", StringMarshalling = StringMarshalling.Utf16)]
         private static partial void GetType(QCallAssembly assembly,
                                             string name,
-                                            bool throwOnError,
-                                            bool ignoreCase,
+                                            [MarshalAs(UnmanagedType.Bool)] bool throwOnError,
+                                            [MarshalAs(UnmanagedType.Bool)] bool ignoreCase,
                                             ObjectHandleOnStack type,
                                             ObjectHandleOnStack keepAlive,
                                             ObjectHandleOnStack assemblyLoadContext);
@@ -349,7 +350,7 @@ namespace System.Reflection
         private static partial void InternalLoad(ObjectHandleOnStack assemblyName,
                                                 ObjectHandleOnStack requestingAssembly,
                                                 StackCrawlMarkHandle stackMark,
-                                                bool throwOnFileNotFound,
+                                                [MarshalAs(UnmanagedType.Bool)] bool throwOnFileNotFound,
                                                 ObjectHandleOnStack assemblyLoadContext,
                                                 ObjectHandleOnStack retAssembly);
 
@@ -605,8 +606,8 @@ namespace System.Reflection
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetModules")]
         private static partial void GetModules(QCallAssembly assembly,
-                                              bool loadIfNotFound,
-                                              bool getResourceModules,
+                                              [MarshalAs(UnmanagedType.Bool)] bool loadIfNotFound,
+                                              [MarshalAs(UnmanagedType.Bool)] bool getResourceModules,
                                               ObjectHandleOnStack retModuleHandles);
 
         private RuntimeModule[] GetModulesInternal(bool loadIfNotFound,

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
@@ -15,7 +15,7 @@ namespace System.Reflection
 
         #region FCalls
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeModule_GetType", StringMarshalling = StringMarshalling.Utf16)]
-        private static partial void GetType(QCallModule module, string className, bool throwOnError, bool ignoreCase, ObjectHandleOnStack type, ObjectHandleOnStack keepAlive);
+        private static partial void GetType(QCallModule module, string className, [MarshalAs(UnmanagedType.Bool)] bool throwOnError, [MarshalAs(UnmanagedType.Bool)] bool ignoreCase, ObjectHandleOnStack type, ObjectHandleOnStack keepAlive);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeModule_GetScopeName")]
         private static partial void GetScopeName(QCallModule module, StringHandleOnStack retString);

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -100,6 +100,7 @@ namespace System.Runtime.InteropServices
         }
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_TryGetOrCreateComInterfaceForObject")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool TryGetOrCreateComInterfaceForObjectInternal(ObjectHandleOnStack comWrappersImpl, long wrapperId, ObjectHandleOnStack instance, CreateComInterfaceFlags flags, out IntPtr retValue);
 
         // Called by the runtime to execute the abstract instance function
@@ -244,6 +245,7 @@ namespace System.Runtime.InteropServices
         }
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_TryGetOrCreateObjectForComInstance")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool TryGetOrCreateObjectForComInstanceInternal(ObjectHandleOnStack comWrappersImpl, long wrapperId, IntPtr externalComObject, IntPtr innerMaybe, CreateObjectFlags flags, ObjectHandleOnStack wrapper, ObjectHandleOnStack retValue);
 
         // Call to execute the virtual instance function

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
@@ -256,6 +256,7 @@ namespace System.Runtime.InteropServices
         internal static bool IsBuiltInComSupported { get; } = IsBuiltInComSupportedInternal();
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "MarshalNative_IsBuiltInComSupported")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool IsBuiltInComSupportedInternal();
 
         /// <summary>

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.CoreCLR.cs
@@ -21,17 +21,17 @@ namespace System.Runtime.InteropServices
         /// External functions that implement the NativeLibrary interface
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "NativeLibrary_LoadFromPath", StringMarshalling = StringMarshalling.Utf16)]
-        internal static partial IntPtr LoadFromPath(string libraryName, bool throwOnError);
+        internal static partial IntPtr LoadFromPath(string libraryName, [MarshalAs(UnmanagedType.Bool)] bool throwOnError);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "NativeLibrary_LoadByName", StringMarshalling = StringMarshalling.Utf16)]
         internal static partial IntPtr LoadByName(string libraryName, QCallAssembly callingAssembly,
-                                                 bool hasDllImportSearchPathFlag, uint dllImportSearchPathFlag,
-                                                 bool throwOnError);
+                                                 [MarshalAs(UnmanagedType.Bool)] bool hasDllImportSearchPathFlag, uint dllImportSearchPathFlag,
+                                                 [MarshalAs(UnmanagedType.Bool)] bool throwOnError);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "NativeLibrary_FreeLib")]
         internal static partial void FreeLib(IntPtr handle);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "NativeLibrary_GetSymbol", StringMarshalling = StringMarshalling.Utf16)]
-        internal static partial IntPtr GetSymbol(IntPtr handle, string symbolName, bool throwOnError);
+        internal static partial IntPtr GetSymbol(IntPtr handle, string symbolName, [MarshalAs(UnmanagedType.Bool)] bool throwOnError);
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ObjectiveCMarshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ObjectiveCMarshal.CoreCLR.cs
@@ -22,11 +22,13 @@ namespace System.Runtime.InteropServices.ObjectiveC
         }
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ObjCMarshal_TrySetGlobalMessageSendCallback")]
+        [return:MarshalAs(UnmanagedType.Bool)]
         private static partial bool TrySetGlobalMessageSendCallback(
             MessageSendFunction msgSendFunction,
             IntPtr func);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ObjCMarshal_TryInitializeReferenceTracker")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static unsafe partial bool TryInitializeReferenceTracker(
             delegate* unmanaged<void> beginEndCallback,
             delegate* unmanaged<IntPtr, int> isReferencedCallback,

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
@@ -12,7 +12,7 @@ namespace System.Runtime.Loader
     public partial class AssemblyLoadContext
     {
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_InitializeAssemblyLoadContext")]
-        private static partial IntPtr InitializeAssemblyLoadContext(IntPtr ptrAssemblyLoadContext, bool fRepresentsTPALoadContext, bool isCollectible);
+        private static partial IntPtr InitializeAssemblyLoadContext(IntPtr ptrAssemblyLoadContext, [MarshalAs(UnmanagedType.Bool)] bool fRepresentsTPALoadContext, [MarshalAs(UnmanagedType.Bool)] bool isCollectible);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_PrepareForAssemblyLoadContextRelease")]
         private static partial void PrepareForAssemblyLoadContextRelease(IntPtr ptrNativeAssemblyBinder, IntPtr ptrAssemblyLoadContextStrong);
@@ -38,15 +38,19 @@ namespace System.Runtime.Loader
         internal static extern bool IsTracingEnabled();
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_TraceResolvingHandlerInvoked", StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool TraceResolvingHandlerInvoked(string assemblyName, string handlerName, string? alcName, string? resultAssemblyName, string? resultAssemblyPath);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_TraceAssemblyResolveHandlerInvoked", StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool TraceAssemblyResolveHandlerInvoked(string assemblyName, string handlerName, string? resultAssemblyName, string? resultAssemblyPath);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_TraceAssemblyLoadFromResolveHandlerInvoked", StringMarshalling = StringMarshalling.Utf16)]
-        internal static partial bool TraceAssemblyLoadFromResolveHandlerInvoked(string assemblyName, bool isTrackedAssembly, string requestingAssemblyPath, string? requestedAssemblyPath);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool TraceAssemblyLoadFromResolveHandlerInvoked(string assemblyName, [MarshalAs(UnmanagedType.Bool)] bool isTrackedAssembly, string requestingAssemblyPath, string? requestedAssemblyPath);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_TraceSatelliteSubdirectoryPathProbed", StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool TraceSatelliteSubdirectoryPathProbed(string filePath, int hResult);
 
         [RequiresUnreferencedCode("Types and members the loaded assembly depends on might be removed")]

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -519,7 +519,7 @@ namespace System
         internal static extern IRuntimeMethodInfo GetDeclaringMethod(RuntimeType type);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetTypeByName", StringMarshalling = StringMarshalling.Utf16)]
-        private static partial void GetTypeByName(string name, bool throwOnError, bool ignoreCase, StackCrawlMarkHandle stackMark,
+        private static partial void GetTypeByName(string name, [MarshalAs(UnmanagedType.Bool)] bool throwOnError, [MarshalAs(UnmanagedType.Bool)] bool ignoreCase, StackCrawlMarkHandle stackMark,
             ObjectHandleOnStack assemblyLoadContext,
             ObjectHandleOnStack type, ObjectHandleOnStack keepalive);
 

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -3987,6 +3987,7 @@ namespace System
     internal readonly unsafe partial struct MdUtf8String
     {
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "MdUtf8String_EqualsCaseInsensitive")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool EqualsCaseInsensitive(void* szLhs, void* szRhs, int cSz);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "MdUtf8String_HashCaseInsensitive")]

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Timer.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Timer.CoreCLR.cs
@@ -63,9 +63,11 @@ namespace System.Threading
         private static partial AppDomainTimerSafeHandle CreateAppDomainTimer(uint dueTime, int id);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AppDomainTimer_Change")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool ChangeAppDomainTimer(AppDomainTimerSafeHandle handle, uint dueTime);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AppDomainTimer_Delete")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool DeleteAppDomainTimer(IntPtr handle);
 
         #endregion

--- a/src/coreclr/System.Private.CoreLib/src/System/TypeNameParser.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/TypeNameParser.cs
@@ -38,7 +38,7 @@ namespace System
     {
         #region QCalls
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeName_CreateTypeNameParser", StringMarshalling = StringMarshalling.Utf16)]
-        private static partial void _CreateTypeNameParser(string typeName, ObjectHandleOnStack retHandle, bool throwOnError);
+        private static partial void _CreateTypeNameParser(string typeName, ObjectHandleOnStack retHandle, [MarshalAs(UnmanagedType.Bool)] bool throwOnError);
 
         [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeName_GetNames")]
         private static partial void _GetNames(SafeTypeNameParserHandle pTypeNameParser, ObjectHandleOnStack retArray);

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
@@ -323,7 +323,7 @@ namespace System.Runtime
         // memory available to satisfy the caller's request.
         [GeneratedDllImport(Redhawk.BaseName)]
         [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static partial int RhpStartNoGCRegion(long totalSize, bool hasLohSize, long lohSize, bool disallowFullBlockingGC);
+        internal static partial int RhpStartNoGCRegion(long totalSize, [MarshalAs(UnmanagedType.Bool)] bool hasLohSize, long lohSize, [MarshalAs(UnmanagedType.Bool)] bool disallowFullBlockingGC);
 
         // Exits a no GC region, possibly doing a GC to clean up the garbage that
         // the caller allocated.

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InteropServices/MarshalAsAttribute.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InteropServices/MarshalAsAttribute.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.InteropServices
+{
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.ReturnValue, Inherited = false)]
+    public sealed partial class MarshalAsAttribute : Attribute
+    {
+        public MarshalAsAttribute(UnmanagedType unmanagedType)
+        {
+            Value = unmanagedType;
+        }
+        public MarshalAsAttribute(short unmanagedType)
+        {
+            Value = (UnmanagedType)unmanagedType;
+        }
+
+        public UnmanagedType Value { get; }
+
+        // Fields used with SubType = ByValArray and LPArray.
+        // Array size =  parameter(PI) * PM + C
+        public UnmanagedType ArraySubType;
+        public short SizeParamIndex;           // param index PI
+        public int SizeConst;                // constant C
+    }
+}

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InteropServices/UnmanagedType.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InteropServices/UnmanagedType.cs
@@ -3,5 +3,8 @@
 
 namespace System.Runtime.InteropServices
 {
-    public class UnmanagedType { }
+    public enum UnmanagedType
+    {
+        Bool = 0x2,         // 4 byte boolean value (true != 0, false == 0)
+    }
 }

--- a/src/coreclr/nativeaot/Test.CoreLib/src/Test.CoreLib.csproj
+++ b/src/coreclr/nativeaot/Test.CoreLib/src/Test.CoreLib.csproj
@@ -67,6 +67,9 @@
     <Compile Include="..\..\Runtime.Base\src\System\Runtime\TypeCast.cs">
       <Link>Runtime.Base\src\System\Runtime\TypeCast.cs</Link>
     </Compile>
+    <Compile Include="..\..\Runtime.Base\src\System\Runtime\InteropServices\MarshalAsAttribute.cs">
+      <Link>Runtime.Base\src\System\Runtime\InteropServices\MarshalAsAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\..\Runtime.Base\src\System\Runtime\InteropServices\UnsafeGCHandle.cs">
       <Link>Runtime.Base\src\System\Runtime\InteropServices\UnsafeGCHandle.cs</Link>
     </Compile>

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.EcDsa.ImportExport.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.EcDsa.ImportExport.cs
@@ -94,7 +94,7 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.AndroidCryptoNative)]
         private static partial int AndroidCryptoNative_GetECKeyParameters(
             SafeEcKeyHandle key,
-            bool includePrivate,
+            [MarshalAs(UnmanagedType.Bool)] bool includePrivate,
             out SafeBignumHandle qx_bn, out int x_cb,
             out SafeBignumHandle qy_bn, out int y_cb,
             out SafeBignumHandle d_bn, out int d_cb);
@@ -152,7 +152,7 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.AndroidCryptoNative)]
         private static partial int AndroidCryptoNative_GetECCurveParameters(
             SafeEcKeyHandle key,
-            bool includePrivate,
+            [MarshalAs(UnmanagedType.Bool)] bool includePrivate,
             out ECCurve.ECCurveType curveType,
             out SafeBignumHandle qx, out int x_cb,
             out SafeBignumHandle qy, out int y_cb,

--- a/src/libraries/Common/src/Interop/Interop.Calendar.cs
+++ b/src/libraries/Common/src/Interop/Interop.Calendar.cs
@@ -21,6 +21,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_EnumCalendarInfo", StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         // We skip the following DllImport because of 'Parsing function pointer types in signatures is not supported.' for some targeted
         // platforms (for example, WASM build).
         private static unsafe partial bool EnumCalendarInfo(IntPtr callback, string localeName, CalendarId calendarId, CalendarDataType calendarDataType, IntPtr context);
@@ -29,6 +30,7 @@ internal static partial class Interop
         internal static partial int GetLatestJapaneseEra();
 
         [GeneratedDllImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_GetJapaneseEraStartDate")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetJapaneseEraStartDate(int era, out int startYear, out int startMonth, out int startDay);
     }
 }

--- a/src/libraries/Common/src/Interop/Interop.Casing.cs
+++ b/src/libraries/Common/src/Interop/Interop.Casing.cs
@@ -8,13 +8,16 @@ internal static partial class Interop
     internal static partial class Globalization
     {
         [GeneratedDllImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_ChangeCase", StringMarshalling = StringMarshalling.Utf16)]
-        internal static unsafe partial void ChangeCase(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static unsafe partial void ChangeCase(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, [MarshalAs(UnmanagedType.Bool)] bool bToUpper);
 
         [GeneratedDllImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_ChangeCaseInvariant", StringMarshalling = StringMarshalling.Utf16)]
-        internal static unsafe partial void ChangeCaseInvariant(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static unsafe partial void ChangeCaseInvariant(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, [MarshalAs(UnmanagedType.Bool)] bool bToUpper);
 
         [GeneratedDllImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_ChangeCaseTurkish", StringMarshalling = StringMarshalling.Utf16)]
-        internal static unsafe partial void ChangeCaseTurkish(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static unsafe partial void ChangeCaseTurkish(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, [MarshalAs(UnmanagedType.Bool)] bool bToUpper);
 
         [GeneratedDllImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_InitOrdinalCasingPage", StringMarshalling = StringMarshalling.Utf16)]
         internal static unsafe partial void InitOrdinalCasingPage(int pageNumber, char* pTarget);

--- a/src/libraries/Common/src/Interop/Interop.Locale.cs
+++ b/src/libraries/Common/src/Interop/Interop.Locale.cs
@@ -25,7 +25,7 @@ internal static partial class Interop
 
         [GeneratedDllImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_GetLocaleTimeFormat", StringMarshalling = StringMarshalling.Utf16)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static unsafe partial bool GetLocaleTimeFormat(string localeName, bool shortFormat, char* value, int valueLength);
+        internal static unsafe partial bool GetLocaleTimeFormat(string localeName, [MarshalAs(UnmanagedType.Bool)] bool shortFormat, char* value, int valueLength);
 
         [GeneratedDllImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_GetLocaleInfoInt", StringMarshalling = StringMarshalling.Utf16)]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
@@ -86,7 +86,7 @@ internal static partial class Interop
         public static partial IntPtr ldap_get_dn(ConnectionHandle ldapHandle, IntPtr result);
 
         [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_option")]
-        public static partial int ldap_get_option_bool(ConnectionHandle ldapHandle, LdapOption option, ref bool outValue);
+        public static partial int ldap_get_option_bool(ConnectionHandle ldapHandle, LdapOption option, [MarshalAs(UnmanagedType.Bool)] ref bool outValue);
 
         [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_option")]
         public static unsafe partial int ldap_get_option_secInfo(ConnectionHandle ldapHandle, LdapOption option, void* outValue);
@@ -119,7 +119,7 @@ internal static partial class Interop
             int scope,
             [MarshalAs(UnmanagedType.LPUTF8Str)] string filter,
             IntPtr attributes,
-            bool attributeOnly,
+            [MarshalAs(UnmanagedType.Bool)] bool attributeOnly,
             IntPtr servercontrol,
             IntPtr clientcontrol,
             int timelimit,
@@ -127,7 +127,7 @@ internal static partial class Interop
             ref int messageNumber);
 
         [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option", SetLastError = true)]
-        public static partial int ldap_set_option_bool(ConnectionHandle ld, LdapOption option, bool value);
+        public static partial int ldap_set_option_bool(ConnectionHandle ld, LdapOption option, [MarshalAs(UnmanagedType.Bool)] bool value);
 
         [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option")]
         public static partial int ldap_set_option_clientcert(ConnectionHandle ldapHandle, LdapOption option, QUERYCLIENTCERT outValue);

--- a/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.cs
@@ -53,7 +53,7 @@ internal static partial class Interop
             IntPtr bytes,
             CFIndex numBytes,
             CFStringBuiltInEncodings encoding,
-            bool isExternalRepresentation);
+            [MarshalAs(UnmanagedType.Bool)] bool isExternalRepresentation);
 
         /// <summary>
         /// Creates a CFStringRef from a 8-bit String object. Follows the "Create Rule" where if you create it, you delete it.

--- a/src/libraries/Common/src/Interop/OSX/Interop.EventStream.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.EventStream.cs
@@ -127,6 +127,7 @@ internal static partial class Interop
         /// <param name="streamRef">The stream to receive events on.</param>
         /// <returns>Returns true if the stream was started; otherwise, returns false and no events will be received.</returns>
         [GeneratedDllImport(Interop.Libraries.CoreServicesLibrary)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool FSEventStreamStart(SafeEventStreamHandle streamRef);
 
         /// <summary>

--- a/src/libraries/Common/src/Interop/OSX/Interop.RunLoop.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.RunLoop.cs
@@ -89,6 +89,7 @@ internal static partial class Interop
         /// false if rl either is not running or is currently processing
         /// a source, timer, or observer.</returns>
         [GeneratedDllImport(Interop.Libraries.CoreFoundationLibrary)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CFRunLoopIsWaiting(CFRunLoopRef rl);
     }
 }

--- a/src/libraries/Common/src/Interop/OSX/Interop.SystemConfiguration.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.SystemConfiguration.cs
@@ -127,6 +127,7 @@ internal static partial class Interop
         /// or IntPtr.Zero if no key patterns are to be monitored.</param>
         /// <returns>Non-zero if the set of notification keys and patterns was successfully updated; zero otherwise.</returns>
         [GeneratedDllImport(Libraries.SystemConfigurationLibrary)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SCDynamicStoreSetNotificationKeys(SCDynamicStoreRef store, CFArrayRef keys, CFArrayRef patterns);
     }
 }

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Keychain.iOS.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Keychain.iOS.cs
@@ -30,7 +30,7 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.AppleCryptoNative)]
         private static partial int AppleCryptoNative_X509StoreRemoveCertificate(
             SafeHandle certOrIdentity,
-            bool isReadOnlyMode);
+            [MarshalAs(UnmanagedType.Bool)] bool isReadOnlyMode);
 
         internal static SafeCFArrayHandle KeychainEnumerateCerts()
         {

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Keychain.macOS.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Keychain.macOS.cs
@@ -76,7 +76,7 @@ internal static partial class Interop
         private static partial int AppleCryptoNative_X509StoreRemoveCertificate(
             SafeKeychainItemHandle cert,
             SafeKeychainHandle keychain,
-            bool isReadOnlyMode,
+            [MarshalAs(UnmanagedType.Bool)] bool isReadOnlyMode,
             out int pOSStatus);
 
         private static SafeKeychainHandle SecKeychainItemCopyKeychain(SafeHandle item)

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509Chain.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509Chain.cs
@@ -28,7 +28,7 @@ internal static partial class Interop
         internal static partial int AppleCryptoNative_X509ChainEvaluate(
             SafeX509ChainHandle chain,
             SafeCFDateHandle cfEvaluationTime,
-            bool allowNetwork,
+            [MarshalAs(UnmanagedType.Bool)] bool allowNetwork,
             out int pOSStatus);
 
         [GeneratedDllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_X509ChainGetChainSize")]

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ConfigureTerminalForChildProcess.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ConfigureTerminalForChildProcess.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ConfigureTerminalForChildProcess")]
-        internal static partial void ConfigureTerminalForChildProcess(bool childUsesTerminal);
+        internal static partial void ConfigureTerminalForChildProcess([MarshalAs(UnmanagedType.Bool)] bool childUsesTerminal);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Fcntl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Fcntl.cs
@@ -17,7 +17,7 @@ internal static partial class Interop
             internal static partial int SetIsNonBlocking(SafeHandle fd, int isNonBlocking);
 
             [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FcntlGetIsNonBlocking", SetLastError = true)]
-            internal static partial int GetIsNonBlocking(SafeHandle fd, out bool isNonBlocking);
+            internal static partial int GetIsNonBlocking(SafeHandle fd, [MarshalAs(UnmanagedType.Bool)] out bool isNonBlocking);
 
             [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FcntlSetFD", SetLastError=true)]
             internal static partial int SetFD(SafeHandle fd, int flags);

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetSocketType.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetSocketType.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSocketType")]
-        internal static partial Error GetSocketType(SafeSocketHandle socket, out AddressFamily addressFamily, out SocketType socketType, out ProtocolType protocolType, out bool isListening);
+        internal static partial Error GetSocketType(SafeSocketHandle socket, out AddressFamily addressFamily, out SocketType socketType, out ProtocolType protocolType, [MarshalAs(UnmanagedType.Bool)] out bool isListening);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.IPPacketInformation.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.IPPacketInformation.cs
@@ -21,6 +21,7 @@ internal static partial class Interop
         internal static partial int GetControlMessageBufferSize(int isIPv4, int isIPv6);
 
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_TryGetIPPacketInformation")]
-        internal static unsafe partial bool TryGetIPPacketInformation(MessageHeader* messageHeader, bool isIPv4, IPPacketInformation* packetInfo);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static unsafe partial bool TryGetIPPacketInformation(MessageHeader* messageHeader, [MarshalAs(UnmanagedType.Bool)] bool isIPv4, IPPacketInformation* packetInfo);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.InitializeTerminalAndSignalHandling.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.InitializeTerminalAndSignalHandling.cs
@@ -8,6 +8,7 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_InitializeTerminalAndSignalHandling", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool InitializeTerminalAndSignalHandling();
 
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetKeypadXmit", StringMarshalling = StringMarshalling.Utf8)]

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.IsATty.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.IsATty.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_IsATty", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool IsATty(SafeFileHandle fd);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.LowLevelMonitor.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.LowLevelMonitor.cs
@@ -24,6 +24,7 @@ internal static partial class Interop
         internal static partial void LowLevelMonitor_Wait(IntPtr monitor);
 
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LowLevelMonitor_TimedWait")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool LowLevelMonitor_TimedWait(IntPtr monitor, int timeoutMilliseconds);
 
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LowLevelMonitor_Signal_Release")]

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.PosixSignal.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.PosixSignal.cs
@@ -12,6 +12,7 @@ internal static partial class Interop
         internal static unsafe partial void SetPosixSignalHandler(delegate* unmanaged<int, PosixSignal, int> handler);
 
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_EnablePosixSignalHandling", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EnablePosixSignalHandling(int signal);
 
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_DisablePosixSignalHandling")]

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.StdinReady.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.StdinReady.cs
@@ -8,6 +8,7 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_StdinReady")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool StdinReady();
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Threading.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Threading.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal unsafe partial class Sys
     {
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateThread")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CreateThread(IntPtr stackSize, delegate* unmanaged<IntPtr, IntPtr> startAddress, IntPtr parameter);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.IsNtlmInstalled.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.IsNtlmInstalled.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class NetSecurityNative
     {
         [GeneratedDllImport(Interop.Libraries.NetSecurityNative, EntryPoint="NetSecurityNative_IsNtlmInstalled")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool IsNtlmInstalled();
 
         [GeneratedDllImport(Interop.Libraries.NetSecurityNative, EntryPoint = "NetSecurityNative_EnsureGssInitialized")]

--- a/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
@@ -61,7 +61,7 @@ internal static partial class Interop
         [GeneratedDllImport(Interop.Libraries.NetSecurityNative, EntryPoint="NetSecurityNative_InitiateCredWithPassword", StringMarshalling = StringMarshalling.Utf8)]
         internal static partial Status InitiateCredWithPassword(
             out Status minorStatus,
-            bool isNtlm,
+            [MarshalAs(UnmanagedType.Bool)] bool isNtlm,
             SafeGssNameHandle desiredName,
             string password,
             int passwordLen,
@@ -77,21 +77,21 @@ internal static partial class Interop
             out Status minorStatus,
             SafeGssCredHandle initiatorCredHandle,
             ref SafeGssContextHandle contextHandle,
-            bool isNtlmOnly,
+            [MarshalAs(UnmanagedType.Bool)] bool isNtlmOnly,
             SafeGssNameHandle? targetName,
             uint reqFlags,
             byte[]? inputBytes,
             int inputLength,
             ref GssBuffer token,
             out uint retFlags,
-            out bool isNtlmUsed);
+            [MarshalAs(UnmanagedType.Bool)] out bool isNtlmUsed);
 
         [GeneratedDllImport(Interop.Libraries.NetSecurityNative, EntryPoint="NetSecurityNative_InitSecContextEx")]
         internal static partial Status InitSecContext(
             out Status minorStatus,
             SafeGssCredHandle initiatorCredHandle,
             ref SafeGssContextHandle contextHandle,
-            bool isNtlmOnly,
+            [MarshalAs(UnmanagedType.Bool)] bool isNtlmOnly,
             IntPtr cbt,
             int cbtSize,
             SafeGssNameHandle? targetName,
@@ -100,7 +100,7 @@ internal static partial class Interop
             int inputLength,
             ref GssBuffer token,
             out uint retFlags,
-            out bool isNtlmUsed);
+            [MarshalAs(UnmanagedType.Bool)] out bool isNtlmUsed);
 
         [GeneratedDllImport(Interop.Libraries.NetSecurityNative, EntryPoint="NetSecurityNative_AcceptSecContext")]
         internal static partial Status AcceptSecContext(
@@ -111,7 +111,7 @@ internal static partial class Interop
             int inputLength,
             ref GssBuffer token,
             out uint retFlags,
-            out bool isNtlmUsed);
+            [MarshalAs(UnmanagedType.Bool)] out bool isNtlmUsed);
 
         [GeneratedDllImport(Interop.Libraries.NetSecurityNative, EntryPoint="NetSecurityNative_DeleteSecContext")]
         internal static partial Status DeleteSecContext(
@@ -128,7 +128,7 @@ internal static partial class Interop
         private static unsafe partial Status Wrap(
             out Status minorStatus,
             SafeGssContextHandle? contextHandle,
-            bool isEncrypt,
+            [MarshalAs(UnmanagedType.Bool)] bool isEncrypt,
             byte* inputBytes,
             int count,
             ref GssBuffer outBuffer);

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.ImportExport.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.ImportExport.cs
@@ -100,7 +100,7 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.CryptoNative)]
         private static partial int CryptoNative_GetECKeyParameters(
             SafeEcKeyHandle key,
-            bool includePrivate,
+            [MarshalAs(UnmanagedType.Bool)] bool includePrivate,
             out SafeBignumHandle qx_bn, out int x_cb,
             out SafeBignumHandle qy_bn, out int y_cb,
             out IntPtr d_bn_not_owned, out int d_cb);
@@ -169,7 +169,7 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.CryptoNative)]
         private static partial int CryptoNative_GetECCurveParameters(
             SafeEcKeyHandle key,
-            bool includePrivate,
+            [MarshalAs(UnmanagedType.Bool)] bool includePrivate,
             out ECCurve.ECCurveType curveType,
             out SafeBignumHandle qx, out int x_cb,
             out SafeBignumHandle qy, out int y_cb,

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -137,6 +137,7 @@ internal static partial class Interop
         private static partial IntPtr GetOpenSslCipherSuiteName(SafeSslHandle ssl, int cipherSuite, out int isTls12OrLower);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SetCiphers")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool SslSetCiphers(SafeSslHandle ssl, byte* cipherList, byte* cipherSuites);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetVerifyPeer")]
@@ -219,9 +220,11 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslAddExtraChainCert")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SslAddExtraChainCert(SafeSslHandle ssl, SafeX509Handle x509);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslAddClientCAs")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static unsafe partial bool SslAddClientCAs(SafeSslHandle ssl, IntPtr* x509s, int count);
 
         internal static unsafe bool SslAddClientCAs(SafeSslHandle ssl, Span<IntPtr> x509handles)

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtxOptions.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtxOptions.cs
@@ -12,6 +12,7 @@ internal static partial class Interop
     internal static partial class Ssl
     {
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxAddExtraChainCert")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SslCtxAddExtraChainCert(SafeSslContextHandle ctx, SafeX509Handle x509);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxUseCertificate")]
@@ -27,9 +28,11 @@ internal static partial class Interop
         internal static partial void SslCtxSetQuietShutdown(SafeSslContextHandle ctx);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetCiphers")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool SslCtxSetCiphers(SafeSslContextHandle ctx, byte* cipherList, byte* cipherSuites);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetEncryptionPolicy")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetEncryptionPolicy(SafeSslContextHandle ctx, EncryptionPolicy policy);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.AdjustTokenPrivileges.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.AdjustTokenPrivileges.cs
@@ -10,9 +10,10 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool AdjustTokenPrivileges(
             SafeTokenHandle TokenHandle,
-            bool DisableAllPrivileges,
+            [MarshalAs(UnmanagedType.Bool)] bool DisableAllPrivileges,
             TOKEN_PRIVILEGE* NewState,
             uint BufferLength,
             TOKEN_PRIVILEGE* PreviousState,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.AllocateLocallyUniqueId.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.AllocateLocallyUniqueId.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool AllocateLocallyUniqueId(LUID* Luid);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ChangeServiceConfig2.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ChangeServiceConfig2.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "ChangeServiceConfig2W", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool ChangeServiceConfig2(SafeServiceHandle serviceHandle, uint infoLevel, ref SERVICE_DESCRIPTION serviceDesc);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CheckTokenMembership.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CheckTokenMembership.cs
@@ -10,9 +10,10 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CheckTokenMembership(
             SafeAccessTokenHandle TokenHandle,
             byte[] SidToCheck,
-            ref bool IsMember);
+            [MarshalAs(UnmanagedType.Bool)] ref bool IsMember);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ClearEventLog.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ClearEventLog.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "ClearEventLogW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool ClearEventLog(SafeEventLogReadHandle hEventLog, string lpBackupFileName);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CloseEventLog.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CloseEventLog.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CloseEventLog(IntPtr hEventLog);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CloseServiceHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CloseServiceHandle.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CloseServiceHandle(IntPtr handle);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ControlService.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ControlService.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool ControlService(SafeServiceHandle serviceHandle, int control, SERVICE_STATUS* pStatus);
 
     }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertSdToStringSd.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertSdToStringSd.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     {
         [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "ConvertSecurityDescriptorToStringSecurityDescriptorW",
             SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool ConvertSdToStringSd(
             byte[] securityDescriptor,
             /* DWORD */ uint requestedRevision,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertStringSdToSd.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertStringSdToSd.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     {
         [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "ConvertStringSecurityDescriptorToSecurityDescriptorW",
             SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool ConvertStringSdToSd(
             string stringSd,
             /* DWORD */ uint stringSdRevision,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertStringSecurityDescriptorToSecurityDescriptor.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertStringSecurityDescriptorToSecurityDescriptor.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "ConvertStringSecurityDescriptorToSecurityDescriptorW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool ConvertStringSecurityDescriptorToSecurityDescriptor(
             string StringSecurityDescriptor,
             int StringSDRevision,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CopySid.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CopySid.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CopySid(int destinationLength, IntPtr pSidDestination, IntPtr pSidSource);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CreateProcessWithLogon.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CreateProcessWithLogon.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "CreateProcessWithLogonW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CreateProcessWithLogonW(
             string userName,
             string domain,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptAcquireContext.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptAcquireContext.cs
@@ -21,6 +21,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "CryptAcquireContextW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptAcquireContext(
             out SafeProvHandle phProv,
             string? szContainer,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptCreateHash.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptCreateHash.cs
@@ -16,6 +16,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CryptCreateHash(
             SafeProvHandle hProv,
             int Algid,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptDecrypt.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptDecrypt.cs
@@ -15,10 +15,11 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptDecrypt(
             SafeCapiKeyHandle hKey,
             SafeHashHandle hHash,
-            bool Final,
+            [MarshalAs(UnmanagedType.Bool)] bool Final,
             int dwFlags,
             byte[] pbData,
             ref int pdwDataLen);

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptDeriveKey.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptDeriveKey.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CryptDeriveKey(
             SafeProvHandle hProv,
             int Algid,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptDestroyHash.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptDestroyHash.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptDestroyHash(IntPtr hHash);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptDestroyKey.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptDestroyKey.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptDestroyKey(IntPtr hKey);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptEncrypt.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptEncrypt.cs
@@ -9,10 +9,11 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptEncrypt(
             SafeCapiKeyHandle hKey,
             SafeHashHandle hHash,
-            bool Final,
+            [MarshalAs(UnmanagedType.Bool)] bool Final,
             int dwFlags,
             byte[]? pbData,
             ref int pdwDataLen,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptExportKey.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptExportKey.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptExportKey(
             SafeCapiKeyHandle hKey,
             SafeCapiKeyHandle hExpKey,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptGenKey.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptGenKey.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CryptGenKey(SafeProvHandle hProv, int Algid, int dwFlags, out SafeCapiKeyHandle phKey);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptGetDefaultProvider.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptGetDefaultProvider.cs
@@ -16,6 +16,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "CryptGetDefaultProviderW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptGetDefaultProvider(
             int dwProvType,
             IntPtr pdwReserved,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptGetHashParam.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptGetHashParam.cs
@@ -19,6 +19,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptGetHashParam(
             SafeHashHandle hHash,
             CryptHashProperty dwParam,
@@ -27,6 +28,7 @@ internal static partial class Interop
             int dwFlags);
 
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptSetHashParam(SafeHashHandle hHash, CryptHashProperty dwParam, byte[] buffer, int dwFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptGetKeyParam.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptGetKeyParam.cs
@@ -18,6 +18,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptGetKeyParam(
             SafeCapiKeyHandle hKey,
             CryptGetKeyParamFlags dwParam,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptGetProvParam.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptGetProvParam.cs
@@ -23,6 +23,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptSetProvParam(
             SafeHandle safeProvHandle,
             CryptProvParam dwParam,
@@ -30,6 +31,7 @@ internal static partial class Interop
             int dwFlags);
 
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptSetProvParam(
             SafeProvHandle hProv,
             CryptProvParam dwParam,
@@ -37,6 +39,7 @@ internal static partial class Interop
             int dwFlags);
 
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptGetProvParam(
             SafeHandle safeProvHandle,
             CryptProvParam dwParam,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptGetUserKey.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptGetUserKey.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CryptGetUserKey(SafeProvHandle hProv, int dwKeySpec, out SafeCapiKeyHandle phUserKey);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptHashData.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptHashData.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptHashData(SafeHashHandle hHash, byte[] pbData, int dwDataLen, int dwFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptImportKey.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptImportKey.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CryptImportKey(
             SafeProvHandle hProv,
             byte* pbData,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptReleaseContext.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptReleaseContext.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptReleaseContext(
             IntPtr hProv,
             int dwFlags);

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptSetKeyParam.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptSetKeyParam.cs
@@ -9,9 +9,11 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptSetKeyParam(SafeCapiKeyHandle hKey, int dwParam, byte[] pbData, int dwFlags);
 
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptSetKeyParam(SafeCapiKeyHandle safeKeyHandle, int dwParam, ref int pdw, int dwFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptSignHash.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptSignHash.cs
@@ -25,6 +25,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "CryptSignHashW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptSignHash(
             SafeHashHandle hHash,
             KeySpec dwKeySpec,
@@ -34,6 +35,7 @@ internal static partial class Interop
             ref int pdwSigLen);
 
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "CryptVerifySignatureW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptVerifySignature(
             SafeHashHandle hHash,
             byte[] pbSignature,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.DeleteService.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.DeleteService.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool DeleteService(SafeServiceHandle serviceHandle);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.DeregisterEventSource.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.DeregisterEventSource.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool DeregisterEventSource(IntPtr hEventLog);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.DuplicateTokenEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.DuplicateTokenEx.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool DuplicateTokenEx(
             SafeAccessTokenHandle hExistingToken,
             uint dwDesiredAccess,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.DuplicateTokenEx_SafeTokenHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.DuplicateTokenEx_SafeTokenHandle.cs
@@ -11,6 +11,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool DuplicateTokenEx(
             SafeTokenHandle ExistingTokenHandle,
             TokenAccessLevels DesiredAccess,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.EncryptDecrypt.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.EncryptDecrypt.cs
@@ -11,7 +11,8 @@ internal static partial class Interop
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use EncryptFile.
         /// </summary>
-        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "EncryptFileW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "EncryptFileW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool EncryptFilePrivate(string lpFileName);
 
         internal static bool EncryptFile(string path)
@@ -23,7 +24,8 @@ internal static partial class Interop
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use DecryptFile.
         /// </summary>
-        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "DecryptFileW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "DecryptFileW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool DecryptFileFilePrivate(
             string lpFileName,
             int dwReserved);

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.EnumDependentServices.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.EnumDependentServices.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "EnumDependentServicesW", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EnumDependentServices(
             SafeServiceHandle serviceHandle,
             int serviceState,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.EnumServicesStatusEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.EnumServicesStatusEx.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "EnumServicesStatusExW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EnumServicesStatusEx(
             SafeServiceHandle databaseHandle,
             int infolevel,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.EqualDomainSid.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.EqualDomainSid.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Interop.Libraries.Advapi32)]
-        public static partial bool EqualDomainSid(IntPtr pSid1, IntPtr pSid2, ref bool equal);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static partial bool EqualDomainSid(IntPtr pSid1, IntPtr pSid2, [MarshalAs(UnmanagedType.Bool)] ref bool equal);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetNumberOfEventLogRecords.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetNumberOfEventLogRecords.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool GetNumberOfEventLogRecords(SafeEventLogReadHandle hEventLog, out int NumberOfRecords);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetServiceDisplayName.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetServiceDisplayName.cs
@@ -13,6 +13,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "GetServiceDisplayNameW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool GetServiceDisplayName(SafeServiceHandle? SCMHandle, string serviceName, char* displayName, ref int displayNameLength);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetServiceKeyName.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetServiceKeyName.cs
@@ -13,6 +13,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "GetServiceKeyNameW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool GetServiceKeyName(SafeServiceHandle? SCMHandle, string displayName, char* KeyName, ref int KeyNameLength);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetTokenInformation.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetTokenInformation.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetTokenInformation(
             IntPtr TokenHandle,
             uint TokenInformationClass,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetTokenInformation_SafeLocalAllocHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetTokenInformation_SafeLocalAllocHandle.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetTokenInformation(
             SafeAccessTokenHandle TokenHandle,
             uint TokenInformationClass,
@@ -18,6 +19,7 @@ internal static partial class Interop
             out uint ReturnLength);
 
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetTokenInformation(
             IntPtr TokenHandle,
             uint TokenInformationClass,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetTokenInformation_void.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetTokenInformation_void.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool GetTokenInformation(
             SafeAccessTokenHandle TokenHandle,
             TOKEN_INFORMATION_CLASS TokenInformationClass,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ImpersonateLoggedOnUser.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ImpersonateLoggedOnUser.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool ImpersonateLoggedOnUser(SafeAccessTokenHandle userToken);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.IsEqualDomainSid.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.IsEqualDomainSid.cs
@@ -12,6 +12,6 @@ internal static partial class Interop
         internal static partial int IsEqualDomainSid(
             byte[] sid1,
             byte[] sid2,
-            out bool result);
+            [MarshalAs(UnmanagedType.Bool)] out bool result);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.IsValidSid.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.IsValidSid.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool IsValidSid(IntPtr sid);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LookupAccountNameW.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LookupAccountNameW.cs
@@ -8,6 +8,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool LookupAccountNameW(
             string? lpSystemName,
             ref char lpAccountName,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LookupPrivilegeValue.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LookupPrivilegeValue.cs
@@ -8,6 +8,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "LookupPrivilegeValueW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool LookupPrivilegeValue(
             [MarshalAs(UnmanagedType.LPTStr)] string? lpSystemName, [MarshalAs(UnmanagedType.LPTStr)] string lpName, out LUID lpLuid);
 

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.OpenProcessToken.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.OpenProcessToken.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32,  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool OpenProcessToken(IntPtr ProcessHandle, int DesiredAccess, out SafeTokenHandle TokenHandle);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.OpenProcessToken_IntPtr.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.OpenProcessToken_IntPtr.cs
@@ -11,6 +11,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool OpenProcessToken(
             IntPtr ProcessToken,
             TokenAccessLevels DesiredAccess,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.OpenProcessToken_SafeAccessTokenHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.OpenProcessToken_SafeAccessTokenHandle.cs
@@ -11,6 +11,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool OpenProcessToken(
             IntPtr ProcessToken,
             TokenAccessLevels DesiredAccess,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.OpenThreadToken.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.OpenThreadToken.cs
@@ -11,10 +11,11 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool OpenThreadToken(
             IntPtr ThreadHandle,
             TokenAccessLevels dwDesiredAccess,
-            bool bOpenAsSelf,
+            [MarshalAs(UnmanagedType.Bool)] bool bOpenAsSelf,
             out SafeAccessTokenHandle phThreadToken);
 
         internal static bool OpenThreadToken(TokenAccessLevels desiredAccess, WinSecurityContext openAs, out SafeAccessTokenHandle tokenHandle)

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.OpenThreadToken_SafeTokenHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.OpenThreadToken_SafeTokenHandle.cs
@@ -11,10 +11,11 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool OpenThreadToken(
             IntPtr ThreadHandle,
             TokenAccessLevels dwDesiredAccess,
-            bool bOpenAsSelf,
+            [MarshalAs(UnmanagedType.Bool)] bool bOpenAsSelf,
             out SafeTokenHandle phThreadToken);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.QueryServiceConfig.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.QueryServiceConfig.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "QueryServiceConfigW", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool QueryServiceConfig(SafeServiceHandle serviceHandle, IntPtr queryServiceConfigPtr, int bufferSize, out int bytesNeeded);
 
     }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.QueryServiceStatus.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.QueryServiceStatus.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool QueryServiceStatus(SafeServiceHandle serviceHandle, SERVICE_STATUS* pStatus);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ReportEvent.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ReportEvent.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "ReportEventW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool ReportEvent(
             SafeEventLogWriteHandle hEventLog,
             short wType,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RevertToSelf.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RevertToSelf.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool RevertToSelf();
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.SetServiceStatus.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.SetServiceStatus.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static unsafe partial bool SetServiceStatus(IntPtr serviceStatusHandle, SERVICE_STATUS* status);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.SetThreadToken.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.SetThreadToken.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetThreadToken(
             IntPtr ThreadHandle,
             SafeTokenHandle? hToken);

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.StartService.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.StartService.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "StartServiceW", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool StartService(SafeServiceHandle serviceHandle, int argNum, IntPtr argPtrs);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.StartServiceCtrlDispatcher.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.StartServiceCtrlDispatcher.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "StartServiceCtrlDispatcherW", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool StartServiceCtrlDispatcher(IntPtr entry);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Authz/Interop.AuthzGetInformationFromContext.cs
+++ b/src/libraries/Common/src/Interop/Windows/Authz/Interop.AuthzGetInformationFromContext.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Authz
     {
         [GeneratedDllImport(Libraries.Authz, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool AuthzGetInformationFromContext(
             IntPtr hAuthzClientContext,
             int InfoClass,

--- a/src/libraries/Common/src/Interop/Windows/Authz/Interop.AuthzInitializeContextFromSid.cs
+++ b/src/libraries/Common/src/Interop/Windows/Authz/Interop.AuthzInitializeContextFromSid.cs
@@ -13,6 +13,7 @@ internal static partial class Interop
         internal const int AUTHZ_VALID_RM_INIT_FLAGS = (AUTHZ_RM_FLAG_NO_AUDIT | AUTHZ_RM_FLAG_INITIALIZE_UNDER_IMPERSONATION);
 
         [GeneratedDllImport(Interop.Libraries.Authz, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool AuthzInitializeContextFromSid(
             int Flags,
             IntPtr UserSid,
@@ -23,6 +24,7 @@ internal static partial class Interop
             out IntPtr pAuthzClientContext);
 
         [GeneratedDllImport(Interop.Libraries.Authz)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool AuthzFreeContext(IntPtr AuthzClientContext);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Authz/Interop.AuthzInitializeResourceManager.cs
+++ b/src/libraries/Common/src/Interop/Windows/Authz/Interop.AuthzInitializeResourceManager.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Authz
     {
         [GeneratedDllImport(Libraries.Authz, SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool AuthzInitializeResourceManager(
             int flags,
             IntPtr pfnAccessCheck,
@@ -18,6 +19,7 @@ internal static partial class Interop
             out IntPtr rm);
 
         [GeneratedDllImport(Libraries.Authz)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool AuthzFreeResourceManager(IntPtr rm);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertAddCertificateContextToStore.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertAddCertificateContextToStore.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CertAddCertificateContextToStore(SafeCertStoreHandle hCertStore, SafeCertContextHandle pCertContext, CertStoreAddDisposition dwAddDisposition, IntPtr ppStoreContext);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertAddCertificateLinkToStore.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertAddCertificateLinkToStore.cs
@@ -11,6 +11,7 @@ internal static partial class Interop
         internal const uint CERT_STORE_ADD_ALWAYS = 4;
 
         [GeneratedDllImport(Interop.Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CertAddCertificateLinkToStore(SafeCertStoreHandle hCertStore, SafeCertContextHandle pCertContext, uint dwAddDisposition, SafeCertContextHandle ppStoreContext);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertAddCertificateLinkToStore_CertStoreAddDisposition.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertAddCertificateLinkToStore_CertStoreAddDisposition.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CertAddCertificateLinkToStore(SafeCertStoreHandle hCertStore, SafeCertContextHandle pCertContext, CertStoreAddDisposition dwAddDisposition, IntPtr ppStoreContext);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertCloseStore.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertCloseStore.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Interop.Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CertCloseStore(IntPtr hCertStore, uint dwFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertControlStore.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertControlStore.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CertControlStore(SafeCertStoreHandle hCertStore, CertControlStoreFlags dwFlags, CertControlStoreType dwControlType, IntPtr pvCtrlPara);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertCreateCertificateChainEngine.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertCreateCertificateChainEngine.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CertCreateCertificateChainEngine(ref CERT_CHAIN_ENGINE_CONFIG pConfig, out SafeChainEngineHandle hChainEngineHandle);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertDeleteCertificateFromStore.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertDeleteCertificateFromStore.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     {
         // Note: CertDeleteCertificateFromStore always calls CertFreeCertificateContext on pCertContext, even if an error is encountered.
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CertDeleteCertificateFromStore(CERT_CONTEXT* pCertContext);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertFreeCertificateContext.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertFreeCertificateContext.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     {
         // Note: This api always return TRUE, regardless of success.
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CertFreeCertificateContext(IntPtr pCertContext);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertGetCertificateChain.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertGetCertificateChain.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CertGetCertificateChain(
             IntPtr hChainEngine,
             SafeCertContextHandle pCertContext,

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertGetCertificateContextProperty.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertGetCertificateContextProperty.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CertGetCertificateContextProperty(
             SafeCertContextHandle pCertContext,
             CertContextPropId dwPropId,
@@ -17,6 +18,7 @@ internal static partial class Interop
             ref int pcbData);
 
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CertGetCertificateContextProperty(
             SafeCertContextHandle pCertContext,
             CertContextPropId dwPropId,
@@ -24,6 +26,7 @@ internal static partial class Interop
             ref int pcbData);
 
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CertGetCertificateContextProperty(
             SafeCertContextHandle pCertContext,
             CertContextPropId dwPropId,

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertGetCertificateContextPropertyString.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertGetCertificateContextPropertyString.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, EntryPoint = "CertGetCertificateContextProperty",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CertGetCertificateContextPropertyString(SafeCertContextHandle pCertContext, CertContextPropId dwPropId, byte* pvData, ref uint pcbData);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertGetCertificateContextProperty_NO_NULLABLE.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertGetCertificateContextProperty_NO_NULLABLE.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CertGetCertificateContextProperty(
             SafeCertContextHandle pCertContext,
             CertContextPropId dwPropId,

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertGetIntendedKeyUsage.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertGetIntendedKeyUsage.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
         // Note: It's somewhat unusual to use an API enum as a parameter type to a P/Invoke but in this case, X509KeyUsageFlags was intentionally designed as bit-wise
         // identical to the wincrypt CERT_*_USAGE values.
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CertGetIntendedKeyUsage(
             CertEncodingType dwCertEncodingType,
             CERT_INFO* pCertInfo,

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertGetValidUsages.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertGetValidUsages.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CertGetValidUsages(int cCerts, ref SafeCertContextHandle rghCerts, out int cNumOIDs, void* rghOIDs, ref int pcbOIDs);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertSaveStore.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertSaveStore.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CertSaveStore(
             SafeCertStoreHandle hCertStore,
             CertEncodingType dwMsgAndCertEncodingType,

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertSerializeCertificateStoreElement.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertSerializeCertificateStoreElement.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CertSerializeCertificateStoreElement(SafeCertContextHandle pCertContext, int dwFlags, byte[]? pbElement, ref int pcbElement);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertSetCertificateContextProperty_CRYPT_KEY_PROV_INFO.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertSetCertificateContextProperty_CRYPT_KEY_PROV_INFO.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CertSetCertificateContextProperty(SafeCertContextHandle pCertContext, CertContextPropId dwPropId, CertSetPropertyFlags dwFlags, CRYPT_KEY_PROV_INFO* pvData);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertSetCertificateContextProperty_DATA_BLOB.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertSetCertificateContextProperty_DATA_BLOB.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CertSetCertificateContextProperty(SafeCertContextHandle pCertContext, CertContextPropId dwPropId, CertSetPropertyFlags dwFlags, DATA_BLOB* pvData);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertSetCertificateContextProperty_SafeNCryptKeyHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertSetCertificateContextProperty_SafeNCryptKeyHandle.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CertSetCertificateContextProperty(SafeCertContextHandle pCertContext, CertContextPropId dwPropId, CertSetPropertyFlags dwFlags, SafeNCryptKeyHandle keyHandle);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertStrToName.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertStrToName.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, EntryPoint = "CertStrToNameW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CertStrToName(CertEncodingType dwCertEncodingType, string pszX500, CertNameStrTypeAndFlags dwStrType, IntPtr pvReserved, byte[]? pbEncoded, ref int pcbEncoded, IntPtr ppszError);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptAcquireCertificatePrivateKey.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptAcquireCertificatePrivateKey.cs
@@ -10,12 +10,13 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CryptAcquireCertificatePrivateKey(
             SafeCertContextHandle pCert,
             CryptAcquireCertificatePrivateKeyFlags dwFlags,
             IntPtr pvParameters,
             out IntPtr phCryptProvOrNCryptKey,
             out CryptKeySpec pdwKeySpec,
-            out bool pfCallerFreeProvOrNCryptKey);
+            [MarshalAs(UnmanagedType.Bool)] out bool pfCallerFreeProvOrNCryptKey);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptAcquireCertificatePrivateKey_SafeNCryptKeyHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptAcquireCertificatePrivateKey_SafeNCryptKeyHandle.cs
@@ -10,12 +10,13 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool CryptAcquireCertificatePrivateKey(
             SafeCertContextHandle pCert,
             CryptAcquireCertificatePrivateKeyFlags dwFlags,
             IntPtr pvParameters,
             out SafeNCryptKeyHandle phCryptProvOrNCryptKey,
             out CryptKeySpec pdwKeySpec,
-            out bool pfCallerFreeProvOrNCryptKey);
+            [MarshalAs(UnmanagedType.Bool)] out bool pfCallerFreeProvOrNCryptKey);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptDecodeObject.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptDecodeObject.cs
@@ -14,6 +14,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static unsafe partial bool CryptDecodeObject(
             MsgEncodingType dwCertEncodingType,
             IntPtr lpszStructType,

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptDecodeObjectPointer_IntPtr.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptDecodeObjectPointer_IntPtr.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, EntryPoint = "CryptDecodeObject",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CryptDecodeObjectPointer(
             CertEncodingType dwCertEncodingType,
             IntPtr lpszStructType,

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptDecodeObjectPointer_string.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptDecodeObjectPointer_string.cs
@@ -8,6 +8,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, EntryPoint = "CryptDecodeObject",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CryptDecodeObjectPointer(
             CertEncodingType dwCertEncodingType,
             [MarshalAs(UnmanagedType.LPStr)] string lpszStructType,

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptDecodeObject_CertEncodingType.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptDecodeObject_CertEncodingType.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CryptDecodeObject(CertEncodingType dwCertEncodingType, IntPtr lpszStructType, byte[] pbEncoded, int cbEncoded, CryptDecodeObjectFlags dwFlags, byte[]? pvStructInfo, ref int pcbStructInfo);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptEncodeObject.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptEncodeObject.cs
@@ -14,6 +14,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static unsafe partial bool CryptEncodeObject(
             MsgEncodingType dwCertEncodingType,
             nint lpszStructType,

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptEncodeObject_CertEncodingType.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptEncodeObject_CertEncodingType.cs
@@ -9,9 +9,11 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CryptEncodeObject(CertEncodingType dwCertEncodingType, IntPtr lpszStructType, void* pvStructInfo, byte[]? pbEncoded, ref int pcbEncoded);
 
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CryptEncodeObject(CertEncodingType dwCertEncodingType, [MarshalAs(UnmanagedType.LPStr)] string lpszStructType, void* pvStructInfo, byte[]? pbEncoded, ref int pcbEncoded);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptFormatObject.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptFormatObject.cs
@@ -13,6 +13,7 @@ internal static partial class Interop
         internal const int CRYPT_FORMAT_STR_NO_HEX     = 0x00000010;
 
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CryptFormatObject(
             int dwCertEncodingType,   // only valid value is X509_ASN_ENCODING
             int dwFormatType,         // unused - pass 0.

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptHashPublicKeyInfo.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptHashPublicKeyInfo.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CryptHashPublicKeyInfo(
             IntPtr hCryptProv,
             int algId,

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptImportPublicKeyInfoEx2.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptImportPublicKeyInfoEx2.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CryptImportPublicKeyInfoEx2(
             CertEncodingType dwCertEncodingType,
             CERT_PUBLIC_KEY_INFO* pInfo,

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptMsgClose.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptMsgClose.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CryptMsgClose(IntPtr hCryptMsg);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptMsgControl.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptMsgControl.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CryptMsgControl(
             SafeCryptMsgHandle hCryptMsg,
             int dwFlags,
@@ -16,6 +17,7 @@ internal static partial class Interop
             ref CMSG_CTRL_DECRYPT_PARA pvCtrlPara);
 
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CryptMsgControl(
             SafeCryptMsgHandle hCryptMsg,
             int dwFlags,

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptMsgGetParam.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptMsgGetParam.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CryptMsgGetParam(
             SafeCryptMsgHandle hCryptMsg,
             CryptMsgParamType dwParamType,
@@ -18,6 +19,7 @@ internal static partial class Interop
             ref int pcbData);
 
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CryptMsgGetParam(
             SafeCryptMsgHandle hCryptMsg,
             CryptMsgParamType dwParamType,
@@ -26,6 +28,7 @@ internal static partial class Interop
             ref int pcbData);
 
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CryptMsgGetParam(
             SafeCryptMsgHandle hCryptMsg,
             CryptMsgParamType dwParamType,
@@ -34,6 +37,7 @@ internal static partial class Interop
             ref int pcbData);
 
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CryptMsgGetParam(
             SafeCryptMsgHandle hCryptMsg,
             CryptMsgParamType dwParamType,

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptMsgUpdate.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptMsgUpdate.cs
@@ -10,12 +10,15 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
-        internal static partial bool CryptMsgUpdate(SafeCryptMsgHandle hCryptMsg, byte[] pbData, int cbData, bool fFinal);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool CryptMsgUpdate(SafeCryptMsgHandle hCryptMsg, byte[] pbData, int cbData, [MarshalAs(UnmanagedType.Bool)] bool fFinal);
 
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
-        internal static partial bool CryptMsgUpdate(SafeCryptMsgHandle hCryptMsg, IntPtr pbData, int cbData, bool fFinal);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool CryptMsgUpdate(SafeCryptMsgHandle hCryptMsg, IntPtr pbData, int cbData, [MarshalAs(UnmanagedType.Bool)] bool fFinal);
 
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
-        internal static partial bool CryptMsgUpdate(SafeCryptMsgHandle hCryptMsg, ref byte pbData, int cbData, bool fFinal);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool CryptMsgUpdate(SafeCryptMsgHandle hCryptMsg, ref byte pbData, int cbData, [MarshalAs(UnmanagedType.Bool)] bool fFinal);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptProtectMemory.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptProtectMemory.cs
@@ -11,9 +11,11 @@ internal static partial class Interop
         internal const uint CRYPTPROTECTMEMORY_SAME_PROCESS = 0;
 
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CryptProtectMemory(SafeBuffer pData, uint cbData, uint dwFlags);
 
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CryptUnprotectMemory(SafeBuffer pData, uint cbData, uint dwFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptQueryObject.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptQueryObject.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CryptQueryObject(
             CertQueryObjectType dwObjectType,
             void* pvObject,
@@ -25,6 +26,7 @@ internal static partial class Interop
             );
 
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CryptQueryObject(
             CertQueryObjectType dwObjectType,
             void* pvObject,
@@ -40,6 +42,7 @@ internal static partial class Interop
             );
 
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CryptQueryObject(
             CertQueryObjectType dwObjectType,
             void* pvObject,

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptQueryObject_IntPtr_out.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptQueryObject_IntPtr_out.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CryptQueryObject(
             CertQueryObjectType dwObjectType,
             void* pvObject,

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.PFXExportCertStore.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.PFXExportCertStore.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool PFXExportCertStore(SafeCertStoreHandle hStore, ref DATA_BLOB pPFX, SafePasswordHandle szPassword, PFXExportFlags dwFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/CryptUI/Interop.CryptUIDlgCertificate.cs
+++ b/src/libraries/Common/src/Interop/Windows/CryptUI/Interop.CryptUIDlgCertificate.cs
@@ -211,6 +211,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Interop.Libraries.CryptUI, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CryptUIDlgViewCertificateW(
             in CRYPTUI_VIEWCERTIFICATE_STRUCTW ViewInfo, IntPtr pfPropertiesChanged);
 

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.DeleteDC.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.DeleteDC.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Gdi32
     {
         [GeneratedDllImport(Libraries.Gdi32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool DeleteDC(IntPtr hdc);
 
         public static bool DeleteDC(HandleRef hdc)

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.DeleteObject.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.DeleteObject.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Gdi32
     {
         [GeneratedDllImport(Libraries.Gdi32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool DeleteObject(IntPtr ho);
 
         public static bool DeleteObject(HandleRef ho)

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.OffsetViewportOrgEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.OffsetViewportOrgEx.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Gdi32
     {
         [GeneratedDllImport(Libraries.Gdi32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool OffsetViewportOrgEx(IntPtr hdc, int x, int y, ref Point lppt);
 
         public static bool OffsetViewportOrgEx(HandleRef hdc, int x, int y, ref Point lppt)

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.RestoreDC.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.RestoreDC.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Gdi32
     {
         [GeneratedDllImport(Libraries.Gdi32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool RestoreDC(IntPtr hdc, int nSavedDC);
 
         public static bool RestoreDC(HandleRef hdc, int nSavedDC)

--- a/src/libraries/Common/src/Interop/Windows/IpHlpApi/Interop.ICMP.cs
+++ b/src/libraries/Common/src/Interop/Windows/IpHlpApi/Interop.ICMP.cs
@@ -96,6 +96,7 @@ internal static partial class Interop
         internal static partial SafeCloseIcmpHandle Icmp6CreateFile();
 
         [GeneratedDllImport(Interop.Libraries.IpHlpApi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool IcmpCloseHandle(IntPtr handle);
 
         [GeneratedDllImport(Interop.Libraries.IpHlpApi, SetLastError = true)]

--- a/src/libraries/Common/src/Interop/Windows/IpHlpApi/Interop.NetworkInformation.cs
+++ b/src/libraries/Common/src/Interop/Windows/IpHlpApi/Interop.NetworkInformation.cs
@@ -531,17 +531,17 @@ internal static partial class Interop
         internal static partial uint GetIcmpStatisticsEx(out MibIcmpInfoEx statistics, AddressFamily family);
 
         [GeneratedDllImport(Interop.Libraries.IpHlpApi)]
-        internal static unsafe partial uint GetTcpTable(IntPtr pTcpTable, uint* dwOutBufLen, bool order);
+        internal static unsafe partial uint GetTcpTable(IntPtr pTcpTable, uint* dwOutBufLen, [MarshalAs(UnmanagedType.Bool)] bool order);
 
         [GeneratedDllImport(Interop.Libraries.IpHlpApi)]
-        internal static unsafe partial uint GetExtendedTcpTable(IntPtr pTcpTable, uint* dwOutBufLen, bool order,
+        internal static unsafe partial uint GetExtendedTcpTable(IntPtr pTcpTable, uint* dwOutBufLen, [MarshalAs(UnmanagedType.Bool)] bool order,
                                                         uint IPVersion, TcpTableClass tableClass, uint reserved);
 
         [GeneratedDllImport(Interop.Libraries.IpHlpApi)]
-        internal static unsafe partial uint GetUdpTable(IntPtr pUdpTable, uint* dwOutBufLen, bool order);
+        internal static unsafe partial uint GetUdpTable(IntPtr pUdpTable, uint* dwOutBufLen, [MarshalAs(UnmanagedType.Bool)] bool order);
 
         [GeneratedDllImport(Interop.Libraries.IpHlpApi)]
-        internal static unsafe partial uint GetExtendedUdpTable(IntPtr pUdpTable, uint* dwOutBufLen, bool order,
+        internal static unsafe partial uint GetExtendedUdpTable(IntPtr pUdpTable, uint* dwOutBufLen, [MarshalAs(UnmanagedType.Bool)] bool order,
                                                         uint IPVersion, UdpTableClass tableClass, uint reserved);
 
         [GeneratedDllImport(Interop.Libraries.IpHlpApi)]

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Beep.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Beep.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool Beep(int frequency, int duration);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CancelIoEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CancelIoEx.cs
@@ -10,9 +10,11 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CancelIoEx(SafeHandle handle, NativeOverlapped* lpOverlapped);
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CancelIoEx(IntPtr handle, NativeOverlapped* lpOverlapped);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ClearCommBreak.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ClearCommBreak.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool ClearCommBreak(
             SafeFileHandle hFile);
     }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ClearCommError.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ClearCommError.cs
@@ -10,12 +10,14 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool ClearCommError(
             SafeFileHandle hFile,
             ref int lpErrors,
             ref COMSTAT lpStat);
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool ClearCommError(
             SafeFileHandle hFile,
             ref int lpErrors,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CloseHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CloseHandle.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CloseHandle(IntPtr handle);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ConditionVariable.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ConditionVariable.cs
@@ -21,6 +21,7 @@ internal static partial class Interop
         internal static unsafe partial void WakeConditionVariable(CONDITION_VARIABLE* ConditionVariable);
 
         [GeneratedDllImport(Libraries.Kernel32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool SleepConditionVariableCS(CONDITION_VARIABLE* ConditionVariable, CRITICAL_SECTION* CriticalSection, int dwMilliseconds);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ConsoleCursorInfo.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ConsoleCursorInfo.cs
@@ -16,9 +16,11 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetConsoleCursorInfo(IntPtr hConsoleOutput, out CONSOLE_CURSOR_INFO cci);
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetConsoleCursorInfo(IntPtr hConsoleOutput, ref CONSOLE_CURSOR_INFO cci);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CopyFileEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CopyFileEx.cs
@@ -13,6 +13,7 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use CopyFileEx.
         /// </summary>
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CopyFileExW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool CopyFileExPrivate(
             string src,
             string dst,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateDirectory.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateDirectory.cs
@@ -13,6 +13,7 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use CreateDirectory.
         /// </summary>
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateDirectoryW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool CreateDirectoryPrivate(
             string path,
             ref SECURITY_ATTRIBUTES lpSecurityAttributes);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreatePipe_SafeFileHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreatePipe_SafeFileHandle.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CreatePipe(out SafeFileHandle hReadPipe, out SafeFileHandle hWritePipe, ref SECURITY_ATTRIBUTES lpPipeAttributes, int nSize);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreatePipe_SafePipeHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreatePipe_SafePipeHandle.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CreatePipe(out SafePipeHandle hReadPipe, out SafePipeHandle hWritePipe, ref SECURITY_ATTRIBUTES lpPipeAttributes, int nSize);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateProcess.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateProcess.cs
@@ -11,12 +11,13 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateProcessW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool CreateProcess(
             string? lpApplicationName,
             char* lpCommandLine,
             ref SECURITY_ATTRIBUTES procSecAttrs,
             ref SECURITY_ATTRIBUTES threadSecAttrs,
-            bool bInheritHandles,
+            [MarshalAs(UnmanagedType.Bool)] bool bInheritHandles,
             int dwCreationFlags,
             IntPtr lpEnvironment,
             string? lpCurrentDirectory,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateSymbolicLink.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateSymbolicLink.cs
@@ -21,6 +21,7 @@ internal static partial class Interop
         internal const int SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE = 0x2;
 
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateSymbolicLinkW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool CreateSymbolicLinkPrivate(string lpSymlinkFileName, string lpTargetFileName, int dwFlags);
 
         /// <summary>

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateToolhelp32Snapshot.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateToolhelp32Snapshot.cs
@@ -42,10 +42,12 @@ internal static partial class Interop
 
         // https://docs.microsoft.com/windows/desktop/api/tlhelp32/nf-tlhelp32-process32first
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "Process32FirstW", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool Process32First(IntPtr hSnapshot, ref PROCESSENTRY32 lppe);
 
         // https://docs.microsoft.com/windows/desktop/api/tlhelp32/nf-tlhelp32-process32next
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "Process32NextW", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool Process32Next(IntPtr hSnapshot, ref PROCESSENTRY32 lppe);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DeleteFile.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DeleteFile.cs
@@ -13,6 +13,7 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use DeleteFile.
         /// </summary>
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "DeleteFileW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool DeleteFilePrivate(string path);
 
         internal static bool DeleteFile(string path)

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DeleteVolumeMountPoint.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DeleteVolumeMountPoint.cs
@@ -13,6 +13,7 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use DeleteVolumeMountPoint.
         /// </summary>
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "DeleteVolumeMountPointW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool DeleteVolumeMountPointPrivate(string mountPoint);
 
         internal static bool DeleteVolumeMountPoint(string mountPoint)

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DeviceIoControl.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DeviceIoControl.cs
@@ -13,6 +13,7 @@ internal static partial class Interop
         internal const int FSCTL_GET_REPARSE_POINT = 0x000900a8;
 
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "DeviceIoControl", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool DeviceIoControl(
             SafeHandle hDevice,
             uint dwIoControlCode,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DuplicateHandle_SafeAccessTokenHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DuplicateHandle_SafeAccessTokenHandle.cs
@@ -10,13 +10,14 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool DuplicateHandle(
             IntPtr hSourceProcessHandle,
             IntPtr hSourceHandle,
             IntPtr hTargetProcessHandle,
             ref SafeAccessTokenHandle lpTargetHandle,
             uint dwDesiredAccess,
-            bool bInheritHandle,
+            [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle,
             uint dwOptions);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DuplicateHandle_SafeFileHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DuplicateHandle_SafeFileHandle.cs
@@ -10,13 +10,14 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool DuplicateHandle(
             IntPtr hSourceProcessHandle,
             SafeHandle hSourceHandle,
             IntPtr hTargetProcess,
             out SafeFileHandle targetHandle,
             int dwDesiredAccess,
-            bool bInheritHandle,
+            [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle,
             int dwOptions
         );
     }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DuplicateHandle_SafePipeHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DuplicateHandle_SafePipeHandle.cs
@@ -10,13 +10,14 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool DuplicateHandle(
             IntPtr hSourceProcessHandle,
             SafeHandle hSourceHandle,
             IntPtr hTargetProcessHandle,
             out SafePipeHandle lpTargetHandle,
             uint dwDesiredAccess,
-            bool bInheritHandle,
+            [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle,
             uint dwOptions);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DuplicateHandle_SafeWaitHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DuplicateHandle_SafeWaitHandle.cs
@@ -10,13 +10,14 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool DuplicateHandle(
             IntPtr hSourceProcessHandle,
             SafeHandle hSourceHandle,
             IntPtr hTargetProcess,
             out SafeWaitHandle targetHandle,
             int dwDesiredAccess,
-            bool bInheritHandle,
+            [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle,
             int dwOptions
         );
     }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EnumProcessModules.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EnumProcessModules.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "K32EnumProcessModules",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EnumProcessModules(SafeProcessHandle handle, IntPtr[]? modules, int size, out int needed);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EnumProcesses.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EnumProcesses.cs
@@ -8,6 +8,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "K32EnumProcesses",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EnumProcesses(int[] processIds, int size, out int needed);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EscapeCommFunction.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EscapeCommFunction.cs
@@ -17,6 +17,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EscapeCommFunction(
             SafeFileHandle hFile,
             int dwFunc);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EventWaitHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EventWaitHandle.cs
@@ -13,15 +13,17 @@ internal static partial class Interop
         internal const uint CREATE_EVENT_MANUAL_RESET = 0x1;
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetEvent(SafeWaitHandle handle);
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool ResetEvent(SafeWaitHandle handle);
 
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateEventExW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
         internal static partial SafeWaitHandle CreateEventEx(IntPtr lpSecurityAttributes, string? name, uint flags, uint desiredAccess);
 
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "OpenEventW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
-        internal static partial SafeWaitHandle OpenEvent(uint desiredAccess, bool inheritHandle, string name);
+        internal static partial SafeWaitHandle OpenEvent(uint desiredAccess, [MarshalAs(UnmanagedType.Bool)] bool inheritHandle, string name);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FillConsoleOutputAttribute.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FillConsoleOutputAttribute.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool FillConsoleOutputAttribute(IntPtr hConsoleOutput, short wColorAttribute, int numCells, COORD startCoord, out int pNumBytesWritten);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FillConsoleOutputCharacter.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FillConsoleOutputCharacter.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "FillConsoleOutputCharacterW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool FillConsoleOutputCharacter(IntPtr hConsoleOutput, char character, int nLength, COORD dwWriteCoord, out int pNumCharsWritten);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FindClose.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FindClose.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool FindClose(IntPtr hFindFile);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FindNextFile.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FindNextFile.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "FindNextFileW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool FindNextFile(SafeFindHandle hndFindFile, ref WIN32_FIND_DATA lpFindFileData);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FlushViewOfFile.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FlushViewOfFile.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool FlushViewOfFile(IntPtr lpBaseAddress, UIntPtr dwNumberOfBytesToFlush);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FreeLibrary.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FreeLibrary.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool FreeLibrary(IntPtr hModule);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetCommModemStatus.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetCommModemStatus.cs
@@ -16,6 +16,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetCommModemStatus(
             SafeFileHandle hFile,
             ref int lpModemStat);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetCommProperties.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetCommProperties.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetCommProperties(
             SafeFileHandle hFile,
             ref COMMPROP lpCommProp);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetCommState.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetCommState.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetCommState(
             SafeFileHandle hFile,
             ref DCB lpDCB);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetConsoleMode.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetConsoleMode.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetConsoleMode(IntPtr handle, out int mode);
 
         internal static bool IsGetConsoleModeCallSuccessful(IntPtr handle)
@@ -17,6 +18,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetConsoleMode(IntPtr handle, int mode);
 
         internal const int ENABLE_PROCESSED_INPUT = 0x0001;

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetConsoleScreenBufferInfo.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetConsoleScreenBufferInfo.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetConsoleScreenBufferInfo(IntPtr hConsoleOutput, out CONSOLE_SCREEN_BUFFER_INFO lpConsoleScreenBufferInfo);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetDiskFreeSpaceEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetDiskFreeSpaceEx.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
         // NOTE: The out parameters are PULARGE_INTEGERs and may require
         // some byte munging magic.
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "GetDiskFreeSpaceExW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetDiskFreeSpaceEx(string drive, out long freeBytesForUser, out long totalBytes, out long freeBytes);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetExitCodeProcess.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetExitCodeProcess.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetExitCodeProcess(SafeProcessHandle processHandle, out int exitCode);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetFileAttributesEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetFileAttributesEx.cs
@@ -12,6 +12,7 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use GetFileAttributesEx.
         /// </summary>
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "GetFileAttributesExW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool GetFileAttributesExPrivate(
             string? name,
             GET_FILEEX_INFO_LEVELS fileInfoLevel,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetFileInformationByHandleEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetFileInformationByHandleEx.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool GetFileInformationByHandleEx(SafeFileHandle hFile, int FileInformationClass, void* lpFileInformation, uint dwBufferSize);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetModuleInformation.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetModuleInformation.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "K32GetModuleInformation",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool GetModuleInformation(SafeProcessHandle processHandle, IntPtr moduleHandle, out NtModuleInfo ntModuleInfo, int size);
 
         internal static unsafe bool GetModuleInformation(SafeProcessHandle processHandle, IntPtr moduleHandle, out NtModuleInfo ntModuleInfo) =>

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetNamedPipeHandleState.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetNamedPipeHandleState.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool GetNamedPipeHandleStateW(
             SafePipeHandle hNamedPipe,
             uint* lpState,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetNamedPipeInfo.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetNamedPipeInfo.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool GetNamedPipeInfo(
             SafePipeHandle hNamedPipe,
             uint* lpFlags,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetOverlappedResult.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetOverlappedResult.cs
@@ -10,10 +10,11 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool GetOverlappedResult(
             SafeFileHandle hFile,
             NativeOverlapped* lpOverlapped,
             ref int lpNumberOfBytesTransferred,
-            bool bWait);
+            [MarshalAs(UnmanagedType.Bool)] bool bWait);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetProcessAffinityMask.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetProcessAffinityMask.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetProcessAffinityMask(SafeProcessHandle handle, out IntPtr processMask, out IntPtr systemMask);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetProcessMemoryInfo.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetProcessMemoryInfo.cs
@@ -24,6 +24,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint ="K32GetProcessMemoryInfo")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetProcessMemoryInfo(IntPtr Process, ref PROCESS_MEMORY_COUNTERS ppsmemCounters, uint cb);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetProcessName.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetProcessName.cs
@@ -11,6 +11,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "QueryFullProcessImageNameW", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static unsafe partial bool QueryFullProcessImageName(
             SafeHandle hProcess,
             uint dwFlags,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetProcessPriorityBoost.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetProcessPriorityBoost.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32,  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
-        internal static partial bool GetProcessPriorityBoost(SafeProcessHandle handle, out bool disabled);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool GetProcessPriorityBoost(SafeProcessHandle handle, [MarshalAs(UnmanagedType.Bool)] out bool disabled);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetProcessTimes.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetProcessTimes.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32,  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetProcessTimes(
             SafeProcessHandle handle, out long creation, out long exit, out long kernel, out long user);
     }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetProcessTimes_IntPtr.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetProcessTimes_IntPtr.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetProcessTimes(IntPtr handleProcess, out long creation, out long exit, out long kernel, out long user);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetProcessWorkingSetSizeEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetProcessWorkingSetSizeEx.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetProcessWorkingSetSizeEx(SafeProcessHandle handle, out IntPtr min, out IntPtr max, out int flags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetSystemTimes.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetSystemTimes.cs
@@ -8,6 +8,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetSystemTimes(out long idle, out long kernel, out long user);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetThreadPriorityBoost.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetThreadPriorityBoost.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
-        internal static partial bool GetThreadPriorityBoost(SafeThreadHandle handle, out bool disabled);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool GetThreadPriorityBoost(SafeThreadHandle handle, [MarshalAs(UnmanagedType.Bool)] out bool disabled);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetThreadTimes.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetThreadTimes.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetThreadTimes(SafeThreadHandle handle, out long creation, out long exit, out long kernel, out long user);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetVolumeInformation.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetVolumeInformation.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "GetVolumeInformationW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool GetVolumeInformation(
             string drive,
             char* volumeName,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Globalization.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Globalization.cs
@@ -96,7 +96,7 @@ internal static partial class Interop
                     int cchCount1,
                     char* lpString2,
                     int cchCount2,
-                    bool bIgnoreCase);
+                    [MarshalAs(UnmanagedType.Bool)] bool bIgnoreCase);
 
         [GeneratedDllImport("kernel32.dll", EntryPoint = "FindStringOrdinal", SetLastError = SetLastErrorForDebug)]
         internal static unsafe partial int FindStringOrdinal(
@@ -108,6 +108,7 @@ internal static partial class Interop
                     BOOL bIgnoreCase);
 
         [GeneratedDllImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool IsNLSDefinedString(
                     int Function,
                     uint dwFlags,
@@ -122,9 +123,11 @@ internal static partial class Interop
         internal static unsafe partial int GetLocaleInfoEx(string lpLocaleName, uint LCType, void* lpLCData, int cchData);
 
         [GeneratedDllImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool EnumSystemLocalesEx(delegate* unmanaged<char*, uint, void*, BOOL> lpLocaleEnumProcEx, uint dwFlags, void* lParam, IntPtr reserved);
 
         [GeneratedDllImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool EnumTimeFormatsEx(delegate* unmanaged<char*, void*, BOOL> lpTimeFmtEnumProcEx, string lpLocaleName, uint dwFlags, void* lParam);
 
         [GeneratedDllImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16)]
@@ -140,6 +143,7 @@ internal static partial class Interop
         internal static unsafe partial int GetGeoInfo(int location, int geoType, char* lpGeoData, int cchData, int LangId);
 
         [GeneratedDllImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool EnumCalendarInfoExEx(delegate* unmanaged<char*, uint, IntPtr, void*, BOOL> pCalInfoEnumProcExEx, string lpLocaleName, uint Calendar, string? lpReserved, uint CalType, void* lParam);
 
         [StructLayout(LayoutKind.Sequential)]
@@ -153,6 +157,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool GetNLSVersionEx(int function, string localeName, NlsVersionInfoEx* lpVersionInformation);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.HandleInformation.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.HandleInformation.cs
@@ -18,6 +18,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetHandleInformation(SafeHandle hObject, HandleFlags dwMask, HandleFlags dwFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Heap.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Heap.cs
@@ -25,6 +25,7 @@ internal static partial class Interop
         internal static partial SafeHeapAllocHandle HeapAlloc(IntPtr hHeap, HeapAllocFlags dwFlags, nint dwBytes);
 
         [GeneratedDllImport(Libraries.Kernel32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool HeapFree(IntPtr hHeap, HeapAllocFlags dwFlags, IntPtr lpMem);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.IsDebuggerPresent.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.IsDebuggerPresent.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool IsDebuggerPresent();
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.IsWow64Process_IntPtr.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.IsWow64Process_IntPtr.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
-        internal static partial bool IsWow64Process(IntPtr hProcess, out bool Wow64Process);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool IsWow64Process(IntPtr hProcess, [MarshalAs(UnmanagedType.Bool)] out bool Wow64Process);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.IsWow64Process_SafeProcessHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.IsWow64Process_SafeProcessHandle.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
-        internal static partial bool IsWow64Process(SafeProcessHandle hProcess, out bool Wow64Process);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool IsWow64Process(SafeProcessHandle hProcess, [MarshalAs(UnmanagedType.Bool)] out bool Wow64Process);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.LockFile.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.LockFile.cs
@@ -9,9 +9,11 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool LockFile(SafeFileHandle handle, int offsetLow, int offsetHigh, int countLow, int countHigh);
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool UnlockFile(SafeFileHandle handle, int offsetLow, int offsetHigh, int countLow, int countHigh);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.MoveFileEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.MoveFileEx.cs
@@ -16,6 +16,7 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use MoveFile.
         /// </summary>
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "MoveFileExW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool MoveFileExPrivate(
             string src, string dst, uint flags);
 

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Mutex.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Mutex.cs
@@ -12,12 +12,13 @@ internal static partial class Interop
         internal const uint CREATE_MUTEX_INITIAL_OWNER = 0x1;
 
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "OpenMutexW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
-        internal static partial SafeWaitHandle OpenMutex(uint desiredAccess, bool inheritHandle, string name);
+        internal static partial SafeWaitHandle OpenMutex(uint desiredAccess, [MarshalAs(UnmanagedType.Bool)] bool inheritHandle, string name);
 
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateMutexExW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
         internal static partial SafeWaitHandle CreateMutexEx(IntPtr lpMutexAttributes, string? name, uint flags, uint desiredAccess);
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return:MarshalAs(UnmanagedType.Bool)]
         internal static partial bool ReleaseMutex(SafeWaitHandle handle);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.OpenProcess.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.OpenProcess.cs
@@ -10,6 +10,6 @@ internal static partial class Interop
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
         internal static partial SafeProcessHandle OpenProcess(
-            int access, bool inherit, int processId);
+            int access, [MarshalAs(UnmanagedType.Bool)] bool inherit, int processId);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.OpenThread.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.OpenThread.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
-        internal static partial SafeThreadHandle OpenThread(int access, bool inherit, int threadId);
+        internal static partial SafeThreadHandle OpenThread(int access, [MarshalAs(UnmanagedType.Bool)] bool inherit, int threadId);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.PeekConsoleInput.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.PeekConsoleInput.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "PeekConsoleInputW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool PeekConsoleInput(IntPtr hConsoleInput, out InputRecord buffer, int numInputRecords_UseOne, out int numEventsRead);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.PurgeComm.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.PurgeComm.cs
@@ -17,6 +17,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool PurgeComm(
             SafeFileHandle hFile,
             uint dwFlags);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.QueryUnbiasedInterruptTime.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.QueryUnbiasedInterruptTime.cs
@@ -8,6 +8,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool QueryUnbiasedInterruptTime(out ulong UnbiasedTime);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadConsole.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadConsole.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "ReadConsoleW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool ReadConsole(
             IntPtr hConsoleInput,
             byte* lpBuffer,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadConsoleInput.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadConsoleInput.cs
@@ -33,6 +33,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "ReadConsoleInputW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool ReadConsoleInput(IntPtr hConsoleInput, out InputRecord buffer, int numInputRecords_UseOne, out int numEventsRead);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadConsoleOutput.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadConsoleOutput.cs
@@ -16,6 +16,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "ReadConsoleOutputW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool ReadConsoleOutput(IntPtr hConsoleOutput, CHAR_INFO* pBuffer, COORD bufferSize, COORD bufferCoord, ref SMALL_RECT readRegion);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadDirectoryChangesW.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadDirectoryChangesW.cs
@@ -11,11 +11,12 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "ReadDirectoryChangesW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool ReadDirectoryChangesW(
             SafeFileHandle hDirectory,
             byte[] lpBuffer,
             uint nBufferLength,
-            bool bWatchSubtree,
+            [MarshalAs(UnmanagedType.Bool)] bool bWatchSubtree,
             uint dwNotifyFilter,
             uint* lpBytesReturned,
             NativeOverlapped* lpOverlapped,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.RemoveDirectory.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.RemoveDirectory.cs
@@ -13,6 +13,7 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use RemoveDirectory.
         /// </summary>
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "RemoveDirectoryW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool RemoveDirectoryPrivate(string path);
 
         internal static bool RemoveDirectory(string path)

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReplaceFile.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReplaceFile.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "ReplaceFileW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool ReplaceFilePrivate(
             string replacedFileName, string replacementFileName, string? backupFileName,
             int dwReplaceFlags, IntPtr lpExclude, IntPtr lpReserved);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Semaphore.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Semaphore.cs
@@ -10,12 +10,13 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "OpenSemaphoreW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
-        internal static partial SafeWaitHandle OpenSemaphore(uint desiredAccess, bool inheritHandle, string name);
+        internal static partial SafeWaitHandle OpenSemaphore(uint desiredAccess, [MarshalAs(UnmanagedType.Bool)] bool inheritHandle, string name);
 
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateSemaphoreExW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
         internal static partial SafeWaitHandle CreateSemaphoreEx(IntPtr lpSecurityAttributes, int initialCount, int maximumCount, string? name, uint flags, uint desiredAccess);
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool ReleaseSemaphore(SafeWaitHandle handle, int releaseCount, out int previousCount);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetCommBreak.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetCommBreak.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetCommBreak(
             SafeFileHandle hFile);
     }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetCommMask.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetCommMask.cs
@@ -16,6 +16,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetCommMask(
             SafeFileHandle hFile,
             int dwEvtMask

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetCommState.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetCommState.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetCommState(
             SafeFileHandle hFile,
             ref DCB lpDCB);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetCommTimeouts.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetCommTimeouts.cs
@@ -11,6 +11,7 @@ internal static partial class Interop
         internal const int MAXDWORD = -1; // This is 0xfffffff, or UInt32.MaxValue, here used as an int
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetCommTimeouts(
             SafeFileHandle hFile,
             ref COMMTIMEOUTS lpCommTimeouts);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetConsoleCP.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetConsoleCP.cs
@@ -8,6 +8,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetConsoleCP(int codePage);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetConsoleCtrlHandler.Delegate.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetConsoleCtrlHandler.Delegate.cs
@@ -12,6 +12,7 @@ internal static partial class Interop
         internal delegate bool ConsoleCtrlHandlerRoutine(int controlType);
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
-        internal static partial bool SetConsoleCtrlHandler(ConsoleCtrlHandlerRoutine handler, bool addOrRemove);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool SetConsoleCtrlHandler(ConsoleCtrlHandlerRoutine handler, [MarshalAs(UnmanagedType.Bool)] bool addOrRemove);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetConsoleCtrlHandler.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetConsoleCtrlHandler.cs
@@ -14,6 +14,7 @@ internal static partial class Interop
         internal const int CTRL_SHUTDOWN_EVENT = 6;
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
-        internal static unsafe partial bool SetConsoleCtrlHandler(delegate* unmanaged<int, BOOL> handler, bool Add);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static unsafe partial bool SetConsoleCtrlHandler(delegate* unmanaged<int, BOOL> handler, [MarshalAs(UnmanagedType.Bool)] bool Add);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetConsoleCursorPosition.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetConsoleCursorPosition.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetConsoleCursorPosition(IntPtr hConsoleOutput, COORD cursorPosition);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetConsoleOutputCP.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetConsoleOutputCP.cs
@@ -8,6 +8,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetConsoleOutputCP(int codePage);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetConsoleScreenBufferSize.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetConsoleScreenBufferSize.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetConsoleScreenBufferSize(IntPtr hConsoleOutput, Interop.Kernel32.COORD size);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetConsoleTitle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetConsoleTitle.cs
@@ -8,6 +8,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "SetConsoleTitleW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetConsoleTitle(string title);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetConsoleWindowInfo.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetConsoleWindowInfo.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
-        internal static unsafe partial bool SetConsoleWindowInfo(IntPtr hConsoleOutput, bool absolute, SMALL_RECT* consoleWindow);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static unsafe partial bool SetConsoleWindowInfo(IntPtr hConsoleOutput, [MarshalAs(UnmanagedType.Bool)] bool absolute, SMALL_RECT* consoleWindow);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetCurrentDirectory.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetCurrentDirectory.cs
@@ -8,6 +8,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "SetCurrentDirectoryW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetCurrentDirectory(string path);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetEnvironmentVariable.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetEnvironmentVariable.cs
@@ -8,6 +8,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "SetEnvironmentVariableW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetEnvironmentVariable(string lpName, string? lpValue);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetFileAttributes.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetFileAttributes.cs
@@ -12,6 +12,7 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use SetFileAttributes.
         /// </summary>
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "SetFileAttributesW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool SetFileAttributesPrivate(
             string name,
             int attr);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetFileCompletionNotificationModes.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetFileCompletionNotificationModes.cs
@@ -17,6 +17,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetFileCompletionNotificationModes(SafeHandle handle, FileCompletionNotificationModes flags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetFileInformationByHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetFileInformationByHandle.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool SetFileInformationByHandle(
             SafeFileHandle hFile,
             int FileInformationClass,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetFilePointerEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetFilePointerEx.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetFilePointerEx(SafeFileHandle hFile, long liDistanceToMove, out long lpNewFilePointer, uint dwMoveMethod);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetPriorityClass.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetPriorityClass.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetPriorityClass(SafeProcessHandle handle, int priorityClass);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetProcessAffinityMask.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetProcessAffinityMask.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetProcessAffinityMask(SafeProcessHandle handle, IntPtr mask);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetProcessPriorityBoost.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetProcessPriorityBoost.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
-        internal static partial bool SetProcessPriorityBoost(SafeProcessHandle handle, bool disabled);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool SetProcessPriorityBoost(SafeProcessHandle handle, [MarshalAs(UnmanagedType.Bool)] bool disabled);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetProcessWorkingSetSizeEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetProcessWorkingSetSizeEx.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetProcessWorkingSetSizeEx(SafeProcessHandle handle, IntPtr min, IntPtr max, int flags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetThreadErrorMode.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetThreadErrorMode.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     {
         [SuppressGCTransition]
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetThreadErrorMode(
             uint dwNewMode,
             out uint lpOldMode);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetThreadPriority.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetThreadPriority.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetThreadPriority(SafeThreadHandle handle, int priority);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetThreadPriorityBoost.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetThreadPriorityBoost.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
-        internal static partial bool SetThreadPriorityBoost(SafeThreadHandle handle, bool disabled);
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool SetThreadPriorityBoost(SafeThreadHandle handle, [MarshalAs(UnmanagedType.Bool)] bool disabled);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetVolumeLabel.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetVolumeLabel.cs
@@ -8,6 +8,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "SetVolumeLabelW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetVolumeLabel(string driveLetter, string? volumeName);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetupComm.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetupComm.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetupComm(
             SafeFileHandle hFile,
             int dwInQueue,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.TerminateProcess.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.TerminateProcess.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool TerminateProcess(SafeProcessHandle processHandle, int exitCode);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ThreadPool.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ThreadPool.cs
@@ -24,7 +24,7 @@ internal static partial class Interop
         internal static partial void SetThreadpoolWait(IntPtr pwa, IntPtr h, IntPtr pftTimeout);
 
         [GeneratedDllImport(Libraries.Kernel32)]
-        internal static partial void WaitForThreadpoolWaitCallbacks(IntPtr pwa, bool fCancelPendingCallbacks);
+        internal static partial void WaitForThreadpoolWaitCallbacks(IntPtr pwa, [MarshalAs(UnmanagedType.Bool)] bool fCancelPendingCallbacks);
 
         [GeneratedDllImport(Libraries.Kernel32)]
         internal static partial void CloseThreadpoolWait(IntPtr pwa);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Threading.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Threading.cs
@@ -44,13 +44,14 @@ internal static partial class Interop
         internal const int DUPLICATE_SAME_ACCESS = 2;
 
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return:MarshalAs(UnmanagedType.Bool)]
         internal static partial bool DuplicateHandle(
             IntPtr hSourceProcessHandle,
             IntPtr hSourceHandle,
             IntPtr hTargetProcessHandle,
             out SafeWaitHandle lpTargetHandle,
             uint dwDesiredAccess,
-            bool bInheritHandle,
+            [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle,
             uint dwOptions);
 
         internal enum ThreadPriority : int
@@ -70,6 +71,7 @@ internal static partial class Interop
         internal static partial ThreadPriority GetThreadPriority(SafeWaitHandle hThread);
 
         [GeneratedDllImport(Libraries.Kernel32)]
+        [return:MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetThreadPriority(SafeWaitHandle hThread, int nPriority);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.UnmapViewOfFile.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.UnmapViewOfFile.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool UnmapViewOfFile(IntPtr lpBaseAddress);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.VerifyVersionExW.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.VerifyVersionExW.cs
@@ -14,6 +14,7 @@ internal static partial class Interop
         internal const uint VER_SERVICEPACKMINOR = 0x0000010;
 
         [GeneratedDllImport(Libraries.Kernel32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool VerifyVersionInfoW(ref OSVERSIONINFOEX lpVersionInfo, uint dwTypeMask, ulong dwlConditionMask);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.VirtualFree.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.VirtualFree.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool VirtualFree(void* lpAddress, UIntPtr dwSize, int dwFreeType);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WaitCommEvent.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WaitCommEvent.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool WaitCommEvent(
             SafeFileHandle hFile,
             int* lpEvtMask,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WriteConsole.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WriteConsole.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "WriteConsoleW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool WriteConsole(
             IntPtr hConsoleOutput,
             byte* lpBuffer,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WriteConsoleOutput.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WriteConsoleOutput.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "WriteConsoleOutputW",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool WriteConsoleOutput(IntPtr hConsoleOutput, CHAR_INFO* buffer, COORD bufferSize, COORD bufferCoord, ref SMALL_RECT writeRegion);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Shell32/Interop.ShellExecuteExW.cs
+++ b/src/libraries/Common/src/Interop/Windows/Shell32/Interop.ShellExecuteExW.cs
@@ -51,6 +51,7 @@ internal static partial class Interop
         internal const uint SEE_MASK_FLAG_NO_UI = 0x00000400;
 
         [GeneratedDllImport(Libraries.Shell32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool ShellExecuteExW(
             SHELLEXECUTEINFO* pExecInfo);
     }

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.DestroyWindow.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.DestroyWindow.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class User32
     {
         [GeneratedDllImport(Libraries.User32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool DestroyWindow(IntPtr hWnd);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.GetClassInfo.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.GetClassInfo.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class User32
     {
         [GeneratedDllImport(Libraries.User32, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool GetClassInfoW(IntPtr hInst, string lpszClass, ref WNDCLASS wc);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.GetUserObjectInformation.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.GetUserObjectInformation.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class User32
     {
         [GeneratedDllImport(Libraries.User32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static unsafe partial bool GetUserObjectInformationW(IntPtr hObj, int nIndex, void* pvBuffer, uint nLength, ref uint lpnLengthNeeded);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.IsWindow.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.IsWindow.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class User32
     {
         [GeneratedDllImport(Libraries.User32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool IsWindow(IntPtr hWnd);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.KillTimer.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.KillTimer.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class User32
     {
         [GeneratedDllImport(Libraries.User32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool KillTimer(IntPtr hwnd, IntPtr idEvent);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.MessageBeep.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.MessageBeep.cs
@@ -14,6 +14,7 @@ internal static partial class Interop
         internal const int MB_ICONASTERISK = 0x40;
 
         [GeneratedDllImport(Libraries.User32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool MessageBeep(int type);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.SystemParametersInfo.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.SystemParametersInfo.cs
@@ -15,6 +15,7 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.User32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static unsafe partial bool SystemParametersInfoW(SystemParametersAction uiAction, uint uiParam, void* pvParam, uint fWinIni);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.TranslateMessage.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.TranslateMessage.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class User32
     {
         [GeneratedDllImport(Libraries.User32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool TranslateMessage(ref MSG msg);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Version/Interop.GetFileVersionInfoEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Version/Interop.GetFileVersionInfoEx.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Version
     {
         [GeneratedDllImport(Libraries.Version, EntryPoint = "GetFileVersionInfoExW", StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetFileVersionInfoEx(
                     uint dwFlags,
                     string lpwstrFilename,

--- a/src/libraries/Common/src/Interop/Windows/Version/Interop.VerQueryValue.cs
+++ b/src/libraries/Common/src/Interop/Windows/Version/Interop.VerQueryValue.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Version
     {
         [GeneratedDllImport(Libraries.Version, EntryPoint = "VerQueryValueW", StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool VerQueryValue(IntPtr pBlock, string lpSubBlock, out IntPtr lplpBuffer, out uint puLen);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/WinMm/Interop.PlaySound.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinMm/Interop.PlaySound.cs
@@ -18,9 +18,11 @@ internal static partial class Interop
         internal const int SND_NOSTOP = 0x10;
 
         [GeneratedDllImport(Libraries.WinMM, EntryPoint = "PlaySoundW", StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool PlaySound(string soundName, IntPtr hmod, int soundFlags);
 
         [GeneratedDllImport(Libraries.WinMM, EntryPoint = "PlaySoundW")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool PlaySound(byte[]? soundName, IntPtr hmod, int soundFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.TransmitFile.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.TransmitFile.cs
@@ -11,6 +11,7 @@ internal static partial class Interop
     internal static partial class Mswsock
     {
         [GeneratedDllImport(Interop.Libraries.Mswsock, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool TransmitFile(
             SafeHandle socket,
             IntPtr fileHandle,

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSAGetOverlappedResult.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSAGetOverlappedResult.cs
@@ -10,11 +10,12 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [GeneratedDllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool WSAGetOverlappedResult(
             SafeSocketHandle socketHandle,
             NativeOverlapped* overlapped,
             out uint bytesTransferred,
-            bool wait,
+            [MarshalAs(UnmanagedType.Bool)] bool wait,
             out SocketFlags socketFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Wldap32/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Windows/Wldap32/Interop.Ldap.cs
@@ -143,7 +143,7 @@ internal static partial class Interop
 
         [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_search_extW", StringMarshalling = StringMarshalling.Utf16)]
         [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-        public static partial int ldap_search(ConnectionHandle ldapHandle, string dn, int scope, string filter, IntPtr attributes, bool attributeOnly, IntPtr servercontrol, IntPtr clientcontrol, int timelimit, int sizelimit, ref int messageNumber);
+        public static partial int ldap_search(ConnectionHandle ldapHandle, string dn, int scope, string filter, IntPtr attributes, [MarshalAs(UnmanagedType.Bool)] bool attributeOnly, IntPtr servercontrol, IntPtr clientcontrol, int timelimit, int sizelimit, ref int messageNumber);
 
         [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_first_entry")]
         [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]

--- a/src/libraries/Common/src/Interop/Windows/WtsApi32/Interop.WTSRegisterSessionNotification.cs
+++ b/src/libraries/Common/src/Interop/Windows/WtsApi32/Interop.WTSRegisterSessionNotification.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Wtsapi32
     {
         [GeneratedDllImport(Libraries.Wtsapi32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool WTSRegisterSessionNotification(IntPtr hWnd, int dwFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/WtsApi32/Interop.WTSUnRegisterSessionNotification.cs
+++ b/src/libraries/Common/src/Interop/Windows/WtsApi32/Interop.WTSUnRegisterSessionNotification.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Wtsapi32
     {
         [GeneratedDllImport(Libraries.Wtsapi32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool WTSUnRegisterSessionNotification(IntPtr hWnd);
     }
 }

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
@@ -146,6 +146,7 @@ namespace System
         private const int PRODUCT_HOME_PREMIUM_N = 0x0000001A;
 
         [GeneratedDllImport("kernel32.dll", SetLastError = false)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool GetProductInfo(
             int dwOSMajorVersion,
             int dwOSMinorVersion,

--- a/src/libraries/Common/tests/TestUtilities/System/WindowsIdentityFixture.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/WindowsIdentityFixture.cs
@@ -110,6 +110,7 @@ namespace System
         }
 
         [GeneratedDllImport("advapi32.dll", EntryPoint = "LogonUserW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool LogonUser(string userName, string domain, string password, int logonType, int logonProvider, out SafeAccessTokenHandle safeAccessTokenHandle);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time

--- a/src/libraries/Microsoft.Win32.Registry/tests/Helpers.cs
+++ b/src/libraries/Microsoft.Win32.Registry/tests/Helpers.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Win32.RegistryTests
         }
 
         [GeneratedDllImport(Interop.Libraries.Kernel32, EntryPoint = "SetEnvironmentVariableW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool SetEnvironmentVariable(string lpName, string lpValue);
     }
 }

--- a/src/libraries/System.Data.OleDb/src/SafeNativeMethods.cs
+++ b/src/libraries/System.Data.OleDb/src/SafeNativeMethods.cs
@@ -39,10 +39,10 @@ namespace System.Data.Common
         internal static partial int ReleaseSemaphore(IntPtr handle, int releaseCount, IntPtr previousCount);
 
         [GeneratedDllImport(Interop.Libraries.Kernel32, SetLastError = true)]
-        internal static partial int WaitForMultipleObjectsEx(uint nCount, IntPtr lpHandles, bool bWaitAll, uint dwMilliseconds, bool bAlertable);
+        internal static partial int WaitForMultipleObjectsEx(uint nCount, IntPtr lpHandles, [MarshalAs(UnmanagedType.Bool)] bool bWaitAll, uint dwMilliseconds, [MarshalAs(UnmanagedType.Bool)] bool bAlertable);
 
         [GeneratedDllImport(Interop.Libraries.Kernel32/*, SetLastError=true*/)]
-        internal static partial int WaitForSingleObjectEx(IntPtr lpHandles, uint dwMilliseconds, bool bAlertable);
+        internal static partial int WaitForSingleObjectEx(IntPtr lpHandles, uint dwMilliseconds, [MarshalAs(UnmanagedType.Bool)] bool bAlertable);
 
         internal sealed class Wrapper
         {

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/UnsafeNativeMethods.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/UnsafeNativeMethods.cs
@@ -441,6 +441,7 @@ namespace Microsoft.Win32
 
         // SEEK
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtSeek(
                             EventLogHandle resultSet,
                             long position,
@@ -460,6 +461,7 @@ namespace Microsoft.Win32
                             int flags);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtNext(
                             EventLogHandle queryHandle,
                             int eventSize,
@@ -469,12 +471,15 @@ namespace Microsoft.Win32
                             ref int returned);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtCancel(EventLogHandle handle);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtClose(IntPtr handle);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtGetEventInfo(
                             EventLogHandle eventHandle,
                             EvtEventPropertyId propertyId,
@@ -483,6 +488,7 @@ namespace Microsoft.Win32
                             out int bufferUsed);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtGetQueryInfo(
                             EventLogHandle queryHandle,
                             EvtQueryPropertyId propertyId,
@@ -500,6 +506,7 @@ namespace Microsoft.Win32
                             int flags);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtGetPublisherMetadataProperty(
                             EventLogHandle publisherMetadataHandle,
                             EvtPublisherMetadataPropertyId propertyId,
@@ -511,11 +518,13 @@ namespace Microsoft.Win32
         // NEW
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtGetObjectArraySize(
                             EventLogHandle objectArray,
                             out int objectArraySize);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtGetObjectArrayProperty(
                             EventLogHandle objectArray,
                             int propertyId,
@@ -537,6 +546,7 @@ namespace Microsoft.Win32
                             int flags);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtGetEventMetadataProperty(
                             EventLogHandle eventMetadata,
                             EvtEventMetadataPropertyId propertyId,
@@ -553,6 +563,7 @@ namespace Microsoft.Win32
                             int flags);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtNextChannelPath(
                             EventLogHandle channelEnum,
                             int channelPathBufferSize,
@@ -565,6 +576,7 @@ namespace Microsoft.Win32
                             int flags);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtNextPublisherId(
                             EventLogHandle publisherEnum,
                             int publisherIdBufferSize,
@@ -578,11 +590,13 @@ namespace Microsoft.Win32
                             int flags);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtSaveChannelConfig(
                             EventLogHandle channelConfig,
                             int flags);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtSetChannelConfigProperty(
                             EventLogHandle channelConfig,
                             EvtChannelConfigPropertyId propertyId,
@@ -590,6 +604,7 @@ namespace Microsoft.Win32
                             ref EvtVariant propertyValue);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtGetChannelConfigProperty(
                             EventLogHandle channelConfig,
                             EvtChannelConfigPropertyId propertyId,
@@ -607,6 +622,7 @@ namespace Microsoft.Win32
                             PathType flags);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtGetLogInfo(
                             EventLogHandle log,
                             EvtLogPropertyId propertyId,
@@ -617,6 +633,7 @@ namespace Microsoft.Win32
         // LOG MANIPULATION
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtExportLog(
                             EventLogHandle session,
                             [MarshalAs(UnmanagedType.LPWStr)] string channelPath,
@@ -625,6 +642,7 @@ namespace Microsoft.Win32
                             int flags);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtArchiveExportedLog(
                             EventLogHandle session,
                             [MarshalAs(UnmanagedType.LPWStr)]string logFilePath,
@@ -632,6 +650,7 @@ namespace Microsoft.Win32
                             int flags);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtClearLog(
                             EventLogHandle session,
                             [MarshalAs(UnmanagedType.LPWStr)]string channelPath,
@@ -647,6 +666,7 @@ namespace Microsoft.Win32
                             EvtRenderContextFlags flags);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtRender(
                             EventLogHandle context,
                             EventLogHandle eventHandle,
@@ -657,6 +677,7 @@ namespace Microsoft.Win32
                             out int propCount);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, EntryPoint = "EvtRender", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtRender(
                             EventLogHandle context,
                             EventLogHandle eventHandle,
@@ -716,6 +737,7 @@ namespace Microsoft.Win32
         };
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtFormatMessage(
                              EventLogHandle publisherMetadataHandle,
                              EventLogHandle eventHandle,
@@ -728,6 +750,7 @@ namespace Microsoft.Win32
                              out int bufferUsed);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, EntryPoint = "EvtFormatMessage", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtFormatMessageBuffer(
                              EventLogHandle publisherMetadataHandle,
                              EventLogHandle eventHandle,
@@ -753,6 +776,7 @@ namespace Microsoft.Win32
                             [MarshalAs(UnmanagedType.LPWStr)] string bookmarkXml);
 
         [GeneratedDllImport(Interop.Libraries.Wevtapi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtUpdateBookmark(
                             EventLogHandle bookmark,
                             EventLogHandle eventHandle);

--- a/src/libraries/System.DirectoryServices/src/Interop/SafeNativeMethods.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/SafeNativeMethods.cs
@@ -13,6 +13,7 @@ namespace System.DirectoryServices.Interop
         public static partial void VariantInit(IntPtr pObject);
 
         [GeneratedDllImport(global::Interop.Libraries.Activeds)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool FreeADsMem(IntPtr pVoid);
 
         public const int

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/NativeMethods.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/NativeMethods.cs
@@ -396,7 +396,7 @@ namespace System.DirectoryServices.ActiveDirectory
         [GeneratedDllImport(global::Interop.Libraries.Dnsapi)]
         internal static partial void DnsRecordListFree(
             IntPtr dnsResultList,
-            bool dnsFreeType);
+            [MarshalAs(UnmanagedType.Bool)] bool dnsFreeType);
 
         /*NTSTATUS LsaConnectUntrusted(
               PHANDLE LsaHandle

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/UnsafeNativeMethods.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/UnsafeNativeMethods.cs
@@ -578,6 +578,7 @@ namespace System.DirectoryServices.ActiveDirectory
         public static partial int ADsEncodeBinaryData(byte[] data, int length, ref IntPtr result);
 
         [GeneratedDllImport(global::Interop.Libraries.Activeds, EntryPoint = "FreeADsMem")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool FreeADsMem(IntPtr pVoid);
 
         [GeneratedDllImport(global::Interop.Libraries.Netapi32, EntryPoint = "DsGetSiteNameW", StringMarshalling = StringMarshalling.Utf16)]
@@ -614,7 +615,7 @@ namespace System.DirectoryServices.ActiveDirectory
         public static partial uint LsaCreateTrustedDomainEx(SafeLsaPolicyHandle handle, in TRUSTED_DOMAIN_INFORMATION_EX domainEx, in TRUSTED_DOMAIN_AUTH_INFORMATION authInfo, int classInfo, out IntPtr domainHandle);
 
         [GeneratedDllImport(global::Interop.Libraries.Kernel32, EntryPoint = "OpenThread", SetLastError = true)]
-        public static partial IntPtr OpenThread(uint desiredAccess, bool inheirted, int threadID);
+        public static partial IntPtr OpenThread(uint desiredAccess, [MarshalAs(UnmanagedType.Bool)] bool inheirted, int threadID);
 
         [GeneratedDllImport(global::Interop.Libraries.Advapi32, EntryPoint = "ImpersonateAnonymousToken", SetLastError = true)]
         public static partial int ImpersonateAnonymousToken(IntPtr token);

--- a/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.Comdlg32.cs
+++ b/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.Comdlg32.cs
@@ -9,9 +9,11 @@ internal static partial class Interop
     internal static partial class Comdlg32
     {
         [GeneratedDllImport(Libraries.Comdlg32, EntryPoint="PrintDlgW", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool PrintDlg(ref PRINTDLG lppd);
 
         [GeneratedDllImport(Libraries.Comdlg32, EntryPoint="PrintDlgW", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool PrintDlg(ref PRINTDLGX86 lppd);
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.User32.cs
+++ b/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.User32.cs
@@ -19,6 +19,7 @@ internal static partial class Interop
             HandleRef hInst, IntPtr iconId);
 
         [GeneratedDllImport(Libraries.User32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool DestroyIcon(
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
@@ -33,6 +34,7 @@ internal static partial class Interop
             HandleRef hImage, int uType, int cxDesired, int cyDesired, int fuFlags);
 
         [GeneratedDllImport(Libraries.User32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetIconInfo(
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
@@ -43,6 +45,7 @@ internal static partial class Interop
         public static partial int GetSystemMetrics(int nIndex);
 
         [GeneratedDllImport(Libraries.User32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool DrawIconEx(
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
@@ -58,7 +61,7 @@ internal static partial class Interop
             HandleRef hBrushFlickerFree, int diFlags);
 
         [GeneratedDllImport(Libraries.User32, SetLastError = true)]
-        internal static unsafe partial IntPtr CreateIconFromResourceEx(byte* pbIconBits, uint cbIconBits, bool fIcon, int dwVersion, int csDesired, int cyDesired, int flags);
+        internal static unsafe partial IntPtr CreateIconFromResourceEx(byte* pbIconBits, uint cbIconBits, [MarshalAs(UnmanagedType.Bool)] bool fIcon, int dwVersion, int csDesired, int cyDesired, int flags);
 
         [StructLayout(LayoutKind.Sequential)]
         internal struct ICONINFO

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -288,7 +288,7 @@ namespace System.Drawing
             internal static partial int GdipAddPathPolygon(IntPtr path, PointF[] points, int count);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipAddPathPath(IntPtr path, IntPtr addingPath, bool connect);
+            internal static partial int GdipAddPathPath(IntPtr path, IntPtr addingPath, [MarshalAs(UnmanagedType.Bool)] bool connect);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipAddPathLineI(IntPtr path, int x1, int y1, int x2, int y2);
@@ -330,16 +330,16 @@ namespace System.Drawing
             internal static partial int GdipGetPathWorldBoundsI(IntPtr path, out Rectangle bounds, IntPtr matrix, IntPtr pen);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipIsVisiblePathPoint(IntPtr path, float x, float y, IntPtr graphics, out bool result);
+            internal static partial int GdipIsVisiblePathPoint(IntPtr path, float x, float y, IntPtr graphics, [MarshalAs(UnmanagedType.Bool)] out bool result);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipIsVisiblePathPointI(IntPtr path, int x, int y, IntPtr graphics, out bool result);
+            internal static partial int GdipIsVisiblePathPointI(IntPtr path, int x, int y, IntPtr graphics, [MarshalAs(UnmanagedType.Bool)] out bool result);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipIsOutlineVisiblePathPoint(IntPtr path, float x, float y, IntPtr pen, IntPtr graphics, out bool result);
+            internal static partial int GdipIsOutlineVisiblePathPoint(IntPtr path, float x, float y, IntPtr pen, IntPtr graphics, [MarshalAs(UnmanagedType.Bool)] out bool result);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipIsOutlineVisiblePathPointI(IntPtr path, int x, int y, IntPtr pen, IntPtr graphics, out bool result);
+            internal static partial int GdipIsOutlineVisiblePathPointI(IntPtr path, int x, int y, IntPtr pen, IntPtr graphics, [MarshalAs(UnmanagedType.Bool)] out bool result);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateFontFromLogfont(IntPtr hdc, ref Interop.User32.LOGFONT lf, out IntPtr ptr);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
@@ -260,7 +260,7 @@ namespace System.Drawing
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef addingPath, bool connect);
+            HandleRef addingPath, [MarshalAs(UnmanagedType.Bool)] bool connect);
 
             [GeneratedDllImport(LibraryName, StringMarshalling = StringMarshalling.Utf16)]
             internal static partial int GdipAddPathString(
@@ -469,7 +469,7 @@ namespace System.Drawing
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef graphics, out bool result);
+            HandleRef graphics, [MarshalAs(UnmanagedType.Bool)] out bool result);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipIsVisiblePathPointI(
@@ -480,7 +480,7 @@ namespace System.Drawing
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef graphics, out bool result);
+            HandleRef graphics, [MarshalAs(UnmanagedType.Bool)] out bool result);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipIsOutlineVisiblePathPoint(
@@ -495,7 +495,7 @@ namespace System.Drawing
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef graphics, out bool result);
+            HandleRef graphics, [MarshalAs(UnmanagedType.Bool)] out bool result);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipIsOutlineVisiblePathPointI(
@@ -510,7 +510,7 @@ namespace System.Drawing
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef graphics, out bool result);
+            HandleRef graphics, [MarshalAs(UnmanagedType.Bool)] out bool result);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipDeleteBrush(

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
@@ -47,7 +47,7 @@ namespace System.Drawing
             HandleRef graphics, int state);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreateAdjustableArrowCap(float height, float width, bool isFilled, out IntPtr adjustableArrowCap);
+            internal static partial int GdipCreateAdjustableArrowCap(float height, float width, [MarshalAs(UnmanagedType.Bool)] bool isFilled, out IntPtr adjustableArrowCap);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetAdjustableArrowCapHeight(
@@ -96,14 +96,14 @@ namespace System.Drawing
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef adjustableArrowCap, bool fillState);
+            HandleRef adjustableArrowCap, [MarshalAs(UnmanagedType.Bool)] bool fillState);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetAdjustableArrowCapFillState(
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef adjustableArrowCap, out bool fillState);
+            HandleRef adjustableArrowCap, [MarshalAs(UnmanagedType.Bool)] out bool fillState);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetCustomLineCapType(IntPtr customCap, out CustomLineCapType capType);
@@ -225,7 +225,7 @@ namespace System.Drawing
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef pathIter, out int resultCount, out int startIndex, out int endIndex, out bool isClosed);
+            HandleRef pathIter, out int resultCount, out int startIndex, out int endIndex, [MarshalAs(UnmanagedType.Bool)] out bool isClosed);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipPathIterNextSubpathPath(
@@ -236,7 +236,7 @@ namespace System.Drawing
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef path, out bool isClosed);
+            HandleRef path, [MarshalAs(UnmanagedType.Bool)] out bool isClosed);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipPathIterNextPathType(
@@ -282,7 +282,7 @@ namespace System.Drawing
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef pathIter, out bool hasCurve);
+            HandleRef pathIter, [MarshalAs(UnmanagedType.Bool)] out bool hasCurve);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipPathIterRewind(
@@ -349,10 +349,10 @@ namespace System.Drawing
             internal static partial int GdipCreateLineBrushFromRectI(ref Rectangle rect, int color1, int color2, LinearGradientMode lineGradientMode, WrapMode wrapMode, out IntPtr lineGradient);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreateLineBrushFromRectWithAngle(ref RectangleF rect, int color1, int color2, float angle, bool isAngleScaleable, WrapMode wrapMode, out IntPtr lineGradient);
+            internal static partial int GdipCreateLineBrushFromRectWithAngle(ref RectangleF rect, int color1, int color2, float angle, [MarshalAs(UnmanagedType.Bool)] bool isAngleScaleable, WrapMode wrapMode, out IntPtr lineGradient);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreateLineBrushFromRectWithAngleI(ref Rectangle rect, int color1, int color2, float angle, bool isAngleScaleable, WrapMode wrapMode, out IntPtr lineGradient);
+            internal static partial int GdipCreateLineBrushFromRectWithAngleI(ref Rectangle rect, int color1, int color2, float angle, [MarshalAs(UnmanagedType.Bool)] bool isAngleScaleable, WrapMode wrapMode, out IntPtr lineGradient);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipSetLineColors(
@@ -380,14 +380,14 @@ namespace System.Drawing
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef brush, out bool useGammaCorrection);
+            HandleRef brush, [MarshalAs(UnmanagedType.Bool)] out bool useGammaCorrection);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipSetLineGammaCorrection(
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef brush, bool useGammaCorrection);
+            HandleRef brush, [MarshalAs(UnmanagedType.Bool)] bool useGammaCorrection);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipSetLineSigmaBlend(
@@ -763,7 +763,7 @@ namespace System.Drawing
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef imageattr, ColorAdjustType type, bool enableFlag,
+            HandleRef imageattr, ColorAdjustType type, [MarshalAs(UnmanagedType.Bool)] bool enableFlag,
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(ColorMatrix.PinningMarshaller))]
 #endif
@@ -778,56 +778,56 @@ namespace System.Drawing
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef imageattr, ColorAdjustType type, bool enableFlag, float threshold);
+            HandleRef imageattr, ColorAdjustType type, [MarshalAs(UnmanagedType.Bool)] bool enableFlag, float threshold);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipSetImageAttributesGamma(
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef imageattr, ColorAdjustType type, bool enableFlag, float gamma);
+            HandleRef imageattr, ColorAdjustType type, [MarshalAs(UnmanagedType.Bool)] bool enableFlag, float gamma);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipSetImageAttributesNoOp(
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef imageattr, ColorAdjustType type, bool enableFlag);
+            HandleRef imageattr, ColorAdjustType type, [MarshalAs(UnmanagedType.Bool)] bool enableFlag);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipSetImageAttributesColorKeys(
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef imageattr, ColorAdjustType type, bool enableFlag, int colorLow, int colorHigh);
+            HandleRef imageattr, ColorAdjustType type, [MarshalAs(UnmanagedType.Bool)] bool enableFlag, int colorLow, int colorHigh);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipSetImageAttributesOutputChannel(
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef imageattr, ColorAdjustType type, bool enableFlag, ColorChannelFlag flags);
+            HandleRef imageattr, ColorAdjustType type, [MarshalAs(UnmanagedType.Bool)] bool enableFlag, ColorChannelFlag flags);
 
             [GeneratedDllImport(LibraryName, StringMarshalling = StringMarshalling.Utf16)]
             internal static partial int GdipSetImageAttributesOutputChannelColorProfile(
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef imageattr, ColorAdjustType type, bool enableFlag, string colorProfileFilename);
+            HandleRef imageattr, ColorAdjustType type, [MarshalAs(UnmanagedType.Bool)] bool enableFlag, string colorProfileFilename);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipSetImageAttributesRemapTable(
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef imageattr, ColorAdjustType type, bool enableFlag, int mapSize, IntPtr map);
+            HandleRef imageattr, ColorAdjustType type, [MarshalAs(UnmanagedType.Bool)] bool enableFlag, int mapSize, IntPtr map);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipSetImageAttributesWrapMode(
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef imageattr, int wrapmode, int argb, bool clamp);
+            HandleRef imageattr, int wrapmode, int argb, [MarshalAs(UnmanagedType.Bool)] bool clamp);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetImageAttributesAdjustedPalette(
@@ -2222,7 +2222,7 @@ namespace System.Drawing
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef graphics, out bool result);
+            HandleRef graphics, [MarshalAs(UnmanagedType.Bool)] out bool result);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetVisibleClipBounds(
@@ -2236,35 +2236,35 @@ namespace System.Drawing
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef graphics, out bool result);
+            HandleRef graphics, [MarshalAs(UnmanagedType.Bool)] out bool result);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipIsVisiblePoint(
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef graphics, float x, float y, out bool result);
+            HandleRef graphics, float x, float y, [MarshalAs(UnmanagedType.Bool)] out bool result);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipIsVisiblePointI(
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef graphics, int x, int y, out bool result);
+            HandleRef graphics, int x, int y, [MarshalAs(UnmanagedType.Bool)] out bool result);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipIsVisibleRect(
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef graphics, float x, float y, float width, float height, out bool result);
+            HandleRef graphics, float x, float y, float width, float height, [MarshalAs(UnmanagedType.Bool)] out bool result);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipIsVisibleRectI(
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef graphics, int x, int y, int width, int height, out bool result);
+            HandleRef graphics, int x, int y, int width, int height, [MarshalAs(UnmanagedType.Bool)] out bool result);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipFlush(
@@ -2686,10 +2686,10 @@ namespace System.Drawing
             HandleRef image, Guid* dimensionIDs, int count);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreateMetafileFromEmf(IntPtr hEnhMetafile, bool deleteEmf, out IntPtr metafile);
+            internal static partial int GdipCreateMetafileFromEmf(IntPtr hEnhMetafile, [MarshalAs(UnmanagedType.Bool)] bool deleteEmf, out IntPtr metafile);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreateMetafileFromWmf(IntPtr hMetafile, bool deleteWmf,
+            internal static partial int GdipCreateMetafileFromWmf(IntPtr hMetafile, [MarshalAs(UnmanagedType.Bool)] bool deleteWmf,
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(WmfPlaceableFileHeader.PinningMarshaller))]
 #endif

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFilesTestsBase.Windows.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFilesTestsBase.Windows.cs
@@ -21,6 +21,7 @@ namespace System.IO.MemoryMappedFiles.Tests
         });
 
         [GeneratedDllImport("kernel32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool GetHandleInformation(IntPtr hObject, out uint lpdwFlags);
 
         private const uint HANDLE_FLAG_INHERIT = 0x00000001;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/XplatEventLogger.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/XplatEventLogger.cs
@@ -39,6 +39,7 @@ namespace System.Diagnostics.Tracing
         }
 
         [GeneratedDllImport(RuntimeHelpers.QCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool IsEventSourceLoggingEnabled();
 
         [GeneratedDllImport(RuntimeHelpers.QCall, StringMarshalling = StringMarshalling.Utf16)]

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshalAsMarshallingGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshalAsMarshallingGeneratorFactory.cs
@@ -76,7 +76,10 @@ namespace Microsoft.Interop
                     return s_blittable;
 
                 case { ManagedType: SpecialTypeInfo { SpecialType: SpecialType.System_Boolean }, MarshallingAttributeInfo: NoMarshallingInfo }:
-                    return s_winBool; // [Compat] Matching the default for the built-in runtime marshallers.
+                    throw new MarshallingNotSupportedException(info, context)
+                    {
+                        NotSupportedDetails = Resources.MarshallingBoolAsUndefinedNotSupported
+                    };
                 case { ManagedType: SpecialTypeInfo { SpecialType: SpecialType.System_Boolean }, MarshallingAttributeInfo: MarshalAsInfo(UnmanagedType.I1 or UnmanagedType.U1, _) }:
                     return s_byteBool;
                 case { ManagedType: SpecialTypeInfo { SpecialType: SpecialType.System_Boolean }, MarshallingAttributeInfo: MarshalAsInfo(UnmanagedType.I4 or UnmanagedType.U4 or UnmanagedType.Bool, _) }:

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
@@ -804,6 +804,17 @@ namespace Microsoft.Interop
                 }
             }
 
+            if (type.SpecialType == SpecialType.System_Boolean)
+            {
+                // We explicitly don't support marshalling bool without any marshalling info
+                // as treating bool as a non-normalized 1-byte value is generally not a good default.
+                // Additionally, that default is different than the runtime marshalling, so by explicitly
+                // blocking bool marshalling without additional info, we make it a little easier
+                // to transition by explicitly notifying people of changing behavior.
+                marshallingInfo = NoMarshallingInfo.Instance;
+                return false;
+            }
+
             if (type is INamedTypeSymbol { IsUnmanagedType: true } unmanagedType
                 && unmanagedType.IsConsideredBlittable())
             {
@@ -818,14 +829,12 @@ namespace Microsoft.Interop
         private MarshallingInfo GetBlittableMarshallingInfo(ITypeSymbol type)
         {
             if (type.TypeKind is TypeKind.Enum or TypeKind.Pointer or TypeKind.FunctionPointer
-                || type.SpecialType.IsAlwaysBlittable()
-                || type.SpecialType == SpecialType.System_Boolean)
+                || type.SpecialType.IsAlwaysBlittable())
             {
                 // Treat primitive types and enums as having no marshalling info.
                 // They are supported in configurations where runtime marshalling is enabled.
                 return NoMarshallingInfo.Instance;
             }
-
             else if (_compilation.GetTypeByMetadataName(TypeNames.System_Runtime_CompilerServices_DisableRuntimeMarshallingAttribute) is null)
             {
                 // If runtime marshalling cannot be disabled, then treat this as a "missing support" scenario so we can gracefully fall back to using the fowarder downlevel.

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Resources.Designer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Resources.Designer.cs
@@ -223,6 +223,15 @@ namespace Microsoft.Interop {
         }
         
         /// <summary>
+        ///   Marshalling bool without explicit marshalling information is not supported. Specify either &apos;MarshalUsingAttribute&apos; or &apos;MarshalAsAttribute&apos;..
+        /// </summary>
+        internal static string MarshallingBoolAsUndefinedNotSupported {
+            get {
+                return ResourceManager.GetString("MarshallingBoolAsUndefinedNotSupported", resourceCulture);
+            }
+        }     
+           
+        /// <summary>
         ///   Looks up a localized string similar to Marshalling char with &apos;CharSet.{0}&apos; is not supported. Instead, manually convert the char type to the desired byte representation and pass to the source-generated P/Invoke..
         /// </summary>
         internal static string MarshallingCharAsSpecifiedCharSetNotSupported {

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Resources.resx
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Resources.resx
@@ -150,6 +150,9 @@
   <data name="InOutAttributeMarshalerNotSupported" xml:space="preserve">
     <value>The provided '[In]' and '[Out]' attributes on this parameter are unsupported on this parameter.</value>
   </data>
+  <data name="MarshallingBoolAsUndefinedNotSupported" xml:space="preserve">
+    <value>Marshalling bool without explicit marshalling information is not supported. Specify either 'MarshalUsingAttribute' or 'MarshalAsAttribute'.</value>
+  </data>
   <data name="MarshallingCharAsSpecifiedCharSetNotSupported" xml:space="preserve">
     <value>Marshalling char with 'CharSet.{0}' is not supported. Instead, manually convert the char type to the desired byte representation and pass to the source-generated P/Invoke.</value>
   </data>

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/ArrayTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/ArrayTests.cs
@@ -69,7 +69,7 @@ namespace DllImportGenerator.IntegrationTests
             public static partial bool FillRangeArray([Out] IntStructWrapper[] array, int length, int start);
 
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "double_values")]
-            public static partial bool DoubleValues([In, Out] IntStructWrapper[] array, int length);
+            public static partial void DoubleValues([In, Out] IntStructWrapper[] array, int length);
 
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "and_all_members")]
             [return:MarshalAs(UnmanagedType.U1)]

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/BooleanTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/BooleanTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 using Xunit;
@@ -19,68 +20,53 @@ namespace DllImportGenerator.IntegrationTests
         [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "variantbool_return_as_uint")]
         public static partial uint ReturnVariantBoolAsUInt([MarshalAs(UnmanagedType.VariantBool)] bool input);
 
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_uint")]
+        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "winbool_return_as_uint")]
         public static partial uint ReturnIntBoolAsUInt([MarshalAs(UnmanagedType.I4)] bool input);
 
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_uint")]
+        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "winbool_return_as_uint")]
         public static partial uint ReturnUIntBoolAsUInt([MarshalAs(UnmanagedType.U4)] bool input);
 
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_uint")]
+        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "winbool_return_as_uint")]
         public static partial uint ReturnWinBoolAsUInt([MarshalAs(UnmanagedType.Bool)] bool input);
 
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_uint")]
-        public static partial uint ReturnDefaultBoolAsUInt(bool input);
-
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_uint")]
+        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "winbool_return_as_uint")]
         [return: MarshalAs(UnmanagedType.U1)]
         public static partial bool ReturnUIntAsByteBool(uint input);
 
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_uint")]
+        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "winbool_return_as_uint")]
         [return: MarshalAs(UnmanagedType.VariantBool)]
         public static partial bool ReturnUIntAsVariantBool(uint input);
 
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_uint")]
+        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "winbool_return_as_uint")]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool ReturnUIntAsWinBool(uint input);
 
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_uint")]
-        public static partial bool ReturnUIntAsDefaultBool(uint input);
-
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_refuint")]
+        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "winbool_return_as_refuint")]
         public static partial void ReturnUIntAsByteBool_Ref(uint input, [MarshalAs(UnmanagedType.U1)] ref bool res);
 
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_refuint")]
+        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "winbool_return_as_refuint")]
         public static partial void ReturnUIntAsByteBool_Out(uint input, [MarshalAs(UnmanagedType.U1)] out bool res);
 
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_refuint")]
+        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "winbool_return_as_refuint")]
         public static partial void ReturnUIntAsByteBool_In(uint input, [MarshalAs(UnmanagedType.U1)] in bool res);
 
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_refuint")]
+        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "winbool_return_as_refuint")]
         public static partial void ReturnUIntAsVariantBool_Ref(uint input, [MarshalAs(UnmanagedType.VariantBool)] ref bool res);
 
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_refuint")]
+        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "winbool_return_as_refuint")]
         public static partial void ReturnUIntAsVariantBool_Out(uint input, [MarshalAs(UnmanagedType.VariantBool)] out bool res);
 
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_refuint")]
+        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "winbool_return_as_refuint")]
         public static partial void ReturnUIntAsVariantBool_In(uint input, [MarshalAs(UnmanagedType.VariantBool)] in bool res);
 
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_refuint")]
+        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "winbool_return_as_refuint")]
         public static partial void ReturnUIntAsWinBool_Ref(uint input, [MarshalAs(UnmanagedType.Bool)] ref bool res);
 
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_refuint")]
+        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "winbool_return_as_refuint")]
         public static partial void ReturnUIntAsWinBool_Out(uint input, [MarshalAs(UnmanagedType.Bool)] out bool res);
 
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_refuint")]
+        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "winbool_return_as_refuint")]
         public static partial void ReturnUIntAsWinBool_In(uint input, [MarshalAs(UnmanagedType.Bool)] in bool res);
-
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_refuint")]
-        public static partial void ReturnUIntAsDefaultBool_Ref(uint input, ref bool res);
-
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_refuint")]
-        public static partial void ReturnUIntAsDefaultBool_Out(uint input, out bool res);
-
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "bool_return_as_refuint")]
-        public static partial void ReturnUIntAsDefaultBool_In(uint input, in bool res);
     }
 
     public class BooleanTests
@@ -105,8 +91,6 @@ namespace DllImportGenerator.IntegrationTests
             Assert.Equal((uint)0, NativeExportsNE.ReturnUIntBoolAsUInt(false));
             Assert.Equal((uint)1, NativeExportsNE.ReturnWinBoolAsUInt(true));
             Assert.Equal((uint)0, NativeExportsNE.ReturnWinBoolAsUInt(false));
-            Assert.Equal((uint)1, NativeExportsNE.ReturnDefaultBoolAsUInt(true));
-            Assert.Equal((uint)0, NativeExportsNE.ReturnDefaultBoolAsUInt(false));
         }
 
         [Theory]
@@ -158,7 +142,7 @@ namespace DllImportGenerator.IntegrationTests
 
         [Theory]
         [InlineData(new object[] { 0, false })]
-        [InlineData(new object[] { 1, true})]
+        [InlineData(new object[] { 1, true })]
         [InlineData(new object[] { 37, true })]
         [InlineData(new object[] { 0xffffffff, true })]
         [InlineData(new object[] { 0x80000000, true })]
@@ -176,29 +160,6 @@ namespace DllImportGenerator.IntegrationTests
 
             result = !expected;
             NativeExportsNE.ReturnUIntAsWinBool_In(value, in result);
-            Assert.Equal(!expected, result); // Should not be updated when using 'in'
-        }
-
-        [Theory]
-        [InlineData(new object[] { 0, false })]
-        [InlineData(new object[] { 1, true })]
-        [InlineData(new object[] { 37, true })]
-        [InlineData(new object[] { 0xffffffff, true })]
-        [InlineData(new object[] { 0x80000000, true })]
-        public void ValidateDefaultBoolReturns(uint value, bool expected)
-        {
-            Assert.Equal(expected, NativeExportsNE.ReturnUIntAsDefaultBool(value));
-
-            bool result = !expected;
-            NativeExportsNE.ReturnUIntAsDefaultBool_Ref(value, ref result);
-            Assert.Equal(expected, result);
-
-            result = !expected;
-            NativeExportsNE.ReturnUIntAsDefaultBool_Out(value, out result);
-            Assert.Equal(expected, result);
-
-            result = !expected;
-            NativeExportsNE.ReturnUIntAsDefaultBool_In(value, in result);
             Assert.Equal(!expected, result); // Should not be updated when using 'in'
         }
     }

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
@@ -135,6 +135,7 @@ using System.Runtime.InteropServices;
 partial class C
 {{
     [GeneratedDllImportAttribute(""DoesNotExist"")]
+    [return: MarshalAs(UnmanagedType.Bool)]
     public static partial bool Method();
 }}";
             Compilation comp = await TestUtils.CreateCompilation(source, targetFramework);

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/AttributeForwarding.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/AttributeForwarding.cs
@@ -299,6 +299,7 @@ using System.Runtime.InteropServices;
 partial class C
 {
     [GeneratedDllImportAttribute(""DoesNotExist"")]
+    [return: MarshalAs(UnmanagedType.Bool)]
     public static partial bool Method1([In, Out] int[] a);
 }
 " + CodeSnippets.GeneratedDllImportAttributeDeclaration;
@@ -341,6 +342,7 @@ using System.Runtime.InteropServices;
 partial class C
 {
     [GeneratedDllImportAttribute(""DoesNotExist"")]
+    [return: MarshalAs(UnmanagedType.Bool)]
     public static partial bool Method1([MarshalAs(UnmanagedType.I2)] int a);
 }
 " + CodeSnippets.GeneratedDllImportAttributeDeclaration;
@@ -369,6 +371,7 @@ using System.Runtime.InteropServices;
 partial class C
 {
     [GeneratedDllImportAttribute(""DoesNotExist"")]
+    [return: MarshalAs(UnmanagedType.Bool)]
     public static partial bool Method1([MarshalAs(UnmanagedType.LPArray, SizeConst = 10, SizeParamIndex = 1, ArraySubType = UnmanagedType.I4)] int[] a, int b);
 }
 " + CodeSnippets.GeneratedDllImportAttributeDeclaration;

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CodeSnippets.cs
@@ -629,7 +629,7 @@ partial class Test
 }}
 ";
 
-        public static string CustomStructMarshallingParametersAndModifiers = BasicParametersAndModifiers("S", DisableRuntimeMarshalling) + @"
+        public static string BasicNonBlittableUserDefinedType = @"
 [NativeMarshalling(typeof(Native))]
 struct S
 {
@@ -645,8 +645,9 @@ struct Native
     }
 
     public S ToManaged() => new S { b = i != 0 };
-}
-";
+}";
+
+        public static string CustomStructMarshallingParametersAndModifiers = BasicParametersAndModifiers("S", DisableRuntimeMarshalling) + BasicNonBlittableUserDefinedType;
 
         public static string CustomStructMarshallingMarshalUsingParametersAndModifiers = MarshalUsingParametersAndModifiers("S", "Native", DisableRuntimeMarshalling) + @"
 struct S

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CompileFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CompileFails.cs
@@ -23,8 +23,12 @@ namespace DllImportGenerator.UnitTests
             // No explicit marshalling for char or string
             yield return new object[] { CodeSnippets.BasicParametersAndModifiers<char>(), 5, 0 };
             yield return new object[] { CodeSnippets.BasicParametersAndModifiers<string>(), 5, 0 };
-            yield return new object[] { CodeSnippets.BasicParametersAndModifiers<char[]>(), 5, 0 };
-            yield return new object[] { CodeSnippets.BasicParametersAndModifiers<string[]>(), 5, 0 };
+            yield return new object[] { CodeSnippets.MarshalAsArrayParametersAndModifiers<char>(), 5, 0 };
+            yield return new object[] { CodeSnippets.MarshalAsArrayParametersAndModifiers<string>(), 5, 0 };
+
+            // No explicit marshaling for bool
+            yield return new object[] { CodeSnippets.BasicParametersAndModifiers<bool>(), 5, 0 };
+            yield return new object[] { CodeSnippets.MarshalAsArrayParametersAndModifiers<bool>(), 5, 0 };
 
             // Unsupported StringMarshalling configuration
             yield return new object[] { CodeSnippets.BasicParametersAndModifiersWithStringMarshalling<char>(StringMarshalling.Utf8), 6, 0 };
@@ -65,23 +69,25 @@ namespace DllImportGenerator.UnitTests
             yield return new object[] { CodeSnippets.BasicParametersAndModifiers<sbyte[]>(CodeSnippets.DisableRuntimeMarshalling), 3, 0 };
             yield return new object[] { CodeSnippets.BasicParametersAndModifiers<short[]>(CodeSnippets.DisableRuntimeMarshalling), 3, 0 };
             yield return new object[] { CodeSnippets.BasicParametersAndModifiers<ushort[]>(CodeSnippets.DisableRuntimeMarshalling), 3, 0 };
+            yield return new object[] { CodeSnippets.BasicParametersAndModifiers<char[]>(CodeSnippets.DisableRuntimeMarshalling), 3, 0 };
+            yield return new object[] { CodeSnippets.BasicParametersAndModifiers<string[]>(CodeSnippets.DisableRuntimeMarshalling), 5, 0 };
             yield return new object[] { CodeSnippets.BasicParametersAndModifiers<int[]>(CodeSnippets.DisableRuntimeMarshalling), 3, 0 };
             yield return new object[] { CodeSnippets.BasicParametersAndModifiers<uint[]>(CodeSnippets.DisableRuntimeMarshalling), 3, 0 };
             yield return new object[] { CodeSnippets.BasicParametersAndModifiers<long[]>(CodeSnippets.DisableRuntimeMarshalling), 3, 0 };
             yield return new object[] { CodeSnippets.BasicParametersAndModifiers<ulong[]>(CodeSnippets.DisableRuntimeMarshalling), 3, 0 };
             yield return new object[] { CodeSnippets.BasicParametersAndModifiers<float[]>(CodeSnippets.DisableRuntimeMarshalling), 3, 0 };
             yield return new object[] { CodeSnippets.BasicParametersAndModifiers<double[]>(CodeSnippets.DisableRuntimeMarshalling), 3, 0 };
-            yield return new object[] { CodeSnippets.BasicParametersAndModifiers<bool[]>(CodeSnippets.DisableRuntimeMarshalling), 3, 0 };
+            yield return new object[] { CodeSnippets.BasicParametersAndModifiers<bool[]>(CodeSnippets.DisableRuntimeMarshalling), 5, 0 };
             yield return new object[] { CodeSnippets.BasicParametersAndModifiers<IntPtr[]>(CodeSnippets.DisableRuntimeMarshalling), 3, 0 };
             yield return new object[] { CodeSnippets.BasicParametersAndModifiers<UIntPtr[]>(CodeSnippets.DisableRuntimeMarshalling), 3, 0 };
 
             // Collection with non-integer size param
             yield return new object[] { CodeSnippets.MarshalAsArrayParameterWithSizeParam<float>(isByRef: false), 1, 0 };
             yield return new object[] { CodeSnippets.MarshalAsArrayParameterWithSizeParam<double>(isByRef: false), 1, 0 };
-            yield return new object[] { CodeSnippets.MarshalAsArrayParameterWithSizeParam<bool>(isByRef: false), 1, 0 };
+            yield return new object[] { CodeSnippets.MarshalAsArrayParameterWithSizeParam<bool>(isByRef: false), 2, 0 };
             yield return new object[] { CodeSnippets.MarshalUsingArrayParameterWithSizeParam<float>(isByRef: false), 1, 0 };
             yield return new object[] { CodeSnippets.MarshalUsingArrayParameterWithSizeParam<double>(isByRef: false), 1, 0 };
-            yield return new object[] { CodeSnippets.MarshalUsingArrayParameterWithSizeParam<bool>(isByRef: false), 1, 0 };
+            yield return new object[] { CodeSnippets.MarshalUsingArrayParameterWithSizeParam<bool>(isByRef: false), 2, 0 };
 
 
             // Custom type marshalling with invalid members

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Compiles.cs
@@ -39,7 +39,6 @@ namespace DllImportGenerator.UnitTests
             yield return new[] { CodeSnippets.BasicParametersAndModifiers<ulong>() };
             yield return new[] { CodeSnippets.BasicParametersAndModifiers<float>() };
             yield return new[] { CodeSnippets.BasicParametersAndModifiers<double>() };
-            yield return new[] { CodeSnippets.BasicParametersAndModifiers<bool>() };
             yield return new[] { CodeSnippets.BasicParametersAndModifiers<IntPtr>() };
             yield return new[] { CodeSnippets.BasicParametersAndModifiers<UIntPtr>() };
 
@@ -54,7 +53,6 @@ namespace DllImportGenerator.UnitTests
             yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers<ulong>() };
             yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers<float>() };
             yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers<double>() };
-            yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers<bool>() };
             yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers<IntPtr>() };
             yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers<UIntPtr>() };
             yield return new[] { CodeSnippets.MarshalAsArrayParameterWithSizeParam<byte>(isByRef: false) };
@@ -105,8 +103,8 @@ namespace DllImportGenerator.UnitTests
 
             // [In, Out] attributes
             // By value non-blittable array
-            yield return new[] { CodeSnippets.ByValueParameterWithModifier<bool[]>("Out", CodeSnippets.DisableRuntimeMarshalling) };
-            yield return new[] { CodeSnippets.ByValueParameterWithModifier<bool[]>("In, Out", CodeSnippets.DisableRuntimeMarshalling) };
+            yield return new[] { CodeSnippets.ByValueParameterWithModifier("S[]", "Out", CodeSnippets.DisableRuntimeMarshalling + CodeSnippets.BasicNonBlittableUserDefinedType) };
+            yield return new[] { CodeSnippets.ByValueParameterWithModifier("S[]", "In, Out", CodeSnippets.DisableRuntimeMarshalling + CodeSnippets.BasicNonBlittableUserDefinedType) };
 
             // Enums
             yield return new[] { CodeSnippets.EnumParameters };
@@ -190,7 +188,6 @@ namespace DllImportGenerator.UnitTests
             yield return new[] { CodeSnippets.CollectionByValue<ulong>() };
             yield return new[] { CodeSnippets.CollectionByValue<float>() };
             yield return new[] { CodeSnippets.CollectionByValue<double>() };
-            yield return new[] { CodeSnippets.CollectionByValue<bool>() };
             yield return new[] { CodeSnippets.CollectionByValue<IntPtr>() };
             yield return new[] { CodeSnippets.CollectionByValue<UIntPtr>() };
             yield return new[] { CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<byte[]>() };
@@ -203,7 +200,6 @@ namespace DllImportGenerator.UnitTests
             yield return new[] { CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<ulong[]>() };
             yield return new[] { CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<float[]>() };
             yield return new[] { CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<double[]>() };
-            yield return new[] { CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<bool[]>() };
             yield return new[] { CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<IntPtr[]>() };
             yield return new[] { CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<UIntPtr[]>() };
             yield return new[] { CodeSnippets.CustomCollectionDefaultMarshallerParametersAndModifiers<byte>() };
@@ -216,7 +212,6 @@ namespace DllImportGenerator.UnitTests
             yield return new[] { CodeSnippets.CustomCollectionDefaultMarshallerParametersAndModifiers<ulong>() };
             yield return new[] { CodeSnippets.CustomCollectionDefaultMarshallerParametersAndModifiers<float>() };
             yield return new[] { CodeSnippets.CustomCollectionDefaultMarshallerParametersAndModifiers<double>() };
-            yield return new[] { CodeSnippets.CustomCollectionDefaultMarshallerParametersAndModifiers<bool>() };
             yield return new[] { CodeSnippets.CustomCollectionDefaultMarshallerParametersAndModifiers<IntPtr>() };
             yield return new[] { CodeSnippets.CustomCollectionDefaultMarshallerParametersAndModifiers<UIntPtr>() };
             yield return new[] { CodeSnippets.CustomCollectionCustomMarshallerParametersAndModifiers<byte>() };
@@ -229,7 +224,6 @@ namespace DllImportGenerator.UnitTests
             yield return new[] { CodeSnippets.CustomCollectionCustomMarshallerParametersAndModifiers<ulong>() };
             yield return new[] { CodeSnippets.CustomCollectionCustomMarshallerParametersAndModifiers<float>() };
             yield return new[] { CodeSnippets.CustomCollectionCustomMarshallerParametersAndModifiers<double>() };
-            yield return new[] { CodeSnippets.CustomCollectionCustomMarshallerParametersAndModifiers<bool>() };
             yield return new[] { CodeSnippets.CustomCollectionCustomMarshallerParametersAndModifiers<IntPtr>() };
             yield return new[] { CodeSnippets.CustomCollectionCustomMarshallerParametersAndModifiers<UIntPtr>() };
             yield return new[] { CodeSnippets.CustomCollectionCustomMarshallerReturnValueLength<int>() };

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportFixerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportFixerTests.cs
@@ -478,5 +478,29 @@ partial class Test
                 source,
                 fixedSource);
         }
+
+        [ConditionalFact]
+        public async Task BooleanMarshalAsAdded()
+        {
+            string source = @$"
+using System.Runtime.InteropServices;
+partial class Test
+{{
+    [DllImport(""DoesNotExist"")]
+    public static extern bool [|Method|](bool b);
+}}";
+            // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
+            string fixedSource = @$"
+using System.Runtime.InteropServices;
+partial class Test
+{{
+    [GeneratedDllImport(""DoesNotExist"")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool {{|CS8795:Method|}}([MarshalAs(UnmanagedType.Bool)] bool b);
+}}";
+            await VerifyCS.VerifyCodeFixAsync(
+                source,
+                fixedSource);
+        }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportFixerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportFixerTests.cs
@@ -444,16 +444,16 @@ using System.Runtime.InteropServices;
 partial class Test
 {
     [DllImport(""DoesNotExist"", PreserveSig = false)]
-    public static extern void [|VoidMethod|](bool param);
+    public static extern void [|VoidMethod|](int param);
     [DllImport(""DoesNotExist"", PreserveSig = false)]
-    public static extern long [|Method|](bool param);
+    public static extern long [|Method|](int param);
 
     public static void Code()
     {
-        Test.VoidMethod(true);
-        Test.Method(true);
-        long value = Test.Method(true);
-        value = Test.Method(true);
+        Test.VoidMethod(1);
+        Test.Method(1);
+        long value = Test.Method(1);
+        value = Test.Method(1);
     }
 }";
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
@@ -462,16 +462,16 @@ using System.Runtime.InteropServices;
 partial class Test
 {
     [GeneratedDllImport(""DoesNotExist"")]
-    public static partial int {|CS8795:VoidMethod|}(bool param);
+    public static partial int {|CS8795:VoidMethod|}(int param);
     [GeneratedDllImport(""DoesNotExist"")]
-    public static partial int {|CS8795:Method|}(bool param, out long @return);
+    public static partial int {|CS8795:Method|}(int param, out long @return);
 
     public static void Code()
     {
-        Marshal.ThrowExceptionForHR(Test.VoidMethod(true));
-        Marshal.ThrowExceptionForHR(Test.Method(true, out _));
-        Marshal.ThrowExceptionForHR(Test.Method(true, out long value));
-        Marshal.ThrowExceptionForHR(Test.Method(true, out value));
+        Marshal.ThrowExceptionForHR(Test.VoidMethod(1));
+        Marshal.ThrowExceptionForHR(Test.Method(1, out _));
+        Marshal.ThrowExceptionForHR(Test.Method(1, out long value));
+        Marshal.ThrowExceptionForHR(Test.Method(1, out value));
     }
 }";
             await VerifyCS.VerifyCodeFixAsync(

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Diagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Diagnostics.cs
@@ -213,7 +213,7 @@ partial class Test
     public static partial void Method1([MarshalAs(UnmanagedType.BStr)] int i1, int i2);
 
     [GeneratedDllImport(""DoesNotExist"")]
-    public static partial void Method2(bool b1, [MarshalAs(UnmanagedType.FunctionPtr)] bool b2);
+    public static partial void Method2(int i1, [MarshalAs(UnmanagedType.FunctionPtr)] bool b2);
 }
 ";
             Compilation comp = await TestUtils.CreateCompilation(source);
@@ -226,7 +226,7 @@ partial class Test
                     .WithSpan(6, 76, 6, 78)
                     .WithArguments(nameof(MarshalAsAttribute), "i1"),
                 (new DiagnosticResult(GeneratorDiagnostics.ParameterConfigurationNotSupported))
-                    .WithSpan(9, 93, 9, 95)
+                    .WithSpan(9, 92, 9, 94)
                     .WithArguments(nameof(MarshalAsAttribute), "b2"),
             };
             VerifyDiagnostics(expectedDiags, GetSortedDiagnostics(generatorDiags));
@@ -248,7 +248,7 @@ partial class Test
 
     [GeneratedDllImport(""DoesNotExist"")]
     [return: MarshalAs(UnmanagedType.FunctionPtr)]
-    public static partial bool Method2(bool b);
+    public static partial bool Method2(int i);
 }
 ";
             Compilation comp = await TestUtils.CreateCompilation(source);
@@ -282,7 +282,7 @@ partial class Test
     public static partial int Method1(int i);
 
     [GeneratedDllImport(""DoesNotExist"")]
-    public static partial bool Method2([MarshalAs((short)0)] bool b);
+    public static partial int Method2([MarshalAs((short)0)] bool b);
 }
 ";
             Compilation comp = await TestUtils.CreateCompilation(source);
@@ -298,10 +298,10 @@ partial class Test
                     .WithSpan(7, 31, 7, 38)
                     .WithArguments(nameof(MarshalAsAttribute), "Method1"),
                 (new DiagnosticResult(GeneratorDiagnostics.ConfigurationValueNotSupported))
-                    .WithSpan(10, 41, 10, 60)
+                    .WithSpan(10, 40, 10, 59)
                     .WithArguments(0, nameof(UnmanagedType)),
                 (new DiagnosticResult(GeneratorDiagnostics.ParameterConfigurationNotSupported))
-                    .WithSpan(10, 67, 10, 68)
+                    .WithSpan(10, 66, 10, 67)
                     .WithArguments(nameof(MarshalAsAttribute), "b"),
             };
             VerifyDiagnostics(expectedDiags, GetSortedDiagnostics(generatorDiags));
@@ -322,7 +322,7 @@ partial class Test
     public static partial int Method1(int i);
 
     [GeneratedDllImport(""DoesNotExist"")]
-    public static partial bool Method2([MarshalAs(UnmanagedType.I1, IidParameterIndex = 1)] bool b);
+    public static partial int Method2([MarshalAs(UnmanagedType.I1, IidParameterIndex = 1)] bool b);
 }
 ";
             Compilation comp = await TestUtils.CreateCompilation(source);
@@ -335,7 +335,7 @@ partial class Test
                     .WithSpan(6, 14, 6, 73)
                     .WithArguments($"{nameof(MarshalAsAttribute)}{Type.Delimiter}{nameof(MarshalAsAttribute.SafeArraySubType)}"),
                 (new DiagnosticResult(GeneratorDiagnostics.ConfigurationNotSupported))
-                    .WithSpan(10, 41, 10, 91)
+                    .WithSpan(10, 40, 10, 90)
                     .WithArguments($"{nameof(MarshalAsAttribute)}{Type.Delimiter}{nameof(MarshalAsAttribute.IidParameterIndex)}"),
             };
             VerifyDiagnostics(expectedDiags, GetSortedDiagnostics(generatorDiags));

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/Booleans.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/Booleans.cs
@@ -19,13 +19,13 @@ namespace NativeExports
             return input;
         }
 
-        [UnmanagedCallersOnly(EntryPoint = "bool_return_as_uint")]
+        [UnmanagedCallersOnly(EntryPoint = "winbool_return_as_uint")]
         public static uint ReturnUIntAsUInt(uint input)
         {
             return input;
         }
 
-        [UnmanagedCallersOnly(EntryPoint = "bool_return_as_refuint")]
+        [UnmanagedCallersOnly(EntryPoint = "winbool_return_as_refuint")]
         public static void ReturnUIntAsRefUInt(uint input, uint* res)
         {
             *res = input;

--- a/src/libraries/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/System.ServiceProcess.ServiceController.TestService.csproj
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/System.ServiceProcess.ServiceController.TestService.csproj
@@ -19,7 +19,7 @@
              Link="Common\DisableRuntimeMarshalling.cs"
              Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs"
-             Link="Common\Interop\Windows\Interop.Libraries.cs" />
+            Link="Common\Interop\Windows\Interop.Libraries.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ServiceProcessOptions.cs"
              Link="Common\Interop\Windows\Interop.ServiceProcessOptions.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CloseServiceHandle.cs"


### PR DESCRIPTION
For consistency with the new default rules for `bool` fields in value types, update the default marshalling for `bool` parameters and return values to be 1-byte non-normalized instead of 4-byte normalized.

I've tried to split up the commits to make them easier to review:

1. updates all existing source-generated P/Invokes to have explicit `[MarshalAs(UnmanagedType.Bool)]` attributes to preserve the current default behavior.
2. updates the default marshalling rules in the generator.
3. updates the conversion code-fix.
4. updates the compatibility doc.