### PR TITLE
[wasm] Fix S.T.Regex test failures due to line ending differences

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/PrecompiledRegexScenarioTest.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/PrecompiledRegexScenarioTest.cs
@@ -15,10 +15,11 @@ namespace System.Text.RegularExpressions.Tests
     public class PrecompiledRegexScenarioTest
     {
         const string text = "asdf134success1245something";
-        const string textWithMultipleMatches = @"asdf134success1245something
+        const string textWithMultipleMatchesCompiled = @"asdf134success1245something
 bsdf135success1245somethingelse
 csdf136success2245somethingnew
 dsdf137success3245somethingold";
+        static string textWithMultipleMatches = LineEndingsHelper.Normalize(textWithMultipleMatchesCompiled);
 
         [Fact]
         public void PrecompiledRegex_MatchesTest()


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/65978 .

When running `System.Text.RegularExpressions.Tests` tests on windows and
targeting `Browser`, the line ending differs between host and target
systems. Use helper `LineEndingsHelper.Normalize` method to update
expected strings.

The `Browser` Environment.NewLine is `\n`, while windows use `\r\n`.