### PR TITLE
Disable SuperPMI replay jobs until #65332 is fixed

### DIFF
--- a/src/coreclr/scripts/superpmi_replay.py
+++ b/src/coreclr/scripts/superpmi_replay.py
@@ -26,11 +26,13 @@ parser.add_argument("-log_directory", help="path to the directory containing sup
 
 jit_flags = [
     "JitStressRegs=0",
-    "JitStressRegs=1",
+    # JitStressRegs=1 disabled due to https://github.com/dotnet/runtime/issues/65332
+    # "JitStressRegs=1",
     "JitStressRegs=2",
     "JitStressRegs=3",
     "JitStressRegs=4",
-    "JitStressRegs=8",
+    # JitStressRegs=8 disabled due to https://github.com/dotnet/runtime/issues/65332
+    # "JitStressRegs=8",
     "JitStressRegs=0x10",
     "JitStressRegs=0x80",
     "JitStressRegs=0x1000",


### PR DESCRIPTION
Specifically, JitStressRegs=1 and JitStressRegs=8 legs.
Note that #65332 only hits 1 failure in each of these legs, and
only on arm64 platforms, but we don't have a way to be more
precise in our disabling.