### PR TITLE
Fix nullability mismatch between `ref` and `src` in `Microsoft.Extensions.Caching.Abstractions`

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/ref/Microsoft.Extensions.Caching.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/ref/Microsoft.Extensions.Caching.Abstractions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.Caching.Memory
     public static partial class CacheExtensions
     {
         public static object? Get(this Microsoft.Extensions.Caching.Memory.IMemoryCache cache, object key) { throw null; }
-        public static System.Threading.Tasks.Task<TItem> GetOrCreateAsync<TItem>(this Microsoft.Extensions.Caching.Memory.IMemoryCache cache, object key, System.Func<Microsoft.Extensions.Caching.Memory.ICacheEntry, System.Threading.Tasks.Task<TItem>> factory) { throw null; }
+        public static System.Threading.Tasks.Task<TItem?> GetOrCreateAsync<TItem>(this Microsoft.Extensions.Caching.Memory.IMemoryCache cache, object key, System.Func<Microsoft.Extensions.Caching.Memory.ICacheEntry, System.Threading.Tasks.Task<TItem>> factory) { throw null; }
         public static TItem? GetOrCreate<TItem>(this Microsoft.Extensions.Caching.Memory.IMemoryCache cache, object key, System.Func<Microsoft.Extensions.Caching.Memory.ICacheEntry, TItem> factory) { throw null; }
         public static TItem? Get<TItem>(this Microsoft.Extensions.Caching.Memory.IMemoryCache cache, object key) { throw null; }
         public static TItem Set<TItem>(this Microsoft.Extensions.Caching.Memory.IMemoryCache cache, object key, TItem value) { throw null; }

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/PostEvictionDelegate.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/PostEvictionDelegate.cs
@@ -10,5 +10,5 @@ namespace Microsoft.Extensions.Caching.Memory
     /// <param name="value">The value of the entry being evicted.</param>
     /// <param name="reason">The <see cref="EvictionReason"/>.</param>
     /// <param name="state">The information that was passed when registering the callback.</param>
-    public delegate void PostEvictionDelegate(object key, object value, EvictionReason reason, object state);
+    public delegate void PostEvictionDelegate(object key, object? value, EvictionReason reason, object? state);
 }


### PR DESCRIPTION
I missed a spot in #64018

Somehow, `PostEvictionDelegate` and `CacheExtensions` were annotated differently in `ref` and `scr`.
@eerhardt CI might need some improvement to catch those issues (if `ref` projects are not removed)