### PR TITLE
Update p/invoke source generator errors to use SYSLIB prefix

### DIFF
--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -150,3 +150,13 @@ The diagnostic id values reserved for .NET Libraries analyzer warnings are `SYSL
 |  __`SYSLIB1047`__ | *_`SYSLIB1045`-`SYSLIB1049` reserved for System.Text.RegularExpressions.Generator._* |
 |  __`SYSLIB1048`__ | *_`SYSLIB1045`-`SYSLIB1049` reserved for System.Text.RegularExpressions.Generator._* |
 |  __`SYSLIB1049`__ | *_`SYSLIB1045`-`SYSLIB1049` reserved for System.Text.RegularExpressions.Generator._* |
+|  __`SYSLIB1050`__ | Invalid LibraryImportAttribute usage |
+|  __`SYSLIB1051`__ | Specified type is not supported by source-generated P/Invokes |
+|  __`SYSLIB1052`__ | Specified configuration is not supported by source-generated P/Invokes |
+|  __`SYSLIB1053`__ | Current target framework is not supported by source-generated P/Invokes |
+|  __`SYSLIB1054`__ | Specified LibraryImportAttribute arguments cannot be forwarded to DllImportAttribute |
+|  __`SYSLIB1055`__ | *_`SYSLIB1055`-`SYSLIB1059` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1056`__ | *_`SYSLIB1055`-`SYSLIB1059` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1057`__ | *_`SYSLIB1055`-`SYSLIB1059` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1058`__ | *_`SYSLIB1055`-`SYSLIB1059` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1059`__ | *_`SYSLIB1055`-`SYSLIB1059` reserved for Microsoft.Interop.LibraryImportGenerator._* |

--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -155,8 +155,18 @@ The diagnostic id values reserved for .NET Libraries analyzer warnings are `SYSL
 |  __`SYSLIB1052`__ | Specified configuration is not supported by source-generated P/Invokes |
 |  __`SYSLIB1053`__ | Current target framework is not supported by source-generated P/Invokes |
 |  __`SYSLIB1054`__ | Specified LibraryImportAttribute arguments cannot be forwarded to DllImportAttribute |
-|  __`SYSLIB1055`__ | *_`SYSLIB1055`-`SYSLIB1059` reserved for Microsoft.Interop.LibraryImportGenerator._* |
-|  __`SYSLIB1056`__ | *_`SYSLIB1055`-`SYSLIB1059` reserved for Microsoft.Interop.LibraryImportGenerator._* |
-|  __`SYSLIB1057`__ | *_`SYSLIB1055`-`SYSLIB1059` reserved for Microsoft.Interop.LibraryImportGenerator._* |
-|  __`SYSLIB1058`__ | *_`SYSLIB1055`-`SYSLIB1059` reserved for Microsoft.Interop.LibraryImportGenerator._* |
-|  __`SYSLIB1059`__ | *_`SYSLIB1055`-`SYSLIB1059` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1055`__ | *_`SYSLIB1055`-`SYSLIB1069` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1056`__ | *_`SYSLIB1055`-`SYSLIB1069` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1057`__ | *_`SYSLIB1055`-`SYSLIB1069` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1058`__ | *_`SYSLIB1055`-`SYSLIB1069` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1059`__ | *_`SYSLIB1055`-`SYSLIB1069` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1060`__ | *_`SYSLIB1055`-`SYSLIB1069` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1061`__ | *_`SYSLIB1055`-`SYSLIB1069` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1062`__ | *_`SYSLIB1055`-`SYSLIB1069` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1063`__ | *_`SYSLIB1055`-`SYSLIB1069` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1064`__ | *_`SYSLIB1055`-`SYSLIB1069` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1065`__ | *_`SYSLIB1055`-`SYSLIB1069` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1066`__ | *_`SYSLIB1055`-`SYSLIB1069` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1067`__ | *_`SYSLIB1055`-`SYSLIB1069` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1068`__ | *_`SYSLIB1055`-`SYSLIB1069` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1069`__ | *_`SYSLIB1055`-`SYSLIB1069` reserved for Microsoft.Interop.LibraryImportGenerator._* |

--- a/src/coreclr/nativeaot/Test.CoreLib/src/Test.CoreLib.csproj
+++ b/src/coreclr/nativeaot/Test.CoreLib/src/Test.CoreLib.csproj
@@ -5,9 +5,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <EnableDllImportGenerator>true</EnableDllImportGenerator>
     <!--
-      DLLIMPORTGEN004: DllImportGenerator Target Framework Not Supported.
+      SYSLIB1053: LibraryImportGenerator Target Framework Not Supported.
      -->
-    <NoWarn>$(NoWarn);DLLIMPORTGEN004</NoWarn>
+    <NoWarn>$(NoWarn);SYSLIB1053</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DefineConstants>FEATURE_GC_STRESS;$(DefineConstants)</DefineConstants>

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/AnalyzerDiagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/AnalyzerDiagnostics.cs
@@ -31,10 +31,6 @@ namespace Microsoft.Interop.Analyzers
             public const string NativeGenericTypeMustBeClosedOrMatchArity = Prefix + "016";
             public const string MarshallerGetPinnableReferenceRequiresValueProperty = Prefix + "018";
 
-            // GeneratedDllImport
-            public const string GeneratedDllImportMissingRequiredModifiers = Prefix + "013";
-            public const string GeneratedDllImportContaiingTypeMissingRequiredModifiers = Prefix + "017";
-
             // Migration from DllImport to GeneratedDllImport
             public const string ConvertToGeneratedDllImport = Prefix + "015";
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.csproj
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyName>Microsoft.Interop.DllImportGenerator</AssemblyName>
+    <AssemblyName>Microsoft.Interop.LibraryImportGenerator</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>Preview</LangVersion>

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/GeneratorDiagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/GeneratorDiagnostics.cs
@@ -5,32 +5,31 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Text;
 
 namespace Microsoft.Interop
 {
     /// <summary>
-    /// Class for reporting diagnostics in the DLL import generator
+    /// Class for reporting diagnostics in the library import generator
     /// </summary>
     public class GeneratorDiagnostics : IGeneratorDiagnostics
     {
         public class Ids
         {
-            public const string Prefix = "DLLIMPORTGEN";
-            public const string InvalidGeneratedDllImportAttributeUsage = Prefix + "001";
-            public const string TypeNotSupported = Prefix + "002";
-            public const string ConfigurationNotSupported = Prefix + "003";
-            public const string TargetFrameworkNotSupported = Prefix + "004";
-            public const string CannotForwardToDllImport = Prefix + "005";
+            // SYSLIB1050-SYSLIB1059 are reserved for LibraryImportGenerator
+            public const string Prefix = "SYSLIB";
+            public const string InvalidLibraryImportAttributeUsage = Prefix + "1050";
+            public const string TypeNotSupported = Prefix + "1051";
+            public const string ConfigurationNotSupported = Prefix + "1052";
+            public const string TargetFrameworkNotSupported = Prefix + "1053";
+            public const string CannotForwardToDllImport = Prefix + "1054";
         }
 
-        private const string Category = "SourceGeneration";
+        private const string Category = "LibraryImportGenerator";
 
         public static readonly DiagnosticDescriptor InvalidAttributedMethodSignature =
             new DiagnosticDescriptor(
-            Ids.InvalidGeneratedDllImportAttributeUsage,
+            Ids.InvalidLibraryImportAttributeUsage,
             GetResourceString(nameof(Resources.InvalidLibraryImportAttributeUsageTitle)),
             GetResourceString(nameof(Resources.InvalidAttributedMethodSignatureMessage)),
             Category,
@@ -40,7 +39,7 @@ namespace Microsoft.Interop
 
         public static readonly DiagnosticDescriptor InvalidAttributedMethodContainingTypeMissingModifiers =
             new DiagnosticDescriptor(
-            Ids.InvalidGeneratedDllImportAttributeUsage,
+            Ids.InvalidLibraryImportAttributeUsage,
             GetResourceString(nameof(Resources.InvalidLibraryImportAttributeUsageTitle)),
             GetResourceString(nameof(Resources.InvalidAttributedMethodContainingTypeMissingModifiersMessage)),
             Category,
@@ -50,7 +49,7 @@ namespace Microsoft.Interop
 
         public static readonly DiagnosticDescriptor InvalidStringMarshallingConfiguration =
             new DiagnosticDescriptor(
-            Ids.InvalidGeneratedDllImportAttributeUsage,
+            Ids.InvalidLibraryImportAttributeUsage,
             GetResourceString(nameof(Resources.InvalidLibraryImportAttributeUsageTitle)),
             GetResourceString(nameof(Resources.InvalidStringMarshallingConfigurationMessage)),
             Category,


### PR DESCRIPTION
Use the established `SYSLIB` prefix convention, since the p/invoke source generator will be part of libraries.