### PR TITLE
[release/6.0] Remove redundant allocations from JsonSerializerOptions.GetConverter calls

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -9,7 +9,8 @@
     <Nullable>enable</Nullable>
     <IncludeInternalObsoleteAttribute>true</IncludeInternalObsoleteAttribute>
     <IsPackable>true</IsPackable>
-    <ServicingVersion>2</ServicingVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>3</ServicingVersion>
     <PackageDescription>Provides high-performance and low-allocating types that serialize objects to JavaScript Object Notation (JSON) text and deserialize JSON text to objects, with UTF-8 support built-in. Also provides types to read and write JSON text encoded as UTF-8, and to create an in-memory document object model (DOM), that is read-only, for random access of the JSON elements within a structured view of the data.
 
 Commonly Used Types:

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -30,23 +30,26 @@ namespace System.Text.Json
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
         private void RootBuiltInConverters()
         {
-            s_defaultSimpleConverters = GetDefaultSimpleConverters();
-            s_defaultFactoryConverters = new JsonConverter[]
+            if (s_defaultSimpleConverters is null)
             {
-                // Check for disallowed types.
-                new UnsupportedTypeConverterFactory(),
-                // Nullable converter should always be next since it forwards to any nullable type.
-                new NullableConverterFactory(),
-                new EnumConverterFactory(),
-                new JsonNodeConverterFactory(),
-                new FSharpTypeConverterFactory(),
-                // IAsyncEnumerable takes precedence over IEnumerable.
-                new IAsyncEnumerableConverterFactory(),
-                // IEnumerable should always be second to last since they can convert any IEnumerable.
-                new IEnumerableConverterFactory(),
-                // Object should always be last since it converts any type.
-                new ObjectConverterFactory()
-            };
+                s_defaultSimpleConverters = GetDefaultSimpleConverters();
+                s_defaultFactoryConverters = new JsonConverter[]
+                {
+                    // Check for disallowed types.
+                    new UnsupportedTypeConverterFactory(),
+                    // Nullable converter should always be next since it forwards to any nullable type.
+                    new NullableConverterFactory(),
+                    new EnumConverterFactory(),
+                    new JsonNodeConverterFactory(),
+                    new FSharpTypeConverterFactory(),
+                    // IAsyncEnumerable takes precedence over IEnumerable.
+                    new IAsyncEnumerableConverterFactory(),
+                    // IEnumerable should always be second to last since they can convert any IEnumerable.
+                    new IEnumerableConverterFactory(),
+                    // Object should always be last since it converts any type.
+                    new ObjectConverterFactory()
+                };
+            }
         }
 
         private static Dictionary<Type, JsonConverter> GetDefaultSimpleConverters()


### PR DESCRIPTION
Fixes Issue #65770, cherry-picks the fix from #65863.

# Customer Impact

Fixes a customer reported issue. Currently every call to `JsonSerializerOptions.GetConverter` will force recreation of the default converters global state, which can substantially impact the allocation profile for custom converters that dynamically look up other converters. This is a regression from .NET 5.

[Diff without whitespace](https://github.com/dotnet/runtime/pull/65898/files?diff=unified&w=1)

# Testing

N/A

# Risk

Low. Brings back a trivial check in the global state initialization method.