### PR TITLE
Fix libraries GCStress pipeline

### DIFF
--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -87,21 +87,6 @@ jobs:
             artifactFileName: $(librariesTestsArtifactName)$(archiveExtension)
             unpackFolder: $(Build.SourcesDirectory)/artifacts
 
-        - ${{ if in(parameters.coreclrTestGroup, 'gcstress0x3-gcstress0xc', 'gcstress-extra') }}:
-          # We need to find and download the GC stress dependencies (namely, coredistools). Put them
-          # in the 'sharedFramework' directory where we unpacked the CoreCLR build artifacts. The 'sharedFramework'
-          # directory is what is copied into the testhost.
-          - ${{ if eq(parameters.osGroup, 'windows') }}:
-            - script: $(Build.SourcesDirectory)\src\coreclr\tests\setup-stress-dependencies.cmd
-                      /arch ${{ parameters.archType }}
-                      /outputdir $(_runtimeDownloadPath)/sharedFramework
-              displayName: Download GC stress dependencies
-          - ${{ if ne(parameters.osGroup, 'windows') }}:
-            - script: $(Build.SourcesDirectory)/src/coreclr/tests/setup-stress-dependencies.sh
-                      --arch=${{ parameters.archType }}
-                      --outputDir=$(_runtimeDownloadPath)/sharedFramework
-              displayName: Download GC stress dependencies
-
         - ${{ if ne(parameters.liveRuntimeBuildConfig, '') }}:
           - script: $(_buildScript)
                     -subset libs.pretest

--- a/src/libraries/externals.csproj
+++ b/src/libraries/externals.csproj
@@ -12,6 +12,16 @@
     <UseLiveBuiltDotNetHost Condition="'$(TargetArchitecture)' == 's390x' or '$(TargetArchitecture)' == 'armv6'">true</UseLiveBuiltDotNetHost>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <GCStressDependsOnCoreDisTools>false</GCStressDependsOnCoreDisTools>
+    <GCStressDependsOnCoreDisTools Condition="'$(TargetOS)' == 'Windows' And ('$(TargetArchitecture)' == 'x64' Or '$(TargetArchitecture)' == 'x86')">true</GCStressDependsOnCoreDisTools>
+    <GCStressDependsOnCoreDisTools Condition="'$(TargetOS)' == 'Linux' And '$(TargetArchitecture)' == 'x64'">true</GCStressDependsOnCoreDisTools>
+    <CopyCoreDisToolsToCoreRoot>false</CopyCoreDisToolsToCoreRoot>
+    <CopyCoreDisToolsToCoreRoot Condition="$(GCStressDependsOnCoreDisTools) And '$(DotNetBuildFromSource)' != 'true'">true</CopyCoreDisToolsToCoreRoot>
+  </PropertyGroup>
+
+  <Import Project="$(RepositoryEngineeringDir)coredistools.targets" Condition="$(CopyCoreDisToolsToCoreRoot)" />
+  
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
     <PackageReference Include="Microsoft.DiaSymReader.Native"
                       Version="$(MicrosoftDiaSymReaderNativeVersion)" />
@@ -67,6 +77,12 @@
 
     <Copy SourceFiles="@(DotnetExe)"
           DestinationFolder="$(NetCoreAppCurrentTestHostPath)"
+          SkipUnchangedFiles="true"
+          UseHardlinksIfPossible="$(UseHardlink)" />
+
+    <Copy Condition="$(CopyCoreDisToolsToCoreRoot)" 
+          SourceFiles="$(CoreDisToolsLibrary)"
+          DestinationFolder="$(NetCoreAppCurrentTestHostPath)shared\Microsoft.NETCore.App\$(ProductVersion)"
           SkipUnchangedFiles="true"
           UseHardlinksIfPossible="$(UseHardlink)" />
 

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -34,7 +34,7 @@
         '$(Scenario)' == 'gcstress0xc_zapdisable_heapverify1' or
         '$(Scenario)' == 'gcstress0xc_jitstress1' or
         '$(Scenario)' == 'gcstress0xc_jitstress2' or
-        '$(Scenario)' == 'gcstress0xc_jitminopts_heapverify1'">01:30:00</_workItemTimeout>
+        '$(Scenario)' == 'gcstress0xc_jitminopts_heapverify1'">06:00:00</_workItemTimeout>
     <_workItemTimeout Condition="'$(_workItemTimeout)' == '' and ('$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOSSimulator' or '$(TargetOS)' == 'MacCatalyst' or '$(TargetOS)' == 'Android')">00:30:00</_workItemTimeout>
     <_workItemTimeout Condition="'$(_workItemTimeout)' == '' and ('$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS')">00:45:00</_workItemTimeout>
     <_workItemTimeout Condition="'$(Scenario)' == '' and '$(_workItemTimeout)' == '' and ('$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'arm')">00:45:00</_workItemTimeout>


### PR DESCRIPTION
Remove reference to deleted setup-stress-dependencies.cmd/sh;
Automatically download and copy coredistools.dll to the libraries testhost.

Increase timeout for GCStress runs.

Note that the pipeline is still not scheduled to run; there are lots of timeouts and failures that
need to be addressed before that can happen.
