### PR TITLE
Improve ICU missing msg for Alpine

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.Unix.cs
@@ -44,7 +44,7 @@ namespace System.Globalization
                 else
                 {
                     return "Couldn't find a valid ICU package installed on the system. " +
-                        "Please install libicu (or icu_libs) using your package manager and try again. " +
+                        "Please install libicu (or icu-libs) using your package manager and try again. " +
                         "Alternatively you can set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support. " +
                         "Please see https://aka.ms/dotnet-missing-libicu for more information.";
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.Unix.cs
@@ -44,7 +44,7 @@ namespace System.Globalization
                 else
                 {
                     return "Couldn't find a valid ICU package installed on the system. " +
-                        "Please install libicu using your package manager and try again. " +
+                        "Please install libicu (or icu_libs) using your package manager and try again. " +
                         "Alternatively you can set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support. " +
                         "Please see https://aka.ms/dotnet-missing-libicu for more information.";
                 }


### PR DESCRIPTION
A common scenario where ICU is missing is when you acquire dotnet on Alpine using dotnet-install.sh (as you might in a dev scenario)

In this case the message recommends to install `libicu` with the package manager, but on Alpine it's `icu-libs` (`apk add icu-libs`). 
```
...
[2022/03/03 17:44:59][INFO] dotnet-install: Adding to current process PATH: `/root/git/performance/tools/dotnet/x64`. Note: This change will be visible only when sourcing script.
[2022/03/03 17:44:59][INFO] dotnet-install: Note that the script does not resolve dependencies during installation.
[2022/03/03 17:44:59][INFO] dotnet-install: To check the list of dependencies, go to https://docs.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
[2022/03/03 17:44:59][INFO] dotnet-install: Installation finished successfully.
[2022/03/03 17:44:59][INFO] $ popd
[2022/03/03 17:44:59][INFO] $ dotnet --info
[2022/03/03 17:44:59][INFO] Process terminated. Couldn't find a valid ICU package installed on the system. Please install libicu using your package manager and try again. Alternatively you can set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support. Please see https://aka.ms/dotnet-missing-libicu for more information.
[2022/03/03 17:44:59][INFO]    at System.Environment.FailFast(System.String)
[2022/03/03 17:44:59][INFO]    at System.Globalization.GlobalizationMode+Settings..cctor()
[2022/03/03 17:44:59][INFO]    at System.Globalization.CultureData.CreateCultureWithInvariantData()
[2022/03/03 17:44:59][INFO]    at System.Globalization.CultureData.get_Invariant()
[2022/03/03 17:44:59][INFO]    at System.Globalization.CultureInfo..cctor()
[2022/03/03 17:44:59][INFO]    at System.Globalization.CultureInfo.get_CurrentUICulture()
[2022/03/03 17:44:59][INFO]    at System.TimeZoneInfo.GetUtcStandardDisplayName()
[2022/03/03 17:44:59][INFO]    at System.TimeZoneInfo.CreateUtcTimeZone()
[2022/03/03 17:44:59][INFO]    at System.TimeZoneInfo..cctor()
[2022/03/03 17:44:59][INFO]    at System.DateTime.get_Now()
[2022/03/03 17:44:59][INFO]    at Microsoft.DotNet.Cli.Program.Main(System.String[])
```

Improve message to provide that hint.