### PR TITLE
[release/6.0] Bump runtime workload manifest to 300 / update emsdk dependency

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,7 +9,7 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-emsdk -->
-    <add key="darc-pub-dotnet-emsdk-ee0a97a" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-ee0a97a0/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-emsdk-572aeed" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-572aeedc/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-emsdk -->
     <!--  Begin: Package sources from dotnet-wcf -->
     <!--  End: Package sources from dotnet-wcf -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -20,14 +20,6 @@
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>572aeedcfa16bdb619fafcecf5924e5c6b65b07b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.200" Version="6.0.2">
-      <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>ee0a97a0009c0e048789126253fea7994db676ac</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.300" Version="6.0.2">
-      <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>ee0a97a0009c0e048789126253fea7994db676ac</Sha>
-    </Dependency>
     <Dependency Name="System.ServiceModel.Primitives" Version="4.9.0">
       <Uri>https://github.com/dotnet/wcf</Uri>
       <Sha>04c3656e0325277aefa18378f24238d39b259222</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,6 +12,14 @@
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>572aeedcfa16bdb619fafcecf5924e5c6b65b07b</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.200" Version="6.0.4">
+      <Uri>https://github.com/dotnet/emsdk</Uri>
+      <Sha>572aeedcfa16bdb619fafcecf5924e5c6b65b07b</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.300" Version="6.0.4">
+      <Uri>https://github.com/dotnet/emsdk</Uri>
+      <Sha>572aeedcfa16bdb619fafcecf5924e5c6b65b07b</Sha>
+    </Dependency>
     <Dependency Name="System.ServiceModel.Primitives" Version="4.9.0">
       <Uri>https://github.com/dotnet/wcf</Uri>
       <Sha>04c3656e0325277aefa18378f24238d39b259222</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,9 +8,9 @@
       <Uri>https://github.com/dotnet/msquic</Uri>
       <Sha>98129287d56a5e0348c291ce4260e630b4aa510d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.100" Version="6.0.2">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.100" Version="6.0.4">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>ee0a97a0009c0e048789126253fea7994db676ac</Sha>
+      <Sha>572aeedcfa16bdb619fafcecf5924e5c6b65b07b</Sha>
     </Dependency>
     <Dependency Name="System.ServiceModel.Primitives" Version="4.9.0">
       <Uri>https://github.com/dotnet/wcf</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,7 +6,7 @@
     <MajorVersion>6</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>4</PatchVersion>
-    <SdkBandVersion>6.0.200</SdkBandVersion>
+    <SdkBandVersion>6.0.300</SdkBandVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>
@@ -169,7 +169,7 @@
     <runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>11.1.0-alpha.1.21416.1</runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
     <runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>11.1.0-alpha.1.21416.1</runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>
     <!-- emscripten / Node -->
-    <MicrosoftNETWorkloadEmscriptenManifest60100Version>6.0.2</MicrosoftNETWorkloadEmscriptenManifest60100Version>
+    <MicrosoftNETWorkloadEmscriptenManifest60100Version>6.0.4</MicrosoftNETWorkloadEmscriptenManifest60100Version>
     <MicrosoftNETRuntimeEmscriptenVersion>$(MicrosoftNETWorkloadEmscriptenManifest60100Version)</MicrosoftNETRuntimeEmscriptenVersion>
     <!-- workloads -->
     <SwixPackageVersion>1.1.87-gba258badda</SwixPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -149,7 +149,7 @@
     <SQLitePCLRawbundle_greenVersion>2.0.4</SQLitePCLRawbundle_greenVersion>
     <MoqVersion>4.12.0</MoqVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
-    <SdkVersionForWorkloadTesting>6.0.200-preview.22055.18</SdkVersionForWorkloadTesting>
+    <SdkVersionForWorkloadTesting>6.0.300-preview.22159.1</SdkVersionForWorkloadTesting>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>6.0.0-preview-20211019.1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -170,6 +170,8 @@
     <runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>11.1.0-alpha.1.21416.1</runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>
     <!-- emscripten / Node -->
     <MicrosoftNETWorkloadEmscriptenManifest60100Version>6.0.4</MicrosoftNETWorkloadEmscriptenManifest60100Version>
+    <MicrosoftNETWorkloadEmscriptenManifest60200Version>6.0.4</MicrosoftNETWorkloadEmscriptenManifest60200Version>
+    <MicrosoftNETWorkloadEmscriptenManifest60300Version>6.0.4</MicrosoftNETWorkloadEmscriptenManifest60300Version>
     <MicrosoftNETRuntimeEmscriptenVersion>$(MicrosoftNETWorkloadEmscriptenManifest60100Version)</MicrosoftNETRuntimeEmscriptenVersion>
     <!-- workloads -->
     <SwixPackageVersion>1.1.87-gba258badda</SwixPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,7 +25,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- The bands we want to produce workload manifests for -->
-    <WorkloadSdkBandVersions Include="6.0.100;6.0.200" />
+    <WorkloadSdkBandVersions Include="6.0.100;6.0.200;6.0.300" />
   </ItemGroup>
   <PropertyGroup>
     <!-- For source generator support we need to target multiple versions of Rolsyn in order to be able to run on older versions of Roslyn -->

--- a/src/libraries/workloads-testing.targets
+++ b/src/libraries/workloads-testing.targets
@@ -46,6 +46,7 @@
                   Condition="!Exists($(_DotNetInstallScriptPath))"/>
 
     <Exec Condition="!$([MSBuild]::IsOSPlatform('windows'))"
+          IgnoreStandardErrorWarningFormat="true"
           Command="chmod +x $(_DotNetInstallScriptPath); $(_DotNetInstallScriptPath) -i $(SdkWithNoWorkloadForTestingPath) -v $(SdkVersionForWorkloadTesting)" />
 
     <Exec Condition="$([MSBuild]::IsOSPlatform('windows'))"


### PR DESCRIPTION
## Customer Impact
Bumps the SDK band manifest for both runtime and emsdk to 300.  Once this change flows to the installer, the 300 sdk will have the correct baseline manifests and can install up to date workloads.

NOTE: This is an important change to unblock MAUI on both Mac and when used through the SDK.

## Testing
Manually validated the packages generate

## Risk

Very low