### PR TITLE
remove invalid System.IO.FileSystem.Watcher tests

### DIFF
--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Args.FileSystemEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Args.FileSystemEventArgs.cs
@@ -65,16 +65,6 @@ namespace System.IO.Tests
         }
 
         [Theory]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        [InlineData("C:", "foo.txt")]
-        public static void FileSystemEventArgs_ctor_RelativePathFromCurrentDirectoryInGivenDrive(string directory, string name)
-        {
-            FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
-
-            Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), name), args.FullPath);
-        }
-
-        [Theory]
         [InlineData("bar", "")]
         [InlineData("bar", null)]
         public static void FileSystemEventArgs_ctor_When_EmptyFileName_Then_FullPathReturnsTheDirectoryFullPath_WithTrailingSeparator(string directory, string name)

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Args.RenamedEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Args.RenamedEventArgs.cs
@@ -68,16 +68,6 @@ namespace System.IO.Tests
         }
 
         [Theory]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        [InlineData("C:", "foo.txt", "bar.txt")]
-        public static void RenamedEventArgs_ctor_OldFullPath_DirectoryIsRelativePathFromCurrentDirectoryInGivenDrive(string directory, string name, string oldName)
-        {
-            RenamedEventArgs args = new RenamedEventArgs(WatcherChangeTypes.All, directory, name, oldName);
-
-            Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), oldName), args.OldFullPath);
-        }
-
-        [Theory]
         [InlineData("bar", "", "")]
         [InlineData("bar", null, null)]
         [InlineData("bar", "foo.txt", null)]


### PR DESCRIPTION
Let's take a look at the simple test, `FileSystemEventArgs_ctor_RelativePathFromCurrentDirectoryInGivenDrive`:

it was using `C:` as directory and `foo.txt` as file name and expecting, the produced path to be ".\foo.txt", while the path was of course `C:\foo.txt`:

```log
Assert.Equal() Failure
↓ (pos 0)
Expected: D:\h\w\B0F409C8\w\A4D408D2\e\foo.txt
Actual:   C:\foo.txt
↑ (pos 0)
```

I believe that these tests are simply invalid. They were failing for me locally I and I have no idea why they were not failing for all CI runs. They were introduced quite recently in https://github.com/dotnet/runtime/pull/63051

fixes #65042