### PR TITLE
Update GenAPI usage and code clean-up

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -62,9 +62,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>68a9b6dc9c0f375893fcdab74b7dd2538afb1c4b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="7.0.0-beta.22122.3">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="7.0.0-beta.22124.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>68a9b6dc9c0f375893fcdab74b7dd2538afb1c4b</Sha>
+      <Sha>f7136626d0109856df867481219eb7366951985d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.GenFacades" Version="7.0.0-beta.22122.3">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -42,7 +42,7 @@
     <MicrosoftDotNetApiCompatVersion>7.0.0-beta.22122.3</MicrosoftDotNetApiCompatVersion>
     <MicrosoftDotNetBuildTasksFeedVersion>7.0.0-beta.22122.3</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetCodeAnalysisVersion>7.0.0-beta.22122.3</MicrosoftDotNetCodeAnalysisVersion>
-    <MicrosoftDotNetGenAPIVersion>7.0.0-beta.22122.3</MicrosoftDotNetGenAPIVersion>
+    <MicrosoftDotNetGenAPIVersion>7.0.0-beta.22124.4</MicrosoftDotNetGenAPIVersion>
     <MicrosoftDotNetGenFacadesVersion>7.0.0-beta.22122.3</MicrosoftDotNetGenFacadesVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>7.0.0-beta.22122.3</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.22122.3</MicrosoftDotNetXUnitConsoleRunnerVersion>

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -7,6 +7,13 @@
     <ContractDependencyPaths Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '$(NetCoreAppCurrent)'))">$(ContractDependencyPaths);$(MicrosoftNetCoreAppRefPackRefDir)</ContractDependencyPaths>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <GenAPIExcludeAttributesList>$(RepositoryEngineeringDir)DefaultGenApiDocIds.txt</GenAPIExcludeAttributesList>
+    <GenAPIHeaderFile>$(RepositoryEngineeringDir)LicenseHeader.txt</GenAPIHeaderFile>
+    <GenAPITargetPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'ref', '$(AssemblyName).cs'))</GenAPITargetPath>
+    <GenAPILangVersion Condition="'$(LangVersion)' != ''">$(LangVersion)</GenAPILangVersion>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(IsSourceProject)' == 'true'">
     <ContractProject Condition="'$(ContractProject)' == ''">$(LibrariesProjectRoot)$(MSBuildProjectName)\ref\$(MSBuildProjectName).csproj</ContractProject>
     <HasMatchingContract Condition="'$(HasMatchingContract)' == '' and Exists('$(ContractProject)')">true</HasMatchingContract>
@@ -53,4 +60,13 @@
                                       ReferenceAssembly="" />
     </ItemGroup>
   </Target>
+  
+    <Target Name="SetGenAPIProperties"
+          BeforeTargets="GenerateReferenceAssemblySource">
+    <PropertyGroup>
+      <GenAPIFollowTypeForwards Condition="'%(ProjectReference.Identity)' == '$(CoreLibProject)'">true</GenAPIFollowTypeForwards>
+    </PropertyGroup>
+  </Target>
+
+  <Import Project="$(RepositoryEngineeringDir)outerBuild.targets" Condition="'$(IsCrossTargetingBuild)' == 'true'" />
 </Project>

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -61,7 +61,7 @@
     </ItemGroup>
   </Target>
   
-    <Target Name="SetGenAPIProperties"
+  <Target Name="SetGenAPIProperties"
           BeforeTargets="GenerateReferenceAssemblySource">
     <PropertyGroup>
       <GenAPIFollowTypeForwards Condition="'%(ProjectReference.Identity)' == '$(CoreLibProject)'">true</GenAPIFollowTypeForwards>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -151,27 +151,6 @@
     <PackageReference Include="Microsoft.DotNet.GenFacades" Version="$(MicrosoftDotNetGenFacadesVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <Target Name="SetGenApiProperties"
-          BeforeTargets="GenerateReferenceAssemblySource">
-    <PropertyGroup>
-      <_ExcludeAPIList>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'ref', 'ReferenceSourceExcludeApi.txt'))</_ExcludeAPIList>
-      <_ExcludeAttributesList>$(RepositoryEngineeringDir)DefaultGenApiDocIds.txt</_ExcludeAttributesList>
-      <_LicenseHeaderTxtPath>$(RepositoryEngineeringDir)LicenseHeader.txt</_LicenseHeaderTxtPath>
-      <GenAPITargetPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'ref', '$(AssemblyName).cs'))</GenAPITargetPath>
-      <GenAPIAdditionalParameters>$(GenAPIAdditionalParameters) --exclude-attributes-list "$(_ExcludeAttributesList)"</GenAPIAdditionalParameters>
-      <GenAPIAdditionalParameters Condition="Exists('$(_ExcludeAPIList)')">$(GenAPIAdditionalParameters) --exclude-api-list "$(_ExcludeAPIList)"</GenAPIAdditionalParameters>
-      <GenAPIAdditionalParameters>$(GenAPIAdditionalParameters) --header-file "$(_LicenseHeaderTxtPath)"</GenAPIAdditionalParameters>
-      <GenAPIAdditionalParameters Condition="'$(LangVersion)' != ''">$(GenAPIAdditionalParameters) --lang-version "$(LangVersion)"</GenAPIAdditionalParameters>
-      <GenAPIAdditionalParameters Condition="'%(ProjectReference.Identity)' == '$(CoreLibProject)'">$(GenAPIAdditionalParameters) --follow-type-forwards</GenAPIAdditionalParameters>
-    </PropertyGroup>
-  </Target>
-
-  <Target Name="GenerateReferenceSource" DependsOnTargets="GenerateReferenceAssemblySource">
-    <Message Text="This is a deprecated target. It will be replaced by GenerateReferenceAssemblySource in next infra rollout changes." Importance="high" />
-  </Target>
-
-  <Import Project="$(RepositoryEngineeringDir)outerBuild.targets" Condition="'$(IsCrossTargetingBuild)' == 'true'" />
-
   <!--
     Do not clean binplace assets in the ref targeting pack to avoid incremental build failures
     when the SDK tries to resolve the assets from the FrameworkList.


### PR DESCRIPTION
https://github.com/dotnet/arcade/commit/e44123d2796c8333cf90f90b51dfd9d04d224bea switched GenAPI to run in-proc as an msbuild task. Because of that, the usage is slightly different when additional parameters are passed in to GenAPI.

Also moving the code into the resolvecontract.targets file which contains contract related logic.