### PR TITLE
Mark architecture-specific tests with ConditionalFact attributes

### DIFF
--- a/src/tests/Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj
+++ b/src/tests/Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj
@@ -17,6 +17,7 @@
     <Compile Include="XPlatformUtils.cs" />
     <Compile Include="CoreClrConfigurationDetection.cs" />
     <Compile Include="OutOfProcessTest.cs" />
+    <Compile Include="PlatformDetection.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Coreclr.TestWrapper\CoreclrTestWrapperLib.cs" Link="CoreclrTestWrapperLib.cs" />

--- a/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+public static class PlatformDetection
+{
+    public static bool Is32BitProcess => IntPtr.Size == 4;
+    public static bool Is64BitProcess => IntPtr.Size == 8;
+
+    public static bool IsX86Process => RuntimeInformation.ProcessArchitecture == Architecture.X86;
+    public static bool IsNotX86Process => !IsX86Process;
+}

--- a/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
@@ -4,11 +4,14 @@
 using System;
 using System.Runtime.InteropServices;
 
-public static class PlatformDetection
+namespace TestLibrary
 {
-    public static bool Is32BitProcess => IntPtr.Size == 4;
-    public static bool Is64BitProcess => IntPtr.Size == 8;
-
-    public static bool IsX86Process => RuntimeInformation.ProcessArchitecture == Architecture.X86;
-    public static bool IsNotX86Process => !IsX86Process;
+    public static class PlatformDetection
+    {
+        public static bool Is32BitProcess => IntPtr.Size == 4;
+        public static bool Is64BitProcess => IntPtr.Size == 8;
+    
+        public static bool IsX86Process => RuntimeInformation.ProcessArchitecture == Architecture.X86;
+        public static bool IsNotX86Process => !IsX86Process;
+    }
 }

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -70,7 +70,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(RepoRoot)\src\tests\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj" Condition="'$(IsMergedTestRunnerAssembly)' == 'true'" />
+    <ProjectReference Include="$(RepoRoot)\src\tests\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 
   <!--

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_32BIT.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_32BIT.il
@@ -17,15 +17,16 @@
 {
 .method private hidebysig static int32 Main() il managed
 {
-    // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
+    // [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.Is32BitProcess))]
     .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
-                                                                                                  string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
-                                                                                                                74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
-                                                                                                                79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
-                                                                                                                2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
-                                                                                                                72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
-                                                                                                                6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0E 49 73 33   // ken=null.....Is3
-                                                                                                                32 42 69 74 50 72 6F 63 65 73 73 00 00 )          // 2BitProcess..
+                                                                                                  string[]) = ( 01 00 61 54 65 73 74 4C 69 62 72 61 72 79 2E 50   // ..aTestLibrary.P
+                                                                                                                6C 61 74 66 6F 72 6D 44 65 74 65 63 74 69 6F 6E   // latformDetection
+                                                                                                                2C 20 54 65 73 74 4C 69 62 72 61 72 79 2C 20 56   // , TestLibrary, V
+                                                                                                                65 72 73 69 6F 6E 3D 30 2E 30 2E 30 2E 30 2C 20   // ersion=0.0.0.0, 
+                                                                                                                43 75 6C 74 75 72 65 3D 6E 65 75 74 72 61 6C 2C   // Culture=neutral,
+                                                                                                                20 50 75 62 6C 69 63 4B 65 79 54 6F 6B 65 6E 3D   //  PublicKeyToken=
+                                                                                                                6E 75 6C 6C 01 00 00 00 0E 49 73 33 32 42 69 74   // null.....Is32Bit
+                                                                                                                50 72 6F 63 65 73 73 00 00 )                      // Process..
 	.entrypoint
 	.maxstack  8
 	.locals (int32[0...], native int[0...], native int, native int)

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_32BIT.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_32BIT.il
@@ -12,13 +12,20 @@
 .assembly 'i_array_merge_Target_32BIT'
 { }
 .assembly extern xunit.core {}
+.assembly extern Microsoft.DotNet.XUnitExtensions {}
 .class public auto ansi Test_i_array_merge_Target_32BIT extends [mscorlib]System.Object
 {
 .method private hidebysig static int32 Main() il managed
 {
-	.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-	    01 00 00 00
-	)
+    // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
+    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
+                                                                                                  string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
+                                                                                                                74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
+                                                                                                                79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
+                                                                                                                2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
+                                                                                                                72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
+                                                                                                                6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0E 49 73 33   // ken=null.....Is3
+                                                                                                                32 42 69 74 50 72 6F 63 65 73 73 00 00 )          // 2BitProcess..
 	.entrypoint
 	.maxstack  8
 	.locals (int32[0...], native int[0...], native int, native int)

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_64BIT.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_64BIT.il
@@ -17,15 +17,16 @@
 {
 .method private hidebysig static int32 Main() il managed
 {
-    // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+    // [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.Is64BitProcess))]
     .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
-                                                                                                  string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
-                                                                                                                74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
-                                                                                                                79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
-                                                                                                                2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
-                                                                                                                72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
-                                                                                                                6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0E 49 73 36   // ken=null.....Is6
-                                                                                                                34 42 69 74 50 72 6F 63 65 73 73 00 00 )          // 4BitProcess..
+                                                                                                  string[]) = ( 01 00 61 54 65 73 74 4C 69 62 72 61 72 79 2E 50   // ..aTestLibrary.P
+                                                                                                                6C 61 74 66 6F 72 6D 44 65 74 65 63 74 69 6F 6E   // latformDetection
+                                                                                                                2C 20 54 65 73 74 4C 69 62 72 61 72 79 2C 20 56   // , TestLibrary, V
+                                                                                                                65 72 73 69 6F 6E 3D 30 2E 30 2E 30 2E 30 2C 20   // ersion=0.0.0.0, 
+                                                                                                                43 75 6C 74 75 72 65 3D 6E 65 75 74 72 61 6C 2C   // Culture=neutral,
+                                                                                                                20 50 75 62 6C 69 63 4B 65 79 54 6F 6B 65 6E 3D   //  PublicKeyToken=
+                                                                                                                6E 75 6C 6C 01 00 00 00 0E 49 73 36 34 42 69 74   // null.....Is64Bit
+                                                                                                                50 72 6F 63 65 73 73 00 00 )                      // Process..
 	.entrypoint
 	.maxstack  8
 	.locals (int64[0...], native int[0...], native int, native int)

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_64BIT.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_64BIT.il
@@ -12,13 +12,20 @@
 .assembly 'i_array_merge_Target_64BIT'
 { }
 .assembly extern xunit.core {}
+.assembly extern Microsoft.DotNet.XUnitExtensions {}
 .class public auto ansi Test_i_array_merge_Target_64BIT extends [mscorlib]System.Object
 {
 .method private hidebysig static int32 Main() il managed
 {
-	.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-	    01 00 00 00
-	)
+    // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
+                                                                                                  string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
+                                                                                                                74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
+                                                                                                                79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
+                                                                                                                2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
+                                                                                                                72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
+                                                                                                                6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0E 49 73 36   // ken=null.....Is6
+                                                                                                                34 42 69 74 50 72 6F 63 65 73 73 00 00 )          // 4BitProcess..
 	.entrypoint
 	.maxstack  8
 	.locals (int64[0...], native int[0...], native int, native int)

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_32BIT.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_32BIT.il
@@ -26,15 +26,16 @@
   {
     .method private hidebysig static int32 Main() il managed
     {
-        // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
+        // [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.Is32BitProcess))]
         .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
-                                                                                                      string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
-                                                                                                                    74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
-                                                                                                                    79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
-                                                                                                                    2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
-                                                                                                                    72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
-                                                                                                                    6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0E 49 73 33   // ken=null.....Is3
-                                                                                                                    32 42 69 74 50 72 6F 63 65 73 73 00 00 )          // 2BitProcess..
+                                                                                                      string[]) = ( 01 00 61 54 65 73 74 4C 69 62 72 61 72 79 2E 50   // ..aTestLibrary.P
+                                                                                                                    6C 61 74 66 6F 72 6D 44 65 74 65 63 74 69 6F 6E   // latformDetection
+                                                                                                                    2C 20 54 65 73 74 4C 69 62 72 61 72 79 2C 20 56   // , TestLibrary, V
+                                                                                                                    65 72 73 69 6F 6E 3D 30 2E 30 2E 30 2E 30 2C 20   // ersion=0.0.0.0, 
+                                                                                                                    43 75 6C 74 75 72 65 3D 6E 65 75 74 72 61 6C 2C   // Culture=neutral,
+                                                                                                                    20 50 75 62 6C 69 63 4B 65 79 54 6F 6B 65 6E 3D   //  PublicKeyToken=
+                                                                                                                    6E 75 6C 6C 01 00 00 00 0E 49 73 33 32 42 69 74   // null.....Is32Bit
+                                                                                                                    50 72 6F 63 65 73 73 00 00 )                      // Process..
 		.entrypoint
 		// Code size       48 (0x30)
 		.maxstack  5

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_32BIT.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_32BIT.il
@@ -17,6 +17,7 @@
 {
 }
 .assembly extern xunit.core {}
+.assembly extern Microsoft.DotNet.XUnitExtensions {}
 // MVID: {BCA6096F-DF11-4FA3-BF16-EEDA01729535}
 .namespace AvgTest
 {
@@ -25,9 +26,15 @@
   {
     .method private hidebysig static int32 Main() il managed
     {
-		.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-		    01 00 00 00
-		)
+        // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
+        .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
+                                                                                                      string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
+                                                                                                                    74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
+                                                                                                                    79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
+                                                                                                                    2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
+                                                                                                                    72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
+                                                                                                                    6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0E 49 73 33   // ken=null.....Is3
+                                                                                                                    32 42 69 74 50 72 6F 63 65 73 73 00 00 )          // 2BitProcess..
 		.entrypoint
 		// Code size       48 (0x30)
 		.maxstack  5

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_64BIT.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_64BIT.il
@@ -26,15 +26,16 @@
   {
     .method private hidebysig static int32 Main() il managed
     {
-        // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+        // [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.Is64BitProcess))]
         .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
-                                                                                                      string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
-                                                                                                                    74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
-                                                                                                                    79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
-                                                                                                                    2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
-                                                                                                                    72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
-                                                                                                                    6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0E 49 73 36   // ken=null.....Is6
-                                                                                                                    34 42 69 74 50 72 6F 63 65 73 73 00 00 )          // 4BitProcess..
+                                                                                                      string[]) = ( 01 00 61 54 65 73 74 4C 69 62 72 61 72 79 2E 50   // ..aTestLibrary.P
+                                                                                                                    6C 61 74 66 6F 72 6D 44 65 74 65 63 74 69 6F 6E   // latformDetection
+                                                                                                                    2C 20 54 65 73 74 4C 69 62 72 61 72 79 2C 20 56   // , TestLibrary, V
+                                                                                                                    65 72 73 69 6F 6E 3D 30 2E 30 2E 30 2E 30 2C 20   // ersion=0.0.0.0, 
+                                                                                                                    43 75 6C 74 75 72 65 3D 6E 65 75 74 72 61 6C 2C   // Culture=neutral,
+                                                                                                                    20 50 75 62 6C 69 63 4B 65 79 54 6F 6B 65 6E 3D   //  PublicKeyToken=
+                                                                                                                    6E 75 6C 6C 01 00 00 00 0E 49 73 36 34 42 69 74   // null.....Is64Bit
+                                                                                                                    50 72 6F 63 65 73 73 00 00 )                      // Process..
 		.entrypoint
 		// Code size       48 (0x30)
 		.maxstack  5

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_64BIT.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_64BIT.il
@@ -17,6 +17,7 @@
 {
 }
 .assembly extern xunit.core {}
+.assembly extern Microsoft.DotNet.XUnitExtensions {}
 // MVID: {BCA6096F-DF11-4FA3-BF16-EEDA01729535}
 .namespace AvgTest_sizeof_Target_64BIT
 {
@@ -25,9 +26,15 @@
   {
     .method private hidebysig static int32 Main() il managed
     {
-		.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-		    01 00 00 00
-		)
+        // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+        .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
+                                                                                                      string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
+                                                                                                                    74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
+                                                                                                                    79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
+                                                                                                                    2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
+                                                                                                                    72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
+                                                                                                                    6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0E 49 73 36   // ken=null.....Is6
+                                                                                                                    34 42 69 74 50 72 6F 63 65 73 73 00 00 )          // 4BitProcess..
 		.entrypoint
 		// Code size       48 (0x30)
 		.maxstack  5

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_32BIT.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_32BIT.il
@@ -12,13 +12,20 @@
 .assembly 'u_array_merge_Target_32BIT'
 { }
 .assembly extern xunit.core {}
+.assembly extern Microsoft.DotNet.XUnitExtensions {}
 .class public auto ansi Test_u_array_merge_Target_32BIT extends [mscorlib]System.Object
 {
 .method private hidebysig static int32 Main() il managed
 {
-	.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-	    01 00 00 00
-	)
+    // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
+    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
+                                                                                                  string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
+                                                                                                                74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
+                                                                                                                79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
+                                                                                                                2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
+                                                                                                                72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
+                                                                                                                6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0E 49 73 33   // ken=null.....Is3
+                                                                                                                32 42 69 74 50 72 6F 63 65 73 73 00 00 )          // 2BitProcess..
 	.entrypoint
 	.maxstack  8
 	.locals (unsigned int32[0...], native unsigned int[0...], native unsigned int, native unsigned int)

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_32BIT.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_32BIT.il
@@ -17,15 +17,16 @@
 {
 .method private hidebysig static int32 Main() il managed
 {
-    // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
-    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
-                                                                                                  string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
-                                                                                                                74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
-                                                                                                                79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
-                                                                                                                2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
-                                                                                                                72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
-                                                                                                                6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0E 49 73 33   // ken=null.....Is3
-                                                                                                                32 42 69 74 50 72 6F 63 65 73 73 00 00 )          // 2BitProcess..
+        // [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.Is32BitProcess))]
+        .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
+                                                                                                      string[]) = ( 01 00 61 54 65 73 74 4C 69 62 72 61 72 79 2E 50   // ..aTestLibrary.P
+                                                                                                                    6C 61 74 66 6F 72 6D 44 65 74 65 63 74 69 6F 6E   // latformDetection
+                                                                                                                    2C 20 54 65 73 74 4C 69 62 72 61 72 79 2C 20 56   // , TestLibrary, V
+                                                                                                                    65 72 73 69 6F 6E 3D 30 2E 30 2E 30 2E 30 2C 20   // ersion=0.0.0.0, 
+                                                                                                                    43 75 6C 74 75 72 65 3D 6E 65 75 74 72 61 6C 2C   // Culture=neutral,
+                                                                                                                    20 50 75 62 6C 69 63 4B 65 79 54 6F 6B 65 6E 3D   //  PublicKeyToken=
+                                                                                                                    6E 75 6C 6C 01 00 00 00 0E 49 73 33 32 42 69 74   // null.....Is32Bit
+                                                                                                                    50 72 6F 63 65 73 73 00 00 )                      // Process..
 	.entrypoint
 	.maxstack  8
 	.locals (unsigned int32[0...], native unsigned int[0...], native unsigned int, native unsigned int)

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_64BIT.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_64BIT.il
@@ -17,15 +17,16 @@
 {
 .method private hidebysig static int32 Main() il managed
 {
-    // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+    // [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.Is64BitProcess))]
     .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
-                                                                                                  string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
-                                                                                                                74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
-                                                                                                                79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
-                                                                                                                2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
-                                                                                                                72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
-                                                                                                                6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0E 49 73 36   // ken=null.....Is6
-                                                                                                                34 42 69 74 50 72 6F 63 65 73 73 00 00 )          // 4BitProcess..
+                                                                                                  string[]) = ( 01 00 61 54 65 73 74 4C 69 62 72 61 72 79 2E 50   // ..aTestLibrary.P
+                                                                                                                6C 61 74 66 6F 72 6D 44 65 74 65 63 74 69 6F 6E   // latformDetection
+                                                                                                                2C 20 54 65 73 74 4C 69 62 72 61 72 79 2C 20 56   // , TestLibrary, V
+                                                                                                                65 72 73 69 6F 6E 3D 30 2E 30 2E 30 2E 30 2C 20   // ersion=0.0.0.0, 
+                                                                                                                43 75 6C 74 75 72 65 3D 6E 65 75 74 72 61 6C 2C   // Culture=neutral,
+                                                                                                                20 50 75 62 6C 69 63 4B 65 79 54 6F 6B 65 6E 3D   //  PublicKeyToken=
+                                                                                                                6E 75 6C 6C 01 00 00 00 0E 49 73 36 34 42 69 74   // null.....Is64Bit
+                                                                                                                50 72 6F 63 65 73 73 00 00 )                      // Process..
 	.entrypoint
 	.maxstack  8
 	.locals (unsigned int64[0...], native unsigned int[0...], native unsigned int, native unsigned int)

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_64BIT.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_64BIT.il
@@ -12,13 +12,20 @@
 .assembly 'u_array_merge_Target_64BIT'
 { }
 .assembly extern xunit.core {}
+.assembly extern Microsoft.DotNet.XUnitExtensions {}
 .class public auto ansi Test_u_array_merge_Target_64BIT extends [mscorlib]System.Object
 {
 .method private hidebysig static int32 Main() il managed
 {
-	.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-	    01 00 00 00
-	)
+    // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
+                                                                                                  string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
+                                                                                                                74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
+                                                                                                                79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
+                                                                                                                2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
+                                                                                                                72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
+                                                                                                                6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0E 49 73 36   // ken=null.....Is6
+                                                                                                                34 42 69 74 50 72 6F 63 65 73 73 00 00 )          // 4BitProcess..
 	.entrypoint
 	.maxstack  8
 	.locals (unsigned int64[0...], native unsigned int[0...], native unsigned int, native unsigned int)

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_32Bit_x86.il
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_32Bit_x86.il
@@ -5,6 +5,7 @@
 .assembly extern mscorlib { }
 .assembly sizeof32_Target_32Bit_x86 { }
 .assembly extern xunit.core {}
+.assembly extern Microsoft.DotNet.XUnitExtensions {}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 )
 .namespace JitTest_sizeof32_Target_32Bit_x86_il
 {
@@ -36,9 +37,15 @@
     .method private hidebysig static int32
             Main() cil managed
     {
-      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-          01 00 00 00
-      )
+      // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsX86Process))]
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
+                                                                                                    string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
+                                                                                                                  74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
+                                                                                                                  79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
+                                                                                                                  2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
+                                                                                                                  72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
+                                                                                                                  6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0C 49 73 58   // ken=null.....IsX
+                                                                                                                  38 36 50 72 6F 63 65 73 73 00 00 )                // 86Process..
       .entrypoint
       .maxstack  4
       .locals (int32 V_0,

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_32Bit_x86.il
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_32Bit_x86.il
@@ -37,15 +37,16 @@
     .method private hidebysig static int32
             Main() cil managed
     {
-      // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsX86Process))]
+      // [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsX86Process))]
       .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
-                                                                                                    string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
-                                                                                                                  74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
-                                                                                                                  79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
-                                                                                                                  2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
-                                                                                                                  72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
-                                                                                                                  6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0C 49 73 58   // ken=null.....IsX
-                                                                                                                  38 36 50 72 6F 63 65 73 73 00 00 )                // 86Process..
+                                                                                                    string[]) = ( 01 00 61 54 65 73 74 4C 69 62 72 61 72 79 2E 50   // ..aTestLibrary.P
+                                                                                                                  6C 61 74 66 6F 72 6D 44 65 74 65 63 74 69 6F 6E   // latformDetection
+                                                                                                                  2C 20 54 65 73 74 4C 69 62 72 61 72 79 2C 20 56   // , TestLibrary, V
+                                                                                                                  65 72 73 69 6F 6E 3D 30 2E 30 2E 30 2E 30 2C 20   // ersion=0.0.0.0, 
+                                                                                                                  43 75 6C 74 75 72 65 3D 6E 65 75 74 72 61 6C 2C   // Culture=neutral,
+                                                                                                                  20 50 75 62 6C 69 63 4B 65 79 54 6F 6B 65 6E 3D   //  PublicKeyToken=
+                                                                                                                  6E 75 6C 6C 01 00 00 00 0C 49 73 58 38 36 50 72   // null.....IsX86Pr
+                                                                                                                  6F 63 65 73 73 00 00 )                            // ocess..
       .entrypoint
       .maxstack  4
       .locals (int32 V_0,

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_64Bit_and_arm.il
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_64Bit_and_arm.il
@@ -4,6 +4,7 @@
 .assembly extern mscorlib { }
 .assembly 'sizeof32_Target_64Bit_and_arm' { }
 .assembly extern xunit.core {}
+.assembly extern Microsoft.DotNet.XUnitExtensions {}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .namespace JitTest_sizeof32_Target_64Bit_and_arm_il
 {
@@ -35,9 +36,15 @@
     .method private hidebysig static int32
             Main() cil managed
     {
-      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-          01 00 00 00
-      )
+      // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotX86Process))]
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
+                                                                                                    string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
+                                                                                                                  74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
+                                                                                                                  79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
+                                                                                                                  2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
+                                                                                                                  72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
+                                                                                                                  6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0F 49 73 4E   // ken=null.....IsN
+                                                                                                                  6F 74 58 38 36 50 72 6F 63 65 73 73 00 00 )       // otX86Process..
       .entrypoint
       .maxstack  4
       .locals (int32 V_0,

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_64Bit_and_arm.il
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_64Bit_and_arm.il
@@ -36,15 +36,16 @@
     .method private hidebysig static int32
             Main() cil managed
     {
-      // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotX86Process))]
+      // [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsNotX86Process))]
       .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
-                                                                                                    string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
-                                                                                                                  74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
-                                                                                                                  79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
-                                                                                                                  2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
-                                                                                                                  72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
-                                                                                                                  6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0F 49 73 4E   // ken=null.....IsN
-                                                                                                                  6F 74 58 38 36 50 72 6F 63 65 73 73 00 00 )       // otX86Process..
+                                                                                                    string[]) = ( 01 00 61 54 65 73 74 4C 69 62 72 61 72 79 2E 50   // ..aTestLibrary.P
+                                                                                                                  6C 61 74 66 6F 72 6D 44 65 74 65 63 74 69 6F 6E   // latformDetection
+                                                                                                                  2C 20 54 65 73 74 4C 69 62 72 61 72 79 2C 20 56   // , TestLibrary, V
+                                                                                                                  65 72 73 69 6F 6E 3D 30 2E 30 2E 30 2E 30 2C 20   // ersion=0.0.0.0, 
+                                                                                                                  43 75 6C 74 75 72 65 3D 6E 65 75 74 72 61 6C 2C   // Culture=neutral,
+                                                                                                                  20 50 75 62 6C 69 63 4B 65 79 54 6F 6B 65 6E 3D   //  PublicKeyToken=
+                                                                                                                  6E 75 6C 6C 01 00 00 00 0F 49 73 4E 6F 74 58 38   // null.....IsNotX8
+                                                                                                                  36 50 72 6F 63 65 73 73 00 00 )                   // 6Process..
       .entrypoint
       .maxstack  4
       .locals (int32 V_0,

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_32Bit_x86.il
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_32Bit_x86.il
@@ -5,6 +5,7 @@
 .assembly extern mscorlib { }
 .assembly sizeof64_Target_32Bit_x86 { }
 .assembly extern xunit.core {}
+.assembly extern Microsoft.DotNet.XUnitExtensions {}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .namespace JitTest_sizeof64_Target_32Bit_x86_il
 {
@@ -37,9 +38,15 @@
     .method private hidebysig static int32
             Main() cil managed
     {
-      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-          01 00 00 00
-      )
+      // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsX86Process))]
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
+                                                                                                    string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
+                                                                                                                  74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
+                                                                                                                  79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
+                                                                                                                  2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
+                                                                                                                  72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
+                                                                                                                  6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0C 49 73 58   // ken=null.....IsX
+                                                                                                                  38 36 50 72 6F 63 65 73 73 00 00 )                // 86Process..
       .entrypoint
       .maxstack  4
       .locals (int64 V_0,

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_32Bit_x86.il
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_32Bit_x86.il
@@ -38,15 +38,16 @@
     .method private hidebysig static int32
             Main() cil managed
     {
-      // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsX86Process))]
+      // [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsX86Process))]
       .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
-                                                                                                    string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
-                                                                                                                  74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
-                                                                                                                  79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
-                                                                                                                  2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
-                                                                                                                  72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
-                                                                                                                  6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0C 49 73 58   // ken=null.....IsX
-                                                                                                                  38 36 50 72 6F 63 65 73 73 00 00 )                // 86Process..
+                                                                                                    string[]) = ( 01 00 61 54 65 73 74 4C 69 62 72 61 72 79 2E 50   // ..aTestLibrary.P
+                                                                                                                  6C 61 74 66 6F 72 6D 44 65 74 65 63 74 69 6F 6E   // latformDetection
+                                                                                                                  2C 20 54 65 73 74 4C 69 62 72 61 72 79 2C 20 56   // , TestLibrary, V
+                                                                                                                  65 72 73 69 6F 6E 3D 30 2E 30 2E 30 2E 30 2C 20   // ersion=0.0.0.0, 
+                                                                                                                  43 75 6C 74 75 72 65 3D 6E 65 75 74 72 61 6C 2C   // Culture=neutral,
+                                                                                                                  20 50 75 62 6C 69 63 4B 65 79 54 6F 6B 65 6E 3D   //  PublicKeyToken=
+                                                                                                                  6E 75 6C 6C 01 00 00 00 0C 49 73 58 38 36 50 72   // null.....IsX86Pr
+                                                                                                                  6F 63 65 73 73 00 00 )                            // ocess..
       .entrypoint
       .maxstack  4
       .locals (int64 V_0,

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_64Bit_and_arm.il
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_64Bit_and_arm.il
@@ -4,6 +4,7 @@
 .assembly extern mscorlib { }
 .assembly 'sizeof64_Target_64Bit_and_arm' { }
 .assembly extern xunit.core {}
+.assembly extern Microsoft.DotNet.XUnitExtensions {}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .namespace JitTest_sizeof64_Target_64Bit_and_arm_il
 {
@@ -36,9 +37,15 @@
     .method private hidebysig static int32
             Main() cil managed
     {
-      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-          01 00 00 00
-      )
+      // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotX86Process))]
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
+                                                                                                    string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
+                                                                                                                  74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
+                                                                                                                  79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
+                                                                                                                  2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
+                                                                                                                  72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
+                                                                                                                  6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0F 49 73 4E   // ken=null.....IsN
+                                                                                                                  6F 74 58 38 36 50 72 6F 63 65 73 73 00 00 )       // otX86Process..
       .entrypoint
       .maxstack  4
       .locals (int64 V_0,

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_64Bit_and_arm.il
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_64Bit_and_arm.il
@@ -37,15 +37,16 @@
     .method private hidebysig static int32
             Main() cil managed
     {
-      // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotX86Process))]
+      // [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsNotX86Process))]
       .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
-                                                                                                    string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
-                                                                                                                  74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
-                                                                                                                  79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
-                                                                                                                  2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
-                                                                                                                  72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
-                                                                                                                  6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0F 49 73 4E   // ken=null.....IsN
-                                                                                                                  6F 74 58 38 36 50 72 6F 63 65 73 73 00 00 )       // otX86Process..
+                                                                                                    string[]) = ( 01 00 61 54 65 73 74 4C 69 62 72 61 72 79 2E 50   // ..aTestLibrary.P
+                                                                                                                  6C 61 74 66 6F 72 6D 44 65 74 65 63 74 69 6F 6E   // latformDetection
+                                                                                                                  2C 20 54 65 73 74 4C 69 62 72 61 72 79 2C 20 56   // , TestLibrary, V
+                                                                                                                  65 72 73 69 6F 6E 3D 30 2E 30 2E 30 2E 30 2C 20   // ersion=0.0.0.0, 
+                                                                                                                  43 75 6C 74 75 72 65 3D 6E 65 75 74 72 61 6C 2C   // Culture=neutral,
+                                                                                                                  20 50 75 62 6C 69 63 4B 65 79 54 6F 6B 65 6E 3D   //  PublicKeyToken=
+                                                                                                                  6E 75 6C 6C 01 00 00 00 0F 49 73 4E 6F 74 58 38   // null.....IsNotX8
+                                                                                                                  36 50 72 6F 63 65 73 73 00 00 )                   // 6Process..
       .entrypoint
       .maxstack  4
       .locals (int64 V_0,

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_32Bit_x86.il
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_32Bit_x86.il
@@ -12,6 +12,7 @@
 {
 }
 .assembly extern xunit.core {}
+.assembly extern Microsoft.DotNet.XUnitExtensions {}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 )
 .namespace JitTest_sizeof_Target_32Bit_x86_il
 {
@@ -78,9 +79,15 @@
     .method private hidebysig static int32
             Main() cil managed
     {
-      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-          01 00 00 00
-      )
+      // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsX86Process))]
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
+                                                                                                    string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
+                                                                                                                  74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
+                                                                                                                  79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
+                                                                                                                  2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
+                                                                                                                  72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
+                                                                                                                  6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0C 49 73 58   // ken=null.....IsX
+                                                                                                                  38 36 50 72 6F 63 65 73 73 00 00 )                // 86Process..
       .entrypoint
       .maxstack  3
       .locals (int32 V_0)

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_32Bit_x86.il
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_32Bit_x86.il
@@ -79,15 +79,16 @@
     .method private hidebysig static int32
             Main() cil managed
     {
-      // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsX86Process))]
+      // [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsX86Process))]
       .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
-                                                                                                    string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
-                                                                                                                  74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
-                                                                                                                  79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
-                                                                                                                  2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
-                                                                                                                  72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
-                                                                                                                  6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0C 49 73 58   // ken=null.....IsX
-                                                                                                                  38 36 50 72 6F 63 65 73 73 00 00 )                // 86Process..
+                                                                                                    string[]) = ( 01 00 61 54 65 73 74 4C 69 62 72 61 72 79 2E 50   // ..aTestLibrary.P
+                                                                                                                  6C 61 74 66 6F 72 6D 44 65 74 65 63 74 69 6F 6E   // latformDetection
+                                                                                                                  2C 20 54 65 73 74 4C 69 62 72 61 72 79 2C 20 56   // , TestLibrary, V
+                                                                                                                  65 72 73 69 6F 6E 3D 30 2E 30 2E 30 2E 30 2C 20   // ersion=0.0.0.0, 
+                                                                                                                  43 75 6C 74 75 72 65 3D 6E 65 75 74 72 61 6C 2C   // Culture=neutral,
+                                                                                                                  20 50 75 62 6C 69 63 4B 65 79 54 6F 6B 65 6E 3D   //  PublicKeyToken=
+                                                                                                                  6E 75 6C 6C 01 00 00 00 0C 49 73 58 38 36 50 72   // null.....IsX86Pr
+                                                                                                                  6F 63 65 73 73 00 00 )                            // ocess..
       .entrypoint
       .maxstack  3
       .locals (int32 V_0)

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_64Bit_and_arm.il
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_64Bit_and_arm.il
@@ -79,15 +79,16 @@
     .method private hidebysig static int32
             Main() cil managed
     {
-      // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotX86Process))]
+      // [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsNotX86Process))]
       .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
-                                                                                                    string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
-                                                                                                                  74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
-                                                                                                                  79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
-                                                                                                                  2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
-                                                                                                                  72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
-                                                                                                                  6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0F 49 73 4E   // ken=null.....IsN
-                                                                                                                  6F 74 58 38 36 50 72 6F 63 65 73 73 00 00 )       // otX86Process..
+                                                                                                    string[]) = ( 01 00 61 54 65 73 74 4C 69 62 72 61 72 79 2E 50   // ..aTestLibrary.P
+                                                                                                                  6C 61 74 66 6F 72 6D 44 65 74 65 63 74 69 6F 6E   // latformDetection
+                                                                                                                  2C 20 54 65 73 74 4C 69 62 72 61 72 79 2C 20 56   // , TestLibrary, V
+                                                                                                                  65 72 73 69 6F 6E 3D 30 2E 30 2E 30 2E 30 2C 20   // ersion=0.0.0.0, 
+                                                                                                                  43 75 6C 74 75 72 65 3D 6E 65 75 74 72 61 6C 2C   // Culture=neutral,
+                                                                                                                  20 50 75 62 6C 69 63 4B 65 79 54 6F 6B 65 6E 3D   //  PublicKeyToken=
+                                                                                                                  6E 75 6C 6C 01 00 00 00 0F 49 73 4E 6F 74 58 38   // null.....IsNotX8
+                                                                                                                  36 50 72 6F 63 65 73 73 00 00 )                   // 6Process..
       .entrypoint
       .maxstack  3
       .locals (int32 V_0)

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_64Bit_and_arm.il
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_64Bit_and_arm.il
@@ -12,6 +12,7 @@
 {
 }
 .assembly extern xunit.core {}
+.assembly extern Microsoft.DotNet.XUnitExtensions {}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .namespace JitTest_sizeof_Target_64Bit_and_arm_il
 {
@@ -78,9 +79,15 @@
     .method private hidebysig static int32
             Main() cil managed
     {
-      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-          01 00 00 00
-      )
+      // [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotX86Process))]
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [mscorlib]System.Type,
+                                                                                                    string[]) = ( 01 00 55 50 6C 61 74 66 6F 72 6D 44 65 74 65 63   // ..UPlatformDetec
+                                                                                                                  74 69 6F 6E 2C 20 54 65 73 74 4C 69 62 72 61 72   // tion, TestLibrar
+                                                                                                                  79 2C 20 56 65 72 73 69 6F 6E 3D 30 2E 30 2E 30   // y, Version=0.0.0
+                                                                                                                  2E 30 2C 20 43 75 6C 74 75 72 65 3D 6E 65 75 74   // .0, Culture=neut
+                                                                                                                  72 61 6C 2C 20 50 75 62 6C 69 63 4B 65 79 54 6F   // ral, PublicKeyTo
+                                                                                                                  6B 65 6E 3D 6E 75 6C 6C 01 00 00 00 0F 49 73 4E   // ken=null.....IsN
+                                                                                                                  6F 74 58 38 36 50 72 6F 63 65 73 73 00 00 )       // otX86Process..
       .entrypoint
       .maxstack  3
       .locals (int32 V_0)


### PR DESCRIPTION
This change adds initial provisions for platform detection similar
to library logic to CoreCLRTestLibrary and marks a few
architecture-conditional tests with ConditionalFact attributes.

While I must admit I'm not happy about the IL representation of
the ConditionalFact attributes, it's technically using the same
representation as the library tests do and it only affects a handful
of tests. During consolidation of the remaining tests we'll
continue working on an easier solution even though it may require
diverging further away from Xunit.

I'm not yet removing the CLRTestTargetUnsupported clauses from
the corresponding project files, that can only be done after
switching these tests over to use the merged wrappers (my next
change) as the legacy XUnit wrapper generator (in particular the
test execution script generator) relies on those properties.

Thanks

Tomas

/cc @dotnet/jit-contrib 