### PR TITLE
[release/6.0][wasm][debugger] Fix incompatibility between runtime and nuget package

### DIFF
--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -699,6 +699,11 @@ var MonoSupportLib = {
 		_create_proxy_from_object_id: function (objectId, details) {
 			if (objectId.startsWith ('dotnet:array:'))
 			{
+				if (details.items === undefined)
+				{
+					const ret = details.map (p => p.value);
+					return ret;
+				}
 				if (details.dimensionsDetails == undefined || details.dimensionsDetails.length == 1)
 				{
 					const ret = details.items.map (p => p.value);


### PR DESCRIPTION
## Customer Impact

When the customer created a project using release 6.0.0 and then install new versions of VS like: 6.0.2, the nuget package of the wasm project is not updated automatically, so the user uses the runtime 6.0.2 and the nuget package 6.0.0, the BrowserDebugProxy is inside this nuget package and one of our changes to show multidimensional array, caused this incompatibility. 

## Related Issues
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1470864
https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1484798

## Testing

Manual testing

## Risk 

Very Low.  This is just keeping the old behavior if the runtime is updated and the BrowserDebugProxy is not, so the multidimensional array will not work, but simple arrays will continue working.