### PR TITLE
runtime: add RIDs for anolis distro

### DIFF
--- a/eng/native/init-distro-rid.sh
+++ b/eng/native/init-distro-rid.sh
@@ -41,7 +41,7 @@ initNonPortableDistroRid()
             # We have forced __PortableBuild=0. This is because -portablebuld
             # has been passed as false.
             if (( isPortable == 0 )); then
-                if [[ "${ID}" == "rhel" || "${ID}" == "rocky" || "${ID}" == "alpine" ]]; then
+                if [[ "${ID}" == "rhel" || "${ID}" == "rocky" || "${ID}" == "alpine" || "${ID}" == "anolis" ]]; then
                     # remove the last version digit
                     VERSION_ID="${VERSION_ID%.*}"
                 fi

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
@@ -30,6 +30,21 @@
       <Versions>21;22;23;24;25;26;27;28;29;30;31;32</Versions>
     </RuntimeGroup>
 
+    <RuntimeGroup Include="anolis">
+      <Parent>rhel</Parent>
+      <Architectures>x64</Architectures>
+      <Versions>7</Versions>
+      <ApplyVersionsToParent>true</ApplyVersionsToParent>
+      <TreatVersionsAsCompatible>false</TreatVersionsAsCompatible>
+    </RuntimeGroup>
+    <RuntimeGroup Include="anolis">
+      <Parent>rhel</Parent>
+      <Architectures>x64;arm64</Architectures>
+      <Versions>8;9</Versions>
+      <ApplyVersionsToParent>true</ApplyVersionsToParent>
+      <TreatVersionsAsCompatible>false</TreatVersionsAsCompatible>
+    </RuntimeGroup>
+
     <RuntimeGroup Include="arch">
       <Parent>linux</Parent>
       <Architectures>x64</Architectures>

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -718,6 +718,7 @@ static
 pal::string_t normalize_linux_rid(pal::string_t rid)
 {
     pal::string_t rhelPrefix(_X("rhel."));
+    pal::string_t anolisPrefix(_X("anolis."));
     pal::string_t alpinePrefix(_X("alpine."));
     pal::string_t rockyPrefix(_X("rocky."));
     size_t lastVersionSeparatorIndex = std::string::npos;
@@ -737,6 +738,10 @@ pal::string_t normalize_linux_rid(pal::string_t rid)
     else if (rid.compare(0, rockyPrefix.length(), rockyPrefix) == 0)
     {
         lastVersionSeparatorIndex = rid.find(_X("."), rockyPrefix.length());
+    }
+    else if (rid.compare(0, anolisPrefix.length(), anolisPrefix) == 0)
+    {
+        lastVersionSeparatorIndex = rid.find(_X("."), anolisPrefix.length());
     }
 
     if (lastVersionSeparatorIndex != std::string::npos)


### PR DESCRIPTION
instead of patching dotnet everytime after
it got updated we plan to add runtime ID for
anolis 7/anolis 8/anolis 9.

Signed-off-by: Livy Ge <livy.ge@gmail.com>