### PR TITLE
EE Suspension on x86 should use RtlRestoreContext when available

### DIFF
--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -3080,7 +3080,7 @@ private:
     // RtlRestoreContext is available on x86, but relatively recently.
     // RestoreContextSimulated uses SEH machinery for a similar result on legacy OS-es.
     // This function should not be used on new OS-es as the pattern is not
-    // guranteed to continue working in the future.
+    // guaranteed to continue working in the future.
     static void RestoreContextSimulated(Thread* pThread, CONTEXT* pCtx, void* pFrame, DWORD dwLastError);
 #endif
 

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -3081,7 +3081,7 @@ private:
     // RestoreContextSimulated uses SEH machinery for a similar result on legacy OS-es.
     // This function should not be used on new OS-es as the pattern is not
     // guranteed to continue working in the future.
-    static void RestoreContextSimulated(Thread* pThread, CONTEXT* pCtx, void* pFrame);
+    static void RestoreContextSimulated(Thread* pThread, CONTEXT* pCtx, void* pFrame, DWORD dwLastError);
 #endif
 
     friend void CPFH_AdjustContextForThreadSuspensionRace(T_CONTEXT *pContext, Thread *pThread);

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -3076,6 +3076,14 @@ private:
     static void __stdcall RedirectedHandledJITCaseForGCStress();
 #endif // defined(HAVE_GCCOVER) && USE_REDIRECT_FOR_GCSTRESS
 
+#ifdef TARGET_X86
+    // RtlRestoreContext is available on x86, but relatively recently.
+    // RestoreContextSimulated uses SEH machinery for a similar result on legacy OS-es.
+    // This function should not be used on new OS-es as the pattern is not
+    // guranteed to continue working in the future.
+    static void __stdcall RestoreContextSimulated(Thread* pThread, CONTEXT* pCtx, void* pFrame);
+#endif
+
     friend void CPFH_AdjustContextForThreadSuspensionRace(T_CONTEXT *pContext, Thread *pThread);
 #endif // FEATURE_HIJACK && !TARGET_UNIX
 

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -3081,7 +3081,7 @@ private:
     // RestoreContextSimulated uses SEH machinery for a similar result on legacy OS-es.
     // This function should not be used on new OS-es as the pattern is not
     // guranteed to continue working in the future.
-    static void __stdcall RestoreContextSimulated(Thread* pThread, CONTEXT* pCtx, void* pFrame);
+    static void RestoreContextSimulated(Thread* pThread, CONTEXT* pCtx, void* pFrame);
 #endif
 
     friend void CPFH_AdjustContextForThreadSuspensionRace(T_CONTEXT *pContext, Thread *pThread);

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -2551,12 +2551,12 @@ int RedirectedHandledJITCaseExceptionFilter(
     // Unlink the frame in preparation for resuming in managed code
     pFrame->Pop();
 
-    // Copy the saved context record into the EH context;
-    // NB: cannot use ReplaceExceptionContextRecord here.
-    //     these contexts may contain extended registers and may have different format
-    //     for reasons such as alignment or context compaction
+    // Copy everything in the saved context record into the EH context.
+    // Historically the EH context has enough space for every enabled context feature.
+    // That may not hold for the future features beyond AVX, but this codepath is
+    // supposed to be used only on OSes that do not have RtlRestoreContext.
     CONTEXT* pTarget = pExcepPtrs->ContextRecord;
-    if (!CopyContext(pTarget, pTarget->ContextFlags, pCtx))
+    if (!CopyContext(pTarget, pCtx->ContextFlags, pCtx))
     {
         STRESS_LOG1(LF_SYNC, LL_ERROR, "ERROR: Could not set context record, lastError = 0x%x\n", GetLastError());
         EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -1968,14 +1968,15 @@ CONTEXT* AllocateOSContextHelper(BYTE** contextBuffer)
     {
         HMODULE hm = GetModuleHandleW(_T("kernel32.dll"));
         pfnInitializeContext2 = (PINITIALIZECONTEXT2)GetProcAddress(hm, "InitializeContext2");
+    }
 
 #ifdef TARGET_X86
-        if (pfnRtlRestoreContext == NULL)
-        {
-            pfnRtlRestoreContext = (PRTLRESTORECONTEXT)GetProcAddress(hm, "RtlRestoreContext");
-        }
-#endif //TARGET_X86
+    if (pfnRtlRestoreContext == NULL)
+    {
+        HMODULE hm = GetModuleHandleW(_T("ntdll.dll"));
+        pfnRtlRestoreContext = (PRTLRESTORECONTEXT)GetProcAddress(hm, "RtlRestoreContext");
     }
+#endif //TARGET_X86
 
     // Determine if the processor supports AVX so we could
     // retrieve extended registers


### PR DESCRIPTION
More reliable fix for: https://github.com/dotnet/runtime/issues/65292

Check dynamically for `RtlRestoreContext` on x86 and if available (i.e. on Win11), use the same codepath as on x64.
Otherwise fallback to preexisting mechanism where a context is patched in an exception filter.
