### PR TITLE
skip the ReadToEndAsync_WithCancellation test if there is not enough disk space

### DIFF
--- a/src/libraries/System.IO/tests/StreamReader/StreamReaderTests.cs
+++ b/src/libraries/System.IO/tests/StreamReader/StreamReaderTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.IO.Tests
@@ -136,12 +137,10 @@ namespace System.IO.Tests
         public async Task ReadToEndAsync_WithCancellation()
         {
             string path = GetTestFilePath();
-            
-            // create large (~1GB) file
-            File.WriteAllLines(path, Enumerable.Repeat("A very large file used for testing StreamReader cancellation. 0123456789012345678901234567890123456789.", 10_000_000));
+            CreateLargeFile(path);
 
             using StreamReader reader = File.OpenText(path);
-            using CancellationTokenSource cts = new ();
+            using CancellationTokenSource cts = new();
             var token = cts.Token;
 
             var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
@@ -160,6 +159,31 @@ namespace System.IO.Tests
                 await readToEndTask;
             });
             Assert.Equal(token, ex.CancellationToken);
+        }
+
+        private void CreateLargeFile(string path)
+        {
+            const string sentence = "A very large file used for testing StreamReader cancellation. 0123456789012345678901234567890123456789.";
+            const int repeatCount = 10_000_000;
+            Encoding encoding = Encoding.UTF8;
+
+            using FileStream fs = File.OpenWrite(path);
+            long fileSize = encoding.GetByteCount(sentence) * repeatCount;
+
+            try
+            {
+                fs.SetLength(fileSize);
+            }
+            catch (IOException)
+            {
+                throw new SkipTestException($"Unable to run {ReadToEndAsync_WithCancellation} due to lack of available disk space");
+            }
+
+            using StreamWriter streamWriter = new StreamWriter(fs, encoding);
+            for (int i = 0; i < repeatCount; i++)
+            {
+                streamWriter.WriteLine(sentence);
+            }
         }
 
         [Fact]

--- a/src/libraries/System.IO/tests/StreamReader/StreamReaderTests.cs
+++ b/src/libraries/System.IO/tests/StreamReader/StreamReaderTests.cs
@@ -132,6 +132,7 @@ namespace System.IO.Tests
             Assert.Equal(token, ex.CancellationToken);
         }
 
+        [OuterLoop("It creates 1GB file")]
         [Fact]
         [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser.")]
         public async Task ReadToEndAsync_WithCancellation()


### PR DESCRIPTION
fixes #66395