### PR TITLE
Do not assume containment

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -5111,7 +5111,8 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
                     assert(rmwSrc == data->gtGetOp2());
                     genCodeForShiftRMW(tree);
                 }
-                else if (data->OperGet() == GT_ADD && (rmwSrc->IsIntegralConst(1) || rmwSrc->IsIntegralConst(-1)))
+                else if (data->OperIs(GT_ADD) && rmwSrc->isContainedIntOrIImmed() &&
+                         (rmwSrc->IsIntegralConst(1) || rmwSrc->IsIntegralConst(-1)))
                 {
                     // Generate "inc/dec [mem]" instead of "add/sub [mem], 1".
                     //
@@ -5123,7 +5124,6 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
                     //     addr modes with inc/dec.  For this reason, inc/dec [mem]
                     //     is not generated while generating debuggable code.  Update
                     //     the above if condition once Decode() routine is fixed.
-                    assert(rmwSrc->isContainedIntOrIImmed());
                     instruction ins = rmwSrc->IsIntegralConst(1) ? INS_inc : INS_dec;
                     GetEmitter()->emitInsRMW(ins, emitTypeSize(tree), tree);
                 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_66335/Runtime_66335.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_66335/Runtime_66335.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+public class Runtime_66335
+{
+    private static S0 s_24;
+
+    public static int Main()
+    {
+        return Problem() == 1 ? 100 : 101;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Problem()
+    {
+        S0 vr7 = new S0(1);
+        s_24.F4 += (sbyte)-vr7.F2;
+
+        return vr7.F2;
+    }
+
+    public struct S0
+    {
+        public ushort F0;
+        public uint F1;
+        public sbyte F2;
+        public sbyte F4;
+        public ulong F5;
+        public S0(sbyte f2) : this()
+        {
+            F2 = f2;
+        }
+    }
+}
+

--- a/src/tests/JIT/Regression/JitBlue/Runtime_66335/Runtime_66335.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_66335/Runtime_66335.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Codegen was assuming lowering would always contain immediates for RMW ops. It did not for some fuzzer-generated code.

Check for containment explicitly instead.

Fixes a failure seen in #66335.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1653584&view=ms.vss-build-web.run-extensions-tab).