### PR TITLE
JIT: Optimize movzx after setcc

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6300,15 +6300,13 @@ void CodeGen::genCompareFloat(GenTree* treeNode)
     if ((targetReg != REG_NA) && (op1->GetRegNum() != targetReg) && (op2->GetRegNum() != targetReg) &&
         !varTypeIsByte(targetType))
     {
-        // memory loads might still use target reg here so we can't clear it
-        if ((op1->isUsedFromReg() || op1->isContainedFltOrDblImmed()) &&
-            (op2->isUsedFromReg() || op2->isContainedFltOrDblImmed()))
+        regMaskTP targetRegMask = genRegMask(targetReg);
+        if (((op1->gtGetContainedRegMask() | op2->gtGetContainedRegMask()) & targetRegMask) == 0)
         {
             instGen_Set_Reg_To_Zero(emitTypeSize(TYP_I_IMPL), targetReg);
             targetType = TYP_BOOL; // just a tip for inst_SETCC that movzx is not needed
         }
     }
-
     GetEmitter()->emitInsBinary(ins, cmpAttr, op1, op2);
 
     // Are we evaluating this into a register?
@@ -6470,9 +6468,8 @@ void CodeGen::genCompareInt(GenTree* treeNode)
         if ((targetReg != REG_NA) && (op1->GetRegNum() != targetReg) && (op2->GetRegNum() != targetReg) &&
             !varTypeIsByte(targetType))
         {
-            // memory loads might still use target reg here so we can't clear it
-            if ((op1->isUsedFromReg() || op1->isContainedIntOrIImmed()) &&
-                (op2->isUsedFromReg() || op2->isContainedIntOrIImmed()))
+            regMaskTP targetRegMask = genRegMask(targetReg);
+            if (((op1->gtGetContainedRegMask() | op2->gtGetContainedRegMask()) & targetRegMask) == 0)
             {
                 instGen_Set_Reg_To_Zero(emitTypeSize(TYP_I_IMPL), targetReg);
                 targetType = TYP_BOOL; // just a tip for inst_SETCC that movzx is not needed

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6452,8 +6452,8 @@ void CodeGen::genCompareInt(GenTree* treeNode)
     else
     {
         // Clear target reg in advance via "xor reg,reg" to avoid movzx after SETCC
-        if ((targetReg != REG_NA) && !varTypeIsByte(targetType) && (op1->GetReg() != targetReg) &&
-            (op2->GetReg() != targetReg))
+        if ((targetReg != REG_NA) && !varTypeIsByte(targetType) && (op1->GetRegNum() != targetReg) &&
+            (op2->GetRegNum() != targetReg))
         {
             instGen_Set_Reg_To_Zero(emitTypeSize(TYP_I_IMPL), targetReg);
             targetType = TYP_BOOL; // just a tip for inst_SETCC that movzx is not needed

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -863,6 +863,26 @@ unsigned GenTree::GetMultiRegCount(Compiler* comp) const
 }
 
 //---------------------------------------------------------------
+// gtGetContainedRegMask: Get the reg mask of the node including
+//    contained nodes (recursive).
+//
+// Arguments:
+//    None
+//
+// Return Value:
+//    Reg Mask of GenTree node.
+//
+regMaskTP GenTree::gtGetContainedRegMask()
+{
+    regMaskTP mask = GetRegNum() != REG_NA ? gtGetRegMask() : 0;
+    for (GenTree* operand : Operands())
+    {
+        mask |= operand->gtGetContainedRegMask();
+    }
+    return mask;
+}
+
+//---------------------------------------------------------------
 // gtGetRegMask: Get the reg mask of the node.
 //
 // Arguments:

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -874,7 +874,12 @@ unsigned GenTree::GetMultiRegCount(Compiler* comp) const
 //
 regMaskTP GenTree::gtGetContainedRegMask()
 {
-    regMaskTP mask = GetRegNum() != REG_NA ? gtGetRegMask() : 0;
+    if (!isContained())
+    {
+        return gtGetRegMask();
+    }
+
+    regMaskTP mask = 0;
     for (GenTree* operand : Operands())
     {
         mask |= operand->gtGetContainedRegMask();

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -990,6 +990,7 @@ public:
     int GetRegisterDstCount(Compiler* compiler) const;
 
     regMaskTP gtGetRegMask() const;
+    regMaskTP gtGetContainedRegMask();
 
     GenTreeFlags gtFlags;
 


### PR DESCRIPTION
Clear target reg via `xor reg, reg` instead of relying on zero-extend after SETCC which is heavier and slower
```csharp
bool Test(int x) => x == 42;
```
```diff
; Method Test(int):bool:this
G_M55728_IG01:              ;; offset=0000H
G_M55728_IG02:              ;; offset=0000H
+      33C0                 xor      eax, eax
       83FA2A               cmp      edx, 42
       0F94C0               sete     al
-      0FB6C0               movzx    rax, al
G_M55728_IG03:              ;; offset=0009H
       C3                   ret      
-; Total bytes of code: 10
+; Total bytes of code: 9
```
Nice diffs: 
```
benchmarks.run.Linux.x64.checked.mch:
Total bytes of delta: -5230 (-0.03 % of base)

coreclr_tests.pmi.Linux.x64.checked.mch:
Total bytes of delta: -210860 (-0.16 % of base)

libraries.crossgen2.Linux.x64.checked.mch:
Total bytes of delta: -4420 (-0.06 % of base)

libraries.pmi.Linux.x64.checked.mch:
Total bytes of delta: -25312 (-0.05 % of base)

libraries_tests.pmi.Linux.x64.checked.mch:
Total bytes of delta: -49314 (-0.04 % of base)
```