### PR TITLE
Use CMakeProjectReference instead of ProjectReference

### DIFF
--- a/docs/workflow/testing/coreclr/test-configuration.md
+++ b/docs/workflow/testing/coreclr/test-configuration.md
@@ -88,6 +88,6 @@ should simply `throw new PlatformNotSupportedException()` in its dummy method im
 
 1. Add any other projects as a dependency, if needed.
     * Managed reference: `<ProjectReference Include="../ManagedDll.csproj" />`
-    * Native reference: `<ProjectReference Include="../NativeDll/CMakeLists.txt" />`
+    * CMake reference: `<CMakeProjectReference Include="../NativeDll/CMakeLists.txt" />`
 1. Build the test.
 1. Follow the steps to re-run a failed test to validate the new test.

--- a/docs/workflow/testing/coreclr/test-configuration.md
+++ b/docs/workflow/testing/coreclr/test-configuration.md
@@ -66,25 +66,28 @@ should simply `throw new PlatformNotSupportedException()` in its dummy method im
 
 1. Set the `<CLRTestKind>`/`<CLRTestPriority>` properties.
 1. Add source files to the new project.
-1. Indicate the success of the test by returning `100`. Failure can be indicated by any non-`100` value.
+1. Add test cases using the Xunit `Fact` attribute.
 
-    Example:
-    ```CSharp
-        static public int Main(string[] notUsed)
-        {
-            try
-            {
-                // Test scenario here
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine($"Test Failure: {e.Message}");
-                return 101;
-            }
+    - We use a source generator to construct the `Main` entry point for test projects. The source generator will discover all methods marked with `Fact` and call them from the generated `Main`.
+    - Alternatively, `Main` can be user-defined. On success, the test returns `100`. Failure can be indicated by any non-`100` value.
 
-            return 100;
-        }
-    ```
+      Example:
+      ```CSharp
+          static public int Main(string[] notUsed)
+          {
+              try
+              {
+                  // Test scenario here
+              }
+              catch (Exception e)
+              {
+                  Console.WriteLine($"Test Failure: {e}");
+                  return 101;
+              }
+
+              return 100;
+          }
+      ```
 
 1. Add any other projects as a dependency, if needed.
     * Managed reference: `<ProjectReference Include="../ManagedDll.csproj" />`

--- a/docs/workflow/testing/coreclr/testing.md
+++ b/docs/workflow/testing/coreclr/testing.md
@@ -35,7 +35,7 @@ Note:  CoreCLR must be built prior to building an individual test. See the first
   ```
   <runtime-repo-root>/dotnet.sh build <runtime-repo-root>/src/tests/<path-to-project> -c <configuration>
   ```
-  * To build managed test projects with dependencies on native test projects, the native test project must first be built. The managed test should then be built using `dotnet build --no-restore` to skip restoring.
+  * To build managed test projects with dependencies on native test projects, the native test project must first be built.
 
 ## Additional Documents
 

--- a/src/tests/Common/CLRTest.MockHosting.targets
+++ b/src/tests/Common/CLRTest.MockHosting.targets
@@ -8,7 +8,7 @@ This file contains the logic for correctly hooking up a mock hostpolicy to a tes
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ProjectReference Include="$(MSBuildThisFileDirectory)hostpolicymock/CMakeLists.txt" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)hostpolicymock/CMakeLists.txt" />
     <!-- %28 decodes to '('. It's needed to keep MSBuild from trying to parse $(pwd) as an MSBuild property -->
     <CLRTestBashEnvironmentVariable Include="export MOCK_HOSTPOLICY=$%28pwd)/libhostpolicy" />
     <!-- %25 decodes to '%'. It's needed to keep %cd itself from being decoded since we want '%cd%' directly in the script. -->

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -208,7 +208,6 @@
           BeforeTargets="ConsolidateNativeProjectReference;BeforeResolveReferences;BeforeClean" >
      <ItemGroup>
         <NativeProjectReference Include="%(CMakeProjectReference.Identity)" Condition="$([System.String]::Copy(%(CMakeProjectReference.FileName)).ToUpper()) == 'CMAKELISTS'" />
-        <CMakeProjectReference Remove="%(NativeProjectReference.Identity)" />
         <NativeProjectReferenceNormalized Include="@(NativeProjectReference -> '%(FullPath)')" />
      </ItemGroup>
   </Target>

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -124,7 +124,7 @@
       <MergedWrapperReferenceFiles Include="%(MergedWrapperReferenceFolders.Identity)/*$(LibSuffix)" />
     </ItemGroup>
     <Copy SourceFiles="@(MergedWrapperReferenceFiles)"
-        DestinationFiles="@(MergedWrapperReferenceFiles->'$(OutDir)/%(FileName)%(Extension)')" 
+        DestinationFiles="@(MergedWrapperReferenceFiles->'$(OutDir)/%(FileName)%(Extension)')"
         SkipUnchangedFiles="true"
         />
   </Target>
@@ -203,12 +203,12 @@
      </Copy>
   </Target>
 
-  <Target Name="ResolveCmakeNativeProjectReference"
-          Condition="'@(ProjectReference)' != ''"
+  <Target Name="ResolveCMakeNativeProjectReference"
+          Condition="'@(CMakeProjectReference)' != ''"
           BeforeTargets="ConsolidateNativeProjectReference;BeforeResolveReferences;BeforeClean" >
      <ItemGroup>
-        <NativeProjectReference Include="%(ProjectReference.Identity)" Condition="$([System.String]::Copy(%(ProjectReference.FileName)).ToUpper()) == 'CMAKELISTS'" />
-        <ProjectReference Remove="%(NativeProjectReference.Identity)" />
+        <NativeProjectReference Include="%(CMakeProjectReference.Identity)" Condition="$([System.String]::Copy(%(CMakeProjectReference.FileName)).ToUpper()) == 'CMAKELISTS'" />
+        <CMakeProjectReference Remove="%(NativeProjectReference.Identity)" />
         <NativeProjectReferenceNormalized Include="@(NativeProjectReference -> '%(FullPath)')" />
      </ItemGroup>
   </Target>
@@ -228,7 +228,7 @@
 
   </Target>
 
-  <Target Name="CopyAllNativeProjectReferenceBinaries" DependsOnTargets="ResolveCmakeNativeProjectReference;ConsolidateNativeProjectReference" />
+  <Target Name="CopyAllNativeProjectReferenceBinaries" DependsOnTargets="ResolveCMakeNativeProjectReference;ConsolidateNativeProjectReference" />
 
   <!-- Build shell or command scripts whenever we copy native binaries -->
   <Import Project="$(MSBuildThisFileDirectory)Common\CLRTest.Execute.targets" />
@@ -281,7 +281,7 @@
   </PropertyGroup>
   <Import Project="$(BaseOutputPath)\packages\Common\test_dependencies\test_dependencies\test_dependencies.*.targets" />
 
-  
+
   <PropertyGroup>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>

--- a/src/tests/Exceptions/ForeignThread/ForeignThreadExceptions.csproj
+++ b/src/tests/Exceptions/ForeignThread/ForeignThreadExceptions.csproj
@@ -6,6 +6,6 @@
     <Compile Include="ForeignThreadExceptions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayTest.csproj
+++ b/src/tests/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayTest.csproj
@@ -8,6 +8,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/ArrayMarshalling/SafeArray/SafeArrayTest.csproj
+++ b/src/tests/Interop/ArrayMarshalling/SafeArray/SafeArrayTest.csproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/BestFitMapping/BestFitMapping.csproj
+++ b/src/tests/Interop/BestFitMapping/BestFitMapping.csproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/ComWrappers/API/ComWrappersTests.csproj
+++ b/src/tests/Interop/COM/ComWrappers/API/ComWrappersTests.csproj
@@ -8,6 +8,6 @@
     <Compile Include="../Common.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../MockReferenceTrackerRuntime/CMakeLists.txt" />
+    <CMakeProjectReference Include="../MockReferenceTrackerRuntime/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/ComWrappers/API/ComWrappersTestsBuiltInComDisabled.csproj
+++ b/src/tests/Interop/COM/ComWrappers/API/ComWrappersTestsBuiltInComDisabled.csproj
@@ -8,7 +8,7 @@
     <Compile Include="../Common.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../MockReferenceTrackerRuntime/CMakeLists.txt" />
+    <CMakeProjectReference Include="../MockReferenceTrackerRuntime/CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.BuiltInComInterop.IsSupported" Value="false" />

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceMarshallingTests.csproj
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceMarshallingTests.csproj
@@ -6,7 +6,7 @@
     <IsManagedCOMClient>true</IsManagedCOMClient>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- There is only a Windows version of this test -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>    
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GlobalInstance.cs" />
@@ -16,8 +16,8 @@
     <Compile Include="../../ServerContracts/ServerGuids.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../MockReferenceTrackerRuntime/CMakeLists.txt" />
-    <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
+    <CMakeProjectReference Include="../MockReferenceTrackerRuntime/CMakeLists.txt" />
+    <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
     <ProjectReference Include="../../NETServer/NETServer.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceMarshallingTestsBuiltInComDisabled.csproj
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceMarshallingTestsBuiltInComDisabled.csproj
@@ -16,8 +16,8 @@
     <Compile Include="../../ServerContracts/ServerGuids.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../MockReferenceTrackerRuntime/CMakeLists.txt" />
-    <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
+    <CMakeProjectReference Include="../MockReferenceTrackerRuntime/CMakeLists.txt" />
+    <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
     <ProjectReference Include="../../NETServer/NETServer.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceTrackerSupportTests_TargetUnix.csproj
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceTrackerSupportTests_TargetUnix.csproj
@@ -13,6 +13,6 @@
     <Compile Include="../../ServerContracts/ServerGuids.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../MockReferenceTrackerRuntime/CMakeLists.txt" />
+    <CMakeProjectReference Include="../MockReferenceTrackerRuntime/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceTrackerSupportTests_TargetWindows.csproj
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceTrackerSupportTests_TargetWindows.csproj
@@ -7,7 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);Windows</DefineConstants>
     <!-- There is a Windows and a non-Windows version of this test to allow it to be compiled for all targets -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>    
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GlobalInstance.cs" />
@@ -17,8 +17,8 @@
     <Compile Include="../../ServerContracts/ServerGuids.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../MockReferenceTrackerRuntime/CMakeLists.txt" />
-    <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
+    <CMakeProjectReference Include="../MockReferenceTrackerRuntime/CMakeLists.txt" />
+    <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
     <ProjectReference Include="../../NETServer/NETServer.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>

--- a/src/tests/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.csproj
+++ b/src/tests/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.csproj
@@ -9,7 +9,7 @@
     <Compile Include="WeakReferenceTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
   <PropertyGroup>
     <CLRTestNeedTarget>1</CLRTestNeedTarget>

--- a/src/tests/Interop/COM/Dynamic/Dynamic.csproj
+++ b/src/tests/Interop/COM/Dynamic/Dynamic.csproj
@@ -25,7 +25,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="Server/CMakeLists.txt" />
+    <CMakeProjectReference Include="Server/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="../NETServer/NETServer.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/tests/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
+++ b/src/tests/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
@@ -10,7 +10,7 @@
     <Compile Include="../../ServerContracts/ServerGuids.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
+    <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NETClients/ComDisabled/NETClientComDisabled.csproj
+++ b/src/tests/Interop/COM/NETClients/ComDisabled/NETClientComDisabled.csproj
@@ -10,7 +10,7 @@
     <Compile Include="../../ServerContracts/ServerGuids.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
+    <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/tests/Interop/COM/NETClients/Events/NETClientEvents.csproj
+++ b/src/tests/Interop/COM/NETClients/Events/NETClientEvents.csproj
@@ -11,7 +11,7 @@
     <Compile Include="../../ServerContracts/ServerGuids.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
+    <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
+++ b/src/tests/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
@@ -10,7 +10,7 @@
     <Compile Include="../../ServerContracts/ServerGuids.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
+    <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NETClients/IInspectable/NETClientIInspectable.csproj
+++ b/src/tests/Interop/COM/NETClients/IInspectable/NETClientIInspectable.csproj
@@ -10,7 +10,7 @@
     <Compile Include="../../ServerContracts/ServerGuids.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
+    <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NETClients/Licensing/NETClientLicense.csproj
+++ b/src/tests/Interop/COM/NETClients/Licensing/NETClientLicense.csproj
@@ -10,7 +10,7 @@
     <Compile Include="../../ServerContracts/ServerGuids.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
+    <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NETClients/Lifetime/NETClientLifetime.csproj
+++ b/src/tests/Interop/COM/NETClients/Lifetime/NETClientLifetime.csproj
@@ -11,7 +11,7 @@
     <Compile Include="../../ServerContracts/ServerGuids.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
+    <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
+++ b/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
@@ -15,7 +15,7 @@
     <Compile Include="../../ServerContracts/ServerGuids.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
+    <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitivesInALC.csproj
+++ b/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitivesInALC.csproj
@@ -7,7 +7,7 @@
     <Compile Include="TestInALC.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
+    <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="NETClientPrimitives.csproj" />
   </ItemGroup>

--- a/src/tests/Interop/COM/NativeClients/DefaultInterfaces.csproj
+++ b/src/tests/Interop/COM/NativeClients/DefaultInterfaces.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="DefaultInterfaces/CMakeLists.txt" />
+    <CMakeProjectReference Include="DefaultInterfaces/CMakeLists.txt" />
     <ProjectReference Include="../NETServer/NETServer.DefaultInterfaces.ilproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NativeClients/Dispatch.csproj
+++ b/src/tests/Interop/COM/NativeClients/Dispatch.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="Dispatch/CMakeLists.txt" />
+    <CMakeProjectReference Include="Dispatch/CMakeLists.txt" />
     <ProjectReference Include="../NETServer/NETServer.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NativeClients/Events.csproj
+++ b/src/tests/Interop/COM/NativeClients/Events.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="Events/CMakeLists.txt" />
+    <CMakeProjectReference Include="Events/CMakeLists.txt" />
     <ProjectReference Include="../NETServer/NETServer.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NativeClients/Licensing.csproj
+++ b/src/tests/Interop/COM/NativeClients/Licensing.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="Licensing/CMakeLists.txt" />
+    <CMakeProjectReference Include="Licensing/CMakeLists.txt" />
     <ProjectReference Include="../NETServer/NETServer.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NativeClients/Primitives.csproj
+++ b/src/tests/Interop/COM/NativeClients/Primitives.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="Primitives/CMakeLists.txt" />
+    <CMakeProjectReference Include="Primitives/CMakeLists.txt" />
     <ProjectReference Include="../NETServer/NETServer.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeAssemblyDisabled.csproj
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeAssemblyDisabled.csproj
@@ -8,6 +8,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="Native_DisabledMarshalling/DisabledRuntimeMarshallingNative_DisabledMarshalling.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeAssemblyEnabled.csproj
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeAssemblyEnabled.csproj
@@ -8,6 +8,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="Native_Default/DisabledRuntimeMarshallingNative_Default.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeTypeInAssembly.csproj
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeTypeInAssembly.csproj
@@ -6,6 +6,6 @@
     <Compile Include="PInvokeAssemblyMarshallingDisabled/*.cs" />
     <Compile Include="*.cs" />
     <Compile Include="Native_DisabledMarshalling/DisabledRuntimeMarshallingNative.cs" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeTypeInAssembly_ro.csproj
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeTypeInAssembly_ro.csproj
@@ -9,6 +9,6 @@
     <Compile Include="PInvokeAssemblyMarshallingDisabled/*.cs" />
     <Compile Include="*.cs" />
     <Compile Include="Native_DisabledMarshalling/DisabledRuntimeMarshallingNative.cs" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_NativeAssemblyDisabled.csproj
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_NativeAssemblyDisabled.csproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="Native_DisabledMarshalling/DisabledRuntimeMarshallingNative_DisabledMarshalling.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/DllImportAttribute/DllImportPath/DllImportPathTest.csproj
+++ b/src/tests/Interop/DllImportAttribute/DllImportPath/DllImportPathTest.csproj
@@ -17,6 +17,6 @@
     <BashCLRTestPreCommands>$(BashCLRTestPreCommands);$(PathEnvSetupCommands)</BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/DllImportAttribute/ExactSpelling/ExactSpellingTest.csproj
+++ b/src/tests/Interop/DllImportAttribute/ExactSpelling/ExactSpellingTest.csproj
@@ -6,7 +6,7 @@
     <Compile Include="ExactSpellingTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/ExecInDefAppDom/ExecInDefAppDom.csproj
+++ b/src/tests/Interop/ExecInDefAppDom/ExecInDefAppDom.csproj
@@ -12,6 +12,6 @@
       <Name>InjectedCode</Name>
     </ProjectReference>
     <!-- This is needed to make sure native binary gets installed in the right location -->
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/FuncPtrAsDelegateParam/FuncPtrAsDelegateParam.csproj
+++ b/src/tests/Interop/FuncPtrAsDelegateParam/FuncPtrAsDelegateParam.csproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/ICustomMarshaler/ConflictingNames/MultipleALCs.csproj
+++ b/src/tests/Interop/ICustomMarshaler/ConflictingNames/MultipleALCs.csproj
@@ -9,7 +9,7 @@
     <Compile Include="RunInALC.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
     <ProjectReference Include="CustomMarshaler.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/ICustomMarshaler/ConflictingNames/SameNameDifferentAssembly.csproj
+++ b/src/tests/Interop/ICustomMarshaler/ConflictingNames/SameNameDifferentAssembly.csproj
@@ -8,7 +8,7 @@
     <Compile Include="SameNameDifferentAssembly.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
     <ProjectReference Include="CustomMarshaler.csproj" />
     <ProjectReference Include="CustomMarshaler2.csproj" />
   </ItemGroup>

--- a/src/tests/Interop/ICustomMarshaler/Primitives/ICustomMarshaler_TargetUnix.csproj
+++ b/src/tests/Interop/ICustomMarshaler/Primitives/ICustomMarshaler_TargetUnix.csproj
@@ -11,6 +11,6 @@
     <Compile Include="ICustomMarshaler.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/ICustomMarshaler/Primitives/ICustomMarshaler_TargetWindows.csproj
+++ b/src/tests/Interop/ICustomMarshaler/Primitives/ICustomMarshaler_TargetWindows.csproj
@@ -12,6 +12,6 @@
     <Compile Include="ICustomMarshaler.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.csproj
+++ b/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.csproj
@@ -16,7 +16,7 @@
     <Compile Include="CopyConstructorMarshaler.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
-    <ProjectReference Include="../ijwhostmock/CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="../ijwhostmock/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/IJW/FixupCallsHostWhenLoaded/FixupCallsHostWhenLoaded.csproj
+++ b/src/tests/Interop/IJW/FixupCallsHostWhenLoaded/FixupCallsHostWhenLoaded.csproj
@@ -16,7 +16,7 @@
     <Compile Include="FixupCallsHostWhenLoaded.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../IjwNativeDll/CMakeLists.txt" />
-    <ProjectReference Include="../ijwhostmock/CMakeLists.txt" />
+    <CMakeProjectReference Include="../IjwNativeDll/CMakeLists.txt" />
+    <CMakeProjectReference Include="../ijwhostmock/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/IJW/LoadIjwFromModuleHandle/LoadIjwFromModuleHandle.csproj
+++ b/src/tests/Interop/IJW/LoadIjwFromModuleHandle/LoadIjwFromModuleHandle.csproj
@@ -19,7 +19,7 @@
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../IjwNativeCallingManagedDll/CMakeLists.txt" />
-    <ProjectReference Include="../ijwhostmock/CMakeLists.txt" />
+    <CMakeProjectReference Include="../IjwNativeCallingManagedDll/CMakeLists.txt" />
+    <CMakeProjectReference Include="../ijwhostmock/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/IJW/ManagedCallingNative/ManagedCallingNative.csproj
+++ b/src/tests/Interop/IJW/ManagedCallingNative/ManagedCallingNative.csproj
@@ -16,8 +16,8 @@
     <Compile Include="ManagedCallingNative.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../IjwNativeDll/CMakeLists.txt" />
-    <ProjectReference Include="../ijwhostmock/CMakeLists.txt" />
+    <CMakeProjectReference Include="../IjwNativeDll/CMakeLists.txt" />
+    <CMakeProjectReference Include="../ijwhostmock/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/IJW/NativeCallingManaged/NativeCallingManaged.csproj
+++ b/src/tests/Interop/IJW/NativeCallingManaged/NativeCallingManaged.csproj
@@ -16,8 +16,8 @@
     <Compile Include="NativeCallingManaged.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../IjwNativeCallingManagedDll/CMakeLists.txt" />
-    <ProjectReference Include="../ijwhostmock/CMakeLists.txt" />
+    <CMakeProjectReference Include="../IjwNativeCallingManagedDll/CMakeLists.txt" />
+    <CMakeProjectReference Include="../ijwhostmock/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/IJW/NativeVarargs/NativeVarargsTest.csproj
+++ b/src/tests/Interop/IJW/NativeVarargs/NativeVarargsTest.csproj
@@ -18,7 +18,7 @@
     <Compile Include="NativeVarargsTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
-    <ProjectReference Include="../ijwhostmock/CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="../ijwhostmock/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/LayoutClass/LayoutClassTest.csproj
+++ b/src/tests/Interop/LayoutClass/LayoutClassTest.csproj
@@ -8,6 +8,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPtrTest.csproj
+++ b/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPtrTest.csproj
@@ -7,6 +7,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTest.csproj
+++ b/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTest.csproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTestInALC.csproj
+++ b/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTestInALC.csproj
@@ -10,6 +10,6 @@
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="IUnknownTest.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/MonoAPI/MonoMono/InstallEHCallback.csproj
+++ b/src/tests/Interop/MonoAPI/MonoMono/InstallEHCallback.csproj
@@ -8,6 +8,6 @@
     <Compile Include="..\Common\*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Native\mono-embedding-api-test\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\Native\mono-embedding-api-test\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/MonoAPI/MonoMono/PInvokeDetach.csproj
+++ b/src/tests/Interop/MonoAPI/MonoMono/PInvokeDetach.csproj
@@ -8,6 +8,6 @@
     <Compile Include="..\Common\*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Native\mono-embedding-api-test\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\Native\mono-embedding-api-test\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/MonoAPI/MonoMono/Thunks.csproj
+++ b/src/tests/Interop/MonoAPI/MonoMono/Thunks.csproj
@@ -8,6 +8,6 @@
     <Compile Include="..\Common\*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Native\mono-embedding-api-test\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\Native\mono-embedding-api-test\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.csproj
+++ b/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.csproj
@@ -14,6 +14,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
+    <CMakeProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/NativeLibrary/AssemblyLoadContext/ResolveUnmanagedDllTests.csproj
+++ b/src/tests/Interop/NativeLibrary/AssemblyLoadContext/ResolveUnmanagedDllTests.csproj
@@ -10,7 +10,7 @@
     <Compile Include="../NativeLibraryToLoad/NativeLibraryToLoad.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
+    <CMakeProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="TestAsm/TestAsm.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/tests/Interop/NativeLibrary/Callback/CallbackStressTest_TargetUnix.csproj
+++ b/src/tests/Interop/NativeLibrary/Callback/CallbackStressTest_TargetUnix.csproj
@@ -10,6 +10,6 @@
     <Compile Include="../NativeLibraryToLoad/NativeLibraryToLoad.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
+    <CMakeProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/NativeLibrary/Callback/CallbackStressTest_TargetWindows.csproj
+++ b/src/tests/Interop/NativeLibrary/Callback/CallbackStressTest_TargetWindows.csproj
@@ -11,6 +11,6 @@
     <Compile Include="../NativeLibraryToLoad/NativeLibraryToLoad.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
+    <CMakeProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/NativeLibrary/Callback/CallbackTests.csproj
+++ b/src/tests/Interop/NativeLibrary/Callback/CallbackTests.csproj
@@ -8,7 +8,7 @@
     <Compile Include="../NativeLibraryToLoad/NativeLibraryToLoad.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
+    <CMakeProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/ObjectiveC/AutoReleaseTest/AutoReleaseTest.csproj
+++ b/src/tests/Interop/ObjectiveC/AutoReleaseTest/AutoReleaseTest.csproj
@@ -11,7 +11,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="./CMakeLists.txt" />
+    <CMakeProjectReference Include="./CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/ObjectiveC/ObjectiveCMarshalAPI/ObjectiveCMarshalAPI.csproj
+++ b/src/tests/Interop/ObjectiveC/ObjectiveCMarshalAPI/ObjectiveCMarshalAPI.csproj
@@ -9,6 +9,6 @@
     <Compile Include="Program.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="./CMakeLists.txt" />
+    <CMakeProjectReference Include="./CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsField/AsByValArray/AsByValArrayTest.csproj
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsField/AsByValArray/AsByValArrayTest.csproj
@@ -6,6 +6,6 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\LPArrayNative\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\LPArrayNative\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsField/AsLPArray/AsLPArrayTest.csproj
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsField/AsLPArray/AsLPArrayTest.csproj
@@ -6,6 +6,6 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\LPArrayNative\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\LPArrayNative\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest.csproj
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest.csproj
@@ -6,6 +6,6 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\LPArrayNative\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\LPArrayNative\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsLPArray/AsLPArrayTest.csproj
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsLPArray/AsLPArrayTest.csproj
@@ -6,6 +6,6 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\LPArrayNative\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\LPArrayNative\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/ArrayWithOffset/ArrayWithOffsetTest.csproj
+++ b/src/tests/Interop/PInvoke/ArrayWithOffset/ArrayWithOffsetTest.csproj
@@ -7,6 +7,6 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/AsAny/AsAnyTest.csproj
+++ b/src/tests/Interop/PInvoke/AsAny/AsAnyTest.csproj
@@ -6,6 +6,6 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/Attributes/LCID/LCIDTest.csproj
+++ b/src/tests/Interop/PInvoke/Attributes/LCID/LCIDTest.csproj
@@ -8,6 +8,6 @@
     <Compile Include="LCIDTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/BestFitMapping/Directory.Build.props
+++ b/src/tests/Interop/PInvoke/BestFitMapping/Directory.Build.props
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\Char\CMakeLists.txt" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\LPStr\CMakeLists.txt" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)\Char\CMakeLists.txt" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)\LPStr\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/CriticalHandles/ArrayTest/ArrayTest.csproj
+++ b/src/tests/Interop/PInvoke/CriticalHandles/ArrayTest/ArrayTest.csproj
@@ -6,6 +6,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/CriticalHandles/ReverseTest/ReverseTest.csproj
+++ b/src/tests/Interop/PInvoke/CriticalHandles/ReverseTest/ReverseTest.csproj
@@ -6,6 +6,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/CriticalHandles/StructTest/StructTest.csproj
+++ b/src/tests/Interop/PInvoke/CriticalHandles/StructTest/StructTest.csproj
@@ -6,6 +6,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/CriticalHandles/Test/Test.csproj
+++ b/src/tests/Interop/PInvoke/CriticalHandles/Test/Test.csproj
@@ -6,6 +6,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/CustomMarshalers/CustomMarshalersTest.csproj
+++ b/src/tests/Interop/PInvoke/CustomMarshalers/CustomMarshalersTest.csproj
@@ -9,6 +9,6 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/DateTime/DateTimeTest.csproj
+++ b/src/tests/Interop/PInvoke/DateTime/DateTimeTest.csproj
@@ -6,6 +6,6 @@
     <Compile Include="DateTimeTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/Decimal/DecimalTest.csproj
+++ b/src/tests/Interop/PInvoke/Decimal/DecimalTest.csproj
@@ -3,6 +3,6 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/Delegate/DelegateTest.csproj
+++ b/src/tests/Interop/PInvoke/Delegate/DelegateTest.csproj
@@ -6,6 +6,6 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.csproj
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.csproj
@@ -8,6 +8,6 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorTest.csproj
+++ b/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorTest.csproj
@@ -13,6 +13,6 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/Miscellaneous/HandleRef/HandleRefTest.csproj
+++ b/src/tests/Interop/PInvoke/Miscellaneous/HandleRef/HandleRefTest.csproj
@@ -7,6 +7,6 @@
     <Compile Include="HandleRefTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/MAWSPITest.csproj
+++ b/src/tests/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/MAWSPITest.csproj
@@ -6,7 +6,7 @@
     <Compile Include="MAWSPITest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
     <ProjectReference Include="ManagedDll1\ManagedDll1.csproj" />
     <ProjectReference Include="ManagedDll2\ManagedDll2.csproj" />
   </ItemGroup>

--- a/src/tests/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/ManagedDll1/ManagedDll1.csproj
+++ b/src/tests/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/ManagedDll1/ManagedDll1.csproj
@@ -7,6 +7,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/ManagedDll2/ManagedDll2.csproj
+++ b/src/tests/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/ManagedDll2/ManagedDll2.csproj
@@ -7,6 +7,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyTrue/AssemblyTrueTest.csproj
+++ b/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyTrue/AssemblyTrueTest.csproj
@@ -9,6 +9,6 @@
     <Compile Include="..\Helpers.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyWithoutComVisible/AssemblyWithoutComVisibleTest.csproj
+++ b/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyWithoutComVisible/AssemblyWithoutComVisibleTest.csproj
@@ -9,6 +9,6 @@
     <Compile Include="..\Helpers.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/NativeCallManagedComVisible/Default/DefaultTest.csproj
+++ b/src/tests/Interop/PInvoke/NativeCallManagedComVisible/Default/DefaultTest.csproj
@@ -9,6 +9,6 @@
     <Compile Include="..\Helpers.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/NativeCallManagedComVisible/Default/DefaultTestInALC.csproj
+++ b/src/tests/Interop/PInvoke/NativeCallManagedComVisible/Default/DefaultTestInALC.csproj
@@ -8,7 +8,7 @@
     <Compile Include="TestInALC.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\CMakeLists.txt" />
     <ProjectReference Include="DefaultTest.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/Primitives/Int/PInvokeIntTest.csproj
+++ b/src/tests/Interop/PInvoke/Primitives/Int/PInvokeIntTest.csproj
@@ -6,6 +6,6 @@
     <Compile Include="PInvokeIntTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/Primitives/Pointer/NonBlittablePointer.csproj
+++ b/src/tests/Interop/PInvoke/Primitives/Pointer/NonBlittablePointer.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <Compile Include="Program.cs" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 
 </Project>

--- a/src/tests/Interop/PInvoke/Primitives/RuntimeHandles/RuntimeHandlesTest.csproj
+++ b/src/tests/Interop/PInvoke/Primitives/RuntimeHandles/RuntimeHandlesTest.csproj
@@ -6,6 +6,6 @@
     <Compile Include="RuntimeHandlesTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/SafeHandles/SafeHandleTests.csproj
+++ b/src/tests/Interop/PInvoke/SafeHandles/SafeHandleTests.csproj
@@ -6,6 +6,6 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/SetLastError/SetLastErrorTest.csproj
+++ b/src/tests/Interop/PInvoke/SetLastError/SetLastErrorTest.csproj
@@ -7,6 +7,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByOut/PassingByOutTest.csproj
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByOut/PassingByOutTest.csproj
@@ -7,6 +7,6 @@
     <Compile Include="..\helper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByRef/PassingByRefTest.csproj
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByRef/PassingByRefTest.csproj
@@ -7,6 +7,6 @@
     <Compile Include="..\helper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByOut/PassingByOutTest.csproj
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByOut/PassingByOutTest.csproj
@@ -7,6 +7,6 @@
     <Compile Include="..\helper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByRef/PassingByRefTest.csproj
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByRef/PassingByRefTest.csproj
@@ -7,6 +7,6 @@
     <Compile Include="..\helper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/Varargs/VarargsTest.csproj
+++ b/src/tests/Interop/PInvoke/Varargs/VarargsTest.csproj
@@ -10,6 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/Variant/VariantTest.csproj
+++ b/src/tests/Interop/PInvoke/Variant/VariantTest.csproj
@@ -11,6 +11,6 @@
     <Compile Include="VariantTest.BuiltInCom.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/Variant/VariantTestBuiltInComDisabled.csproj
+++ b/src/tests/Interop/PInvoke/Variant/VariantTestBuiltInComDisabled.csproj
@@ -11,7 +11,7 @@
     <Compile Include="VariantTest.BuiltInCom.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.BuiltInComInterop.IsSupported" Value="false" />

--- a/src/tests/Interop/PInvoke/Variant/VariantTestComWrappers.csproj
+++ b/src/tests/Interop/PInvoke/Variant/VariantTestComWrappers.csproj
@@ -11,7 +11,7 @@
     <Compile Include="VariantTest.ComWrappers.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.BuiltInComInterop.IsSupported" Value="false" />

--- a/src/tests/Interop/PInvoke/Vector2_3_4/Vector2_3_4.csproj
+++ b/src/tests/Interop/PInvoke/Vector2_3_4/Vector2_3_4.csproj
@@ -3,6 +3,6 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PrimitiveMarshalling/Bool/BoolTest.csproj
+++ b/src/tests/Interop/PrimitiveMarshalling/Bool/BoolTest.csproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PrimitiveMarshalling/EnumMarshalling/EnumTest.csproj
+++ b/src/tests/Interop/PrimitiveMarshalling/EnumMarshalling/EnumTest.csproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PrimitiveMarshalling/UIntPtr/PInvokeUIntPtrTest.csproj
+++ b/src/tests/Interop/PrimitiveMarshalling/UIntPtr/PInvokeUIntPtrTest.csproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/RefCharArray/RefCharArrayTest.csproj
+++ b/src/tests/Interop/RefCharArray/RefCharArrayTest.csproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/SimpleStruct/SimpleStruct.csproj
+++ b/src/tests/Interop/SimpleStruct/SimpleStruct.csproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StringMarshalling/AnsiBSTR/AnsiBStrTest.csproj
+++ b/src/tests/Interop/StringMarshalling/AnsiBSTR/AnsiBStrTest.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StringMarshalling/BSTR/BSTRTest.csproj
+++ b/src/tests/Interop/StringMarshalling/BSTR/BSTRTest.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StringMarshalling/LPSTR/LPSTRTest.csproj
+++ b/src/tests/Interop/StringMarshalling/LPSTR/LPSTRTest.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StringMarshalling/LPTSTR/LPTSTRTest.csproj
+++ b/src/tests/Interop/StringMarshalling/LPTSTR/LPTSTRTest.csproj
@@ -12,6 +12,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StringMarshalling/UTF8/UTF8Test.csproj
+++ b/src/tests/Interop/StringMarshalling/UTF8/UTF8Test.csproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StringMarshalling/VBByRefStr/VBByRefStrTest.csproj
+++ b/src/tests/Interop/StringMarshalling/VBByRefStr/VBByRefStrTest.csproj
@@ -9,6 +9,6 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp.csproj
+++ b/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.csproj
+++ b/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.csproj
@@ -10,6 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/DelegatePInvoke/DelegatePInvokeTest.csproj
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/DelegatePInvoke/DelegatePInvokeTest.csproj
@@ -11,6 +11,6 @@
     <Compile Include="..\..\Struct.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/ReversePInvokeManaged/ReversePInvokeTest.csproj
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/ReversePInvokeManaged/ReversePInvokeTest.csproj
@@ -11,6 +11,6 @@
     <Compile Include="..\..\Struct.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/DelegatePInvoke/DelegatePInvokeTest.csproj
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/DelegatePInvoke/DelegatePInvokeTest.csproj
@@ -9,6 +9,6 @@
     <Compile Include="..\..\Struct.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/ReversePInvoke/ReversePInvokeTest.csproj
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/ReversePInvoke/ReversePInvokeTest.csproj
@@ -9,6 +9,6 @@
     <Compile Include="..\..\Struct.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionTest.csproj
+++ b/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionTest.csproj
@@ -8,7 +8,7 @@
     <Compile Include="SuppressGCTransitionTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
     <ProjectReference Include="SuppressGCTransitionUtil.ilproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/UnmanagedCallConv/UnmanagedCallConvTest.csproj
+++ b/src/tests/Interop/UnmanagedCallConv/UnmanagedCallConvTest.csproj
@@ -9,7 +9,7 @@
     <Compile Include="UnmanagedCallConvTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="PInvokesIL.ilproj" />
   </ItemGroup>

--- a/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.csproj
+++ b/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.csproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <!-- This is needed to make sure native binary gets installed in the right location -->
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="InvalidCSharp.ilproj" />
   </ItemGroup>

--- a/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.csproj
+++ b/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.csproj
@@ -10,6 +10,6 @@
     <Compile Include="out_of_range_fp_to_int_conversions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Directed/StructABI/StructABI.csproj
+++ b/src/tests/JIT/Directed/StructABI/StructABI.csproj
@@ -14,6 +14,6 @@
     <Compile Include="StructABI.OSX.cs" Condition="'$(TargetOS)' == 'OSX'" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Directed/arglist/vararg_TargetUnix.csproj
+++ b/src/tests/JIT/Directed/arglist/vararg_TargetUnix.csproj
@@ -12,6 +12,6 @@
     <Compile Include="varargtypes.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Directed/arglist/vararg_TargetWindows.csproj
+++ b/src/tests/JIT/Directed/arglist/vararg_TargetWindows.csproj
@@ -13,6 +13,6 @@
     <Compile Include="varargtypes.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Directed/callconv/CdeclMemberFunction/CdeclMemberFunctionTest.csproj
+++ b/src/tests/JIT/Directed/callconv/CdeclMemberFunction/CdeclMemberFunctionTest.csproj
@@ -7,7 +7,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../CMakeLists.txt" />
+    <CMakeProjectReference Include="../CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Directed/callconv/PlatformDefaultMemberFunction/PlatformDefaultMemberFunctionTest.csproj
+++ b/src/tests/JIT/Directed/callconv/PlatformDefaultMemberFunction/PlatformDefaultMemberFunctionTest.csproj
@@ -7,7 +7,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../CMakeLists.txt" />
+    <CMakeProjectReference Include="../CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Directed/callconv/StdCallMemberFunction/StdCallMemberFunctionTest.csproj
+++ b/src/tests/JIT/Directed/callconv/StdCallMemberFunction/StdCallMemberFunctionTest.csproj
@@ -7,7 +7,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../CMakeLists.txt" />
+    <CMakeProjectReference Include="../CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Directed/callconv/ThisCall/ThisCallTest.csproj
+++ b/src/tests/JIT/Directed/callconv/ThisCall/ThisCallTest.csproj
@@ -7,7 +7,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../CMakeLists.txt" />
+    <CMakeProjectReference Include="../CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Directed/pinning/object-pin/object-pin.ilproj
+++ b/src/tests/JIT/Directed/pinning/object-pin/object-pin.ilproj
@@ -11,6 +11,6 @@
     <Compile Include="Object-Pin.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakelists.txt" />
+    <CMakeProjectReference Include="CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Directed/pinvoke/pinvoke-examples.csproj
+++ b/src/tests/JIT/Directed/pinvoke/pinvoke-examples.csproj
@@ -12,6 +12,6 @@
     <Compile Include="pinvoke-examples.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Directed/pinvoke/tail.ilproj
+++ b/src/tests/JIT/Directed/pinvoke/tail.ilproj
@@ -11,6 +11,6 @@
     <Compile Include="tail.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/gc_poll/InsertGCPoll.csproj
+++ b/src/tests/JIT/Methodical/gc_poll/InsertGCPoll.csproj
@@ -10,6 +10,6 @@
     <Compile Include="InsertGCPoll.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/structs/systemvbringup/structinregs.csproj
+++ b/src/tests/JIT/Methodical/structs/systemvbringup/structinregs.csproj
@@ -15,6 +15,6 @@
     <Compile Include="structpinvoketests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/VS-ia64-JIT/V1.2-M02/b108129/b108129.csproj
+++ b/src/tests/JIT/Regression/VS-ia64-JIT/V1.2-M02/b108129/b108129.csproj
@@ -13,6 +13,6 @@
     <Compile Include="test2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/SIMD/Vector3Interop_r.csproj
+++ b/src/tests/JIT/SIMD/Vector3Interop_r.csproj
@@ -10,6 +10,6 @@
     <Compile Include="Vector3Interop.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/SIMD/Vector3Interop_ro.csproj
+++ b/src/tests/JIT/SIMD/Vector3Interop_ro.csproj
@@ -10,6 +10,6 @@
     <Compile Include="Vector3Interop.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f64_interop_cpp.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f64_interop_cpp.csproj
@@ -13,6 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="hfa_nested_f64_common.csproj" />
-    <ProjectReference Include="CMakelists.txt" />
+    <CMakeProjectReference Include="CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nd0A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nd0A_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nd0A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nd0A_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nd1A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nd1A_d.csproj
@@ -12,7 +12,7 @@
     <Compile Include="hfa_testA.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nd1A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nd1A_r.csproj
@@ -11,7 +11,7 @@
     <Compile Include="hfa_testA.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nd2A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nd2A_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nd2A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nd2A_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nf0A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nf0A_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nf0A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nf0A_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nf1A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nf1A_d.csproj
@@ -12,7 +12,7 @@
     <Compile Include="hfa_testA.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nf1A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nf1A_r.csproj
@@ -11,7 +11,7 @@
     <Compile Include="hfa_testA.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nf2A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nf2A_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nf2A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nf2A_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sd0A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sd0A_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sd0A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sd0A_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sd1A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sd1A_d.csproj
@@ -12,7 +12,7 @@
     <Compile Include="hfa_testA.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sd1A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sd1A_r.csproj
@@ -11,7 +11,7 @@
     <Compile Include="hfa_testA.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sd2A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sd2A_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sd2A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sd2A_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sf0A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sf0A_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sf0A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sf0A_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sf1A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sf1A_d.csproj
@@ -12,7 +12,7 @@
     <Compile Include="hfa_testA.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sf1A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sf1A_r.csproj
@@ -11,7 +11,7 @@
     <Compile Include="hfa_testA.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sf2A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sf2A_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sf2A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sf2A_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nd0B_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nd0B_d.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nd0B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nd0B_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nd2B_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nd2B_d.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nd2B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nd2B_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nf0B_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nf0B_d.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nf0B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nf0B_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nf2B_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nf2B_d.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nf2B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nf2B_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sd0B_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sd0B_d.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sd0B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sd0B_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sd2B_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sd2B_d.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sd2B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sd2B_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sf0B_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sf0B_d.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sf0B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sf0B_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sf2B_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sf2B_d.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sf2B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sf2B_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nd0C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nd0C_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nd0C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nd0C_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nd1C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nd1C_d.csproj
@@ -12,7 +12,7 @@
     <Compile Include="hfa_testC.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nd1C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nd1C_r.csproj
@@ -10,7 +10,7 @@
     <Compile Include="hfa_testC.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nd2C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nd2C_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nd2C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nd2C_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nf0C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nf0C_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nf0C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nf0C_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nf1C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nf1C_d.csproj
@@ -12,7 +12,7 @@
     <Compile Include="hfa_testC.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nf1C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nf1C_r.csproj
@@ -11,7 +11,7 @@
     <Compile Include="hfa_testC.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nf2C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nf2C_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nf2C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nf2C_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sd0C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sd0C_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sd0C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sd0C_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sd1C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sd1C_d.csproj
@@ -12,7 +12,7 @@
     <Compile Include="hfa_testC.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sd1C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sd1C_r.csproj
@@ -11,7 +11,7 @@
     <Compile Include="hfa_testC.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sd2C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sd2C_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sd2C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sd2C_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sf0C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sf0C_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sf0C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sf0C_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sf1C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sf1C_d.csproj
@@ -12,7 +12,7 @@
     <Compile Include="hfa_testC.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sf1C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sf1C_r.csproj
@@ -11,7 +11,7 @@
     <Compile Include="hfa_testC.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sf2C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sf2C_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sf2C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sf2C_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nd0E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nd0E_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nd0E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nd0E_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nd1E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nd1E_d.csproj
@@ -12,7 +12,7 @@
     <Compile Include="hfa_testE.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nd1E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nd1E_r.csproj
@@ -11,7 +11,7 @@
     <Compile Include="hfa_testE.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nd2E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nd2E_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nd2E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nd2E_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nf0E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nf0E_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nf0E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nf0E_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nf1E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nf1E_d.csproj
@@ -12,7 +12,7 @@
     <Compile Include="hfa_testE.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nf1E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nf1E_r.csproj
@@ -11,7 +11,7 @@
     <Compile Include="hfa_testE.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nf2E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nf2E_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nf2E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nf2E_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sd0E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sd0E_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sd0E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sd0E_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sd1E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sd1E_d.csproj
@@ -12,7 +12,7 @@
     <Compile Include="hfa_testE.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sd1E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sd1E_r.csproj
@@ -11,7 +11,7 @@
     <Compile Include="hfa_testE.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sd2E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sd2E_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sd2E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sd2E_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sf0E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sf0E_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sf0E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sf0E_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sf1E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sf1E_d.csproj
@@ -12,7 +12,7 @@
     <Compile Include="hfa_testE.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sf1E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sf1E_r.csproj
@@ -11,7 +11,7 @@
     <Compile Include="hfa_testE.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sf2E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sf2E_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sf2E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sf2E_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nd0G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nd0G_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nd0G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nd0G_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nd1G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nd1G_d.csproj
@@ -12,7 +12,7 @@
     <Compile Include="hfa_testG.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nd1G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nd1G_r.csproj
@@ -11,7 +11,7 @@
     <Compile Include="hfa_testG.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nd2G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nd2G_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nd2G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nd2G_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nf0G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nf0G_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nf0G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nf0G_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nf1G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nf1G_d.csproj
@@ -12,7 +12,7 @@
     <Compile Include="hfa_testG.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nf1G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nf1G_r.csproj
@@ -11,7 +11,7 @@
     <Compile Include="hfa_testG.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nf2G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nf2G_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nf2G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nf2G_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_nested_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sd0G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sd0G_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sd0G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sd0G_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sd1G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sd1G_d.csproj
@@ -12,7 +12,7 @@
     <Compile Include="hfa_testG.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sd1G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sd1G_r.csproj
@@ -11,7 +11,7 @@
     <Compile Include="hfa_testG.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sd2G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sd2G_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sd2G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sd2G_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f64_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sf0G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sf0G_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sf0G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sf0G_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sf1G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sf1G_d.csproj
@@ -12,7 +12,7 @@
     <Compile Include="hfa_testG.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sf1G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sf1G_r.csproj
@@ -11,7 +11,7 @@
     <Compile Include="hfa_testG.cs" />
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_managed.csproj" />
-    <ProjectReference Include="..\dll\CMakeLists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakeLists.txt" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sf2G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sf2G_d.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sf2G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sf2G_r.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\dll\common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_common.csproj" />
     <ProjectReference Include="..\dll\hfa_simple_f32_interop_cpp.csproj" />
-    <ProjectReference Include="..\dll\CMakelists.txt" />
+    <CMakeProjectReference Include="..\dll\CMakelists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i00.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i00.ilproj
@@ -11,6 +11,6 @@
     <Compile Include="mcc_i00.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i01.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i01.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i01.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i02.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i02.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i02.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i03.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i03.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i03.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i04.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i04.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i04.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i05.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i05.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i05.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i06.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i06.ilproj
@@ -12,6 +12,6 @@
     <Compile Include="mcc_i06.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i07.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i07.ilproj
@@ -12,6 +12,6 @@
     <Compile Include="mcc_i07.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i10.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i10.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i10.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i11.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i11.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i11.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i12.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i12.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i12.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i13.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i13.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i13.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i14.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i14.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i14.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i15.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i15.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i15.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i16.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i16.ilproj
@@ -12,6 +12,6 @@
     <Compile Include="mcc_i16.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i17.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i17.ilproj
@@ -12,6 +12,6 @@
     <Compile Include="mcc_i17.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i30.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i30.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i30.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i31.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i31.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i31.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i32.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i32.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i32.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i33.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i33.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i33.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i34.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i34.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i34.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i35.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i35.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i35.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i36.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i36.ilproj
@@ -12,6 +12,6 @@
     <Compile Include="mcc_i36.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i37.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i37.ilproj
@@ -12,6 +12,6 @@
     <Compile Include="mcc_i37.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i50.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i50.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i50.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i51.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i51.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i51.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i52.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i52.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i52.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i53.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i53.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i53.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i54.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i54.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i54.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i55.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i55.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i55.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i56.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i56.ilproj
@@ -12,6 +12,6 @@
     <Compile Include="mcc_i56.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i57.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i57.ilproj
@@ -12,6 +12,6 @@
     <Compile Include="mcc_i57.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i60.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i60.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i60.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i61.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i61.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i61.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i62.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i62.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i62.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i63.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i63.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i63.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i64.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i64.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i64.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i65.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i65.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i65.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i66.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i66.ilproj
@@ -12,6 +12,6 @@
     <Compile Include="mcc_i66.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i67.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i67.ilproj
@@ -12,6 +12,6 @@
     <Compile Include="mcc_i67.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i70.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i70.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i70.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i71.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i71.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i71.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i72.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i72.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i72.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i73.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i73.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i73.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i74.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i74.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i74.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i75.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i75.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i75.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i76.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i76.ilproj
@@ -12,6 +12,6 @@
     <Compile Include="mcc_i76.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i77.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i77.ilproj
@@ -12,6 +12,6 @@
     <Compile Include="mcc_i77.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i80.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i80.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i80.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i81.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i81.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i81.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i82.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i82.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i82.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i83.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i83.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i83.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i84.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i84.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i84.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i85.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i85.ilproj
@@ -13,6 +13,6 @@
     <Compile Include="mcc_i85.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i86.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i86.ilproj
@@ -12,6 +12,6 @@
     <Compile Include="mcc_i86.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i87.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i87.ilproj
@@ -12,6 +12,6 @@
     <Compile Include="mcc_i87.il ..\common\common.il" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Loader/NativeLibs/FromNativePaths.csproj
+++ b/src/tests/Loader/NativeLibs/FromNativePaths.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>
     <CLRTestBashEnvironmentVariable Include="export CORE_LIBRARIES=$CORE_LIBRARIES:$%28pwd)/Subdirectory" />

--- a/src/tests/baseservices/callconvs/TestCallingConventions.csproj
+++ b/src/tests/baseservices/callconvs/TestCallingConventions.csproj
@@ -7,7 +7,7 @@
     <Compile Include="TestCallingConventions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
     <ProjectReference Include="CallFunctionPointers.ilproj" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>

--- a/src/tests/baseservices/exceptions/regressions/Dev11/147911/test147911.csproj
+++ b/src/tests/baseservices/exceptions/regressions/Dev11/147911/test147911.csproj
@@ -10,6 +10,6 @@
     <Compile Include="test147911.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/baseservices/exceptions/regressions/V1/SEH/VJ/UnmanagedToManaged.csproj
+++ b/src/tests/baseservices/exceptions/regressions/V1/SEH/VJ/UnmanagedToManaged.csproj
@@ -10,6 +10,6 @@
     <Compile Include="UnmanagedToManaged.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/nativeaot/SmokeTests/ComWrappers/ComWrappers.csproj
+++ b/src/tests/nativeaot/SmokeTests/ComWrappers/ComWrappers.csproj
@@ -13,6 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.csproj
+++ b/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.csproj
@@ -13,6 +13,6 @@
     <Compile Include="PInvoke.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/nativeaot/SmokeTests/SharedLibrary/SharedLibrary.csproj
+++ b/src/tests/nativeaot/SmokeTests/SharedLibrary/SharedLibrary.csproj
@@ -25,6 +25,6 @@ cp SharedLibraryDriver native/SharedLibrary
     <Compile Include="SharedLibrary.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/elt/slowpatheltenter.csproj
+++ b/src/tests/profiler/elt/slowpatheltenter.csproj
@@ -5,7 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
     <!-- The test launches a secondary process and process launch creates
-    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    an infinite event loop in the SocketAsyncEngine on Linux. Since
     runincontext loads even framework assemblies into the unloadable
     context, locals in this loop prevent unloading -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
@@ -15,6 +15,6 @@
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="../common/profiler_common.csproj" />
     <ProjectReference Include="slowpathcommon.csproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/elt/slowpatheltleave.csproj
+++ b/src/tests/profiler/elt/slowpatheltleave.csproj
@@ -5,7 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
     <!-- The test launches a secondary process and process launch creates
-    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    an infinite event loop in the SocketAsyncEngine on Linux. Since
     runincontext loads even framework assemblies into the unloadable
     context, locals in this loop prevent unloading -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
@@ -15,6 +15,6 @@
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="../common/profiler_common.csproj" />
     <ProjectReference Include="slowpathcommon.csproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/eventpipe/eventpipe.csproj
+++ b/src/tests/profiler/eventpipe/eventpipe.csproj
@@ -7,7 +7,7 @@
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- The test launches a secondary process and process launch creates
-    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    an infinite event loop in the SocketAsyncEngine on Linux. Since
     runincontext loads even framework assemblies into the unloadable
     context, locals in this loop prevent unloading -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
@@ -16,7 +16,7 @@
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="../common/profiler_common.csproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/eventpipe/eventpipe_readevents.csproj
+++ b/src/tests/profiler/eventpipe/eventpipe_readevents.csproj
@@ -7,7 +7,7 @@
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- The test launches a secondary process and process launch creates
-    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    an infinite event loop in the SocketAsyncEngine on Linux. Since
     runincontext loads even framework assemblies into the unloadable
     context, locals in this loop prevent unloading -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
@@ -16,6 +16,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="../common/profiler_common.csproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/eventpipe/reverse_startup.csproj
+++ b/src/tests/profiler/eventpipe/reverse_startup.csproj
@@ -7,7 +7,7 @@
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- The test launches a secondary process and process launch creates
-    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    an infinite event loop in the SocketAsyncEngine on Linux. Since
     runincontext loads even framework assemblies into the unloadable
     context, locals in this loop prevent unloading -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
@@ -17,7 +17,7 @@
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="../common/profiler_common.csproj" />
     <ProjectReference Include="$(TestSourceDir)tracing/eventpipe/common/common.csproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/gc/gc.csproj
+++ b/src/tests/profiler/gc/gc.csproj
@@ -7,7 +7,7 @@
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- The test launches a secondary process and process launch creates
-    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    an infinite event loop in the SocketAsyncEngine on Linux. Since
     runincontext loads even framework assemblies into the unloadable
     context, locals in this loop prevent unloading -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
@@ -16,6 +16,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="../common/profiler_common.csproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/gc/gcallocate.csproj
+++ b/src/tests/profiler/gc/gcallocate.csproj
@@ -7,7 +7,7 @@
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- The test launches a secondary process and process launch creates
-    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    an infinite event loop in the SocketAsyncEngine on Linux. Since
     runincontext loads even framework assemblies into the unloadable
     context, locals in this loop prevent unloading -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
@@ -16,6 +16,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="../common/profiler_common.csproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/gc/gcbasic.csproj
+++ b/src/tests/profiler/gc/gcbasic.csproj
@@ -7,7 +7,7 @@
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- The test launches a secondary process and process launch creates
-    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    an infinite event loop in the SocketAsyncEngine on Linux. Since
     runincontext loads even framework assemblies into the unloadable
     context, locals in this loop prevent unloading -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
@@ -16,6 +16,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="../common/profiler_common.csproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/multiple/multiple.csproj
+++ b/src/tests/profiler/multiple/multiple.csproj
@@ -10,6 +10,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="../common/profiler_common.csproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/rejit/rejit.csproj
+++ b/src/tests/profiler/rejit/rejit.csproj
@@ -8,7 +8,7 @@
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- The test launches a secondary process and process launch creates
-    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    an infinite event loop in the SocketAsyncEngine on Linux. Since
     runincontext loads even framework assemblies into the unloadable
     context, locals in this loop prevent unloading -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
@@ -17,6 +17,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="../common/profiler_common.csproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/transitions/transitions.csproj
+++ b/src/tests/profiler/transitions/transitions.csproj
@@ -10,6 +10,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="../common/profiler_common.csproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/unittest/getappdomainstaticaddress.csproj
+++ b/src/tests/profiler/unittest/getappdomainstaticaddress.csproj
@@ -7,7 +7,7 @@
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- The test launches a secondary process and process launch creates
-    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    an infinite event loop in the SocketAsyncEngine on Linux. Since
     runincontext loads even framework assemblies into the unloadable
     context, locals in this loop prevent unloading -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
@@ -17,6 +17,6 @@
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="../common/profiler_common.csproj" />
     <ProjectReference Include="unloadlibrary.csproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/unittest/inlining.csproj
+++ b/src/tests/profiler/unittest/inlining.csproj
@@ -7,7 +7,7 @@
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- The test launches a secondary process and process launch creates
-    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    an infinite event loop in the SocketAsyncEngine on Linux. Since
     runincontext loads even framework assemblies into the unloadable
     context, locals in this loop prevent unloading -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
@@ -16,6 +16,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="../common/profiler_common.csproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/unittest/metadatagetdispenser.csproj
+++ b/src/tests/profiler/unittest/metadatagetdispenser.csproj
@@ -7,7 +7,7 @@
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- The test launches a secondary process and process launch creates
-    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    an infinite event loop in the SocketAsyncEngine on Linux. Since
     runincontext loads even framework assemblies into the unloadable
     context, locals in this loop prevent unloading -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
@@ -16,6 +16,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="../common/profiler_common.csproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/profiler/unittest/releaseondetach.csproj
+++ b/src/tests/profiler/unittest/releaseondetach.csproj
@@ -4,7 +4,7 @@
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- The test launches a secondary process and process launch creates
-    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    an infinite event loop in the SocketAsyncEngine on Linux. Since
     runincontext loads even framework assemblies into the unloadable
     context, locals in this loop prevent unloading -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
@@ -15,6 +15,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="../common/profiler_common.csproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/readytorun/tests/mainv1.csproj
+++ b/src/tests/readytorun/tests/mainv1.csproj
@@ -8,7 +8,7 @@
     <ProjectReference Include="testv1\test.csproj">
       <Project>{F74F55A1-DFCF-4C7C-B462-E96E1D0BB667}</Project>
     </ProjectReference>
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="main.cs" />
@@ -47,7 +47,7 @@ if not exist test.ni.dll (
     exit /b 1
 )
 
-%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll -r:%Core_Root%\*.dll -r:%25CD% -o:fieldgetter.ni.dll fieldgetter.dll 
+%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll -r:%Core_Root%\*.dll -r:%25CD% -o:fieldgetter.ni.dll fieldgetter.dll
 
 set CrossGenStatus=!ERRORLEVEL!
 IF NOT !CrossGenStatus!==0 (

--- a/src/tests/readytorun/tests/mainv2.csproj
+++ b/src/tests/readytorun/tests/mainv2.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="fieldgetter.ilproj" />
     <ProjectReference Include="testv1\test.csproj" />
-    <ProjectReference Include="CMakeLists.txt" />
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="main.cs" />
@@ -45,7 +45,7 @@ if not exist mainv2.ni.dll (
     exit /b 1
 )
 
-%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll -r:%Core_Root%\*.dll -r:%25CD% -o:fieldgetter.ni.dll fieldgetter.dll 
+%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll -r:%Core_Root%\*.dll -r:%25CD% -o:fieldgetter.ni.dll fieldgetter.dll
 
 set CrossGenStatus=!ERRORLEVEL!
 IF NOT !CrossGenStatus!==0 (
@@ -67,7 +67,7 @@ if not exist test.dll (
     exit /b 1
 )
 
-%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll -r:%Core_Root%\*.dll -r:%25CD% -o:test.ni.dll test.dll 
+%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll -r:%Core_Root%\*.dll -r:%25CD% -o:test.ni.dll test.dll
 
 set CrossGenStatus=!ERRORLEVEL!
 IF NOT !CrossGenStatus!==0 (


### PR DESCRIPTION
Changing this permits usage of `\runtime\dotnet.cmd build` as opposed to forcing users to use `\runtime\dotnet.cmd msbuild`.

The change here is converting all `ProjectReference` items that point at a CMakelists.txt file to now be `CMakeProjectReference`. The `NativeProjectReference` concept remains because CMake is simply our current choice.

/cc @jkoritzinsky @elinor-fung @trylek 