### PR TITLE
Reduce TypeGeneratorTests log spew to 1% of its previous size

### DIFF
--- a/src/tests/Loader/classloader/TypeGeneratorTests/TestFramework/TestFramework.cs
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TestFramework/TestFramework.cs
@@ -11,44 +11,46 @@ public class TestFramework
 {
     public static void MethodCallTest(string actualResult, string expectedResults, string invocationString)
     {
-        Console.WriteLine(invocationString);
-        Console.WriteLine("    -> EXPECTED: " + expectedResults);
-        Console.WriteLine("    -> GOT:      " + actualResult);
-
         if (expectedResults != actualResult)
         {
             Console.WriteLine("Wrong method called when calling " + invocationString);
+
+            Console.WriteLine(invocationString);
+            Console.WriteLine("    -> EXPECTED: " + expectedResults);
+            Console.WriteLine("    -> GOT:      " + actualResult);
+
             throw new Exception("Wrong method called");
         }
     }
 
     public static void MethodCallTest(string expectedResults, string constrainedCallerMethod, int count, params string[] actualResults)
     {
-        Console.WriteLine(constrainedCallerMethod);
-
         string[] expectedResultsArray = expectedResults.Split(new char[] { '#' });
-
-        Console.WriteLine("   # count = " + count);
-        Console.WriteLine("   # expectedResultsArray.Length = " + (expectedResultsArray.Length - 1));
-        for (int i = 0; i < expectedResultsArray.Length - 1; i++)
-            Console.WriteLine("      # expectedResultsArray[" + i + "] = '" + expectedResultsArray[i] + "'");
-
 
         if ((expectedResults == "" && count != 0) || (expectedResults != "" && count == 0) || ((expectedResultsArray.Length - 1) != count) || (count > 0 && count != actualResults.Length))
         {
             Console.WriteLine("Error in method count in constrained caller [ " + constrainedCallerMethod + " ]");
+
+            Console.WriteLine(constrainedCallerMethod);
+    
+            Console.WriteLine("   # count = " + count);
+            Console.WriteLine("   # expectedResultsArray.Length = " + (expectedResultsArray.Length - 1));
+            for (int i = 0; i < expectedResultsArray.Length - 1; i++)
+                Console.WriteLine("      # expectedResultsArray[" + i + "] = '" + expectedResultsArray[i] + "'");
+    
             throw new Exception("Method count failure");
         }
 
         bool success = true;
         for (int i = 0; i < count; i++)
         {
-            Console.WriteLine("    -> EXPECTED: " + expectedResultsArray[i]);
-            Console.WriteLine("    -> GOT:      " + actualResults[i]);
-
             if (expectedResultsArray[i] != actualResults[i])
             {
                 Console.WriteLine("Wrong method called in constrained caller " + constrainedCallerMethod);
+
+                Console.WriteLine("    -> EXPECTED: " + expectedResultsArray[i]);
+                Console.WriteLine("    -> GOT:      " + actualResults[i]);
+
                 success = false;
             }
         }


### PR DESCRIPTION
As JanV noticed during an independent investigation,
TypeGeneratorTests historically used to produce an enormous amount
of stdout spew due to individually reporting the details of all
passing test cases; for the entire set of 1501 tests the total
size of the spew was about 150 MB. In combination with the change
to capture stdout spew in the xml test reports this effectively
canceled out all previous wins achieved via test merging - in fact,
the tests became twice as slow compared to before the merging.

This modification only reports mismatches i.e. failures where we
don't receive the expected answer in one of the test cases. This
reduces the total spew from 150 MB to just over a megabyte and
restores the perf improvement achieved via test merging.

Thanks

Tomas