### PR TITLE
Stop generating `CLS_VAR` for 64 bit targets

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6341,8 +6341,7 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
             CLANG_FORMAT_COMMENT_ANCHOR;
 
 #ifdef TARGET_64BIT
-            bool preferIndir =
-                isBoxedStatic || isStaticReadOnlyInited || (IMAGE_REL_BASED_REL32 != eeGetRelocTypeHint(fldAddr));
+            bool preferIndir = true;
 #else  // !TARGET_64BIT
             bool preferIndir = isBoxedStatic;
 #endif // !TARGET_64BIT


### PR DESCRIPTION
This is the first change that fully disables `CLS_VAR` - on 64 bit platforms. The reason I am doing it this way is because there will be many more (positive) diffs on x86, and ARM likely requires some CSE heuristic changes and/or quirks to avoid some regressions.

We are not expecting diffs on ARM64. But expecting some limited amount of them on x64, caused by:
1)  "Hoisting" more constants (#64039).
2) Slightly different `gtSetEvalOrder` behavior: more aggressive reversal of `ASG(..., IND(static addr))` (it didn't reverse for leaf `CLS_VAR` RHSs).
3) Very subtle changes in register allocation due to more opportunities for reuse of constants.

At first, my goal was to make this a zero-diff change, by mititigating all the above ("and more") with other changes, but after some weeks of looking at the problems from different angles, I "gave up" and decided it would be more productive to accept the diffs.

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1649167&view=ms.vss-build-web.run-extensions-tab).