### PR TITLE
Fix performance regression in SSL handshake

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -48,11 +48,18 @@ namespace System.Net
             SafeFreeCertContext? remoteContext = null;
             try
             {
-                if (!SSPIWrapper.QueryContextAttributes_SECPKG_ATTR_REMOTE_CERT_CONTEXT(GlobalSSPI.SSPISecureChannel, securityContext, out remoteContext))
+                // SECPKG_ATTR_REMOTE_CERT_CONTEXT will not succeed before TLS handshake completes. Inside the handshake,
+                // we need to use (more expensive) SECPKG_ATTR_REMOTE_CERT_CHAIN. That one may be unsupported on older
+                // versions of windows. In that case, we have no option than to return null.
+                //
+                // We can use retrieveCollection to distinguish between in-handshake and after-handshake calls, because
+                // the collection is retrieved for cert validation purposes after the handshake completes.
+                if (retrieveCollection) // handshake completed
                 {
-                    // The query can fail if TLS handshake has not completed yet. In that case we fallback to querying
-                    // SECPKG_ATTR_REMOTE_CERT_CHAIN that is more expensive but works even during handshake.
-                    // Note: On Windows versions which don't support querying CERT_CHAIN, we fail and always return null
+                    SSPIWrapper.QueryContextAttributes_SECPKG_ATTR_REMOTE_CERT_CONTEXT(GlobalSSPI.SSPISecureChannel, securityContext, out remoteContext);
+                }
+                else // in handshake
+                {
                     SSPIWrapper.QueryContextAttributes_SECPKG_ATTR_REMOTE_CERT_CHAIN(GlobalSSPI.SSPISecureChannel, securityContext, out remoteContext);
                 }
 


### PR DESCRIPTION
Fixes Issue #66012

The perf regression seems to be due to `SECPKG_ATTR_REMOTE_CERT_CHAIN` being more expensive to query than `SECPKG_ATTR_REMOTE_CERT_CONTEXT` used until #65134. This PR swaps the order of their querying so that CERT_CHAIN is queried only when we really need the certificate before TLS handshake is completed (i.e. during `LocalClientCertificateSelectionCallback`).

local run of the affected benchmark:
- main - current main as of defd20c1c58887b0af733ebc7b2498ba3a8e8e12
- reverted - main with changes from #65134 reverted (baseline comparison)
- 7.0.0 - this PR

```ini
 BenchmarkDotNet=v0.13.1.1702-nightly, OS=Windows 11 (10.0.22000.493/21H2)                                                                                                                
 Intel Core i9-10900K CPU 3.70GHz, 1 CPU, 20 logical and 10 physical cores                                                                                                                
 .NET SDK=7.0.100-preview.3.22151.18                                                                                                                                                      
   [Host]     : .NET 7.0.0 (7.0.22.11609), X64 RyuJIT                                                                                                                                     
   Job-CGHVCJ : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT                                                                                                                                   
   Job-GSIUQU : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT                                                                                                                                   
   Job-RHRBBQ : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT                                                                                                                                   
                                                                                                                                                                                          
 PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:DebugType=portable,-bl:benchmarkdotnet.binlog  IterationTime=250.0000 ms                                                
 MaxIterationCount=20  MinIterationCount=15  WarmupCount=1                                                                                                                                
                                                                                                                                                                                          
 |                           Method |        Job |             Toolchain |     Mean |     Error |    StdDev |   Median |      Min |      Max | Ratio | RatioSD | Allocated | Alloc Ratio |
 |--------------------------------- |----------- |---------------------- |---------:|----------:|----------:|---------:|---------:|---------:|------:|--------:|----------:|------------:|
 | DefaultHandshakeContextIPv6Async | Job-CGHVCJ |    \7.0.0\corerun.exe | 1.677 ms | 0.0928 ms | 0.1069 ms | 1.632 ms | 1.523 ms | 1.846 ms |  0.99 |    0.10 |   5.59 KB |        1.00 |
 | DefaultHandshakeContextIPv6Async | Job-GSIUQU |     \main\corerun.exe | 1.736 ms | 0.0469 ms | 0.0521 ms | 1.726 ms | 1.656 ms | 1.850 ms |  1.02 |    0.07 |   5.58 KB |        0.99 |
 | DefaultHandshakeContextIPv6Async | Job-RHRBBQ | \reverted\corerun.exe | 1.709 ms | 0.0915 ms | 0.1054 ms | 1.679 ms | 1.545 ms | 1.856 ms |  1.00 |    0.00 |   5.62 KB |        1.00 |
```

The perf diff seems to be small on my machine, but maybe it is more pronounced on Win10 where the product benchmarks run.