### PR TITLE
Do not copy XState other than AVX when redirecting for GC stress

### DIFF
--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -1960,7 +1960,6 @@ CONTEXT* AllocateOSContextHelper(BYTE** contextBuffer)
 
 #if !defined(TARGET_UNIX) && (defined(TARGET_X86) || defined(TARGET_AMD64))
     DWORD context = CONTEXT_COMPLETE;
-    BOOL supportsAVX = FALSE;
 
     if (pfnInitializeContext2 == NULL)
     {
@@ -1974,7 +1973,6 @@ CONTEXT* AllocateOSContextHelper(BYTE** contextBuffer)
     if ((FeatureMask & XSTATE_MASK_AVX) != 0)
     {
         context = context | CONTEXT_XSTATE;
-        supportsAVX = TRUE;
     }
 
     // Retrieve contextSize by passing NULL for Buffer
@@ -3039,7 +3037,7 @@ BOOL Thread::RedirectCurrentThreadAtHandledJITCase(PFN_REDIRECTTARGET pTgt, CONT
 #if defined(TARGET_X86) || defined(TARGET_AMD64)
     // This method is called for GC stress interrupts in managed code.
     // The current context may have various XState features, depending on what is used/dirty,
-    // but only AVX feature may contain live data. (that could change in the future)
+    // but only AVX feature may contain live data. (that could change with new features in JIT)
     // Besides pCtx may not have space to store other features.
     // So we will mask out everything but AVX.
     DWORD64 srcFeatures = 0;

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -3035,11 +3035,8 @@ BOOL Thread::RedirectCurrentThreadAtHandledJITCase(PFN_REDIRECTTARGET pTgt, CONT
     // this method is called for GC stress in managed code.
     // if current context has XState features, we are only interested in AVX
     DWORD64 srcFeatures = 0;
-    success = GetXStateFeaturesMask(pCurrentThreadCtx, &srcFeatures);
-    if (srcFeatures & XSTATE_MASK_AVX)
-    {
-        success &= SetXStateFeaturesMask(pCurrentThreadCtx, XSTATE_MASK_AVX);
-    }
+    success &= GetXStateFeaturesMask(pCurrentThreadCtx, &srcFeatures);
+    success &= SetXStateFeaturesMask(pCurrentThreadCtx, srcFeatures & XSTATE_MASK_AVX);
 #endif //defined(TARGET_X86) || defined(TARGET_AMD64)
 
     success &= CopyContext(pCtx, pCtx->ContextFlags, pCurrentThreadCtx);

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -3029,15 +3029,18 @@ BOOL Thread::RedirectCurrentThreadAtHandledJITCase(PFN_REDIRECTTARGET pTgt, CONT
 
     //////////////////////////////////////
     // Get and save the thread's context
+    BOOL success = true;
 
+#if defined(TARGET_X86) || defined(TARGET_AMD64)
     // this method is called for GC stress in managed code.
     // if current context has XState features, we are only interested in AVX
     DWORD64 srcFeatures = 0;
-    BOOL success = GetXStateFeaturesMask(pCurrentThreadCtx, &srcFeatures);
+    success = GetXStateFeaturesMask(pCurrentThreadCtx, &srcFeatures);
     if (srcFeatures & XSTATE_MASK_AVX)
     {
         success &= SetXStateFeaturesMask(pCurrentThreadCtx, XSTATE_MASK_AVX);
     }
+#endif //defined(TARGET_X86) || defined(TARGET_AMD64)
 
     success &= CopyContext(pCtx, pCtx->ContextFlags, pCurrentThreadCtx);
     _ASSERTE(success);


### PR DESCRIPTION
GC stress mechanism relies on exceptions thrown from random locations in managed code. 

The context that OS passes for the exception location may contain whatever XState that happens to be dirty. However only AVX matters in managed code. 
Besides, the redirection context that stores the state may not have space to save other XState features.

To avoid dealing with the state that we do not expect, we will indicate via the feature mask that only AVX state is valid in the provided context.

Fixes: https://github.com/dotnet/runtime/issues/65776