### PR TITLE
Update RegexGenerator to require LangVersion > 10

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
@@ -138,7 +138,7 @@ namespace System.Text.RegularExpressions.Generator
                 return Diagnostic.Create(DiagnosticDescriptors.RegexMethodMustHaveValidSignature, methodSyntax.GetLocation());
             }
 
-            if (typeDec.SyntaxTree.Options is CSharpParseOptions { LanguageVersion: < LanguageVersion.CSharp10 })
+            if (typeDec.SyntaxTree.Options is CSharpParseOptions { LanguageVersion: <= LanguageVersion.CSharp10 })
             {
                 return Diagnostic.Create(DiagnosticDescriptors.InvalidLangVersion, methodSyntax.GetLocation());
             }

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/Strings.resx
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/Strings.resx
@@ -135,7 +135,7 @@
     <value>Regex method must be partial, parameterless, non-generic, and return Regex</value>
   </data>
   <data name="InvalidLangVersionMessage" xml:space="preserve">
-    <value>C# LangVersion of 10 or greater is required</value>
+    <value>C# LangVersion of 11 or greater is required</value>
   </data>
   <data name="LimitedSourceGenerationTitle" xml:space="preserve">
     <value>RegexGenerator limitation reached.</value>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.cs.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 10 or greater is required</source>
-        <target state="translated">Je požadována verze jazyku C# LangVersion 10 nebo vyšší.</target>
+        <source>C# LangVersion of 11 or greater is required</source>
+        <target state="needs-review-translation">Je požadována verze jazyku C# LangVersion 10 nebo vyšší.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.de.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 10 or greater is required</source>
-        <target state="translated">C#-LangVersion von 10 oder höher ist erforderlich</target>
+        <source>C# LangVersion of 11 or greater is required</source>
+        <target state="needs-review-translation">C#-LangVersion von 10 oder höher ist erforderlich</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.es.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 10 or greater is required</source>
-        <target state="translated">Se requiere C# LangVersion de 10 o superior.</target>
+        <source>C# LangVersion of 11 or greater is required</source>
+        <target state="needs-review-translation">Se requiere C# LangVersion de 10 o superior.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.fr.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 10 or greater is required</source>
-        <target state="translated">C# LangVersion supérieur ou égal à 10 est requis</target>
+        <source>C# LangVersion of 11 or greater is required</source>
+        <target state="needs-review-translation">C# LangVersion supérieur ou égal à 10 est requis</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.it.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 10 or greater is required</source>
-        <target state="translated">È richiesta la versione 10 o successiva del linguaggio C#</target>
+        <source>C# LangVersion of 11 or greater is required</source>
+        <target state="needs-review-translation">È richiesta la versione 10 o successiva del linguaggio C#</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ja.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 10 or greater is required</source>
-        <target state="translated">C# LangVersion 10 以上が必要です</target>
+        <source>C# LangVersion of 11 or greater is required</source>
+        <target state="needs-review-translation">C# LangVersion 10 以上が必要です</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ko.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 10 or greater is required</source>
-        <target state="translated">10 이상의 C# LangVersion이 필요합니다.</target>
+        <source>C# LangVersion of 11 or greater is required</source>
+        <target state="needs-review-translation">10 이상의 C# LangVersion이 필요합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pl.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 10 or greater is required</source>
-        <target state="translated">Wymagane jest wersja 10 lub nowsza języka C# LangVersion </target>
+        <source>C# LangVersion of 11 or greater is required</source>
+        <target state="needs-review-translation">Wymagane jest wersja 10 lub nowsza języka C# LangVersion </target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 10 or greater is required</source>
-        <target state="translated">C# LangVersion de 10 ou maior é necessário</target>
+        <source>C# LangVersion of 11 or greater is required</source>
+        <target state="needs-review-translation">C# LangVersion de 10 ou maior é necessário</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ru.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 10 or greater is required</source>
-        <target state="translated">Требуется C# LangVersion 10 или выше</target>
+        <source>C# LangVersion of 11 or greater is required</source>
+        <target state="needs-review-translation">Требуется C# LangVersion 10 или выше</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.tr.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 10 or greater is required</source>
-        <target state="translated">C# LangVersion 10 veya üstü gereklidir</target>
+        <source>C# LangVersion of 11 or greater is required</source>
+        <target state="needs-review-translation">C# LangVersion 10 veya üstü gereklidir</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 10 or greater is required</source>
-        <target state="translated">需要 C# LangVersion 10 或更高版本</target>
+        <source>C# LangVersion of 11 or greater is required</source>
+        <target state="needs-review-translation">需要 C# LangVersion 10 或更高版本</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidLangVersionMessage">
-        <source>C# LangVersion of 10 or greater is required</source>
-        <target state="translated">需要 10 或更大的 C# LangVersion</target>
+        <source>C# LangVersion of 11 or greater is required</source>
+        <target state="needs-review-translation">需要 10 或更大的 C# LangVersion</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidRegexArgumentsMessage">

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorParserTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorParserTests.cs
@@ -180,9 +180,10 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Equal("SYSLIB1043", Assert.Single(diagnostics).Id);
         }
 
-        [ActiveIssue("https://github.com/dotnet/roslyn/pull/55866")]
-        [Fact]
-        public async Task Diagnostic_InvalidLangVersion()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp9)]
+        [InlineData(LanguageVersion.CSharp10)]
+        public async Task Diagnostic_InvalidLangVersion(LanguageVersion version)
         {
             IReadOnlyList<Diagnostic> diagnostics = await RegexGeneratorHelper.RunGenerator(@"
                 using System.Text.RegularExpressions;
@@ -191,7 +192,7 @@ namespace System.Text.RegularExpressions.Tests
                     [RegexGenerator(""ab"")]
                     private static partial Regex InvalidLangVersion();
                 }
-            ", langVersion: LanguageVersion.CSharp9);
+            ", langVersion: version);
 
             Assert.Equal("SYSLIB1044", Assert.Single(diagnostics).Id);
         }


### PR DESCRIPTION
We plan to take a dependency on a C# 11 language feature.  For now, reserve that right by requiring a version > 10.  We can downgrade it later if possible and desired.