### PR TITLE
[wasm][tests] Fix use of `RandomTest*Orderer` with trimming

### DIFF
--- a/eng/testing/ILLink.Descriptor.TestUtilities.xml
+++ b/eng/testing/ILLink.Descriptor.TestUtilities.xml
@@ -1,5 +1,7 @@
 <linker>
   <assembly fullname="TestUtilities">
     <namespace fullname="System" />
+    <!-- for TestUtilities.RandomTest*Orderer types -->
+    <namespace fullname="TestUtilities" />
   </assembly>
 </linker>


### PR DESCRIPTION
With trimming the tests would fail to load the types:
```
[21:11:50] info: Discovered:  System.Runtime.Tests.dll (found 6200 of 6302 test cases)
[21:11:50] info: Could not find type 'TestUtilities.RandomTestCaseOrderer' in TestUtilities for assembly-level test case orderer
[21:11:50] info: Could not find type 'TestUtilities.RandomTestCollectionOrderer' in TestUtilities for assembly-level test collection orderer
```