### PR TITLE
Remove incorrect exception comment from AsSpan

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -101,7 +101,6 @@ namespace System
         /// </summary>
         /// <param name="text">The target string.</param>
         /// <param name="start">The index at which to begin this slice.</param>
-        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="text"/> is null.</exception>
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified <paramref name="start"/> index is not in range (&lt;0 or &gt;text.Length).
         /// </exception>


### PR DESCRIPTION
# Description

This method never throws an `ArgumentNullException` for a null `text` input, and is even annotated as accepting `string?`.

# Customer Impact

Docs are wrong.

# Regression

No.

# Testing

None. Doc fix.

# Risk

None. Doc fix.

