### PR TITLE
JIT: add hash and tiering name to assert message

### DIFF
--- a/src/coreclr/jit/error.cpp
+++ b/src/coreclr/jit/error.cpp
@@ -280,8 +280,10 @@ extern "C" void __cdecl assertAbort(const char* why, const char* file, unsigned 
     if (env->compiler)
     {
         phaseName = PhaseNames[env->compiler->mostRecentlyActivePhase];
-        _snprintf_s(buff, BUFF_SIZE, _TRUNCATE, "Assertion failed '%s' in '%s' during '%s' (IL size %d)\n", why,
-                    env->compiler->info.compFullName, phaseName, env->compiler->info.compILCodeSize);
+        _snprintf_s(buff, BUFF_SIZE, _TRUNCATE,
+                    "Assertion failed '%s' in '%s' during '%s' (IL size %d; hash 0x%08x; %s)\n", why,
+                    env->compiler->info.compFullName, phaseName, env->compiler->info.compILCodeSize,
+                    env->compiler->info.compMethodHash(), env->compiler->compGetTieringName(/* short name */ true));
         msg = buff;
     }
     printf(""); // null string means flush


### PR DESCRIPTION
Now that methods may be jitted multiple times and may have complex names, it is
useful to know their hashes and tiering names as part of asserts.