### PR TITLE
A better fix for #66242

### DIFF
--- a/src/coreclr/jit/forwardsub.cpp
+++ b/src/coreclr/jit/forwardsub.cpp
@@ -636,7 +636,7 @@ bool Compiler::fgForwardSubStatement(Statement* stmt)
     // If fwdSubNode is an address-exposed local, forwarding it may lose optimizations.
     // (maybe similar for dner?)
     //
-    if (fwdSubNode->IsLocal())
+    if (fwdSubNode->OperIs(GT_LCL_VAR))
     {
         unsigned const   fwdLclNum = fwdSubNode->AsLclVarCommon()->GetLclNum();
         LclVarDsc* const fwdVarDsc = lvaGetDesc(fwdLclNum);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2757,7 +2757,7 @@ GenTree* Lowering::DecomposeLongCompare(GenTree* cmp)
             // to have a constant as the first operand.
             //
 
-            if (hiSrc1->OperIs(GT_LCL_VAR, GT_LCL_FLD))
+            if (hiSrc1->OperIs(GT_LCL_VAR, GT_LCL_FLD) && IsInvariantInRange(hiSrc1, hiCmp))
             {
                 BlockRange().Remove(hiSrc1);
                 BlockRange().InsertBefore(hiCmp, hiSrc1);


### PR DESCRIPTION
Lowering was moving nodes without checking legality first.

The conservative forward substitution condition was causing some regressions for `TYP_STRUCT` `LCL_FLD`s.

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1651358&view=ms.vss-build-web.run-extensions-tab).