### PR TITLE
Fix System.IO.Ports native package not getting published any longer after the oob + sfx split

### DIFF
--- a/src/libraries/oob-all.proj
+++ b/src/libraries/oob-all.proj
@@ -28,10 +28,6 @@
     <!-- During an official build, build the identity package only in the allconfigurations build, otherwise always. -->
     <ProjectReference Include="$(MSBuildThisFileDirectory)*\pkg\runtime.native.*.proj"
                       Condition="'$(BuildingAnOfficialBuildLeg)' != 'true' or '$(BuildAllConfigurations)' == 'true'" />
-    <!-- During an official Build, build the rid specific package matching the OutputRid only outside of an allconfigurations build and only when targeting the CoreCLR runtime.
-         The limitation on the CoreCLR runtime is entirely artificial but avoids duplicate assets being publish. -->
-    <ProjectReference Include="$(MSBuildThisFileDirectory)*\pkg\runtime.$(OutputRid).*.proj"
-                      Condition="'$(BuildingAnOfficialBuildLeg)' != 'true' or ('$(BuildAllConfigurations)' != 'true' and '$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)')" />
   </ItemGroup>
 
 </Project>

--- a/src/libraries/oob-src.proj
+++ b/src/libraries/oob-src.proj
@@ -15,6 +15,11 @@
                                @(NetCoreAppLibrary->'%(Identity)\src\%(Identity).csproj');
                                Microsoft.VisualBasic.Core\src\Microsoft.VisualBasic.Core.vbproj" />
 
+    <!-- During an official Build, build the rid specific package matching the OutputRid only outside of an allconfigurations build and only when targeting the CoreCLR runtime.
+         The limitation on the CoreCLR runtime is entirely artificial but avoids duplicate assets being publish. -->
+    <ProjectReference Include="$(MSBuildThisFileDirectory)*\pkg\runtime.$(OutputRid).*.proj" Condition="'$(BuildingAnOfficialBuildLeg)' != 'true' or
+                                                                                                            ('$(BuildAllConfigurations)' != 'true' and '$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)')" />
+
     <!-- Don't build task and tools project in the NetCoreAppCurrent vertical. -->
     <ProjectReference Remove="Microsoft.NETCore.Platforms\src\Microsoft.NETCore.Platforms.csproj;
                               Microsoft.XmlSerializer.Generator\src\Microsoft.XmlSerializer.Generator.csproj" />


### PR DESCRIPTION
FYI: @ViktorHofer @ericstj @mmitche 

The native component package of System.IO.Ports doesn't get build in the all configurations leg, and instead should be build in individual Unix verticals. With the recent changes to split sfx and oob builds, these packages builds got moved into the all configurations leg in Windows which would never build the unix packages. The changes in this PR will fix this and have the native packages build on the individual verticals as they were before.