### PR TITLE
Fix timeout checking in FindFinalStatePosition

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -1120,12 +1120,6 @@ namespace System.Text.RegularExpressions.Tests
         [MemberData(nameof(RegexHelpers.AvailableEngines_MemberData), MemberType = typeof(RegexHelpers))]
         public async Task Match_Timeout_Repetition_Throws(RegexEngine engine)
         {
-            if (engine == RegexEngine.NonBacktracking)
-            {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/65991")]
-                return;
-            }
-
             int repetitionCount = 800_000_000;
             Regex regex = await RegexHelpers.GetRegexAsync(engine, @"a\s{" + repetitionCount + "}", RegexOptions.None, TimeSpan.FromSeconds(1));
             string input = @"a" + new string(' ', repetitionCount) + @"b";


### PR DESCRIPTION
Exit the inner loop every now and then to do a timeout check.

Fixes https://github.com/dotnet/runtime/issues/65991