### PR TITLE
Correct JsonPropertyOrderAttribute's ctor XMLDoc

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonPropertyOrderAttribute.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonPropertyOrderAttribute.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json.Serialization
     public sealed class JsonPropertyOrderAttribute : JsonAttribute
     {
         /// <summary>
-        /// Initializes a new instance of <see cref="JsonPropertyNameAttribute"/> with the specified order.
+        /// Initializes a new instance of <see cref="JsonPropertyOrderAttribute"/> with the specified order.
         /// </summary>
         /// <param name="order">The order of the property.</param>
         public JsonPropertyOrderAttribute(int order)


### PR DESCRIPTION
Change the ctor XML docs on JsonPropertyOrderAttribute to property self-reference the JsonPropertyOrderAttribute type. The current revision is referencing JsonPropertyNameAttribute, instead.