### PR TITLE
Don't add TestLibrary as a reference to all runtime tests

### DIFF
--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -67,10 +67,11 @@
   <PropertyGroup>
     <!-- Since bug in Roslyn for Linux empty DebugType property leads to build failure. See issue Roslyn@20343 -->
     <DebugType Condition=" '$(DebugType)' == '' and '$(RunningOnUnix)' == 'true' ">None</DebugType>
+    <TestLibraryProjectPath>$(RepoRoot)\src\tests\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj</TestLibraryProjectPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(RepoRoot)\src\tests\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" Condition="'$(IsMergedTestRunnerAssembly)' == 'true'" />
   </ItemGroup>
 
   <!--

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_32BIT_il_d.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_32BIT_il_d.ilproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i_array_merge_Target_32BIT.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_32BIT_il_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_32BIT_il_r.ilproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i_array_merge_Target_32BIT.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_64BIT_il_d.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_64BIT_il_d.ilproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i_array_merge_Target_64BIT.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_64BIT_il_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_64BIT_il_r.ilproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i_array_merge_Target_64BIT.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_32BIT_il_d.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_32BIT_il_d.ilproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="u_array_merge_Target_32BIT.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_32BIT_il_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_32BIT_il_r.ilproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="u_array_merge_Target_32BIT.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_64BIT_il_d.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_64BIT_il_d.ilproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="u_array_merge_Target_64BIT.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_64BIT_il_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_64BIT_il_r.ilproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="u_array_merge_Target_64BIT.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_32Bit_x86_il_d.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_32Bit_x86_il_d.ilproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sizeof32_Target_32Bit_x86.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_32Bit_x86_il_r.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_32Bit_x86_il_r.ilproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sizeof32_Target_32Bit_x86.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_64Bit_and_arm_il_d.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_64Bit_and_arm_il_d.ilproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sizeof32_Target_64Bit_and_arm.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_64Bit_and_arm_il_r.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_64Bit_and_arm_il_r.ilproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sizeof32_Target_64Bit_and_arm.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_32Bit_x86_il_d.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_32Bit_x86_il_d.ilproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sizeof64_Target_32Bit_x86.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_32Bit_x86_il_r.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_32Bit_x86_il_r.ilproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sizeof64_Target_32Bit_x86.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_64Bit_and_arm_il_d.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_64Bit_and_arm_il_d.ilproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sizeof64_Target_64Bit_and_arm.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_64Bit_and_arm_il_r.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_64Bit_and_arm_il_r.ilproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sizeof64_Target_64Bit_and_arm.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_32Bit_x86_il_d.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_32Bit_x86_il_d.ilproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sizeof_Target_32Bit_x86.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_32Bit_x86_il_r.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_32Bit_x86_il_r.ilproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sizeof_Target_32Bit_x86.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_64Bit_and_arm_il_d.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_64Bit_and_arm_il_d.ilproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sizeof_Target_64Bit_and_arm.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_64Bit_and_arm_il_r.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_64Bit_and_arm_il_r.ilproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sizeof_Target_64Bit_and_arm.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
When I was tagging several architecture-dependent runtime tests
with the ConditionalFact attribute, I added CoreCLRTestLibrary
as a general reference. This started causing timeouts in Mono AOT
tests because the library needs to be compiled many times.
As there's only a small number of architecture-dependent tests,
I have modified the change so that the test library is only added
explicitly to architecture-dependent tests.

Fixes: #66083

Thanks

Tomas

/cc @dotnet/runtime-infrastructure 