### PR TITLE
Do not propagate RHS flags in block morphing

### DIFF
--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -1282,12 +1282,10 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
         GenTree* srcFld = nullptr;
         if (m_srcDoFldAsg)
         {
-            noway_assert(m_srcLclNum != BAD_VAR_NUM);
+            noway_assert((m_srcLclNum != BAD_VAR_NUM) && (m_srcLclNode != nullptr));
             unsigned srcFieldLclNum = m_comp->lvaGetDesc(m_srcLclNum)->lvFieldLclStart + i;
-            srcFld = m_comp->gtNewLclvNode(srcFieldLclNum, m_comp->lvaGetDesc(srcFieldLclNum)->TypeGet());
 
-            noway_assert(m_srcLclNode != nullptr);
-            srcFld->gtFlags |= m_srcLclNode->gtFlags & ~GTF_NODE_MASK;
+            srcFld = m_comp->gtNewLclvNode(srcFieldLclNum, m_comp->lvaGetDesc(srcFieldLclNum)->TypeGet());
         }
         else
         {


### PR DESCRIPTION
It is not necessary to copy flags from the source node to the field nodes when doing a field-by-field copy in block morphing. In fact, it can be a pessimization in cases where the source node had NO_CSE set, which would block constant propagation.

Broadly good [diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1648741&view=ms.vss-build-web.run-extensions-tab), with a couple size regressions due to said constant propagation not always being better.