### PR TITLE
[wasm] Add disabled tests to ProjectExclusions

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -189,10 +189,10 @@
 
   <ItemGroup Condition="'$(TargetOS)' == 'iOS' and '$(RunDisablediOSTests)' != 'true'">
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\*.Tests.csproj" />
-    
+
     <!-- Ref.Emit in XSLCompiledTransform -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\Xslt\XslCompiledTransformApi\System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj" />
-    
+
     <!-- Functional tests on devices have problems with return codes from mlaunch -->
     <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\$(TargetOS)\Device\**\*.Test.csproj" />
   </ItemGroup>
@@ -214,9 +214,9 @@
     <!-- Has deps that JIT, need re-done in order to pass -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Hosting/tests/UnitTests/Microsoft.Extensions.Hosting.Unit.Tests.csproj" />
 
-    <!-- 
+    <!--
         Test suites hang and time out.
-        https://github.com/dotnet/runtime/issues/60713 
+        https://github.com/dotnet/runtime/issues/60713
     -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj" />
@@ -230,11 +230,11 @@
   <!-- Excluding all tests for aot catalyst until building on helix works properly -->
   <ItemGroup Condition="('$(TargetOS)' == 'MacCatalyst' and '$(BuildTestsOnHelix)' == 'true') and '$(RunDisablediOSTests)' != 'true'">
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\*.Tests.csproj" />
-    
+
     <!-- No functional tests until helix stabilizes -->
     <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\iOS\Simulator\**\*.Test.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetOS)' == 'MacCatalyst'">
     <ProjectExclusions Include="$(RepoRoot)/src/tests/FunctionalTests/iOS/Simulator/XmlFormatWriterGeneratorAOT/iOS.Simulator.XmlFormatWriterGeneratorAot.Test.csproj" />
   </ItemGroup>
@@ -282,6 +282,12 @@
 
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(RunDisabledWasmTests)' != 'true'">
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.NETCore.Platforms\tests\Microsoft.NETCore.Platforms.Tests.csproj" />
+
+    <!-- https://github.com/dotnet/runtime/issues/35970 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Caching.Memory\tests\Microsoft.Extensions.Caching.Memory.Tests.csproj" />
+
+    <!-- https://github.com/mono/mono/issues/16417 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ComponentModel.Composition\tests\System.ComponentModel.Composition.Tests.csproj" />
 
     <!-- Mono-Browser ignores runtimeconfig.template.json (e.g. for this it has "System.Globalization.EnforceJapaneseEraYearRanges": true) -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Calendars\tests\CalendarTestWithConfigSwitch\System.Globalization.CalendarsWithConfigSwitch.Tests.csproj" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -283,10 +283,12 @@
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(RunDisabledWasmTests)' != 'true'">
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.NETCore.Platforms\tests\Microsoft.NETCore.Platforms.Tests.csproj" />
 
-    <!-- https://github.com/dotnet/runtime/issues/35970 -->
+    <!-- This test is disabled via an assembly-level attribute in source. We exclude it here to avoid queuing/running a work item entirely.
+         https://github.com/dotnet/runtime/issues/35970 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Caching.Memory\tests\Microsoft.Extensions.Caching.Memory.Tests.csproj" />
 
-    <!-- https://github.com/mono/mono/issues/16417 -->
+    <!-- This test is disabled via an assembly-level attribute in source. We exclude it here to avoid queuing/running a work item entirely.
+         https://github.com/mono/mono/issues/16417 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ComponentModel.Composition\tests\System.ComponentModel.Composition.Tests.csproj" />
 
     <!-- Mono-Browser ignores runtimeconfig.template.json (e.g. for this it has "System.Globalization.EnforceJapaneseEraYearRanges": true) -->


### PR DESCRIPTION
`Microsoft.Extensions.Caching.Memory.Tests` and `System.ComponentModel.Composition.Tests` are already disabled via assembly-level attributes in source.

https://github.com/dotnet/runtime/blob/c32b1f5c7c476aa7a4391558d88b4adf178f3df7/src/libraries/Microsoft.Extensions.Caching.Memory/tests/AssemblyAttributes.cs#L6
https://github.com/dotnet/runtime/blob/c32b1f5c7c476aa7a4391558d88b4adf178f3df7/src/libraries/System.ComponentModel.Composition/tests/AssemblyInfo.cs#L6

They are actually disabled for all mono, but we don't have a mechanism in place of avoiding the build, work item queuing, test discovery, result upload, and such for desktop Mono (since we build libraries tests once and use them for coreclr and non-device mono test runs). The wasm ones were the most time-intensive due to AOT-ing on the helix machine.

Based on the below query, in the past two days, running those two tests suites (neither of which actually run any tests) for wasm has taken about **6.75 days** of various machines' time.
```kusto
WorkItems
| where Started > ago(2d)
| join kind=inner Jobs on JobId
| where FriendlyName endswith "System.ComponentModel.Composition.Tests"
  or FriendlyName endswith "Microsoft.Extensions.Caching.Memory.Tests"
| project
  FriendlyName,
  Queued, Started, Finished,
  Duration = Finished - Started,
  QueueName,
  Pipeline = tostring(parse_json(Properties).DefinitionName),
  PhaseName = tostring(parse_json(Properties)["System.PhaseName"]),
  Runtime = tostring(parse_json(Properties).runtimeFlavor),
  ConsoleUri,
  Source
| where Runtime == "mono"
| where PhaseName contains "Browser"
| summarize sum(Duration) 
```

cc @dotnet/runtime-infrastructure