### PR TITLE
[PERF][MAUI] Add ios-arm64 logic to create .ipa for perf runs

### DIFF
--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -126,6 +126,9 @@ steps:
     displayName: Install MAUI workload
     workingDirectory: $(Build.SourcesDirectory)
 
+  - script: $(Build.SourcesDirectory)/eng/testing/performance/create-provisioning-profile.sh
+    displayName: Create iOS code signing and provisioning profile
+
   - script: |
       ./dotnet new maui -n MauiTesting
       cd MauiTesting
@@ -156,8 +159,15 @@ steps:
 
   - script: |
       chmod -R a+r .
-      ../dotnet build -bl:MauiiOS.binlog -f net6.0-ios -c Release
-      mv ./bin/Release/net6.0-ios/iossimulator-x64/MauiTesting.app ./MauiiOSDefault.app
+
+      # remove net6.0-maccatalyst to work around https://github.com/dotnet/sdk/issues/21877
+      cp MauiTesting.csproj MauiTesting.csproj.bak
+      sed -i'' -e 's/net6.0-ios;net6.0-maccatalyst/net6.0-ios/g' MauiTesting.csproj
+
+      ../dotnet publish -bl:MauiiOS.binlog -f net6.0-ios --self-contained -r ios-arm64 -c Release /p:_RequireCodeSigning=false
+      mv ./bin/Release/net6.0-ios/ios-arm64/publish/MauiTesting.ipa ./MauiiOSDefault.ipa
+
+      cp MauiTesting.csproj.bak MauiTesting.csproj
     displayName: Build MAUI iOS
     workingDirectory: $(Build.SourcesDirectory)/MauiTesting
 
@@ -201,7 +211,7 @@ steps:
 
   - template: /eng/pipelines/common/upload-artifact-step.yml
     parameters:
-        rootFolder: $(Build.SourcesDirectory)/MauiTesting/MauiiOSDefault.app
+        rootFolder: $(Build.SourcesDirectory)/MauiTesting/MauiiOSDefault.ipa
         includeRootFolder: true
         displayName: Maui iOS App
         artifactName: MauiiOSDefault

--- a/eng/testing/performance/create-provisioning-profile.sh
+++ b/eng/testing/performance/create-provisioning-profile.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+set -ex
+
+CERT_COMMON_NAME="Apple Development: Self Sign"
+TEMP_FOLDER=$(mktemp -d)
+
+cd "$TEMP_FOLDER"
+
+# Generate self-signed codesigning cert
+cat <<EOF > selfsigncert.conf
+[ req ]
+distinguished_name = self_sign
+prompt = no
+[ self_sign ]
+CN = $CERT_COMMON_NAME
+[ extensions ]
+basicConstraints = critical,CA:false
+keyUsage = critical,digitalSignature
+extendedKeyUsage = critical,1.3.6.1.5.5.7.3.3
+EOF
+
+openssl genrsa -out selfsigncert.key 2048
+openssl req -x509 -new -config selfsigncert.conf -nodes -key selfsigncert.key -extensions extensions -sha256 -out selfsigncert.crt
+openssl pkcs12 -export -inkey selfsigncert.key -in selfsigncert.crt -passout pass:PLACEHOLDERselfsignpass -out selfsigncert.p12
+
+# create keychain and import cert into it
+security delete-keychain selfsign.keychain || true
+security create-keychain -p PLACEHOLDERselfsignpass selfsign.keychain
+security import selfsigncert.p12 -P PLACEHOLDERselfsignpass -k selfsign.keychain -T /usr/bin/codesign -T /usr/bin/security
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k PLACEHOLDERselfsignpass selfsign.keychain
+security unlock-keychain -p PLACEHOLDERselfsignpass selfsign.keychain
+security set-keychain-settings -lut 21600 selfsign.keychain
+
+# create template for provisioning profile .plist
+cat <<EOF > SelfSign.plist
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ApplicationIdentifierPrefix</key>
+	<array>
+	<string>SELFSIGN</string>
+	</array>
+	<key>CreationDate</key>
+	<date>2000-01-01T00:00:00Z</date>
+	<key>Platform</key>
+	<array>
+		<string>iOS</string>
+	</array>
+	<key>DeveloperCertificates</key>
+	<array>
+	</array>
+	<key>Entitlements</key>
+	<dict>
+		<key>keychain-access-groups</key>
+		<array>
+			<string>SELFSIGN.*</string>
+		</array>
+		<key>get-task-allow</key>
+		<false/>
+		<key>application-identifier</key>
+		<string>SELFSIGN.*</string>
+		<key>com.apple.developer.team-identifier</key>
+		<string>SELFSIGN</string>
+	</dict>
+	<key>ExpirationDate</key>
+	<date>2100-01-01T00:00:00Z</date>
+	<key>Name</key>
+	<string>Self Sign Profile</string>
+	<key>ProvisionedDevices</key>
+	<array>
+	</array>
+	<key>TeamIdentifier</key>
+	<array>
+		<string>SELFSIGN</string>
+	</array>
+	<key>TeamName</key>
+	<string>Selfsign Team</string>
+	<key>TimeToLive</key>
+	<integer>36500</integer>
+	<key>UUID</key>
+	<string></string>
+	<key>Version</key>
+	<integer>1</integer>
+</dict>
+</plist>
+EOF
+
+# fill out the template (UUID and the certificate content)
+PROFILE_UUID=$(uuidgen)
+CERT_CONTENT=$(sed -e '/BEGIN CERTIFICATE/d;/END CERTIFICATE/d' selfsigncert.crt)
+
+plutil -replace UUID -string "$PROFILE_UUID" SelfSign.plist
+plutil -replace DeveloperCertificates.0 -data "$CERT_CONTENT" SelfSign.plist
+
+# append new keychain to keychain search so "security cms" finds the new certs
+security list-keychains -d user -s $(security list-keychains -d user | tr -d '"') selfsign.keychain
+
+# build .mobileprovision file out of the provisioning profile .plist
+security cms -S -N "$CERT_COMMON_NAME" -k selfsign.keychain -p PLACEHOLDERselfsignpass -i SelfSign.plist -o SelfSign.mobileprovision
+
+# copy provisioning profile to the right location
+mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles/"
+rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/SelfSign.mobileprovision"
+cp SelfSign.mobileprovision "$HOME/Library/MobileDevice/Provisioning Profiles/SelfSign.mobileprovision"


### PR DESCRIPTION
Switches from simulator builds to device builds so we can track the size for the .ipa.

We generate a dummy codesigning cert and provisioning profile since device builds require that.