### PR TITLE
Add timestamp-based expiration to cached SafeFreeCredentials

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
@@ -171,8 +170,8 @@ namespace System.Net.Security
     internal abstract class SafeFreeCredentials : SafeHandle
     {
 #endif
-        internal DateTime _expiry;
 
+        internal DateTime _expiry;
         internal Interop.SspiCli.CredHandle _handle;    //should be always used as by ref in PInvokes parameters
 
         protected SafeFreeCredentials() : base(IntPtr.Zero, true)
@@ -202,6 +201,7 @@ namespace System.Net.Security
             out SafeFreeCredentials outCredential)
         {
             int errorCode = -1;
+            long timeStamp;
 
             outCredential = new SafeFreeCredential_SECURITY();
 
@@ -214,9 +214,7 @@ namespace System.Net.Security
                             null,
                             null,
                             ref outCredential._handle,
-                            out long timestamp);
-
-            outCredential._expiry = DateTime.FromFileTimeUtc(timestamp);
+                            out timeStamp);
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Verbose(null, $"{nameof(Interop.SspiCli.AcquireCredentialsHandleW)} returns 0x{errorCode:x}, handle = {outCredential}");
 
@@ -235,7 +233,6 @@ namespace System.Net.Security
             out SafeFreeCredentials outCredential)
         {
             outCredential = new SafeFreeCredential_SECURITY();
-
             int errorCode = Interop.SspiCli.AcquireCredentialsHandleW(
                             null,
                             package,
@@ -245,9 +242,7 @@ namespace System.Net.Security
                             null,
                             null,
                             ref outCredential._handle,
-                            out long timestamp);
-
-            outCredential._expiry = DateTime.FromFileTimeUtc(timestamp);
+                            out _);
 
             if (errorCode != 0)
             {
@@ -276,9 +271,7 @@ namespace System.Net.Security
                                 null,
                                 null,
                                 ref outCredential._handle,
-                                out long timestamp);
-
-            outCredential._expiry = DateTime.FromFileTimeUtc(timestamp);
+                                out _);
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Verbose(null, $"{nameof(Interop.SspiCli.AcquireCredentialsHandleW)} returns 0x{errorCode:x}, handle = {outCredential}");
 
@@ -296,6 +289,8 @@ namespace System.Net.Security
             Interop.SspiCli.SCH_CREDENTIALS* authdata,
             out SafeFreeCredentials outCredential)
         {
+            long timeStamp;
+
             outCredential = new SafeFreeCredential_SECURITY();
 
             int errorCode = Interop.SspiCli.AcquireCredentialsHandleW(
@@ -307,9 +302,7 @@ namespace System.Net.Security
                                 null,
                                 null,
                                 ref outCredential._handle,
-                                out long timestamp);
-
-            outCredential._expiry = DateTime.FromFileTimeUtc(timestamp);
+                                out timeStamp);
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Verbose(null, $"{nameof(Interop.SspiCli.AcquireCredentialsHandleW)} returns 0x{errorCode:x}, handle = {outCredential}");
 

--- a/src/libraries/Common/src/System/Net/Security/Unix/SafeFreeCredentials.cs
+++ b/src/libraries/Common/src/System/Net/Security/Unix/SafeFreeCredentials.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Diagnostics;
 using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
@@ -18,8 +19,13 @@ namespace System.Net.Security
     internal abstract class SafeFreeCredentials : SafeHandle
     {
 #endif
+        internal DateTime _expiry;
+
+        public DateTime Expiry => _expiry;
+
         protected SafeFreeCredentials(IntPtr handle, bool ownsHandle) : base(handle, ownsHandle)
         {
+            _expiry = DateTime.MaxValue;
         }
     }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -607,9 +607,7 @@ namespace System.Net.Security
                         _sslAuthenticationOptions.CertificateContext = SslStreamCertificateContext.Create(selectedCert!);
                     }
 
-
                     _credentialsHandle = AcquireCredentialsHandle(_sslAuthenticationOptions);
-
                     thumbPrint = guessedThumbPrint; // Delay until here in case something above threw.
                 }
             }
@@ -735,17 +733,38 @@ namespace System.Net.Security
                 // certificate chain.
                 //
                 SslStreamCertificateContext certificateContext = sslAuthenticationOptions.CertificateContext;
-                DateTime expiry = certificateContext.Certificate.NotAfter;
+                cred._expiry = GetExpiryTimestamp(certificateContext);
 
-                foreach (X509Certificate2 cert in certificateContext.IntermediateCertificates)
+                if (cred._expiry < DateTime.UtcNow)
                 {
-                    if (cert.NotAfter < expiry)
-                    {
-                        expiry = cert.NotAfter;
-                    }
+                    //
+                    // The CertificateContext from auth options is recreated just before creating the SafeFreeCredentials. However, in case when
+                    // it was provided by the user code, it may still contain the (now expired) certificate chain. Such expiration timestamp would
+                    // effectively disable caching as it would lead to creating new credentials for each connection. We attempt to recover by creating
+                    // a temporary certificate context (which builds a new chain with hopefully more recent chain).
+                    //
+                    certificateContext = SslStreamCertificateContext.Create(
+                        certificateContext.Certificate,
+                        new X509Certificate2Collection(certificateContext.IntermediateCertificates),
+                        trust: certificateContext.Trust);
+
+                    cred._expiry = GetExpiryTimestamp(certificateContext);
                 }
 
-                cred._expiry = expiry.ToUniversalTime();
+                static DateTime GetExpiryTimestamp(SslStreamCertificateContext certificateContext)
+                {
+                    DateTime expiry = certificateContext.Certificate.NotAfter;
+
+                    foreach (X509Certificate2 cert in certificateContext.IntermediateCertificates)
+                    {
+                        if (cert.NotAfter < expiry)
+                        {
+                            expiry = cert.NotAfter;
+                        }
+                    }
+
+                    return expiry.ToUniversalTime();
+                }
             }
 
             return cred;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslSessionsCache.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslSessionsCache.cs
@@ -134,9 +134,9 @@ namespace System.Net.Security
 
             //SafeCredentialReference? cached;
             SafeFreeCredentials? credentials = GetCachedCredential(key);
-            if (credentials == null || credentials.IsClosed || credentials.IsInvalid)
+            if (credentials == null || credentials.IsClosed || credentials.IsInvalid || credentials.Expiry < DateTime.UtcNow)
             {
-                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"Not found or invalid, Current Cache Coun = {s_cachedCreds.Count}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"Not found or invalid, Current Cache Count = {s_cachedCreds.Count}");
                 return null;
             }
 
@@ -169,12 +169,13 @@ namespace System.Net.Security
 
             SafeFreeCredentials? credentials = GetCachedCredential(key);
 
-            if (credentials == null || credentials.IsClosed || credentials.IsInvalid)
+            DateTime now = DateTime.UtcNow;
+            if (credentials == null || credentials.IsClosed || credentials.IsInvalid || credentials.Expiry < now)
             {
                 lock (s_cachedCreds)
                 {
                     credentials = GetCachedCredential(key);
-                    if (credentials == null || credentials.IsClosed || credentials.IsInvalid)
+                    if (credentials == null || credentials.IsClosed || credentials.IsInvalid || credentials.Expiry < now)
                     {
                         SafeCredentialReference? cached = SafeCredentialReference.CreateReference(creds);
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslSessionsCache.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslSessionsCache.cs
@@ -169,13 +169,13 @@ namespace System.Net.Security
 
             SafeFreeCredentials? credentials = GetCachedCredential(key);
 
-            DateTime now = DateTime.UtcNow;
-            if (credentials == null || credentials.IsClosed || credentials.IsInvalid || credentials.Expiry < now)
+            DateTime utcNow = DateTime.UtcNow;
+            if (credentials == null || credentials.IsClosed || credentials.IsInvalid || credentials.Expiry < utcNow)
             {
                 lock (s_cachedCreds)
                 {
                     credentials = GetCachedCredential(key);
-                    if (credentials == null || credentials.IsClosed || credentials.IsInvalid || credentials.Expiry < now)
+                    if (credentials == null || credentials.IsClosed || credentials.IsInvalid || credentials.Expiry < utcNow)
                     {
                         SafeCredentialReference? cached = SafeCredentialReference.CreateReference(creds);
 


### PR DESCRIPTION
Fixes #43879

This PR adds timestamp-based invalidation of `SafeFreeCredentials` in `SslSessionCache`. The expiration timestamp is calculated based on `NotAfter` fields of the certificates in the `SslAuthenticationOptions.CertificateContext` (both the actual certificates and the intermediate certs in the chain).

Since this PR does not add any `X509Chain.Build()` calls to the hot path, I believe there should not be a significant perf hit from this change. I can run benchmarks next week once I have access to my desktop machine.

Also to consider: does it make sense to try to create a test for this? It would probably go to OuterLoop since it would run around 2 minutes, but since the repro requires admin privileges (at least on Windows), I am not sure how viable it is. Maybe running the test on Linux would be sufficient.