### PR TITLE
attempt to fix up EnterpriseTests

### DIFF
--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -20,10 +20,6 @@ pr:
       - src/libraries/System.Net.Http/*
       - src/libraries/System.Net.Security/*
 
-pool:
-  name: NetCore1ESPool-Public
-  demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
-
 variables:
   - template: ../variables.yml
   - name: enterpriseTestsSetup
@@ -33,34 +29,40 @@ variables:
   - name: containerLibrariesRoot
     value: /repo/src/libraries
 
-steps:
-- bash: |
-    cd $(enterpriseTestsSetup)
-    docker-compose build
-  displayName: Build test machine images
-  env:
-    DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
-
-- bash: |
-    cd $(enterpriseTestsSetup)
-    docker-compose up -d
-  displayName: Start test network and machines
-  env:
-    DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
-
-- bash: |
-    docker exec linuxclient bash /setup/test-webserver.sh
-  displayName: Test linuxclient connection to web server
-
-- bash: |
-    docker exec linuxclient bash -c '/repo/build.sh -subset clr+libs -runtimeconfiguration release -ci /p:NativeOptimizationDataSupported=false'
-  displayName: Build product sources
+jobs:
+- job: Enterprise Linux tests
   timeoutInMinutes: 180
+  pool:
+    name: NetCore1ESPool-Public
+    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+  steps:
+    - bash: |
+        cd $(enterpriseTestsSetup)
+        docker-compose build
+      displayName: Build test machine images
+      env:
+        DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
 
-- bash: |
-    docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj
-    docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Security/tests/EnterpriseTests/System.Net.Security.Enterprise.Tests.csproj
-  displayName: Build and run tests
+    - bash: |
+        cd $(enterpriseTestsSetup)
+        docker-compose up -d
+      displayName: Start test network and machines
+      env:
+        DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
+
+    - bash: |
+        docker exec linuxclient bash /setup/test-webserver.sh
+      displayName: Test linuxclient connection to web server
+
+    - bash: |
+        docker exec linuxclient bash -c '/repo/build.sh -subset clr+libs -runtimeconfiguration release -ci /p:NativeOptimizationDataSupported=false'
+      displayName: Build product sources
+      timeoutInMinutes: 120
+
+    - bash: |
+        docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj
+        docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Security/tests/EnterpriseTests/System.Net.Security.Enterprise.Tests.csproj
+      displayName: Build and run tests
 
 - bash: |
     cd $(enterpriseTestsSetup)

--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -1,7 +1,6 @@
 
 # Disable pipeline for ordinary pushes to the branches
 trigger: none
-timeoutInMinutes: 180
 
 # To reduce load on the pipeline, enable it only for PRs that affect critical networking code
 pr:

--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -64,17 +64,17 @@ jobs:
         docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Security/tests/EnterpriseTests/System.Net.Security.Enterprise.Tests.csproj
       displayName: Build and run tests
 
-- bash: |
-    cd $(enterpriseTestsSetup)
-    docker-compose down
-  displayName: Stop test network and machines
-  env:
-    DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
+    - bash: |
+        cd $(enterpriseTestsSetup)
+        docker-compose down
+    displayName: Stop test network and machines
+    env:
+      DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
 
-- task: PublishTestResults@2
-  inputs:
-    testRunner: 'xUnit'
-    testResultsFiles: '**/testResults.xml'
-    testRunTitle: 'Enterprise Tests'
-    mergeTestResults: true
-    failTaskOnFailedTests: true
+    - task: PublishTestResults@2
+      inputs:
+        testRunner: 'xUnit'
+        testResultsFiles: '**/testResults.xml'
+        testRunTitle: 'Enterprise Tests'
+        mergeTestResults: true
+        failTaskOnFailedTests: true

--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -31,7 +31,7 @@ variables:
 
 jobs:
 - job: EnterpriseLinuxTests
-  timeoutInMinutes: 180
+  timeoutInMinutes: 120
   pool:
     name: NetCore1ESPool-Public
     demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
@@ -56,10 +56,12 @@ jobs:
 
   - bash: |
       docker exec linuxclient bash -c '/repo/build.sh -subset clr+libs -runtimeconfiguration release -ci /p:NativeOptimizationDataSupported=false'
+      docker exec linuxclient bash -c '/repo/dotnet.sh build $(containerLibrariesRoot)/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj'
+      docker exec linuxclient bash -c '/repo/dotnet.sh build $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Security/tests/EnterpriseTests/System.Net.Security.Enterprise.Tests.csproj'
     displayName: Build product sources
-    timeoutInMinutes: 120
 
   - bash: |
+      docker exec linuxclient bash -c 'if [ -f /erc/resolv.conf.ORI ]; then cp -f /erc/resolv.conf.ORI /etc/resolv.conf; fi'
       docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj
       docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Security/tests/EnterpriseTests/System.Net.Security.Enterprise.Tests.csproj
     displayName: Build and run tests

--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -30,7 +30,7 @@ variables:
     value: /repo/src/libraries
 
 jobs:
-- job: Enterprise Linux tests
+- job: EnterpriseLinuxTests
   timeoutInMinutes: 180
   pool:
     name: NetCore1ESPool-Public

--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -36,45 +36,45 @@ jobs:
     name: NetCore1ESPool-Public
     demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
   steps:
-    - bash: |
-        cd $(enterpriseTestsSetup)
-        docker-compose build
-      displayName: Build test machine images
-      env:
-        DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
+  - bash: |
+      cd $(enterpriseTestsSetup)
+      docker-compose build
+    displayName: Build test machine images
+    env:
+      DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
 
-    - bash: |
-        cd $(enterpriseTestsSetup)
-        docker-compose up -d
-      displayName: Start test network and machines
-      env:
-        DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
+  - bash: |
+      cd $(enterpriseTestsSetup)
+      docker-compose up -d
+    displayName: Start test network and machines
+    env:
+      DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
 
-    - bash: |
-        docker exec linuxclient bash /setup/test-webserver.sh
-      displayName: Test linuxclient connection to web server
+  - bash: |
+      docker exec linuxclient bash /setup/test-webserver.sh
+    displayName: Test linuxclient connection to web server
 
-    - bash: |
-        docker exec linuxclient bash -c '/repo/build.sh -subset clr+libs -runtimeconfiguration release -ci /p:NativeOptimizationDataSupported=false'
-      displayName: Build product sources
-      timeoutInMinutes: 120
+  - bash: |
+      docker exec linuxclient bash -c '/repo/build.sh -subset clr+libs -runtimeconfiguration release -ci /p:NativeOptimizationDataSupported=false'
+    displayName: Build product sources
+    timeoutInMinutes: 120
 
-    - bash: |
-        docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj
-        docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Security/tests/EnterpriseTests/System.Net.Security.Enterprise.Tests.csproj
-      displayName: Build and run tests
+  - bash: |
+      docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj
+      docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Security/tests/EnterpriseTests/System.Net.Security.Enterprise.Tests.csproj
+    displayName: Build and run tests
 
-    - bash: |
-        cd $(enterpriseTestsSetup)
-        docker-compose down
+  - bash: |
+      cd $(enterpriseTestsSetup)
+      docker-compose down
     displayName: Stop test network and machines
     env:
       DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
 
-    - task: PublishTestResults@2
-      inputs:
-        testRunner: 'xUnit'
-        testResultsFiles: '**/testResults.xml'
-        testRunTitle: 'Enterprise Tests'
-        mergeTestResults: true
-        failTaskOnFailedTests: true
+  - task: PublishTestResults@2
+    inputs:
+      testRunner: 'xUnit'
+      testResultsFiles: '**/testResults.xml'
+      testRunTitle: 'Enterprise Tests'
+      mergeTestResults: true
+      failTaskOnFailedTests: true

--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -57,7 +57,7 @@ jobs:
   - bash: |
       docker exec linuxclient bash -c '/repo/build.sh -subset clr+libs -runtimeconfiguration release -ci /p:NativeOptimizationDataSupported=false'
       docker exec linuxclient bash -c '/repo/dotnet.sh build $(containerLibrariesRoot)/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj'
-      docker exec linuxclient bash -c '/repo/dotnet.sh build $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Security/tests/EnterpriseTests/System.Net.Security.Enterprise.Tests.csproj'
+      docker exec linuxclient bash -c '/repo/dotnet.sh build $(containerLibrariesRoot)/System.Net.Security/tests/EnterpriseTests/System.Net.Security.Enterprise.Tests.csproj'
     displayName: Build product sources
 
   - bash: |

--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -1,6 +1,7 @@
 
 # Disable pipeline for ordinary pushes to the branches
 trigger: none
+timeoutInMinutes: 180
 
 # To reduce load on the pipeline, enable it only for PRs that affect critical networking code
 pr:
@@ -55,6 +56,7 @@ steps:
 - bash: |
     docker exec linuxclient bash -c '/repo/build.sh -subset clr+libs -runtimeconfiguration release -ci /p:NativeOptimizationDataSupported=false'
   displayName: Build product sources
+  timeoutInMinutes: 180
 
 - bash: |
     docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/docker-compose.yml
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/docker-compose.yml
@@ -60,6 +60,9 @@ services:
     hostname: linuxclient
     domainname: linux.contoso.com
     dns_search: linux.contoso.com
+    privileged: true
+    dns:
+      - 8.8.8.8
     volumes:
       - shared-volume:/SHARED
       - ${DOTNET_RUNTIME_REPO_ROOT}:/repo

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/test-webserver.sh
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/test-webserver.sh
@@ -4,3 +4,10 @@ kdestroy
 echo password | kinit user1
 curl --verbose --negotiate -u: http://apacheweb.linux.contoso.com
 kdestroy
+
+nslookup github.com
+if [ $? -ne 0 ]; then
+  # try to fix-up DNS adding public server
+  echo nameserver 8.8.8.8 >> /etc/resolv.conf
+fi
+nslookup github.com

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/test-webserver.sh
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/test-webserver.sh
@@ -7,6 +7,7 @@ kdestroy
 
 nslookup github.com
 if [ $? -ne 0 ]; then
+  cp /etc/resolv.conf /etc/resolv.conf.ORI
   # try to fix-up DNS by adding public server
   echo nameserver 8.8.8.8 >> /etc/resolv.conf
 

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/test-webserver.sh
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/test-webserver.sh
@@ -6,12 +6,4 @@ curl --verbose --negotiate -u: http://apacheweb.linux.contoso.com
 kdestroy
 
 nslookup github.com
-if [ $? -ne 0 ]; then
-  cp /etc/resolv.conf /etc/resolv.conf.ORI
-  # try to fix-up DNS by adding public server
-  echo nameserver 8.8.8.8 >> /etc/resolv.conf
-
-  nslookup github.com
-  curl --verbose http://apacheweb.linux.contoso.com
-fi
 

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/test-webserver.sh
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/test-webserver.sh
@@ -7,7 +7,7 @@ kdestroy
 
 nslookup github.com
 if [ $? -ne 0 ]; then
-  # try to fix-up DNS adding public server
+  # try to fix-up DNS by adding public server
   echo nameserver 8.8.8.8 >> /etc/resolv.conf
 fi
 nslookup github.com

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/test-webserver.sh
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/test-webserver.sh
@@ -9,5 +9,8 @@ nslookup github.com
 if [ $? -ne 0 ]; then
   # try to fix-up DNS by adding public server
   echo nameserver 8.8.8.8 >> /etc/resolv.conf
+
+  nslookup github.com
+  curl --verbose http://apacheweb.linux.contoso.com
 fi
-nslookup github.com
+


### PR DESCRIPTION
contributes to  https://github.com/dotnet/core-eng/issues/15594. It seems like te container cannot resolve outside addresses, 
There may be cleaner ways how to fix this But as stop-gap, tis seems to work e.g. there is already test script so if the lookup fails it would add public server.  