### PR TITLE
Remove compiler warning suppression 2

### DIFF
--- a/src/coreclr/gc/env/volatile.h
+++ b/src/coreclr/gc/env/volatile.h
@@ -152,7 +152,6 @@ T VolatileLoad(T const * pt)
 #elif defined(HOST_ARM64) && defined(_MSC_VER)
 // silence warnings on casts in branches that are not taken.
 #pragma warning(push)
-#pragma warning(disable : 4302)
 #pragma warning(disable : 4311)
 #pragma warning(disable : 4312)
     T val;
@@ -233,7 +232,6 @@ void VolatileStore(T* pt, T val)
 #elif defined(HOST_ARM64) && defined(_MSC_VER)
 // silence warnings on casts in branches that are not taken.
 #pragma warning(push)
-#pragma warning(disable : 4302)
 #pragma warning(disable : 4311)
 #pragma warning(disable : 4312)
     T* pv = &val;

--- a/src/coreclr/inc/safemath.h
+++ b/src/coreclr/inc/safemath.h
@@ -689,7 +689,7 @@ private:
 };
 
 template <>
-bool ClrSafeInt<int64_t>::multiply(int64_t lhs, int64_t rhs, int64_t &result)
+inline bool ClrSafeInt<int64_t>::multiply(int64_t lhs, int64_t rhs, int64_t &result)
 {
     //fast track this one - and avoid DIV_0 below
     if(lhs == 0 || rhs == 0)
@@ -764,7 +764,7 @@ bool ClrSafeInt<int64_t>::multiply(int64_t lhs, int64_t rhs, int64_t &result)
 }
 
 template <>
-bool ClrSafeInt<uint64_t>::multiply(uint64_t lhs, uint64_t rhs, uint64_t &result)
+inline bool ClrSafeInt<uint64_t>::multiply(uint64_t lhs, uint64_t rhs, uint64_t &result)
 {
     //fast track this one - and avoid DIV_0 below
     if(lhs == 0 || rhs == 0)
@@ -784,7 +784,7 @@ bool ClrSafeInt<uint64_t>::multiply(uint64_t lhs, uint64_t rhs, uint64_t &result
 }
 
 template <>
-bool ClrSafeInt<int32_t>::multiply(int32_t lhs, int32_t rhs, int32_t &result)
+inline bool ClrSafeInt<int32_t>::multiply(int32_t lhs, int32_t rhs, int32_t &result)
 {
     INT64 tmp = (INT64)lhs * (INT64)rhs;
 
@@ -803,7 +803,7 @@ bool ClrSafeInt<int32_t>::multiply(int32_t lhs, int32_t rhs, int32_t &result)
 }
 
 template <>
-bool ClrSafeInt<uint32_t>::multiply(uint32_t lhs, uint32_t rhs, uint32_t &result)
+inline bool ClrSafeInt<uint32_t>::multiply(uint32_t lhs, uint32_t rhs, uint32_t &result)
 {
     UINT64 tmp = (UINT64)lhs * (UINT64)rhs;
     if (tmp & 0xffffffff00000000ULL) //overflow
@@ -816,7 +816,7 @@ bool ClrSafeInt<uint32_t>::multiply(uint32_t lhs, uint32_t rhs, uint32_t &result
 }
 
 template <>
-bool ClrSafeInt<int16_t>::multiply(int16_t lhs, int16_t rhs, int16_t &result)
+inline bool ClrSafeInt<int16_t>::multiply(int16_t lhs, int16_t rhs, int16_t &result)
 {
     INT32 tmp = (INT32)lhs * (INT32)rhs;
     //upper 17 bits must be the same
@@ -833,7 +833,7 @@ bool ClrSafeInt<int16_t>::multiply(int16_t lhs, int16_t rhs, int16_t &result)
 }
 
 template <>
-bool ClrSafeInt<uint16_t>::multiply(uint16_t lhs, uint16_t rhs, uint16_t &result)
+inline bool ClrSafeInt<uint16_t>::multiply(uint16_t lhs, uint16_t rhs, uint16_t &result)
 {
     UINT32 tmp = (UINT32)lhs * (UINT32)rhs;
     if (tmp & 0xffff0000) //overflow
@@ -845,7 +845,7 @@ bool ClrSafeInt<uint16_t>::multiply(uint16_t lhs, uint16_t rhs, uint16_t &result
 }
 
 template <>
-bool ClrSafeInt<int8_t>::multiply(int8_t lhs, int8_t rhs, int8_t &result)
+inline bool ClrSafeInt<int8_t>::multiply(int8_t lhs, int8_t rhs, int8_t &result)
 {
     INT16 tmp = (INT16)lhs * (INT16)rhs;
     //upper 9 bits must be the same
@@ -862,7 +862,7 @@ bool ClrSafeInt<int8_t>::multiply(int8_t lhs, int8_t rhs, int8_t &result)
 }
 
 template <>
-bool ClrSafeInt<uint8_t>::multiply(uint8_t lhs, uint8_t rhs, uint8_t &result)
+inline bool ClrSafeInt<uint8_t>::multiply(uint8_t lhs, uint8_t rhs, uint8_t &result)
 {
     UINT16 tmp = ((UINT16)lhs) * ((UINT16)rhs);
 

--- a/src/coreclr/inc/safemath.h
+++ b/src/coreclr/inc/safemath.h
@@ -485,100 +485,14 @@ public:
     {
         if(Is64Bit())
         {
-            //fast track this one - and avoid DIV_0 below
-            if(lhs == 0 || rhs == 0)
-            {
-                result = 0;
-                return true;
-            }
-
             //we're 64 bit - slow, but the only way to do it
             if(IsSigned())
             {
-                if(!IsMixedSign(lhs, rhs))
-                {
-                    //both positive or both negative
-                    //result will be positive, check for lhs * rhs > MaxInt
-                    if(lhs > 0)
-                    {
-                        //both positive
-                        if(MaxInt()/lhs < rhs)
-                        {
-                            //overflow
-                            return false;
-                        }
-                    }
-                    else
-                    {
-                        //both negative
-
-                        //comparison gets tricky unless we force it to positive
-                        //EXCEPT that -MinInt is undefined - can't be done
-                        //And MinInt always has a greater magnitude than MaxInt
-                        if(lhs == MinInt() || rhs == MinInt())
-                        {
-                            //overflow
-                            return false;
-                        }
-
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning( disable : 4146 )   // unary minus applied to unsigned is still unsigned
-#endif
-                        if(MaxInt()/(-lhs) < (-rhs) )
-                        {
-                            //overflow
-                            return false;
-                        }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-                    }
-                }
-                else
-                {
-                    //mixed sign - this case is difficult
-                    //test case is lhs * rhs < MinInt => overflow
-                    //if lhs < 0 (implies rhs > 0),
-                    //lhs < MinInt/rhs is the correct test
-                    //else if lhs > 0
-                    //rhs < MinInt/lhs is the correct test
-                    //avoid dividing MinInt by a negative number,
-                    //because MinInt/-1 is a corner case
-
-                    if(lhs < 0)
-                    {
-                        if(lhs < MinInt()/rhs)
-                        {
-                            //overflow
-                            return false;
-                        }
-                    }
-                    else
-                    {
-                        if(rhs < MinInt()/lhs)
-                        {
-                            //overflow
-                            return false;
-                        }
-                    }
-                }
-
-                //ok
-                result = lhs * rhs;
-                return true;
+                return ClrSafeInt<int64_t>::multiply((int64_t)lhs, (int64_t)rhs, (int64_t&)result);
             }
             else
             {
-                //unsigned, easy case
-                if(MaxInt()/lhs < rhs)
-                {
-                    //overflow
-                    return false;
-                }
-                //ok
-                result = lhs * rhs;
-                return true;
+                return ClrSafeInt<uint64_t>::multiply((uint64_t)lhs, (uint64_t)rhs, (uint64_t&)result);
             }
         }
         else if(Is32Bit())
@@ -586,32 +500,11 @@ public:
             //we're 32-bit
             if(IsSigned())
             {
-                INT64 tmp = (INT64)lhs * (INT64)rhs;
-
-                //upper 33 bits must be the same
-                //most common case is likely that both are positive - test first
-                if( (tmp & 0xffffffff80000000LL) == 0 ||
-                    (tmp & 0xffffffff80000000LL) == 0xffffffff80000000LL)
-                {
-                    //this is OK
-                    result = (T)tmp;
-                    return true;
-                }
-
-                //overflow
-                return false;
-
+                return ClrSafeInt<int32_t>::multiply((int32_t)lhs, (int32_t)rhs, (int32_t&)result);
             }
             else
             {
-                UINT64 tmp = (UINT64)lhs * (UINT64)rhs;
-                if (tmp & 0xffffffff00000000ULL) //overflow
-                {
-                    //overflow
-                    return false;
-                }
-                result = (T)tmp;
-                return true;
+                return ClrSafeInt<uint32_t>::multiply((uint32_t)lhs, (uint32_t)rhs, (uint32_t&)result);
             }
         }
         else if(Is16Bit())
@@ -619,59 +512,23 @@ public:
             //16-bit
             if(IsSigned())
             {
-                INT32 tmp = (INT32)lhs * (INT32)rhs;
-                //upper 17 bits must be the same
-                //most common case is likely that both are positive - test first
-                if( (tmp & 0xffff8000) == 0 || (tmp & 0xffff8000) == 0xffff8000)
-                {
-                    //this is OK
-                    result = (T)tmp;
-                    return true;
-                }
-
-                //overflow
-                return false;
+                return ClrSafeInt<int16_t>::multiply((int16_t)lhs, (int16_t)rhs, (int16_t&)result);
             }
             else
             {
-                UINT32 tmp = (UINT32)lhs * (UINT32)rhs;
-                if (tmp & 0xffff0000) //overflow
-                {
-                    return false;
-                }
-                result = (T)tmp;
-                return true;
+                return ClrSafeInt<uint16_t>::multiply((uint16_t)lhs, (uint16_t)rhs, (uint16_t&)result);
             }
         }
         else //8-bit
         {
             _ASSERTE_SAFEMATH(Is8Bit());
-
             if(IsSigned())
             {
-                INT16 tmp = (INT16)lhs * (INT16)rhs;
-                //upper 9 bits must be the same
-                //most common case is likely that both are positive - test first
-                if( (tmp & 0xff80) == 0 || (tmp & 0xff80) == 0xff80)
-                {
-                    //this is OK
-                    result = (T)tmp;
-                    return true;
-                }
-
-                //overflow
-                return false;
+                return ClrSafeInt<int8_t>::multiply((int8_t)lhs, (int8_t)rhs, (int8_t&)result);
             }
             else
             {
-                UINT16 tmp = ((UINT16)lhs) * ((UINT16)rhs);
-
-                if (tmp & 0xff00) //overflow
-                {
-                    return false;
-                }
-                result = (T)tmp;
-                return true;
+                return ClrSafeInt<uint8_t>::multiply((uint8_t)lhs, (uint8_t)rhs, (uint8_t&)result);
             }
         }
     }
@@ -830,6 +687,192 @@ private:
     // is called.
     INDEBUG( mutable bool m_checkedOverflow; )
 };
+
+template <>
+bool ClrSafeInt<int64_t>::multiply(int64_t lhs, int64_t rhs, int64_t &result)
+{
+    //fast track this one - and avoid DIV_0 below
+    if(lhs == 0 || rhs == 0)
+    {
+        result = 0;
+        return true;
+    }
+    if(!IsMixedSign(lhs, rhs))
+    {
+        //both positive or both negative
+        //result will be positive, check for lhs * rhs > MaxInt
+        if(lhs > 0)
+        {
+            //both positive
+            if(MaxInt()/lhs < rhs)
+            {
+                //overflow
+                return false;
+            }
+        }
+        else
+        {
+            //both negative
+
+            //comparison gets tricky unless we force it to positive
+            //EXCEPT that -MinInt is undefined - can't be done
+            //And MinInt always has a greater magnitude than MaxInt
+            if(lhs == MinInt() || rhs == MinInt())
+            {
+                //overflow
+                return false;
+            }
+            if(MaxInt()/(-lhs) < (-rhs) )
+            {
+                //overflow
+                return false;
+            }
+        }
+    }
+    else
+    {
+        //mixed sign - this case is difficult
+        //test case is lhs * rhs < MinInt => overflow
+        //if lhs < 0 (implies rhs > 0),
+        //lhs < MinInt/rhs is the correct test
+        //else if lhs > 0
+        //rhs < MinInt/lhs is the correct test
+        //avoid dividing MinInt by a negative number,
+        //because MinInt/-1 is a corner case
+
+        if(lhs < 0)
+        {
+            if(lhs < MinInt()/rhs)
+            {
+                //overflow
+                return false;
+            }
+        }
+        else
+        {
+            if(rhs < MinInt()/lhs)
+            {
+                //overflow
+                return false;
+            }
+        }
+    }
+
+    //ok
+    result = lhs * rhs;
+    return true;
+}
+
+template <>
+bool ClrSafeInt<uint64_t>::multiply(uint64_t lhs, uint64_t rhs, uint64_t &result)
+{
+    //fast track this one - and avoid DIV_0 below
+    if(lhs == 0 || rhs == 0)
+    {
+        result = 0;
+        return true;
+    }
+    //unsigned, easy case
+    if(MaxInt()/lhs < rhs)
+    {
+        //overflow
+        return false;
+    }
+    //ok
+    result = lhs * rhs;
+    return true;
+}
+
+template <>
+bool ClrSafeInt<int32_t>::multiply(int32_t lhs, int32_t rhs, int32_t &result)
+{
+    INT64 tmp = (INT64)lhs * (INT64)rhs;
+
+    //upper 33 bits must be the same
+    //most common case is likely that both are positive - test first
+    if( (tmp & 0xffffffff80000000LL) == 0 ||
+        (tmp & 0xffffffff80000000LL) == 0xffffffff80000000LL)
+    {
+        //this is OK
+        result = (int32_t)tmp;
+        return true;
+    }
+
+    //overflow
+    return false;
+}
+
+template <>
+bool ClrSafeInt<uint32_t>::multiply(uint32_t lhs, uint32_t rhs, uint32_t &result)
+{
+    UINT64 tmp = (UINT64)lhs * (UINT64)rhs;
+    if (tmp & 0xffffffff00000000ULL) //overflow
+    {
+        //overflow
+        return false;
+    }
+    result = (uint32_t)tmp;
+    return true;
+}
+
+template <>
+bool ClrSafeInt<int16_t>::multiply(int16_t lhs, int16_t rhs, int16_t &result)
+{
+    INT32 tmp = (INT32)lhs * (INT32)rhs;
+    //upper 17 bits must be the same
+    //most common case is likely that both are positive - test first
+    if( (tmp & 0xffff8000) == 0 || (tmp & 0xffff8000) == 0xffff8000)
+    {
+        //this is OK
+        result = (int16_t)tmp;
+        return true;
+    }
+
+    //overflow
+    return false;
+}
+
+template <>
+bool ClrSafeInt<uint16_t>::multiply(uint16_t lhs, uint16_t rhs, uint16_t &result)
+{
+    UINT32 tmp = (UINT32)lhs * (UINT32)rhs;
+    if (tmp & 0xffff0000) //overflow
+    {
+        return false;
+    }
+    result = (uint16_t)tmp;
+    return true;
+}
+
+template <>
+bool ClrSafeInt<int8_t>::multiply(int8_t lhs, int8_t rhs, int8_t &result)
+{
+    INT16 tmp = (INT16)lhs * (INT16)rhs;
+    //upper 9 bits must be the same
+    //most common case is likely that both are positive - test first
+    if( (tmp & 0xff80) == 0 || (tmp & 0xff80) == 0xff80)
+    {
+        //this is OK
+        result = (int8_t)tmp;
+        return true;
+    }
+
+    //overflow
+    return false;
+}
+
+template <>
+bool ClrSafeInt<uint8_t>::multiply(uint8_t lhs, uint8_t rhs, uint8_t &result)
+{
+    UINT16 tmp = ((UINT16)lhs) * ((UINT16)rhs);
+
+    if (tmp & 0xff00) //overflow
+    {
+        return false;
+    }
+    result = (uint8_t)tmp;
+    return true;
+}
 
 // Allows creation of a ClrSafeInt corresponding to the type of the argument.
 template <typename T>

--- a/src/coreclr/inc/volatile.h
+++ b/src/coreclr/inc/volatile.h
@@ -159,7 +159,6 @@ T VolatileLoad(T const * pt)
 #elif defined(HOST_ARM64) && defined(_MSC_VER)
 // silence warnings on casts in branches that are not taken.
 #pragma warning(push)
-#pragma warning(disable : 4302)
 #pragma warning(disable : 4311)
 #pragma warning(disable : 4312)
     T val;
@@ -245,7 +244,6 @@ void VolatileStore(T* pt, T val)
 #elif defined(HOST_ARM64) && defined(_MSC_VER)
 // silence warnings on casts in branches that are not taken.
 #pragma warning(push)
-#pragma warning(disable : 4302)
 #pragma warning(disable : 4311)
 #pragma warning(disable : 4312)
     T* pv = &val;
@@ -308,7 +306,7 @@ void VolatileLoadBarrier()
     __dmb(_ARM64_BARRIER_ISHLD);
 #else
     VOLATILE_MEMORY_BARRIER();
-#endif   
+#endif
 }
 
 //


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/66154

Remove 4146 from coreclr
Remove 4302 from all code bases

/cc @GrabYourPitchforks @jkotas @janvorli 