### PR TITLE
Count `OBJ/BLK` as memory uses

### DIFF
--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -245,6 +245,8 @@ void Compiler::fgPerNodeLocalVarLiveness(GenTree* tree)
             break;
 
         case GT_IND:
+        case GT_OBJ:
+        case GT_BLK:
             // For Volatile indirection, first mutate GcHeap/ByrefExposed
             // see comments in ValueNum.cpp (under case GT_CLS_VAR)
             // This models Volatile reads as def-then-use of memory.

--- a/src/tests/JIT/Directed/lifetime/ObjBlkMemLiveness.cs
+++ b/src/tests/JIT/Directed/lifetime/ObjBlkMemLiveness.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+// Test that memory liveness does not miss a memory use (in the form of an OBJ/BLK).
+
+using System;
+using System.Runtime.Intrinsics;
+using System.Runtime.CompilerServices;
+
+unsafe class ObjBlkLiveness
+{
+    public static int Main()
+    {
+        var a = Vector128<int>.Zero;
+        return Problem(&a, 1) ? 100 : 101;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Problem(Vector128<int>* p, int b)
+    {
+        var a = 2 * *p;
+
+        if (b is 1)
+        {
+            *p = Vector128<int>.AllBitsSet;
+        }
+
+        if (a + *p == Vector128<int>.Zero)
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/tests/JIT/Directed/lifetime/ObjBlkMemLiveness.csproj
+++ b/src/tests/JIT/Directed/lifetime/ObjBlkMemLiveness.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Otherwise SSA can fail to insert a memory PHI where one is needed.

We're expecting diff in one test where I noticed this while rewriting liveness to stop relying on location nodes.