### PR TITLE
remove MemoryManagerPinLargeArray test as it tests something that we don't ship

### DIFF
--- a/src/libraries/System.Memory/tests/Memory/MemoryManager.cs
+++ b/src/libraries/System.Memory/tests/Memory/MemoryManager.cs
@@ -139,21 +139,6 @@ namespace System.MemoryTests
         }
 
         [Fact]
-        [OuterLoop]
-        public static void MemoryManagerPinLargeArray()
-        {
-            // Early-out: we can only run this test on 64-bit platforms.
-            if (IntPtr.Size == 4)
-            {
-                return;
-            }
-
-            int[] array = new int[0x2000_0000]; // will produce array with total byte length > 2 GB
-            MemoryManager<int> manager = new CustomMemoryForTest<int>(array);
-            Assert.Throws<ArgumentOutOfRangeException>(() => manager.Pin(int.MinValue));
-        }
-
-        [Fact]
         public static void SpanFromMemoryManagerAfterDispose()
         {
             int[] a = { 91, 92, -93, 94 };


### PR DESCRIPTION
Explanation: the `MemoryManagerPinLargeArray` test fails with OOM from time to time, as it tries to allocate a 2GB array and we don't always have the resources to allow for that.

Since it tests the following logic:

https://github.com/dotnet/runtime/blob/7db092a6ed68a5fbf47962c45bb0c1bb965d02c6/src/libraries/System.Memory/tests/Memory/CustomMemoryForTest.cs#L54-L57

that we don't ship (it's an example implementation of `MemoryManager<T>` derived type) I think that we should just remove it.

fixes #33943