### PR TITLE
Do not mark implicit byrefs with GTF_GLOB_REF

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1114,14 +1114,6 @@ inline GenTreeField* Compiler::gtNewFieldRef(var_types type, CORINFO_FIELD_HANDL
         LclVarDsc* varDsc = lvaGetDesc(obj->AsUnOp()->gtOp1->AsLclVarCommon());
 
         varDsc->lvFieldAccessed = 1;
-#if defined(TARGET_AMD64) || defined(TARGET_ARM64)
-        // These structs are passed by reference; we should probably be able to treat these
-        // as non-global refs, but downstream logic expects these to be marked this way.
-        if (varDsc->lvIsParam)
-        {
-            fieldNode->gtFlags |= GTF_GLOB_REF;
-        }
-#endif // defined(TARGET_AMD64) || defined(TARGET_ARM64)
     }
     else
     {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5902,8 +5902,9 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
         fgMorphImplicitByRefArgs(objRef);
     }
 
-    noway_assert(((objRef != nullptr) && (objRef->IsLocalAddrExpr() != nullptr)) ||
-                 ((tree->gtFlags & GTF_GLOB_REF) != 0));
+    noway_assert(((objRef != nullptr) && ((objRef->IsLocalAddrExpr() != nullptr) ||
+                                          (objRef->IsImplicitByrefParameterValue(this) != nullptr))) ||
+                 (tree->gtFlags & GTF_GLOB_REF) != 0);
 
     if (tree->AsField()->gtFldMayOverlap)
     {


### PR DESCRIPTION
This should not be necessary and inhibits optimizing `dup` of field addresses off of implicit byref params.

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1647777&view=ms.vss-build-web.run-extensions-tab)