### PR TITLE
Fix copy propagation

### DIFF
--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -43,11 +43,13 @@ void Compiler::optBlockCopyPropPopStacks(BasicBlock* block, LclNumToLiveDefsMap*
                 }
 
                 CopyPropSsaDefStack* stack = nullptr;
-                curSsaName->Lookup(lclNum, &stack);
-                stack->Pop();
-                if (stack->Empty())
+                if (curSsaName->Lookup(lclNum, &stack))
                 {
-                    curSsaName->Remove(lclNum);
+                    stack->Pop();
+                    if (stack->Empty())
+                    {
+                        curSsaName->Remove(lclNum);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Now that we don't push any defs for shadowed parameters, we don't want to pop them as well.