### PR TITLE
Condition Windows SslCertificateTrust test on Registry value

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -238,11 +238,13 @@ namespace System
         private static Lazy<bool> s_supportsTls11 = new Lazy<bool>(GetTls11Support);
         private static Lazy<bool> s_supportsTls12 = new Lazy<bool>(GetTls12Support);
         private static Lazy<bool> s_supportsTls13 = new Lazy<bool>(GetTls13Support);
+        private static Lazy<bool> s_supportsSendingCANamesInTls = new Lazy<bool>(GetTlsHandshakeCAListSupport);
 
         public static bool SupportsTls10 => s_supportsTls10.Value;
         public static bool SupportsTls11 => s_supportsTls11.Value;
         public static bool SupportsTls12 => s_supportsTls12.Value;
         public static bool SupportsTls13 => s_supportsTls13.Value;
+        public static bool SupportsSendingCANamesInTls => s_supportsSendingCANamesInTls.Value;
 
         private static Lazy<bool> s_largeArrayIsNotSupported = new Lazy<bool>(IsLargeArrayNotSupported);
 
@@ -295,7 +297,7 @@ namespace System
 
         public static bool IsInvariantGlobalization => m_isInvariant.Value;
         public static bool IsNotInvariantGlobalization => !IsInvariantGlobalization;
-        public static bool IsIcuGlobalization => ICUVersion > new Version(0,0,0,0);
+        public static bool IsIcuGlobalization => ICUVersion > new Version(0, 0, 0, 0);
         public static bool IsNlsGlobalization => IsNotInvariantGlobalization && !IsIcuGlobalization;
 
         public static bool IsSubstAvailable
@@ -360,7 +362,7 @@ namespace System
 
         private static bool GetProtocolSupportFromWindowsRegistry(SslProtocols protocol, bool defaultProtocolSupport)
         {
-            string registryProtocolName = protocol switch 
+            string registryProtocolName = protocol switch
             {
 #pragma warning disable CS0618 // Ssl2 and Ssl3 are obsolete
                 SslProtocols.Ssl3 => "SSL 3.0",
@@ -410,7 +412,7 @@ namespace System
 #pragma warning disable CS0618 // Ssl2 and Ssl3 are obsolete
                 return GetProtocolSupportFromWindowsRegistry(SslProtocols.Ssl3, ssl3DefaultSupport);
 #pragma warning restore CS0618
-                
+
             }
 
             return (IsOSX || (IsLinux && OpenSslVersion < new Version(1, 0, 2) && !IsDebian));
@@ -437,7 +439,7 @@ namespace System
             if (IsOSXLike || IsAndroid)
             {
                 return true;
-            } 
+            }
             if (IsWindows)
             {
                 return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls, true);
@@ -466,7 +468,7 @@ namespace System
         private static bool GetTls12Support()
         {
             // TLS 1.1 and 1.2 can work on Windows7 but it is not enabled by default.
-            bool defaultProtocolSupport =  !IsWindows7;
+            bool defaultProtocolSupport = !IsWindows7;
             return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls12, defaultProtocolSupport);
         }
 
@@ -506,7 +508,27 @@ namespace System
             else if (IsOpenSslSupported)
             {
                 // Covers Linux, FreeBSD, illumos and Solaris
-                return OpenSslVersion >= new Version(1,1,1);
+                return OpenSslVersion >= new Version(1, 1, 1);
+            }
+
+            return false;
+        }
+
+        private static bool GetTlsHandshakeCAListSupport()
+        {
+            if (IsOpenSslSupported || IsOSX)
+            {
+                return true;
+            }
+
+            if (IsWindows)
+            {
+                // Sending TrustedIssuers is conditioned on the registry.
+                object val = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL", "SendTrustedIssuerList", IsWindows7 ? 1 : 0);
+                if (val is int i)
+                {
+                    return i == 1;
+                }
             }
 
             return false;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslCertificateTrust.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslCertificateTrust.cs
@@ -21,7 +21,9 @@ namespace System.Net.Security
                 throw new PlatformNotSupportedException(SR.net_ssl_trust_store);
             }
 #else
-            if (sendTrustInHandshake && !System.OperatingSystem.IsLinux() && !System.OperatingSystem.IsMacOS())
+            if (sendTrustInHandshake && !System.OperatingSystem.IsLinux() && !System.OperatingSystem.IsMacOS() &&
+                // Necessary functions are available only on win 8 onwards
+                !OperatingSystem.IsWindowsVersionAtLeast(6, 2))
             {
                 // to be removed when implemented.
                 throw new PlatformNotSupportedException(SR.net_ssl_trust_handshake);
@@ -43,16 +45,9 @@ namespace System.Net.Security
         {
             if (sendTrustInHandshake && !System.OperatingSystem.IsLinux() && !System.OperatingSystem.IsMacOS())
             {
-                // to be removed when implemented.
                 throw new PlatformNotSupportedException(SR.net_ssl_trust_handshake);
             }
 
-#if TARGET_WINDOWS
-            if (sendTrustInHandshake)
-            {
-                throw new PlatformNotSupportedException(SR.net_ssl_trust_collection);
-            }
-#endif
             var trust = new SslCertificateTrust();
             trust._trustList = trustList;
             trust._sendTrustInHandshake = sendTrustInHandshake;

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateTrustTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateTrustTests.cs
@@ -91,6 +91,7 @@ namespace System.Net.Security.Tests
         }
 
         [ConditionalFact(nameof(SupportsSendingCustomCANamesInTls))]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void SslStream_SendCertificateTrust_CertificateCollection_ThrowsOnWindows()
         {
             (X509Certificate2 certificate, X509Certificate2Collection caCerts) = TestHelper.GenerateCertificates(nameof(SslStream_SendCertificateTrust_CertificateCollection));
@@ -99,7 +100,7 @@ namespace System.Net.Security.Tests
         }
 
         [ConditionalFact(nameof(DoesNotSupportSendingCustomCANamesInTls))]
-        [SkipOnPlatform(TestPlatform.Windows)]
+        [SkipOnPlatform(TestPlatforms.Windows, "Windows tested separately")]
         public void SslStream_SendCertificateTrust_ThrowsOnUnsupportedPlatform()
         {
             (X509Certificate2 certificate, X509Certificate2Collection caCerts) = TestHelper.GenerateCertificates(nameof(SslStream_SendCertificateTrust_CertificateCollection));

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateTrustTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateTrustTests.cs
@@ -15,9 +15,10 @@ namespace System.Net.Security.Tests
 
     public class SslStreamCertificateTrustTest
     {
-        [Fact]
-        // not supported on Windows, not implemented elsewhere
-        [PlatformSpecific(TestPlatforms.Linux | TestPlatforms.OSX)]
+        public static bool SupportsSendingCANamesInTls => PlatformDetection.SupportsSendingCANamesInTls;
+
+        [ConditionalFact(nameof(SupportsSendingCANamesInTls))]
+        [SkipOnPlatform(TestPlatforms.Windows, "CertificateCollection-based SslCertificateTrust is not Supported on Windows")]
         public async Task SslStream_SendCertificateTrust_CertificateCollection()
         {
             (X509Certificate2 certificate, X509Certificate2Collection caCerts) = TestHelper.GenerateCertificates(nameof(SslStream_SendCertificateTrust_CertificateCollection));
@@ -29,9 +30,7 @@ namespace System.Net.Security.Tests
             Assert.Equal(caCerts.Select(c => c.Subject), acceptableIssuers);
         }
 
-        [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/65515", TestPlatforms.Windows)]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.Linux | TestPlatforms.OSX)]
+        [ConditionalFact(nameof(SupportsSendingCANamesInTls))]
         public async Task SslStream_SendCertificateTrust_CertificateStore()
         {
             using X509Store store = new X509Store("Root", StoreLocation.LocalMachine);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamEKUTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamEKUTest.cs
@@ -11,11 +11,12 @@ using Xunit;
 
 namespace System.Net.Security.Tests
 {
-    using Configuration =   System.Net.Test.Common.Configuration;
+    using Configuration = System.Net.Test.Common.Configuration;
 
     public class SslStreamEKUTest
     {
         public static bool IsRootCertificateInstalled => Capability.IsTrustedRootCertificateInstalled();
+        public static bool DoesNotSendCAListByDefault => !PlatformDetection.SendsCAListByDefault;
 
         public const int TestTimeoutMilliseconds = 15 * 1000;
 
@@ -134,7 +135,7 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [ConditionalFact(nameof(IsRootCertificateInstalled))]
+        [ConditionalFact(nameof(IsRootCertificateInstalled), nameof(DoesNotSendCAListByDefault))]
         public async Task SslStream_SelfSignedClientEKUClientAuth_Ok()
         {
             var serverOptions = new HttpsTestServer.Options();

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -275,8 +275,11 @@ namespace System.Net.Security.Tests
                     return sendClientCertificate ? clientCertificate : null;
                 };
 
-                SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions() { ServerCertificate = serverCertificate,
-                                                                                                      AllowRenegotiation = false  };
+                SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions()
+                {
+                    ServerCertificate = serverCertificate,
+                    AllowRenegotiation = false
+                };
                 serverOptions.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) =>
                 {
                     if (negotiateClientCertificateCalled && sendClientCertificate)
@@ -353,7 +356,7 @@ namespace System.Net.Security.Tests
                 // Send application data instead of Client hello.
                 await client.WriteAsync(new byte[500], cts.Token);
                 // Fail as it is not allowed to receive non handshake frames during handshake.
-                await Assert.ThrowsAsync<InvalidOperationException>(()=> t);
+                await Assert.ThrowsAsync<InvalidOperationException>(() => t);
             }
         }
 
@@ -404,7 +407,7 @@ namespace System.Net.Security.Tests
                 int read = await server.ReadAsync(buffer, cts.Token);
 
                 // Fail as there are still some undrained data (incomplete incoming TLS frame)
-                await Assert.ThrowsAsync<InvalidOperationException>(()=>
+                await Assert.ThrowsAsync<InvalidOperationException>(() =>
                     server.NegotiateClientCertificateAsync(cts.Token)
                 );
 
@@ -472,17 +475,10 @@ namespace System.Net.Security.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.SupportsTls13))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/58927", TestPlatforms.Windows)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task SslStream_NegotiateClientCertificateAsyncTls13_Succeeds(bool sendClientCertificate)
         {
-            if (PlatformDetection.IsWindows10Version22000OrGreater)
-            {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/58927")]
-                throw new SkipTestException("Unstable on Windows 11");
-            }
-
             bool negotiateClientCertificateCalled = false;
             using CancellationTokenSource cts = new CancellationTokenSource();
             cts.CancelAfter(TestConfiguration.PassingTestTimeout);
@@ -727,12 +723,11 @@ namespace System.Net.Security.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/46837", TestPlatforms.OSX)]
         public async Task SslStream_UntrustedCaWithCustomCallback_OK(bool usePartialChain)
         {
             int split = Random.Shared.Next(0, certificates.serverChain.Count - 1);
 
-            var clientOptions = new  SslClientAuthenticationOptions() { TargetHost = "localhost" };
+            var clientOptions = new SslClientAuthenticationOptions() { TargetHost = "localhost" };
             clientOptions.RemoteCertificateValidationCallback =
                 (sender, certificate, chain, sslPolicyErrors) =>
                 {
@@ -790,11 +785,10 @@ namespace System.Net.Security.Tests
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/46837", TestPlatforms.OSX)]
         public async Task SslStream_UntrustedCaWithCustomCallback_Throws(bool customCallback)
         {
             string errorMessage;
-            var clientOptions = new  SslClientAuthenticationOptions() { TargetHost = "localhost" };
+            var clientOptions = new SslClientAuthenticationOptions() { TargetHost = "localhost" };
             if (customCallback)
             {
                 clientOptions.RemoteCertificateValidationCallback =
@@ -836,8 +830,7 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [ConditionalFact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/46837", TestPlatforms.OSX)]
+        [Fact]
         public async Task SslStream_ClientCertificate_SendsChain()
         {
             List<SslStream> streams = new List<SslStream>();
@@ -864,7 +857,7 @@ namespace System.Net.Security.Tests
                 }
             }
 
-            var clientOptions = new  SslClientAuthenticationOptions() { TargetHost = "localhost",  };
+            var clientOptions = new SslClientAuthenticationOptions() { TargetHost = "localhost", };
             clientOptions.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
             clientOptions.LocalCertificateSelectionCallback = (sender, target, certificates, remoteCertificate, issuers) => clientCertificate;
 
@@ -908,7 +901,7 @@ namespace System.Net.Security.Tests
                 c.Dispose();
             }
 
-            foreach (SslStream s in  streams)
+            foreach (SslStream s in streams)
             {
                 s.Dispose();
             }


### PR DESCRIPTION
Fixes #65515

Sending trusted issuers list on Windows is problematic (depends on registry settings), so there were no tests. This PR conditionally enables existing tests on Windows if the relevant registry setting is set.