### PR TITLE
Add xarch `blsi`

### DIFF
--- a/src/coreclr/jit/instrsxarch.h
+++ b/src/coreclr/jit/instrsxarch.h
@@ -593,7 +593,7 @@ INST3(LAST_AVXVNNI_INSTRUCTION, "LAST_AVXVNNI_INSTRUCTION", IUM_WR, BAD_CODE, BA
 // BMI1
 INST3(FIRST_BMI_INSTRUCTION, "FIRST_BMI_INSTRUCTION", IUM_WR, BAD_CODE, BAD_CODE, BAD_CODE, INS_FLAGS_None)
 INST3(andn,             "andn",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF2),                             Resets_OF      | Writes_SF     | Writes_ZF     | Undefined_AF  | Undefined_PF  | Resets_CF     | INS_Flags_IsDstDstSrcAVXInstruction)    // Logical AND NOT
-INST3(blsi,             "blsi",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF3),                             INS_Flags_IsDstDstSrcAVXInstruction)    // Extract Lowest Set Isolated Bit
+INST3(blsi,             "blsi",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF3),                             Resets_OF      | Writes_SF     | Writes_ZF     | Undefined_AF  | Undefined_PF  | Writes_CF     | INS_Flags_IsDstDstSrcAVXInstruction)    // Extract Lowest Set Isolated Bit
 INST3(blsmsk,           "blsmsk",           IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF3),                             INS_Flags_IsDstDstSrcAVXInstruction)    // Get Mask Up to Lowest Set Bit
 INST3(blsr,             "blsr",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF3),                             Resets_OF      | Writes_SF     | Writes_ZF     | Undefined_AF  | Undefined_PF  | Writes_CF     | INS_Flags_IsDstDstSrcAVXInstruction)    // Reset Lowest Set Bit
 INST3(bextr,            "bextr",            IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF7),                             INS_Flags_IsDstDstSrcAVXInstruction)    // Bit Field Extract

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -348,6 +348,7 @@ private:
     void LowerHWIntrinsicGetElement(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicWithElement(GenTreeHWIntrinsic* node);
     GenTree* TryLowerAndOpToResetLowestSetBit(GenTreeOp* andNode);
+    GenTree* TryLowerAndOpToExtractLowestSetBit(GenTreeOp* andNode);
     GenTree* TryLowerAndOpToAndNot(GenTreeOp* andNode);
 #elif defined(TARGET_ARM64)
     bool IsValidConstForMovImm(GenTreeHWIntrinsic* node);

--- a/src/tests/JIT/Intrinsics/BMI1Intrinsics.cs
+++ b/src/tests/JIT/Intrinsics/BMI1Intrinsics.cs
@@ -1,0 +1,62 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace BMI1Intrinsics
+{
+    internal class Program
+    {
+        private static int _errorCode = 100;
+
+        static int Main(string[] args)
+        {
+            // bmi1 expression are folded to to hwintrinsics that return identical results
+
+            var values = new (uint input1, uint input2, uint andnExpected, uint blsiExpected, uint blsrExpected, uint blmskExpected)[] {
+                (0, 0, 0, 0 ,0 ,0),
+                (1, 0, 1, 1 ,0 ,0xfffffffe),
+                (uint.MaxValue / 2, 0, 0x7fffffff, 0x1 ,0x7ffffffe ,0xfffffffe),
+                ((uint.MaxValue / 2) - 1,  0, 0x7FFFFFFE, 2 ,0x7FFFFFFC ,0xFFFFFFFC),
+                ((uint.MaxValue / 2) + 1, 0, 0x80000000, 0x80000000 ,0 ,0),
+                (uint.MaxValue - 1, 0, 0xFFFFFFFE, 2 ,0xFFFFFFFC ,0xFFFFFFFC),
+                (uint.MaxValue , 0, 0xFFFFFFFF, 1 ,0xFFFFFFFE ,0xFFFFFFFE),
+                (0xAAAAAAAA,0xAAAAAAAA,0,2,0xAAAAAAA8,0xFFFFFFFC),
+                (0xAAAAAAAA,0x55555555,0xAAAAAAAA,2,0xAAAAAAA8,0xFFFFFFFC),
+            };
+
+            foreach (var value in values)
+            {
+                Test(value.input1, AndNot(value.input1, value.input2), value.andnExpected, nameof(AndNot));
+                Test(value.input1, ExtractLowestSetIsolatedBit(value.input1), value.blsiExpected, nameof(ExtractLowestSetIsolatedBit));
+                Test(value.input1, ResetLowestSetBit(value.input1), value.blsrExpected, nameof(ResetLowestSetBit));
+                Test(value.input1, GetMaskUpToLowestSetBit(value.input1), value.blmskExpected, nameof(GetMaskUpToLowestSetBit));
+            }
+
+            return _errorCode;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static uint AndNot(uint x, uint y) => x & (~y); // bmi1 andn
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static uint ExtractLowestSetIsolatedBit(uint x) => (uint)(x & (-x)); // bmi1 blsi
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static uint ResetLowestSetBit(uint x) => x & (x - 1); // bmi1 blsr
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static uint GetMaskUpToLowestSetBit(uint x) => (uint)(x ^ (-x)); // bmi1 blmsk
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void Test(uint input, uint output, uint expected,string callerName)
+        {
+            if (output != expected)
+            {
+                Console.WriteLine($"{callerName} failed.");
+                Console.WriteLine($"Input:    {input:X}");
+                Console.WriteLine($"Output:   {output:X}");
+                Console.WriteLine($"Expected: {expected:X}");
+
+                _errorCode++;
+            }
+        }
+    }
+}

--- a/src/tests/JIT/Intrinsics/BMI1Intrinsics.cs
+++ b/src/tests/JIT/Intrinsics/BMI1Intrinsics.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Runtime.CompilerServices;
 
 namespace BMI1Intrinsics
 {

--- a/src/tests/JIT/Intrinsics/BMI1Intrinsics_ro.csproj
+++ b/src/tests/JIT/Intrinsics/BMI1Intrinsics_ro.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BMI1Intrinsics.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Intrinsics/BMI1Intrinsicss_r.csproj
+++ b/src/tests/JIT/Intrinsics/BMI1Intrinsicss_r.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize />
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BMI1Intrinsics.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This adds a lowering for the pattern `AND(x, NEG(x))` to the ExtractLowestSetBit hwintrinsic. 

The spmi replay is clean and there is only one asm diff:

```diff
; Assembly listing for method System.String:GetCompareOptionsFromOrdinalStringComparison(int):int
; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
; optimized code
; rsp based frame
; partially interruptible
; No matching PGO data
; 0 inlinees with PGO data; 1 single block inlinees; 1 inlinees without PGO data
; Final local variable assignments
;
-;  V00 arg0         [V00,T00] (  6,  5.50)     int  ->  rsi         single-def
+;  V00 arg0         [V00,T00] (  5,  4.50)     int  ->  rsi         single-def
;* V01 loc0         [V01    ] (  0,  0   )     int  ->  zero-ref   
;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+00H]   "OutgoingArgSpace"
;  V03 tmp1         [V03,T02] (  3,  2   )     int  ->  rcx        
;  V04 tmp2         [V04,T01] (  2,  4   )    bool  ->  rcx         "Inlining Arg"
;  V05 cse0         [V05,T03] (  3,  1.50)     ref  ->  rdx         "CSE - moderate"
;
; Lcl frame size = 32

G_M29069_IG01:        ; gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref, nogc <-- Prolog IG
       push     rsi
       sub      rsp, 32
       mov      esi, ecx
						;; bbWeight=1    PerfScore 1.50
G_M29069_IG02:        ; gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref, isz
       cmp      esi, 4
       je       SHORT G_M29069_IG04
						;; bbWeight=1    PerfScore 1.25
G_M29069_IG03:        ; gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref, isz
       cmp      esi, 5
       sete     cl
       movzx    rcx, cl
       jmp      SHORT G_M29069_IG05
						;; bbWeight=0.50 PerfScore 1.75
G_M29069_IG04:        ; gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref
       mov      ecx, 1
						;; bbWeight=0.50 PerfScore 0.12
G_M29069_IG05:        ; gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref, isz
       movzx    rcx, cl
       test     ecx, ecx
       jne      SHORT G_M29069_IG07
						;; bbWeight=1    PerfScore 1.50
G_M29069_IG06:        ; gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref
       mov      rcx, 0xD1FFAB1E      ; string handle
       mov      rdx, gword ptr [rcx]
       ; gcrRegs +[rdx]
       mov      rcx, rdx
       ; gcrRegs +[rcx]
       call     hackishModuleName:hackishMethodName()
       ; gcrRegs -[rcx rdx]
       ; gcr arg pop 0
						;; bbWeight=0.50 PerfScore 1.75
G_M29069_IG07:        ; gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref
+      blsi     eax, esi
-      mov      eax, esi
-      neg      eax
-      and      eax, esi
       shl      eax, 28
+						;; bbWeight=1    PerfScore 1.00
-						;; bbWeight=1    PerfScore 1.25
G_M29069_IG08:        ; , epilog, nogc, extend
       add      rsp, 32
       pop      rsi
       ret      
						;; bbWeight=1    PerfScore 1.75
+; Total bytes of code 70, prolog size 5, PerfScore 17.63, instruction count 22, allocated bytes for code 70 (MethodHash=20958e72) for method System.String:GetCompareOptionsFromOrdinalStringComparison(int):int
-; Total bytes of code 71, prolog size 5, PerfScore 17.98, instruction count 24, allocated bytes for code 71 (MethodHash=20958e72) for method System.String:GetCompareOptionsFromOrdinalStringComparison(int):int
; ============================================================

Unwind Info:
  >> Start offset   : 0x000000 (not in unwind data)
  >>   End offset   : 0xd1ffab1e (not in unwind data)
  Version           : 1
  Flags             : 0x00
  SizeOfProlog      : 0x05
  CountOfUnwindCodes: 2
  FrameRegister     : none (0)
  FrameOffset       : N/A (no FrameRegister) (Value=0)
  UnwindCodes       :
    CodeOffset: 0x05 UnwindOp: UWOP_ALLOC_SMALL (2)     OpInfo: 3 * 8 + 8 = 32 = 0x20
    CodeOffset: 0x01 UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: rsi (6)

```

The value is low but if it is ever used it is an improvement. I chose to open the PR even though the value is low so that even if this is closed anyone else ever wonders why `blsi` isn't used can see the results of implementing it.

/cc @dotnet/jit-contrib 