### PR TITLE
Disable packaging for DllImportGenerator for now

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Directory.Build.props
+++ b/src/libraries/System.Runtime.InteropServices/gen/Directory.Build.props
@@ -1,8 +1,7 @@
-﻿<Project>
+<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <IsShipping>false</IsShipping>
-    <IsPackable>false</IsPackable>
     <!-- We manually enable DllImportGenerator for projects in this folder as part of testing. -->
     <EnableDllImportGenerator>false</EnableDllImportGenerator>
     <EnableDefaultItems>true</EnableDefaultItems>

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.csproj
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.csproj
@@ -11,7 +11,7 @@
     <RunAnalyzers>true</RunAnalyzers>
 
     <!-- Packaging properties -->
-    <!-- DllImportGenerator should currently not produce a package. -->
+    <!-- In the future DllImportGenerator might ship as part of a package, but meanwhile disable packaging. -->
     <IsPackable>false</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.csproj
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.csproj
@@ -11,7 +11,8 @@
     <RunAnalyzers>true</RunAnalyzers>
 
     <!-- Packaging properties -->
-    <IsPackable>true</IsPackable>
+    <!-- DllImportGenerator should currently not produce a package. -->
+    <IsPackable>false</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageProjectUrl>https://github.com/dotnet/runtime/tree/main/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator</PackageProjectUrl>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/65495

For reasoning see https://github.com/dotnet/runtime/issues/65495#issuecomment-1049111768.