### PR TITLE
Simplify RuntimeHelpers.GetSubArray

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -27,33 +27,18 @@ namespace System.Runtime.CompilerServices
 
             (int offset, int length) = range.GetOffsetAndLength(array.Length);
 
-            T[] dest;
-
-            if (typeof(T).IsValueType || typeof(T[]) == array.GetType())
+            if (length == 0)
             {
-                // We know the type of the array to be exactly T[] or an array variance
-                // compatible value type substitution like int[] <-> uint[].
-
-                if (length == 0)
-                {
-                    return Array.Empty<T>();
-                }
-
-                dest = new T[length];
-            }
-            else
-            {
-                // The array is actually a U[] where U:T. We'll make sure to create
-                // an array of the exact same backing type. The cast to T[] will
-                // never fail.
-
-                dest = Unsafe.As<T[]>(Array.CreateInstance(array.GetType().GetElementType()!, length));
+                return Array.Empty<T>();
             }
 
-            // In either case, the newly-allocated array is the exact same type as the
-            // original incoming array. It's safe for us to Buffer.Memmove the contents
-            // from the source array to the destination array, otherwise the contents
-            // wouldn't have been valid for the source array in the first place.
+            T[] dest = new T[length];
+
+            // Due to array variance, it's possible that the incoming array is
+            // actually of type U[], where U:T; or that an int[] <-> uint[] or
+            // similar cast has occurred. In any case, since it's always legal
+            // to reinterpret U as T in this scenario (but not necessarily the
+            // other way around), we can use Buffer.Memmove here.
 
             Buffer.Memmove(
                 ref MemoryMarshal.GetArrayDataReference(dest),


### PR DESCRIPTION
The special casing of co-variant arrays was added in the original safe implementation to avoid exceptions from AsSpan (https://github.com/dotnet/coreclr/pull/22331#discussion_r252904254). ArrayTypeMismatchException is no longer a concern with the new unsafe implementation. There is a subtle behavior change in the actual type for co-variant arrays of reference types. However, the new behavior matches Array.Resize and it is very unlikely for any code out there to depend on this co-variant arrays corner case.