### PR TITLE
Swap out a Debug.Fail for a more graceful diagnostic failure.

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
@@ -364,8 +364,10 @@ namespace Microsoft.Interop
                 switch (namedArg.Key)
                 {
                     default:
-                        Debug.Fail($"An unknown member '{namedArg.Key}' was found on {attrData.AttributeClass}");
-                        continue;
+                        // This should never occur in a released build,
+                        // but can happen when evolving the ecosystem.
+                        // Return null here to indicate invalid attribute data.
+                        return null;
                     case nameof(GeneratedDllImportData.StringMarshalling):
                         userDefinedValues |= DllImportMember.StringMarshalling;
                         // TypedConstant's Value property only contains primitive values.

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
@@ -367,6 +367,7 @@ namespace Microsoft.Interop
                         // This should never occur in a released build,
                         // but can happen when evolving the ecosystem.
                         // Return null here to indicate invalid attribute data.
+                        Debug.WriteLine($"An unknown member '{namedArg.Key}' was found on {attrData.AttributeClass}");
                         return null;
                     case nameof(GeneratedDllImportData.StringMarshalling):
                         userDefinedValues |= DllImportMember.StringMarshalling;


### PR DESCRIPTION
This case will never trigger in a release application, but can trigger when switching branches where each branch has a different definition of GeneratedDllImport.

This fix was requested by @stephentoub over email.