### PR TITLE
Fix ZipArchiveEntry names shown as corrupted on other zip programs

### DIFF
--- a/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
@@ -388,6 +388,7 @@ namespace System.IO.Compression.Tests
         protected const string Utf8LowerCaseOUmlautChar = "\u00F6";
         protected const string Utf8CopyrightChar = "\u00A9";
         protected const string AsciiFileName = "file.txt";
+        protected const string UnicodeFileName = "\u4f60\u597D.txt";
         // The o with umlaut is a character that exists in both latin1 and utf8
         protected const string Utf8AndLatin1FileName = $"{Utf8LowerCaseOUmlautChar}.txt";
         // emojis only make sense in utf8

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -42,7 +42,6 @@ namespace System.IO.Compression
         private List<ZipGenericExtraField>? _lhUnknownExtraFields;
         private byte[] _fileComment;
         private readonly CompressionLevel? _compressionLevel;
-        private bool _hasUnicodeEntryNameOrComment;
 
         // Initializes a ZipArchiveEntry instance for an existing archive entry.
         internal ZipArchiveEntry(ZipArchive archive, ZipCentralDirectoryFileHeader cd)
@@ -84,8 +83,6 @@ namespace System.IO.Compression
             _fileComment = cd.FileComment;
 
             _compressionLevel = null;
-
-            _hasUnicodeEntryNameOrComment = (_generalPurposeBitFlag & BitFlagValues.UnicodeFileNameAndComment) != 0;
         }
 
         // Initializes a ZipArchiveEntry instance for a new archive entry with a specified compression level.
@@ -144,8 +141,6 @@ namespace System.IO.Compression
             {
                 _archive.AcquireArchiveStream(this);
             }
-
-            _hasUnicodeEntryNameOrComment = false;
         }
 
         /// <summary>
@@ -197,7 +192,11 @@ namespace System.IO.Compression
             set
             {
                 _fileComment = ZipHelper.GetEncodedTruncatedBytesFromString(value, _archive.EntryNameAndCommentEncoding, ushort.MaxValue, out bool isUTF8);
-                _hasUnicodeEntryNameOrComment |= isUTF8;
+
+                if (isUTF8)
+                {
+                    _generalPurposeBitFlag |= BitFlagValues.UnicodeFileNameAndComment;
+                }
             }
         }
 
@@ -218,10 +217,18 @@ namespace System.IO.Compression
                 ArgumentNullException.ThrowIfNull(value, nameof(FullName));
 
                 _storedEntryNameBytes = ZipHelper.GetEncodedTruncatedBytesFromString(
-                    value, _archive.EntryNameAndCommentEncoding, 0 /* No truncation */, out bool hasUnicodeEntryName);
+                    value, _archive.EntryNameAndCommentEncoding, 0 /* No truncation */, out bool isUTF8);
 
-                _hasUnicodeEntryNameOrComment |= hasUnicodeEntryName;
                 _storedEntryName = value;
+
+                if (isUTF8)
+                {
+                    _generalPurposeBitFlag |= BitFlagValues.UnicodeFileNameAndComment;
+                }
+                else
+                {
+                    _generalPurposeBitFlag &= ~BitFlagValues.UnicodeFileNameAndComment;
+                }
 
                 DetectEntryNameVersion();
             }
@@ -504,11 +511,6 @@ namespace System.IO.Compression
             {
                 extraFieldLength = (ushort)bigExtraFieldLength;
             }
-
-            if (_hasUnicodeEntryNameOrComment)
-                _generalPurposeBitFlag |= BitFlagValues.UnicodeFileNameAndComment;
-            else
-                _generalPurposeBitFlag &= ~BitFlagValues.UnicodeFileNameAndComment;
 
             writer.Write(ZipCentralDirectoryFileHeader.SignatureConstant);      // Central directory file header signature  (4 bytes)
             writer.Write((byte)_versionMadeBySpecification);                    // Version made by Specification (version)  (1 byte)

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -554,7 +554,7 @@ namespace System.IO.Compression
         public uint OffsetOfStartOfCentralDirectoryWithRespectToTheStartingDiskNumber;
         public byte[] ArchiveComment;
 
-        public static void WriteBlock(Stream stream, long numberOfEntries, long startOfCentralDirectory, long sizeOfCentralDirectory, byte[]? archiveComment)
+        public static void WriteBlock(Stream stream, long numberOfEntries, long startOfCentralDirectory, long sizeOfCentralDirectory, byte[] archiveComment)
         {
             BinaryWriter writer = new BinaryWriter(stream);
 
@@ -574,10 +574,10 @@ namespace System.IO.Compression
             writer.Write(startOfCentralDirectoryTruncated);
 
             // Should be valid because of how we read archiveComment in TryReadBlock:
-            Debug.Assert((archiveComment == null) || (archiveComment.Length <= ZipFileCommentMaxLength));
+            Debug.Assert(archiveComment.Length <= ZipFileCommentMaxLength);
 
-            writer.Write(archiveComment != null ? (ushort)archiveComment.Length : (ushort)0); // zip file comment length
-            if (archiveComment != null)
+            writer.Write((ushort)archiveComment.Length); // zip file comment length
+            if (archiveComment.Length > 0)
                 writer.Write(archiveComment);
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/65750
Due to changes in https://github.com/dotnet/runtime/pull/59442, _generalPurposeBitFlag didn't have the proper value when it was written here:
https://github.com/dotnet/runtime/blob/afc2f118e7177107655c5f7bf5d02df9953a2742/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs#L874

A test may or may not be required as .NET is resilient to the error reported, I think is because it decodes with UTF8 regardless. cc @GrabYourPitchforks.
