### PR TITLE
Fix handling of atomic nodes in RegexCompiler / source generator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -125,6 +125,7 @@ namespace System.Text.RegularExpressions.Tests
                         yield return (Case("(?>a*)123"), "aa1234", options, 0, 5, true, "aa123");
                         yield return (Case("(?>(?>a*))123"), "aa1234", options, 0, 5, true, "aa123");
                         yield return (Case("(?>a{2,})b"), "aaab", options, 0, 4, true, "aaab");
+                        yield return (Case("[a-z]{0,4}(?>[x-z]*.)(?=xyz1)"), "abcdxyz1", options, 0, 8, true, "abcd");
 
                         // Atomic lazy
                         yield return (Case("(?>[0-9]+?)abc"), "abc12345abc", options, 3, 8, true, "5abc");

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -126,6 +126,8 @@ namespace System.Text.RegularExpressions.Tests
                         yield return (Case("(?>(?>a*))123"), "aa1234", options, 0, 5, true, "aa123");
                         yield return (Case("(?>a{2,})b"), "aaab", options, 0, 4, true, "aaab");
                         yield return (Case("[a-z]{0,4}(?>[x-z]*.)(?=xyz1)"), "abcdxyz1", options, 0, 8, true, "abcd");
+                        yield return (Case("[a-z]{0,4}(?=[x-z]*.)(?=cd)"), "abcdxyz1", options, 0, 8, true, "ab");
+                        yield return (Case("[a-z]{0,4}(?![x-z]*[wx])(?=cd)"), "abcdxyz1", options, 0, 8, true, "ab");
 
                         // Atomic lazy
                         yield return (Case("(?>[0-9]+?)abc"), "abc12345abc", options, 3, 8, true, "5abc");


### PR DESCRIPTION
We weren't properly resetting the stack position, so if we had an atomic group that contained something that backtracked, any backtracking positions left on the stack by that nested construct would then be consumed by a previous backtracking construct and lead to it reading the wrong state.