### PR TITLE
Backport docs fixes for Cbor

### DIFF
--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/CborConformanceLevel.cs
@@ -17,9 +17,9 @@ namespace System.Formats.Cbor
         /// <para>Ensures that the CBOR data adheres to strict mode, as specified in RFC7049 section 3.10.</para>
         /// <para>Extends lax conformance with the following requirements:</para>
         /// <list type="bullet">
-        /// <item>Maps (major type 5) must not contain duplicate keys.</item>
-        /// <item>Simple values (major type 7) must be encoded as small a possible and exclude the reserved values 24-31.</item>
-        /// <item>UTF-8 string encodings must be valid.</item>
+        /// <item><description>Maps (major type 5) must not contain duplicate keys.</description></item>
+        /// <item><description>Simple values (major type 7) must be encoded as small a possible and exclude the reserved values 24-31.</description></item>
+        /// <item><description>UTF-8 string encodings must be valid.</description></item>
         /// </list>
         /// </summary>
         Strict,
@@ -28,9 +28,9 @@ namespace System.Formats.Cbor
         /// <para>Ensures that the CBOR data is canonical, as specified in RFC7049 section 3.9.</para>
         /// <para>Extends strict conformance with the following requirements:</para>
         /// <list type="bullet">
-        /// <item>Integers must be encoded as small as possible.</item>
-        /// <item>Maps (major type 5) must contain keys sorted by encoding.</item>
-        /// <item>Indefinite-length items must be made into definite-length items.</item>
+        /// <item><description>Integers must be encoded as small as possible.</description></item>
+        /// <item><description>Maps (major type 5) must contain keys sorted by encoding.</description></item>
+        /// <item><description>Indefinite-length items must be made into definite-length items.</description></item>
         /// </list>
         /// </summary>
         Canonical,
@@ -39,11 +39,11 @@ namespace System.Formats.Cbor
         /// <para>Ensures that the CBOR data is canonical, as specified by the CTAP v2.0 standard, section 6.</para>
         /// <para>Extends strict conformance with the following requirements:</para>
         /// <list type="bullet">
-        /// <item>Maps (major type 5) must contain keys sorted by encoding.</item>
-        /// <item>Indefinite-length items must be made into definite-length items.</item>
-        /// <item>Integers must be encoded as small as possible.</item>
-        /// <item>The representations of any floating-point values are not changed.</item>
-        /// <item>CBOR tags (major type 6) are not permitted.</item>
+        /// <item><description>Maps (major type 5) must contain keys sorted by encoding.</description></item>
+        /// <item><description>Indefinite-length items must be made into definite-length items.</description></item>
+        /// <item><description>Integers must be encoded as small as possible.</description></item>
+        /// <item><description>The representations of any floating-point values are not changed.</description></item>
+        /// <item><description>CBOR tags (major type 6) are not permitted.</description></item>
         /// </list>
         /// </summary>
         Ctap2Canonical,

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/CborContentException.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/CborContentException.cs
@@ -10,7 +10,7 @@ namespace System.Formats.Cbor
     public class CborContentException : Exception
     {
         /// <summary>
-        ///  Initializes a new instance of the <see cref="CborContentException" /> class, using the provided message.
+        /// Initializes a new instance of the <see cref="CborContentException" /> class using the provided message.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
         public CborContentException(string? message)
@@ -20,8 +20,8 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///  Initializes a new instance of the <see cref="CborContentException" /> class,
-        ///  using the provided message and exception that is the cause of this exception.
+        /// Initializes a new instance of the <see cref="CborContentException" /> class,
+        /// using the provided message and exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="inner">The exception that is the cause of the current exception.</param>
@@ -32,7 +32,7 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Initializes a new instance of the <see cref="CborContentException" /> class with serialized data.
+        /// Initializes a new instance of the <see cref="CborContentException" /> class with serialized data.
         /// </summary>
         /// <param name="info">The object that holds the serialized object data.</param>
         /// <param name="context">The contextual information about the source or destination.</param>

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Array.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Array.cs
@@ -8,11 +8,11 @@ namespace System.Formats.Cbor
         /// <summary>Reads the next data item as the start of an array (major type 4).</summary>
         /// <returns>The length of the definite-length array, or <see langword="null" /> if the array is indefinite-length.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public int? ReadStartArray()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Array);
@@ -40,12 +40,12 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Reads the end of an array (major type 4).</summary>
-        /// <exception cref="InvalidOperationException">The current context is not an array.
-        /// -or-
-        /// The reader is not at the end of the array.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.</exception>
+        /// <exception cref="InvalidOperationException"><p>The current context is not an array.</p>
+        /// <p>-or-</p>
+        /// <p>The reader is not at the end of the array.</p></exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p></exception>
         public void ReadEndArray()
         {
             if (_definiteLength is null)

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Array.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Array.cs
@@ -8,11 +8,11 @@ namespace System.Formats.Cbor
         /// <summary>Reads the next data item as the start of an array (major type 4).</summary>
         /// <returns>The length of the definite-length array, or <see langword="null" /> if the array is indefinite-length.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public int? ReadStartArray()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Array);
@@ -40,12 +40,12 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Reads the end of an array (major type 4).</summary>
-        /// <exception cref="InvalidOperationException"><p>The current context is not an array.</p>
-        /// <p>-or-</p>
-        /// <p>The reader is not at the end of the array.</p></exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The current context is not an array.</para>
+        /// <para>-or-</para>
+        /// <para>The reader is not at the end of the array.</para></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para></exception>
         public void ReadEndArray()
         {
             if (_definiteLength is null)

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Integer.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Integer.cs
@@ -13,11 +13,11 @@ namespace System.Formats.Cbor
         /// <returns>The decoded integer value.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
         /// <exception cref="OverflowException">The encoded integer is out of range for <see cref="int" />.</exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public int ReadInt32()
         {
             int value = checked((int)PeekSignedInteger(out int bytesRead));
@@ -30,11 +30,11 @@ namespace System.Formats.Cbor
         /// <returns>The decoded integer value.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
         /// <exception cref="OverflowException">The encoded integer is out of range for <see cref="uint" />.</exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         [CLSCompliant(false)]
         public uint ReadUInt32()
         {
@@ -48,11 +48,11 @@ namespace System.Formats.Cbor
         /// <returns>The decoded integer value.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
         /// <exception cref="OverflowException">The encoded integer is out of range for <see cref="long" />.</exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public long ReadInt64()
         {
             long value = PeekSignedInteger(out int bytesRead);
@@ -65,11 +65,11 @@ namespace System.Formats.Cbor
         /// <returns>The decoded integer value.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
         /// <exception cref="OverflowException">The encoded integer is out of range for <see cref="ulong" />.</exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         [CLSCompliant(false)]
         public ulong ReadUInt64()
         {
@@ -83,11 +83,11 @@ namespace System.Formats.Cbor
         /// <returns>An unsigned integer denoting -1 minus the integer.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
         /// <exception cref="OverflowException">The encoded integer is out of range for <see cref="uint" /></exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         /// <remarks>
         /// This method supports decoding integers between -18446744073709551616 and -1.
         /// Useful for handling values that do not fit in the <see cref="long" /> type.

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Integer.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Integer.cs
@@ -13,11 +13,11 @@ namespace System.Formats.Cbor
         /// <returns>The decoded integer value.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
         /// <exception cref="OverflowException">The encoded integer is out of range for <see cref="int" />.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public int ReadInt32()
         {
             int value = checked((int)PeekSignedInteger(out int bytesRead));
@@ -30,11 +30,11 @@ namespace System.Formats.Cbor
         /// <returns>The decoded integer value.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
         /// <exception cref="OverflowException">The encoded integer is out of range for <see cref="uint" />.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         [CLSCompliant(false)]
         public uint ReadUInt32()
         {
@@ -48,11 +48,11 @@ namespace System.Formats.Cbor
         /// <returns>The decoded integer value.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
         /// <exception cref="OverflowException">The encoded integer is out of range for <see cref="long" />.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public long ReadInt64()
         {
             long value = PeekSignedInteger(out int bytesRead);
@@ -65,11 +65,11 @@ namespace System.Formats.Cbor
         /// <returns>The decoded integer value.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
         /// <exception cref="OverflowException">The encoded integer is out of range for <see cref="ulong" />.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         [CLSCompliant(false)]
         public ulong ReadUInt64()
         {
@@ -83,11 +83,11 @@ namespace System.Formats.Cbor
         /// <returns>An unsigned integer denoting -1 minus the integer.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
         /// <exception cref="OverflowException">The encoded integer is out of range for <see cref="uint" /></exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         /// <remarks>
         /// This method supports decoding integers between -18446744073709551616 and -1.
         /// Useful for handling values that do not fit in the <see cref="long" /> type.

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Map.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Map.cs
@@ -14,11 +14,11 @@ namespace System.Formats.Cbor
         /// <summary>Reads the next data item as the start of a map (major type 5).</summary>
         /// <returns>The number of key-value pairs in a definite-length map, or <see langword="null" /> if the map is indefinite-length.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         /// <remarks>
         /// Map contents are consumed as if they were arrays twice the length of the map's declared size.
         /// For instance, a map of size 1 containing a key of type <see cref="int" /> with a value of type <see cref="string" />
@@ -64,14 +64,14 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Reads the end of a map (major type 5).</summary>
-        /// <exception cref="InvalidOperationException">The current context is not a map.
-        /// -or-
-        /// The reader is not at the end of the map.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>The current context is not a map.</p>
+        /// <p>-or-</p>
+        /// <p>The reader is not at the end of the map.</p></exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public void ReadEndMap()
         {
             if (_definiteLength is null)

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Map.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Map.cs
@@ -14,11 +14,11 @@ namespace System.Formats.Cbor
         /// <summary>Reads the next data item as the start of a map (major type 5).</summary>
         /// <returns>The number of key-value pairs in a definite-length map, or <see langword="null" /> if the map is indefinite-length.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         /// <remarks>
         /// Map contents are consumed as if they were arrays twice the length of the map's declared size.
         /// For instance, a map of size 1 containing a key of type <see cref="int" /> with a value of type <see cref="string" />
@@ -64,14 +64,14 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Reads the end of a map (major type 5).</summary>
-        /// <exception cref="InvalidOperationException"><p>The current context is not a map.</p>
-        /// <p>-or-</p>
-        /// <p>The reader is not at the end of the map.</p></exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The current context is not a map.</para>
+        /// <para>-or-</para>
+        /// <para>The reader is not at the end of the map.</para></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public void ReadEndMap()
         {
             if (_definiteLength is null)

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Simple.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Simple.cs
@@ -9,16 +9,16 @@ namespace System.Formats.Cbor
     {
         /// <summary>Reads the next data item as a single-precision floating point number (major type 7).</summary>
         /// <returns>The decoded value.</returns>
-        /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.
-        /// -or-
-        /// The next simple value is not a floating-point number encoding.
-        /// -or-
-        /// The encoded value is a double-precision float</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
+        /// <p>-or-</p>
+        /// <p>The next simple value is not a floating-point number encoding.</p>
+        /// <p>-or-</p>
+        /// <p>The encoded value is a double-precision float.</p></exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public float ReadSingle()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);
@@ -52,14 +52,14 @@ namespace System.Formats.Cbor
 
         /// <summary>Reads the next data item as a double-precision floating point number (major type 7).</summary>
         /// <returns>The decoded <see cref="double" /> value.</returns>
-        /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.
-        /// -or-
-        /// The next simple value is not a floating-point number encoding</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
+        /// <p>-or-</p>
+        /// <p>The next simple value is not a floating-point number encoding.</p></exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public double ReadDouble()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);
@@ -96,14 +96,14 @@ namespace System.Formats.Cbor
 
         /// <summary>Reads the next data item as a boolean value (major type 7).</summary>
         /// <returns>The decoded value.</returns>
-        /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.
-        /// -or-
-        /// The next simple value is not a boolean encoding</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
+        /// <p>-or-</p>
+        /// <p>The next simple value is not a boolean encoding.</p></exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public bool ReadBoolean()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);
@@ -121,14 +121,14 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Reads the next data item as a <see langword="null" /> value (major type 7).</summary>
-        /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.
-        /// -or-
-        /// The next simple value is not a <see langword="null" /> value encoding.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
+        /// <p>-or-</p>
+        /// <p>The next simple value is not a <see langword="null" /> value encoding.</p></exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public void ReadNull()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);
@@ -146,14 +146,14 @@ namespace System.Formats.Cbor
 
         /// <summary>Reads the next data item as a CBOR simple value (major type 7).</summary>
         /// <returns>The decoded CBOR simple value.</returns>
-        /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.
-        /// -or-
-        /// The next simple value is not a simple value encoding.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
+        /// <p>-or-</p>
+        /// <p>The next simple value is not a simple value encoding.</p></exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public CborSimpleValue ReadSimpleValue()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Simple.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Simple.cs
@@ -9,16 +9,16 @@ namespace System.Formats.Cbor
     {
         /// <summary>Reads the next data item as a single-precision floating point number (major type 7).</summary>
         /// <returns>The decoded value.</returns>
-        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
-        /// <p>-or-</p>
-        /// <p>The next simple value is not a floating-point number encoding.</p>
-        /// <p>-or-</p>
-        /// <p>The encoded value is a double-precision float.</p></exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The next data item does not have the correct major type.</para>
+        /// <para>-or-</para>
+        /// <para>The next simple value is not a floating-point number encoding.</para>
+        /// <para>-or-</para>
+        /// <para>The encoded value is a double-precision float.</para></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public float ReadSingle()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);
@@ -52,14 +52,14 @@ namespace System.Formats.Cbor
 
         /// <summary>Reads the next data item as a double-precision floating point number (major type 7).</summary>
         /// <returns>The decoded <see cref="double" /> value.</returns>
-        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
-        /// <p>-or-</p>
-        /// <p>The next simple value is not a floating-point number encoding.</p></exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The next data item does not have the correct major type.</para>
+        /// <para>-or-</para>
+        /// <para>The next simple value is not a floating-point number encoding.</para></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public double ReadDouble()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);
@@ -96,14 +96,14 @@ namespace System.Formats.Cbor
 
         /// <summary>Reads the next data item as a boolean value (major type 7).</summary>
         /// <returns>The decoded value.</returns>
-        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
-        /// <p>-or-</p>
-        /// <p>The next simple value is not a boolean encoding.</p></exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The next data item does not have the correct major type.</para>
+        /// <para>-or-</para>
+        /// <para>The next simple value is not a boolean encoding.</para></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public bool ReadBoolean()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);
@@ -121,14 +121,14 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Reads the next data item as a <see langword="null" /> value (major type 7).</summary>
-        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
-        /// <p>-or-</p>
-        /// <p>The next simple value is not a <see langword="null" /> value encoding.</p></exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The next data item does not have the correct major type.</para>
+        /// <para>-or-</para>
+        /// <para>The next simple value is not a <see langword="null" /> value encoding.</para></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public void ReadNull()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);
@@ -146,14 +146,14 @@ namespace System.Formats.Cbor
 
         /// <summary>Reads the next data item as a CBOR simple value (major type 7).</summary>
         /// <returns>The decoded CBOR simple value.</returns>
-        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
-        /// <p>-or-</p>
-        /// <p>The next simple value is not a simple value encoding.</p></exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The next data item does not have the correct major type.</para>
+        /// <para>-or-</para>
+        /// <para>The next simple value is not a simple value encoding.</para></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public CborSimpleValue ReadSimpleValue()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Simple.netcoreapp.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Simple.netcoreapp.cs
@@ -9,16 +9,16 @@ namespace System.Formats.Cbor
     {
         /// <summary>Reads the next data item as a half-precision floating point number (major type 7).</summary>
         /// <returns>The decoded value.</returns>
-        /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.
-        /// -or-
-        /// The next simple value is not a floating-point number encoding.
-        /// -or-
-        /// The encoded value is a double-precision float.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
+        /// <p>-or-</p>
+        /// <p>The next simple value is not a floating-point number encoding.</p>
+        /// <p>-or-</p>
+        /// <p>The encoded value is a double-precision float.</p></exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public Half ReadHalf()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Simple.netcoreapp.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Simple.netcoreapp.cs
@@ -9,16 +9,16 @@ namespace System.Formats.Cbor
     {
         /// <summary>Reads the next data item as a half-precision floating point number (major type 7).</summary>
         /// <returns>The decoded value.</returns>
-        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
-        /// <p>-or-</p>
-        /// <p>The next simple value is not a floating-point number encoding.</p>
-        /// <p>-or-</p>
-        /// <p>The encoded value is a double-precision float.</p></exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The next data item does not have the correct major type.</para>
+        /// <para>-or-</para>
+        /// <para>The next simple value is not a floating-point number encoding.</para>
+        /// <para>-or-</para>
+        /// <para>The encoded value is a double-precision float.</para></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public Half ReadHalf()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.SkipValue.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.SkipValue.cs
@@ -10,11 +10,11 @@ namespace System.Formats.Cbor
         /// <summary>Reads the contents of the next value, discarding the result and advancing the reader.</summary>
         /// <param name="disableConformanceModeChecks"><see langword="true" /> to disable conformance mode validation for the skipped values, equivalent to using <see cref="CborConformanceMode.Lax" />; otherwise, <see langword="false" />.</param>
         /// <exception cref="InvalidOperationException">The reader is not at the start of new value.</exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public void SkipValue(bool disableConformanceModeChecks = false)
         {
             SkipToAncestor(0, disableConformanceModeChecks);
@@ -23,11 +23,11 @@ namespace System.Formats.Cbor
         /// <summary>Reads the remaining contents of the current value context, discarding results and advancing the reader to the next value in the parent context.</summary>
         /// <param name="disableConformanceModeChecks"><see langword="true" /> to disable conformance mode validation for the skipped values, equivalent to using <see cref="CborConformanceMode.Lax" />; otherwise, <see langword="false" />.</param>
         /// <exception cref="InvalidOperationException">The reader is at the root context</exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public void SkipToParent(bool disableConformanceModeChecks = false)
         {
             if (_currentMajorType is null)

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.SkipValue.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.SkipValue.cs
@@ -10,11 +10,11 @@ namespace System.Formats.Cbor
         /// <summary>Reads the contents of the next value, discarding the result and advancing the reader.</summary>
         /// <param name="disableConformanceModeChecks"><see langword="true" /> to disable conformance mode validation for the skipped values, equivalent to using <see cref="CborConformanceMode.Lax" />; otherwise, <see langword="false" />.</param>
         /// <exception cref="InvalidOperationException">The reader is not at the start of new value.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public void SkipValue(bool disableConformanceModeChecks = false)
         {
             SkipToAncestor(0, disableConformanceModeChecks);
@@ -23,11 +23,11 @@ namespace System.Formats.Cbor
         /// <summary>Reads the remaining contents of the current value context, discarding results and advancing the reader to the next value in the parent context.</summary>
         /// <param name="disableConformanceModeChecks"><see langword="true" /> to disable conformance mode validation for the skipped values, equivalent to using <see cref="CborConformanceMode.Lax" />; otherwise, <see langword="false" />.</param>
         /// <exception cref="InvalidOperationException">The reader is at the root context</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public void SkipToParent(bool disableConformanceModeChecks = false)
         {
             if (_currentMajorType is null)

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.String.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.String.cs
@@ -18,11 +18,11 @@ namespace System.Formats.Cbor
         /// <summary>Reads the next data item as a byte string (major type 2).</summary>
         /// <returns>The decoded byte array.</returns>
         /// <exception cref="InvalidOperationException">The next date item does not have the correct major type.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         /// <remarks>The method accepts indefinite length strings, which it concatenates to a single string.</remarks>
         public byte[] ReadByteString()
         {
@@ -53,11 +53,11 @@ namespace System.Formats.Cbor
         /// <param name="bytesWritten">On success, receives the number of bytes written to <paramref name="destination" />.</param>
         /// <returns><see langword="true" /> if <paramref name="destination" /> had sufficient length to receive the value and the reader advances; otherwise, <see langword="false" />.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         /// <remarks>The method accepts indefinite length strings, which it will concatenate to a single string.</remarks>
         public bool TryReadByteString(Span<byte> destination, out int bytesWritten)
         {
@@ -93,14 +93,14 @@ namespace System.Formats.Cbor
 
         /// <summary>Reads the next data item as a definite-length byte string (major type 2).</summary>
         /// <returns>A <see cref="ReadOnlyMemory{T}" /> view of the byte string payload.</returns>
-        /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.
-        /// -or-
-        /// The data item is an indefinite-length byte string.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
+        /// <p>-or-</p>
+        /// <p>The data item is an indefinite-length byte string.</p></exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public ReadOnlyMemory<byte> ReadDefiniteLengthByteString()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.ByteString);
@@ -121,14 +121,14 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Reads the next data item as the start of an indefinite-length byte string (major type 2).</summary>
-        /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.
-        /// -or-
-        /// The next data item is a definite-length encoded string.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
+        /// <p>-or-</p>
+        /// <p>The next data item is a definite-length encoded string.</p></exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public void ReadStartIndefiniteLengthByteString()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.ByteString);
@@ -148,9 +148,9 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Ends reading an indefinite-length byte string (major type 2).</summary>
-        /// <exception cref="InvalidOperationException">The current context is not an indefinite-length string.
-        /// -or-
-        /// The reader is not at the end of the string.</exception>
+        /// <exception cref="InvalidOperationException"><p>The current context is not an indefinite-length string.</p>
+        /// <p>-or-</p>
+        /// <p>The reader is not at the end of the string.</p></exception>
         /// <exception cref="CborContentException">There was an unexpected end of CBOR encoding data.</exception>
         public void ReadEndIndefiniteLengthByteString()
         {
@@ -163,11 +163,11 @@ namespace System.Formats.Cbor
         /// <summary>Reads the next data item as a UTF-8 text string (major type 3).</summary>
         /// <returns>The decoded string.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         /// <remarks>The method accepts indefinite length strings, which it will concatenate to a single string.</remarks>
         public string ReadTextString()
         {
@@ -209,11 +209,11 @@ namespace System.Formats.Cbor
         /// <param name="charsWritten">On success, receives the number of chars written to <paramref name="destination" />.</param>
         /// <returns><see langword="true" /> and advances the reader if <paramref name="destination" /> had sufficient length to receive the value, otherwise <see langword="false" /> and the reader does not advance.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         /// <remarks>The method accepts indefinite length strings, which it will concatenate to a single string.</remarks>
         public bool TryReadTextString(Span<char> destination, out int charsWritten)
         {
@@ -253,14 +253,14 @@ namespace System.Formats.Cbor
 
         /// <summary>Reads the next data item as a definite-length UTF-8 text string (major type 3).</summary>
         /// <returns>A <see cref="ReadOnlyMemory{T}" /> view of the raw UTF-8 payload.</returns>
-        /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.
-        /// -or-
-        /// The data item is an indefinite-length text string.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
+        /// <p>-or-</p>
+        /// <p>The data item is an indefinite-length text string.</p></exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public ReadOnlyMemory<byte> ReadDefiniteLengthTextStringBytes()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.TextString);
@@ -288,14 +288,14 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Reads the next data item as the start of an indefinite-length UTF-8 text string (major type 3).</summary>
-        /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.
-        /// -or-
-        /// The next data item is a definite-length encoded string.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
+        /// <p>-or-</p>
+        /// <p>The next data item is a definite-length encoded string.</p></exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public void ReadStartIndefiniteLengthTextString()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.TextString);
@@ -315,9 +315,9 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Ends reading an indefinite-length UTF-8 text string (major type 3).</summary>
-        /// <exception cref="InvalidOperationException">The current context is not an indefinite-length string.
-        /// -or-
-        /// The reader is not at the end of the string.</exception>
+        /// <exception cref="InvalidOperationException"><p>The current context is not an indefinite-length string.</p>
+        /// <p>-or-</p>
+        /// <p>The reader is not at the end of the string.</p></exception>
         /// <exception cref="CborContentException">There was an unexpected end of CBOR encoding data.</exception>
         public void ReadEndIndefiniteLengthTextString()
         {

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.String.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.String.cs
@@ -18,11 +18,11 @@ namespace System.Formats.Cbor
         /// <summary>Reads the next data item as a byte string (major type 2).</summary>
         /// <returns>The decoded byte array.</returns>
         /// <exception cref="InvalidOperationException">The next date item does not have the correct major type.</exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         /// <remarks>The method accepts indefinite length strings, which it concatenates to a single string.</remarks>
         public byte[] ReadByteString()
         {
@@ -53,11 +53,11 @@ namespace System.Formats.Cbor
         /// <param name="bytesWritten">On success, receives the number of bytes written to <paramref name="destination" />.</param>
         /// <returns><see langword="true" /> if <paramref name="destination" /> had sufficient length to receive the value and the reader advances; otherwise, <see langword="false" />.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         /// <remarks>The method accepts indefinite length strings, which it will concatenate to a single string.</remarks>
         public bool TryReadByteString(Span<byte> destination, out int bytesWritten)
         {
@@ -93,14 +93,14 @@ namespace System.Formats.Cbor
 
         /// <summary>Reads the next data item as a definite-length byte string (major type 2).</summary>
         /// <returns>A <see cref="ReadOnlyMemory{T}" /> view of the byte string payload.</returns>
-        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
-        /// <p>-or-</p>
-        /// <p>The data item is an indefinite-length byte string.</p></exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The next data item does not have the correct major type.</para>
+        /// <para>-or-</para>
+        /// <para>The data item is an indefinite-length byte string.</para></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public ReadOnlyMemory<byte> ReadDefiniteLengthByteString()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.ByteString);
@@ -121,14 +121,14 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Reads the next data item as the start of an indefinite-length byte string (major type 2).</summary>
-        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
-        /// <p>-or-</p>
-        /// <p>The next data item is a definite-length encoded string.</p></exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The next data item does not have the correct major type.</para>
+        /// <para>-or-</para>
+        /// <para>The next data item is a definite-length encoded string.</para></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public void ReadStartIndefiniteLengthByteString()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.ByteString);
@@ -148,9 +148,9 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Ends reading an indefinite-length byte string (major type 2).</summary>
-        /// <exception cref="InvalidOperationException"><p>The current context is not an indefinite-length string.</p>
-        /// <p>-or-</p>
-        /// <p>The reader is not at the end of the string.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The current context is not an indefinite-length string.</para>
+        /// <para>-or-</para>
+        /// <para>The reader is not at the end of the string.</para></exception>
         /// <exception cref="CborContentException">There was an unexpected end of CBOR encoding data.</exception>
         public void ReadEndIndefiniteLengthByteString()
         {
@@ -163,11 +163,11 @@ namespace System.Formats.Cbor
         /// <summary>Reads the next data item as a UTF-8 text string (major type 3).</summary>
         /// <returns>The decoded string.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         /// <remarks>The method accepts indefinite length strings, which it will concatenate to a single string.</remarks>
         public string ReadTextString()
         {
@@ -209,11 +209,11 @@ namespace System.Formats.Cbor
         /// <param name="charsWritten">On success, receives the number of chars written to <paramref name="destination" />.</param>
         /// <returns><see langword="true" /> and advances the reader if <paramref name="destination" /> had sufficient length to receive the value, otherwise <see langword="false" /> and the reader does not advance.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         /// <remarks>The method accepts indefinite length strings, which it will concatenate to a single string.</remarks>
         public bool TryReadTextString(Span<char> destination, out int charsWritten)
         {
@@ -253,14 +253,14 @@ namespace System.Formats.Cbor
 
         /// <summary>Reads the next data item as a definite-length UTF-8 text string (major type 3).</summary>
         /// <returns>A <see cref="ReadOnlyMemory{T}" /> view of the raw UTF-8 payload.</returns>
-        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
-        /// <p>-or-</p>
-        /// <p>The data item is an indefinite-length text string.</p></exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The next data item does not have the correct major type.</para>
+        /// <para>-or-</para>
+        /// <para>The data item is an indefinite-length text string.</para></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public ReadOnlyMemory<byte> ReadDefiniteLengthTextStringBytes()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.TextString);
@@ -288,14 +288,14 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Reads the next data item as the start of an indefinite-length UTF-8 text string (major type 3).</summary>
-        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
-        /// <p>-or-</p>
-        /// <p>The next data item is a definite-length encoded string.</p></exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The next data item does not have the correct major type.</para>
+        /// <para>-or-</para>
+        /// <para>The next data item is a definite-length encoded string.</para></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public void ReadStartIndefiniteLengthTextString()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.TextString);
@@ -315,9 +315,9 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Ends reading an indefinite-length UTF-8 text string (major type 3).</summary>
-        /// <exception cref="InvalidOperationException"><p>The current context is not an indefinite-length string.</p>
-        /// <p>-or-</p>
-        /// <p>The reader is not at the end of the string.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The current context is not an indefinite-length string.</para>
+        /// <para>-or-</para>
+        /// <para>The reader is not at the end of the string.</para></exception>
         /// <exception cref="CborContentException">There was an unexpected end of CBOR encoding data.</exception>
         public void ReadEndIndefiniteLengthTextString()
         {

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Tag.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Tag.cs
@@ -11,11 +11,11 @@ namespace System.Formats.Cbor
         /// <summary>Reads the next data item as a semantic tag (major type 6).</summary>
         /// <returns>The decoded value.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         [CLSCompliant(false)]
         public CborTag ReadTag()
         {
@@ -29,27 +29,27 @@ namespace System.Formats.Cbor
         /// <summary>Reads the next data item as a semantic tag (major type 6), without advancing the reader.</summary>
         /// <returns>The decoded value.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         /// <remarks>Useful in scenarios where the semantic value decoder needs to be determined at run time.</remarks>
         [CLSCompliant(false)]
         public CborTag PeekTag() => PeekTagCore(out int _);
 
         /// <summary>Reads the next data item as a tagged date/time string, as described in RFC7049 section 2.4.1.</summary>
         /// <returns>The decoded value.</returns>
-        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
-        /// <p>-or-</p>
-        /// <p>The next date item does not have the correct semantic tag.</p></exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The semantic date/time encoding is invalid.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The next data item does not have the correct major type.</para>
+        /// <para>-or-</para>
+        /// <para>The next date item does not have the correct semantic tag.</para></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The semantic date/time encoding is invalid.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public DateTimeOffset ReadDateTimeOffset()
         {
             // implements https://tools.ietf.org/html/rfc7049#section-2.4.1
@@ -88,16 +88,16 @@ namespace System.Formats.Cbor
 
         /// <summary>Reads the next data item as a tagged unix time in seconds, as described in RFC7049 section 2.4.1.</summary>
         /// <returns>The decoded value.</returns>
-        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
-        /// <p>-or-</p>
-        /// <p>The next date item does not have the correct semantic tag.</p></exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The semantic date/time encoding is invalid.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The next data item does not have the correct major type.</para>
+        /// <para>-or-</para>
+        /// <para>The next date item does not have the correct semantic tag.</para></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The semantic date/time encoding is invalid.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public DateTimeOffset ReadUnixTimeSeconds()
         {
             // implements https://tools.ietf.org/html/rfc7049#section-2.4.1
@@ -140,16 +140,16 @@ namespace System.Formats.Cbor
 
         /// <summary>Reads the next data item as a tagged bignum encoding, as described in RFC7049 section 2.4.2.</summary>
         /// <returns>The decoded value.</returns>
-        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
-        /// <p>-or-</p>
-        /// <p>The next date item does not have the correct semantic tag.</p></exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The semantic bignum encoding is invalid.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The next data item does not have the correct major type.</para>
+        /// <para>-or-</para>
+        /// <para>The next date item does not have the correct semantic tag.</para></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The semantic bignum encoding is invalid.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public BigInteger ReadBigInteger()
         {
             // implements https://tools.ietf.org/html/rfc7049#section-2.4.2
@@ -187,17 +187,17 @@ namespace System.Formats.Cbor
 
         /// <summary>Reads the next data item as a tagged decimal fraction encoding, as described in RFC7049 section 2.4.3.</summary>
         /// <returns>The decoded value.</returns>
-        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
-        /// <p>-or-</p>
-        /// <p>The next date item does not have the correct semantic tag.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The next data item does not have the correct major type.</para>
+        /// <para>-or-</para>
+        /// <para>The next date item does not have the correct semantic tag.</para></exception>
         /// <exception cref="OverflowException">The decoded decimal fraction is either too large or too small for a <see cref="decimal" /> value.</exception>
-        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p>There was an unexpected end of CBOR encoding data.</p>
-        /// <p>-or-</p>
-        /// <p>The semantic decimal fraction encoding is invalid.</p>
-        /// <p>-or-</p>
-        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data.</para>
+        /// <para>-or-</para>
+        /// <para>The semantic decimal fraction encoding is invalid.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public decimal ReadDecimal()
         {
             // implements https://tools.ietf.org/html/rfc7049#section-2.4.3

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Tag.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Tag.cs
@@ -11,11 +11,11 @@ namespace System.Formats.Cbor
         /// <summary>Reads the next data item as a semantic tag (major type 6).</summary>
         /// <returns>The decoded value.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         [CLSCompliant(false)]
         public CborTag ReadTag()
         {
@@ -29,27 +29,27 @@ namespace System.Formats.Cbor
         /// <summary>Reads the next data item as a semantic tag (major type 6), without advancing the reader.</summary>
         /// <returns>The decoded value.</returns>
         /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         /// <remarks>Useful in scenarios where the semantic value decoder needs to be determined at run time.</remarks>
         [CLSCompliant(false)]
         public CborTag PeekTag() => PeekTagCore(out int _);
 
         /// <summary>Reads the next data item as a tagged date/time string, as described in RFC7049 section 2.4.1.</summary>
         /// <returns>The decoded value.</returns>
-        /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.
-        /// -or-
-        /// The next date item does not have the correct semantic tag.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// Invalid semantic date/time encoding.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
+        /// <p>-or-</p>
+        /// <p>The next date item does not have the correct semantic tag.</p></exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The semantic date/time encoding is invalid.</p>
+        /// <p>-or-</p>
+        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public DateTimeOffset ReadDateTimeOffset()
         {
             // implements https://tools.ietf.org/html/rfc7049#section-2.4.1
@@ -88,16 +88,16 @@ namespace System.Formats.Cbor
 
         /// <summary>Reads the next data item as a tagged unix time in seconds, as described in RFC7049 section 2.4.1.</summary>
         /// <returns>The decoded value.</returns>
-        /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.
-        /// -or-
-        /// The next date item does not have the correct semantic tag.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// invalid semantic date/time encoding.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
+        /// <p>-or-</p>
+        /// <p>The next date item does not have the correct semantic tag.</p></exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The semantic date/time encoding is invalid.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public DateTimeOffset ReadUnixTimeSeconds()
         {
             // implements https://tools.ietf.org/html/rfc7049#section-2.4.1
@@ -140,16 +140,16 @@ namespace System.Formats.Cbor
 
         /// <summary>Reads the next data item as a tagged bignum encoding, as described in RFC7049 section 2.4.2.</summary>
         /// <returns>The decoded value.</returns>
-        /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.
-        /// -or-
-        /// The next date item does not have the correct semantic tag.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// Invalid semantic bignum encoding.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
+        /// <p>-or-</p>
+        /// <p>The next date item does not have the correct semantic tag.</p></exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The semantic bignum encoding is invalid.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public BigInteger ReadBigInteger()
         {
             // implements https://tools.ietf.org/html/rfc7049#section-2.4.2
@@ -187,17 +187,17 @@ namespace System.Formats.Cbor
 
         /// <summary>Reads the next data item as a tagged decimal fraction encoding, as described in RFC7049 section 2.4.3.</summary>
         /// <returns>The decoded value.</returns>
-        /// <exception cref="InvalidOperationException">The next data item does not have the correct major type.
-        /// -or-
-        /// The next date item does not have the correct semantic tag.</exception>
-        /// <exception cref="OverflowException">Decoded decimal fraction is either too large or too small for a <see cref="decimal" /> value.</exception>
-        /// <exception cref="CborContentException">The next value has an invalid CBOR encoding.
-        /// -or-
-        /// There was an unexpected end of CBOR encoding data.
-        /// -or-
-        /// Invalid semantic decimal fraction encoding.
-        /// -or-
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>The next data item does not have the correct major type.</p>
+        /// <p>-or-</p>
+        /// <p>The next date item does not have the correct semantic tag.</p></exception>
+        /// <exception cref="OverflowException">The decoded decimal fraction is either too large or too small for a <see cref="decimal" /> value.</exception>
+        /// <exception cref="CborContentException"><p>The next value has an invalid CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p>There was an unexpected end of CBOR encoding data.</p>
+        /// <p>-or-</p>
+        /// <p>The semantic decimal fraction encoding is invalid.</p>
+        /// <p>-or-</p>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public decimal ReadDecimal()
         {
             // implements https://tools.ietf.org/html/rfc7049#section-2.4.3

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Tag.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Tag.cs
@@ -49,7 +49,7 @@ namespace System.Formats.Cbor
         /// <p>-or-</p>
         /// <p>The semantic date/time encoding is invalid.</p>
         /// <p>-or-</p>
-        /// The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
+        /// <p>The next value uses a CBOR encoding that is not valid under the current conformance mode.</p></exception>
         public DateTimeOffset ReadDateTimeOffset()
         {
             // implements https://tools.ietf.org/html/rfc7049#section-2.4.1

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.cs
@@ -66,9 +66,9 @@ namespace System.Formats.Cbor
         /// <summary>Reads the next CBOR data item, returning a <see cref="ReadOnlyMemory{T}" /> view of the encoded value. For indefinite length encodings this includes the break byte.</summary>
         /// <param name="disableConformanceModeChecks"><see langword="true" /> to disable conformance mode validation for the read value, equivalent to using <see cref="CborConformanceMode.Lax" />; otherwise, <see langword="false" />.</param>
         /// <returns>A view of the encoded value as a contiguous region of memory.</returns>
-        /// <exception cref="CborContentException">The data item is not a valid CBOR data item encoding.
-        /// -or-
-        /// The CBOR encoding is not valid under the current conformance mode.</exception>
+        /// <exception cref="CborContentException"><p>The data item is not a valid CBOR data item encoding.</p>
+        /// <p>-or-</p>
+        /// <p>The CBOR encoding is not valid under the current conformance mode.</p></exception>
         public ReadOnlyMemory<byte> ReadEncodedValue(bool disableConformanceModeChecks = false)
         {
             // keep a snapshot of the current offset

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.cs
@@ -66,9 +66,9 @@ namespace System.Formats.Cbor
         /// <summary>Reads the next CBOR data item, returning a <see cref="ReadOnlyMemory{T}" /> view of the encoded value. For indefinite length encodings this includes the break byte.</summary>
         /// <param name="disableConformanceModeChecks"><see langword="true" /> to disable conformance mode validation for the read value, equivalent to using <see cref="CborConformanceMode.Lax" />; otherwise, <see langword="false" />.</param>
         /// <returns>A view of the encoded value as a contiguous region of memory.</returns>
-        /// <exception cref="CborContentException"><p>The data item is not a valid CBOR data item encoding.</p>
-        /// <p>-or-</p>
-        /// <p>The CBOR encoding is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="CborContentException"><para>The data item is not a valid CBOR data item encoding.</para>
+        /// <para>-or-</para>
+        /// <para>The CBOR encoding is not valid under the current conformance mode.</para></exception>
         public ReadOnlyMemory<byte> ReadEncodedValue(bool disableConformanceModeChecks = false)
         {
             // keep a snapshot of the current offset

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Array.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Array.cs
@@ -12,11 +12,11 @@ namespace System.Formats.Cbor
         /// <summary>Writes the start of a definite or indefinite-length array (major type 4).</summary>
         /// <param name="definiteLength">The length of the definite-length array, or <see langword="null" /> for an indefinite-length array.</param>
         /// <exception cref="ArgumentOutOfRangeException">The <paramref name="definiteLength" /> parameter cannot be negative.</exception>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         /// <remarks>
         /// In canonical conformance modes, the writer will reject indefinite-length writes unless
         /// the <see cref="ConvertIndefiniteLengthEncodings" /> flag is enabled.
@@ -34,9 +34,9 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Writes the end of an array (major type 4).</summary>
-        /// <exception cref="InvalidOperationException"><p>The written data is not accepted under the current conformance mode.</p>
-        /// <p>-or-</p>
-        /// <p>The definite-length array anticipates more data items.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The written data is not accepted under the current conformance mode.</para>
+        /// <para>-or-</para>
+        /// <para>The definite-length array anticipates more data items.</para></exception>
         public void WriteEndArray()
         {
             PopDataItem(CborMajorType.Array);

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Array.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Array.cs
@@ -12,11 +12,11 @@ namespace System.Formats.Cbor
         /// <summary>Writes the start of a definite or indefinite-length array (major type 4).</summary>
         /// <param name="definiteLength">The length of the definite-length array, or <see langword="null" /> for an indefinite-length array.</param>
         /// <exception cref="ArgumentOutOfRangeException">The <paramref name="definiteLength" /> parameter cannot be negative.</exception>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         /// <remarks>
         /// In canonical conformance modes, the writer will reject indefinite-length writes unless
         /// the <see cref="ConvertIndefiniteLengthEncodings" /> flag is enabled.
@@ -34,9 +34,9 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Writes the end of an array (major type 4).</summary>
-        /// <exception cref="InvalidOperationException">The written data is not accepted under the current conformance mode.
-        /// -or-
-        /// The definite-length array anticipates more data items.</exception>
+        /// <exception cref="InvalidOperationException"><p>The written data is not accepted under the current conformance mode.</p>
+        /// <p>-or-</p>
+        /// <p>The definite-length array anticipates more data items.</p></exception>
         public void WriteEndArray()
         {
             PopDataItem(CborMajorType.Array);

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Integer.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Integer.cs
@@ -11,20 +11,20 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a value as a signed integer encoding (major types 0,1)</summary>
         /// <param name="value">The value to write</param>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         public void WriteInt32(int value) => WriteInt64(value);
 
         /// <summary>Writes the provided value as a signed integer encoding (major types 0,1)</summary>
         /// <param name="value">The value to write</param>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         public void WriteInt64(long value)
         {
             if (value < 0)
@@ -42,21 +42,21 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a value as an unsigned integer encoding (major type 0).</summary>
         /// <param name="value">The value to write</param>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         [CLSCompliant(false)]
         public void WriteUInt32(uint value) => WriteUInt64(value);
 
         /// <summary>Writes a value as an unsigned integer encoding (major type 0).</summary>
         /// <param name="value">The value to write</param>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         [CLSCompliant(false)]
         public void WriteUInt64(ulong value)
         {
@@ -66,11 +66,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes the provided value as a CBOR negative integer representation (major type 1).</summary>
         /// <param name="value">An unsigned integer denoting -1 minus the integer.</param>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         /// <remarks>
         /// This method supports encoding integers between -18446744073709551616 and -1.
         /// Useful for handling values that do not fit in the <see cref="long" /> type.

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Integer.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Integer.cs
@@ -11,20 +11,20 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a value as a signed integer encoding (major types 0,1)</summary>
         /// <param name="value">The value to write</param>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         public void WriteInt32(int value) => WriteInt64(value);
 
         /// <summary>Writes the provided value as a signed integer encoding (major types 0,1)</summary>
         /// <param name="value">The value to write</param>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         public void WriteInt64(long value)
         {
             if (value < 0)
@@ -42,21 +42,21 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a value as an unsigned integer encoding (major type 0).</summary>
         /// <param name="value">The value to write</param>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         [CLSCompliant(false)]
         public void WriteUInt32(uint value) => WriteUInt64(value);
 
         /// <summary>Writes a value as an unsigned integer encoding (major type 0).</summary>
         /// <param name="value">The value to write</param>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         [CLSCompliant(false)]
         public void WriteUInt64(ulong value)
         {
@@ -66,11 +66,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes the provided value as a CBOR negative integer representation (major type 1).</summary>
         /// <param name="value">An unsigned integer denoting -1 minus the integer.</param>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         /// <remarks>
         /// This method supports encoding integers between -18446744073709551616 and -1.
         /// Useful for handling values that do not fit in the <see cref="long" /> type.

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Map.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Map.cs
@@ -17,11 +17,11 @@ namespace System.Formats.Cbor
         /// <summary>Writes the start of a definite or indefinite-length map (major type 5).</summary>
         /// <param name="definiteLength">The length of the definite-length map, or <see langword="null" /> for an indefinite-length map.</param>
         /// <exception cref="ArgumentOutOfRangeException">The <paramref name="definiteLength" /> parameter cannot be negative.</exception>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         /// <remarks>
         /// In canonical conformance modes, the writer will reject indefinite-length writes unless
         /// the <see cref="ConvertIndefiniteLengthEncodings" /> flag is enabled.
@@ -45,11 +45,11 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Writes the end of a map (major type 5).</summary>
-        /// <exception cref="InvalidOperationException"><p>The written data is not accepted under the current conformance mode.</p>
-        /// <p>-or-</p>
-        /// <p>The definite-length map anticipates more data items.</p>
-        /// <p>-or-</p>
-        /// <p>The latest key/value pair is lacking a value.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>The written data is not accepted under the current conformance mode.</para>
+        /// <para>-or-</para>
+        /// <para>The definite-length map anticipates more data items.</para>
+        /// <para>-or-</para>
+        /// <para>The latest key/value pair is lacking a value.</para></exception>
         public void WriteEndMap()
         {
             if (_itemsWritten % 2 == 1)

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Map.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Map.cs
@@ -17,20 +17,20 @@ namespace System.Formats.Cbor
         /// <summary>Writes the start of a definite or indefinite-length map (major type 5).</summary>
         /// <param name="definiteLength">The length of the definite-length map, or <see langword="null" /> for an indefinite-length map.</param>
         /// <exception cref="ArgumentOutOfRangeException">The <paramref name="definiteLength" /> parameter cannot be negative.</exception>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         /// <remarks>
         /// In canonical conformance modes, the writer will reject indefinite-length writes unless
         /// the <see cref="ConvertIndefiniteLengthEncodings" /> flag is enabled.
         /// Map contents are written as if arrays twice the length of the map's declared size.
-        /// For instance, a map of size 1 containing a key of type <see cref="int" /> with a value of type string must be written
+        /// For example, a map of size 1 containing a key of type <see cref="int" /> with a value of type string must be written
         /// by successive calls to <see cref="WriteInt32(int)" /> and <see cref="WriteTextString(System.ReadOnlySpan{char})" />.
         /// It is up to the caller to keep track of whether the next call is a key or a value.
         /// Fundamentally, this is a technical restriction stemming from the fact that CBOR allows keys of any type,
-        /// for instance a map can contain keys that are maps themselves.
+        /// for example, a map can contain keys that are maps themselves.
         /// </remarks>
         public void WriteStartMap(int? definiteLength)
         {
@@ -45,11 +45,11 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Writes the end of a map (major type 5).</summary>
-        /// <exception cref="InvalidOperationException">The written data is not accepted under the current conformance mode.
-        /// -or-
-        /// The definite-length map anticipates more data items.
-        /// -or-
-        /// The latest key/value pair is lacking a value.</exception>
+        /// <exception cref="InvalidOperationException"><p>The written data is not accepted under the current conformance mode.</p>
+        /// <p>-or-</p>
+        /// <p>The definite-length map anticipates more data items.</p>
+        /// <p>-or-</p>
+        /// <p>The latest key/value pair is lacking a value.</p></exception>
         public void WriteEndMap()
         {
             if (_itemsWritten % 2 == 1)

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Simple.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Simple.cs
@@ -11,11 +11,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a single-precision floating point number (major type 7).</summary>
         /// <param name="value">The value to write.</param>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         public void WriteSingle(float value)
         {
             if (!CborConformanceModeHelpers.RequiresPreservingFloatPrecision(ConformanceMode) &&
@@ -31,11 +31,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a double-precision floating point number (major type 7).</summary>
         /// <param name="value">The value to write.</param>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         public void WriteDouble(double value)
         {
             if (!CborConformanceModeHelpers.RequiresPreservingFloatPrecision(ConformanceMode) &&

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Simple.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Simple.cs
@@ -11,11 +11,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a single-precision floating point number (major type 7).</summary>
         /// <param name="value">The value to write.</param>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         public void WriteSingle(float value)
         {
             if (!CborConformanceModeHelpers.RequiresPreservingFloatPrecision(ConformanceMode) &&
@@ -31,11 +31,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a double-precision floating point number (major type 7).</summary>
         /// <param name="value">The value to write.</param>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         public void WriteDouble(double value)
         {
             if (!CborConformanceModeHelpers.RequiresPreservingFloatPrecision(ConformanceMode) &&

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Simple.netcoreapp.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Simple.netcoreapp.cs
@@ -12,11 +12,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a half-precision floating point number (major type 7).</summary>
         /// <param name="value">The value to write.</param>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         public void WriteHalf(Half value)
         {
             EnsureWriteCapacity(1 + sizeof(short));

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Simple.netcoreapp.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Simple.netcoreapp.cs
@@ -12,11 +12,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a half-precision floating point number (major type 7).</summary>
         /// <param name="value">The value to write.</param>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         public void WriteHalf(Half value)
         {
             EnsureWriteCapacity(1 + sizeof(short));

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Simple.netstandard.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Simple.netstandard.cs
@@ -12,11 +12,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a half-precision floating point number (major type 7).</summary>
         /// <param name="value">The value to write.</param>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         private void WriteHalf(ushort value)
         {
             EnsureWriteCapacity(1 + sizeof(ushort));

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Simple.netstandard.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Simple.netstandard.cs
@@ -12,11 +12,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a half-precision floating point number (major type 7).</summary>
         /// <param name="value">The value to write.</param>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         private void WriteHalf(ushort value)
         {
             EnsureWriteCapacity(1 + sizeof(ushort));

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.String.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.String.cs
@@ -17,11 +17,11 @@ namespace System.Formats.Cbor
         /// <summary>Writes a buffer as a byte string encoding (major type 2).</summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="ArgumentNullException">The provided value cannot be <see langword="null" />.</exception>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         public void WriteByteString(byte[] value!!)
         {
             WriteByteString(value.AsSpan());
@@ -29,11 +29,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a buffer as a byte string encoding (major type 2).</summary>
         /// <param name="value">The value to write.</param>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         public void WriteByteString(ReadOnlySpan<byte> value)
         {
             WriteUnsignedInteger(CborMajorType.ByteString, (ulong)value.Length);
@@ -54,11 +54,11 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Writes the start of an indefinite-length byte string (major type 2).</summary>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         /// <remarks>
         /// Pushes a context where definite-length chunks of the same major type can be written.
         /// In canonical conformance modes, the writer will reject indefinite-length writes unless
@@ -96,11 +96,11 @@ namespace System.Formats.Cbor
         /// <param name="value">The value to write.</param>
         /// <exception cref="ArgumentNullException">The provided value cannot be <see langword="null" />.</exception>
         /// <exception cref="ArgumentException">The supplied string is not a valid UTF-8 encoding, which is not permitted under the current conformance mode.</exception>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         public void WriteTextString(string value!!)
         {
             WriteTextString(value.AsSpan());
@@ -109,11 +109,11 @@ namespace System.Formats.Cbor
         /// <summary>Writes a buffer as a UTF-8 string encoding (major type 3).</summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="ArgumentException">The supplied string is not a valid UTF-8 encoding, which is not permitted under the current conformance mode.</exception>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         public void WriteTextString(ReadOnlySpan<char> value)
         {
             Encoding utf8Encoding = CborConformanceModeHelpers.GetUtf8Encoding(ConformanceMode);
@@ -146,11 +146,11 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Writes the start of an indefinite-length UTF-8 string (major type 3).</summary>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         /// <remarks>
         /// Pushes a context where definite-length chunks of the same major type can be written.
         /// In canonical conformance modes, the writer will reject indefinite-length writes unless

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.String.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.String.cs
@@ -17,11 +17,11 @@ namespace System.Formats.Cbor
         /// <summary>Writes a buffer as a byte string encoding (major type 2).</summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="ArgumentNullException">The provided value cannot be <see langword="null" />.</exception>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         public void WriteByteString(byte[] value!!)
         {
             WriteByteString(value.AsSpan());
@@ -29,11 +29,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a buffer as a byte string encoding (major type 2).</summary>
         /// <param name="value">The value to write.</param>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         public void WriteByteString(ReadOnlySpan<byte> value)
         {
             WriteUnsignedInteger(CborMajorType.ByteString, (ulong)value.Length);
@@ -54,11 +54,11 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Writes the start of an indefinite-length byte string (major type 2).</summary>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         /// <remarks>
         /// Pushes a context where definite-length chunks of the same major type can be written.
         /// In canonical conformance modes, the writer will reject indefinite-length writes unless
@@ -96,11 +96,11 @@ namespace System.Formats.Cbor
         /// <param name="value">The value to write.</param>
         /// <exception cref="ArgumentNullException">The provided value cannot be <see langword="null" />.</exception>
         /// <exception cref="ArgumentException">The supplied string is not a valid UTF-8 encoding, which is not permitted under the current conformance mode.</exception>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         public void WriteTextString(string value!!)
         {
             WriteTextString(value.AsSpan());
@@ -109,11 +109,11 @@ namespace System.Formats.Cbor
         /// <summary>Writes a buffer as a UTF-8 string encoding (major type 3).</summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="ArgumentException">The supplied string is not a valid UTF-8 encoding, which is not permitted under the current conformance mode.</exception>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         public void WriteTextString(ReadOnlySpan<char> value)
         {
             Encoding utf8Encoding = CborConformanceModeHelpers.GetUtf8Encoding(ConformanceMode);
@@ -146,11 +146,11 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>Writes the start of an indefinite-length UTF-8 string (major type 3).</summary>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         /// <remarks>
         /// Pushes a context where definite-length chunks of the same major type can be written.
         /// In canonical conformance modes, the writer will reject indefinite-length writes unless

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Tag.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Tag.cs
@@ -60,7 +60,7 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a unix time in seconds as a tagged date/time value, as described in RFC7049 section 2.4.1.</summary>
         /// <param name="seconds">The value to write.</param>
-        /// <exception cref="ArgumentException">The <paramref name="seconds" /> parameter cannot be infinite or NaN</exception>
+        /// <exception cref="ArgumentException">The <paramref name="seconds" /> parameter cannot be infinite or NaN.</exception>
         /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
         /// <p>-or-</p>
         /// <p>The major type of the encoded value is not permitted in the parent data item.</p>

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Tag.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Tag.cs
@@ -10,11 +10,11 @@ namespace System.Formats.Cbor
     {
         /// <summary>Assign a semantic tag (major type 6) to the next data item.</summary>
         /// <param name="tag">The value to write.</param>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         [CLSCompliant(false)]
         public void WriteTag(CborTag tag)
         {
@@ -29,11 +29,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes the provided value as a tagged date/time string, as described in RFC7049 section 2.4.1.</summary>
         /// <param name="value">The value to write.</param>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         public void WriteDateTimeOffset(DateTimeOffset value)
         {
             string dateString =
@@ -47,11 +47,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a unix time in seconds as a tagged date/time value, as described in RFC7049 section 2.4.1.</summary>
         /// <param name="seconds">The value to write.</param>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         public void WriteUnixTimeSeconds(long seconds)
         {
             WriteTag(CborTag.UnixTimeSeconds);
@@ -61,11 +61,11 @@ namespace System.Formats.Cbor
         /// <summary>Writes a unix time in seconds as a tagged date/time value, as described in RFC7049 section 2.4.1.</summary>
         /// <param name="seconds">The value to write.</param>
         /// <exception cref="ArgumentException">The <paramref name="seconds" /> parameter cannot be infinite or NaN.</exception>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         public void WriteUnixTimeSeconds(double seconds)
         {
             if (double.IsInfinity(seconds) || double.IsNaN(seconds))
@@ -79,11 +79,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes the provided value as a tagged bignum encoding, as described in RFC7049 section 2.4.2.</summary>
         /// <param name="value">The value to write.</param>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         public void WriteBigInteger(BigInteger value)
         {
             bool isUnsigned = value.Sign >= 0;
@@ -96,11 +96,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes the provided value value as a tagged decimal fraction encoding, as described in RFC7049 section 2.4.3</summary>
         /// <param name="value">The value to write.</param>
-        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
-        /// <p>-or-</p>
-        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
+        /// <exception cref="InvalidOperationException"><para>Writing a new value exceeds the definite length of the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The major type of the encoded value is not permitted in the parent data item.</para>
+        /// <para>-or-</para>
+        /// <para>The written data is not accepted under the current conformance mode.</para></exception>
         public void WriteDecimal(decimal value)
         {
             DecimalHelpers.Deconstruct(value, out decimal mantissa, out byte scale);

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Tag.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Tag.cs
@@ -10,11 +10,11 @@ namespace System.Formats.Cbor
     {
         /// <summary>Assign a semantic tag (major type 6) to the next data item.</summary>
         /// <param name="tag">The value to write.</param>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         [CLSCompliant(false)]
         public void WriteTag(CborTag tag)
         {
@@ -29,11 +29,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes the provided value as a tagged date/time string, as described in RFC7049 section 2.4.1.</summary>
         /// <param name="value">The value to write.</param>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         public void WriteDateTimeOffset(DateTimeOffset value)
         {
             string dateString =
@@ -47,11 +47,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a unix time in seconds as a tagged date/time value, as described in RFC7049 section 2.4.1.</summary>
         /// <param name="seconds">The value to write.</param>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         public void WriteUnixTimeSeconds(long seconds)
         {
             WriteTag(CborTag.UnixTimeSeconds);
@@ -61,11 +61,11 @@ namespace System.Formats.Cbor
         /// <summary>Writes a unix time in seconds as a tagged date/time value, as described in RFC7049 section 2.4.1.</summary>
         /// <param name="seconds">The value to write.</param>
         /// <exception cref="ArgumentException">The <paramref name="seconds" /> parameter cannot be infinite or NaN</exception>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         public void WriteUnixTimeSeconds(double seconds)
         {
             if (double.IsInfinity(seconds) || double.IsNaN(seconds))
@@ -79,11 +79,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes the provided value as a tagged bignum encoding, as described in RFC7049 section 2.4.2.</summary>
         /// <param name="value">The value to write.</param>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         public void WriteBigInteger(BigInteger value)
         {
             bool isUnsigned = value.Sign >= 0;
@@ -96,11 +96,11 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes the provided value value as a tagged decimal fraction encoding, as described in RFC7049 section 2.4.3</summary>
         /// <param name="value">The value to write.</param>
-        /// <exception cref="InvalidOperationException">Writing a new value exceeds the definite length of the parent data item.
-        /// -or-
-        /// The major type of the encoded value is not permitted in the parent data item.
-        /// -or-
-        /// The written data is not accepted under the current conformance mode.</exception>
+        /// <exception cref="InvalidOperationException"><p>Writing a new value exceeds the definite length of the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The major type of the encoded value is not permitted in the parent data item.</p>
+        /// <p>-or-</p>
+        /// <p>The written data is not accepted under the current conformance mode.</p></exception>
         public void WriteDecimal(decimal value)
         {
             DecimalHelpers.Deconstruct(value, out decimal mantissa, out byte scale);

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.cs
@@ -57,7 +57,7 @@ namespace System.Formats.Cbor
         /// <summary>Initializes a new instance of <see cref="CborWriter" /> class using the specified configuration.</summary>
         /// <param name="conformanceMode">One of the enumeration values that specifies the guidance on the conformance checks performed on the encoded data.
         /// Defaults to <see cref="CborConformanceMode.Strict" /> conformance mode.</param>
-        /// <param name="convertIndefiniteLengthEncodings"><see langword="true" /> to enable automatically converting indefinite-length encodings into definite-length equivalents and allow use of indefinite-length write APIs in conformance modes that otherwise do not permit it; otherwise, <see langword="false" /></param>
+        /// <param name="convertIndefiniteLengthEncodings"><see langword="true" /> to enable automatically converting indefinite-length encodings into definite-length equivalents and allow use of indefinite-length write APIs in conformance modes that otherwise do not permit it; otherwise, <see langword="false" />.</param>
         /// <param name="allowMultipleRootLevelValues"><see langword="true" /> to allow multiple root-level values to be written by the writer; otherwise, <see langword="false" />.</param>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="conformanceMode" /> is not a defined <see cref="CborConformanceMode" />.</exception>
         public CborWriter(CborConformanceMode conformanceMode = CborConformanceMode.Strict, bool convertIndefiniteLengthEncodings = false, bool allowMultipleRootLevelValues = false)

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.cs
@@ -95,9 +95,9 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a single CBOR data item which has already been encoded.</summary>
         /// <param name="encodedValue">The encoded value to write.</param>
-        /// <exception cref="ArgumentException"><paramref name="encodedValue" /> is not a well-formed CBOR encoding.
-        /// -or-
-        /// <paramref name="encodedValue" /> is not valid under the current conformance mode.</exception>
+        /// <exception cref="ArgumentException"><p><paramref name="encodedValue" /> is not a well-formed CBOR encoding.</p>
+        /// <p>-or-</p>
+        /// <p><paramref name="encodedValue" /> is not valid under the current conformance mode.</p></exception>
         public void WriteEncodedValue(ReadOnlySpan<byte> encodedValue)
         {
             ValidateEncoding(encodedValue, ConformanceMode);

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.cs
@@ -95,9 +95,9 @@ namespace System.Formats.Cbor
 
         /// <summary>Writes a single CBOR data item which has already been encoded.</summary>
         /// <param name="encodedValue">The encoded value to write.</param>
-        /// <exception cref="ArgumentException"><p><paramref name="encodedValue" /> is not a well-formed CBOR encoding.</p>
-        /// <p>-or-</p>
-        /// <p><paramref name="encodedValue" /> is not valid under the current conformance mode.</p></exception>
+        /// <exception cref="ArgumentException"><para><paramref name="encodedValue" /> is not a well-formed CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para><paramref name="encodedValue" /> is not valid under the current conformance mode.</para></exception>
         public void WriteEncodedValue(ReadOnlySpan<byte> encodedValue)
         {
             ValidateEncoding(encodedValue, ConformanceMode);


### PR DESCRIPTION
The `<p>` tags are needed around the separate exception lines, otherwise the newlines are lost on the rendered page:

![image](https://user-images.githubusercontent.com/24882762/156695909-31cc2837-64e0-4bae-b94e-1fed1f3c93d8.png)
