### PR TITLE
Partial revert of Maui Install Fix #65904

### DIFF
--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -114,383 +114,383 @@ jobs:
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
-  # build coreclr and libraries
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-      buildConfig: release
-      platforms:
-      - Linux_x64
-      - windows_x64
-      - windows_x86
-      - Linux_musl_x64
-      jobParameters:
-        testGroup: perf
+  ## build coreclr and libraries
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+  #    buildConfig: release
+  #    platforms:
+  #    - Linux_x64
+  #    - windows_x64
+  #    - windows_x86
+  #    - Linux_musl_x64
+  #    jobParameters:
+  #      testGroup: perf
 
-  # build mono on wasm
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Browser_wasm
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: wasm
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: Browser Wasm Artifacts
-          artifactName: BrowserWasm
-          archiveType: zip
-          archiveExtension: .zip
+  ## build mono on wasm
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Browser_wasm
+  #    jobParameters:
+  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #      nameSuffix: wasm
+  #      isOfficialBuild: false
+  #      extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+  #      extraStepsParameters:
+  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #        includeRootFolder: true
+  #        displayName: Browser Wasm Artifacts
+  #        artifactName: BrowserWasm
+  #        archiveType: zip
+  #        archiveExtension: .zip
 
-  # build mono for AOT
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Linux_x64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: AOT
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: AOT Mono Artifacts
-          artifactName: LinuxMonoAOTx64
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  ## build mono for AOT
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #      nameSuffix: AOT
+  #      isOfficialBuild: false
+  #      extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+  #      extraStepsParameters:
+  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #        includeRootFolder: true
+  #        displayName: AOT Mono Artifacts
+  #        artifactName: LinuxMonoAOTx64
+  #        archiveExtension: '.tar.gz'
+  #        archiveType: tar
+  #        tarCompression: gz
 
-  # build mono Android scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Android_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: AndroidMono
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: Android Mono Artifacts
-          artifactName: AndroidMonoarm64
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  ## build mono Android scenarios
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Android_arm64
+  #    jobParameters:
+  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #      nameSuffix: AndroidMono
+  #      isOfficialBuild: false
+  #      extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+  #      extraStepsParameters:
+  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #        includeRootFolder: true
+  #        displayName: Android Mono Artifacts
+  #        artifactName: AndroidMonoarm64
+  #        archiveExtension: '.tar.gz'
+  #        archiveType: tar
+  #        tarCompression: gz
     
-  # build mono iOS scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - iOS_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: iOSMono
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: iOS Mono Artifacts
-          artifactName: iOSMonoarm64
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  ## build mono iOS scenarios
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - iOS_arm64
+  #    jobParameters:
+  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #      nameSuffix: iOSMono
+  #      isOfficialBuild: false
+  #      extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+  #      extraStepsParameters:
+  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #        includeRootFolder: true
+  #        displayName: iOS Mono Artifacts
+  #        artifactName: iOSMonoarm64
+  #        archiveExtension: '.tar.gz'
+  #        archiveType: tar
+  #        tarCompression: gz
 
-  # build mono
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-      runtimeFlavor: mono
-      buildConfig: release
-      platforms:
-      - Linux_x64
+  ## build mono
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+  #    runtimeFlavor: mono
+  #    buildConfig: release
+  #    platforms:
+  #    - Linux_x64
 
-  # run mono and maui android scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - Windows_x64
-      variables:
-        - name: mauiVersion
-          value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMaui.outputs['getMauiVersion.mauiVersion'] ]
-      jobParameters:
-        testGroup: perf
-        runtimeType: AndroidMono
-        projectFile: android_scenarios.proj
-        runKind: android_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
-        additionalSetupParameters: "-MauiVersion $env:mauiVersion"
+  ## run mono and maui android scenarios
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #      - Windows_x64
+  #    variables:
+  #      - name: mauiVersion
+  #        value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMaui.outputs['getMauiVersion.mauiVersion'] ]
+  #    jobParameters:
+  #      testGroup: perf
+  #      runtimeType: AndroidMono
+  #      projectFile: android_scenarios.proj
+  #      runKind: android_scenarios
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #      logicalmachine: 'perfpixel4a'
+  #      additionalSetupParameters: "-MauiVersion $env:mauiVersion"
 
-  # run mono iOS scenarios and maui iOS scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - Windows_x64
-      variables:
-        - name: mauiVersion
-          value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMaui.outputs['getMauiVersion.mauiVersion'] ]
-      jobParameters:
-        testGroup: perf
-        runtimeType: iOSMono
-        projectFile: ios_scenarios.proj
-        runKind: ios_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
-        iosLlvmBuild: False
-        additionalSetupParameters: "-MauiVersion $env:mauiVersion"
+  ## run mono iOS scenarios and maui iOS scenarios
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #      - Windows_x64
+  #    variables:
+  #      - name: mauiVersion
+  #        value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMaui.outputs['getMauiVersion.mauiVersion'] ]
+  #    jobParameters:
+  #      testGroup: perf
+  #      runtimeType: iOSMono
+  #      projectFile: ios_scenarios.proj
+  #      runKind: ios_scenarios
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #      logicalmachine: 'perfpixel4a'
+  #      iosLlvmBuild: False
+  #      additionalSetupParameters: "-MauiVersion $env:mauiVersion"
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - Windows_x64
-      jobParameters:
-        testGroup: perf
-        runtimeType: iOSMono
-        projectFile: ios_scenarios.proj
-        runKind: ios_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
-        iosLlvmBuild: True
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #      - Windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      runtimeType: iOSMono
+  #      projectFile: ios_scenarios.proj
+  #      runKind: ios_scenarios
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #      logicalmachine: 'perfpixel4a'
+  #      iosLlvmBuild: True
 
-  # run mono microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  ## run mono microbenchmarks perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      runtimeType: mono
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro_mono
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
 
-  # run mono interpreter perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'Interpreter'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  ## run mono interpreter perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      runtimeType: mono
+  #      codeGenType: 'Interpreter'
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro_mono
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
 
-  # run mono wasm interpreter (default) microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: release
-      runtimeFlavor: wasm
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        codeGenType: 'wasm'
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        javascriptEngine: 'v8'
+  ## run mono wasm interpreter (default) microbenchmarks perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+  #    buildConfig: release
+  #    runtimeFlavor: wasm
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      runtimeType: wasm
+  #      codeGenType: 'wasm'
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
+  #      javascriptEngine: 'v8'
 
-  #run mono wasm aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildconfig: release
-      runtimeflavor: wasm
-      platforms:
-      - linux_x64
-      jobparameters:
-        testgroup: perf
-        livelibrariesbuildconfig: Release
-        runtimetype: wasm
-        codegentype: 'aot'
-        projectfile: microbenchmarks.proj
-        runkind: micro
-        runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        javascriptEngine: 'v8'
+  ##run mono wasm aot microbenchmarks perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
+  #    buildconfig: release
+  #    runtimeflavor: wasm
+  #    platforms:
+  #    - linux_x64
+  #    jobparameters:
+  #      testgroup: perf
+  #      livelibrariesbuildconfig: Release
+  #      runtimetype: wasm
+  #      codegentype: 'aot'
+  #      projectfile: microbenchmarks.proj
+  #      runkind: micro
+  #      runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
+  #      javascriptEngine: 'v8'
 
-  # run mono aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: release
-      runtimeFlavor: aot
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'AOT'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  ## run mono aot microbenchmarks perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+  #    buildConfig: release
+  #    runtimeFlavor: aot
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      runtimeType: mono
+  #      codeGenType: 'AOT'
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro_mono
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
 
-  # run coreclr perftiger microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_x64
-      - windows_x64
-      - windows_x86
-      - Linux_musl_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  ## run coreclr perftiger microbenchmarks perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: coreclr
+  #    platforms:
+  #    - Linux_x64
+  #    - windows_x64
+  #    - windows_x86
+  #    - Linux_musl_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
 
-  # run coreclr perftiger microbenchmarks pgo perf jobs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -NoPgo
+  ## run coreclr perftiger microbenchmarks pgo perf jobs
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: coreclr
+  #    platforms:
+  #    - windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
+  #      pgoRunType: -NoPgo
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -DynamicPgo
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: coreclr
+  #    platforms:
+  #    - windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
+  #      pgoRunType: -DynamicPgo
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -FullPgo
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: coreclr
+  #    platforms:
+  #    - windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
+  #      pgoRunType: -FullPgo
 
-  # run coreclr perfowl microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_x64
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perfowl'
+  ## run coreclr perfowl microbenchmarks perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: coreclr
+  #    platforms:
+  #    - Linux_x64
+  #    - windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perfowl'
 
-  # run coreclr crossgen perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_x64
-      - windows_x64
-      - windows_x86
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: crossgen_perf.proj
-        runKind: crossgen_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perftiger'
+  ## run coreclr crossgen perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: coreclr
+  #    platforms:
+  #    - Linux_x64
+  #    - windows_x64
+  #    - windows_x86
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      projectFile: crossgen_perf.proj
+  #      runKind: crossgen_scenarios
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #      logicalmachine: 'perftiger'
 
-  # run mono wasm blazor perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: wasm
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        projectFile: blazor_perf.proj
-        runKind: blazor_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        additionalSetupParameters: '--latestdotnet'
-        logicalmachine: 'perftiger'
+  ## run mono wasm blazor perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: wasm
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      runtimeType: wasm
+  #      projectFile: blazor_perf.proj
+  #      runKind: blazor_scenarios
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #      additionalSetupParameters: '--latestdotnet'
+  #      logicalmachine: 'perftiger'
 
   # Uncomment to reenable package replacement
   ## build maui runtime packs

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -114,383 +114,383 @@ jobs:
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
-  ## build coreclr and libraries
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-  #    buildConfig: release
-  #    platforms:
-  #    - Linux_x64
-  #    - windows_x64
-  #    - windows_x86
-  #    - Linux_musl_x64
-  #    jobParameters:
-  #      testGroup: perf
+  # build coreclr and libraries
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+      buildConfig: release
+      platforms:
+      - Linux_x64
+      - windows_x64
+      - windows_x86
+      - Linux_musl_x64
+      jobParameters:
+        testGroup: perf
 
-  ## build mono on wasm
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Browser_wasm
-  #    jobParameters:
-  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #      nameSuffix: wasm
-  #      isOfficialBuild: false
-  #      extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-  #      extraStepsParameters:
-  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #        includeRootFolder: true
-  #        displayName: Browser Wasm Artifacts
-  #        artifactName: BrowserWasm
-  #        archiveType: zip
-  #        archiveExtension: .zip
+  # build mono on wasm
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Browser_wasm
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: wasm
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: Browser Wasm Artifacts
+          artifactName: BrowserWasm
+          archiveType: zip
+          archiveExtension: .zip
 
-  ## build mono for AOT
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #      nameSuffix: AOT
-  #      isOfficialBuild: false
-  #      extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-  #      extraStepsParameters:
-  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #        includeRootFolder: true
-  #        displayName: AOT Mono Artifacts
-  #        artifactName: LinuxMonoAOTx64
-  #        archiveExtension: '.tar.gz'
-  #        archiveType: tar
-  #        tarCompression: gz
+  # build mono for AOT
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Linux_x64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: AOT
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: AOT Mono Artifacts
+          artifactName: LinuxMonoAOTx64
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
 
-  ## build mono Android scenarios
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Android_arm64
-  #    jobParameters:
-  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #      nameSuffix: AndroidMono
-  #      isOfficialBuild: false
-  #      extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-  #      extraStepsParameters:
-  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #        includeRootFolder: true
-  #        displayName: Android Mono Artifacts
-  #        artifactName: AndroidMonoarm64
-  #        archiveExtension: '.tar.gz'
-  #        archiveType: tar
-  #        tarCompression: gz
+  # build mono Android scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Android_arm64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: AndroidMono
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: Android Mono Artifacts
+          artifactName: AndroidMonoarm64
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
     
-  ## build mono iOS scenarios
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - iOS_arm64
-  #    jobParameters:
-  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #      nameSuffix: iOSMono
-  #      isOfficialBuild: false
-  #      extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-  #      extraStepsParameters:
-  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #        includeRootFolder: true
-  #        displayName: iOS Mono Artifacts
-  #        artifactName: iOSMonoarm64
-  #        archiveExtension: '.tar.gz'
-  #        archiveType: tar
-  #        tarCompression: gz
+  # build mono iOS scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - iOS_arm64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: iOSMono
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: iOS Mono Artifacts
+          artifactName: iOSMonoarm64
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
 
-  ## build mono
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-  #    runtimeFlavor: mono
-  #    buildConfig: release
-  #    platforms:
-  #    - Linux_x64
+  # build mono
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+      runtimeFlavor: mono
+      buildConfig: release
+      platforms:
+      - Linux_x64
 
-  ## run mono and maui android scenarios
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #      - Windows_x64
-  #    variables:
-  #      - name: mauiVersion
-  #        value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMaui.outputs['getMauiVersion.mauiVersion'] ]
-  #    jobParameters:
-  #      testGroup: perf
-  #      runtimeType: AndroidMono
-  #      projectFile: android_scenarios.proj
-  #      runKind: android_scenarios
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #      logicalmachine: 'perfpixel4a'
-  #      additionalSetupParameters: "-MauiVersion $env:mauiVersion"
+  # run mono and maui android scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+        - Windows_x64
+      variables:
+        - name: mauiVersion
+          value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMaui.outputs['getMauiVersion.mauiVersion'] ]
+      jobParameters:
+        testGroup: perf
+        runtimeType: AndroidMono
+        projectFile: android_scenarios.proj
+        runKind: android_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perfpixel4a'
+        additionalSetupParameters: "-MauiVersion $env:mauiVersion"
 
-  ## run mono iOS scenarios and maui iOS scenarios
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #      - Windows_x64
-  #    variables:
-  #      - name: mauiVersion
-  #        value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMaui.outputs['getMauiVersion.mauiVersion'] ]
-  #    jobParameters:
-  #      testGroup: perf
-  #      runtimeType: iOSMono
-  #      projectFile: ios_scenarios.proj
-  #      runKind: ios_scenarios
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #      logicalmachine: 'perfpixel4a'
-  #      iosLlvmBuild: False
-  #      additionalSetupParameters: "-MauiVersion $env:mauiVersion"
+  # run mono iOS scenarios and maui iOS scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+        - Windows_x64
+      variables:
+        - name: mauiVersion
+          value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMaui.outputs['getMauiVersion.mauiVersion'] ]
+      jobParameters:
+        testGroup: perf
+        runtimeType: iOSMono
+        projectFile: ios_scenarios.proj
+        runKind: ios_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perfpixel4a'
+        iosLlvmBuild: False
+        additionalSetupParameters: "-MauiVersion $env:mauiVersion"
 
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #      - Windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      runtimeType: iOSMono
-  #      projectFile: ios_scenarios.proj
-  #      runKind: ios_scenarios
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #      logicalmachine: 'perfpixel4a'
-  #      iosLlvmBuild: True
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+        - Windows_x64
+      jobParameters:
+        testGroup: perf
+        runtimeType: iOSMono
+        projectFile: ios_scenarios.proj
+        runKind: ios_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perfpixel4a'
+        iosLlvmBuild: True
 
-  ## run mono microbenchmarks perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      runtimeType: mono
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro_mono
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
+  # run mono microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  ## run mono interpreter perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      runtimeType: mono
-  #      codeGenType: 'Interpreter'
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro_mono
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
+  # run mono interpreter perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'Interpreter'
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  ## run mono wasm interpreter (default) microbenchmarks perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-  #    buildConfig: release
-  #    runtimeFlavor: wasm
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      runtimeType: wasm
-  #      codeGenType: 'wasm'
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
-  #      javascriptEngine: 'v8'
+  # run mono wasm interpreter (default) microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildConfig: release
+      runtimeFlavor: wasm
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: wasm
+        codeGenType: 'wasm'
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        javascriptEngine: 'v8'
 
-  ##run mono wasm aot microbenchmarks perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
-  #    buildconfig: release
-  #    runtimeflavor: wasm
-  #    platforms:
-  #    - linux_x64
-  #    jobparameters:
-  #      testgroup: perf
-  #      livelibrariesbuildconfig: Release
-  #      runtimetype: wasm
-  #      codegentype: 'aot'
-  #      projectfile: microbenchmarks.proj
-  #      runkind: micro
-  #      runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
-  #      javascriptEngine: 'v8'
+  #run mono wasm aot microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildconfig: release
+      runtimeflavor: wasm
+      platforms:
+      - linux_x64
+      jobparameters:
+        testgroup: perf
+        livelibrariesbuildconfig: Release
+        runtimetype: wasm
+        codegentype: 'aot'
+        projectfile: microbenchmarks.proj
+        runkind: micro
+        runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        javascriptEngine: 'v8'
 
-  ## run mono aot microbenchmarks perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-  #    buildConfig: release
-  #    runtimeFlavor: aot
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      runtimeType: mono
-  #      codeGenType: 'AOT'
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro_mono
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
+  # run mono aot microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildConfig: release
+      runtimeFlavor: aot
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'AOT'
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  ## run coreclr perftiger microbenchmarks perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: coreclr
-  #    platforms:
-  #    - Linux_x64
-  #    - windows_x64
-  #    - windows_x86
-  #    - Linux_musl_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
+  # run coreclr perftiger microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - Linux_x64
+      - windows_x64
+      - windows_x86
+      - Linux_musl_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  ## run coreclr perftiger microbenchmarks pgo perf jobs
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: coreclr
-  #    platforms:
-  #    - windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
-  #      pgoRunType: -NoPgo
+  # run coreclr perftiger microbenchmarks pgo perf jobs
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: -NoPgo
 
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: coreclr
-  #    platforms:
-  #    - windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
-  #      pgoRunType: -DynamicPgo
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: -DynamicPgo
 
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: coreclr
-  #    platforms:
-  #    - windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
-  #      pgoRunType: -FullPgo
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: -FullPgo
 
-  ## run coreclr perfowl microbenchmarks perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: coreclr
-  #    platforms:
-  #    - Linux_x64
-  #    - windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perfowl'
+  # run coreclr perfowl microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - Linux_x64
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perfowl'
 
-  ## run coreclr crossgen perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: coreclr
-  #    platforms:
-  #    - Linux_x64
-  #    - windows_x64
-  #    - windows_x86
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      projectFile: crossgen_perf.proj
-  #      runKind: crossgen_scenarios
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #      logicalmachine: 'perftiger'
+  # run coreclr crossgen perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - Linux_x64
+      - windows_x64
+      - windows_x86
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: crossgen_perf.proj
+        runKind: crossgen_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perftiger'
 
-  ## run mono wasm blazor perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: wasm
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      runtimeType: wasm
-  #      projectFile: blazor_perf.proj
-  #      runKind: blazor_scenarios
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #      additionalSetupParameters: '--latestdotnet'
-  #      logicalmachine: 'perftiger'
+  # run mono wasm blazor perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: wasm
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: wasm
+        projectFile: blazor_perf.proj
+        runKind: blazor_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        additionalSetupParameters: '--latestdotnet'
+        logicalmachine: 'perftiger'
 
   # Uncomment to reenable package replacement
   ## build maui runtime packs

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -115,14 +115,11 @@ steps:
   # This is a workaround as the current
   - script: |
       curl -o NuGet.config 'https://raw.githubusercontent.com/dotnet/maui/main/NuGet.config'
-      curl -o rollback.json 'https://maui.blob.core.windows.net/metadata/rollbacks/main.json'
-      sed -n 'H;${x;s/^\n//;s/  "microsoft.net.sdk.android".*$/  "microsoft.net.workload.emscripten": "6.0.2",\n&/;p;}' rollback.json > updated_rollback.json
-      cat updated_rollback.json
       curl -o dotnet-install.sh 'https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh'
       chmod -R a+rx .
       ./dotnet-install.sh --channel 6.0.2xx --quality daily --install-dir .
       ./dotnet --info
-      ./dotnet workload install maui --from-rollback-file ./updated_rollback.json --configfile NuGet.config
+      ./dotnet workload install maui --from-rollback-file https://aka.ms/dotnet/maui/main.json --configfile NuGet.config
     displayName: Install MAUI workload
     workingDirectory: $(Build.SourcesDirectory)
 

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -110,9 +110,7 @@ steps:
   #      overwriteExistingFiles: true
   #      cleanDestinationFolder: false
 
-  # Get the current maui nuget config so all things can be found, and add the Emscription version to the rollback file
-  # Add emscription line using sed based on https://stackoverflow.com/questions/6739258/how-do-i-add-a-line-of-text-to-the-middle-of-a-file-using-bash.
-  # This is a workaround as the current
+  # Get the current maui nuget config so all things can be found and darc based package sources are kept up to date.
   - script: |
       curl -o NuGet.config 'https://raw.githubusercontent.com/dotnet/maui/main/NuGet.config'
       curl -o dotnet-install.sh 'https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh'


### PR DESCRIPTION
Partially reverts the Maui Install Mitigation put in place as part of #65904. This is possible because the Maui team added the emscription line back into the main.json rollback file so we no longer need to add it ourselves. I kept the Nuget.config file download and usage because there are 2 Darc package sources that were added as install sources and using the Nuget.config instead will keep us automatically up to date as the package sources update.