### PR TITLE
Keep MemberNotNullAttribute in sync for src <-> ref

### DIFF
--- a/eng/ApiCompatExcludeAttributes.txt
+++ b/eng/ApiCompatExcludeAttributes.txt
@@ -1,3 +1,2 @@
-T:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute
 T:System.Diagnostics.DebuggerGuidedStepThroughAttribute
 T:System.Runtime.CompilerServices.EagerStaticClassConstructionAttribute

--- a/eng/DefaultGenApiDocIds.txt
+++ b/eng/DefaultGenApiDocIds.txt
@@ -4,7 +4,6 @@ T:System.ComponentModel.Design.Serialization.RootDesignerSerializerAttribute
 T:System.Configuration.ConfigurationPropertyAttribute
 T:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
 T:System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute
-T:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute
 T:System.Diagnostics.CodeAnalysis.SuppressMessageAttribute
 T:System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute
 T:System.Diagnostics.DebuggerBrowsableAttribute

--- a/eng/referenceAssemblies.props
+++ b/eng/referenceAssemblies.props
@@ -15,6 +15,9 @@
 
     <!-- We dont need to add null annotation within the ref for explicit interface methods. -->
     <NoWarn>$(NoWarn);CS8617</NoWarn>
+
+    <!-- MemberNotNullAttribute without underlying field. -->
+    <NoWarn>$(NoWarn);CS8776</NoWarn>
   </PropertyGroup>
 
   <!-- All reference assemblies should have a ReferenceAssemblyAttribute and the 0x70 flag which prevents them from loading. -->

--- a/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -277,6 +277,7 @@ namespace System.ComponentModel
         public override object? ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object value) { throw null; }
         public override object? ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type destinationType) { throw null; }
         protected virtual string GetCultureName(System.Globalization.CultureInfo culture) { throw null; }
+        [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_values")]
         public override System.ComponentModel.TypeConverter.StandardValuesCollection GetStandardValues(System.ComponentModel.ITypeDescriptorContext? context) { throw null; }
         public override bool GetStandardValuesExclusive(System.ComponentModel.ITypeDescriptorContext? context) { throw null; }
         public override bool GetStandardValuesSupported(System.ComponentModel.ITypeDescriptorContext? context) { throw null; }

--- a/src/libraries/System.Diagnostics.TraceSource/ref/System.Diagnostics.TraceSource.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/ref/System.Diagnostics.TraceSource.cs
@@ -42,7 +42,7 @@ namespace System.Diagnostics
     public partial class SourceFilter : System.Diagnostics.TraceFilter
     {
         public SourceFilter(string source) { }
-        public string Source { get { throw null; } set { } }
+        public string Source { get { throw null; } [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_src")] set { } }
         public override bool ShouldTrace(System.Diagnostics.TraceEventCache? cache, string source, System.Diagnostics.TraceEventType eventType, int id, string? formatOrMessage, object?[]? args, object? data1, object?[]? data) { throw null; }
     }
     [System.FlagsAttribute]
@@ -84,8 +84,8 @@ namespace System.Diagnostics
     {
         public SwitchAttribute(string switchName, System.Type switchType) { }
         public string? SwitchDescription { get { throw null; } set { } }
-        public string SwitchName { get { throw null; } set { } }
-        public System.Type SwitchType { get { throw null; } set { } }
+        public string SwitchName { get { throw null; } [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_name")] set { } }
+        public System.Type SwitchType { get { throw null; } [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_type")] set { } }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Types may be trimmed from the assembly.")]
         public static System.Diagnostics.SwitchAttribute[] GetAll(System.Reflection.Assembly assembly) { throw null; }
     }
@@ -93,7 +93,7 @@ namespace System.Diagnostics
     public sealed partial class SwitchLevelAttribute : System.Attribute
     {
         public SwitchLevelAttribute(System.Type switchLevelType) { }
-        public System.Type SwitchLevelType { get { throw null; } set { } }
+        public System.Type SwitchLevelType { get { throw null; } [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_type")] set { } }
     }
     public sealed partial class Trace
     {

--- a/src/libraries/System.DirectoryServices/ref/System.DirectoryServices.cs
+++ b/src/libraries/System.DirectoryServices/ref/System.DirectoryServices.cs
@@ -182,6 +182,7 @@ namespace System.DirectoryServices
         public void InvokeSet(string propertyName, params object?[]? args) { }
         public void MoveTo(System.DirectoryServices.DirectoryEntry newParent) { }
         public void MoveTo(System.DirectoryServices.DirectoryEntry newParent, string? newName) { }
+        [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_adsObject")]
         public void RefreshCache() { }
         public void RefreshCache(string[] propertyNames) { }
         public void Rename(string? newName) { }

--- a/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -297,7 +297,7 @@ namespace System.Net
         public NetworkCredential(string? userName, string? password) { }
         public NetworkCredential(string? userName, string? password, string? domain) { }
         [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
-        public string Domain { get { throw null; } set { } }
+        public string Domain { get { throw null; } [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_domain")] set { } }
         [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public string Password { get { throw null; } set { } }
         [System.CLSCompliantAttribute(false)]

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -9494,7 +9494,7 @@ namespace System.Globalization
         public string[] AbbreviatedMonthGenitiveNames { get { throw null; } set { } }
         public string[] AbbreviatedMonthNames { get { throw null; } set { } }
         public string AMDesignator { get { throw null; } set { } }
-        public System.Globalization.Calendar Calendar { get { throw null; } set { } }
+        public System.Globalization.Calendar Calendar { get { throw null; } [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("calendar")] set { } }
         public System.Globalization.CalendarWeekRule CalendarWeekRule { get { throw null; } set { } }
         public static System.Globalization.DateTimeFormatInfo CurrentInfo { get { throw null; } }
         public string DateSeparator { get { throw null; } set { } }
@@ -9943,7 +9943,7 @@ namespace System.Globalization
         public StringInfo() { }
         public StringInfo(string value) { }
         public int LengthInTextElements { get { throw null; } }
-        public string String { get { throw null; } set { } }
+        public string String { get { throw null; } [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_str")] set { } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? value) { throw null; }
         public override int GetHashCode() { throw null; }
         public static string GetNextTextElement(string str) { throw null; }

--- a/src/libraries/System.Security.AccessControl/ref/System.Security.AccessControl.cs
+++ b/src/libraries/System.Security.AccessControl/ref/System.Security.AccessControl.cs
@@ -317,7 +317,7 @@ namespace System.Security.AccessControl
     {
         internal KnownAce() { }
         public int AccessMask { get { throw null; } set { } }
-        public System.Security.Principal.SecurityIdentifier SecurityIdentifier { get { throw null; } set { } }
+        public System.Security.Principal.SecurityIdentifier SecurityIdentifier { get { throw null; } [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_sid")] set { } }
     }
     public abstract partial class NativeObjectSecurity : System.Security.AccessControl.CommonObjectSecurity
     {

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -167,7 +167,7 @@ namespace System.Security.Cryptography
         public AsnEncodedData(string oid, byte[] rawData) { }
         public AsnEncodedData(string oid, System.ReadOnlySpan<byte> rawData) { }
         public System.Security.Cryptography.Oid? Oid { get { throw null; } set { } }
-        public byte[] RawData { get { throw null; } set { } }
+        public byte[] RawData { get { throw null; } [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_rawData")] set { } }
         public virtual void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
         public virtual string Format(bool multiLine) { throw null; }
     }

--- a/src/libraries/System.ServiceProcess.ServiceController/ref/System.ServiceProcess.ServiceController.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/ref/System.ServiceProcess.ServiceController.cs
@@ -40,7 +40,7 @@ namespace System.ServiceProcess
         public int ExitCode { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
         protected System.IntPtr ServiceHandle { get { throw null; } }
-        public string ServiceName { get { throw null; } set { } }
+        public string ServiceName { get { throw null; } [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_serviceName")] set { } }
         protected override void Dispose(bool disposing) { }
         protected virtual void OnContinue() { }
         protected virtual void OnCustomCommand(int command) { }

--- a/src/libraries/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
+++ b/src/libraries/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
@@ -223,10 +223,10 @@ namespace System.Text.RegularExpressions
         public RegexCompilationInfo(string pattern, System.Text.RegularExpressions.RegexOptions options, string name, string fullnamespace, bool ispublic, System.TimeSpan matchTimeout) { }
         public bool IsPublic { get { throw null; } set { } }
         public System.TimeSpan MatchTimeout { get { throw null; } set { } }
-        public string Name { get { throw null; } set { } }
-        public string Namespace { get { throw null; } set { } }
+        public string Name { get { throw null; } [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_name")] set { } }
+        public string Namespace { get { throw null; } [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_nspace")] set { } }
         public System.Text.RegularExpressions.RegexOptions Options { get { throw null; } set { } }
-        public string Pattern { get { throw null; } set { } }
+        public string Pattern { get { throw null; } [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_pattern")] set { } }
     }
     [System.AttributeUsageAttribute(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
     public sealed partial class RegexGeneratorAttribute : System.Attribute

--- a/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
+++ b/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
@@ -283,13 +283,13 @@ namespace System.Xml
     {
         protected internal XmlDeclaration(string version, string? encoding, string? standalone, System.Xml.XmlDocument doc) { }
         [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
-        public string Encoding { get { throw null; } set { } }
+        public string Encoding { get { throw null; } [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_encoding")] set { } }
         public override string InnerText { get { throw null; } set { } }
         public override string LocalName { get { throw null; } }
         public override string Name { get { throw null; } }
         public override System.Xml.XmlNodeType NodeType { get { throw null; } }
         [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
-        public string Standalone { get { throw null; } set { } }
+        public string Standalone { get { throw null; } [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_standalone")] set { } }
         public override string? Value { get { throw null; } set { } }
         public string Version { get { throw null; } }
         public override System.Xml.XmlNode CloneNode(bool deep) { throw null; }
@@ -1337,11 +1337,11 @@ namespace System.Xml
         public bool CloseOutput { get { throw null; } set { } }
         public System.Xml.ConformanceLevel ConformanceLevel { get { throw null; } set { } }
         public bool DoNotEscapeUriAttributes { get { throw null; } set { } }
-        public System.Text.Encoding Encoding { get { throw null; } set { } }
+        public System.Text.Encoding Encoding { get { throw null; } [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_encoding")] set { } }
         public bool Indent { get { throw null; } set { } }
-        public string IndentChars { get { throw null; } set { } }
+        public string IndentChars { get { throw null; } [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_indentChars")] set { } }
         public System.Xml.NamespaceHandling NamespaceHandling { get { throw null; } set { } }
-        public string NewLineChars { get { throw null; } set { } }
+        public string NewLineChars { get { throw null; } [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_newLineChars")] set { } }
         public System.Xml.NewLineHandling NewLineHandling { get { throw null; } set { } }
         public bool NewLineOnAttributes { get { throw null; } set { } }
         public bool OmitXmlDeclaration { get { throw null; } set { } }

--- a/src/libraries/System.Xml.XmlSerializer/ref/System.Xml.XmlSerializer.cs
+++ b/src/libraries/System.Xml.XmlSerializer/ref/System.Xml.XmlSerializer.cs
@@ -519,6 +519,7 @@ namespace System.Xml.Serialization
         protected object? ReadReferencedElement(string? name, string? ns) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Members from serialized types may be trimmed if not referenced directly")]
         protected void ReadReferencedElements() { }
+        [System.Diagnostics.CodeAnalysis.MemberNotNullAttribute("_callbacks")]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Members from serialized types may be trimmed if not referenced directly")]
         protected object? ReadReferencingElement(string? name, string? ns, bool elementCanBeType, out string? fixupReference) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Members from serialized types may be trimmed if not referenced directly")]


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/58163

Enable ApiCompat protection for the MemberNotNull attribute.