### PR TITLE
Revert "[release/6.0] Fix ReadyToRun loading on Apple Silicon (#64104)"

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -6960,9 +6960,7 @@ void Compiler::impImportNewObjArray(CORINFO_RESOLVED_TOKEN* pResolvedToken, CORI
     //
     CLANG_FORMAT_COMMENT_ANCHOR;
 
-#ifndef OSX_ARM64_ABI
     if (!opts.IsReadyToRun() || IsTargetAbi(CORINFO_CORERT_ABI))
-#endif // !OSX_ARM64_ABI
     {
 
         // Reuse the temp used to pass the array dimensions to avoid bloating
@@ -7019,7 +7017,6 @@ void Compiler::impImportNewObjArray(CORINFO_RESOLVED_TOKEN* pResolvedToken, CORI
 
         node = gtNewHelperCallNode(CORINFO_HELP_NEW_MDARR_NONVARARG, TYP_REF, args);
     }
-#ifndef OSX_ARM64_ABI
     else
     {
         //
@@ -7049,7 +7046,6 @@ void Compiler::impImportNewObjArray(CORINFO_RESOLVED_TOKEN* pResolvedToken, CORI
         }
 #endif
     }
-#endif // !OSX_ARM64_ABI
 
     for (GenTreeCall::Use& use : node->AsCall()->Args())
     {

--- a/src/coreclr/pal/src/map/map.cpp
+++ b/src/coreclr/pal/src/map/map.cpp
@@ -2047,9 +2047,9 @@ MAPmmapAndRecord(
 
         // Set the requested mapping with forced PROT_WRITE to ensure data from the file can be read there,
         // read the data in and finally remove the forced PROT_WRITE
-        if ((mprotect(pvBaseAddress, len + adjust, PROT_WRITE) == -1) ||
+        if ((mprotect(pvBaseAddress, len + adjust, prot | PROT_WRITE) == -1) ||
             (pread(fd, pvBaseAddress, len + adjust, offset - adjust) == -1) ||
-            (mprotect(pvBaseAddress, len + adjust, prot) == -1))
+            (((prot & PROT_WRITE) == 0) && mprotect(pvBaseAddress, len + adjust, prot) == -1))
         {
             palError = FILEGetLastErrorFromErrno();
         }

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -14200,13 +14200,6 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
             CorInfoHelpFunc corInfoHelpFunc = MapReadyToRunHelper((ReadyToRunHelper)helperNum);
             if (corInfoHelpFunc != CORINFO_HELP_UNDEF)
             {
-#ifdef OSX_ARM64_ABI
-                if (corInfoHelpFunc == CORINFO_HELP_NEW_MDARR)
-                {
-                    STRESS_LOG(LF_ZAP, LL_WARNING, "CORINFO_HELP_NEW_MDARR is not supported on osx-arm64\n");
-                    return FALSE;
-                }
-#endif // OSX_ARM64_ABI
                 result = (size_t)CEEJitInfo::getHelperFtnStatic(corInfoHelpFunc);
             }
             else

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -235,14 +235,14 @@ void PEImageLayout::ApplyBaseRelocations()
             if (((pSection->Characteristics & VAL32(IMAGE_SCN_MEM_WRITE)) == 0))
             {
                 DWORD dwNewProtection = PAGE_READWRITE;
-#if defined(TARGET_UNIX) && !defined(CROSSGEN_COMPILE) && !defined(__APPLE__)
+#if defined(TARGET_UNIX) && !defined(CROSSGEN_COMPILE)
                 if (((pSection->Characteristics & VAL32(IMAGE_SCN_MEM_EXECUTE)) != 0))
                 {
                     // On SELinux, we cannot change protection that doesn't have execute access rights
                     // to one that has it, so we need to set the protection to RWX instead of RW
                     dwNewProtection = PAGE_EXECUTE_READWRITE;
                 }
-#endif // TARGET_UNIX && !CROSSGEN_COMPILE && !__APPLE__
+#endif // TARGET_UNIX && !CROSSGEN_COMPILE
                 if (!ClrVirtualProtect(pWriteableRegion, cbWriteableRegion,
                                        dwNewProtection, &dwOldProtection))
                     ThrowLastError();


### PR DESCRIPTION
This reverts commit to enable R2R for MacOS arm64. It appears to be causing some diagnostics failures which are being investigated. We will reapply the original fix once those are resolved. 