### PR TITLE
Fix JsonSerializerOptions.GetConverter recreating built-in converters

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -159,7 +159,10 @@ namespace System.Text.Json
         [RequiresUnreferencedCode("Getting a converter for a type may require reflection which depends on unreferenced code.")]
         public JsonConverter GetConverter(Type typeToConvert!!)
         {
-            RootBuiltInConverters();
+            if (!IsInitializedForReflectionSerializer)
+            {
+                InitializeForReflectionSerializer();
+            }
             return GetConverterInternal(typeToConvert);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -99,7 +99,6 @@ namespace System.Text.Json
         public JsonConverter Initialize(Type type, JsonSerializerOptions options, bool supportContinuation)
         {
             JsonTypeInfo jsonTypeInfo = options.GetOrAddJsonTypeInfoForRootType(type);
-            Debug.Assert(options == jsonTypeInfo.Options);
             return Initialize(jsonTypeInfo, supportContinuation);
         }
 

--- a/src/libraries/System.Text.Json/tests/Common/TestClasses/TestClasses.Constructor.cs
+++ b/src/libraries/System.Text.Json/tests/Common/TestClasses/TestClasses.Constructor.cs
@@ -456,6 +456,8 @@ namespace System.Text.Json.Serialization.Tests
         [JsonConstructor]
         public Point_2D(int x, int y) => (X, Y) = (x, y);
 
+        public Point_2D() : this(0, 0) { }
+
         public void Initialize() { }
 
         public void Verify()


### PR DESCRIPTION
Fix #65770.

@layomia do you think is this the right approach? I changed `GetConverter` so that it now calls `InitializeForReflectionSerializer` instead of `RootBuiltInConverter` since it already has a flag guarding access. The only difference is that additionally roots the reflection-based `JsonTypeInfo` factory delegate. I suspect this is fine since `GetConverter` is already marked `RequiresUnreferencedCode` and might actually fix a broken corner case (see changes in test code).

@ericstj Do you think this meets the bar for 6.0 servicing? I can imagine certain use cases where this could incur a substantial amount of added allocations (and it's a regression from 5.0)