### PR TITLE
 delete the test file with custom security settings when it's being closed

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
@@ -103,7 +103,7 @@ namespace System.IO
         /// <param name="lineNumber">The line number of the function calling this method.</param>
         protected string GetTestFileName(int? index = null, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
         {
-            string testFileName = GenerateTestFileName(index, memberName, lineNumber);
+            string testFileName = PathGenerator.GenerateTestFileName(index, memberName, lineNumber);
             string testFilePath = Path.Combine(TestDirectory, testFileName);
 
             const int maxLength = 260 - 5; // Windows MAX_PATH minus a bit
@@ -121,7 +121,7 @@ namespace System.IO
                     int halfExcessLength = (int)Math.Ceiling((double)excessLength / 2);
                     memberName = memberName.Substring(0, halfMemberNameLength - halfExcessLength) + "..." + memberName.Substring(halfMemberNameLength + halfExcessLength);
 
-                    testFileName = GenerateTestFileName(index, memberName, lineNumber);
+                    testFileName = PathGenerator.GenerateTestFileName(index, memberName, lineNumber);
                     testFilePath = Path.Combine(TestDirectory, testFileName);
                 }
                 else
@@ -166,14 +166,6 @@ namespace System.IO
             }
             return sb.ToString();
         }
-
-        private string GenerateTestFileName(int? index, string memberName, int lineNumber) =>
-            string.Format(
-                index.HasValue ? "{0}_{1}_{2}_{3}" : "{0}_{1}_{3}",
-                memberName ?? "TestBase",
-                lineNumber,
-                index.GetValueOrDefault(),
-                Guid.NewGuid().ToString("N").Substring(0, 8)); // randomness to avoid collisions between derived test classes using same base method concurrently
 
         // Some Windows versions like Windows Nano Server have the %TEMP% environment variable set to "C:\TEMP" but the
         // actual folder name is "C:\Temp", which prevents asserting path values using Assert.Equal due to case sensitiveness.

--- a/src/libraries/Common/tests/TestUtilities/System/IO/PathGenerator.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/IO/PathGenerator.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace System.IO
+{
+    public static class PathGenerator
+    {
+        public static string GenerateTestFileName([CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+            => GenerateTestFileName(null, memberName, lineNumber);
+
+        public static string GenerateTestFileName(int? index, string memberName, int lineNumber) =>
+            string.Format(
+                index.HasValue ? "{0}_{1}_{2}_{3}" : "{0}_{1}_{3}",
+                memberName ?? "TestBase",
+                lineNumber,
+                index.GetValueOrDefault(),
+                Guid.NewGuid().ToString("N").Substring(0, 8)); // randomness to avoid collisions between derived test classes using same base method concurrently
+    }
+}

--- a/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
+++ b/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
@@ -18,6 +18,7 @@
     <Compile Include="System\AdminHelpers.cs" />
     <Compile Include="System\AssertExtensions.cs" />
     <Compile Include="System\IO\StreamExtensions.cs" />
+    <Compile Include="System\IO\PathGenerator.cs" />
     <Compile Include="System\RetryHelper.cs" />
     <Compile Include="System\Buffers\BoundedMemory.cs" />
     <Compile Include="System\Buffers\BoundedMemory.Creation.cs" />

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -191,7 +191,7 @@ namespace System.IO
         public void DirectoryInfo_Create_NotFound()
         {
             using var tempRootDir = new TempAclDirectory();
-            string dirPath = Path.Combine(tempRootDir.Path, Guid.NewGuid().ToString(), "ParentDoesNotExist");
+            string dirPath = Path.Combine(tempRootDir.GenerateSubItemPath(), "ParentDoesNotExist");
 
             var dirInfo = new DirectoryInfo(dirPath);
             var security = new DirectorySecurity();
@@ -203,7 +203,7 @@ namespace System.IO
         public void DirectoryInfo_Create_NotFound_FullControl()
         {
             using var tempRootDir = new TempAclDirectory();
-            string dirPath = Path.Combine(tempRootDir.Path, Guid.NewGuid().ToString(), "ParentDoesNotExist");
+            string dirPath = Path.Combine(tempRootDir.GenerateSubItemPath(), "ParentDoesNotExist");
 
             var dirInfo = new DirectoryInfo(dirPath);
             var security = GetDirectorySecurity(FileSystemRights.FullControl);
@@ -292,7 +292,7 @@ namespace System.IO
         public void FileInfo_Create_DirectoryNotFound()
         {
             using var tempRootDir = new TempAclDirectory();
-            string path = Path.Combine(tempRootDir.Path, Guid.NewGuid().ToString(), "file.txt");
+            string path = Path.Combine(tempRootDir.GenerateSubItemPath(), "file.txt");
             var info = new FileInfo(path);
             var security = new FileSecurity();
             Assert.Throws<DirectoryNotFoundException>(() =>
@@ -397,7 +397,7 @@ namespace System.IO
             // - In .NET, throws IOException: "The parameter is incorrect"
 
             var security = new FileSecurity();
-            var info = new FileInfo(Guid.NewGuid().ToString());
+            var info = new FileInfo(PathGenerator.GenerateTestFileName());
             Assert.Throws<IOException>(() => info.Create(FileMode.Truncate, FileSystemRights.Write | FileSystemRights.ReadData, FileShare.None, DefaultBufferSize, FileOptions.None, security));
         }
 
@@ -469,7 +469,7 @@ namespace System.IO
 
             using var tempRootDir = new TempAclDirectory();
 
-            string path = Path.Combine(tempRootDir.Path, Guid.NewGuid().ToString());
+            string path = tempRootDir.GenerateSubItemPath();
             var fileInfo = new FileInfo(path);
 
             using FileStream stream = fileInfo.Create(
@@ -515,7 +515,7 @@ namespace System.IO
         public void DirectorySecurity_CreateDirectory_DirectoryAlreadyExists()
         {
             using var tempRootDir = new TempAclDirectory();
-            string path = Path.Combine(tempRootDir.Path, Guid.NewGuid().ToString());
+            string path = tempRootDir.GenerateSubItemPath();
 
             DirectorySecurity expectedSecurity = GetDirectorySecurity(FileSystemRights.FullControl);
             DirectoryInfo dirInfo = expectedSecurity.CreateDirectory(path);
@@ -618,7 +618,7 @@ namespace System.IO
         private void FileInfo_Create_FileSecurity_ArgumentOutOfRangeException(string paramName, FileMode mode = FileMode.CreateNew, FileShare share = FileShare.None, int bufferSize = DefaultBufferSize)
         {
             var security = new FileSecurity();
-            var info = new FileInfo(Guid.NewGuid().ToString());
+            var info = new FileInfo(PathGenerator.GenerateTestFileName());
             Assert.Throws<ArgumentOutOfRangeException>(paramName, () =>
                 info.Create(mode, FileSystemRights.FullControl, share, bufferSize, FileOptions.None, security));
         }
@@ -626,7 +626,7 @@ namespace System.IO
         private void FileInfo_Create_FileSecurity_ArgumentException(FileMode mode, FileSystemRights rights)
         {
             var security = new FileSecurity();
-            var info = new FileInfo(Guid.NewGuid().ToString());
+            var info = new FileInfo(PathGenerator.GenerateTestFileName());
             Assert.Throws<ArgumentException>(() =>
                 info.Create(mode, rights, FileShare.None, DefaultBufferSize, FileOptions.None, security));
         }
@@ -634,14 +634,14 @@ namespace System.IO
         private void FileInfo_Create_FileSecurity_Successful(FileMode mode, FileSystemRights rights)
         {
             var security = new FileSecurity();
-            var info = new FileInfo(Guid.NewGuid().ToString());
+            var info = new FileInfo(PathGenerator.GenerateTestFileName());
             info.Create(mode, rights, FileShare.None, DefaultBufferSize, FileOptions.None, security).Dispose();
         }
 
         private void Verify_FileSecurity_CreateFile(FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options, FileSecurity expectedSecurity)
         {
             using var tempRootDir = new TempAclDirectory();
-            string path = Path.Combine(tempRootDir.Path, Guid.NewGuid().ToString());
+            string path = tempRootDir.GenerateSubItemPath();
             var fileInfo = new FileInfo(path);
 
             using (FileStream fs = fileInfo.Create(mode, rights, share, bufferSize, options, expectedSecurity))
@@ -667,7 +667,7 @@ namespace System.IO
         private void Verify_DirectorySecurity_CreateDirectory(DirectorySecurity expectedSecurity)
         {
             using var tempRootDir = new TempAclDirectory();
-            string path = Path.Combine(tempRootDir.Path, Guid.NewGuid().ToString());
+            string path = tempRootDir.GenerateSubItemPath();
             DirectoryInfo dirInfo = expectedSecurity.CreateDirectory(path);
             Assert.True(dirInfo.Exists);
             tempRootDir.CreatedSubdirectories.Add(dirInfo);

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -635,7 +635,7 @@ namespace System.IO
         {
             var security = new FileSecurity();
             var info = new FileInfo(PathGenerator.GenerateTestFileName());
-            info.Create(mode, rights, FileShare.None, DefaultBufferSize, FileOptions.None, security).Dispose();
+            info.Create(mode, rights, FileShare.None, DefaultBufferSize, FileOptions.DeleteOnClose, security).Dispose();
         }
 
         private void Verify_FileSecurity_CreateFile(FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options, FileSecurity expectedSecurity)

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/TempAclDirectory.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/TempAclDirectory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Security.AccessControl;
 using System.Security.Principal;
 
@@ -16,6 +17,18 @@ namespace System.IO
     {
         internal readonly List<DirectoryInfo> CreatedSubdirectories = new();
         internal readonly List<FileInfo> CreatedSubfiles = new();
+
+        public TempAclDirectory([CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+            : base(IO.Path.Combine(IO.Path.GetTempPath(), PathGenerator.GenerateTestFileName(null, memberName, lineNumber)))
+        {
+        }
+
+        /// <summary>
+        /// the returned path can be used both as directory and as file name
+        /// </summary>
+        public string GenerateSubItemPath([CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
+            => IO.Path.Combine(Path, PathGenerator.GenerateTestFileName(null, memberName, lineNumber));
+
         protected override void DeleteDirectory()
         {
             try


### PR DESCRIPTION
The problematic files/folders names were just guids, so it was hard to find out which test is creating them. So in the first commit, I've added a logic that uses the test name when generating the paths. This has allowed me to identify that `FileInfo_Create_FileSecurity_Successful` is the method which creates unremovable files.

The fix was to use `FileOptions.DeleteOnClose` which ensures that given file is being deleted when it's getting closed.

fixes #66108
