### PR TITLE
Do not generate `TYP_STRUCT` `LCL_FLD` nodes

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7001,16 +7001,9 @@ void Compiler::gtBlockOpInit(GenTree* result, GenTree* dst, GenTree* srcOrFillVa
 GenTree* Compiler::gtNewBlkOpNode(GenTree* dst, GenTree* srcOrFillVal, bool isVolatile, bool isCopyBlock)
 {
     assert(dst->OperIsBlk() || dst->OperIsLocal());
-    if (isCopyBlock)
+
+    if (!isCopyBlock) // InitBlk
     {
-        if (srcOrFillVal->OperIsIndir() && (srcOrFillVal->gtGetOp1()->gtOper == GT_ADDR))
-        {
-            srcOrFillVal = srcOrFillVal->gtGetOp1()->gtGetOp1();
-        }
-    }
-    else
-    {
-        // InitBlk
         assert(varTypeIsIntegral(srcOrFillVal));
         if (varTypeIsStruct(dst))
         {
@@ -22216,6 +22209,17 @@ uint16_t GenTreeLclVarCommon::GetLclOffs() const
     {
         return 0;
     }
+}
+
+//------------------------------------------------------------------------
+// GetFieldSeq: Get the field sequence for this local node.
+//
+// Return Value:
+//    The sequence of the node for local fields, empty ("nullptr") otherwise.
+//
+FieldSeqNode* GenTreeLclVarCommon::GetFieldSeq() const
+{
+    return OperIsLocalField() ? AsLclFld()->GetFieldSeq() : nullptr;
 }
 
 #if defined(TARGET_XARCH) && defined(FEATURE_HW_INTRINSICS)

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -15641,8 +15641,15 @@ bool GenTree::IsLocalAddrExpr(Compiler*             comp,
     {
         assert(!comp->compRationalIRForm);
         GenTree* addrArg = AsOp()->gtOp1;
+
         if (addrArg->IsLocal()) // Note that this covers "GT_LCL_FLD."
         {
+            FieldSeqNode* zeroOffsetFieldSeq = nullptr;
+            if (comp->GetZeroOffsetFieldMap()->Lookup(this, &zeroOffsetFieldSeq))
+            {
+                *pFldSeq = comp->GetFieldSeqStore()->Append(zeroOffsetFieldSeq, *pFldSeq);
+            }
+
             *pLclVarTree = addrArg->AsLclVarCommon();
             if (addrArg->OperGet() == GT_LCL_FLD)
             {

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3330,6 +3330,8 @@ public:
         return (GetSsaNum() != SsaConfig::RESERVED_SSA_NUM);
     }
 
+    FieldSeqNode* GetFieldSeq() const;
+
 #if DEBUGGABLE_GENTREE
     GenTreeLclVarCommon() : GenTreeUnOp()
     {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13745,6 +13745,7 @@ GenTree* Compiler::fgOptimizeAddition(GenTreeOp* add)
         {
             unsigned offset = lclNode->GetLclOffs() + static_cast<uint16_t>(offsetNode->IconValue());
 
+            // Note: the emitter does not expect out-of-bounds access for LCL_FLD_ADDR.
             if (FitsIn<uint16_t>(offset) && (offset < lvaLclExactSize(lclNode->GetLclNum())))
             {
                 // Compose the field sequence: [LCL, ADDR, OFFSET].

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12440,7 +12440,8 @@ DONE_MORPHING_CHILDREN:
             ival1                  = 0;
 
             // Don't remove a volatile GT_IND, even if the address points to a local variable.
-            if ((tree->gtFlags & GTF_IND_VOLATILE) == 0)
+            // For TYP_STRUCT INDs, we do not know their size, and so will not morph as well.
+            if (!tree->AsIndir()->IsVolatile() && !tree->TypeIs(TYP_STRUCT))
             {
                 /* Try to Fold *(&X) into X */
                 if (op1->gtOper == GT_ADDR)
@@ -12453,13 +12454,9 @@ DONE_MORPHING_CHILDREN:
 
                     temp = op1->AsOp()->gtOp1; // X
 
-                    // In the test below, if they're both TYP_STRUCT, this of course does *not* mean that
-                    // they are the *same* struct type.  In fact, they almost certainly aren't.  If the
-                    // address has an associated field sequence, that identifies this case; go through
-                    // the "lcl_fld" path rather than this one.
-                    FieldSeqNode* addrFieldSeq = nullptr; // This is an unused out parameter below.
-                    if (typ == temp->TypeGet() && !GetZeroOffsetFieldMap()->Lookup(op1, &addrFieldSeq))
+                    if (typ == temp->TypeGet())
                     {
+                        assert(typ != TYP_STRUCT);
                         foldAndReturnTemp = true;
                     }
                     else if (temp->OperIsLocal())
@@ -13738,6 +13735,46 @@ GenTree* Compiler::fgOptimizeAddition(GenTreeOp* add)
         DEBUG_DESTROY_NODE(add);
 
         return op1;
+    }
+
+    // Reduce local addresses: ADD(ADDR(LCL_VAR), OFFSET) => ADDR(LCL_FLD OFFSET).
+    // TODO-ADDR: do ADD(LCL_FLD/VAR_ADDR, OFFSET) => LCL_FLD_ADDR instead.
+    //
+    if (opts.OptimizationEnabled() && fgGlobalMorph && op1->OperIs(GT_ADDR) && op2->IsCnsIntOrI() &&
+        op1->AsUnOp()->gtGetOp1()->OperIs(GT_LCL_VAR, GT_LCL_FLD))
+    {
+        GenTreeUnOp*         addrNode   = op1->AsUnOp();
+        GenTreeLclVarCommon* lclNode    = addrNode->gtGetOp1()->AsLclVarCommon();
+        GenTreeIntCon*       offsetNode = op2->AsIntCon();
+        if (FitsIn<uint16_t>(offsetNode->IconValue()))
+        {
+            unsigned offset = lclNode->GetLclOffs() + static_cast<uint16_t>(offsetNode->IconValue());
+
+            if (FitsIn<uint16_t>(offset) && (offset < lvaLclExactSize(lclNode->GetLclNum())))
+            {
+                // Compose the field sequence: [LCL, ADDR, OFFSET].
+                FieldSeqNode* fieldSeq           = lclNode->GetFieldSeq();
+                FieldSeqNode* zeroOffsetFieldSeq = nullptr;
+                if (GetZeroOffsetFieldMap()->Lookup(addrNode, &zeroOffsetFieldSeq))
+                {
+                    fieldSeq = GetFieldSeqStore()->Append(fieldSeq, zeroOffsetFieldSeq);
+                    GetZeroOffsetFieldMap()->Remove(addrNode);
+                }
+                fieldSeq = GetFieldSeqStore()->Append(fieldSeq, offsetNode->gtFieldSeq);
+
+                // Types of location nodes under ADDRs do not matter. We arbitrarily choose TYP_UBYTE.
+                lclNode->ChangeType(TYP_UBYTE);
+                lclNode->SetOper(GT_LCL_FLD);
+                lclNode->AsLclFld()->SetLclOffs(offset);
+                lclNode->AsLclFld()->SetFieldSeq(fieldSeq);
+                lvaSetVarDoNotEnregister(lclNode->GetLclNum() DEBUGARG(DoNotEnregisterReason::LocalField));
+
+                DEBUG_DESTROY_NODE(offsetNode);
+                DEBUG_DESTROY_NODE(add);
+
+                return addrNode;
+            }
+        }
     }
 
     // Note that these transformations are legal for floating-point ADDs as well.

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12632,14 +12632,9 @@ DONE_MORPHING_CHILDREN:
             // out-of-bounds w.r.t. the local).
             if ((temp != nullptr) && !foldAndReturnTemp)
             {
-                assert(temp->OperIsLocal());
+                assert(temp->OperIsLocalRead());
 
-                const unsigned   lclNum = temp->AsLclVarCommon()->GetLclNum();
-                LclVarDsc* const varDsc = lvaGetDesc(lclNum);
-
-                const var_types tempTyp = temp->TypeGet();
-                const bool useExactSize = varTypeIsStruct(tempTyp) || (tempTyp == TYP_BLK) || (tempTyp == TYP_LCLBLK);
-                const unsigned varSize  = useExactSize ? varDsc->lvExactSize : genTypeSize(temp);
+                unsigned lclNum = temp->AsLclVarCommon()->GetLclNum();
 
                 // Make sure we do not enregister this lclVar.
                 lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::LocalField));
@@ -12647,7 +12642,7 @@ DONE_MORPHING_CHILDREN:
                 // If the size of the load is greater than the size of the lclVar, we cannot fold this access into
                 // a lclFld: the access represented by an lclFld node must begin at or after the start of the
                 // lclVar and must not extend beyond the end of the lclVar.
-                if ((ival1 >= 0) && ((ival1 + genTypeSize(typ)) <= varSize))
+                if ((ival1 >= 0) && ((ival1 + genTypeSize(typ)) <= lvaLclExactSize(lclNum)))
                 {
                     GenTreeLclFld* lclFld;
 


### PR DESCRIPTION
Today, the morpher can fold `IND(struct ADDR(LCL))` into `LCL_FLD` `TYP_STRUCT` layout-less nodes, these end up being locations, always (well -- there is one case where that's not true, such a node can end up under a return of a small struct later to be retyped by lowering, but this is rare).

These will be a significant impediment to actual, proper `TYP_STRUCT` local field nodes, as it would mean handling the case, everywhere in code, where the layout would be missing, that we don't want to allow in the first place.

This change fixed that by introducing the folding that the creation of these location nodes achieves at the address level, where we can choose the type of the location node arbitrarily and freely.

Along the way, `IsLocalAddrExpr` was fixed to not forget to look at zero-offset sequences attached to `ADDR`s, to avoid regressions.

We are expecting some positive diffs here, from the `IsLocalAddrExpr` change (enabling more precise VNs) and the folding change itself (the old code path would, ever so rarely, miss out on some things).

We are also expecting one small regression due to call retyping of reg-sized `IND struct(ADDR(LCL))` nodes losing the field sequence. I did not fix it because a) it was small, and rare, b) I do not want to permeate the zero-offset code any more than is strictly required.

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1653792&view=results).