### PR TITLE
Use a unique EventId for Verbose in NetEventSource.Common

### DIFF
--- a/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.cs
+++ b/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.cs
@@ -68,6 +68,7 @@ namespace System.Net
         private const int AssociateEventId = 3;
         private const int InfoEventId = 4;
         private const int ErrorEventId = 5;
+        private const int VerboseEventId = 6;
         private const int DumpArrayEventId = 7;
 
         // These events are implemented in NetEventSource.Security.cs.
@@ -156,7 +157,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(formattableString);
-            if (Log.IsEnabled()) Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(formattableString));
+            if (Log.IsEnabled()) Log.VerboseMessage(IdOf(thisOrContextObject), memberName, Format(formattableString));
         }
 
         /// <summary>Logs an info at verbose mode.</summary>
@@ -171,9 +172,9 @@ namespace System.Net
             if (Log.IsEnabled()) Log.VerboseMessage(IdOf(thisOrContextObject), memberName, Format(message).ToString());
         }
 
-        [Event(ErrorEventId, Level = EventLevel.Verbose, Keywords = Keywords.Default)]
+        [Event(VerboseEventId, Level = EventLevel.Verbose, Keywords = Keywords.Default)]
         private void VerboseMessage(string thisOrContextObject, string? memberName, string? message) =>
-            WriteEvent(ErrorEventId, thisOrContextObject, memberName ?? MissingMember, message);
+            WriteEvent(VerboseEventId, thisOrContextObject, memberName ?? MissingMember, message);
         #endregion
 
         #region DumpBuffer


### PR DESCRIPTION
The `NetEventSource.Common.VerboseMessage` event was annotated to use `ErrorEventId`, but that id is already being used by the `ErrorMessage` event.
As multiple events can't share an ID, this results in `EventSource` throwing at runtime when you try to initialize it.

(Un)fortunately, we don't use both `Verbose` and `Error` from the same assembly anywhere. As a result, they are trimmed out as part of a full build. Since they don't both co-exist at runtime, everyone's happy and our tests don't complain.

If you happen to build the assembly without trimming, or add a `Verbose` call anywhere in `System.Net.Http`, then trying to listen to `NetEventSource` will blow up at runtime.


This PR fixes the issue by assigning `VerboseMessage` a unique event id.