### PR TITLE
Try to remove "-" and "'" from HighCharTable

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
@@ -877,13 +877,13 @@ namespace System.Globalization
             false, /*0x24,  $*/
             false, /*0x25,  %*/
             false, /*0x26,  &*/
-            true,  /*0x27, '*/
+            false,  /*0x27, '*/
             false, /*0x28, (*/
             false, /*0x29, )*/
             false, /*0x2A **/
             false, /*0x2B, +*/
             false, /*0x2C, ,*/
-            true,  /*0x2D, -*/
+            false,  /*0x2D, -*/
             false, /*0x2E, .*/
             false, /*0x2F, /*/
             false, /*0x30, 0*/

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
@@ -91,7 +91,7 @@ namespace System.Globalization
             Debug.Assert(!GlobalizationMode.Invariant);
 
             Debug.Assert(!target.IsEmpty);
-            Debug.Assert(_isAsciiEqualityOrdinal);
+            Debug.Assert(_isAsciiEqualityOrdinal && CanUseAsciiOrdinalForOptions(options));
 
             fixed (char* ap = &MemoryMarshal.GetReference(source))
             fixed (char* bp = &MemoryMarshal.GetReference(target))
@@ -195,7 +195,7 @@ namespace System.Globalization
             Debug.Assert(!GlobalizationMode.Invariant);
 
             Debug.Assert(!target.IsEmpty);
-            Debug.Assert(_isAsciiEqualityOrdinal);
+            Debug.Assert(_isAsciiEqualityOrdinal && CanUseAsciiOrdinalForOptions(options));
 
             fixed (char* ap = &MemoryMarshal.GetReference(source))
             fixed (char* bp = &MemoryMarshal.GetReference(target))
@@ -314,7 +314,7 @@ namespace System.Globalization
             Debug.Assert(!GlobalizationMode.Invariant);
 
             Debug.Assert(!prefix.IsEmpty);
-            Debug.Assert(_isAsciiEqualityOrdinal);
+            Debug.Assert(_isAsciiEqualityOrdinal && CanUseAsciiOrdinalForOptions(options));
 
             int length = Math.Min(source.Length, prefix.Length);
 
@@ -389,7 +389,7 @@ namespace System.Globalization
             Debug.Assert(!GlobalizationMode.Invariant);
 
             Debug.Assert(!prefix.IsEmpty);
-            Debug.Assert(_isAsciiEqualityOrdinal);
+            Debug.Assert(_isAsciiEqualityOrdinal && CanUseAsciiOrdinalForOptions(options));
 
             int length = Math.Min(source.Length, prefix.Length);
 
@@ -479,7 +479,7 @@ namespace System.Globalization
             Debug.Assert(!GlobalizationMode.Invariant);
 
             Debug.Assert(!suffix.IsEmpty);
-            Debug.Assert(_isAsciiEqualityOrdinal);
+            Debug.Assert(_isAsciiEqualityOrdinal && CanUseAsciiOrdinalForOptions(options));
 
             int length = Math.Min(source.Length, suffix.Length);
 
@@ -554,7 +554,7 @@ namespace System.Globalization
             Debug.Assert(!GlobalizationMode.Invariant);
 
             Debug.Assert(!suffix.IsEmpty);
-            Debug.Assert(_isAsciiEqualityOrdinal);
+            Debug.Assert(_isAsciiEqualityOrdinal && CanUseAsciiOrdinalForOptions(options));
 
             int length = Math.Min(source.Length, suffix.Length);
 


### PR DESCRIPTION
Since IndexOf doesn't do sorting, do these characters still need to be treated in a special way?