### PR TITLE
Revert "Use SSA def descriptors in copy propagation (#65250)"

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -352,13 +352,6 @@ public:
         assert(ssaNum != SsaConfig::RESERVED_SSA_NUM);
         return GetSsaDefByIndex(ssaNum - GetMinSsaNum());
     }
-
-    // Get an SSA number associated with the specified SSA def (that must be in this array).
-    unsigned GetSsaNum(T* ssaDef)
-    {
-        assert((m_array <= ssaDef) && (ssaDef < &m_array[m_count]));
-        return GetMinSsaNum() + static_cast<unsigned>(ssaDef - &m_array[0]);
-    }
 };
 
 enum RefCountState
@@ -1087,13 +1080,6 @@ public:
     LclSsaVarDsc* GetPerSsaData(unsigned ssaNum)
     {
         return lvPerSsaData.GetSsaDef(ssaNum);
-    }
-
-    // Returns the SSA number for "ssaDef". Requires "ssaDef" to be a valid definition
-    // of this variable.
-    unsigned GetSsaNumForSsaDef(LclSsaVarDsc* ssaDef)
-    {
-        return lvPerSsaData.GetSsaNum(ssaDef);
     }
 
     var_types GetRegisterType(const GenTreeLclVarCommon* tree) const;
@@ -7414,54 +7400,17 @@ protected:
 
 public:
     // VN based copy propagation.
-
-    // In DEBUG builds, we'd like to know the tree that the SSA definition was pushed for.
-    // While for ordinary SSA defs it will be available (as an ASG) in the SSA descriptor,
-    // for locals which will use "definitions from uses", it will not be, so we store it
-    // in this class instead.
-    class CopyPropSsaDef
-    {
-        LclSsaVarDsc* m_ssaDef;
-#ifdef DEBUG
-        GenTree* m_defNode;
-#endif
-    public:
-        CopyPropSsaDef(LclSsaVarDsc* ssaDef, GenTree* defNode)
-            : m_ssaDef(ssaDef)
-#ifdef DEBUG
-            , m_defNode(defNode)
-#endif
-        {
-        }
-
-        LclSsaVarDsc* GetSsaDef() const
-        {
-            return m_ssaDef;
-        }
-
-#ifdef DEBUG
-        GenTree* GetDefNode() const
-        {
-            return m_defNode;
-        }
-#endif
-    };
-
-    typedef ArrayStack<CopyPropSsaDef> CopyPropSsaDefStack;
-    typedef JitHashTable<unsigned, JitSmallPrimitiveKeyFuncs<unsigned>, CopyPropSsaDefStack*> LclNumToLiveDefsMap;
+    typedef ArrayStack<GenTree*> GenTreePtrStack;
+    typedef JitHashTable<unsigned, JitSmallPrimitiveKeyFuncs<unsigned>, GenTreePtrStack*> LclNumToGenTreePtrStack;
 
     // Copy propagation functions.
-    void optCopyProp(Statement* stmt, GenTreeLclVarCommon* tree, unsigned lclNum, LclNumToLiveDefsMap* curSsaName);
-    void optBlockCopyPropPopStacks(BasicBlock* block, LclNumToLiveDefsMap* curSsaName);
-    void optBlockCopyProp(BasicBlock* block, LclNumToLiveDefsMap* curSsaName);
-    void optCopyPropPushDef(GenTreeOp*           asg,
-                            GenTreeLclVarCommon* lclNode,
-                            unsigned             lclNum,
-                            LclNumToLiveDefsMap* curSsaName);
+    void optCopyProp(Statement* stmt, GenTreeLclVarCommon* tree, unsigned lclNum, LclNumToGenTreePtrStack* curSsaName);
+    void optBlockCopyPropPopStacks(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName);
+    void optBlockCopyProp(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName);
     unsigned optIsSsaLocal(GenTreeLclVarCommon* lclNode);
-    int optCopyProp_LclVarScore(const LclVarDsc* lclVarDsc, const LclVarDsc* copyVarDsc, bool preferOp2);
+    int optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc, bool preferOp2);
     void optVnCopyProp();
-    INDEBUG(void optDumpCopyPropStack(LclNumToLiveDefsMap* curSsaName));
+    INDEBUG(void optDumpCopyPropStack(LclNumToGenTreePtrStack* curSsaName));
 
     /**************************************************************************
      *               Early value propagation

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12849,7 +12849,7 @@ DONE_MORPHING_CHILDREN:
                 // Perform the transform ADDR(COMMA(x, ..., z)) == COMMA(x, ..., ADDR(z)).
                 // (Be sure to mark "z" as an l-value...)
 
-                ArrayStack<GenTree*> commas(getAllocator(CMK_ArrayStack));
+                GenTreePtrStack commas(getAllocator(CMK_ArrayStack));
                 for (GenTree* comma = op1; comma != nullptr && comma->gtOper == GT_COMMA; comma = comma->gtGetOp2())
                 {
                     commas.Push(comma);

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -467,7 +467,7 @@ GenTree* MorphInitBlockHelper::MorphCommaBlock(Compiler* comp, GenTreeOp* firstC
 {
     assert(firstComma->OperIs(GT_COMMA));
 
-    ArrayStack<GenTree*> commas(comp->getAllocator(CMK_ArrayStack));
+    Compiler::GenTreePtrStack commas(comp->getAllocator(CMK_ArrayStack));
     for (GenTree* currComma = firstComma; currComma != nullptr && currComma->OperIs(GT_COMMA);
          currComma          = currComma->gtGetOp2())
     {


### PR DESCRIPTION
This reverts commit 9012b2373581b6f0d1e0418bd3646b05f37958e1.

Fixes #65940
