### PR TITLE
Fix marshalling issue with BerVal

### DIFF
--- a/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
@@ -168,7 +168,7 @@ internal static partial class Interop
             ConnectionHandle ld,
             [MarshalAs(UnmanagedType.LPUTF8Str)] string dn,
             [MarshalAs(UnmanagedType.LPUTF8Str)] string mechanism,
-            in BerVal cred,
+            BerVal cred,
             IntPtr serverctrls,
             IntPtr clientctrls,
             IntPtr servercredp);
@@ -188,7 +188,7 @@ internal static partial class Interop
         public static partial IntPtr ldap_err2string(int err);
 
         [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_extended_operation")]
-        public static partial int ldap_extended_operation(ConnectionHandle ldapHandle, [MarshalAs(UnmanagedType.LPUTF8Str)] string oid, in BerVal data, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
+        public static partial int ldap_extended_operation(ConnectionHandle ldapHandle, [MarshalAs(UnmanagedType.LPUTF8Str)] string oid, BerVal data, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
 
         [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_first_attribute")]
         public static partial IntPtr ldap_first_attribute(ConnectionHandle ldapHandle, IntPtr result, ref IntPtr address);
@@ -257,7 +257,7 @@ internal static partial class Interop
             ConnectionHandle ldapHandle,
             [MarshalAs(UnmanagedType.LPUTF8Str)] string dn,
             [MarshalAs(UnmanagedType.LPUTF8Str)] string attributeName,
-            in BerVal binaryValue,
+            BerVal binaryValue,
             IntPtr servercontrol,
             IntPtr clientcontrol,
             ref int messageNumber);


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/64279 introduced an issue with the marshalling of BerVal which is causing System.DirectoryServces.Protocols to fail to authenticate against an LDAP server when using credentials due to an encoding issue caused by an extra indirection. With the help of @jkoritzinsky we found that this was because we had an extra indirection on the PInvokes where we passed in this struct.

This PR fixes that issue and I have validated that our DirectoryServicesProtocols manual tests all pass after this change.

cc: @lscorcia since you were seeing this issue locally. After merging this you should be able to run your scenario tests again.