### PR TITLE
Mark EncryptionPolicy.NoEncryption and EncryptionPolicy.AllowNoEncryption as obsolete

### DIFF
--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -94,6 +94,7 @@ The PR that reveals the implementation of the `<IncludeInternalObsoleteAttribute
 |  __`SYSLIB0037`__ | AssemblyName members HashAlgorithm, ProcessorArchitecture, and VersionCompatibility are obsolete and not supported. |
 |  __`SYSLIB0038`__ | SerializationFormat.Binary is obsolete and should not be used. See https://aka.ms/serializationformat-binary-obsolete for more information. |
 |  __`SYSLIB0039`__ | TLS versions 1.0 and 1.1 have known vulnerabilities and are not recommended. Use a newer TLS version instead, or use SslProtocols.None to defer to OS defaults. |
+|  __`SYSLIB0040`__ | EncryptionPolicy.NoEncryption and AllowEncryption circumvent security and should not be used in production code. |
 
 ## Analyzer Warnings
 

--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -94,7 +94,7 @@ The PR that reveals the implementation of the `<IncludeInternalObsoleteAttribute
 |  __`SYSLIB0037`__ | AssemblyName members HashAlgorithm, ProcessorArchitecture, and VersionCompatibility are obsolete and not supported. |
 |  __`SYSLIB0038`__ | SerializationFormat.Binary is obsolete and should not be used. See https://aka.ms/serializationformat-binary-obsolete for more information. |
 |  __`SYSLIB0039`__ | TLS versions 1.0 and 1.1 have known vulnerabilities and are not recommended. Use a newer TLS version instead, or use SslProtocols.None to defer to OS defaults. |
-|  __`SYSLIB0040`__ | EncryptionPolicy.NoEncryption and AllowEncryption circumvent security and should not be used in production code. |
+|  __`SYSLIB0040`__ | EncryptionPolicy.NoEncryption and AllowEncryption significantly reduce security and should not be used in production code. |
 
 ## Analyzer Warnings
 

--- a/src/libraries/Common/src/System/Obsoletions.cs
+++ b/src/libraries/Common/src/System/Obsoletions.cs
@@ -129,5 +129,8 @@ namespace System
 
         internal const string TlsVersion10and11Message = "TLS versions 1.0 and 1.1 have known vulnerabilities and are not recommended. Use a newer TLS version instead, or use SslProtocols.None to defer to OS defaults.";
         internal const string TlsVersion10and11DiagId = "SYSLIB0039";
+
+        internal const string EncryptionPolicyMessage = "EncryptionPolicy.NoEncryption and AllowEncryption circumvent security and should not be used in production code.";
+        internal const string EncryptionPolicyDiagId = "SYSLIB0040";
     }
 }

--- a/src/libraries/Common/src/System/Obsoletions.cs
+++ b/src/libraries/Common/src/System/Obsoletions.cs
@@ -130,7 +130,7 @@ namespace System
         internal const string TlsVersion10and11Message = "TLS versions 1.0 and 1.1 have known vulnerabilities and are not recommended. Use a newer TLS version instead, or use SslProtocols.None to defer to OS defaults.";
         internal const string TlsVersion10and11DiagId = "SYSLIB0039";
 
-        internal const string EncryptionPolicyMessage = "EncryptionPolicy.NoEncryption and AllowEncryption circumvent security and should not be used in production code.";
+        internal const string EncryptionPolicyMessage = "EncryptionPolicy.NoEncryption and AllowEncryption significantly reduce security and should not be used in production code.";
         internal const string EncryptionPolicyDiagId = "SYSLIB0040";
     }
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/SafeMsQuicConfigurationHandle.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/SafeMsQuicConfigurationHandle.cs
@@ -44,10 +44,12 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                     throw new PlatformNotSupportedException(SR.Format(SR.net_quic_ssl_option, nameof(options.ClientAuthenticationOptions.CipherSuitesPolicy)));
                 }
 
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 if (options.ClientAuthenticationOptions.EncryptionPolicy == EncryptionPolicy.NoEncryption)
                 {
                     throw new PlatformNotSupportedException(SR.Format(SR.net_quic_ssl_option, nameof(options.ClientAuthenticationOptions.EncryptionPolicy)));
                 }
+#pragma warning restore SYSLIB0040
 
                 if (options.ClientAuthenticationOptions.ClientCertificates != null)
                 {
@@ -82,10 +84,12 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                     throw new PlatformNotSupportedException(SR.Format(SR.net_quic_ssl_option, nameof(serverAuthenticationOptions.CipherSuitesPolicy)));
                 }
 
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 if (serverAuthenticationOptions.EncryptionPolicy == EncryptionPolicy.NoEncryption)
                 {
                     throw new PlatformNotSupportedException(SR.Format(SR.net_quic_ssl_option, nameof(serverAuthenticationOptions.EncryptionPolicy)));
                 }
+#pragma warning restore SYSLIB0040
 
                 if (serverAuthenticationOptions.ClientCertificateRequired)
                 {

--- a/src/libraries/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/libraries/System.Net.Security/ref/System.Net.Security.cs
@@ -29,7 +29,9 @@ namespace System.Net.Security
     public enum EncryptionPolicy
     {
         RequireEncryption = 0,
+        [System.ObsoleteAttribute("EncryptionPolicy.NoEncryption and AllowEncryption circumvent security and should not be used in production code.", DiagnosticId = "SYSLIB0040", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         AllowNoEncryption = 1,
+        [System.ObsoleteAttribute("EncryptionPolicy.NoEncryption and AllowEncryption circumvent security and should not be used in production code.", DiagnosticId = "SYSLIB0040", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         NoEncryption = 2,
     }
     public delegate System.Security.Cryptography.X509Certificates.X509Certificate LocalCertificateSelectionCallback(object sender, string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection localCertificates, System.Security.Cryptography.X509Certificates.X509Certificate? remoteCertificate, string[] acceptableIssuers);

--- a/src/libraries/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/libraries/System.Net.Security/ref/System.Net.Security.cs
@@ -29,9 +29,9 @@ namespace System.Net.Security
     public enum EncryptionPolicy
     {
         RequireEncryption = 0,
-        [System.ObsoleteAttribute("EncryptionPolicy.NoEncryption and AllowEncryption circumvent security and should not be used in production code.", DiagnosticId = "SYSLIB0040", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("EncryptionPolicy.NoEncryption and AllowEncryption significantly reduce security and should not be used in production code.", DiagnosticId = "SYSLIB0040", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         AllowNoEncryption = 1,
-        [System.ObsoleteAttribute("EncryptionPolicy.NoEncryption and AllowEncryption circumvent security and should not be used in production code.", DiagnosticId = "SYSLIB0040", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("EncryptionPolicy.NoEncryption and AllowEncryption significantly reduce security and should not be used in production code.", DiagnosticId = "SYSLIB0040", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         NoEncryption = 2,
     }
     public delegate System.Security.Cryptography.X509Certificates.X509Certificate LocalCertificateSelectionCallback(object sender, string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection localCertificates, System.Security.Cryptography.X509Certificates.X509Certificate? remoteCertificate, string[] acceptableIssuers);

--- a/src/libraries/System.Net.Security/src/System/Net/Security/CipherSuitesPolicyPal.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/CipherSuitesPolicyPal.Linux.cs
@@ -80,12 +80,14 @@ namespace System.Net.Security
             // if TLS 1.3 was explicitly requested the underlying code will throw
             // if default option (SslProtocols.None) is used we will opt-out of TLS 1.3
 
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
             if (encryptionPolicy == EncryptionPolicy.NoEncryption)
             {
                 // TLS 1.3 uses different ciphersuite restrictions than previous versions.
                 // It has no equivalent to a NoEncryption option.
                 return true;
             }
+#pragma warning restore SYSLIB0040
 
             if (policy == null)
             {
@@ -141,10 +143,12 @@ namespace System.Net.Security
                 return CipherListFromEncryptionPolicy(encryptionPolicy);
             }
 
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
             if (encryptionPolicy == EncryptionPolicy.NoEncryption)
             {
                 throw new PlatformNotSupportedException(SR.net_ssl_ciphersuites_policy_not_supported);
             }
+#pragma warning restore SYSLIB0040
 
             return policy.Pal._cipherSuites;
         }
@@ -160,10 +164,12 @@ namespace System.Net.Security
                 return null;
             }
 
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
             if (encryptionPolicy == EncryptionPolicy.NoEncryption)
             {
                 throw new PlatformNotSupportedException(SR.net_ssl_ciphersuites_policy_not_supported);
             }
+#pragma warning restore SYSLIB0040
 
             return policy.Pal._tls13CipherSuites;
         }
@@ -174,10 +180,12 @@ namespace System.Net.Security
             {
                 case EncryptionPolicy.RequireEncryption:
                     return null;
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 case EncryptionPolicy.AllowNoEncryption:
                     return AllowNoEncryptionDefault;
                 case EncryptionPolicy.NoEncryption:
                     return NoEncryptionDefault;
+#pragma warning restore SYSLIB0040
                 default:
                     Debug.Fail($"Unknown EncryptionPolicy value ({policy})");
                     return null;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
@@ -209,8 +209,10 @@ namespace System.Net
             switch (credential.Policy)
             {
                 case EncryptionPolicy.RequireEncryption:
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 case EncryptionPolicy.AllowNoEncryption:
                     break;
+#pragma warning restore SYSLIB0040
                 default:
                     throw new PlatformNotSupportedException(SR.Format(SR.net_encryptionpolicy_notsupported, credential.Policy));
             }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
@@ -137,11 +137,13 @@ namespace System.Net
             switch (credential.Policy)
             {
                 case EncryptionPolicy.RequireEncryption:
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 case EncryptionPolicy.AllowNoEncryption:
                     // SecureTransport doesn't allow TLS_NULL_NULL_WITH_NULL, but
                     // since AllowNoEncryption intersect OS-supported isn't nothing,
                     // let it pass.
                     break;
+#pragma warning restore SYSLIB0040
                 default:
                     throw new PlatformNotSupportedException(SR.Format(SR.net_encryptionpolicy_notsupported, credential.Policy));
             }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslClientAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslClientAuthenticationOptions.cs
@@ -50,10 +50,12 @@ namespace System.Net.Security
             get => _encryptionPolicy;
             set
             {
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 if (value != EncryptionPolicy.RequireEncryption && value != EncryptionPolicy.AllowNoEncryption && value != EncryptionPolicy.NoEncryption)
                 {
                     throw new ArgumentException(SR.Format(SR.net_invalid_enum, nameof(EncryptionPolicy)), nameof(value));
                 }
+#pragma warning restore SYSLIB0040
 
                 _encryptionPolicy = value;
             }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
@@ -57,10 +57,12 @@ namespace System.Net.Security
             get => _encryptionPolicy;
             set
             {
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 if (value != EncryptionPolicy.RequireEncryption && value != EncryptionPolicy.AllowNoEncryption && value != EncryptionPolicy.NoEncryption)
                 {
                     throw new ArgumentException(SR.Format(SR.net_invalid_enum, nameof(EncryptionPolicy)), nameof(value));
                 }
+#pragma warning restore SYSLIB0040
 
                 _encryptionPolicy = value;
             }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -19,9 +19,11 @@ namespace System.Net.Security
         RequireEncryption = 0,
 
         // Add null ciphers to current system defaults
+        [System.ObsoleteAttribute(Obsoletions.EncryptionPolicyMessage, DiagnosticId = Obsoletions.EncryptionPolicyDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         AllowNoEncryption,
 
         // Request null ciphers only
+        [System.ObsoleteAttribute(Obsoletions.EncryptionPolicyMessage, DiagnosticId = Obsoletions.EncryptionPolicyDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         NoEncryption
     }
 
@@ -211,10 +213,12 @@ namespace System.Net.Security
             LocalCertificateSelectionCallback? userCertificateSelectionCallback, EncryptionPolicy encryptionPolicy)
             : base(innerStream, leaveInnerStreamOpen)
         {
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
             if (encryptionPolicy != EncryptionPolicy.RequireEncryption && encryptionPolicy != EncryptionPolicy.AllowNoEncryption && encryptionPolicy != EncryptionPolicy.NoEncryption)
             {
                 throw new ArgumentException(SR.Format(SR.net_invalid_enum, "EncryptionPolicy"), nameof(encryptionPolicy));
             }
+#pragma warning restore SYSLIB0040
 
             _userCertificateValidationCallback = userCertificateValidationCallback;
             _userCertificateSelectionCallback = userCertificateSelectionCallback;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -143,9 +143,11 @@ namespace System.Net.Security
             try
             {
                 // New crypto API supports TLS1.3 but it does not allow to force NULL encryption.
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 SafeFreeCredentials cred = !UseNewCryptoApi || policy == EncryptionPolicy.NoEncryption ?
                             AcquireCredentialsHandleSchannelCred(certificateContext, protocols, policy, isServer) :
                             AcquireCredentialsHandleSchCredentials(certificateContext, protocols, policy, isServer);
+#pragma warning restore SYSLIB0040
                 if (certificateContext != null && certificateContext.Trust != null && certificateContext.Trust._sendTrustInHandshake)
                 {
                     AttachCertificateStore(cred, certificateContext.Trust._store!);
@@ -197,6 +199,7 @@ namespace System.Net.Security
                     Interop.SspiCli.SCHANNEL_CRED.Flags.SCH_CRED_NO_DEFAULT_CREDS |
                     Interop.SspiCli.SCHANNEL_CRED.Flags.SCH_SEND_AUX_RECORD;
 
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 // Always opt-in SCH_USE_STRONG_CRYPTO for TLS.
                 if (((protocolFlags == 0) ||
                         (protocolFlags & ~(Interop.SChannel.SP_PROT_SSL2 | Interop.SChannel.SP_PROT_SSL3)) != 0)
@@ -204,6 +207,7 @@ namespace System.Net.Security
                 {
                     flags |= Interop.SspiCli.SCHANNEL_CRED.Flags.SCH_USE_STRONG_CRYPTO;
                 }
+#pragma warning restore SYSLIB0040
             }
             else
             {
@@ -264,11 +268,13 @@ namespace System.Net.Security
                     flags |= Interop.SspiCli.SCH_CREDENTIALS.Flags.SCH_USE_STRONG_CRYPTO;
                 }
             }
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
             else if (policy == EncryptionPolicy.AllowNoEncryption)
             {
                 // Allow null encryption cipher in addition to other ciphers.
                 flags |= Interop.SspiCli.SCH_CREDENTIALS.Flags.SCH_ALLOW_NULL_ENCRYPTION;
             }
+#pragma warning restore SYSLIB0040
             else
             {
                 throw new ArgumentException(SR.Format(SR.net_invalid_enum, "EncryptionPolicy"), nameof(policy));
@@ -532,6 +538,7 @@ namespace System.Net.Security
                 credential.dwMinimumCipherStrength = 0;
                 credential.dwMaximumCipherStrength = 0;
             }
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
             else if (policy == EncryptionPolicy.AllowNoEncryption)
             {
                 // Allow null encryption cipher in addition to other ciphers.
@@ -544,6 +551,7 @@ namespace System.Net.Security
                 credential.dwMinimumCipherStrength = -1;
                 credential.dwMaximumCipherStrength = -1;
             }
+#pragma warning restore SYSLIB0040
             else
             {
                 throw new ArgumentException(SR.Format(SR.net_invalid_enum, "EncryptionPolicy"), nameof(policy));

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -39,7 +39,9 @@ namespace System.Net.Security.Tests
             // Don't use Tls13 since we are trying to use NullEncryption
             await Assert.ThrowsAsync<AuthenticationException>(
                 () => ClientAsyncSslHelper(
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                     EncryptionPolicy.NoEncryption,
+#pragma warning restore SYSLIB0040
 #pragma warning disable SYSLIB0039 // TLS 1.0 and 1.1 are obsolete
                     SslProtocolSupport.DefaultSslProtocols, SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12));
 #pragma warning restore SYSLIB0039

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ClientDefaultEncryptionTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ClientDefaultEncryptionTest.cs
@@ -72,7 +72,9 @@ namespace System.Net.Security.Tests
             using (serverStream)
             {
                 using (var client = new SslStream(clientStream, false, TestHelper.AllowAnyServerCertificate, null))
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 using (var server = new SslStream(serverStream, false, TestHelper.AllowAnyServerCertificate, null, EncryptionPolicy.NoEncryption))
+#pragma warning restore SYSLIB0040
                 {
                     Task serverTask = server.AuthenticateAsServerAsync(TestConfiguration.ServerCertificate);
                     await Assert.ThrowsAsync<AuthenticationException>(() =>

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAllowNoEncryptionTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAllowNoEncryptionTest.cs
@@ -27,7 +27,9 @@ namespace System.Net.Security.Tests
             using (serverStream)
             {
                 using (var client = new SslStream(clientStream, false, TestHelper.AllowAnyServerCertificate, null, EncryptionPolicy.RequireEncryption))
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 using (var server = new SslStream(serverStream, false, TestHelper.AllowAnyServerCertificate, null, EncryptionPolicy.AllowNoEncryption))
+#pragma warning restore SYSLIB0040
                 {
                     await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
                         client.AuthenticateAsClientAsync("localhost", null, SslProtocols.None, false),
@@ -48,8 +50,10 @@ namespace System.Net.Security.Tests
             using (clientStream)
             using (serverStream)
             {
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 using (var client = new SslStream(clientStream, false, TestHelper.AllowAnyServerCertificate, null, EncryptionPolicy.AllowNoEncryption))
                 using (var server = new SslStream(serverStream, false, TestHelper.AllowAnyServerCertificate, null, EncryptionPolicy.AllowNoEncryption))
+#pragma warning restore SYSLIB0040
                 {
                     await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
                         client.AuthenticateAsClientAsync("localhost", null, SslProtocols.None, false),
@@ -70,8 +74,10 @@ namespace System.Net.Security.Tests
             using (clientStream)
             using (serverStream)
             {
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 using (var client = new SslStream(clientStream, false, TestHelper.AllowAnyServerCertificate, null, EncryptionPolicy.NoEncryption))
                 using (var server = new SslStream(serverStream, false, TestHelper.AllowAnyServerCertificate, null, EncryptionPolicy.AllowNoEncryption))
+#pragma warning restore SYSLIB0040
                 {
 #pragma warning disable SYSLIB0039 // TLS 1.0 and 1.1 are obsolete
                     await TestConfiguration.WhenAllOrAnyFailedWithTimeout(

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
@@ -29,7 +29,9 @@ namespace System.Net.Security.Tests
             using (serverStream)
             {
                 using (var client = new SslStream(clientStream, false, TestHelper.AllowAnyServerCertificate, null, EncryptionPolicy.RequireEncryption))
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 using (var server = new SslStream(serverStream, false, TestHelper.AllowAnyServerCertificate, null, EncryptionPolicy.NoEncryption))
+#pragma warning restore SYSLIB0040
                 {
                     Task serverTask = server.AuthenticateAsServerAsync(TestConfiguration.ServerCertificate);
                     await Assert.ThrowsAsync<AuthenticationException>(() =>
@@ -48,8 +50,10 @@ namespace System.Net.Security.Tests
         }
 
         [ConditionalTheory(typeof(TestConfiguration), nameof(TestConfiguration.SupportsNullEncryption))]
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
         [InlineData(EncryptionPolicy.AllowNoEncryption)]
         [InlineData(EncryptionPolicy.NoEncryption)]
+#pragma warning restore SYSLIB0040
         public async Task ServerNoEncryption_ClientPermitsNoEncryption_ConnectWithNoEncryption(EncryptionPolicy policy)
         {
             (NetworkStream clientStream, NetworkStream serverStream) = TestHelper.GetConnectedTcpStreams();
@@ -57,7 +61,9 @@ namespace System.Net.Security.Tests
             using (serverStream)
             {
                 using (var client = new SslStream(clientStream, false, TestHelper.AllowAnyServerCertificate, null, policy))
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 using (var server = new SslStream(serverStream, false, TestHelper.AllowAnyServerCertificate, null, EncryptionPolicy.NoEncryption))
+#pragma warning restore SYSLIB0040
                 {
 #pragma warning disable SYSLIB0039 // TLS 1.0 and 1.1 are obsolete
                     await TestConfiguration.WhenAllOrAnyFailedWithTimeout(

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerRequireEncryptionTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerRequireEncryptionTest.cs
@@ -49,7 +49,9 @@ namespace System.Net.Security.Tests
             using (clientStream)
             using (serverStream)
             {
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 using (var client = new SslStream(clientStream, false, TestHelper.AllowAnyServerCertificate, null, EncryptionPolicy.AllowNoEncryption))
+#pragma warning restore SYSLIB0040
                 using (var server = new SslStream(serverStream))
                 {
                     await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
@@ -71,7 +73,9 @@ namespace System.Net.Security.Tests
             using (clientStream)
             using (serverStream)
             {
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 using (var client = new SslStream(clientStream, false, TestHelper.AllowAnyServerCertificate, null, EncryptionPolicy.NoEncryption))
+#pragma warning restore SYSLIB0040
                 using (var server = new SslStream(serverStream))
                 {
                     Task serverTask = server.AuthenticateAsServerAsync(TestConfiguration.ServerCertificate);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslAuthenticationOptionsTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslAuthenticationOptionsTest.cs
@@ -43,7 +43,9 @@ namespace System.Net.Security.Tests
 #pragma warning disable SYSLIB0039 // TLS 1.0 and 1.1 are obsolete
                 SslProtocols serverSslProtocols = SslProtocols.Tls11 | SslProtocols.Tls12;
 #pragma warning restore SYSLIB0039
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 EncryptionPolicy serverEncryption = EncryptionPolicy.AllowNoEncryption;
+#pragma warning restore SYSLIB0040
                 RemoteCertificateValidationCallback serverRemoteCallback = new RemoteCertificateValidationCallback(delegate { return true; });
                 SslStreamCertificateContext certificateContext = SslStreamCertificateContext.Create(serverCert, null, false);
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNegotiatedCipherSuiteTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNegotiatedCipherSuiteTest.cs
@@ -129,7 +129,9 @@ namespace System.Net.Security.Tests
             {
                 CipherSuitesPolicy = BuildPolicy(TlsCipherSuite.TLS_AES_128_GCM_SHA256,
                                                  SupportedNonTls13CipherSuites[0]),
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
                 EncryptionPolicy = EncryptionPolicy.NoEncryption,
+#pragma warning restore SYSLIB0040
             };
 
             NegotiatedParams ret = ConnectAndGetNegotiatedParams(p, p);

--- a/src/libraries/System.Net.Security/tests/UnitTests/SslAuthenticationOptionsTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/SslAuthenticationOptionsTests.cs
@@ -150,11 +150,13 @@ namespace System.Net.Security.Tests
             Assert.Equal(EncryptionPolicy.RequireEncryption, _clientOptions.EncryptionPolicy);
             Assert.Equal(EncryptionPolicy.RequireEncryption, _serverOptions.EncryptionPolicy);
 
+#pragma warning disable SYSLIB0040 // NoEncryption and AllowNoEncryption are obsolete
             _clientOptions.EncryptionPolicy = EncryptionPolicy.AllowNoEncryption;
             _serverOptions.EncryptionPolicy = EncryptionPolicy.NoEncryption;
 
             Assert.Equal(EncryptionPolicy.AllowNoEncryption, _clientOptions.EncryptionPolicy);
             Assert.Equal(EncryptionPolicy.NoEncryption, _serverOptions.EncryptionPolicy);
+#pragma warning restore SYSLIB0040
 
             Assert.Throws<ArgumentException>(() => _clientOptions.EncryptionPolicy = (EncryptionPolicy)3);
             Assert.Throws<ArgumentException>(() => _serverOptions.EncryptionPolicy = (EncryptionPolicy)3);

--- a/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
@@ -74,6 +74,8 @@
              Link="Common\Interop\Windows\SChannel\Interop.Alerts.cs" />
     <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs"
              Link="Common\System\Threading\Tasks\TaskToApm.cs" />
+    <Compile Include="$(CommonPath)System\Obsoletions.cs" 
+             Link="Common\System\Obsoletions.cs" />
     <!-- Logging -->
     <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs"
              Link="ProductionCode\Common\System\Net\Logging\NetEventSource.Common.cs" />


### PR DESCRIPTION
Fixes #65545

I don't think the current wording of the warning message is appropriate, but I could not come up with anything better for now. Suggestions welcome.