### PR TITLE
Fold IND(LDELEMA_REF(obj, index, type)) to INDEX(obj, index)

### DIFF
--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -3058,13 +3058,13 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
 
             if (call->IsUnmanaged() && ((call->gtCallMoreFlags & GTF_CALL_M_UNMGD_THISCALL) != 0))
             {
-                if (call->gtCallArgs->GetNode()->OperGet() == GT_NOP)
+                if (call->GetArg(0)->OperIs(GT_NOP))
                 {
                     assert(call->gtCallLateArgs->GetNode()->TypeIs(TYP_I_IMPL, TYP_BYREF));
                 }
                 else
                 {
-                    assert(call->gtCallArgs->GetNode()->TypeIs(TYP_I_IMPL, TYP_BYREF));
+                    assert(call->GetArg(0)->TypeIs(TYP_I_IMPL, TYP_BYREF));
                 }
             }
             break;

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -1053,7 +1053,7 @@ GenTree* Compiler::fgOptimizeDelegateConstructor(GenTreeCall*            call,
     CORINFO_METHOD_HANDLE methHnd = call->gtCallMethHnd;
     CORINFO_CLASS_HANDLE  clsHnd  = info.compCompHnd->getMethodClass(methHnd);
 
-    GenTree* targetMethod = call->gtCallArgs->GetNext()->GetNode();
+    GenTree* targetMethod = call->GetArg(1);
     noway_assert(targetMethod->TypeGet() == TYP_I_IMPL);
     genTreeOps            oper            = targetMethod->OperGet();
     CORINFO_METHOD_HANDLE targetMethodHnd = nullptr;
@@ -1066,7 +1066,7 @@ GenTree* Compiler::fgOptimizeDelegateConstructor(GenTreeCall*            call,
     }
     else if (oper == GT_CALL && targetMethod->AsCall()->gtCallMethHnd == eeFindHelper(CORINFO_HELP_VIRTUAL_FUNC_PTR))
     {
-        GenTree* handleNode = targetMethod->AsCall()->gtCallArgs->GetNext()->GetNext()->GetNode();
+        GenTree* handleNode = targetMethod->AsCall()->GetArg(2);
 
         if (handleNode->OperGet() == GT_CNS_INT)
         {
@@ -1105,7 +1105,7 @@ GenTree* Compiler::fgOptimizeDelegateConstructor(GenTreeCall*            call,
         GenTreeCall* runtimeLookupCall = qmarkNode->AsOp()->gtOp2->AsOp()->gtOp1->AsCall();
 
         // This could be any of CORINFO_HELP_RUNTIMEHANDLE_(METHOD|CLASS)(_LOG?)
-        GenTree* tokenNode = runtimeLookupCall->gtCallArgs->GetNext()->GetNode();
+        GenTree* tokenNode = runtimeLookupCall->GetArg(1);
         noway_assert(tokenNode->OperGet() == GT_CNS_INT);
         targetMethodHnd = CORINFO_METHOD_HANDLE(tokenNode->AsIntCon()->gtCompileTimeHandle);
     }
@@ -1138,7 +1138,7 @@ GenTree* Compiler::fgOptimizeDelegateConstructor(GenTreeCall*            call,
                 JITDUMP("optimized\n");
 
                 GenTree*             thisPointer       = call->gtCallThisArg->GetNode();
-                GenTree*             targetObjPointers = call->gtCallArgs->GetNode();
+                GenTree*             targetObjPointers = call->GetArg(0);
                 GenTreeCall::Use*    helperArgs        = nullptr;
                 CORINFO_LOOKUP       pLookup;
                 CORINFO_CONST_LOOKUP entryPoint;
@@ -1172,7 +1172,7 @@ GenTree* Compiler::fgOptimizeDelegateConstructor(GenTreeCall*            call,
             JITDUMP("optimized\n");
 
             GenTree*          thisPointer       = call->gtCallThisArg->GetNode();
-            GenTree*          targetObjPointers = call->gtCallArgs->GetNode();
+            GenTree*          targetObjPointers = call->GetArg(0);
             GenTreeCall::Use* helperArgs        = gtNewCallArgs(thisPointer, targetObjPointers);
 
             call = gtNewHelperCallNode(CORINFO_HELP_READYTORUN_DELEGATE_CTOR, TYP_VOID, helperArgs);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11789,7 +11789,7 @@ GenTree* Compiler::gtFoldExprCall(GenTreeCall* call)
         case NI_System_Enum_HasFlag:
         {
             GenTree* thisOp = call->gtCallThisArg->GetNode();
-            GenTree* flagOp = call->gtCallArgs->GetNode();
+            GenTree* flagOp = call->GetArg(0);
             GenTree* result = gtOptimizeEnumHasFlag(thisOp, flagOp);
 
             if (result != nullptr)
@@ -11802,9 +11802,9 @@ GenTree* Compiler::gtFoldExprCall(GenTreeCall* call)
         case NI_System_Type_op_Equality:
         case NI_System_Type_op_Inequality:
         {
-            noway_assert(call->TypeGet() == TYP_INT);
-            GenTree* op1 = call->gtCallArgs->GetNode();
-            GenTree* op2 = call->gtCallArgs->GetNext()->GetNode();
+            noway_assert(call->TypeIs(TYP_INT));
+            GenTree* op1 = call->GetArg(0);
+            GenTree* op2 = call->GetArg(1);
 
             // If either operand is known to be a RuntimeType, this can be folded
             GenTree* result = gtFoldTypeEqualityCall(ni == NI_System_Type_op_Equality, op1, op2);
@@ -12045,8 +12045,8 @@ GenTree* Compiler::gtFoldTypeCompare(GenTree* tree)
     if ((op1Kind == TPK_Handle) && (op2Kind == TPK_Handle))
     {
         JITDUMP("Optimizing compare of types-from-handles to instead compare handles\n");
-        GenTree*             op1ClassFromHandle = tree->AsOp()->gtOp1->AsCall()->gtCallArgs->GetNode();
-        GenTree*             op2ClassFromHandle = tree->AsOp()->gtOp2->AsCall()->gtCallArgs->GetNode();
+        GenTree*             op1ClassFromHandle = tree->AsOp()->gtOp1->AsCall()->GetArg(0);
+        GenTree*             op2ClassFromHandle = tree->AsOp()->gtOp2->AsCall()->GetArg(0);
         CORINFO_CLASS_HANDLE cls1Hnd            = NO_CLASS_HANDLE;
         CORINFO_CLASS_HANDLE cls2Hnd            = NO_CLASS_HANDLE;
 
@@ -12168,7 +12168,7 @@ GenTree* Compiler::gtFoldTypeCompare(GenTree* tree)
     GenTree* const opOther  = (op1Kind == TPK_Handle) ? op2 : op1;
 
     // Tunnel through the handle operand to get at the class handle involved.
-    GenTree* const       opHandleArgument = opHandle->AsCall()->gtCallArgs->GetNode();
+    GenTree* const       opHandleArgument = opHandle->AsCall()->GetArg(0);
     CORINFO_CLASS_HANDLE clsHnd           = gtGetHelperArgClassHandle(opHandleArgument);
 
     // If we couldn't find the class handle, give up.
@@ -12705,7 +12705,7 @@ GenTree* Compiler::gtFoldBoxNullable(GenTree* tree)
     JITDUMP("\nAttempting to optimize BOX_NULLABLE(&x) %s null [%06u]\n", GenTree::OpName(oper), dspTreeID(tree));
 
     // Get the address of the struct being boxed
-    GenTree* const arg = call->gtCallArgs->GetNext()->GetNode();
+    GenTree* const arg = call->GetArg(1);
 
     if (arg->OperIs(GT_ADDR) && ((arg->gtFlags & GTF_LATE_ARG) == 0))
     {

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4137,7 +4137,7 @@ struct GenTreeCall final : public GenTree
     GenTree* GetArg(unsigned index)
     {
         Use* use = gtCallArgs;
-        for (size_t i = 0; i < index; i++)
+        for (unsigned i = 0; i < index; i++)
         {
             use = use->GetNext();
         }
@@ -4147,16 +4147,6 @@ struct GenTreeCall final : public GenTree
     UseList LateArgs()
     {
         return UseList(gtCallLateArgs);
-    }
-
-    GenTree* GetLateArg(unsigned index)
-    {
-        Use* use = gtCallArgs;
-        for (size_t i = 0; i < index; i++)
-        {
-            use = use->GetNext();
-        }
-        return use->GetNode();
     }
 
 #ifdef DEBUG

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4134,9 +4134,29 @@ struct GenTreeCall final : public GenTree
         return UseList(gtCallArgs);
     }
 
+    GenTree* GetArg(unsigned index)
+    {
+        Use* use = gtCallArgs;
+        for (size_t i = 0; i < index; i++)
+        {
+            use = use->GetNext();
+        }
+        return use->GetNode();
+    }
+
     UseList LateArgs()
     {
         return UseList(gtCallLateArgs);
+    }
+
+    GenTree* GetLateArg(unsigned index)
+    {
+        Use* use = gtCallArgs;
+        for (size_t i = 0; i < index; i++)
+        {
+            use = use->GetNext();
+        }
+        return use->GetNode();
     }
 
 #ifdef DEBUG

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3279,7 +3279,7 @@ GenTree* Compiler::impInitializeArrayIntrinsic(CORINFO_SIG_INFO* sig)
     }
 
     // Strip helper call away
-    fieldTokenNode = fieldTokenNode->AsCall()->gtCallArgs->GetNode();
+    fieldTokenNode = fieldTokenNode->AsCall()->GetArg(0);
 
     if (fieldTokenNode->gtOper == GT_IND)
     {
@@ -3636,7 +3636,7 @@ GenTree* Compiler::impCreateSpanIntrinsic(CORINFO_SIG_INFO* sig)
     }
 
     // Strip helper call away
-    fieldTokenNode = fieldTokenNode->AsCall()->gtCallArgs->GetNode();
+    fieldTokenNode = fieldTokenNode->AsCall()->GetArg(0);
     if (fieldTokenNode->gtOper == GT_IND)
     {
         fieldTokenNode = fieldTokenNode->AsOp()->gtOp1;
@@ -4264,7 +4264,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                     GenTreeCall* call = impStackTop().val->AsCall();
                     if (call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE))
                     {
-                        CORINFO_CLASS_HANDLE hClass = gtGetHelperArgClassHandle(call->gtCallArgs->GetNode());
+                        CORINFO_CLASS_HANDLE hClass = gtGetHelperArgClassHandle(call->GetArg(0));
                         if (hClass != NO_CLASS_HANDLE)
                         {
                             retNode =
@@ -4831,8 +4831,8 @@ GenTree* Compiler::impTypeIsAssignable(GenTree* typeTo, GenTree* typeFrom)
         CORINFO_METHOD_HANDLE hTypeof = eeFindHelper(CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE);
         if ((typeTo->AsCall()->gtCallMethHnd == hTypeof) && (typeFrom->AsCall()->gtCallMethHnd == hTypeof))
         {
-            CORINFO_CLASS_HANDLE hClassTo   = gtGetHelperArgClassHandle(typeTo->AsCall()->gtCallArgs->GetNode());
-            CORINFO_CLASS_HANDLE hClassFrom = gtGetHelperArgClassHandle(typeFrom->AsCall()->gtCallArgs->GetNode());
+            CORINFO_CLASS_HANDLE hClassTo   = gtGetHelperArgClassHandle(typeTo->AsCall()->GetArg(0));
+            CORINFO_CLASS_HANDLE hClassFrom = gtGetHelperArgClassHandle(typeFrom->AsCall()->GetArg(0));
 
             if (hClassTo == NO_CLASS_HANDLE || hClassFrom == NO_CLASS_HANDLE)
             {
@@ -17268,7 +17268,7 @@ bool Compiler::impReturnInstruction(int prefixFlags, OPCODE& opcode)
 #endif // defined(TARGET_ARM64)
                 {
                     assert(iciCall->HasRetBufArg());
-                    GenTree* dest = gtCloneExpr(iciCall->gtCallArgs->GetNode());
+                    GenTree* dest = gtCloneExpr(iciCall->GetArg(0));
                     // spill temp only exists if there are multiple return points
                     if (fgNeedReturnSpillTemp())
                     {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11554,8 +11554,8 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
                     GenTree*             indexOp    = call->GetArg(1);
                     GenTree*             clsOp      = call->GetArg(2);
                     CORINFO_CLASS_HANDLE ldelemaCls = gtGetHelperArgClassHandle(clsOp);
-                    CORINFO_CLASS_HANDLE objElemCls = gtGetArrayElementClassHandle(objOp);
-                    if ((ldelemaCls == objElemCls) && impIsClassExact(ldelemaCls))
+                    if ((ldelemaCls != NO_CLASS_HANDLE) && (ldelemaCls == gtGetArrayElementClassHandle(objOp)) &&
+                        impIsClassExact(ldelemaCls))
                     {
                         JITDUMP("Folding\n");
                         DISPTREE(tree);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11550,11 +11550,12 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
                 if ((call->gtCallType == CT_HELPER) &&
                     (eeGetHelperNum(call->gtCallMethHnd) == CORINFO_HELP_LDELEMA_REF))
                 {
-                    GenTree*             objOp   = call->gtCallArgs->GetNode();
-                    GenTree*             indexOp = call->gtCallArgs->GetNext()->GetNode();
-                    GenTree*             clsOp   = call->gtCallArgs->GetNext()->GetNext()->GetNode();
-                    CORINFO_CLASS_HANDLE cls     = gtGetHelperArgClassHandle(clsOp);
-                    if ((cls != NO_CLASS_HANDLE) && impIsClassExact(cls))
+                    GenTree*             objOp      = call->GetArg(0);
+                    GenTree*             indexOp    = call->GetArg(1);
+                    GenTree*             clsOp      = call->GetArg(2);
+                    CORINFO_CLASS_HANDLE ldelemaCls = gtGetHelperArgClassHandle(clsOp);
+                    CORINFO_CLASS_HANDLE objElemCls = gtGetArrayElementClassHandle(objOp);
+                    if ((ldelemaCls == objElemCls) && impIsClassExact(ldelemaCls))
                     {
                         JITDUMP("Folding\n");
                         DISPTREE(tree);


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/65789 let's see what diffs think
```csharp
public sealed class C
{
    C[] _array;

    C Test1() => Volatile.Read(ref _array[3]);

    void Test2()
    {
        ref C c = ref _array[0];
        c = null;
    }
}
```
Codegen diff: https://www.diffchecker.com/VQ8cweA8