### PR TITLE
Try additional nuget retries

### DIFF
--- a/src/coreclr/scripts/jitutil.py
+++ b/src/coreclr/scripts/jitutil.py
@@ -139,6 +139,12 @@ def run_command(command_to_run, _cwd=None, _exit_on_fail=False, _output_file=Non
     print("Running: " + " ".join(command_to_run))
     command_stdout = ""
     command_stderr = ""
+
+    if _env:
+        print("  with environment:")
+        for name, value in _env.items():
+            print("    {0}={1}".format(name,value))
+
     return_code = 1
 
     output_type = subprocess.STDOUT if _output_file else subprocess.PIPE

--- a/src/coreclr/scripts/superpmi_benchmarks.py
+++ b/src/coreclr/scripts/superpmi_benchmarks.py
@@ -155,7 +155,7 @@ def build_and_run(coreclr_args, output_mch_name):
         #   error NU3037: Package 'System.Runtime 4.1.0' from source 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json':
         #     The repository primary signature validity period has expired. [C:\h\w\A3B008C0\w\B581097F\u\performance\src\benchmarks\micro\MicroBenchmarks.csproj]
         # Using environment variable specified in https://github.com/NuGet/NuGet.Client/pull/4259.
-        env_copy["NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY"] = "3,1000"
+        env_copy["NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY"] = "9,2000"
 
     run_command(
         [dotnet_exe, "restore", project_file, "--packages",


### PR DESCRIPTION
After adding NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY, we still see
some benchmarks SPMI collection runs fail with the same nuget errors.

In case this is actually a potential workaround, try increasing the
number of retries and delay between them.

Also, print out the environment used so we can verify it, and see if
there are any other relevant variables set.