### PR TITLE
Run superpmi-replay pipeline on JIT PRs

### DIFF
--- a/eng/pipelines/coreclr/superpmi-replay.yml
+++ b/eng/pipelines/coreclr/superpmi-replay.yml
@@ -1,8 +1,10 @@
+# This pipeline only runs on GitHub PRs, not on merges.
+trigger: none
+
 # Only run on changes to the JIT directory. Don't run if the JIT-EE GUID has changed,
 # since there won't be any SuperPMI collections with the new GUID until the collection
-# pipeline completes.
-trigger:
-  batch: false
+# pipeline completes after this PR is merged.
+pr:
   branches:
     include:
     - main


### PR DESCRIPTION
Currently, the `runtime-coreclr superpmi-replay` pipeline is run
when a JIT change is merged. This change moves the checking to happen
on the PR pre-merge, as a requirement for merging.