### PR TITLE
Switch field being examined by NullablePublicOnlyOtherTypesTest

### DIFF
--- a/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
@@ -759,7 +759,7 @@ namespace System.Reflection.Tests
             Assert.Equal(NullabilityState.Nullable, info.ReadState);
             Assert.Equal(NullabilityState.Nullable, info.WriteState);
 
-            privateNullableField = regexType.GetField("_code", flags)!;
+            privateNullableField = regexType.GetField("_runner", flags)!;
             info = nullabilityContext.Create(privateNullableField);
             Assert.Equal(NullabilityState.Unknown, info.ReadState);
             Assert.Equal(NullabilityState.Unknown, info.WriteState);


### PR DESCRIPTION
We should subsequently rewrite the tests to stop relying on the private members of types in other assemblies, but for now this gets the test passing.