### PR TITLE
[release/6.0] Fix race conditions in SystemEvents shutdown logic

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.Constants.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.Constants.cs
@@ -198,6 +198,7 @@ internal static partial class Interop
 
         public const int WAIT_TIMEOUT = 0x00000102;
 
+        public const int WM_DESTROY = 0x0002;
         public const int WM_CLOSE = 0x0010;
         public const int WM_QUERYENDSESSION = 0x0011;
         public const int WM_QUIT = 0x0012;

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.GetMessage.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.GetMessage.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     internal static partial class User32
     {
         [DllImport(Libraries.User32, CharSet = CharSet.Unicode, ExactSpelling = true)]
-        public static extern bool PeekMessageW([In, Out] ref MSG msg, IntPtr hwnd, int msgMin, int msgMax, int remove);
+        public static extern int GetMessageW(ref MSG msg, IntPtr hwnd, int msgMin, int msgMax);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.PostQuitMessage.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.PostQuitMessage.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        public static extern void PostQuitMessage(int exitCode);
+    }
+}

--- a/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft.Win32.SystemEvents.csproj
+++ b/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft.Win32.SystemEvents.csproj
@@ -35,6 +35,8 @@ Microsoft.Win32.SystemEvents</PackageDescription>
              Link="Common\Interop\Windows\User32\Interop.DispatchMessage.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.GetClassInfo.cs"
              Link="Common\Interop\Windows\User32\Interop.GetClassInfo.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.GetMessage.cs"
+             Link="Common\Interop\Windows\User32\Interop.GetMessage.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.GetProcessWindowStation.cs"
              Link="Common\Interop\Windows\User32\Interop.GetProcessWindowStation.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.GetUserObjectInformation.cs"
@@ -49,10 +51,10 @@ Microsoft.Win32.SystemEvents</PackageDescription>
              Link="Common\Interop\Windows\User32\Interop.MSG.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.MsgWaitForMultipleObjectsEx.cs"
              Link="Common\Interop\Windows\User32\Interop.MsgWaitForMultipleObjectsEx.cs" />
-    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.PeekMessage.cs"
-             Link="Common\Interop\Windows\User32\Interop.PeekMessage.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.PostMessage.cs"
              Link="Common\Interop\Windows\User32\Interop.PostMessage.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.PostQuitMessage.cs"
+             Link="Common\Interop\Windows\User32\Interop.PostQuitMessage.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.RegisterClass.cs"
              Link="Common\Interop\Windows\User32\Interop.RegisterClass.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.RegisterWindowMessage.cs"

--- a/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft.Win32.SystemEvents.csproj
+++ b/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft.Win32.SystemEvents.csproj
@@ -5,6 +5,8 @@
 
 Commonly Used Types:
 Microsoft.Win32.SystemEvents</PackageDescription>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>1</ServicingVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);netcoreapp3.1-windows;netcoreapp3.1;netstandard2.0;net461</TargetFrameworks>

--- a/src/libraries/Microsoft.Win32.SystemEvents/tests/Microsoft.Win32.SystemEvents.Tests.csproj
+++ b/src/libraries/Microsoft.Win32.SystemEvents/tests/Microsoft.Win32.SystemEvents.Tests.csproj
@@ -23,6 +23,7 @@
     <Compile Include="SystemEvents.SessionSwitch.cs" />
     <Compile Include="SystemEvents.PowerMode.cs" />
     <Compile Include="SystemEvents.TimeChanged.cs" />
+    <Compile Include="ShutdownTest.cs" />
     <Compile Include="SystemEventsTest.cs" />
     <Compile Include="SystemEvents.DisplaySettings.cs" />
     <Compile Include="SystemEvents.CreateTimer.cs" />

--- a/src/libraries/Microsoft.Win32.SystemEvents/tests/ShutdownTest.cs
+++ b/src/libraries/Microsoft.Win32.SystemEvents/tests/ShutdownTest.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using Microsoft.DotNet.RemoteExecutor;
+using Xunit;
+using static Interop;
+
+namespace Microsoft.Win32.SystemEventsTests
+{
+    public abstract class ShutdownTest : SystemEventsTest
+    {
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoNorServerCore))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void ShutdownThroughRestartManager()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                // Register any event to ensure that SystemEvents get initialized
+                SystemEvents.TimeChanged += (o, e) => { };
+
+                // Fake Restart Manager behavior by sending external WM_CLOSE message
+                SendMessage(Interop.User32.WM_CLOSE, IntPtr.Zero, IntPtr.Zero);
+
+                // Emulate calling the Shutdown event
+                var shutdownMethod = typeof(SystemEvents).GetMethod("Shutdown", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic, null, new Type[0], null);
+                Assert.NotNull(shutdownMethod);
+                shutdownMethod.Invoke(null, null);
+            }).Dispose();
+        }
+    }
+}


### PR DESCRIPTION
# Description
Application attached to SystemEvents hangs when being shutdown by RestartManager.

original PR #62773
original issue #62042

# Customer Impact
Reported by customer.  Their application cannot be updated by Microsoft Store.

# Regression
No

# Testing
Automated testing added.  Fix has been in main for a month.  Customer has validated fix.

# Risk
Low.  Fix is isolated to SystemEvents, used mostly by winforms who has signed off.

# Package authoring signed off?
Added ✔️ 