### PR TITLE
check for IReadOnlyList<T> in ElementAt<T>

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/ElementAt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/ElementAt.cs
@@ -28,6 +28,10 @@ namespace System.Linq
             {
                 return list[index];
             }
+            else if (source is IReadOnlyList<TSource> list)
+            {
+                return list[index];
+            }
             else if (TryGetElement(source, index, out TSource? element))
             {
                 return element;


### PR DESCRIPTION
check for `IReadOnlyList<T>` in `ElementAt<T>` to use random accessor (`O(1)`) instead of forward iterator (`O(n)`)