### PR TITLE
Mark ImageAnimator.UpdateFrames to accept a nullable Image

### DIFF
--- a/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.cs
+++ b/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.cs
@@ -776,7 +776,7 @@ namespace System.Drawing
         public static bool CanAnimate([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] System.Drawing.Image? image) { throw null; }
         public static void StopAnimate(System.Drawing.Image image, System.EventHandler onFrameChangedHandler) { }
         public static void UpdateFrames() { }
-        public static void UpdateFrames(System.Drawing.Image image) { }
+        public static void UpdateFrames(System.Drawing.Image? image) { }
     }
     public partial class ImageConverter : System.ComponentModel.TypeConverter
     {

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/ImageAnimator.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/ImageAnimator.cs
@@ -100,7 +100,7 @@ namespace System.Drawing
         /// <summary>
         ///     Advances the frame in the specified image. The new frame is drawn the next time the image is rendered.
         /// </summary>
-        public static void UpdateFrames(Image image)
+        public static void UpdateFrames(Image? image)
         {
             if (image == null || s_imageInfoList == null)
             {


### PR DESCRIPTION
Updating the nullable annotation per a discussion here: https://github.com/dotnet/winforms/pull/6545#discussion_r795315760

The method will no-op if `null` is received for the `Image` parameter. Since `null` is handled gracefully, we can mark the argument as nullable so that callers don't need to guard it.

/cc @RussKie @gpetrou