### PR TITLE
skip the test when dotnet.exe is locked

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -475,15 +475,20 @@ namespace System.Diagnostics.Tests
             bool hasStarted = false;
             SafeProcessHandle handle = null;
             Process p = null;
+            string workingDirectory = null;
 
             try
             {
                 p = CreateProcessLong();
 
+                workingDirectory = string.IsNullOrEmpty(p.StartInfo.WorkingDirectory)
+                    ? Directory.GetCurrentDirectory()
+                    : p.StartInfo.WorkingDirectory;
+
                 if (PlatformDetection.IsNotWindowsServerCore) // for this particular Windows version it fails with Attempted to perform an unauthorized operation (#46619)
                 {
                     // ensure the new user can access the .exe (otherwise you get Access is denied exception)
-                    SetAccessControl(username, p.StartInfo.FileName, p.StartInfo.WorkingDirectory, add: true);
+                    SetAccessControl(username, p.StartInfo.FileName, workingDirectory, add: true);
                 }
 
                 p.StartInfo.LoadUserProfile = true;
@@ -530,7 +535,7 @@ namespace System.Diagnostics.Tests
 
                 if (PlatformDetection.IsNotWindowsServerCore)
                 {
-                    SetAccessControl(username, p.StartInfo.FileName, p.StartInfo.WorkingDirectory, add: false); // remove the access
+                    SetAccessControl(username, p.StartInfo.FileName, workingDirectory, add: false); // remove the access
                 }
 
                 Assert.Equal(Interop.ExitCodes.NERR_Success, Interop.NetUserDel(null, username));


### PR DESCRIPTION
I've tried to repro #65820 and of course I've failed to do that.

However, I was able to repro the same exception by opening the dotnet.exe for **writing with exclusive file access** before starting the process:

```cs
ProcessStartInfo startInfo = new ProcessStartInfo()
{
    FileName = @"C:\Program Files\dotnet\dotnet2.exe",
    Arguments = "--info",
    RedirectStandardOutput = true, // avoid visible output
    UseShellExecute = false
};

var fs = new FileStream(startInfo.FileName, FileMode.Open, FileAccess.ReadWrite, FileShare.None, 4096, false);
Console.WriteLine(fs.Length);

using Process dotnet = Process.Start(startInfo);
dotnet.WaitForExit();
fs.Dispose();
```

In the perfect world, I would enable ETW logging for file events on the CI machines and find out who is locking the file and why, but in my opinion it would take more time than it's worth it. I think that we can just skip this test when `dotnet.exe` is locked.

fixes #65820