### PR TITLE
[mono] Put WeakAttribute support under an ifdef

### DIFF
--- a/src/mono/cmake/config.h.in
+++ b/src/mono/cmake/config.h.in
@@ -1062,6 +1062,9 @@
 /* Enable perf jit dump support */
 #cmakedefine ENABLE_JIT_DUMP 1
 
+/* Enable System.WeakAttribute support */
+#cmakedefine ENABLE_WEAK_ATTR 1
+
 #if defined(ENABLE_LLVM) && defined(HOST_WIN32) && defined(TARGET_WIN32) && (!defined(TARGET_AMD64) || !defined(_MSC_VER))
 #error LLVM for host=Windows and target=Windows is only supported on x64 MSVC build.
 #endif

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -2475,6 +2475,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 	// - Disallow on structs/static fields/nonref fields
 	gboolean has_weak_fields = FALSE;
 
+#ifdef ENABLE_WEAK_ATTR
 	if (mono_class_has_static_metadata (klass)) {
 		for (MonoClass *p = klass; p != NULL; p = p->parent) {
 			gpointer iter = NULL;
@@ -2489,6 +2490,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 			}
 		}
 	}
+#endif
 
 	/*
 	 * Check that any fields of IsByRefLike type are instance

--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -2592,6 +2592,7 @@ mono_method_metadata_foreach_custom_attr (MonoMethod *method, MonoAssemblyMetada
 	metadata_foreach_custom_attr_from_index (image, idx, func, user_data);
 }
 
+#ifdef ENABLE_WEAK_ATTR
 static void
 init_weak_fields_inner (MonoImage *image, GHashTable *indexes)
 {
@@ -2725,6 +2726,7 @@ init_weak_fields_inner (MonoImage *image, GHashTable *indexes)
 		}
 	}
 }
+#endif
 
 /*
  * mono_assembly_init_weak_fields:
@@ -2734,6 +2736,7 @@ init_weak_fields_inner (MonoImage *image, GHashTable *indexes)
 void
 mono_assembly_init_weak_fields (MonoImage *image)
 {
+#ifdef ENABLE_WEAK_ATTR
 	if (image->weak_fields_inited)
 		return;
 
@@ -2760,6 +2763,7 @@ mono_assembly_init_weak_fields (MonoImage *image)
 		g_hash_table_destroy (indexes);
 	}
 	mono_image_unlock (image);
+#endif
 }
 
 /*
@@ -2771,6 +2775,7 @@ mono_assembly_init_weak_fields (MonoImage *image)
 gboolean
 mono_assembly_is_weak_field (MonoImage *image, guint32 field_idx)
 {
+#ifdef ENABLE_WEAK_ATTR
 	if (image->dynamic)
 		return FALSE;
 
@@ -2778,4 +2783,7 @@ mono_assembly_is_weak_field (MonoImage *image, guint32 field_idx)
 
 	/* The hash is not mutated, no need to lock */
 	return g_hash_table_lookup (image->weak_field_indexes, GINT_TO_POINTER (field_idx)) != NULL;
+#else
+	g_assert_not_reached ();
+#endif
 }

--- a/src/mono/mono/metadata/image.c
+++ b/src/mono/mono/metadata/image.c
@@ -2219,7 +2219,9 @@ mono_image_close_except_pools (MonoImage *image)
 	free_hash (image->wrapper_param_names);
 	free_hash (image->native_func_wrapper_cache);
 	mono_conc_hashtable_destroy (image->typespec_cache);
+#ifdef ENABLE_WEAK_ATTR
 	free_hash (image->weak_field_indexes);
+#endif
 
 	mono_wrapper_caches_free (&image->wrapper_caches);
 

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -503,9 +503,11 @@ struct _MonoImage {
 	MonoGenericContainer *anonymous_generic_class_container;
 	MonoGenericContainer *anonymous_generic_method_container;
 
+#ifdef ENABLE_WEAK_ATTR
 	gboolean weak_fields_inited;
 	/* Contains 1 based indexes */
 	GHashTable *weak_field_indexes;
+#endif
 
         /* baseline images only: whether any metadata updates have been applied to this image */
         gboolean has_updates;

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -1137,6 +1137,7 @@ mono_class_compute_gc_descriptor (MonoClass *klass)
 		*/
 		/*printf ("new descriptor: %p 0x%x for %s.%s\n", class->gc_descr, bitmap [0], class->name_space, class->name);*/
 
+#ifdef ENABLE_WEAK_ATTR
 		if (m_class_has_weak_fields (klass)) {
 			gsize *weak_bitmap = NULL;
 			int weak_bitmap_nbits = 0;
@@ -1173,6 +1174,7 @@ mono_class_compute_gc_descriptor (MonoClass *klass)
 			mono_class_set_weak_bitmap (klass, weak_bitmap_nbits, weak_bitmap);
 			mono_loader_unlock ();
 		}
+#endif
 
 		gc_descr = mono_gc_make_descr_for_object (bitmap, max_set + 1, m_class_get_instance_size (klass));
 	}
@@ -4943,8 +4945,10 @@ object_new_common_tail (MonoObject *o, MonoClass *klass, MonoError *error)
 	if (G_UNLIKELY (m_class_has_finalize (klass)))
 		mono_object_register_finalizer (o);
 
+#ifdef ENABLE_WEAK_ATTR
 	if (G_UNLIKELY (m_class_has_weak_fields (klass)))
 		mono_gc_register_obj_with_weak_fields (o);
+#endif
 
 	return o;
 }
@@ -4968,8 +4972,10 @@ object_new_handle_common_tail (MonoObjectHandle o, MonoClass *klass, MonoError *
 	if (G_UNLIKELY (m_class_has_finalize (klass)))
 		mono_object_register_finalizer_handle (o);
 
+#ifdef ENABLE_WEAK_ATTR
 	if (G_UNLIKELY (m_class_has_weak_fields (klass)))
 		mono_gc_register_object_with_weak_fields (o);
+#endif
 
 	return o;
 }

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -11220,6 +11220,7 @@ emit_image_table (MonoAotCompile *acfg)
 static void
 emit_weak_field_indexes (MonoAotCompile *acfg)
 {
+#ifdef ENABLE_WEAK_ATTR
 	GHashTable *indexes;
 	GHashTableIter iter;
 	gpointer key, value;
@@ -11245,6 +11246,13 @@ emit_weak_field_indexes (MonoAotCompile *acfg)
 	emit_aot_data (acfg, MONO_AOT_TABLE_WEAK_FIELD_INDEXES, "weak_field_indexes", buf, p - buf);
 
 	g_free (buf);
+#else
+	guint8 buf [4];
+	guint8 *p = &buf[0];
+
+	encode_int (0, p, &p);
+	emit_aot_data (acfg, MONO_AOT_TABLE_WEAK_FIELD_INDEXES, "weak_field_indexes", buf, p - buf);
+#endif	
 }
 
 static void

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -2646,6 +2646,7 @@ mono_aot_get_weak_field_indexes (MonoImage *image)
 	if (!amodule)
 		return NULL;
 
+#if ENABLE_WEAK_ATTR
 	/* Initialize weak field indexes from the cached copy */
 	guint32 *indexes = (guint32*)amodule->weak_field_indexes;
 	int len  = indexes [0];
@@ -2653,6 +2654,9 @@ mono_aot_get_weak_field_indexes (MonoImage *image)
 	for (int i = 0; i < len; ++i)
 		g_hash_table_insert (indexes_hash, GUINT_TO_POINTER (indexes [i + 1]), GUINT_TO_POINTER (1));
 	return indexes_hash;
+#else
+	g_assert_not_reached ();
+#endif
 }
 
 /* Compute the boundaries of the LLVM code for AMODULE. */

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4461,7 +4461,9 @@ mini_init (const char *filename, const char *runtime_version)
 	callbacks.get_ftnptr = get_ftnptr_for_method;
 #endif
 	callbacks.is_interpreter_enabled = mini_is_interpreter_enabled;
+#if ENABLE_WEAK_ATTR
 	callbacks.get_weak_field_indexes = mono_aot_get_weak_field_indexes;
+#endif
 
 	callbacks.metadata_update_published = mini_invalidate_transformed_interp_methods;
 	callbacks.interp_jit_info_foreach = mini_interp_jit_info_foreach;


### PR DESCRIPTION
This code has been effectively dead in .NET 6 on all platforms since `System.WeakAttribute` is not in CoreLib (it was a pre-.NET 5 mono-specific extension)

Not everything is removed:

- `MonoClass:has_weak_fields` bit is still present (and always 0).

- the AOT compiler still emits a (size 0) `weak_field_indexes` symbol (but the AOT runtime reader code is under an ifdef).  Likewise the AOT table definitions, etc are still there.  It seemed unnecessary to perturb the AOT format.