### PR TITLE
Allow marshalling IL_STUB compilation for ndirect methods using crossgen2 if SPC.dll is in the same bubble

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -1383,11 +1383,6 @@ namespace Internal.TypeSystem.Interop
                 ILLocalVariable vPinnedFirstElement = emitter.NewLocal(ManagedElementType.MakeByRefType(), true);
 
                 LoadManagedValue(codeStream);
-                codeStream.Emit(ILOpcode.ldlen);
-                codeStream.Emit(ILOpcode.conv_i4);
-                codeStream.Emit(ILOpcode.brfalse, lNullArray);
-
-                LoadManagedValue(codeStream);
                 codeStream.Emit(ILOpcode.call, emitter.NewToken(getArrayDataReferenceMethod));
                 codeStream.EmitStLoc(vPinnedFirstElement);
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
@@ -347,10 +347,8 @@ namespace ILCompiler
         {
             // PInvokes depend on details of the core library, so for now only compile them if:
             //    1) We're compiling the core library module, or
-            //    2) We're compiling any module, and no marshalling is needed
-            //
-            // TODO Future: consider compiling PInvokes with complex marshalling in version bubble
-            // mode when the core library is included in the bubble.
+            //    2) We're compiling any module, and no marshalling is needed, or
+            //    3) We're compiling any module, and core library module is in the same bubble, and marshaller supports compilation
 
             Debug.Assert(method is EcmaMethod);
 
@@ -359,7 +357,7 @@ namespace ILCompiler
             if (!_versionBubbleModuleSet.Contains(((EcmaMethod)method).Module))
                 return false;
 
-            if (((EcmaMethod)method).Module.Equals(method.Context.SystemModule))
+            if (_versionBubbleModuleSet.Contains(method.Context.SystemModule))
                 return true;
 
             return !Marshaller.IsMarshallingRequired(method);


### PR DESCRIPTION
This is an updated version of https://github.com/dotnet/runtime/pull/54847.

This change reduces number of IL_STUBs compiled during startup on ~70 on tizen xamarin apps. Startup time is improved on ~2.5%.

Fix for `BlittableArrayMarshaller` is required because `Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest/AsDefaultTest.sh` and `Interop/PInvoke/Array/MarshalArrayAsParam/AsLPArray/AsLPArrayTest/AsLPArrayTest.sh` fail when compiled with crossgen2 with input bubble. For example:
```
============ [CStyle_Array_Int_InOut_ZeroLength]	 ============
[CStyle_Array_Int_InOut_ZeroLength] Error: parameter actual is NULL

TEST FAIL: TestLibrary.AssertTestException: Assert.IsTrue: CStyle_Array_Int_InOut_ZeroLength
   at TestLibrary.Assert.HandleFail(String assertionName, String message) in /home/z/Dev/runtime/src/tests/Common/CoreCLRTestLibrary/Assertion.cs:line 734
   at ArrayMarshal.TestMarshalInOut_ByVal() in /home/z/Dev/runtime/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest.cs:line 397
   at ArrayMarshal.Main() in /home/z/Dev/runtime/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest.cs:line 661
```

For both tests problem is with array with 0 length, which is passed as NULL to native function. But it should be a pointer to the non-existing element, and IL_STUB generated at runtime does exactly this. This error might occur even without IL_STUB saving part of this PR when array with 0 length is marshalled in SPC.dll.

Minimal example to reproduce:
```c#
using System;
using System.Runtime.InteropServices;

namespace marshal_test
{
    class Program
    {
  	[DllImport("tmp.so", EntryPoint = "test_func")]
        internal static extern int testFunc([In, Out] int[] value);
	
        static void Main(string[] args)
        {
            Console.WriteLine("Hello World!");
			
	    int[] array = new int[0];

            testFunc(array);
            Console.WriteLine(array.Length);
        }
    }
}
```

```c
#include <malloc.h>
#include <string.h>
#include <stdio.h>

int test_func(int * array)
{
  if (array != NULL)
  {
    printf("NOT NULL ARRAY\n");
  }  
  else
  {
    printf("NULL ARRAY\n");
  }
  return 0;
}
```

cc @alpencolt @jkotas