### PR TITLE
Make Is*Project properties unambiguous and improve IsGeneratorProject detection

### DIFF
--- a/eng/codeOptimization.targets
+++ b/eng/codeOptimization.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup Condition="'$(IsEligibleForNgenOptimization)' == ''">
      <IsEligibleForNgenOptimization>true</IsEligibleForNgenOptimization>
-     <IsEligibleForNgenOptimization Condition="'$(IsReferenceProject)' == 'true'">false</IsEligibleForNgenOptimization>
+     <IsEligibleForNgenOptimization Condition="'$(IsReferenceAssemblyProject)' == 'true'">false</IsEligibleForNgenOptimization>
      <IsEligibleForNgenOptimization Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">false</IsEligibleForNgenOptimization>
       <!-- There's an issue causing IBCMerge failures because of mismatched MVIDs
            across many of our assemblies on Mac, so disable

--- a/eng/codeOptimization.targets
+++ b/eng/codeOptimization.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup Condition="'$(IsEligibleForNgenOptimization)' == ''">
      <IsEligibleForNgenOptimization>true</IsEligibleForNgenOptimization>
-     <IsEligibleForNgenOptimization Condition="'$(IsReferenceAssembly)' == 'true'">false</IsEligibleForNgenOptimization>
+     <IsEligibleForNgenOptimization Condition="'$(IsReferenceProject)' == 'true'">false</IsEligibleForNgenOptimization>
      <IsEligibleForNgenOptimization Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">false</IsEligibleForNgenOptimization>
       <!-- There's an issue causing IBCMerge failures because of mismatched MVIDs
            across many of our assemblies on Mac, so disable

--- a/eng/generators.targets
+++ b/eng/generators.targets
@@ -13,7 +13,7 @@
          - references System.Runtime.InteropServices -->
     <EnabledGenerators Include="DllImportGenerator"
                        Condition="'$(EnableDllImportGenerator)' == ''
-                        and '$(IsRuntimeAssembly)' == 'true'
+                        and '$(IsSourceProject)' == 'true'
                         and '$(MSBuildProjectExtension)' == '.csproj'
                         and (
                           ('@(Reference)' != ''
@@ -24,7 +24,7 @@
                             and '$(DisableImplicitAssemblyReferences)' == 'false'))" />
     <EnabledGenerators Include="DllImportGenerator"
                        Condition="'$(EnableDllImportGenerator)' == ''
-                        and '$(IsRuntimeAssembly)' == 'true'
+                        and '$(IsSourceProject)' == 'true'
                         and '$(MSBuildProjectExtension)' == '.csproj'
                         and ('$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == '.NETFramework' or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '$(NetCoreAppCurrentVersion)'))))" />
   </ItemGroup>

--- a/eng/references.targets
+++ b/eng/references.targets
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <!-- Project references shouldn't be copied to the output for reference or source projects. -->
-  <ItemDefinitionGroup Condition="'$(IsSourceProject)' == 'true' or '$(IsReferenceProject)' == 'true'">
+  <ItemDefinitionGroup Condition="'$(IsSourceProject)' == 'true' or '$(IsReferenceAssemblyProject)' == 'true'">
     <ProjectReference>
       <Private>false</Private>
     </ProjectReference>
@@ -70,15 +70,15 @@
 
   <ItemDefinitionGroup>
     <TargetPathWithTargetPlatformMoniker>
-      <IsReferenceProject>$(IsReferenceProject)</IsReferenceProject>
+      <IsReferenceAssemblyProject>$(IsReferenceAssemblyProject)</IsReferenceAssemblyProject>
     </TargetPathWithTargetPlatformMoniker>
   </ItemDefinitionGroup>
 
   <Target Name="ValidateReferenceAssemblyProjectReferences"
           AfterTargets="ResolveReferences"
-          Condition="'$(IsReferenceProject)' == 'true' and
+          Condition="'$(IsReferenceAssemblyProject)' == 'true' and
                      '$(SkipValidateReferenceAssemblyProjectReferences)' != 'true'">
-    <Error Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference' and '%(ReferencePath.IsReferenceProject)' != 'true' and '%(ReferencePath.ReferenceAssembly)' == ''"
+    <Error Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference' and '%(ReferencePath.IsReferenceAssemblyProject)' != 'true' and '%(ReferencePath.ReferenceAssembly)' == ''"
            Text="Reference assemblies must only reference other reference assemblies and '%(ReferencePath.ProjectReferenceOriginalItemSpec)' is not a reference assembly project and does not set 'ProduceReferenceAssembly'." />
   </Target>
 

--- a/eng/references.targets
+++ b/eng/references.targets
@@ -7,8 +7,8 @@
     <_FindDependencies>false</_FindDependencies>
   </PropertyGroup>
 
-  <!-- Project references shouldn't be copied to the output for non test apps. -->
-  <ItemDefinitionGroup Condition="'$(IsTestProject)' != 'true' and '$(IsTestSupportProject)' != 'true' and '$(IsGeneratorProject)' != 'true'">
+  <!-- Project references shouldn't be copied to the output for reference or source projects. -->
+  <ItemDefinitionGroup Condition="'$(IsSourceProject)' == 'true' or '$(IsReferenceProject)' == 'true'">
     <ProjectReference>
       <Private>false</Private>
     </ProjectReference>
@@ -70,15 +70,15 @@
 
   <ItemDefinitionGroup>
     <TargetPathWithTargetPlatformMoniker>
-      <IsReferenceAssembly>$(IsReferenceAssembly)</IsReferenceAssembly>
+      <IsReferenceProject>$(IsReferenceProject)</IsReferenceProject>
     </TargetPathWithTargetPlatformMoniker>
   </ItemDefinitionGroup>
 
   <Target Name="ValidateReferenceAssemblyProjectReferences"
           AfterTargets="ResolveReferences"
-          Condition="'$(IsReferenceAssembly)' == 'true' and
+          Condition="'$(IsReferenceProject)' == 'true' and
                      '$(SkipValidateReferenceAssemblyProjectReferences)' != 'true'">
-    <Error Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference' and '%(ReferencePath.IsReferenceAssembly)' != 'true' and '%(ReferencePath.ReferenceAssembly)' == ''"
+    <Error Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference' and '%(ReferencePath.IsReferenceProject)' != 'true' and '%(ReferencePath.ReferenceAssembly)' == ''"
            Text="Reference assemblies must only reference other reference assemblies and '%(ReferencePath.ProjectReferenceOriginalItemSpec)' is not a reference assembly project and does not set 'ProduceReferenceAssembly'." />
   </Target>
 

--- a/eng/slngen.targets
+++ b/eng/slngen.targets
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <SlnGenSolutionFolder Condition="'$(IsGeneratorProject)' == 'true'">gen</SlnGenSolutionFolder>
-    <SlnGenSolutionFolder Condition="'$(IsReferenceProject)' == 'true'">ref</SlnGenSolutionFolder>
+    <SlnGenSolutionFolder Condition="'$(IsReferenceAssemblyProject)' == 'true'">ref</SlnGenSolutionFolder>
     <SlnGenSolutionFolder Condition="'$(IsTestProject)' == 'true' or '$(IsTrimmingTestProject)' == 'true' or '$(IsTestSupportProject)' == 'true'">tests</SlnGenSolutionFolder>
     <SlnGenSolutionFolder Condition="'$(SlnGenSolutionFolder)' == ''">src</SlnGenSolutionFolder>
 

--- a/eng/slngen.targets
+++ b/eng/slngen.targets
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <SlnGenSolutionFolder Condition="'$(IsGeneratorProject)' == 'true'">gen</SlnGenSolutionFolder>
-    <SlnGenSolutionFolder Condition="'$(IsReferenceAssembly)' == 'true'">ref</SlnGenSolutionFolder>
-    <SlnGenSolutionFolder Condition="'$(IsTestProject)' == 'true' or '$(IsTestSupportProject)' == 'true'">tests</SlnGenSolutionFolder>
+    <SlnGenSolutionFolder Condition="'$(IsReferenceProject)' == 'true'">ref</SlnGenSolutionFolder>
+    <SlnGenSolutionFolder Condition="'$(IsTestProject)' == 'true' or '$(IsTrimmingTestProject)' == 'true' or '$(IsTestSupportProject)' == 'true'">tests</SlnGenSolutionFolder>
     <SlnGenSolutionFolder Condition="'$(SlnGenSolutionFolder)' == ''">src</SlnGenSolutionFolder>
 
     <!-- Don't include reference projects which compose the microsoft.netcore.app targeting pack (except the current leaf's reference project) as those are referenced by the source project via named references

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -5,8 +5,8 @@
 
     <!-- Set OutDirName to change the BaseOutputPath and BaseIntermediateOutputPath properties to include the ref subfolder. -->
     <_projectDirName>$([System.IO.Path]::GetFileName('$(MSBuildProjectDirectory)'))</_projectDirName>
-    <IsReferenceProject Condition="'$(_projectDirName)' == 'ref'">true</IsReferenceProject>
-    <OutDirName Condition="'$(IsReferenceProject)' == 'true'">$(MSBuildProjectName)$([System.IO.Path]::DirectorySeparatorChar)ref</OutDirName>
+    <IsReferenceAssemblyProject Condition="'$(_projectDirName)' == 'ref'">true</IsReferenceAssemblyProject>
+    <OutDirName Condition="'$(IsReferenceAssemblyProject)' == 'true'">$(MSBuildProjectName)$([System.IO.Path]::DirectorySeparatorChar)ref</OutDirName>
   </PropertyGroup>
 
   <Import Project="..\..\Directory.Build.props" />
@@ -33,7 +33,7 @@
     <IsGeneratorProject Condition="'$(_projectDirName)' == 'gen' or
                                    $([System.IO.Path]::GetFileName('$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..'))')) == 'gen'">true</IsGeneratorProject>
     <IsSourceProject Condition="'$(IsSourceProject)' == '' and
-                                '$(IsReferenceProject)' != 'true' and
+                                '$(IsReferenceAssemblyProject)' != 'true' and
                                 '$(IsGeneratorProject)' != 'true' and
                                 '$(IsTestProject)' != 'true' and
                                 '$(IsTrimmingTestProject)' != 'true' and
@@ -70,7 +70,7 @@
   </ItemGroup>
 
   <Import Project="NetCoreAppLibrary.props" />
-  <Import Project="$(RepositoryEngineeringDir)referenceAssemblies.props" Condition="'$(IsReferenceProject)' == 'true'" />
+  <Import Project="$(RepositoryEngineeringDir)referenceAssemblies.props" Condition="'$(IsReferenceAssemblyProject)' == 'true'" />
 
   <PropertyGroup>
     <!-- Default any assembly not specifying a key to use the Open Key -->

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -1,15 +1,12 @@
-<Project TreatAsLocalProperty="TargetOS">
+<Project>
   <PropertyGroup>
     <SkipInferTargetOSName>true</SkipInferTargetOSName>
     <DisableArcadeTestFramework>true</DisableArcadeTestFramework>
 
+    <!-- Set OutDirName to change the BaseOutputPath and BaseIntermediateOutputPath properties to include the ref subfolder. -->
     <_projectDirName>$([System.IO.Path]::GetFileName('$(MSBuildProjectDirectory)'))</_projectDirName>
-    <IsReferenceAssembly Condition="'$(_projectDirName)' == 'ref'">true</IsReferenceAssembly>
-    <IsSourceProject Condition="'$(_projectDirName)' == 'src'">true</IsSourceProject>
-    <IsGeneratorProject Condition="'$(_projectDirName)' == 'gen'">true</IsGeneratorProject>
-
-    <!-- Set OutDirName to change BaseOutputPath and BaseIntermediateOutputPath to include the ref subfolder. -->
-    <OutDirName Condition="'$(IsReferenceAssembly)' == 'true'">$(MSBuildProjectName)$([System.IO.Path]::DirectorySeparatorChar)ref</OutDirName>
+    <IsReferenceProject Condition="'$(_projectDirName)' == 'ref'">true</IsReferenceProject>
+    <OutDirName Condition="'$(IsReferenceProject)' == 'true'">$(MSBuildProjectName)$([System.IO.Path]::DirectorySeparatorChar)ref</OutDirName>
   </PropertyGroup>
 
   <Import Project="..\..\Directory.Build.props" />
@@ -19,29 +16,30 @@
     <RuntimeGraph>$(LibrariesProjectRoot)OSGroups.json</RuntimeGraph>
     <ShouldUnsetParentConfigurationAndPlatform>false</ShouldUnsetParentConfigurationAndPlatform>
     <GeneratePlatformNotSupportedAssemblyHeaderFile>$(RepositoryEngineeringDir)LicenseHeader.txt</GeneratePlatformNotSupportedAssemblyHeaderFile>
-    <!-- Build all .NET Framework configurations when net48 is passed in. This is for convenience. -->
-    <AdditionalBuildTargetFrameworks Condition="'$(BuildTargetFramework)' == 'net48'">net462;net47;net471;net472</AdditionalBuildTargetFrameworks>
-  </PropertyGroup>
-
-  <!-- Unique assembly versions increases(3x) the compiler throughput during reference package updates. -->
-  <PropertyGroup Condition="'$(IsGeneratorProject)' == 'true'">
-    <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
-    <!-- To suppress warnings about reseting the assembly version.-->
-    <AssemblyVersion />
   </PropertyGroup>
 
   <!-- Define test projects and companions -->
-  <PropertyGroup Condition="'$(IsSourceProject)' != 'true'">
-    <IsTestProject Condition="'$(IsTestProject)' == ''">false</IsTestProject>
+  <PropertyGroup Condition="$(MSBuildProjectFullPath.Contains('$([System.IO.Path]::DirectorySeparatorChar)tests$([System.IO.Path]::DirectorySeparatorChar)'))">
     <IsTestProject Condition="$(MSBuildProjectName.EndsWith('.UnitTests')) or $(MSBuildProjectName.EndsWith('.Tests'))">true</IsTestProject>
-
-    <IsTestSupportProject>false</IsTestSupportProject>
-    <IsTestSupportProject Condition="($(MSBuildProjectFullPath.Contains('\tests\')) or $(MSBuildProjectFullPath.Contains('/tests/'))) and '$(IsTestProject)' != 'true'">true</IsTestSupportProject>
-
     <IsTrimmingTestProject Condition="$(MSBuildProjectName.EndsWith('.TrimmingTests'))">true</IsTrimmingTestProject>
+    <IsTestSupportProject Condition="'$(IsTestProject)' != 'true' and '$(IsTrimmingTestProject)' != 'true'">true</IsTestSupportProject>
 
     <!-- Treat test assemblies as non-shipping (do not publish or sign them). -->
-    <IsShipping Condition="'$(IsTestProject)' == 'true' or '$(IsTestSupportProject)' == 'true'">false</IsShipping>
+    <IsShipping Condition="'$(IsTestProject)' == 'true' or '$(IsTestSupportProject)' == 'true' or '$(IsTrimmingTestProject)' == 'true'">false</IsShipping>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Treat as a generator project if either the parent or the parent parent directory is named gen. -->
+    <IsGeneratorProject Condition="'$(_projectDirName)' == 'gen' or
+                                   $([System.IO.Path]::GetFileName('$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..'))')) == 'gen'">true</IsGeneratorProject>
+    <IsSourceProject Condition="'$(IsSourceProject)' == '' and
+                                '$(IsReferenceProject)' != 'true' and
+                                '$(IsGeneratorProject)' != 'true' and
+                                '$(IsTestProject)' != 'true' and
+                                '$(IsTrimmingTestProject)' != 'true' and
+                                '$(IsTestSupportProject)' != 'true' and
+                                '$(UsingMicrosoftNoTargetsSdk)' != 'true' and
+                                '$(UsingMicrosoftTraversalSdk)' != 'true'">true</IsSourceProject>
   </PropertyGroup>
 
   <!-- Warnings that should be disabled in our test projects. -->
@@ -50,6 +48,13 @@
     <NoWarn>$(NoWarn);SYSLIB0011</NoWarn>
     <!-- allow nullable annotated files to be incorporated into tests without warning -->
     <Nullable Condition="'$(Nullable)' == '' and '$(Language)' == 'C#'">annotations</Nullable>
+  </PropertyGroup>
+
+  <!-- Unique assembly versions increases(3x) the compiler throughput during reference package updates. -->
+  <PropertyGroup Condition="'$(IsGeneratorProject)' == 'true'">
+    <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
+    <!-- To suppress warnings about reseting the assembly version.-->
+    <AssemblyVersion />
   </PropertyGroup>
 
   <PropertyGroup>
@@ -65,7 +70,7 @@
   </ItemGroup>
 
   <Import Project="NetCoreAppLibrary.props" />
-  <Import Project="$(RepositoryEngineeringDir)referenceAssemblies.props" Condition="'$(IsReferenceAssembly)' == 'true'" />
+  <Import Project="$(RepositoryEngineeringDir)referenceAssemblies.props" Condition="'$(IsReferenceProject)' == 'true'" />
 
   <PropertyGroup>
     <!-- Default any assembly not specifying a key to use the Open Key -->
@@ -95,8 +100,6 @@
   <PropertyGroup>
     <!-- Helix properties -->
     <OSPlatformConfig>$(TargetOS).$(Platform).$(Configuration)</OSPlatformConfig>
-    <AnyOSPlatformConfig>AnyOS.AnyCPU.$(Configuration)</AnyOSPlatformConfig>
-    <UnixPlatformConfig>Unix.$(Platform).$(Configuration)</UnixPlatformConfig>
     <TestArchiveRoot>$(ArtifactsDir)helix/</TestArchiveRoot>
     <TestArchiveTestsRoot Condition="$(IsFunctionalTest) != true">$(TestArchiveRoot)tests/</TestArchiveTestsRoot>
     <TestArchiveTestsRoot Condition="$(IsFunctionalTest) == true">$(TestArchiveRoot)runonly/</TestArchiveTestsRoot>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -44,7 +44,7 @@
     <!-- The source of truth for these IsNETCoreApp* properties is NetCoreAppLibrary.props. -->
     <IsNETCoreAppSrc Condition="('$(IsSourceProject)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true') and
                                 $(NetCoreAppLibrary.Contains('$(AssemblyName);'))">true</IsNETCoreAppSrc>
-    <IsNETCoreAppRef Condition="('$(IsReferenceProject)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true') and
+    <IsNETCoreAppRef Condition="('$(IsReferenceAssemblyProject)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true') and
                                 $(NetCoreAppLibrary.Contains('$(AssemblyName);')) and
                                 !$(NetCoreAppLibraryNoReference.Contains('$(AssemblyName);'))">true</IsNETCoreAppRef>
     <!-- By default, disable implicit framework references for NetCoreAppCurrent libraries. -->
@@ -55,7 +55,7 @@
     <DisableImplicitAssemblyReferences Condition="'$(DisableImplicitAssemblyReferences)' == '' and
                                                   '$(DisableImplicitFrameworkReferences)' != 'true' and
                                                   '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
-                                                  ('$(IsReferenceProject)' == 'true' or '$(IsSourceProject)' == 'true')">true</DisableImplicitAssemblyReferences>
+                                                  ('$(IsReferenceAssemblyProject)' == 'true' or '$(IsSourceProject)' == 'true')">true</DisableImplicitAssemblyReferences>
     <!-- Enable trimming for any source project that's part of the shared framework.
          Don't attempt to trim PNSE assemblies which are generated from the reference source. -->
     <ILLinkTrimAssembly Condition="'$(ILLinkTrimAssembly)' == '' and
@@ -69,7 +69,7 @@
 
   <!-- Libraries-specific binplacing properties -->
   <PropertyGroup>
-    <BinPlaceRef Condition="'$(BinPlaceRef)' == '' and ('$(IsReferenceProject)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true')">true</BinPlaceRef>
+    <BinPlaceRef Condition="'$(BinPlaceRef)' == '' and ('$(IsReferenceAssemblyProject)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true')">true</BinPlaceRef>
     <BinPlaceRuntime Condition="'$(BinPlaceRuntime)' == '' and ('$(IsSourceProject)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true')">true</BinPlaceRuntime>
     <BinPlaceForTargetVertical Condition="'$(BinPlaceForTargetVertical)' == ''">true</BinPlaceForTargetVertical>
     <GetBinPlaceItemsDependsOn Condition="$(MSBuildProjectName.StartsWith('Microsoft.Extensions.'))">$(GetBinPlaceItemsDependsOn);AddDocumentationFileAsBinPlaceItemForExtensionsProjects</GetBinPlaceItemsDependsOn>
@@ -138,7 +138,7 @@
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.TargetFramework" Version="$(MicrosoftDotNetBuildTasksTargetFrameworkVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(IsSourceProject)' == 'true' or '$(IsReferenceProject)' == 'true' or '$(IsPartialFacadeAssembly)' == 'true'">
+  <ItemGroup Condition="'$(IsSourceProject)' == 'true' or '$(IsReferenceAssemblyProject)' == 'true' or '$(IsPartialFacadeAssembly)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.ApiCompat" Condition="'$(DotNetBuildFromSource)' != 'true'" Version="$(MicrosoftDotNetApiCompatVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
     <PackageReference Include="Microsoft.DotNet.GenAPI" Condition="'$(DotNetBuildFromSource)' != 'true'" Version="$(MicrosoftDotNetGenApiVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
     <PackageReference Include="Microsoft.DotNet.GenFacades" Version="$(MicrosoftDotNetGenFacadesVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -35,23 +35,16 @@
     <!-- Reset these properties back to blank, since they are defaulted by Microsoft.NET.Sdk -->
     <WarningsAsErrors Condition="'$(WarningsAsErrors)' == 'NU1605'" />
 
-    <IsRuntimeAssembly Condition="'$(IsRuntimeAssembly)' == '' and
-                                  '$(IsReferenceAssembly)' != 'true' and
-                                  '$(IsGeneratorProject)' != 'true' and
-                                  '$(IsTestProject)' != 'true' and
-                                  '$(IsTestSupportProject)' != 'true' and
-                                  '$(UsingMicrosoftNoTargetsSdk)' != 'true' and
-                                  '$(UsingMicrosoftTraversalSdk)' != 'true'">true</IsRuntimeAssembly>
     <IsRuntimeAndReferenceAssembly Condition="'$(IsRuntimeAndReferenceAssembly)' == '' and
-                                              '$(IsRuntimeAssembly)' == 'true' and
+                                              '$(IsSourceProject)' == 'true' and
                                               Exists('$(LibrariesProjectRoot)$(MSBuildProjectName)') and
-                                              !Exists('$(LibrariesProjectRoot)$(MSBuildProjectName)/ref') and
+                                              !Exists('$(LibrariesProjectRoot)$(MSBuildProjectName)$([System.IO.Path]::DirectorySeparatorChar)ref') and
                                               !$(MSBuildProjectName.StartsWith('System.Private'))">true</IsRuntimeAndReferenceAssembly>
 
     <!-- The source of truth for these IsNETCoreApp* properties is NetCoreAppLibrary.props. -->
-    <IsNETCoreAppSrc Condition="('$(IsRuntimeAssembly)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true')  and
+    <IsNETCoreAppSrc Condition="('$(IsSourceProject)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true') and
                                 $(NetCoreAppLibrary.Contains('$(AssemblyName);'))">true</IsNETCoreAppSrc>
-    <IsNETCoreAppRef Condition="('$(IsReferenceAssembly)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true') and
+    <IsNETCoreAppRef Condition="('$(IsReferenceProject)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true') and
                                 $(NetCoreAppLibrary.Contains('$(AssemblyName);')) and
                                 !$(NetCoreAppLibraryNoReference.Contains('$(AssemblyName);'))">true</IsNETCoreAppRef>
     <!-- By default, disable implicit framework references for NetCoreAppCurrent libraries. -->
@@ -62,7 +55,7 @@
     <DisableImplicitAssemblyReferences Condition="'$(DisableImplicitAssemblyReferences)' == '' and
                                                   '$(DisableImplicitFrameworkReferences)' != 'true' and
                                                   '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
-                                                  ('$(IsReferenceAssembly)' == 'true' or '$(IsSourceProject)' == 'true')">true</DisableImplicitAssemblyReferences>
+                                                  ('$(IsReferenceProject)' == 'true' or '$(IsSourceProject)' == 'true')">true</DisableImplicitAssemblyReferences>
     <!-- Enable trimming for any source project that's part of the shared framework.
          Don't attempt to trim PNSE assemblies which are generated from the reference source. -->
     <ILLinkTrimAssembly Condition="'$(ILLinkTrimAssembly)' == '' and
@@ -76,8 +69,8 @@
 
   <!-- Libraries-specific binplacing properties -->
   <PropertyGroup>
-    <BinPlaceRef Condition="'$(BinPlaceRef)' == '' and ('$(IsReferenceAssembly)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true')">true</BinPlaceRef>
-    <BinPlaceRuntime Condition="'$(BinPlaceRuntime)' == '' and ('$(IsRuntimeAssembly)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true')">true</BinPlaceRuntime>
+    <BinPlaceRef Condition="'$(BinPlaceRef)' == '' and ('$(IsReferenceProject)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true')">true</BinPlaceRef>
+    <BinPlaceRuntime Condition="'$(BinPlaceRuntime)' == '' and ('$(IsSourceProject)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true')">true</BinPlaceRuntime>
     <BinPlaceForTargetVertical Condition="'$(BinPlaceForTargetVertical)' == ''">true</BinPlaceForTargetVertical>
     <GetBinPlaceItemsDependsOn Condition="$(MSBuildProjectName.StartsWith('Microsoft.Extensions.'))">$(GetBinPlaceItemsDependsOn);AddDocumentationFileAsBinPlaceItemForExtensionsProjects</GetBinPlaceItemsDependsOn>
   </PropertyGroup>
@@ -145,7 +138,7 @@
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.TargetFramework" Version="$(MicrosoftDotNetBuildTasksTargetFrameworkVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(IsSourceProject)' == 'true' or '$(IsReferenceAssembly)' == 'true' or '$(IsPartialFacadeAssembly)' == 'true'">
+  <ItemGroup Condition="'$(IsSourceProject)' == 'true' or '$(IsReferenceProject)' == 'true' or '$(IsPartialFacadeAssembly)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.ApiCompat" Condition="'$(DotNetBuildFromSource)' != 'true'" Version="$(MicrosoftDotNetApiCompatVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
     <PackageReference Include="Microsoft.DotNet.GenAPI" Condition="'$(DotNetBuildFromSource)' != 'true'" Version="$(MicrosoftDotNetGenApiVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
     <PackageReference Include="Microsoft.DotNet.GenFacades" Version="$(MicrosoftDotNetGenFacadesVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />

--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -4,8 +4,9 @@
     <EnableBinPlacing>false</EnableBinPlacing>
     <!-- This project should not build against the live built .NETCoreApp targeting pack as it contributes to the build itself. -->
     <UseLocalTargetingRuntimePack>false</UseLocalTargetingRuntimePack>
+    <!-- Use targeting pack references instead of granular ones in the project file. -->
+    <DisableImplicitAssemblyReferences>false</DisableImplicitAssemblyReferences>
     <AssemblyName>Microsoft.NETCore.Platforms.BuildTasks</AssemblyName>
-    <IsSourceProject>false</IsSourceProject>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Directory.Build.props
+++ b/src/libraries/System.Runtime.InteropServices/gen/Directory.Build.props
@@ -7,6 +7,5 @@
     <EnableDefaultItems>true</EnableDefaultItems>
     <CLSCompliant>false</CLSCompliant>
     <ILLinkTrimAssembly>false</ILLinkTrimAssembly>
-    <IsGeneratorProject>true</IsGeneratorProject>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Currently these properties exist which categorize projects:
- `IsReferenceAssembly`: The project's parent directory is 'ref'
- `IsGeneratorProject`: The project's parent directory is 'gen'
- `IsTestProject`: The project is located somewhere under a '/tests/'
                 directory and the project name's suffix is either
                 '.Tests' or '.UnitTests'.
- `IsTrimmingTestProject`: Same as IsTestProject but the project name's
                         suffix is '.TrimmingTests'.
- `IsTestSupportProject`: The project is located somewhere under a
                        '/tests/' directory and the above IsTestProject
                        property is false.
- `UsingMicrosoftNoTargetsSdk`: The project uses the NoTargets msbuild SDK
- `UsingMicrosoftTraversalSdk`: The project uses the Traversal msbuild SDK
- `IsRuntimeAssembly`: True when all above is false
- `IsSourceProject`: True when the project's parent directory is 'src'

The IsRuntimeAssembly and IsSourceProject properties are ambiguous
and the property names aren't consistent (IsReferenceAssembly
vs IsGeneratorProject). Additionally the tree shows that the parent directory
of generator projects often isn't 'gen' but the project name in cases when
there are multiple generator projects under "gen". This led to such projects
being treated incorrectly and developers manually having to set the
"IsGeneratorProject" property for such projects.

### Change

- **`IsReferenceAssemblyProject`**: The project's parent directory is 'ref'
- `IsGeneratorProject`: **The project's parent directory is 'gen' or
                                     the parent's parent directory is 'gen'**
- `IsTestProject`: The project is located somewhere under a '/tests/'
                 directory and the project name's suffix is either
                 '.Tests' or '.UnitTests'.
- `IsTrimmingTestProject`: Same as IsTestProject but the project name's
                         suffix is '.TrimmingTests'.
- `IsTestSupportProject`: The project is located somewhere under a
                        '/tests/' directory and the above IsTestProject
                        **and IsTrimmingTestProject** props are false.
- `UsingMicrosoftNoTargetsSdk`: The project uses the NoTargets msbuild SDK
- `UsingMicrosoftTraversalSdk`: The project uses the Traversal msbuild SDK
- `IsSourceProject`: **True when all above is false.**