### PR TITLE
Initial lookbehind support for RegexCompiler / source generator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -1024,16 +1024,20 @@ namespace System.Text.RegularExpressions.Generator
                 // the whole alternation can be treated as a simple switch, so we special-case that. However,
                 // we can't goto _into_ switch cases, which means we can't use this approach if there's any
                 // possibility of backtracking into the alternation.
-                bool useSwitchedBranches = isAtomic;
-                if (!useSwitchedBranches)
+                bool useSwitchedBranches = false;
+                if ((node.Options & RegexOptions.RightToLeft) == 0)
                 {
-                    useSwitchedBranches = true;
-                    for (int i = 0; i < childCount; i++)
+                    useSwitchedBranches = isAtomic;
+                    if (!useSwitchedBranches)
                     {
-                        if (analysis.MayBacktrack(node.Child(i)))
+                        useSwitchedBranches = true;
+                        for (int i = 0; i < childCount; i++)
                         {
-                            useSwitchedBranches = false;
-                            break;
+                            if (analysis.MayBacktrack(node.Child(i)))
+                            {
+                                useSwitchedBranches = false;
+                                break;
+                            }
                         }
                     }
                 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -2603,6 +2603,7 @@ namespace System.Text.RegularExpressions
                     case RegexNodeKind.Capture:
                     case RegexNodeKind.Concatenate:
                     case RegexNodeKind.Alternate:
+                    case RegexNodeKind.BackreferenceConditional or RegexNodeKind.ExpressionConditional:
                     case RegexNodeKind.Empty:
                     case RegexNodeKind.Nothing:
                     case RegexNodeKind.PositiveLookaround:
@@ -2625,7 +2626,6 @@ namespace System.Text.RegularExpressions
                     case RegexNodeKind.Loop:
                     case RegexNodeKind.Lazyloop:
                     case RegexNodeKind.Backreference:
-                    case RegexNodeKind.BackreferenceConditional or RegexNodeKind.ExpressionConditional:
                         reason = "an unsupported positive or negative lookbehind was used";
                         return false;
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -2610,6 +2610,9 @@ namespace System.Text.RegularExpressions
                     case RegexNodeKind.NonBoundary:
                     case RegexNodeKind.ECMABoundary:
                     case RegexNodeKind.NonECMABoundary:
+                    case RegexNodeKind.Beginning or RegexNodeKind.Start:
+                    case RegexNodeKind.Bol or RegexNodeKind.Eol:
+                    case RegexNodeKind.End or RegexNodeKind.EndZ:
                         break;
 
                     // Not yet supported for RightToLeft (when this section is empty because
@@ -2623,9 +2626,6 @@ namespace System.Text.RegularExpressions
                     case RegexNodeKind.Alternate:
                     case RegexNodeKind.Backreference:
                     case RegexNodeKind.BackreferenceConditional or RegexNodeKind.ExpressionConditional:
-                    case RegexNodeKind.Beginning or RegexNodeKind.Start:
-                    case RegexNodeKind.Bol or RegexNodeKind.Eol:
-                    case RegexNodeKind.End or RegexNodeKind.EndZ:
                         reason = "an unsupported positive or negative lookbehind was used";
                         return false;
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -2602,6 +2602,7 @@ namespace System.Text.RegularExpressions
                     case RegexNodeKind.Atomic:
                     case RegexNodeKind.Capture:
                     case RegexNodeKind.Concatenate:
+                    case RegexNodeKind.Alternate:
                     case RegexNodeKind.Empty:
                     case RegexNodeKind.Nothing:
                     case RegexNodeKind.PositiveLookaround:
@@ -2623,7 +2624,6 @@ namespace System.Text.RegularExpressions
                     case RegexNodeKind.Oneloopatomic or RegexNodeKind.Notoneloopatomic or RegexNodeKind.Setloopatomic:
                     case RegexNodeKind.Loop:
                     case RegexNodeKind.Lazyloop:
-                    case RegexNodeKind.Alternate:
                     case RegexNodeKind.Backreference:
                     case RegexNodeKind.BackreferenceConditional or RegexNodeKind.ExpressionConditional:
                         reason = "an unsupported positive or negative lookbehind was used";

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -98,6 +98,7 @@ namespace System.Text.RegularExpressions.Tests
                     yield return (@"(?<=^123 abc)def", "123 abcdef", RegexOptions.Multiline, 0, 10, true, "def");
                     yield return (@"(?<=123$\nabc)def", "123\nabcdef", RegexOptions.Multiline, 0, 10, true, "def");
                     yield return (@"123(?<!$) abcdef", "123 abcdef", RegexOptions.None, 0, 10, true, "123 abcdef");
+                    yield return (@"\w{3}(?<=^xyz|^abc)defg", "abcdefg", RegexOptions.Multiline, 0, 7, true, "abcdefg");
 
                     // Zero-width negative lookbehind assertion: Actual - "(\\w){6}(?<!XXX)def"
                     yield return (@"(\w){6}(?<!XXX)def", "XXXabcdef", RegexOptions.None, 0, 9, true, "XXXabcdef");

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -94,6 +94,10 @@ namespace System.Text.RegularExpressions.Tests
                     yield return (@"(?<=a\wc)def", "123abcdef", RegexOptions.None, 0, 9, true, "def");
                     yield return (@"(?<=\ba\wc)def", "123 abcdef", RegexOptions.None, 0, 10, true, "def");
                     yield return (@"(?<=.\ba\wc\B)def", "123 abcdef", RegexOptions.None, 0, 10, true, "def");
+                    yield return (@"(?<=^123 abc)def", "123 abcdef", RegexOptions.None, 0, 10, true, "def");
+                    yield return (@"(?<=^123 abc)def", "123 abcdef", RegexOptions.Multiline, 0, 10, true, "def");
+                    yield return (@"(?<=123$\nabc)def", "123\nabcdef", RegexOptions.Multiline, 0, 10, true, "def");
+                    yield return (@"123(?<!$) abcdef", "123 abcdef", RegexOptions.None, 0, 10, true, "123 abcdef");
 
                     // Zero-width negative lookbehind assertion: Actual - "(\\w){6}(?<!XXX)def"
                     yield return (@"(\w){6}(?<!XXX)def", "XXXabcdef", RegexOptions.None, 0, 9, true, "XXXabcdef");

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -84,11 +84,16 @@ namespace System.Text.RegularExpressions.Tests
 
                 if (!RegexHelpers.IsNonBacktracking(engine))
                 {
-                    // Zero-width negative lookahead assertion: Actual - "abc(?!XXX)\\w+"
+                    // Zero-width negative lookahead assertion
                     yield return (@"abc(?!XXX)\w+", "abcXXXdef", RegexOptions.None, 0, 9, false, string.Empty);
 
-                    // Zero-width positive lookbehind assertion: Actual - "(\\w){6}(?<=XXX)def"
+                    // Zero-width positive lookbehind assertion
                     yield return (@"(\w){6}(?<=XXX)def", "abcXXXdef", RegexOptions.None, 0, 9, true, "abcXXXdef");
+                    yield return (@"(?<=c)def", "123abcdef", RegexOptions.None, 0, 9, true, "def");
+                    yield return (@"(?<=abc)def", "123abcdef", RegexOptions.None, 0, 9, true, "def");
+                    yield return (@"(?<=a\wc)def", "123abcdef", RegexOptions.None, 0, 9, true, "def");
+                    yield return (@"(?<=\ba\wc)def", "123 abcdef", RegexOptions.None, 0, 10, true, "def");
+                    yield return (@"(?<=.\ba\wc\B)def", "123 abcdef", RegexOptions.None, 0, 10, true, "def");
 
                     // Zero-width negative lookbehind assertion: Actual - "(\\w){6}(?<!XXX)def"
                     yield return (@"(\w){6}(?<!XXX)def", "XXXabcdef", RegexOptions.None, 0, 9, true, "XXXabcdef");

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -98,7 +98,11 @@ namespace System.Text.RegularExpressions.Tests
                     yield return (@"(?<=^123 abc)def", "123 abcdef", RegexOptions.Multiline, 0, 10, true, "def");
                     yield return (@"(?<=123$\nabc)def", "123\nabcdef", RegexOptions.Multiline, 0, 10, true, "def");
                     yield return (@"123(?<!$) abcdef", "123 abcdef", RegexOptions.None, 0, 10, true, "123 abcdef");
-                    yield return (@"\w{3}(?<=^xyz|^abc)defg", "abcdefg", RegexOptions.Multiline, 0, 7, true, "abcdefg");
+                    yield return (@"\w{3}(?<=^xyz|^abc)defg", "abcdefg", RegexOptions.None, 0, 7, true, "abcdefg");
+                    yield return (@"(abc)\w(?<=(?(1)d|e))", "abcdabc", RegexOptions.None, 0, 7, true, "abcd");
+                    yield return (@"(abc)\w(?<!(?(1)e|d))", "abcdabc", RegexOptions.None, 0, 7, true, "abcd");
+                    yield return (@"(abc)\w(?<=(?(cd)d|e))", "abcdabc", RegexOptions.None, 0, 7, true, "abcd");
+                    yield return (@"(abc)\w(?<!(?(cd)e|d))", "abcdabc", RegexOptions.None, 0, 7, true, "abcd");
 
                     // Zero-width negative lookbehind assertion: Actual - "(\\w){6}(?<!XXX)def"
                     yield return (@"(\w){6}(?<!XXX)def", "XXXabcdef", RegexOptions.None, 0, 9, true, "XXXabcdef");

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorParserTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorParserTests.cs
@@ -234,7 +234,7 @@ namespace System.Text.RegularExpressions.Tests
                 using System.Text.RegularExpressions;
                 partial class C
                 {
-                    [RegexGenerator(""(?<=\b20)\d{2}\b"")]
+                    [RegexGenerator(@""(?<=20*)\d{2}\b"")]
                     private static partial Regex PositiveLookbehindNotSupported();
                 }
             ");
@@ -249,7 +249,7 @@ namespace System.Text.RegularExpressions.Tests
                 using System.Text.RegularExpressions;
                 partial class C
                 {
-                    [RegexGenerator(""(?<!(Saturday|Sunday) )\b\w+ \d{1,2}, \d{4}\b"")]
+                    [RegexGenerator(@""(?<!(Saturday|Sunday) )\b\w+ \d{1,2}, \d{4}\b"")]
                     private static partial Regex NegativeLookbehindNotSupported();
                 }
             ");

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorParserTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorParserTests.cs
@@ -249,7 +249,7 @@ namespace System.Text.RegularExpressions.Tests
                 using System.Text.RegularExpressions;
                 partial class C
                 {
-                    [RegexGenerator(@""(?<!(Saturday|Sunday) )\b\w+ \d{1,2}, \d{4}\b"")]
+                    [RegexGenerator(@""(?<!(Saturday|Sun?day) )\b\w+ \d{1,2}, \d{4}\b"")]
                     private static partial Regex NegativeLookbehindNotSupported();
                 }
             ");


### PR DESCRIPTION
For .NET 7 we rewrote RegexCompiler as we were writing the source generator, and the primary feature that was left out in doing so was support for the rarely-used RegexOptions.RightToLeft.  However, lookbehinds are implemented using RightToLeft support, and that's a more interesting gap.  While adding back full lookbehind support would essentially entail adding back full RightToLeft support, we can get more than half of lookbehinds used in practice (based on our corpus) by supporting only a few of the fixed-width constructs.  This PR adds that support back in to both RegexCompiler and the source generator.  It also sets things up so we can incrementally add in more constructs as we see fit.

Of the 18,964 regexes in our corpus, 17,840 are supported with the compiler / source generator today.  This PR increases the supported count to 18,346, cutting the gap appx in half.  To get the bulk of the remaining ~600, we'd need to add support for loops (in particular set loops).

Contributes to https://github.com/dotnet/runtime/issues/62345