### PR TITLE
[Release/6.0] Backport of Mariner 2.0 and Linux Arm64 packaging work

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -54,9 +54,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>fe5cc1841d12196d94a4ae3b276cb92d8d7ca73d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="6.0.0-beta.22107.2">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="6.0.0-beta.22122.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>fe5cc1841d12196d94a4ae3b276cb92d8d7ca73d</Sha>
+      <Sha>853684cf39fdc68035736a4ff0f81303bf4b4361</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="6.0.0-beta.22107.2">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -49,7 +49,7 @@
     <MicrosoftDotNetXUnitExtensionsVersion>6.0.0-beta.22107.2</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.22107.2</MicrosoftDotNetXUnitConsoleRunnerVersion>
     <MicrosoftDotNetBuildTasksArchivesVersion>6.0.0-beta.22107.2</MicrosoftDotNetBuildTasksArchivesVersion>
-    <MicrosoftDotNetBuildTasksInstallersVersion>6.0.0-beta.22107.2</MicrosoftDotNetBuildTasksInstallersVersion>
+    <MicrosoftDotNetBuildTasksInstallersVersion>6.0.0-beta.22122.4</MicrosoftDotNetBuildTasksInstallersVersion>
     <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-beta.22107.2</MicrosoftDotNetBuildTasksPackagingVersion>
     <MicrosoftDotNetBuildTasksTemplatingVersion>6.0.0-beta.22107.2</MicrosoftDotNetBuildTasksTemplatingVersion>
     <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>6.0.0-beta.22107.2</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -422,18 +422,20 @@ jobs:
       displayName: Disk Usage after Build
 
   # Only in glibc leg, we produce RPMs and Debs
-  - ${{ if and(eq(parameters.runtimeFlavor, 'coreclr'), eq(parameters.platform, 'Linux_x64'), eq(parameters.osSubgroup, ''), eq(parameters.pgoType, ''))}}:
+  - ${{ if and(eq(parameters.runtimeFlavor, 'coreclr'), or(eq(parameters.platform, 'Linux_x64'), eq(parameters.platform, 'Linux_arm64')), eq(parameters.osSubgroup, ''), eq(parameters.pgoType, ''))}}:
     - ${{ each packageBuild in parameters.packageDistroList }}:
       # This leg's RID matches the build image. Build its distro-dependent packages, as well as
       # the distro-independent installers. (There's no particular reason to build the distro-
       # independent installers on this leg, but we need to do it somewhere.)
-      - template: steps/build-linux-package.yml
-        parameters:
-          packageType: ${{ packageBuild.packageType }}
-          image: ${{ packageBuild.image }}
-          packageStepDescription: Runtime Deps, Runtime, Framework Packs installers
-          subsetArg: $(installersSubsetArg)
-          packagingArgs: ${{ packageBuild.packagingArgs }}
+      # Currently, Linux_arm64 supports 'rpm' type only.
+      - ${{ if or(not(eq(parameters.platform, 'Linux_arm64')), eq(packageBuild.packageType, 'rpm')) }}:
+        - template: steps/build-linux-package.yml
+          parameters:
+            packageType: ${{ packageBuild.packageType }}
+            image: ${{ packageBuild.image }}
+            packageStepDescription: Runtime Deps, Runtime, Framework Packs installers
+            subsetArg: $(installersSubsetArg)
+            packagingArgs: ${{ packageBuild.packagingArgs }}
 
   - ${{ if ne(parameters.container, '') }}:
     # Files may be owned by root because builds don't set user ID. Later build steps run 'find' in

--- a/src/installer/pkg/sfx/installers.proj
+++ b/src/installer/pkg/sfx/installers.proj
@@ -12,6 +12,7 @@
   <ItemGroup Condition="'$(BuildRpmPackage)' == 'true'">
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-centos.7.proj" />
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-cm.1.proj" />
+    <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-cm.2.proj" />
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-fedora.27.proj" />
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-fedora.34.proj" />
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-opensuse.42.proj" />

--- a/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-cm.2.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-cm.2.proj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <GenerateInstallers Condition="'$(BuildRpmPackage)' != 'true'">false</GenerateInstallers>
+    <PackageTargetOS>cm.2</PackageTargetOS>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <LinuxPackageDependency Include="openssl-libs;icu;krb5" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Implements runtime changes for Mariner 2.0 and Linux Arm64 packaging, tracked in following issues:
- [ ] https://github.com/dotnet/runtime/issues/64755
- [ ] https://github.com/dotnet/runtime/issues/65441
- [ ] https://github.com/dotnet/runtime/issues/65541

This is a straightforward backport of the following PRs:

- [ ] https://github.com/dotnet/runtime/pull/65345
- [ ] https://github.com/dotnet/runtime/pull/65442
- [ ] https://github.com/dotnet/runtime/pull/65542

## Testing

Built and tested installation of private RPM packages.
