### PR TITLE
[wasm] Refactor script to load NPM modules for NodeJS on Helix

### DIFF
--- a/eng/testing/tests.wasm.targets
+++ b/eng/testing/tests.wasm.targets
@@ -244,4 +244,25 @@
                              RelativePath="%(_PdbFilesToCheck.FileName)%(_PdbFilesToCheck.Extension)" />
     </ItemGroup>
   </Target>
+
+  <Target Name="ProvideNodeNpmRestoreScripts" BeforeTargets="GenerateRunScript">
+    <!-- Combine optional alias on all NodeNpmModule and trim separator where alias is empty -->
+    <ItemGroup>
+      <_NodeNpmModuleString Include="%(NodeNpmModule.Identity):%(NodeNpmModule.Alias)" />
+      <_NodeNpmModuleStringTrimmed Include="@(_NodeNpmModuleString->Trim(':'))" />
+    </ItemGroup>
+    <PropertyGroup>
+      <NodeNpmModuleString>@(_NodeNpmModuleStringTrimmed, ',')</NodeNpmModuleString>
+    </PropertyGroup>
+
+    <!-- Restore NPM packages -->
+    <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
+      <SetScriptCommands Include="if [[ &quot;$SCENARIO&quot; == &quot;WasmTestOnNodeJs&quot; || &quot;$SCENARIO&quot; == &quot;wasmtestonnodejs&quot; ]]; then export WasmXHarnessMonoArgs=&quot;$WasmXHarnessMonoArgs --setenv=NPM_MODULES=$(NodeNpmModuleString)&quot;; fi" />
+      <RunScriptCommands Include="if [[ &quot;$SCENARIO&quot; == &quot;WasmTestOnNodeJs&quot; || &quot;$SCENARIO&quot; == &quot;wasmtestonnodejs&quot; ]]; then npm ci; fi" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
+      <SetScriptCommands Include="if /I [%SCENARIO%]==[WasmTestOnNodeJS] ( set &quot;WasmXHarnessMonoArgs=%WasmXHarnessMonoArgs% --setenv=NPM_MODULES^=$(NodeNpmModuleString)&quot; )" />
+      <RunScriptCommands Include="if /I [%SCENARIO%]==[WasmTestOnNodeJS] ( call npm ci )" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/libraries/Common/tests/System/Net/Prerequisites/LocalEchoServer.props
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/LocalEchoServer.props
@@ -15,4 +15,14 @@
     <WasmXHarnessArgs>$(WasmXHarnessArgs) --web-server-middleware=$(_RemoteLoopMiddleware)/RemoteLoopServer.dll,GenericHandler</WasmXHarnessArgs>
     <WasmXHarnessArgs>$(WasmXHarnessArgs) --web-server-middleware=$(_TestEchoMiddleware)/NetCoreServer.dll,GenericHandler</WasmXHarnessArgs>
   </PropertyGroup>
+  
+  <!-- Tests use self-signed certificates that are refused by NodeJS -->
+  <Target Name="AcceptUnauthorizedOnNodeJS" BeforeTargets="GenerateRunScript">
+    <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
+      <SetScriptCommands Include="if [[ &quot;$SCENARIO&quot; == &quot;WasmTestOnNodeJs&quot; || &quot;$SCENARIO&quot; == &quot;wasmtestonnodejs&quot; ]]; then export NODE_TLS_REJECT_UNAUTHORIZED=0; fi" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
+      <SetScriptCommands Include="if /I [%SCENARIO%]==[WasmTestOnNodeJS] ( set &quot;NODE_TLS_REJECT_UNAUTHORIZED=0&quot; )" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -30,24 +30,11 @@
   <ItemGroup>
     <WasmExtraFilesToDeploy Include="package.json" />
     <WasmExtraFilesToDeploy Include="package-lock.json" />
-  </ItemGroup>
 
-  <Target Name="ProvideNpmRestoreScripts" BeforeTargets="GenerateRunScript">
-    <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
-      <!-- WebSocket tests use self-signed certificates for wss protocol that are refused by NodeJS -->
-      <SetScriptCommands Include="if [[ &quot;$SCENARIO&quot; == &quot;WasmTestOnNodeJs&quot; || &quot;$SCENARIO&quot; == &quot;wasmtestonnodejs&quot; ]]; then export NODE_TLS_REJECT_UNAUTHORIZED=0; fi" />
-      <SetScriptCommands Include="if [[ &quot;$SCENARIO&quot; == &quot;WasmTestOnNodeJs&quot; || &quot;$SCENARIO&quot; == &quot;wasmtestonnodejs&quot; ]]; then export WasmXHarnessMonoArgs=&quot;$WasmXHarnessMonoArgs --setenv=NPM_MODULES=ws:WebSocket,node-fetch,node-abort-controller&quot;; fi" />
-      <!-- Restore NPM packages -->
-      <RunScriptCommands Include="if [[ &quot;$SCENARIO&quot; == &quot;WasmTestOnNodeJs&quot; || &quot;$SCENARIO&quot; == &quot;wasmtestonnodejs&quot; ]]; then npm ci; fi" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-      <!-- WebSocket tests use self-signed certificates for wss protocol that are refused by NodeJS -->
-      <SetScriptCommands Include="if /I [%SCENARIO%]==[WasmTestOnNodeJS] ( set &quot;NODE_TLS_REJECT_UNAUTHORIZED=0&quot; )" />
-      <SetScriptCommands Include="if /I [%SCENARIO%]==[WasmTestOnNodeJS] ( set &quot;WasmXHarnessMonoArgs=%WasmXHarnessMonoArgs% --setenv=NPM_MODULES^=ws:WebSocket,node-fetch,node-abort-controller&quot; )" />
-      <!-- Restore NPM packages -->
-      <RunScriptCommands Include="if /I [%SCENARIO%]==[WasmTestOnNodeJS] ( call npm ci )" />
-    </ItemGroup>
-  </Target>
+    <NodeNpmModule Include="ws" Alias="WebSocket" />
+    <NodeNpmModule Include="node-fetch" />
+    <NodeNpmModule Include="node-abort-controller" />
+  </ItemGroup>
 
   <Import Condition="'$(TargetOS)' == 'Browser'" Project="$(CommonTestPath)System/Net/Prerequisites/LocalEchoServer.props" />
 

--- a/src/libraries/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/libraries/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -18,24 +18,9 @@
   <ItemGroup>
     <WasmExtraFilesToDeploy Include="package.json" />
     <WasmExtraFilesToDeploy Include="package-lock.json" />
-  </ItemGroup>
 
-  <Target Name="ProvideNpmRestoreScripts" BeforeTargets="GenerateRunScript">
-    <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
-      <!-- WebSocket tests use self-signed certificates for wss protocol that are refused by NodeJS -->
-      <SetScriptCommands Include="if [[ &quot;$SCENARIO&quot; == &quot;WasmTestOnNodeJs&quot; || &quot;$SCENARIO&quot; == &quot;wasmtestonnodejs&quot; ]]; then export NODE_TLS_REJECT_UNAUTHORIZED=0; fi" />
-      <SetScriptCommands Include="if [[ &quot;$SCENARIO&quot; == &quot;WasmTestOnNodeJs&quot; || &quot;$SCENARIO&quot; == &quot;wasmtestonnodejs&quot; ]]; then export WasmXHarnessMonoArgs=&quot;$WasmXHarnessMonoArgs --setenv=NPM_MODULES=ws:WebSocket&quot;; fi" />
-      <!-- Restore NPM packages -->
-      <RunScriptCommands Include="if [[ &quot;$SCENARIO&quot; == &quot;WasmTestOnNodeJs&quot; || &quot;$SCENARIO&quot; == &quot;wasmtestonnodejs&quot; ]]; then npm ci; fi" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-      <!-- WebSocket tests use self-signed certificates for wss protocol that are refused by NodeJS -->
-      <SetScriptCommands Include="if /I [%SCENARIO%]==[WasmTestOnNodeJS] ( set &quot;NODE_TLS_REJECT_UNAUTHORIZED=0&quot; )" />
-      <SetScriptCommands Include="if /I [%SCENARIO%]==[WasmTestOnNodeJS] ( set &quot;WasmXHarnessMonoArgs=%WasmXHarnessMonoArgs% --setenv=NPM_MODULES^=ws:WebSocket&quot; )" />
-      <!-- Restore NPM packages -->
-      <RunScriptCommands Include="if /I [%SCENARIO%]==[WasmTestOnNodeJS] ( call npm ci )" />
-    </ItemGroup>
-  </Target>
+    <NodeNpmModule Include="ws" Alias="WebSocket" />
+  </ItemGroup>
 
   <!-- Browser specific files -->
   <ItemGroup Condition="'$(TargetOS)' == 'Browser'">


### PR DESCRIPTION
- Refactor script to load NPM modules for NodeJS on Helix to `tests.wasm.targets`. Only list of modules is required per csproj.
- Move `NODE_TLS_REJECT_UNAUTHORIZED=0` to `LocalEchoServer.props` as it is always needed when communicating with loopback server from NodeJS.