### PR TITLE
Keep CLSCompliantAttribute in sync for src <-> ref

### DIFF
--- a/eng/ApiCompatExcludeAttributes.txt
+++ b/eng/ApiCompatExcludeAttributes.txt
@@ -1,4 +1,3 @@
-T:System.CLSCompliantAttribute
 T:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute
 T:System.Diagnostics.DebuggerGuidedStepThroughAttribute
 T:System.Runtime.CompilerServices.EagerStaticClassConstructionAttribute

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -1438,6 +1438,7 @@ namespace System.Runtime.InteropServices.ComTypes
         void EnumConnectionPoints(out System.Runtime.InteropServices.ComTypes.IEnumConnectionPoints ppEnum);
         void FindConnectionPoint(ref System.Guid riid, out System.Runtime.InteropServices.ComTypes.IConnectionPoint? ppCP);
     }
+    [System.CLSCompliantAttribute(false)]
     [System.Runtime.InteropServices.InterfaceTypeAttribute(System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIUnknown)]
     public partial interface IDataObject
     {

--- a/src/libraries/apicompat/ApiCompatBaselineExcludedAttributes.txt
+++ b/src/libraries/apicompat/ApiCompatBaselineExcludedAttributes.txt
@@ -1,4 +1,5 @@
 // These attributes shouldn't be checked against baseline reference assemblies
 
+T:System.CLSCompliantAttribute
 T:System.ComponentModel.EditorBrowsableAttribute
 T:System.ObsoleteAttribute


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/58163

Until two years ago, ApiCompat validated the CLSCompliantAttribute
but that check was then disabled with a675e1c2c4f46b98ecac1253223649d8f36d5da7.

Re-enable it and only disable the check during baseline api compat
validation, which is performed in ApiCompat.proj.