### PR TITLE
Fix workaround for static virtual methods

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectableMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectableMethodNode.cs
@@ -32,10 +32,6 @@ namespace ILCompiler.DependencyAnalysis
         {
             Debug.Assert(!factory.MetadataManager.IsReflectionBlocked(_method.GetTypicalMethodDefinition()));
 
-            // Depends on static virtual method support. Turning off reflection for now.
-            if (_method.IsVirtual && _method.Signature.IsStatic)
-                return null;
-
             DependencyList dependencies = new DependencyList();
             factory.MetadataManager.GetDependenciesDueToReflectability(ref dependencies, factory, _method);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -283,6 +283,10 @@ namespace ILCompiler
                     return false;
             }
 
+            // TODO: Reflection invoking static virtual methods
+            if (method.IsVirtual && method.Signature.IsStatic)
+                return false;
+
             // Everything else can go in the mapping table.
             return true;
         }

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -845,7 +845,7 @@ namespace ILCompiler
                 // Check that methods and types generated during compilation are a subset of method and types scanned
                 bool scanningFail = false;
                 DiffCompilationResults(ref scanningFail, compilationResults.CompiledMethodBodies, scanResults.CompiledMethodBodies,
-                    "Methods", "compiled", "scanned", method => !(method.GetTypicalMethodDefinition() is EcmaMethod) || method.Name == "ThrowPlatformNotSupportedException" || method.Name == "ThrowArgumentOutOfRangeException");
+                    "Methods", "compiled", "scanned", method => !(method.GetTypicalMethodDefinition() is EcmaMethod) || method.Name == "ThrowPlatformNotSupportedException" || method.Name == "ThrowArgumentOutOfRangeException" || method.Name == "ThrowArgumentException");
                 DiffCompilationResults(ref scanningFail, compilationResults.ConstructedEETypes, scanResults.ConstructedEETypes,
                     "EETypes", "compiled", "scanned", type => !(type.GetTypeDefinition() is EcmaType));
 


### PR DESCRIPTION
The workaround for reflection invoking static virtual methods wasn't working around well enough. Fixes #66028.

The repro case also hit a scanning failure due to scanner not scanning a throw helper. Those are more of asserts, so add them to the collection of throw helpers to ignore.