### PR TITLE
[iOS] Fix return code when failing to load ICU data

### DIFF
--- a/src/native/libs/System.Globalization.Native/pal_icushim_static.c
+++ b/src/native/libs/System.Globalization.Native/pal_icushim_static.c
@@ -459,13 +459,13 @@ GlobalizationNative_LoadICUData(const char* path)
     if (icu_data == NULL)
     {
         log_shim_error("Failed to load ICU data.");
-        return -1;
+        return 0;
     }
 
     if (load_icu_data(icu_data) == 0)
     {
         log_shim_error("ICU BAD EXIT.");
-        return -1;
+        return 0;
     }
 
     return GlobalizationNative_LoadICU();


### PR DESCRIPTION
`GlobalizationNative_LoadICUData` was returning -1 when loading failed instead of 0. The result would be a misleading exception as opposed to failing the application fast.

Fixes https://github.com/dotnet/runtime/issues/66030