### PR TITLE
null-check the redirect context before using.

### DIFF
--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -1983,9 +1983,14 @@ CONTEXT* AllocateOSContextHelper(BYTE** contextBuffer)
         pfnInitializeContext2(NULL, context, NULL, &contextSize, xStateCompactionMask) :
         InitializeContext(NULL, context, NULL, &contextSize);
 
-    // The following assert is valid, but gets triggered in some Win7 runs with no impact on functionality.
-    // commenting this out to reduce noise, as long as Win7 is supported.
-    // _ASSERTE(!success && GetLastError() == ERROR_INSUFFICIENT_BUFFER);
+    // Spec mentions that we may get a different error (it was observed on Windows7).
+    // In such case the contextSize is undefined.
+    if (success || GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+    {
+        STRESS_LOG2(LF_SYNC, LL_INFO1000, "AllocateOSContextHelper: Unexpected result from InitializeContext (success: %d, error: %d).\n",
+            success, GetLastError());
+        return NULL;
+    }
 
     // So now allocate a buffer of that size and call InitializeContext again
     BYTE* buffer = new (nothrow)BYTE[contextSize];

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -2898,9 +2898,10 @@ BOOL Thread::RedirectThreadAtHandledJITCase(PFN_REDIRECTTARGET pTgt)
         pCtx = m_pSavedRedirectContext = ThreadStore::GrabOSContext(&m_pOSContextBuffer);
     }
 
-    // We may not have a preallocated context, could be short on memory, and cannot allocate
-    // here since we have a thread stopped in a random place, possibly holding some lock.
-    // Other ways and attempts at suspending may yet succeed, but this one is a failure.
+    // We may not have a preallocated context. Could be short on memory when we tried to preallocate.
+    // We cannot allocate here since we have a thread stopped in a random place, possibly holding locks
+    // that we would need while allocating.
+    // Other ways and attempts at suspending may yet succeed, but this redirection cannot continue.
     if (!pCtx)
         return (FALSE);
 

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -2896,8 +2896,13 @@ BOOL Thread::RedirectThreadAtHandledJITCase(PFN_REDIRECTTARGET pTgt)
     if (!pCtx)
     {
         pCtx = m_pSavedRedirectContext = ThreadStore::GrabOSContext(&m_pOSContextBuffer);
-        _ASSERTE(GetSavedRedirectContext() != NULL);
     }
+
+    // We may not have a preallocated context, could be short on memory, and cannot allocate
+    // here since we have a thread stopped in a random place, possibly holding some lock.
+    // Other ways and attempts at suspending may yet succeed, but this one is a failure.
+    if (!pCtx)
+        return (FALSE);
 
     //////////////////////////////////////
     // Get and save the thread's context


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/65890

In rare cases (typically on x86) the redirect context can be `NULL`. It is supposed to be preallocated before redirecting a thread, but we could be short on memory at the time when we tried to allocate.

The condition should not be fatal. It should just cause the current redirection attempt to fail and cause a retry. 
On the next attempt we may be able to allocate or stop the thread via other mechanisms.
We used to indirectly rely on `EEGetThreadContext` to fail when the context is `NULL`. Now the first use is `SetXStateFeaturesMask` which crashes with NRE.

We should just check `pCtx` for `NULL` before using it.