### PR TITLE
Reduce alignment of dispatch maps

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -234,7 +234,7 @@ namespace ILCompiler.DependencyAnalysis
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             ObjectDataBuilder objData = new ObjectDataBuilder(factory, relocsOnly);
-            objData.RequireInitialAlignment(16);
+            objData.RequireInitialAlignment(2);
             objData.AddSymbol(this);
 
             if (!relocsOnly)


### PR DESCRIPTION
We've been aligning these at 16 bytes [since dispatch maps were added](https://github.com/dotnet/corert/pull/626) in 2016. Not clear where the 16 came from. Rhbind seems to be aligning these at pointer boundaries, but we only place `ushort`s in here.

This likely results in some size savings.