### PR TITLE
Remove checks and settings for Internal.Runtime.CompilerServices.Unsafe since that type is gone

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGeneratorOptions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGeneratorOptions.cs
@@ -5,10 +5,10 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.Interop
 {
-    internal record DllImportGeneratorOptions(bool GenerateForwarders, bool UseMarshalType, bool UseInternalUnsafeType)
+    internal record DllImportGeneratorOptions(bool GenerateForwarders, bool UseMarshalType)
     {
         public DllImportGeneratorOptions(AnalyzerConfigOptions options)
-            : this(options.GenerateForwarders(), options.UseMarshalType(), options.UseInternalUnsafeType())
+            : this(options.GenerateForwarders(), options.UseMarshalType())
         {
         }
     }
@@ -17,8 +17,6 @@ namespace Microsoft.Interop
     {
         public const string UseMarshalTypeOption = "build_property.DllImportGenerator_UseMarshalType";
         public const string GenerateForwardersOption = "build_property.DllImportGenerator_GenerateForwarders";
-        public const string UseInternalUnsafeTypeOption = "build_property.DllImportGenerator_UseInternalUnsafeType";
-
         private static bool GetBoolOption(this AnalyzerConfigOptions options, string key)
         {
             return options.TryGetValue(key, out string? value)
@@ -29,7 +27,5 @@ namespace Microsoft.Interop
         internal static bool UseMarshalType(this AnalyzerConfigOptions options) => options.GetBoolOption(UseMarshalTypeOption);
 
         internal static bool GenerateForwarders(this AnalyzerConfigOptions options) => options.GetBoolOption(GenerateForwardersOption);
-
-        internal static bool UseInternalUnsafeType(this AnalyzerConfigOptions options) => options.GetBoolOption(UseInternalUnsafeTypeOption);
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Microsoft.Interop.DllImportGenerator.props
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Microsoft.Interop.DllImportGenerator.props
@@ -15,10 +15,5 @@
         of generating a stub that handles all of the marshalling.
       -->
       <CompilerVisibleProperty Include="DllImportGenerator_GenerateForwarders" />
-      <!--
-        Use the Internal.Runtime.ComplierServices.Unsafe type instead of
-        the System.Runtime.CompilerServices.Unsafe type when emitting code.
-      -->
-    <CompilerVisibleProperty Include="DllImportGenerator_UseInternalUnsafeType" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/InteropGenerationOptions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/InteropGenerationOptions.cs
@@ -7,5 +7,5 @@ using System.Text;
 
 namespace Microsoft.Interop
 {
-    public readonly record struct InteropGenerationOptions(bool UseMarshalType, bool UseInternalUnsafeType);
+    public readonly record struct InteropGenerationOptions(bool UseMarshalType);
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ArrayMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ArrayMarshaller.cs
@@ -14,14 +14,12 @@ namespace Microsoft.Interop
         private readonly IMarshallingGenerator _manualMarshallingGenerator;
         private readonly TypeSyntax _elementType;
         private readonly bool _enablePinning;
-        private readonly InteropGenerationOptions _options;
 
-        public ArrayMarshaller(IMarshallingGenerator manualMarshallingGenerator, TypeSyntax elementType, bool enablePinning, InteropGenerationOptions options)
+        public ArrayMarshaller(IMarshallingGenerator manualMarshallingGenerator, TypeSyntax elementType, bool enablePinning)
         {
             _manualMarshallingGenerator = manualMarshallingGenerator;
             _elementType = elementType;
             _enablePinning = enablePinning;
-            _options = options;
         }
 
         public bool IsSupported(TargetFramework target, Version version)
@@ -138,7 +136,7 @@ namespace Microsoft.Interop
                                 PrefixUnaryExpression(SyntaxKind.AddressOfExpression,
                                 InvocationExpression(
                                     MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                        ParseTypeName(TypeNames.Unsafe(_options)),
+                                        ParseTypeName(TypeNames.System_Runtime_CompilerServices_Unsafe),
                                         GenericName("As").AddTypeArgumentListArguments(
                                             arrayElementType,
                                             PredefinedType(Token(SyntaxKind.ByteKeyword)))))

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
@@ -9,7 +9,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Interop
 {
-    public readonly record struct AttributedMarshallingModelOptions(InteropGenerationOptions InteropOptions, bool RuntimeMarshallingDisabled);
+    public readonly record struct AttributedMarshallingModelOptions(bool RuntimeMarshallingDisabled);
 
     public class AttributedMarshallingModelGeneratorFactory : IMarshallingGeneratorFactory
     {
@@ -294,8 +294,7 @@ namespace Microsoft.Interop
                 return new ArrayMarshaller(
                     new CustomNativeTypeMarshallingGenerator(marshallingStrategy, enableByValueContentsMarshalling: true),
                     elementType,
-                    isBlittable,
-                    Options.InteropOptions);
+                    isBlittable);
             }
 
             IMarshallingGenerator marshallingGenerator = new CustomNativeTypeMarshallingGenerator(marshallingStrategy, enableByValueContentsMarshalling: false);

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
@@ -65,16 +65,12 @@ namespace Microsoft.Interop
 
         public const string System_Runtime_CompilerServices_SkipLocalsInitAttribute = "System.Runtime.CompilerServices.SkipLocalsInitAttribute";
 
-        private const string System_Runtime_CompilerServices_Unsafe = "System.Runtime.CompilerServices.Unsafe";
-
-
-        public static string Unsafe(InteropGenerationOptions options)
-        {
-            return System_Runtime_CompilerServices_Unsafe;
-        }
+        public const string System_Runtime_CompilerServices_Unsafe = "System.Runtime.CompilerServices.Unsafe";
 
         public const string System_Runtime_CompilerServices_DisableRuntimeMarshallingAttribute = "System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute";
+
         public const string DefaultDllImportSearchPathsAttribute = "System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute";
+
         public const string DllImportSearchPath = "System.Runtime.InteropServices.DllImportSearchPath";
     }
 }


### PR DESCRIPTION
Follow up to #64861 