### PR TITLE
Reduce the amount of memory allocated by System.IO.Tests

### DIFF
--- a/src/libraries/System.IO/tests/BinaryWriter/BinaryWriter.EncodingTests.cs
+++ b/src/libraries/System.IO/tests/BinaryWriter/BinaryWriter.EncodingTests.cs
@@ -203,7 +203,7 @@ namespace System.IO.Tests
                 }
                 catch (OutOfMemoryException)
                 {
-                    return; // skip test in low-mem conditions
+                    throw new SkipTestException($"Unable to execute {nameof(WriteChars_VeryLargeArray_DoesNotOverflow)} due to OOM"); // skip test in low-mem conditions
                 }
 
                 Assert.True((long)unmanagedBuffer.ByteLength > int.MaxValue);

--- a/src/libraries/System.IO/tests/BinaryWriter/BinaryWriter.EncodingTests.cs
+++ b/src/libraries/System.IO/tests/BinaryWriter/BinaryWriter.EncodingTests.cs
@@ -191,6 +191,7 @@ namespace System.IO.Tests
             Assert.Equal(expectedBytes, stream.GetBuffer()[Get7BitEncodedIntByteLength((uint)expectedBytes.Length)..(int)stream.Length]);
         }
 
+        [OuterLoop("Allocates a lot of memory")]
         [Fact]
         [SkipOnPlatform(TestPlatforms.Android, "OOM on Android could be uncatchable & kill the test runner")]
         public unsafe void WriteChars_VeryLargeArray_DoesNotOverflow()

--- a/src/libraries/System.IO/tests/BinaryWriter/BinaryWriter.EncodingTests.cs
+++ b/src/libraries/System.IO/tests/BinaryWriter/BinaryWriter.EncodingTests.cs
@@ -10,6 +10,9 @@ using Xunit;
 
 namespace System.IO.Tests
 {
+    // WriteChars_VeryLargeArray_DoesNotOverflow allocates a lot of memory and can cause OOM,
+    // it should not be executed in parallel with other tests
+    [Collection(nameof(DisableParallelization))]
     public class BinaryWriter_EncodingTests
     {
         [Fact]

--- a/src/libraries/System.IO/tests/System.IO.Tests.csproj
+++ b/src/libraries/System.IO/tests/System.IO.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>System.IO</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -44,6 +44,7 @@
     <Compile Include="Stream\Stream.ValidateArguments.cs" />
     <Compile Include="StringReader\StringReader.CtorTests.cs" />
     <Compile Include="StringWriter\StringWriterTests.cs" />
+    <Compile Include="$(CommonTestPath)TestUtilities\System\DisableParallelization.cs" Link="Common\TestUtilities\System\DisableParallelization.cs" />
     <Compile Include="$(CommonTestPath)System\Buffers\NativeMemoryManager.cs" Link="Common\System\Buffers\NativeMemoryManager.cs" />
     <Compile Include="$(CommonTestPath)System\IO\CallTrackingStream.cs" Link="Common\System\IO\CallTrackingStream.cs" />
     <Compile Include="$(CommonTestPath)System\IO\DelegateStream.cs" Link="Common\System\IO\DelegateStream.cs" />


### PR DESCRIPTION
Recently `System.IO.Tests` have started failing with OOM on Unix-like OSes. Since the CI has not produced any dump file and according to my knowledge we don't offer any memory profiler for Linux, I've used VS Memory Profiler to profile System.IO.Tests on Windows.

![image](https://user-images.githubusercontent.com/6011991/157437886-d531dbdf-704f-43f6-8a71-bbede648009d.png)

The number of live objects goes back to previous value (or a very similar number) after each GC collection, so I don't think that we have introduced a memory leak to the product itself.

However, one of the tests, namely `WriteChars_VeryLargeArray_DoesNotOverflow` allocated 6.5 GB and it has already been causing OOMs in the past as it's marked to skip on Android:

https://github.com/dotnet/runtime/blob/57bfe474518ab5b7cfe6bf7424a79ce3af9d6657/src/libraries/System.IO/tests/BinaryWriter/BinaryWriter.EncodingTests.cs#L191-L192

I **guess** (I have no memory dump from the CI) that the problem is caused by `WriteChars_VeryLargeArray_DoesNotOverflow` which allocates 6.5GB and causes other tests which run in parallel to fail with OOM.

My proposal:

- allocate less memory to validate  Int32Overflow, just slightly more than `int.MaxValue`
- since we don't validate the buffers content (just the stream position) use the same memory for input and output
- don't run other tests in parallel
- throw `SkipTestException` on OOM so we can differentiate successful and skipped test

This is nicely reducing the amount of memory used by the `System.IO.Tests` and hopefully is still testing what author wanted to test (cc @GrabYourPitchforks)

![image](https://user-images.githubusercontent.com/6011991/157439079-40021c88-b391-481b-bbd7-ef260024452e.png)

fixes #65791