### PR TITLE
Remove compiler warning suppression

### DIFF
--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -209,15 +209,8 @@ GetFullMethodNameFromMetadata(IMDInternalImport* mdImport,
 
     LPCUTF8 methodName;
     IfFailRet(mdImport->GetNameOfMethodDef(methodToken, &methodName));
-// Review conversion of size_t to ULONG32.
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4267)
-#endif
+
     len = strlen(methodName);
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
     if (len >= bufferChars)
     {
         return E_OUTOFMEMORY;

--- a/src/coreclr/jit/eeinterface.cpp
+++ b/src/coreclr/jit/eeinterface.cpp
@@ -21,9 +21,6 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 #if defined(DEBUG) || defined(FEATURE_JIT_METHOD_PERF) || defined(FEATURE_SIMD)
 
-#pragma warning(push)
-#pragma warning(disable : 4701) // difficult to get rid of C4701 with 'sig' below
-
 /*****************************************************************************/
 
 /*****************************************************************************
@@ -245,8 +242,6 @@ const char* Compiler::eeGetMethodFullName(CORINFO_METHOD_HANDLE hnd)
 
     return (retName);
 }
-
-#pragma warning(pop)
 
 #endif // defined(DEBUG) || defined(FEATURE_JIT_METHOD_PERF) || defined(FEATURE_SIMD)
 

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -13,7 +13,6 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include "jitpch.h"
 #ifdef _MSC_VER
 #pragma hdrstop
-#pragma warning(disable : 4701)
 #endif
 
 /*****************************************************************************/
@@ -7365,8 +7364,8 @@ void Compiler::fgCreateLoopPreHeader(unsigned lnum)
 
             if (allValidProfileWeights)
             {
-                weight_t loopEnteredCount;
-                weight_t loopSkippedCount;
+                weight_t loopEnteredCount = 0;
+                weight_t loopSkippedCount = 0;
                 bool     useEdgeWeights = fgHaveValidEdgeWeights;
 
                 if (useEdgeWeights)

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -7366,7 +7366,7 @@ void Compiler::fgCreateLoopPreHeader(unsigned lnum)
             {
                 weight_t loopEnteredCount = 0;
                 weight_t loopSkippedCount = 0;
-                bool     useEdgeWeights = fgHaveValidEdgeWeights;
+                bool     useEdgeWeights   = fgHaveValidEdgeWeights;
 
                 if (useEdgeWeights)
                 {

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -5037,10 +5037,6 @@ public:
 
 #define PAL_CPP_ENDTRY                  }
 
-#ifdef _MSC_VER
-#pragma warning(disable:4611) // interaction between '_setjmp' and C++ object destruction is non-portable
-#endif
-
 #define PAL_TRY_FOR_DLLMAIN(ParamType, paramDef, paramRef, _reason) PAL_TRY(ParamType, paramDef, paramRef)
 
 #endif // __cplusplus

--- a/src/coreclr/pal/src/libunwind/CMakeLists.txt
+++ b/src/coreclr/pal/src/libunwind/CMakeLists.txt
@@ -159,7 +159,6 @@ if(CLR_CMAKE_HOST_WIN32)
     add_compile_options(-wd4068) # ignore unknown pragma warnings (gcc pragmas)
     add_compile_options(-wd4146) # minus operator applied to unsigned
     add_compile_options(-wd4244) # possible loss of data
-    add_compile_options(-wd4267) # possible loss of data
     add_compile_options(-wd4334) # 32-bit shift implicitly converted to 64 bits
 
     # Disable warning due to incorrect format specifier in debugging printf via the Debug macro

--- a/src/coreclr/pal/src/libunwind/include/mempool.h
+++ b/src/coreclr/pal/src/libunwind/include/mempool.h
@@ -63,7 +63,7 @@ struct mempool
     pthread_mutex_t lock;
     size_t obj_size;            /* object size (rounded up for alignment) */
     size_t chunk_size;          /* allocation granularity */
-    unsigned int reserve;       /* minimum (desired) size of the free-list */
+    size_t reserve;             /* minimum (desired) size of the free-list */
     unsigned int num_free;      /* number of objects on the free-list */
     struct object
       {

--- a/src/coreclr/pal/src/libunwind/include/mempool.h
+++ b/src/coreclr/pal/src/libunwind/include/mempool.h
@@ -64,7 +64,7 @@ struct mempool
     size_t obj_size;            /* object size (rounded up for alignment) */
     size_t chunk_size;          /* allocation granularity */
     size_t reserve;             /* minimum (desired) size of the free-list */
-    unsigned int num_free;      /* number of objects on the free-list */
+    size_t num_free;            /* number of objects on the free-list */
     struct object
       {
         struct object *next;

--- a/src/coreclr/pal/src/libunwind/libunwind-version.txt
+++ b/src/coreclr/pal/src/libunwind/libunwind-version.txt
@@ -5,6 +5,7 @@ Replace CMakeLists.txt, src/CMakeLists.txt, configure.cmake with .NET custom ver
 Keep .NET oop directory
 Reapply changes from https://github.com/dotnet/runtime/commit/1b5719c2e3dde393531eaeb5b5cde05dabeef5b8
 Apply https://github.com/libunwind/libunwind/pull/317
+Apply https://github.com/libunwind/libunwind/pull/333
 
 For LoongArch64:
 Apply https://github.com/libunwind/libunwind/pull/316 and https://github.com/libunwind/libunwind/pull/322

--- a/src/coreclr/pal/src/libunwind/src/dwarf/Gfind_proc_info-lsb.c
+++ b/src/coreclr/pal/src/libunwind/src/dwarf/Gfind_proc_info-lsb.c
@@ -866,9 +866,9 @@ remote_lookup (unw_addr_space_t as,
                unw_word_t table, size_t table_size, int32_t rel_ip,
                struct table_entry *e, int32_t *last_ip_offset, void *arg)
 {
-  unsigned long table_len = table_size / sizeof (struct table_entry);
+  size_t table_len = table_size / sizeof (struct table_entry);
   unw_accessors_t *a = unw_get_accessors_int (as);
-  unsigned long lo, hi, mid;
+  size_t lo, hi, mid;
   unw_word_t e_addr = 0;
   int32_t start = 0;
   int ret;

--- a/src/coreclr/pal/src/libunwind/src/mi/mempool.c
+++ b/src/coreclr/pal/src/libunwind/src/mi/mempool.c
@@ -127,7 +127,7 @@ mempool_init (struct mempool *pool, size_t obj_size, size_t reserve)
     }
 
   pool->obj_size = obj_size;
-  pool->reserve = reserve;
+  pool->reserve = (unsigned int)reserve;
   pool->chunk_size = UNW_ALIGN(2*reserve*obj_size, pg_size);
 
   expand (pool);

--- a/src/coreclr/pal/src/libunwind/src/mi/mempool.c
+++ b/src/coreclr/pal/src/libunwind/src/mi/mempool.c
@@ -127,7 +127,7 @@ mempool_init (struct mempool *pool, size_t obj_size, size_t reserve)
     }
 
   pool->obj_size = obj_size;
-  pool->reserve = (unsigned int)reserve;
+  pool->reserve = reserve;
   pool->chunk_size = UNW_ALIGN(2*reserve*obj_size, pg_size);
 
   expand (pool);

--- a/src/coreclr/pal/src/safecrt/input.inl
+++ b/src/coreclr/pal/src/safecrt/input.inl
@@ -40,9 +40,6 @@
 
 #define UNALIGNED
 
-#define _BEGIN_SECURE_CRT_DEPRECATION_DISABLE
-#define _END_SECURE_CRT_DEPRECATION_DISABLE
-
 #define _CVTBUFSIZE (309+40) /* # of digits in max. dp value + slop */
 
 #define _MBTOWC(x,y,z) _minimal_chartowchar( x, y )
@@ -695,16 +692,12 @@ scanit:
                                     /* convert wide to multibyte */
                                     if (array_width >= ((size_t)MB_CUR_MAX))
                                     {
-_BEGIN_SECURE_CRT_DEPRECATION_DISABLE
                                         temp = wctomb((char *)pointer, ch);
-_END_SECURE_CRT_DEPRECATION_DISABLE
                                     }
                                     else
                                     {
                                         char tmpbuf[MB_LEN_MAX];
-_BEGIN_SECURE_CRT_DEPRECATION_DISABLE
                                         temp = wctomb(tmpbuf, ch);
-_END_SECURE_CRT_DEPRECATION_DISABLE
                                         if (temp > 0 && ((size_t)temp) > array_width)
                                         {
                                             /* We have exhausted the user's buffer */

--- a/src/coreclr/pal/src/safecrt/internal.h
+++ b/src/coreclr/pal/src/safecrt/internal.h
@@ -1033,16 +1033,6 @@ _CRTIMP void * __cdecl _decode_pointer(void *);
 /* internal helper function for communicating with the debugger */
 BOOL DebuggerKnownHandle();
 
-/* Macros to simplify the use of Secure CRT in the CRT itself.
- * We should use [_BEGIN/_END]_SECURE_CRT_DEPRECATION_DISABLE sparingly.
- */
-#define _BEGIN_SECURE_CRT_DEPRECATION_DISABLE \
-    __pragma(warning(push)) \
-    __pragma(warning(disable:4996))
-
-#define _END_SECURE_CRT_DEPRECATION_DISABLE \
-    __pragma(warning(pop))
-
 #define _ERRCHECK(e) \
     _INVOKE_WATSON_IF_ERROR(e)
 

--- a/src/coreclr/tools/superpmi/superpmi-shared/standardpch.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/standardpch.h
@@ -24,8 +24,6 @@
 #endif // INTERNAL_BUILD
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4996) // The compiler encountered a deprecated declaration.
-
 // On Windows, we build against PAL macros that convert to Windows SEH. But we don't want all the
 // Contract stuff that normally gets pulled it. Defining JIT_BUILD prevents this, just as it does
 // when building the JIT using parts of utilcode.

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -5468,21 +5468,11 @@ static void EnumRuntimeFunctionEntriesToFindEntry(PTR_RUNTIME_FUNCTION pRtf, PTR
         return;
     }
 
-    // Review conversion of size_t to ULONG.
-#if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable:4267)
-#endif // defined(_MSC_VER)
+    UINT_PTR indexToLocate = pRtf - firstFunctionEntry;
 
-    ULONG indexToLocate = pRtf - firstFunctionEntry;
-
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif // defined(_MSC_VER)
-
-    ULONG low = 0; // index in the function entry table of low end of search range
-    ULONG high = (pProgramExceptionsDirectory->Size) / sizeof(T_RUNTIME_FUNCTION) - 1; // index of high end of search range
-    ULONG mid = (low + high) / 2; // index of entry to be compared
+    UINT_PTR low = 0; // index in the function entry table of low end of search range
+    UINT_PTR high = (pProgramExceptionsDirectory->Size) / sizeof(T_RUNTIME_FUNCTION) - 1; // index of high end of search range
+    UINT_PTR mid = (low + high) / 2; // index of entry to be compared
 
     if (indexToLocate > high)
     {

--- a/src/coreclr/vm/common.h
+++ b/src/coreclr/vm/common.h
@@ -56,9 +56,6 @@
 #pragma warning(disable:4710)   // function not inlined
 #pragma warning(disable:4527)   // user-defined destructor required
 #pragma warning(disable:4513)   // destructor could not be generated
-
-    // <TODO>TODO we really probably need this one put back in!!!</TODO>
-//#pragma warning(disable:4701)   // local variable may be used without being initialized
 #endif // _MSC_VER
 
 #define _CRT_DEPENDENCY_   //this code depends on the crt file functions

--- a/src/coreclr/vm/common.h
+++ b/src/coreclr/vm/common.h
@@ -26,7 +26,6 @@
 
     // These don't seem useful, so turning them off is no big deal
 #pragma warning(disable:4201)   // nameless struct/union
-#pragma warning(disable:4510)   // can't generate default constructor
 #pragma warning(disable:4512)   // can't generate assignment constructor
 #pragma warning(disable:4211)   // nonstandard extention used (char name[0] in structs)
 #pragma warning(disable:4268)   // 'const' static/global data initialized with compiler generated default constructor fills the object with zeros

--- a/src/coreclr/vm/common.h
+++ b/src/coreclr/vm/common.h
@@ -27,9 +27,7 @@
     // These don't seem useful, so turning them off is no big deal
 #pragma warning(disable:4201)   // nameless struct/union
 #pragma warning(disable:4510)   // can't generate default constructor
-//#pragma warning(disable:4511)   // can't generate copy constructor
 #pragma warning(disable:4512)   // can't generate assignment constructor
-#pragma warning(disable:4610)   // user defined constructor required
 #pragma warning(disable:4211)   // nonstandard extention used (char name[0] in structs)
 #pragma warning(disable:4268)   // 'const' static/global data initialized with compiler generated default constructor fills the object with zeros
 #pragma warning(disable:4238)   // nonstandard extension used : class rvalue used as lvalue
@@ -38,8 +36,6 @@
 
     // Depending on the code base, you may want to not disable these
 #pragma warning(disable:4245)   // assigning signed / unsigned
-//#pragma warning(disable:4146)   // unary minus applied to unsigned
-//#pragma warning(disable:4244)   // loss of data int -> char ..
 #pragma warning(disable:4127)   // conditional expression is constant
 #pragma warning(disable:4100)   // unreferenced formal parameter
 
@@ -47,7 +43,6 @@
 
 #ifndef DEBUG
 #pragma warning(disable:4505)   // unreferenced local function has been removed
-//#pragma warning(disable:4702)   // unreachable code
 #pragma warning(disable:4313)   // 'format specifier' in format string conflicts with argument %d of type 'type'
 #endif // !DEBUG
 

--- a/src/coreclr/vm/eehash.cpp
+++ b/src/coreclr/vm/eehash.cpp
@@ -32,17 +32,9 @@ EEHashEntry_t * EEUtf8HashTableHelper::AllocateEntry(LPCUTF8 pKey, BOOL bDeepCop
 
     if (bDeepCopy)
     {
-        DWORD StringLen = (DWORD)strlen(pKey);
-        DWORD BufLen = 0;
-// Review conversion of size_t to DWORD.
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4267)
-#endif
-        if (!ClrSafeInt<DWORD>::addition(StringLen, SIZEOF_EEHASH_ENTRY + sizeof(LPUTF8) + 1, BufLen))
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+        SIZE_T StringLen = strlen(pKey);
+        SIZE_T BufLen = 0;
+        if (!ClrSafeInt<SIZE_T>::addition(StringLen, SIZEOF_EEHASH_ENTRY + sizeof(LPUTF8) + 1, BufLen))
             return NULL;
         pEntry = (EEHashEntry_t *) new (nothrow) BYTE[BufLen];
         if (!pEntry)

--- a/src/coreclr/vm/fcall.h
+++ b/src/coreclr/vm/fcall.h
@@ -240,13 +240,6 @@
 //
 #include <setjmp.h>
 
-//
-// Use of setjmp is temporary, we will eventually have compiler intrinsics to
-// disable the optimizations.  Besides, we don't actually execute setjmp in
-// these macros (or anywhere else in the VM on AMD64).
-//
-#pragma warning(disable:4611) // interaction between '_setjmp' and C++ object destruction is non-portable
-
 #ifdef _DEBUG
 //
 // Linked list of unmanaged methods preceeding a HelperMethodFrame push.  This

--- a/src/coreclr/vm/object.cpp
+++ b/src/coreclr/vm/object.cpp
@@ -1488,10 +1488,6 @@ void StackTraceArray::EnsureThreadAffinity()
     }
 }
 
-#ifdef _MSC_VER
-#pragma warning(disable: 4267)
-#endif
-
 // Deep copies the stack trace array
 void StackTraceArray::CopyFrom(StackTraceArray const & src)
 {
@@ -1515,11 +1511,6 @@ void StackTraceArray::CopyFrom(StackTraceArray const & src)
                     // another thread might have changed it at the time of copying
     SetObjectThread();  // affinitize the newly created array with the current thread
 }
-
-#ifdef _MSC_VER
-#pragma warning(default: 4267)
-#endif
-
 
 #ifdef _DEBUG
 //===============================================================================

--- a/src/coreclr/vm/reflectioninvocation.cpp
+++ b/src/coreclr/vm/reflectioninvocation.cpp
@@ -1483,14 +1483,8 @@ FCIMPL5(void, RuntimeFieldHandle::SetValueDirect, ReflectFieldObject *pFieldUNSA
         if (gc.oValue != 0) {
             value = 0;
             if (CoreLibBinder::IsClass(gc.oValue->GetMethodTable(), CLASS__POINTER)) {
-                value = (size_t) InvokeUtil::GetPointerValue(gc.oValue);
-#ifdef _MSC_VER
-#pragma warning(disable: 4267) //work-around for compiler
-#endif
-                VolatileStore((size_t*) pDst, (size_t) value);
-#ifdef _MSC_VER
-#pragma warning(default: 4267)
-#endif
+                value = (SIZE_T) InvokeUtil::GetPointerValue(gc.oValue);
+                VolatileStore((SIZE_T*) pDst, (SIZE_T) value);
                 break;
             }
         }
@@ -1502,13 +1496,7 @@ FCIMPL5(void, RuntimeFieldHandle::SetValueDirect, ReflectFieldObject *pFieldUNSA
             CorElementType objType = gc.oValue->GetTypeHandle().GetInternalCorElementType();
             InvokeUtil::CreatePrimitiveValue(objType, objType, gc.oValue, &value);
         }
-#ifdef _MSC_VER
-#pragma warning(disable: 4267) //work-around for compiler
-#endif
-        VolatileStore((size_t*) pDst, (size_t) value);
-#ifdef _MSC_VER
-#pragma warning(default: 4267)
-#endif
+        VolatileStore((SIZE_T*) pDst, (SIZE_T) value);
     }
     break;
 

--- a/src/coreclr/vm/virtualcallstub.h
+++ b/src/coreclr/vm/virtualcallstub.h
@@ -1679,19 +1679,12 @@ private:
         CONSISTENCY_CHECK(index <= bucketMask()+CALL_STUB_FIRST_INDEX);
         return VolatileLoad(&buckets[index]);
     }
-
-#ifdef _MSC_VER
-#pragma warning(disable: 4267) //work-around for the compiler
-#endif
     inline void Write(size_t index, size_t value)
     {
         LIMITED_METHOD_CONTRACT;
         CONSISTENCY_CHECK(index <= bucketMask()+CALL_STUB_FIRST_INDEX);
         VolatileStore(&buckets[index], value);
     }
-#ifdef _MSC_VER
-#pragma warning(default: 4267)
-#endif
 
     // We store (#buckets-1) in    bucket[CALL_STUB_MASK_INDEX  ==0]
     // We have two unused cells at bucket[CALL_STUB_COUNT_INDEX ==1]


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/66154

All changes, except warning 4267, impact both mono and coreclr. Warning 4267 is extensive in mono and will require more effort to address.

~~@janvorli or @am11 - there are updates to the libunwind source. I was planning on submitting a PR to https://github.com/libunwind/libunwind, is that appropriate?~~

Upstream PR: https://github.com/libunwind/libunwind/pull/333

/cc @GrabYourPitchforks 