### PR TITLE
Make ReadStack.JsonTypeInfo derivation logic consistent with WriteStack's

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
@@ -83,6 +83,7 @@ namespace System.Text.Json.Serialization
 
                 CreateCollection(ref reader, ref state, options);
 
+                state.Current.JsonPropertyInfo = elementTypeInfo.PropertyInfoForTypeInfo;
                 JsonConverter<TElement> elementConverter = GetElementConverter(elementTypeInfo);
                 if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
                 {
@@ -141,6 +142,8 @@ namespace System.Text.Json.Serialization
                     {
                         ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(TypeToConvert);
                     }
+
+                    state.Current.JsonPropertyInfo = elementTypeInfo.PropertyInfoForTypeInfo;
                 }
 
                 // Handle the metadata properties.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
@@ -168,7 +168,6 @@ namespace System.Text.Json.Serialization
                 if (state.Current.ObjectState < StackFrameObjectState.CreatedObject)
                 {
                     CreateCollection(ref reader, ref state, options);
-                    state.Current.JsonPropertyInfo = state.Current.JsonTypeInfo.ElementTypeInfo!.PropertyInfoForTypeInfo;
                     state.Current.ObjectState = StackFrameObjectState.CreatedObject;
                 }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
@@ -96,6 +96,7 @@ namespace System.Text.Json.Serialization
 
                 CreateCollection(ref reader, ref state);
 
+                state.Current.JsonPropertyInfo = elementTypeInfo.PropertyInfoForTypeInfo;
                 _valueConverter ??= GetConverter<TValue>(elementTypeInfo);
                 if (_valueConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
                 {
@@ -159,6 +160,7 @@ namespace System.Text.Json.Serialization
                     }
 
                     state.Current.ObjectState = StackFrameObjectState.StartToken;
+                    state.Current.JsonPropertyInfo = elementTypeInfo.PropertyInfoForTypeInfo;
                 }
 
                 // Handle the metadata properties.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -120,31 +120,9 @@ namespace System.Text.Json
                 }
                 else
                 {
-                    JsonTypeInfo jsonTypeInfo;
+                    JsonTypeInfo jsonTypeInfo = Current.JsonPropertyInfo?.JsonTypeInfo ?? Current.CtorArgumentState!.JsonParameterInfo!.JsonTypeInfo;
                     JsonNumberHandling? numberHandling = Current.NumberHandling;
                     ConverterStrategy converterStrategy = Current.JsonTypeInfo.PropertyInfoForTypeInfo.ConverterStrategy;
-
-                    if (converterStrategy == ConverterStrategy.Object)
-                    {
-                        if (Current.JsonPropertyInfo != null)
-                        {
-                            jsonTypeInfo = Current.JsonPropertyInfo.JsonTypeInfo;
-                        }
-                        else
-                        {
-                            jsonTypeInfo = Current.CtorArgumentState!.JsonParameterInfo!.JsonTypeInfo;
-                        }
-                    }
-                    else if (converterStrategy == ConverterStrategy.Value)
-                    {
-                        // Although ConverterStrategy.Value doesn't push, a custom custom converter may re-enter serialization.
-                        jsonTypeInfo = Current.JsonPropertyInfo!.JsonTypeInfo;
-                    }
-                    else
-                    {
-                        Debug.Assert(((ConverterStrategy.Enumerable | ConverterStrategy.Dictionary) & converterStrategy) != 0);
-                        jsonTypeInfo = Current.JsonTypeInfo.ElementTypeInfo!;
-                    }
 
                     EnsurePushCapacity();
                     _stack[_count - 1] = Current;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -290,12 +290,7 @@ namespace System.Text.Json
             if (string.IsNullOrEmpty(message))
             {
                 // Use a default message.
-                Type? propertyType = state.Current.JsonPropertyInfo?.PropertyType;
-                if (propertyType == null)
-                {
-                    propertyType = state.Current.JsonTypeInfo?.Type;
-                }
-
+                Type propertyType = state.Current.JsonTypeInfo.Type;
                 message = SR.Format(SR.DeserializeUnableToConvertValue, propertyType);
                 ex.AppendPathInformation = true;
             }
@@ -376,11 +371,7 @@ namespace System.Text.Json
             Debug.Assert(!message.Contains(" Path: "));
 
             // Obtain the type to show in the message.
-            Type? propertyType = state.Current.JsonPropertyInfo?.PropertyType;
-            if (propertyType == null)
-            {
-                propertyType = state.Current.JsonTypeInfo.Type;
-            }
+            Type propertyType = state.Current.JsonTypeInfo.Type;
 
             if (!message.Contains(propertyType.ToString()))
             {
@@ -408,11 +399,7 @@ namespace System.Text.Json
             Debug.Assert(!message.Contains(" Path: "));
 
             // Obtain the type to show in the message.
-            Type? propertyType = state.Current.JsonPropertyInfo?.PropertyType;
-            if (propertyType == null)
-            {
-                propertyType = state.Current.JsonTypeInfo.Type;
-            }
+            Type propertyType = state.Current.JsonTypeInfo.Type;
 
             if (!message.Contains(propertyType.ToString()))
             {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CustomConverterTests/CustomConverterTests.Callback.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CustomConverterTests/CustomConverterTests.Callback.cs
@@ -133,7 +133,7 @@ namespace System.Text.Json.Serialization.Tests
 
             ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<TopLevelPocoWithNoConverter>(Json, options));
             Assert.Contains(typeof(int[,]).ToString(), ex.ToString());
-            Assert.Contains(typeof(ChildPocoWithNoConverterAndInvalidProperty).ToString(), ex.ToString());
+            Assert.Contains(typeof(ChildPocoWithNoConverter).ToString(), ex.ToString());
             Assert.Contains("Path: $.InvalidProperty | LineNumber: 0 | BytePositionInLine: 20.", ex.ToString());
             Assert.Equal(2, ex.ToString().Split(new string[] { "Path:" }, StringSplitOptions.None).Length);
 
@@ -153,7 +153,7 @@ namespace System.Text.Json.Serialization.Tests
 
             ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(poco, options));
             Assert.Contains(typeof(int[,]).ToString(), ex.ToString());
-            Assert.Contains(typeof(ChildPocoWithNoConverterAndInvalidProperty).ToString(), ex.ToString());
+            Assert.Contains(typeof(ChildPocoWithNoConverter).ToString(), ex.ToString());
             Assert.Contains("Path: $.InvalidProperty.", ex.ToString());
             Assert.Equal(2, ex.ToString().Split(new string[] { "Path:" }, StringSplitOptions.None).Length);
         }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ExceptionTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ExceptionTests.cs
@@ -458,7 +458,7 @@ namespace System.Text.Json.Serialization.Tests
                 JsonSerializer.Serialize(new ClassWithPropertyToClassWithInvalidArray()));
 
             Assert.Contains(typeof(int[,]).ToString(), ex.Message);
-            Assert.Contains(typeof(ClassWithInvalidArray).ToString(), ex.Message);
+            Assert.Contains(typeof(ClassWithPropertyToClassWithInvalidArray).ToString(), ex.Message);
             Assert.Contains("Path: $.Inner.", ex.Message);
 
             // The original exception contains the type.


### PR DESCRIPTION
Simplifies the derivation logic for the `ReadStack.JsonTypeInfo` property, making it consistent with `WriteStack.JsonTypeInfo`. Backported change from the polymorphism prototype.