### PR TITLE
Remove WebRequest from SoundPlayer

### DIFF
--- a/src/libraries/System.Windows.Extensions/src/System.Windows.Extensions.csproj
+++ b/src/libraries/System.Windows.Extensions/src/System.Windows.Extensions.csproj
@@ -98,7 +98,7 @@ System.Security.Cryptography.X509Certificates.X509SelectionFlag</PackageDescript
     <Reference Include="System.Diagnostics.Tools" />
     <Reference Include="System.IO.FileSystem" />
     <Reference Include="System.Memory" />
-    <Reference Include="System.Net.Requests" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.Extensions" />


### PR DESCRIPTION
I have removed the two instances of `WebRequest` and instead use `HttpClient`.

I could maybe refine it to only allocate a `HttpClient` if required.

Fix #41516