### PR TITLE
Update stale comments that reference GitHub issues

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStandardConsoleTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStandardConsoleTests.cs
@@ -31,8 +31,8 @@ namespace System.Diagnostics.Tests
                 Assert.True(p.WaitForExit(WaitInMS));
             };
 
-            // Don't test this on Windows containers, as the test is currently failing
-            // cf. https://github.com/dotnet/runtime/issues/42000
+            // Don't test this on Windows containers, as there is a known issue.
+            // See https://github.com/dotnet/runtime/issues/42000 for more details.
             if (!OperatingSystem.IsWindows() || PlatformDetection.IsInContainer)
             {
                 RunWithExpectedCodePage(Encoding.UTF8.CodePage);

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatterWriter.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatterWriter.cs
@@ -117,7 +117,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
             int assemId;
             int objectId = (int)nameInfo._objectId;
 
-            Debug.Assert(typeNameInfo != null); // Explicitly called with null, asserting for now https://github.com/dotnet/runtime/issues/31402
+            Debug.Assert(typeNameInfo != null); // Explicitly called with null. Potential bug, but closed as Won't Fix: https://github.com/dotnet/runtime/issues/31402
             string? objectName = objectId < 0 ?
                 typeNameInfo.NIname : // Nested Object
                 nameInfo.NIname; // Non-Nested

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -390,7 +390,7 @@ namespace System.Text.RegularExpressions.Tests
                 yield return new object[] { engine, null, @"(cat)(\cZ*)(dog)", "asdlkcat\u001adogiwod", RegexOptions.None, new string[] { "cat\u001adog", "cat", "\u001a", "dog" } };
                 yield return new object[] { engine, null, @"(cat)(\cz*)(dog)", "asdlkcat\u001adogiwod", RegexOptions.None, new string[] { "cat\u001adog", "cat", "\u001a", "dog" } };
 
-                if (!PlatformDetection.IsNetFramework) // missing fix for https://github.com/dotnet/runtime/issues/24759
+                if (!PlatformDetection.IsNetFramework) // `\c[` was not handled in .NET Framework. See https://github.com/dotnet/runtime/issues/24759.
                 {
                     yield return new object[] { engine, null, @"(cat)(\c[*)(dog)", "asdlkcat\u001bdogiwod", RegexOptions.None, new string[] { "cat\u001bdog", "cat", "\u001b", "dog" } };
                 }


### PR DESCRIPTION
Fixes #65931

[Cleanup Issue-URLs in Code · Issue #63902 · dotnet/runtime](https://github.com/dotnet/runtime/issues/63902) identified stale comments that reference GitHub issues. This PR updates comments to reflect updated statuses.

_I'm marking this PR as a draft while working through that issue to see if other comments can also be quickly updated._

/cc @deeprobin 