### PR TITLE
Fix cancellation race condition in PipeStream cancellation callback

### DIFF
--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.ValueTaskSource.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.ValueTaskSource.cs
@@ -75,7 +75,7 @@ namespace System.IO.Pipes
                         _cancellationRegistration = cancellationToken.UnsafeRegister(static (s, token) =>
                         {
                             PipeValueTaskSource vts = (PipeValueTaskSource)s!;
-                            if (vts._pipeStream.InternalHandle is { IsInvalid: false } handle)
+                            if (vts._pipeStream.InternalHandle is { IsClosed: false } handle)
                             {
                                 try
                                 {

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.ValueTaskSource.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.ValueTaskSource.cs
@@ -75,11 +75,11 @@ namespace System.IO.Pipes
                         _cancellationRegistration = cancellationToken.UnsafeRegister(static (s, token) =>
                         {
                             PipeValueTaskSource vts = (PipeValueTaskSource)s!;
-                            if (!vts._pipeStream.SafePipeHandle.IsInvalid)
+                            if (vts._pipeStream.InternalHandle is { IsInvalid: false } handle)
                             {
                                 try
                                 {
-                                    Interop.Kernel32.CancelIoEx(vts._pipeStream.SafePipeHandle, vts._overlapped);
+                                    Interop.Kernel32.CancelIoEx(handle, vts._overlapped);
                                     // Ignore all failures: no matter whether it succeeds or fails, completion is handled via the IOCallback.
                                 }
                                 catch (ObjectDisposedException) { } // in case the SafeHandle is (erroneously) closed concurrently


### PR DESCRIPTION
The public PipeStream.SafePipeHandle property throws an exception if the handle has already been closed.  This code should have been using the internal InternalHandle property, which just gets the SafePipeHandle object if it exists.

Fixes https://github.com/dotnet/roslyn/issues/59145
cc: @jaredpar, @danmoseley 