### PR TITLE
Remove leftover runtextbeg/end references from RegexCompiler / source generator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -375,7 +375,7 @@ namespace System.Text.RegularExpressions.Generator
             var additionalDeclarations = new HashSet<string>();
 
             // Emit locals initialization
-            writer.WriteLine("int pos = base.runtextpos, end = base.runtextend;");
+            writer.WriteLine("int pos = base.runtextpos;");
             writer.Flush();
             int additionalDeclarationsPosition = ((StringWriter)writer.InnerWriter).GetStringBuilder().Length;
             int additionalDeclarationsIndent = writer.Indent;
@@ -388,9 +388,9 @@ namespace System.Text.RegularExpressions.Generator
             Debug.Assert(minRequiredLength >= 0);
             string clause = minRequiredLength switch
                             {
-                                0 => "if (pos <= end)",
-                                1 => "if (pos < end)",
-                                _ => $"if (pos < end - {minRequiredLength - 1})"
+                                0 => "if (pos <= inputSpan.Length)",
+                                1 => "if (pos < inputSpan.Length)",
+                                _ => $"if (pos < inputSpan.Length - {minRequiredLength - 1})"
                             };
             using (EmitBlock(writer, clause))
             {
@@ -440,7 +440,7 @@ namespace System.Text.RegularExpressions.Generator
             const string NoStartingPositionFound = "NoStartingPositionFound";
             writer.WriteLine("// No starting position found");
             writer.WriteLine($"{NoStartingPositionFound}:");
-            writer.WriteLine("base.runtextpos = end;");
+            writer.WriteLine("base.runtextpos = inputSpan.Length;");
             writer.WriteLine("return false;");
 
             // We're done.  Patch up any additional declarations.
@@ -459,8 +459,7 @@ namespace System.Text.RegularExpressions.Generator
                 {
                     case FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning:
                         writer.WriteLine("// Beginning \\A anchor");
-                        additionalDeclarations.Add("int beginning = base.runtextbeg;");
-                        using (EmitBlock(writer, "if (pos > beginning)"))
+                        using (EmitBlock(writer, "if (pos > 0)"))
                         {
                             Goto(NoStartingPositionFound);
                         }
@@ -478,18 +477,18 @@ namespace System.Text.RegularExpressions.Generator
 
                     case FindNextStartingPositionMode.LeadingAnchor_LeftToRight_EndZ:
                         writer.WriteLine("// Leading end \\Z anchor");
-                        using (EmitBlock(writer, "if (pos < end - 1)"))
+                        using (EmitBlock(writer, "if (pos < inputSpan.Length - 1)"))
                         {
-                            writer.WriteLine("base.runtextpos = end - 1;");
+                            writer.WriteLine("base.runtextpos = inputSpan.Length - 1;");
                         }
                         writer.WriteLine("return true;");
                         return true;
 
                     case FindNextStartingPositionMode.LeadingAnchor_LeftToRight_End:
                         writer.WriteLine("// Leading end \\z anchor");
-                        using (EmitBlock(writer, "if (pos < end)"))
+                        using (EmitBlock(writer, "if (pos < inputSpan.Length)"))
                         {
-                            writer.WriteLine("base.runtextpos = end;");
+                            writer.WriteLine("base.runtextpos = inputSpan.Length;");
                         }
                         writer.WriteLine("return true;");
                         return true;
@@ -497,9 +496,9 @@ namespace System.Text.RegularExpressions.Generator
                     case FindNextStartingPositionMode.TrailingAnchor_FixedLength_LeftToRight_EndZ:
                         // Jump to the end, minus the min required length, which in this case is actually the fixed length, minus 1 (for a possible ending \n).
                         writer.WriteLine("// Trailing end \\Z anchor with fixed-length match");
-                        using (EmitBlock(writer, $"if (pos < end - {regexTree.FindOptimizations.MinRequiredLength + 1})"))
+                        using (EmitBlock(writer, $"if (pos < inputSpan.Length - {regexTree.FindOptimizations.MinRequiredLength + 1})"))
                         {
-                            writer.WriteLine($"base.runtextpos = end - {regexTree.FindOptimizations.MinRequiredLength + 1};");
+                            writer.WriteLine($"base.runtextpos = inputSpan.Length - {regexTree.FindOptimizations.MinRequiredLength + 1};");
                         }
                         writer.WriteLine("return true;");
                         return true;
@@ -507,9 +506,9 @@ namespace System.Text.RegularExpressions.Generator
                     case FindNextStartingPositionMode.TrailingAnchor_FixedLength_LeftToRight_End:
                         // Jump to the end, minus the min required length, which in this case is actually the fixed length.
                         writer.WriteLine("// Trailing end \\z anchor with fixed-length match");
-                        using (EmitBlock(writer, $"if (pos < end - {regexTree.FindOptimizations.MinRequiredLength})"))
+                        using (EmitBlock(writer, $"if (pos < inputSpan.Length - {regexTree.FindOptimizations.MinRequiredLength})"))
                         {
-                            writer.WriteLine($"base.runtextpos = end - {regexTree.FindOptimizations.MinRequiredLength};");
+                            writer.WriteLine($"base.runtextpos = inputSpan.Length - {regexTree.FindOptimizations.MinRequiredLength};");
                         }
                         writer.WriteLine("return true;");
                         return true;
@@ -525,11 +524,10 @@ namespace System.Text.RegularExpressions.Generator
                         // the other anchors, which all skip all subsequent processing if found, with BOL we just use it
                         // to boost our position to the next line, and then continue normally with any searches.
                         writer.WriteLine("// Beginning-of-line anchor");
-                        additionalDeclarations.Add("int beginning = base.runtextbeg;");
-                        using (EmitBlock(writer, "if (pos > beginning && inputSpan[pos - 1] != '\\n')"))
+                        using (EmitBlock(writer, "if (pos > 0 && inputSpan[pos - 1] != '\\n')"))
                         {
                             writer.WriteLine("int newlinePos = global::System.MemoryExtensions.IndexOf(inputSpan.Slice(pos), '\\n');");
-                            using (EmitBlock(writer, "if (newlinePos < 0 || newlinePos + pos + 1 > end)"))
+                            using (EmitBlock(writer, "if ((uint)newlinePos > inputSpan.Length - pos - 1)"))
                             {
                                 Goto(NoStartingPositionFound);
                             }
@@ -543,18 +541,18 @@ namespace System.Text.RegularExpressions.Generator
                 {
                     case RegexNodeKind.End when regexTree.FindOptimizations.MaxPossibleLength is int maxLength:
                         writer.WriteLine("// End \\z anchor with maximum-length match");
-                        using (EmitBlock(writer, $"if (pos < end - {maxLength})"))
+                        using (EmitBlock(writer, $"if (pos < inputSpan.Length - {maxLength})"))
                         {
-                            writer.WriteLine($"pos = end - {maxLength};");
+                            writer.WriteLine($"pos = inputSpan.Length - {maxLength};");
                         }
                         writer.WriteLine();
                         break;
 
                     case RegexNodeKind.EndZ when regexTree.FindOptimizations.MaxPossibleLength is int maxLength:
                         writer.WriteLine("// End \\Z anchor with maximum-length match");
-                        using (EmitBlock(writer, $"if (pos < end - {maxLength + 1})"))
+                        using (EmitBlock(writer, $"if (pos < inputSpan.Length - {maxLength + 1})"))
                         {
-                            writer.WriteLine($"pos = end - {maxLength + 1};");
+                            writer.WriteLine($"pos = inputSpan.Length - {maxLength + 1};");
                         }
                         writer.WriteLine();
                         break;
@@ -566,7 +564,7 @@ namespace System.Text.RegularExpressions.Generator
             // Emits a case-sensitive prefix search for a string at the beginning of the pattern.
             void EmitIndexOf(string prefix)
             {
-                writer.WriteLine($"int i = global::System.MemoryExtensions.IndexOf(inputSpan.Slice(pos, end - pos), {Literal(prefix)});");
+                writer.WriteLine($"int i = global::System.MemoryExtensions.IndexOf(inputSpan.Slice(pos), {Literal(prefix)});");
                 writer.WriteLine("if (i >= 0)");
                 writer.WriteLine("{");
                 writer.WriteLine("    base.runtextpos = pos + i;");
@@ -592,7 +590,7 @@ namespace System.Text.RegularExpressions.Generator
                 FinishEmitScope loopBlock = default;
                 if (needLoop)
                 {
-                    writer.WriteLine("global::System.ReadOnlySpan<char> span = inputSpan.Slice(pos, end - pos);");
+                    writer.WriteLine("global::System.ReadOnlySpan<char> span = inputSpan.Slice(pos);");
                     string upperBound = "span.Length" + (setsToUse > 1 || primarySet.Distance != 0 ? $" - {minRequiredLength - 1}" : "");
                     loopBlock = EmitBlock(writer, $"for (int i = 0; i < {upperBound}; i++)");
                 }
@@ -601,7 +599,7 @@ namespace System.Text.RegularExpressions.Generator
                 {
                     string span = needLoop ?
                         "span" :
-                        "inputSpan.Slice(pos, end - pos)";
+                        "inputSpan.Slice(pos)";
 
                     span = (needLoop, primarySet.Distance) switch
                     {
@@ -701,7 +699,7 @@ namespace System.Text.RegularExpressions.Generator
 
                 using (EmitBlock(writer, "while (true)"))
                 {
-                    writer.WriteLine($"global::System.ReadOnlySpan<char> slice = inputSpan.Slice(pos, end - pos);");
+                    writer.WriteLine($"global::System.ReadOnlySpan<char> slice = inputSpan.Slice(pos);");
                     writer.WriteLine();
 
                     // Find the literal.  If we can't find it, we're done searching.
@@ -844,7 +842,7 @@ namespace System.Text.RegularExpressions.Generator
 
             // Declare some locals.
             string sliceSpan = "slice";
-            writer.WriteLine("int pos = base.runtextpos, end = base.runtextend;");
+            writer.WriteLine("int pos = base.runtextpos;");
             writer.WriteLine($"int original_pos = pos;");
             bool hasTimeout = EmitLoopTimeoutCounterIfNeeded(writer, rm);
             bool hasTextInfo = EmitInitializeCultureForTryMatchAtCurrentPositionIfNecessary(writer, rm, analysis);
@@ -962,7 +960,7 @@ namespace System.Text.RegularExpressions.Generator
                 {
                     writer.Write("global::System.ReadOnlySpan<char> ");
                 }
-                writer.WriteLine($"{sliceSpan} = inputSpan.Slice(pos, end - pos);");
+                writer.WriteLine($"{sliceSpan} = inputSpan.Slice(pos);");
             }
 
             // Emits the sum of a constant and a value from a local.
@@ -2256,8 +2254,7 @@ namespace System.Text.RegularExpressions.Generator
                         }
                         else
                         {
-                            additionalDeclarations.Add(node.Kind == RegexNodeKind.Beginning ? "int beginning = base.runtextbeg;" : "int start = base.runtextstart;");
-                            using (EmitBlock(writer, node.Kind == RegexNodeKind.Beginning ? "if (pos != beginning)" : "if (pos != start)"))
+                            using (EmitBlock(writer, node.Kind == RegexNodeKind.Beginning ? "if (pos != 0)" : "if (pos != base.runtextstart)"))
                             {
                                 Goto(doneLabel);
                             }
@@ -2275,8 +2272,7 @@ namespace System.Text.RegularExpressions.Generator
                         else
                         {
                             // We can't use our slice in this case, because we'd need to access slice[-1], so we access the inputSpan field directly:
-                            additionalDeclarations.Add("int beginning = base.runtextbeg;");
-                            using (EmitBlock(writer, $"if (pos > beginning && inputSpan[pos - 1] != '\\n')"))
+                            using (EmitBlock(writer, $"if (pos > 0 && inputSpan[pos - 1] != '\\n')"))
                             {
                                 Goto(doneLabel);
                             }
@@ -3000,9 +2996,8 @@ namespace System.Text.RegularExpressions.Generator
                     // .* was used with RegexOptions.Singleline, which means it'll consume everything.  Just jump to the end.
                     // The unbounded constraint is the same as in the Notone case above, done purely for simplicity.
 
-                    // int i = end - pos;
                     TransferSliceStaticPosToPos();
-                    writer.WriteLine($"int {iterationLocal} = end - pos;");
+                    writer.WriteLine($"int {iterationLocal} = inputSpan.Length - pos;");
                 }
                 else
                 {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -17,8 +17,6 @@ namespace System.Text.RegularExpressions
     /// </summary>
     internal abstract class RegexCompiler
     {
-        private static readonly FieldInfo s_runtextbegField = RegexRunnerField("runtextbeg");
-        private static readonly FieldInfo s_runtextendField = RegexRunnerField("runtextend");
         private static readonly FieldInfo s_runtextstartField = RegexRunnerField("runtextstart");
         private static readonly FieldInfo s_runtextposField = RegexRunnerField("runtextpos");
         private static readonly FieldInfo s_runstackField = RegexRunnerField("runstack");
@@ -372,7 +370,6 @@ namespace System.Text.RegularExpressions
 
             LocalBuilder inputSpan = DeclareReadOnlySpanChar();
             LocalBuilder pos = DeclareInt32();
-            LocalBuilder end = DeclareInt32();
 
             _textInfo = null;
             if ((_options & RegexOptions.CultureInvariant) == 0)
@@ -397,10 +394,8 @@ namespace System.Text.RegularExpressions
 
             // Load necessary locals
             // int pos = base.runtextpos;
-            // int end = base.runtextend;
-            // ReadOnlySpan<char> inputSpan = input;
+            // ReadOnlySpan<char> inputSpan = dynamicMethodArg; // TODO: We can reference the arg directly rather than using another local.
             Mvfldloc(s_runtextposField, pos);
-            Mvfldloc(s_runtextendField, end);
             Ldarg_1();
             Stloc(inputSpan);
 
@@ -412,13 +407,14 @@ namespace System.Text.RegularExpressions
             Label returnFalse = DefineLabel();
             Label finishedLengthCheck = DefineLabel();
 
-            // if (pos > end - _code.Tree.MinRequiredLength)
+            // if (pos > inputSpan.Length - _code.Tree.MinRequiredLength)
             // {
-            //     base.runtextpos = end;
+            //     base.runtextpos = inputSpan.Length;
             //     return false;
             // }
             Ldloc(pos);
-            Ldloc(end);
+            Ldloca(inputSpan);
+            Call(s_spanGetLengthMethod);
             if (minRequiredLength > 0)
             {
                 Ldc(minRequiredLength);
@@ -428,7 +424,8 @@ namespace System.Text.RegularExpressions
 
             MarkLabel(returnFalse);
             Ldthis();
-            Ldloc(end);
+            Ldloca(inputSpan);
+            Call(s_spanGetLengthMethod);
 
             Stfld(s_runtextposField);
             Ldc(0);
@@ -485,7 +482,7 @@ namespace System.Text.RegularExpressions
                     case FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning:
                         label = DefineLabel();
                         Ldloc(pos);
-                        Ldthisfld(s_runtextbegField);
+                        Ldc(0);
                         Ble(label);
                         Br(returnFalse);
                         MarkLabel(label);
@@ -507,12 +504,14 @@ namespace System.Text.RegularExpressions
                     case FindNextStartingPositionMode.LeadingAnchor_LeftToRight_EndZ:
                         label = DefineLabel();
                         Ldloc(pos);
-                        Ldloc(end);
+                        Ldloca(inputSpan);
+                        Call(s_spanGetLengthMethod);
                         Ldc(1);
                         Sub();
                         Bge(label);
                         Ldthis();
-                        Ldloc(end);
+                        Ldloca(inputSpan);
+                        Call(s_spanGetLengthMethod);
                         Ldc(1);
                         Sub();
                         Stfld(s_runtextposField);
@@ -524,10 +523,12 @@ namespace System.Text.RegularExpressions
                     case FindNextStartingPositionMode.LeadingAnchor_LeftToRight_End:
                         label = DefineLabel();
                         Ldloc(pos);
-                        Ldloc(end);
+                        Ldloca(inputSpan);
+                        Call(s_spanGetLengthMethod);
                         Bge(label);
                         Ldthis();
-                        Ldloc(end);
+                        Ldloca(inputSpan);
+                        Call(s_spanGetLengthMethod);
                         Stfld(s_runtextposField);
                         MarkLabel(label);
                         Ldc(1);
@@ -541,12 +542,14 @@ namespace System.Text.RegularExpressions
                             int extraNewlineBump = _regexTree.FindOptimizations.FindMode == FindNextStartingPositionMode.TrailingAnchor_FixedLength_LeftToRight_EndZ ? 1 : 0;
                             label = DefineLabel();
                             Ldloc(pos);
-                            Ldloc(end);
+                            Ldloca(inputSpan);
+                            Call(s_spanGetLengthMethod);
                             Ldc(_regexTree.FindOptimizations.MinRequiredLength + extraNewlineBump);
                             Sub();
                             Bge(label);
                             Ldthis();
-                            Ldloc(end);
+                            Ldloca(inputSpan);
+                            Call(s_spanGetLengthMethod);
                             Ldc(_regexTree.FindOptimizations.MinRequiredLength + extraNewlineBump);
                             Sub();
                             Stfld(s_runtextposField);
@@ -570,9 +573,9 @@ namespace System.Text.RegularExpressions
 
                             label = DefineLabel();
 
-                            // if (pos > runtextbeg...
+                            // if (pos > 0...
                             Ldloc(pos!);
-                            Ldthisfld(s_runtextbegField);
+                            Ldc(0);
                             Ble(label);
 
                             // ... && inputSpan[pos - 1] != '\n') { ... }
@@ -595,9 +598,9 @@ namespace System.Text.RegularExpressions
                             {
                                 Stloc(newlinePos);
 
-                                // if (newlinePos < 0 || newlinePos + pos + 1 > end)
+                                // if (newlinePos < 0 || newlinePos + pos + 1 > inputSpan.Length)
                                 // {
-                                //     base.runtextpos = end;
+                                //     base.runtextpos = inputSpan.Length;
                                 //     return false;
                                 // }
                                 Ldloc(newlinePos);
@@ -608,7 +611,8 @@ namespace System.Text.RegularExpressions
                                 Add();
                                 Ldc(1);
                                 Add();
-                                Ldloc(end);
+                                Ldloca(inputSpan);
+                                Call(s_spanGetLengthMethod);
                                 Bgt(returnFalse);
 
                                 // pos += newlinePos + 1;
@@ -633,11 +637,13 @@ namespace System.Text.RegularExpressions
                             int extraNewlineBump = _regexTree.FindOptimizations.FindMode == FindNextStartingPositionMode.TrailingAnchor_FixedLength_LeftToRight_EndZ ? 1 : 0;
                             label = DefineLabel();
                             Ldloc(pos);
-                            Ldloc(end);
+                            Ldloca(inputSpan);
+                            Call(s_spanGetLengthMethod);
                             Ldc(maxLength + extraNewlineBump);
                             Sub();
                             Bge(label);
-                            Ldloc(end);
+                            Ldloca(inputSpan);
+                            Call(s_spanGetLengthMethod);
                             Ldc(maxLength + extraNewlineBump);
                             Sub();
                             Stloc(pos);
@@ -653,13 +659,10 @@ namespace System.Text.RegularExpressions
             {
                 using RentedLocalBuilder i = RentInt32Local();
 
-                // int i = inputSpan.Slice(pos, end - pos).IndexOf(prefix);
+                // int i = inputSpan.Slice(pos).IndexOf(prefix);
                 Ldloca(inputSpan);
                 Ldloc(pos);
-                Ldloc(end);
-                Ldloc(pos);
-                Sub();
-                Call(s_spanSliceIntIntMethod);
+                Call(s_spanSliceIntMethod);
                 Ldstr(prefix);
                 Call(s_stringAsSpanMethod);
                 Call(s_spanIndexOfSpan);
@@ -691,13 +694,10 @@ namespace System.Text.RegularExpressions
                 using RentedLocalBuilder iLocal = RentInt32Local();
                 using RentedLocalBuilder textSpanLocal = RentReadOnlySpanCharLocal();
 
-                // ReadOnlySpan<char> span = inputSpan.Slice(pos, end - pos);
+                // ReadOnlySpan<char> span = inputSpan.Slice(pos);
                 Ldloca(inputSpan);
                 Ldloc(pos);
-                Ldloc(end);
-                Ldloc(pos);
-                Sub();
-                Call(s_spanSliceIntIntMethod);
+                Call(s_spanSliceIntMethod);
                 Stloc(textSpanLocal);
 
                 // If we can use IndexOf{Any}, try to accelerate the skip loop via vectorization to match the first prefix.
@@ -873,7 +873,7 @@ namespace System.Text.RegularExpressions
                     }
                     BltFar(loopBody);
 
-                    // base.runtextpos = end;
+                    // base.runtextpos = inputSpan.Length;
                     // return false;
                     BrFar(returnFalse);
                 }
@@ -893,14 +893,11 @@ namespace System.Text.RegularExpressions
                 Label loopEnd = DefineLabel();
                 MarkLabel(loopBody);
 
-                // ReadOnlySpan<char> slice = inputSpan.Slice(pos, end - pos);
+                // ReadOnlySpan<char> slice = inputSpan.Slice(pos);
                 using RentedLocalBuilder slice = RentReadOnlySpanCharLocal();
                 Ldloca(inputSpan);
                 Ldloc(pos);
-                Ldloc(end);
-                Ldloc(pos);
-                Sub();
-                Call(s_spanSliceIntIntMethod);
+                Call(s_spanSliceIntMethod);
                 Stloc(slice);
 
                 // Find the literal.  If we can't find it, we're done searching.
@@ -1019,7 +1016,7 @@ namespace System.Text.RegularExpressions
                 // }
                 MarkLabel(loopEnd);
 
-                // base.runtextpos = end;
+                // base.runtextpos = inputSpan.Length;
                 // return false;
                 BrFar(returnFalse);
             }
@@ -1097,7 +1094,6 @@ namespace System.Text.RegularExpressions
             LocalBuilder originalPos = DeclareInt32();
             LocalBuilder pos = DeclareInt32();
             LocalBuilder slice = DeclareReadOnlySpanChar();
-            LocalBuilder end = DeclareInt32();
             Label doneLabel = DefineLabel();
             Label originalDoneLabel = doneLabel;
             if (_hasTimeout)
@@ -1109,10 +1105,8 @@ namespace System.Text.RegularExpressions
             InitializeCultureForTryMatchAtCurrentPositionIfNecessary(analysis);
 
             // ReadOnlySpan<char> inputSpan = input;
-            // int end = base.runtextend;
             Ldarg_1();
             Stloc(inputSpan);
-            Mvfldloc(s_runtextendField, end);
 
             // int pos = base.runtextpos;
             // int originalpos = pos;
@@ -1213,13 +1207,10 @@ namespace System.Text.RegularExpressions
             // Slices the inputSpan starting at pos until end and stores it into slice.
             void SliceInputSpan()
             {
-                // slice = inputSpan.Slice(pos, end - pos);
+                // slice = inputSpan.Slice(pos);
                 Ldloca(inputSpan);
                 Ldloc(pos);
-                Ldloc(end);
-                Ldloc(pos);
-                Sub();
-                Call(s_spanSliceIntIntMethod);
+                Call(s_spanSliceIntMethod);
                 Stloc(slice);
             }
 
@@ -1416,7 +1407,7 @@ namespace System.Text.RegularExpressions
                     {
                         // NextBranch:
                         // pos = startingPos;
-                        // slice = inputSpan.Slice(pos, end - pos);
+                        // slice = inputSpan.Slice(pos);
                         // while (base.Crawlpos() > startingCapturePos) base.Uncapture();
                         MarkLabel(nextBranch);
                         Ldloc(startingPos);
@@ -1770,7 +1761,7 @@ namespace System.Text.RegularExpressions
                 // After the condition completes successfully, reset the text positions.
                 // Do not reset captures, which persist beyond the lookahead.
                 // pos = startingPos;
-                // slice = inputSpan.Slice(pos, end - pos);
+                // slice = inputSpan.Slice(pos);
                 Ldloc(startingPos);
                 Stloc(pos);
                 SliceInputSpan();
@@ -2031,7 +2022,7 @@ namespace System.Text.RegularExpressions
                 // After the child completes successfully, reset the text positions.
                 // Do not reset captures, which persist beyond the lookahead.
                 // pos = startingPos;
-                // slice = inputSpan.Slice(pos, end - pos);
+                // slice = inputSpan.Slice(pos);
                 Ldloc(startingPos);
                 Stloc(pos);
                 SliceInputSpan();
@@ -2381,9 +2372,16 @@ namespace System.Text.RegularExpressions
                         }
                         else
                         {
-                            // if (pos > base.runtextbeg/start) goto doneLabel;
+                            // if (pos > 0/start) goto doneLabel;
                             Ldloc(pos);
-                            Ldthisfld(node.Kind == RegexNodeKind.Beginning ? s_runtextbegField : s_runtextstartField);
+                            if (node.Kind == RegexNodeKind.Beginning)
+                            {
+                                Ldc(0);
+                            }
+                            else
+                            {
+                                Ldthisfld(s_runtextstartField);
+                            }
                             BneFar(doneLabel);
                         }
                         break;
@@ -2402,10 +2400,10 @@ namespace System.Text.RegularExpressions
                         else
                         {
                             // We can't use our slice in this case, because we'd need to access slice[-1], so we access the runtext field directly:
-                            // if (pos > base.runtextbeg && base.runtext[pos - 1] != '\n') goto doneLabel;
+                            // if (pos > 0 && base.runtext[pos - 1] != '\n') goto doneLabel;
                             Label success = DefineLabel();
                             Ldloc(pos);
-                            Ldthisfld(s_runtextbegField);
+                            Ldc(0);
                             Ble(success);
                             Ldloca(inputSpan);
                             Ldloc(pos);
@@ -2676,7 +2674,7 @@ namespace System.Text.RegularExpressions
                 Ldloc(endingPos);
                 Stloc(pos);
 
-                // slice = inputSpan.Slice(pos, end - pos);
+                // slice = inputSpan.Slice(pos);
                 SliceInputSpan();
 
                 MarkLabel(endLoop);
@@ -2842,7 +2840,7 @@ namespace System.Text.RegularExpressions
                     BeqFar(doneLabel);
 
                     // pos += startingPos;
-                    // slice = inputSpace.Slice(pos, end - pos);
+                    // slice = inputSpace.Slice(pos);
                     Ldloc(pos);
                     Ldloc(startingPos);
                     Add();
@@ -2903,7 +2901,7 @@ namespace System.Text.RegularExpressions
                     BltFar(doneLabel);
 
                     // pos += startingPos;
-                    // slice = inputSpace.Slice(pos, end - pos);
+                    // slice = inputSpace.Slice(pos);
                     Ldloc(pos);
                     Ldloc(startingPos);
                     Add();
@@ -3463,9 +3461,10 @@ namespace System.Text.RegularExpressions
                     // .* was used with RegexOptions.Singleline, which means it'll consume everything.  Just jump to the end.
                     // The unbounded constraint is the same as in the Notone case above, done purely for simplicity.
 
-                    // int i = end - pos;
+                    // int i = inputSpan.Length - pos;
                     TransferSliceStaticPosToPos();
-                    Ldloc(end);
+                    Ldloca(inputSpan);
+                    Call(s_spanGetLengthMethod);
                     Ldloc(pos);
                     Sub();
                     Stloc(iterationLocal);


### PR DESCRIPTION
Now that we're operating over a span that represents the full input from beginning to end, we no longer need to access runtextbeg/runtextend, we can use inputSpan.Slice(pos) instead of inputSpan.Slice(pos, end - pos), etc.