### PR TITLE
Fix `mcs -merge` to stop printing an error message on success

### DIFF
--- a/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
+++ b/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
@@ -578,10 +578,15 @@ CLEAN_UP:
     }
     else
     {
-        // if no files found to merge, then there was some problem.
-        LogError("No files found to merge.");
-        result = (totalSize == 0) ? 1 : 0;
+        if (totalSize == 0)
+        {
+            // If the total size of merged files is zero, or there were no files found to merge,
+            // then there was some problem.
+            LogError("No files found to merge.");
+            result = 1;
+        }
     }
+
     delete[] nameOfOutputFileAsWchar;
 
     return result;


### PR DESCRIPTION
Even on success, it would print "ERROR: No files found to merge."