### PR TITLE
FastMod for EEHashTable (Faster virtual generics)

### DIFF
--- a/src/coreclr/vm/eehash.h
+++ b/src/coreclr/vm/eehash.h
@@ -152,7 +152,9 @@ protected:
     {
         DPTR(PTR_EEHashEntry_t) m_pBuckets;       // Pointer to first entry for each bucket
         DWORD                   m_dwNumBuckets;
+#ifdef TARGET_64BIT
         UINT64                  m_dwNumBucketsMul; // "Fast Mod" multiplier for "X % m_dwNumBuckets"
+#endif
     } m_BucketTable[2];
     typedef DPTR(BucketTable) PTR_BucketTable;
 
@@ -194,10 +196,13 @@ public:
         LIMITED_METHOD_CONTRACT;
         this->m_BucketTable[0].m_pBuckets        = NULL;
         this->m_BucketTable[0].m_dwNumBuckets    = 0;
-        this->m_BucketTable[0].m_dwNumBucketsMul = 0;
         this->m_BucketTable[1].m_pBuckets        = NULL;
         this->m_BucketTable[1].m_dwNumBuckets    = 0;
+#ifdef TARGET_64BIT
+        this->m_BucketTable[0].m_dwNumBucketsMul = 0;
         this->m_BucketTable[1].m_dwNumBucketsMul = 0;
+#endif
+
 #ifndef DACCESS_COMPILE
         this->m_pVolatileBucketTable = NULL;
 #endif

--- a/src/coreclr/vm/eehash.h
+++ b/src/coreclr/vm/eehash.h
@@ -150,8 +150,9 @@ protected:
 
     struct BucketTable
     {
-        DPTR(PTR_EEHashEntry_t) m_pBuckets;    // Pointer to first entry for each bucket
-        DWORD            m_dwNumBuckets;
+        DPTR(PTR_EEHashEntry_t) m_pBuckets;       // Pointer to first entry for each bucket
+        DWORD                   m_dwNumBuckets;
+        UINT64                  m_dwNumBucketsMul; // "Fast Mod" multiplier for "X % m_dwNumBuckets"
     } m_BucketTable[2];
     typedef DPTR(BucketTable) PTR_BucketTable;
 
@@ -191,10 +192,12 @@ public:
     EEHashTable()
     {
         LIMITED_METHOD_CONTRACT;
-        this->m_BucketTable[0].m_pBuckets     = NULL;
-        this->m_BucketTable[0].m_dwNumBuckets = 0;
-        this->m_BucketTable[1].m_pBuckets     = NULL;
-        this->m_BucketTable[1].m_dwNumBuckets = 0;
+        this->m_BucketTable[0].m_pBuckets        = NULL;
+        this->m_BucketTable[0].m_dwNumBuckets    = 0;
+        this->m_BucketTable[0].m_dwNumBucketsMul = 0;
+        this->m_BucketTable[1].m_pBuckets        = NULL;
+        this->m_BucketTable[1].m_dwNumBuckets    = 0;
+        this->m_BucketTable[1].m_dwNumBucketsMul = 0;
 #ifndef DACCESS_COMPILE
         this->m_pVolatileBucketTable = NULL;
 #endif

--- a/src/coreclr/vm/eehash.inl
+++ b/src/coreclr/vm/eehash.inl
@@ -106,7 +106,9 @@ void EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::ClearHashTable()
     }
 
     m_pVolatileBucketTable->m_dwNumBuckets = 0;
+#ifdef TARGET_64BIT
     m_pVolatileBucketTable->m_dwNumBucketsMul = 0;
+#endif
     m_dwNumEntries = 0;
 }
 
@@ -194,13 +196,9 @@ BOOL EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::Init(DWORD dwNumBucke
 
     // The first slot links to the next list.
     m_pVolatileBucketTable->m_pBuckets++;
-
     m_pVolatileBucketTable->m_dwNumBuckets = dwNumBuckets;
-
 #ifdef TARGET_64BIT
     m_pVolatileBucketTable->m_dwNumBucketsMul = GetFastModMultiplier(dwNumBuckets);
-#else
-    m_pVolatileBucketTable->m_dwNumBucketsMul = 0;
 #endif
 
     m_Heap = pHeap;
@@ -787,11 +785,8 @@ BOOL EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::GrowHashTable()
 
     pNewBucketTable->m_pBuckets = pNewBuckets;
     pNewBucketTable->m_dwNumBuckets = dwNewNumBuckets;
-
 #ifdef TARGET_64BIT
     pNewBucketTable->m_dwNumBucketsMul = GetFastModMultiplier(dwNewNumBuckets);
-#else
-    pNewBucketTable->m_dwNumBucketsMul = 0;
 #endif
 
     // Add old table to the to free list. Note that the SyncClean thing will only

--- a/src/coreclr/vm/eehash.inl
+++ b/src/coreclr/vm/eehash.inl
@@ -106,6 +106,7 @@ void EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::ClearHashTable()
     }
 
     m_pVolatileBucketTable->m_dwNumBuckets = 0;
+    m_pVolatileBucketTable->m_dwNumBucketsMul = 0;
     m_dwNumEntries = 0;
 }
 
@@ -195,6 +196,18 @@ BOOL EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::Init(DWORD dwNumBucke
     m_pVolatileBucketTable->m_pBuckets++;
 
     m_pVolatileBucketTable->m_dwNumBuckets = dwNumBuckets;
+
+#ifdef TARGET_64BIT
+    if (dwNumBuckets <= UINT32_MAX)
+    {
+        m_pVolatileBucketTable->m_dwNumBucketsMul = GetFastModMultiplier((UINT32)dwNumBuckets);
+    }
+    else
+#endif
+    {
+        // dwNumBuckets (unlikely) is too big to be used with "Fast mod"
+        m_pVolatileBucketTable->m_dwNumBucketsMul = 0;
+    }
 
     m_Heap = pHeap;
 
@@ -637,7 +650,19 @@ FORCEINLINE EEHashEntry_t *EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>:
 
     _ASSERTE(pBucketTable->m_dwNumBuckets != 0);
 
-    DWORD           dwBucket = dwHash % pBucketTable->m_dwNumBuckets;
+#ifdef TARGET_64BIT
+    DWORD dwBucket;
+    // Use precalculated multiplier for FastMod if both NumBuckets and dwHash fit into UINT32 
+    if ((pBucketTable->m_dwNumBuckets | dwHash) <= UINT_MAX)
+    {
+        _ASSERTE(pBucketTable->m_dwNumBucketsMul != 0);
+        dwBucket = FastMod(dwHash, pBucketTable->m_dwNumBuckets, pBucketTable->m_dwNumBucketsMul);
+    }
+    else
+#endif
+    {
+        dwBucket = dwHash % pBucketTable->m_dwNumBuckets;
+    }
     EEHashEntry_t * pSearch;
 
     for (pSearch = pBucketTable->m_pBuckets[dwBucket]; pSearch; pSearch = pSearch->pNext)
@@ -774,6 +799,18 @@ BOOL EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::GrowHashTable()
 
     pNewBucketTable->m_pBuckets = pNewBuckets;
     pNewBucketTable->m_dwNumBuckets = dwNewNumBuckets;
+
+#ifdef TARGET_64BIT
+    if (dwNewNumBuckets <= UINT32_MAX)
+    {
+        pNewBucketTable->m_dwNumBucketsMul = GetFastModMultiplier((UINT32)dwNewNumBuckets);
+    }
+    else
+#endif
+    {
+        // dwNumBuckets (unlikely) is too big to be used with "Fast mod"
+        pNewBucketTable->m_dwNumBucketsMul = 0;
+    }
 
     // Add old table to the to free list. Note that the SyncClean thing will only
     // delete the buckets at a safe point

--- a/src/coreclr/vm/util.hpp
+++ b/src/coreclr/vm/util.hpp
@@ -1006,4 +1006,19 @@ public:
 HRESULT GetFileVersion(LPCWSTR wszFilePath, ULARGE_INTEGER* pFileVersion);
 #endif // !TARGET_UNIX
 
+#ifdef TARGET_64BIT
+// We use modified Daniel Lemire's fastmod algorithm (https://github.com/dotnet/runtime/pull/406),
+// which allows to avoid the long multiplication if the divisor is less than 2**31.
+// This is a copy of HashHelpers.cs, see that impl (or linked PR) for more details
+inline UINT64 GetFastModMultiplier(UINT32 divisor)
+{
+    return UINT64_MAX / divisor + 1;
+}
+
+inline UINT32 FastMod(UINT32 value, UINT32 divisor, UINT64 multiplier)
+{
+    return (UINT32)(((((multiplier * value) >> 32) + 1) * divisor) >> 32);
+}
+#endif
+
 #endif /* _H_UTIL */


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/65778

It was suggested to use a different data structure for `CORINFO_HELP_VIRTUAL_FUNC_PTR` but that is a more complicated change and I think this one worth having too anyway.

Benchmark:
```csharp
using System.Text.Json.Nodes;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkSwitcher.FromAssembly(typeof(Benchmarks).Assembly).Run(args);

public class Benchmarks
{
    public virtual void VGM<T>() { }

    [Benchmark]
    public void CallVirtualGenericMethod() => VGM<int>();



    // System.Text.Json
    JsonNode _jsonNode = true;

    [Benchmark]
    public bool JsonNodeConversion() => (bool)_jsonNode;



    // string interning
    string str = "Hello";

    [Benchmark]
    public string StrIsInterned() => string.IsInterned(str);
}
```

|                    Method |                 Toolchain |      Mean |     Error |    StdDev | Ratio |
|-------------------------- |-------------------------- |----------:|----------:|----------:|------:|
|  CallVirtualGenericMethod |    \Core_Root\corerun.exe |  5.299 ns | 0.0364 ns | 0.0322 ns |  1.00 |
|  CallVirtualGenericMethod | \Core_Root_PR\corerun.exe |  4.166 ns | 0.1064 ns | 0.1383 ns |  0.79 |
|                           |                           |           |           |           |       |
|        JsonNodeConversion |    \Core_Root\corerun.exe |  5.509 ns | 0.0070 ns | 0.0062 ns |  1.00 |
|        JsonNodeConversion | \Core_Root_PR\corerun.exe |  4.177 ns | 0.0461 ns | 0.0431 ns |  0.76 |
|                           |                           |           |           |           |       |
|             StrIsInterned |    \Core_Root\corerun.exe | 54.741 ns | 0.1900 ns | 0.1780 ns |  1.00 |
|             StrIsInterned | \Core_Root_PR\corerun.exe | 50.172 ns | 0.3521 ns | 0.2750 ns |  0.92 |
