### PR TITLE
Skip Upper vector save/restore for blocks that THROW

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -6359,7 +6359,7 @@ void LinearScan::insertUpperVectorRestore(GenTree*     tree,
                                           Interval*    upperVectorInterval,
                                           BasicBlock*  block)
 {
-    JITDUMP("Adding UpperVectorRestore for RP #%d ", refPosition->rpNum);
+    JITDUMP("Inserting UpperVectorRestore for RP #%d ", refPosition->rpNum);
     Interval* lclVarInterval = upperVectorInterval->relatedInterval;
     assert(lclVarInterval->isLocalVar == true);
     regNumber lclVarReg = lclVarInterval->physReg;
@@ -6407,7 +6407,6 @@ void LinearScan::insertUpperVectorRestore(GenTree*     tree,
     simdNode->SetRegNum(restoreReg);
 
     LIR::Range& blockRange = LIR::AsRange(block);
-    JITDUMP("Adding UpperVectorRestore ");
     if (tree != nullptr)
     {
         JITDUMP("before %d.%s:\n", tree->gtTreeID, GenTree::OpName(tree->gtOper));

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -2275,7 +2275,7 @@ public:
 
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
     // If upper vector save/restore can be avoided.
-    unsigned char skipSaveRestore: 1;
+    unsigned char skipSaveRestore : 1;
 #endif
 
 #ifdef DEBUG

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -996,7 +996,6 @@ private:
     void buildRefPositionsForNode(GenTree* tree, LsraLocation loc);
 
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-    bool shouldBuildUpperVectorSaveRestore(GenTree* tree);
     void buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation currentLoc, regMaskTP fpCalleeKillSet);
     void buildUpperVectorRestoreRefPosition(Interval* lclVarInterval, LsraLocation currentLoc, GenTree* node);
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -997,7 +997,10 @@ private:
 
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
     void buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation currentLoc, regMaskTP fpCalleeKillSet);
-    void buildUpperVectorRestoreRefPosition(Interval* lclVarInterval, LsraLocation currentLoc, GenTree* node);
+    void buildUpperVectorRestoreRefPosition(Interval*    lclVarInterval,
+                                            LsraLocation currentLoc,
+                                            GenTree*     node,
+                                            bool         isUse);
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
 
 #if defined(UNIX_AMD64_ABI)
@@ -2269,6 +2272,11 @@ public:
     // register currently assigned to the Interval.  This happens when we use the assigned
     // register from a predecessor that is not the most recently allocated BasicBlock.
     unsigned char outOfOrder : 1;
+
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+    // If upper vector save/restore can be avoided.
+    unsigned char skipSaveRestore: 1;
+#endif
 
 #ifdef DEBUG
     // Minimum number registers that needs to be ensured while

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -996,6 +996,7 @@ private:
     void buildRefPositionsForNode(GenTree* tree, LsraLocation loc);
 
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+    bool shouldBuildUpperVectorSaveRestore(GenTree* tree);
     void buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation currentLoc, regMaskTP fpCalleeKillSet);
     void buildUpperVectorRestoreRefPosition(Interval* lclVarInterval, LsraLocation currentLoc, GenTree* node);
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -618,6 +618,10 @@ RefPosition* LinearScan::newRefPosition(Interval*    theInterval,
     newRP->setMultiRegIdx(multiRegIdx);
     newRP->setRegOptional(false);
 
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+    newRP->skipSaveRestore = false;
+#endif
+
     associateRefPosWithInterval(newRP);
 
     if (RefTypeIsDef(newRP->refType))
@@ -1475,7 +1479,7 @@ void LinearScan::buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation cu
 {
     if ((tree != nullptr) && tree->IsCall())
     {
-        if (tree->AsCall()->IsNoReturn())
+        if (tree->AsCall()->IsNoReturn() || compiler->fgIsThrow(tree))
         {
             // No point in having vector save/restore if the call will not return.
             return;
@@ -1492,7 +1496,9 @@ void LinearScan::buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation cu
         // We only need to save the upper half of any large vector vars that are currently live.
         VARSET_TP       liveLargeVectors(VarSetOps::Intersection(compiler, currentLiveVars, largeVectorVars));
         VarSetOps::Iter iter(compiler, liveLargeVectors);
-        unsigned        varIndex = 0;
+        unsigned        varIndex     = 0;
+        bool            isThrowBlock = compiler->compCurBB->KindIs(BBJ_THROW);
+
         while (iter.NextElem(&varIndex))
         {
             Interval* varInterval = getIntervalForLocalVar(varIndex);
@@ -1502,6 +1508,7 @@ void LinearScan::buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation cu
                 RefPosition* pos =
                     newRefPosition(upperVectorInterval, currentLoc, RefTypeUpperVectorSave, tree, RBM_FLT_CALLEE_SAVED);
                 varInterval->isPartiallySpilled = true;
+                pos->skipSaveRestore = isThrowBlock;
 #ifdef TARGET_XARCH
                 pos->regOptional = true;
 #endif
@@ -1570,17 +1577,33 @@ void LinearScan::buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation cu
 //    currentLoc     - The current location for which we're building RefPositions
 //    node           - The node, if any, that the restore would be inserted before.
 //                     If null, the restore will be inserted at the end of the block.
+//    isUse          - If the refPosition that is about to be created represents a use or not.
+//                   - If not, it would be the one at the end of the block.
 //
-void LinearScan::buildUpperVectorRestoreRefPosition(Interval* lclVarInterval, LsraLocation currentLoc, GenTree* node)
+void LinearScan::buildUpperVectorRestoreRefPosition(Interval* lclVarInterval, LsraLocation currentLoc, GenTree* node, bool isUse)
 {
     if (lclVarInterval->isPartiallySpilled)
     {
         unsigned     varIndex            = lclVarInterval->getVarIndex(compiler);
         Interval*    upperVectorInterval = getUpperVectorInterval(varIndex);
-        RefPosition* pos = newRefPosition(upperVectorInterval, currentLoc, RefTypeUpperVectorRestore, node, RBM_NONE);
+        RefPosition*  savePos            = upperVectorInterval->recentRefPosition;
+        RefPosition* restorePos = newRefPosition(upperVectorInterval, currentLoc, RefTypeUpperVectorRestore, node, RBM_NONE);
         lclVarInterval->isPartiallySpilled = false;
+
+        if (isUse)
+        {
+            // If there was a use of the restore before end of the block restore,
+            // then it is needed and cannot be eliminated
+            savePos->skipSaveRestore = false;
+        }
+        else
+        {
+            // otherwise, just do the whatever was decided for save position
+            restorePos->skipSaveRestore = savePos->skipSaveRestore;
+        }
+
 #ifdef TARGET_XARCH
-        pos->regOptional = true;
+        restorePos->regOptional = true;
 #endif
     }
 }
@@ -2254,6 +2277,7 @@ void LinearScan::buildIntervals()
     for (block = startBlockSequence(); block != nullptr; block = moveToNextBlock())
     {
         JITDUMP("\nNEW BLOCK " FMT_BB "\n", block->bbNum);
+        compiler->compCurBB = block;
 
         bool predBlockIsAllocated = false;
         predBlock                 = findPredBlockForLiveIn(block, prevBlock DEBUGARG(&predBlockIsAllocated));
@@ -2406,16 +2430,12 @@ void LinearScan::buildIntervals()
         // they *may) be partially spilled at any point.
         if (enregisterLocalVars)
         {
-            if (!block->KindIs(BBJ_THROW))
+            VarSetOps::Iter largeVectorVarsIter(compiler, largeVectorVars);
+            unsigned        largeVectorVarIndex = 0;
+            while (largeVectorVarsIter.NextElem(&largeVectorVarIndex))
             {
-                // No point in having vector save/restore if the block ends with throw.
-                VarSetOps::Iter largeVectorVarsIter(compiler, largeVectorVars);
-                unsigned        largeVectorVarIndex = 0;
-                while (largeVectorVarsIter.NextElem(&largeVectorVarIndex))
-                {
-                    Interval* lclVarInterval = getIntervalForLocalVar(largeVectorVarIndex);
-                    buildUpperVectorRestoreRefPosition(lclVarInterval, currentLoc, nullptr);
-                }
+                Interval* lclVarInterval = getIntervalForLocalVar(largeVectorVarIndex);
+                buildUpperVectorRestoreRefPosition(lclVarInterval, currentLoc, nullptr, false);
             }
         }
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
@@ -2968,7 +2988,7 @@ RefPosition* LinearScan::BuildUse(GenTree* operand, regMaskTP candidates, int mu
             VarSetOps::RemoveElemD(compiler, currentLiveVars, varIndex);
         }
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-        buildUpperVectorRestoreRefPosition(interval, currentLoc, operand);
+        buildUpperVectorRestoreRefPosition(interval, currentLoc, operand, true);
 #endif
     }
     else if (operand->IsMultiRegLclVar())
@@ -2982,7 +3002,7 @@ RefPosition* LinearScan::BuildUse(GenTree* operand, regMaskTP candidates, int mu
             VarSetOps::RemoveElemD(compiler, currentLiveVars, fieldVarDsc->lvVarIndex);
         }
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-        buildUpperVectorRestoreRefPosition(interval, currentLoc, operand);
+        buildUpperVectorRestoreRefPosition(interval, currentLoc, operand, true);
 #endif
     }
     else

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -1508,7 +1508,7 @@ void LinearScan::buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation cu
                 RefPosition* pos =
                     newRefPosition(upperVectorInterval, currentLoc, RefTypeUpperVectorSave, tree, RBM_FLT_CALLEE_SAVED);
                 varInterval->isPartiallySpilled = true;
-                pos->skipSaveRestore = isThrowBlock;
+                pos->skipSaveRestore            = isThrowBlock;
 #ifdef TARGET_XARCH
                 pos->regOptional = true;
 #endif
@@ -1580,14 +1580,18 @@ void LinearScan::buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation cu
 //    isUse          - If the refPosition that is about to be created represents a use or not.
 //                   - If not, it would be the one at the end of the block.
 //
-void LinearScan::buildUpperVectorRestoreRefPosition(Interval* lclVarInterval, LsraLocation currentLoc, GenTree* node, bool isUse)
+void LinearScan::buildUpperVectorRestoreRefPosition(Interval*    lclVarInterval,
+                                                    LsraLocation currentLoc,
+                                                    GenTree*     node,
+                                                    bool         isUse)
 {
     if (lclVarInterval->isPartiallySpilled)
     {
         unsigned     varIndex            = lclVarInterval->getVarIndex(compiler);
         Interval*    upperVectorInterval = getUpperVectorInterval(varIndex);
-        RefPosition*  savePos            = upperVectorInterval->recentRefPosition;
-        RefPosition* restorePos = newRefPosition(upperVectorInterval, currentLoc, RefTypeUpperVectorRestore, node, RBM_NONE);
+        RefPosition* savePos             = upperVectorInterval->recentRefPosition;
+        RefPosition* restorePos =
+            newRefPosition(upperVectorInterval, currentLoc, RefTypeUpperVectorRestore, node, RBM_NONE);
         lclVarInterval->isPartiallySpilled = false;
 
         if (isUse)

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -1457,6 +1457,34 @@ Interval* LinearScan::getUpperVectorInterval(unsigned varIndex)
 }
 
 //------------------------------------------------------------------------
+// shouldBuildUpperVectorSaveRestore - Check if vector save/restore is needed.
+//
+// Arguments:
+//    tree       - The current node being handled
+//
+// Notes: Vector save/restore is usually not needed before the call that never returns.
+//        It is also not needed if the block ends with a throw.
+bool LinearScan::shouldBuildUpperVectorSaveRestore(GenTree* tree)
+{
+    if ((tree != nullptr) && tree->IsCall())
+    {
+        if (tree->AsCall()->IsNoReturn())
+        {
+            // No point in having vector save/restore if the call will not return.
+            return false;
+        }
+    }
+
+    if ((compiler->compCurBB != nullptr) && (compiler->compCurBB->KindIs(BBJ_THROW)))
+    {
+        // No point in having vector save/restore if the block ends with throw.
+        return false;
+    }
+
+    return true;
+}
+
+//------------------------------------------------------------------------
 // buildUpperVectorSaveRefPositions - Create special RefPositions for saving
 //                                    the upper half of a set of large vectors.
 //
@@ -1473,13 +1501,9 @@ Interval* LinearScan::getUpperVectorInterval(unsigned varIndex)
 //
 void LinearScan::buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation currentLoc, regMaskTP fpCalleeKillSet)
 {
-    if ((tree != nullptr) && tree->IsCall())
+    if (!shouldBuildUpperVectorSaveRestore(tree))
     {
-        if (tree->AsCall()->IsNoReturn())
-        {
-            // No point in having vector save/restore if the call will not return.
-            return;
-        }
+        return;
     }
 
     if (enregisterLocalVars && !VarSetOps::IsEmpty(compiler, largeVectorVars))
@@ -1575,6 +1599,8 @@ void LinearScan::buildUpperVectorRestoreRefPosition(Interval* lclVarInterval, Ls
 {
     if (lclVarInterval->isPartiallySpilled)
     {
+        assert(shouldBuildUpperVectorSaveRestore(node));
+
         unsigned     varIndex            = lclVarInterval->getVarIndex(compiler);
         Interval*    upperVectorInterval = getUpperVectorInterval(varIndex);
         RefPosition* pos = newRefPosition(upperVectorInterval, currentLoc, RefTypeUpperVectorRestore, node, RBM_NONE);
@@ -2254,6 +2280,7 @@ void LinearScan::buildIntervals()
     for (block = startBlockSequence(); block != nullptr; block = moveToNextBlock())
     {
         JITDUMP("\nNEW BLOCK " FMT_BB "\n", block->bbNum);
+        compiler->compCurBB = block;
 
         bool predBlockIsAllocated = false;
         predBlock                 = findPredBlockForLiveIn(block, prevBlock DEBUGARG(&predBlockIsAllocated));

--- a/src/coreclr/scripts/superpmi_replay.py
+++ b/src/coreclr/scripts/superpmi_replay.py
@@ -26,13 +26,11 @@ parser.add_argument("-log_directory", help="path to the directory containing sup
 
 jit_flags = [
     "JitStressRegs=0",
-    # JitStressRegs=1 disabled due to https://github.com/dotnet/runtime/issues/65332
-    # "JitStressRegs=1",
+    "JitStressRegs=1",
     "JitStressRegs=2",
     "JitStressRegs=3",
     "JitStressRegs=4",
-    # JitStressRegs=8 disabled due to https://github.com/dotnet/runtime/issues/65332
-    # "JitStressRegs=8",
+    "JitStressRegs=8",
     "JitStressRegs=0x10",
     "JitStressRegs=0x80",
     "JitStressRegs=0x1000",


### PR DESCRIPTION
Currently, we save and restore vectors for `BBJ_THROW` blocks as well, which is not really needed. In https://github.com/dotnet/runtime/pull/62662, we avoiding doing save/restore for calls that do not return. This PR extends the logic to also skip save/restore if the block ends with throw.

This also reverts https://github.com/dotnet/runtime/pull/66062.

Fixes: https://github.com/dotnet/runtime/issues/65332