### PR TITLE
Add tests for `comhost` with managed host

### DIFF
--- a/docs/workflow/testing/host/testing.md
+++ b/docs/workflow/testing/host/testing.md
@@ -69,7 +69,7 @@ dotnet test artifacts/bin/HostActivation.Tests/Debug/net5.0/HostActivation.Tests
 
 To filter to specific tests within the test library, use the [filter options](https://docs.microsoft.com/dotnet/core/tools/dotnet-test#filter-option-details) available for `dotnet test`. For example:
 ```
-dotnet test artifacts/bin/HostActivation.Tests/Debug/net5.0/HostActivation.Tests.dll --filter DependencyResolution&category!=failing
+dotnet test artifacts/bin/HostActivation.Tests/Debug/net5.0/HostActivation.Tests.dll --filter "DependencyResolution&category!=failing"
 ```
 
 The `category!=failing` is to respect the [filtering traits](../libraries/filtering-tests.md) used by the runtime repo.

--- a/src/installer/tests/Assets/TestProjects/ManagedHost/App.manifest
+++ b/src/installer/tests/Assets/TestProjects/ManagedHost/App.manifest
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity
+    type="win32"
+    name="ManagedHost"
+    version="1.0.0.0" />
+
+  <dependency>
+    <dependentAssembly>
+      <!-- RegFree COM -->
+      <assemblyIdentity
+          type="win32"
+          name="ComLibrary.X"
+          version="1.0.0.0"/>
+    </dependentAssembly>
+  </dependency>
+
+</assembly>

--- a/src/installer/tests/Assets/TestProjects/ManagedHost/ManagedHost.cs
+++ b/src/installer/tests/Assets/TestProjects/ManagedHost/ManagedHost.cs
@@ -17,6 +17,17 @@ namespace ComClient
 
             switch (args[0])
             {
+                case "comhost":
+                {
+                    // args: ... <clsid>
+                    if (args.Length != 2)
+                    {
+                        throw new Exception("Invalid number of arguments passed");
+                    }
+
+                    ComTest(args[1]);
+                    break;
+                }
                 case "ijwhost":
                 {
                     // args: ... <ijw_library_path> <entry_point>
@@ -31,6 +42,17 @@ namespace ComClient
                 default:
                     throw new ArgumentException("Unknown scenario");
             }
+        }
+
+        private static unsafe void ComTest(string clsidString)
+        {
+            Console.WriteLine($"Activating class ID {clsidString}");
+
+            Guid clsid = Guid.Parse(clsidString);
+            Type t = Type.GetTypeFromCLSID(clsid);
+            var server = Activator.CreateInstance(t);
+
+            Console.WriteLine($"Activation of {clsidString} succeeded.");
         }
 
         private static unsafe void IjwTest(string libraryPath, string entryPointName)

--- a/src/installer/tests/Assets/TestProjects/ManagedHost/ManagedHost.csproj
+++ b/src/installer/tests/Assets/TestProjects/ManagedHost/ManagedHost.csproj
@@ -7,6 +7,7 @@
     <RuntimeIdentifier>$(TestTargetRid)</RuntimeIdentifier>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ApplicationManifest Condition="'$(RegFreeCom)' == 'true'">App.manifest</ApplicationManifest>
   </PropertyGroup>
 
 </Project>

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Comhost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Comhost.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 {
+    [PlatformSpecific(TestPlatforms.Windows)] // COM activation is only supported on Windows
     public class Comhost : IClassFixture<Comhost.SharedTestState>
     {
         private readonly SharedTestState sharedState;
@@ -23,7 +24,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Theory]
-        [PlatformSpecific(TestPlatforms.Windows)] // COM activation is only supported on Windows
         [InlineData(1, true)]
         [InlineData(10, true)]
         [InlineData(10, false)]
@@ -49,7 +49,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)] // COM activation is only supported on Windows
         public void ActivateClass_IgnoreAppLocalHostFxr()
         {
             using (var fixture = sharedState.ComLibraryFixture.Copy())
@@ -77,7 +76,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)] // COM activation is only supported on Windows
         public void ActivateClass_ValidateIErrorInfoResult()
         {
             using (var fixture = sharedState.ComLibraryFixture.Copy())
@@ -107,7 +105,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)] // COM activation is only supported on Windows
         public void LoadTypeLibraries()
         {
             using (var fixture = sharedState.ComLibraryFixture.Copy())
@@ -185,7 +182,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                     ComHostPath,
                     ClsidMapPath,
                     TypeLibraries);
-
             }
 
             protected override void Dispose(bool disposing)


### PR DESCRIPTION
Add tests using `comhost` (reg-free) loaded by managed host (framework-dependent and self-contained).

This should resolve https://github.com/dotnet/runtime/issues/3452 finally :grimacing:

cc @AaronRobinsonMSFT @jkoritzinsky 