### PR TITLE
[wasm][debugger] Fix incompatibility between runtime and nuget package

### DIFF
--- a/src/mono/wasm/runtime/debug.ts
+++ b/src/mono/wasm/runtime/debug.ts
@@ -150,7 +150,7 @@ function _create_proxy_from_object_id(objectId: string, details: any) {
     if (objectId.startsWith("dotnet:array:")) {
         let ret: Array<any>;
         if (details.items === undefined) {
-            ret = details.map (p => p.value);
+            ret = details.map ((p: any) => p.value);
             return ret;
         }
         if (details.dimensionsDetails === undefined || details.dimensionsDetails.length === 1) {

--- a/src/mono/wasm/runtime/debug.ts
+++ b/src/mono/wasm/runtime/debug.ts
@@ -149,6 +149,10 @@ export function mono_wasm_get_loaded_files(): string[] {
 function _create_proxy_from_object_id(objectId: string, details: any) {
     if (objectId.startsWith("dotnet:array:")) {
         let ret: Array<any>;
+        if (details.items === undefined) {
+            ret = details.map (p => p.value);
+            return ret;
+        }
         if (details.dimensionsDetails === undefined || details.dimensionsDetails.length === 1) {
             ret = details.items.map((p: any) => p.value);
             return ret;


### PR DESCRIPTION
If the user is using runtime version 6.0.2 or higher and nuget package version 6.0.1 or lower, it would get an error to view array elements.