### PR TITLE
Fix instruction hex display for arm/arm64 when W^X is on

### DIFF
--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -7121,8 +7121,10 @@ void emitter::emitDispInsHelp(
     emitDispInsOffs(offset, doffs);
 
     /* Display the instruction hex code */
+    assert(((code >= emitCodeBlock) && (code < emitCodeBlock + emitTotalHotCodeSize)) ||
+           ((code >= emitColdCodeBlock) && (code < emitColdCodeBlock + emitTotalColdCodeSize)));
 
-    emitDispInsHex(id, code, sz);
+    emitDispInsHex(id, code + writeableOffset, sz);
 
     printf("      ");
 

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -12276,8 +12276,10 @@ void emitter::emitDispIns(
     emitDispInsOffs(offset, doffs);
 
     /* Display the instruction hex code */
+    assert(((pCode >= emitCodeBlock) && (pCode < emitCodeBlock + emitTotalHotCodeSize)) ||
+           ((pCode >= emitColdCodeBlock) && (pCode < emitColdCodeBlock + emitTotalColdCodeSize)));
 
-    emitDispInsHex(id, pCode, sz);
+    emitDispInsHex(id, pCode + writeableOffset, sz);
 
     printf("      ");
 


### PR DESCRIPTION
Fix #65638

cc @dotnet/jit-contrib PTAL @AndyAyersMS 