### PR TITLE
[release/6.0] Add a target to force packages which reference serviced packages to also be serviced

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -288,4 +288,19 @@
     <Error Condition="'$(ServicingVersion)' == '0'" Text="ServicingVersion is set to 0 and it should be an increment of the patch version from the last released package." />
   </Target>
 
+  <ItemDefinitionGroup>
+    <TargetPathWithTargetPlatformMoniker>
+      <GeneratePackageOnBuild>$(GeneratePackageOnBuild)</GeneratePackageOnBuild>
+    </TargetPathWithTargetPlatformMoniker>
+  </ItemDefinitionGroup>
+
+  <Target Name="ValidateBuiltPackageInServicing" 
+          Condition="'$(PreReleaseVersionLabel)' == 'servicing' and '$(IsPackable)' == 'true'"
+          AfterTargets="ResolveReferences">
+
+      <Error Condition="'$(GeneratePackageOnBuild)' != 'true' and 
+                        '%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference' and 
+                        '%(ReferencePath.GeneratePackageOnBuild)' == 'true'"
+             Text="This project did not set GeneratePackageOnBuild, but dependencies '%(ReferencePath.OriginalProjectReferenceItemSpec)' did.  Please ship this project by setting GeneratePackageOnBuild to true." />
+  </Target>
 </Project>


### PR DESCRIPTION
Putting this out as a suggestion and demonstrating how it would work.

This would make it so that any other packages in dotnet/runtime would also ship whenever one of their dependencies ship.