### PR TITLE
Reenable compiler warning 4244 under coreclr/

### DIFF
--- a/src/coreclr/debug/daccess/gcdump_dac.cpp
+++ b/src/coreclr/debug/daccess/gcdump_dac.cpp
@@ -8,7 +8,6 @@
  * are all about.
  */
 #ifdef __MSC_VER
-#pragma warning(disable:4244)   // conversion from 'unsigned int' to 'unsigned short', possible loss of data
 #pragma warning(disable:4189)   // local variable is initialized but not referenced
 #endif // __MSC_VER
 
@@ -43,6 +42,5 @@
 #endif // !TARGET_X86
 
 #ifdef __MSC_VER
-#pragma warning(default:4244)
 #pragma warning(default:4189)
 #endif // __MSC_VER

--- a/src/coreclr/inc/gcinfotypes.h
+++ b/src/coreclr/inc/gcinfotypes.h
@@ -53,7 +53,7 @@ inline UINT32 CeilOfLog2(size_t x)
     return result;
 }
 
-enum GcSlotFlags : unsigned short
+enum GcSlotFlags
 {
     GC_SLOT_BASE      = 0x0,
     GC_SLOT_INTERIOR  = 0x1,

--- a/src/coreclr/inc/gcinfotypes.h
+++ b/src/coreclr/inc/gcinfotypes.h
@@ -53,7 +53,7 @@ inline UINT32 CeilOfLog2(size_t x)
     return result;
 }
 
-enum GcSlotFlags
+enum GcSlotFlags : unsigned short
 {
     GC_SLOT_BASE      = 0x0,
     GC_SLOT_INTERIOR  = 0x1,

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -15,9 +15,6 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include "jitpch.h"
 #ifdef _MSC_VER
 #pragma hdrstop
-
-#pragma warning(disable : 4244) // loss of data int -> char ..
-
 #endif
 
 #include "gcinfotypes.h"
@@ -516,10 +513,10 @@ int FASTCALL lookupCallPattern(unsigned argCnt, unsigned regMask, unsigned argMa
     {
         CallPattern pat;
 
-        pat.fld.argCnt    = argCnt;
-        pat.fld.regMask   = regMask; // EBP,EBX,ESI,EDI
-        pat.fld.argMask   = argMask;
-        pat.fld.codeDelta = codeDelta;
+        pat.fld.argCnt    = (unsigned char)argCnt;
+        pat.fld.regMask   = (unsigned char)regMask; // EBP,EBX,ESI,EDI
+        pat.fld.argMask   = (unsigned char)argMask;
+        pat.fld.codeDelta = (unsigned char)codeDelta;
 
         bool     codeDeltaOK = (pat.fld.codeDelta == codeDelta);
         unsigned bestDelta2  = 0xff;
@@ -651,7 +648,7 @@ BYTE FASTCALL encodeHeaderNext(const InfoHdr& header, InfoHdr* state, BYTE& code
         if (header.argCount <= SET_ARGCOUNT_MAX)
         {
             state->argCount = header.argCount;
-            encoding        = SET_ARGCOUNT + header.argCount;
+            encoding        = (BYTE)(SET_ARGCOUNT + header.argCount);
             goto DO_RETURN;
         }
         else
@@ -660,16 +657,16 @@ BYTE FASTCALL encodeHeaderNext(const InfoHdr& header, InfoHdr* state, BYTE& code
             if (initNeeded4(state->argCount, header.argCount, SET_ARGCOUNT_MAX, &hint))
             {
                 assert(hint <= SET_ARGCOUNT_MAX);
-                state->argCount = hint;
-                encoding        = SET_ARGCOUNT + hint;
+                state->argCount = (unsigned short)hint;
+                encoding        = (BYTE)(SET_ARGCOUNT + hint);
                 goto DO_RETURN;
             }
             else
             {
                 assert(hint <= 0xf);
                 state->argCount <<= 4;
-                state->argCount += hint;
-                encoding = NEXT_FOUR_ARGCOUNT + hint;
+                state->argCount += ((unsigned short)hint);
+                encoding = (BYTE)(NEXT_FOUR_ARGCOUNT + hint);
                 goto DO_RETURN;
             }
         }
@@ -681,7 +678,7 @@ BYTE FASTCALL encodeHeaderNext(const InfoHdr& header, InfoHdr* state, BYTE& code
         if (header.frameSize <= SET_FRAMESIZE_MAX)
         {
             state->frameSize = header.frameSize;
-            encoding         = SET_FRAMESIZE + header.frameSize;
+            encoding         = (BYTE)(SET_FRAMESIZE + header.frameSize);
             goto DO_RETURN;
         }
         else
@@ -691,7 +688,7 @@ BYTE FASTCALL encodeHeaderNext(const InfoHdr& header, InfoHdr* state, BYTE& code
             {
                 assert(hint <= SET_FRAMESIZE_MAX);
                 state->frameSize = hint;
-                encoding         = SET_FRAMESIZE + hint;
+                encoding         = (BYTE)(SET_FRAMESIZE + hint);
                 goto DO_RETURN;
             }
             else
@@ -699,7 +696,7 @@ BYTE FASTCALL encodeHeaderNext(const InfoHdr& header, InfoHdr* state, BYTE& code
                 assert(hint <= 0xf);
                 state->frameSize <<= 4;
                 state->frameSize += hint;
-                encoding = NEXT_FOUR_FRAMESIZE + hint;
+                encoding = (BYTE)(NEXT_FOUR_FRAMESIZE + hint);
                 goto DO_RETURN;
             }
         }
@@ -744,7 +741,7 @@ BYTE FASTCALL encodeHeaderNext(const InfoHdr& header, InfoHdr* state, BYTE& code
         if (header.untrackedCnt <= SET_UNTRACKED_MAX)
         {
             state->untrackedCnt = header.untrackedCnt;
-            encoding            = SET_UNTRACKED + header.untrackedCnt;
+            encoding            = (BYTE)(SET_UNTRACKED + header.untrackedCnt);
             goto DO_RETURN;
         }
         else if (state->untrackedCnt != HAS_UNTRACKED)
@@ -770,16 +767,16 @@ BYTE FASTCALL encodeHeaderNext(const InfoHdr& header, InfoHdr* state, BYTE& code
             if (initNeeded3(state->epilogSize, header.epilogSize, SET_EPILOGSIZE_MAX, &hint))
             {
                 assert(hint <= SET_EPILOGSIZE_MAX);
-                state->epilogSize = hint;
-                encoding          = SET_EPILOGSIZE + hint;
+                state->epilogSize = (BYTE)hint;
+                encoding          = (BYTE)(SET_EPILOGSIZE + hint);
                 goto DO_RETURN;
             }
             else
             {
                 assert(hint <= 0x7);
                 state->epilogSize <<= 3;
-                state->epilogSize += hint;
-                encoding = NEXT_THREE_EPILOGSIZE + hint;
+                state->epilogSize += (BYTE)hint;
+                encoding = (BYTE)(NEXT_THREE_EPILOGSIZE + hint);
                 goto DO_RETURN;
             }
         }
@@ -801,16 +798,16 @@ BYTE FASTCALL encodeHeaderNext(const InfoHdr& header, InfoHdr* state, BYTE& code
             if (initNeeded3(state->prologSize, header.prologSize, 15, &hint))
             {
                 assert(hint <= 15);
-                state->prologSize = hint;
-                encoding          = SET_PROLOGSIZE + hint;
+                state->prologSize = (BYTE)hint;
+                encoding          = (BYTE)(SET_PROLOGSIZE + hint);
                 goto DO_RETURN;
             }
             else
             {
                 assert(hint <= 0x7);
                 state->prologSize <<= 3;
-                state->prologSize += hint;
-                encoding = NEXT_THREE_PROLOGSIZE + hint;
+                state->prologSize += ((BYTE)hint);
+                encoding = (BYTE)(NEXT_THREE_PROLOGSIZE + hint);
                 goto DO_RETURN;
             }
         }
@@ -1336,7 +1333,7 @@ BYTE FASTCALL encodeHeaderFirst(const InfoHdr& header, InfoHdr* state, int* more
             // exact match found
             GetInfoHdr(n, state);
             *more = 0;
-            return n;
+            return (BYTE)n;
         }
     }
 
@@ -1363,7 +1360,7 @@ BYTE FASTCALL encodeHeaderFirst(const InfoHdr& header, InfoHdr* state, int* more
                 GetInfoHdr(n, state);
                 *pCached = n; // cache the value
                 *more    = 0;
-                return n;
+                return (BYTE)n;
             }
         }
     }
@@ -1408,7 +1405,7 @@ BYTE FASTCALL encodeHeaderFirst(const InfoHdr& header, InfoHdr* state, int* more
         {
             GetInfoHdr(*pCached, state);
             *more = distance;
-            return 0x80 | *pCached;
+            return (BYTE)(0x80 | *pCached);
         }
         else
         {
@@ -1432,7 +1429,7 @@ BYTE FASTCALL encodeHeaderFirst(const InfoHdr& header, InfoHdr* state, int* more
             GetInfoHdr(n, state);
             *pCached = n; // Cache this value
             *more    = distance;
-            return 0x80 | n;
+            return (BYTE)(0x80 | n);
         }
         else if (distance < closeness)
         {
@@ -1459,7 +1456,7 @@ BYTE FASTCALL encodeHeaderFirst(const InfoHdr& header, InfoHdr* state, int* more
             GetInfoHdr(n, state);
             *pCached = n; // Cache this value
             *more    = distance;
-            return 0x80 | n;
+            return (BYTE)(0x80 | n);
         }
         else if (distance < closeness)
         {
@@ -1477,7 +1474,7 @@ BYTE FASTCALL encodeHeaderFirst(const InfoHdr& header, InfoHdr* state, int* more
     GetInfoHdr(nearest, state);
     *pCached = nearest; // Cache this value
     *more    = closeness;
-    return 0x80 | nearest;
+    return (BYTE)(0x80 | nearest);
 }
 
 /*****************************************************************************
@@ -2542,7 +2539,7 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
             if ((codeDelta >= 8) && (codeDelta <= (64 + 7)))
             {
                 unsigned biggerDelta = ((codeDelta - 8) & 0x38) + 8;
-                *dest++              = 0xF0 | ((biggerDelta - 8) >> 3);
+                *dest++              = (BYTE)(0xF0 | ((biggerDelta - 8) >> 3));
                 lastOffset += biggerDelta;
                 codeDelta &= 0x07;
             }
@@ -2606,7 +2603,7 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
 
                         bool isPop = genRegPtrTemp->rpdArgTypeGet() == rpdARG_POP;
 
-                        *dest++ = 0x80 | (BYTE)codeDelta | genRegPtrTemp->rpdPtrArg << 3 | isPop << 6;
+                        *dest++ = (BYTE)(0x80 | (BYTE)codeDelta | genRegPtrTemp->rpdPtrArg << 3 | isPop << 6);
 
                         /* Remember the new 'last' offset */
 
@@ -2708,7 +2705,7 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
                      */
 
                     assert((codeDelta & 0x7) == codeDelta);
-                    *dest++ = 0x00 | regNum << 3 | (BYTE)codeDelta;
+                    *dest++ = (BYTE)(0x00 | regNum << 3 | (BYTE)codeDelta);
 
                     /* Turn the bit we've just generated off and continue */
 
@@ -2763,7 +2760,7 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
                     }
 
                     assert((codeDelta & 0x7) == codeDelta);
-                    *dest++ = 0x40 | (regNum << 3) | (BYTE)codeDelta;
+                    *dest++ = (BYTE)(0x40 | (regNum << 3) | (BYTE)codeDelta);
 
                     /* Turn the bit we've just generated off and continue */
 
@@ -2925,7 +2922,7 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
             {
                 totalSize += 1;
                 if (mask)
-                    *dest++ = thisPtrRegEnc;
+                    *dest++ = (BYTE)thisPtrRegEnc;
             }
         }
 
@@ -2981,7 +2978,7 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
                 if (mask != 0)
                 {
                     *dest++       = 0xFB;
-                    *dest++       = (byrefRegMask << 4) | regMask;
+                    *dest++       = (BYTE)((byrefRegMask << 4) | regMask);
                     *(DWORD*)dest = codeDelta;
                     dest += sizeof(DWORD);
                     *(DWORD*)dest = argCnt;
@@ -3014,23 +3011,23 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
             /* Check if we can use a tiny encoding */
             else if ((codeDelta < 16) && (codeDelta != 0) && (call->u1.cdArgMask == 0) && !byref)
             {
-                *dest++ = (regMask << 4) | (BYTE)codeDelta;
+                *dest++ = (BYTE)((regMask << 4) | (BYTE)codeDelta);
             }
 
             /* Check if we can use the small encoding */
             else if ((codeDelta < 0x79) && (call->u1.cdArgMask <= 0x1F) && !byref)
             {
                 *dest++ = 0x80 | (BYTE)codeDelta;
-                *dest++ = call->u1.cdArgMask | (regMask << 5);
+                *dest++ = (BYTE)(call->u1.cdArgMask | (regMask << 5));
             }
 
             /* Check if we can use the medium encoding */
             else if (codeDelta <= 0x01FF && call->u1.cdArgMask <= 0x0FFF && !byref)
             {
                 *dest++ = 0xFD;
-                *dest++ = call->u1.cdArgMask;
+                *dest++ = (BYTE)call->u1.cdArgMask;
                 *dest++ = ((call->u1.cdArgMask >> 4) & 0xF0) | ((BYTE)codeDelta & 0x0F);
-                *dest++ = (regMask << 5) | (BYTE)((codeDelta >> 4) & 0x1F);
+                *dest++ = (BYTE)(regMask << 5) | (BYTE)((codeDelta >> 4) & 0x1F);
             }
 
             /* Check if we can use the medium encoding with byrefs */
@@ -3038,15 +3035,15 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
             {
                 *dest++ = 0xF9;
                 *dest++ = (BYTE)codeDelta;
-                *dest++ = (regMask << 5) | call->u1.cdArgMask;
-                *dest++ = (byrefRegMask << 5) | call->u1.cdByrefArgMask;
+                *dest++ = (BYTE)((regMask << 5) | call->u1.cdArgMask);
+                *dest++ = (BYTE)((byrefRegMask << 5) | call->u1.cdByrefArgMask);
             }
 
             /* We'll use the large encoding */
             else if (!byref)
             {
                 *dest++       = 0xFE;
-                *dest++       = (byrefRegMask << 4) | regMask;
+                *dest++       = (BYTE)((byrefRegMask << 4) | regMask);
                 *(DWORD*)dest = codeDelta;
                 dest += sizeof(DWORD);
                 *(DWORD*)dest = call->u1.cdArgMask;
@@ -3057,7 +3054,7 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
             else
             {
                 *dest++       = 0xFA;
-                *dest++       = (byrefRegMask << 4) | regMask;
+                *dest++       = (BYTE)((byrefRegMask << 4) | regMask);
                 *(DWORD*)dest = codeDelta;
                 dest += sizeof(DWORD);
                 *(DWORD*)dest = call->u1.cdArgMask;
@@ -3273,7 +3270,7 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
                         if (mask)
                         {
                             *dest++       = 0xF8;
-                            *dest++       = (byrefRegMask << 4) | regMask;
+                            *dest++       = (BYTE)((byrefRegMask << 4) | regMask);
                             *(DWORD*)dest = codeDelta;
                             dest += sizeof(DWORD);
                             *(DWORD*)dest = callArgCnt;
@@ -3370,7 +3367,7 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
                             CHK_NON_INTRPT_ESP_IPtrMask;
 
                             assert((pattern >= 0) && (pattern < 80));
-                            *dest++ = 0x80 | pattern;
+                            *dest++ = (BYTE)(0x80 | pattern);
                             goto NEXT_RPD;
                         }
 
@@ -3411,8 +3408,8 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
                                     // Emit IPtrMask if needed
                                     CHK_NON_INTRPT_ESP_IPtrMask;
 
-                                    *dest++ = 0xD0 | regMask;
-                                    *dest++ = (inx << 6) | (callArgCnt << 3) | argMask;
+                                    *dest++ = (BYTE)(0xD0 | regMask);
+                                    *dest++ = (BYTE)((inx << 6) | (callArgCnt << 3) | argMask);
                                     goto NEXT_RPD;
                                 }
                             }
@@ -3467,7 +3464,7 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
                     /* use encoding:                                   */
                     /*   call 1110RRRR [ArgCnt] [ArgMask]              */
 
-                    *dest++ = 0xE0 | regMask;
+                    *dest++ = (BYTE)(0xE0 | regMask);
                     dest += encodeUnsigned(dest, callArgCnt);
 
                     dest += encodeUnsigned(dest, argMask);
@@ -4509,7 +4506,9 @@ void GCInfo::gcMakeRegPtrTable(
                 if (mode == MAKE_REG_PTR_MODE_DO_WORK)
                 {
                     pCallSites[callSiteNum]     = callOffset;
-                    pCallSiteSizes[callSiteNum] = call->cdCallInstrSize;
+
+                    assert(call->cdCallInstrSize <= BYTE_MAX);
+                    pCallSiteSizes[callSiteNum] = (BYTE)call->cdCallInstrSize;
                 }
                 callSiteNum++;
 

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -513,10 +513,10 @@ int FASTCALL lookupCallPattern(unsigned argCnt, unsigned regMask, unsigned argMa
     {
         CallPattern pat;
 
-        pat.fld.argCnt    = (unsigned char)argCnt;
-        pat.fld.regMask   = (unsigned char)regMask; // EBP,EBX,ESI,EDI
-        pat.fld.argMask   = (unsigned char)argMask;
-        pat.fld.codeDelta = (unsigned char)codeDelta;
+        pat.fld.argCnt    = (BYTE)argCnt;
+        pat.fld.regMask   = (BYTE)regMask; // EBP,EBX,ESI,EDI
+        pat.fld.argMask   = (BYTE)argMask;
+        pat.fld.codeDelta = (BYTE)codeDelta;
 
         bool     codeDeltaOK = (pat.fld.codeDelta == codeDelta);
         unsigned bestDelta2  = 0xff;
@@ -4505,7 +4505,7 @@ void GCInfo::gcMakeRegPtrTable(
                 // Append an entry for the call if doing the real thing.
                 if (mode == MAKE_REG_PTR_MODE_DO_WORK)
                 {
-                    pCallSites[callSiteNum]     = callOffset;
+                    pCallSites[callSiteNum] = callOffset;
 
                     assert(call->cdCallInstrSize <= BYTE_MAX);
                     pCallSiteSizes[callSiteNum] = (BYTE)call->cdCallInstrSize;
@@ -4661,7 +4661,8 @@ void GCInfo::gcInfoRecordGCRegStateChange(GcInfoEncoder* gcInfoEncoder,
             regFlags = (GcSlotFlags)(regFlags | GC_SLOT_INTERIOR);
         }
 
-        RegSlotIdKey rskey(regNum, regFlags);
+        assert(regNum == (regNumberSmall)regNum);
+        RegSlotIdKey rskey((unsigned short)regNum, regFlags);
         GcSlotId     regSlotId;
         if (mode == MAKE_REG_PTR_MODE_ASSIGN_SLOTS)
         {

--- a/src/coreclr/jit/jitgcinfo.h
+++ b/src/coreclr/jit/jitgcinfo.h
@@ -53,7 +53,8 @@ struct StackSlotIdKey
     {
     }
 
-    StackSlotIdKey(int offset, bool fpRel, unsigned flags) : m_offset(offset), m_fpRel(fpRel), m_flags((unsigned short)flags)
+    StackSlotIdKey(int offset, bool fpRel, unsigned flags)
+        : m_offset(offset), m_fpRel(fpRel), m_flags((unsigned short)flags)
     {
         assert(flags == m_flags);
     }

--- a/src/coreclr/jit/jitgcinfo.h
+++ b/src/coreclr/jit/jitgcinfo.h
@@ -20,14 +20,14 @@
 // Shash typedefs
 struct RegSlotIdKey
 {
-    unsigned short m_regNum;
+    unsigned m_regNum;
     unsigned short m_flags;
 
     RegSlotIdKey()
     {
     }
 
-    RegSlotIdKey(unsigned short regNum, unsigned short flags) : m_regNum(regNum), m_flags(flags)
+    RegSlotIdKey(unsigned regNum, unsigned short flags) : m_regNum(regNum), m_flags(flags)
     {
     }
 

--- a/src/coreclr/jit/jitgcinfo.h
+++ b/src/coreclr/jit/jitgcinfo.h
@@ -20,15 +20,16 @@
 // Shash typedefs
 struct RegSlotIdKey
 {
-    unsigned m_regNum;
+    unsigned short m_regNum;
     unsigned short m_flags;
 
     RegSlotIdKey()
     {
     }
 
-    RegSlotIdKey(unsigned regNum, unsigned short flags) : m_regNum(regNum), m_flags(flags)
+    RegSlotIdKey(unsigned short regNum, unsigned flags) : m_regNum(regNum), m_flags((unsigned short)flags)
     {
+        assert(m_flags == flags);
     }
 
     static unsigned GetHashCode(RegSlotIdKey rsk)
@@ -52,8 +53,9 @@ struct StackSlotIdKey
     {
     }
 
-    StackSlotIdKey(int offset, bool fpRel, unsigned short flags) : m_offset(offset), m_fpRel(fpRel), m_flags(flags)
+    StackSlotIdKey(int offset, bool fpRel, unsigned flags) : m_offset(offset), m_fpRel(fpRel), m_flags((unsigned short)flags)
     {
+        assert(flags == m_flags);
     }
 
     static unsigned GetHashCode(StackSlotIdKey ssk)

--- a/src/coreclr/pal/inc/rt/intsafe.h
+++ b/src/coreclr/pal/inc/rt/intsafe.h
@@ -49,8 +49,6 @@
 
 #endif
 
-#define DWORD_MAX       0xffffffffUL
-
 //
 // It is common for -1 to be used as an error value for various types
 //

--- a/src/coreclr/utilcode/stgpooli.cpp
+++ b/src/coreclr/utilcode/stgpooli.cpp
@@ -309,9 +309,6 @@ ULONG CPackedLen::GetLength(			// Length or -1 on error.
 //*****************************************************************************
 // Encode a length.
 //*****************************************************************************
-#ifdef _MSC_VER
-#pragma warning(disable:4244) // conversion from unsigned long to unsigned char
-#endif
 void* CPackedLen::PutLength(			// First byte past length.
 	void		*pData, 				// Pack the length here.
 	ULONG		iLen)					// The length.
@@ -323,13 +320,13 @@ void* CPackedLen::PutLength(			// First byte past length.
 
 	if (iLen <= 0x7F)
 	{
-		*pBytes = iLen;
+		*pBytes = (BYTE)iLen;
 		return pBytes + 1;
 	}
 
 	if (iLen <= 0x3FFF)
 	{
-		*pBytes = (iLen >> 8) | 0x80;
+		*pBytes = (BYTE)((iLen >> 8) | 0x80);
 		*(pBytes+1) = iLen & 0xFF;
 		return pBytes + 2;
 	}
@@ -341,7 +338,3 @@ void* CPackedLen::PutLength(			// First byte past length.
 	*(pBytes+3) = iLen & 0xFF;
 	return pBytes + 4;
 } // void* CPackedLen::PutLength()
-#ifdef _MSC_VER
-#pragma warning(default:4244) // conversion from unsigned long to unsigned char
-#endif
-

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -64,11 +64,6 @@
 #include "typekey.h"
 #include "peimagelayout.inl"
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4244)
-#endif // _MSC_VER
-
 #ifdef TARGET_64BIT
 #define COR_VTABLE_PTRSIZED     COR_VTABLE_64BIT
 #define COR_VTABLE_NOT_PTRSIZED COR_VTABLE_32BIT
@@ -1854,9 +1849,10 @@ void Module::FreeModuleIndex(ModuleIndex index)
     WRAPPER_NO_CONTRACT;
     // We subtracted 1 after we allocated this ID, so we need to
     // add 1 before we free it.
-    DWORD val = index.m_dwIndex + 1;
+    SIZE_T val = index.m_dwIndex + 1;
 
-    g_pModuleIndexDispenser->DisposeId(val);
+    _ASSERTE(val <= DWORD_MAX);
+    g_pModuleIndexDispenser->DisposeId((DWORD)val);
 }
 
 
@@ -4790,7 +4786,7 @@ ICorJitInfo::BlockCounts * Module::AllocateMethodBlockCounts(mdToken _token, DWO
     }
     CONTRACT_END;
 
-    assert(_ILSize != 0);
+    _ASSERTE(_ILSize != 0);
 
     DWORD   listSize   = sizeof(CORCOMPILE_METHOD_PROFILE_LIST);
     DWORD   headerSize = sizeof(CORBBTPROF_METHOD_HEADER);
@@ -4809,7 +4805,7 @@ ICorJitInfo::BlockCounts * Module::AllocateMethodBlockCounts(mdToken _token, DWO
     methodProfileData->method.ILSize = _ILSize;
     methodProfileData->method.cBlock = _count;
 
-    assert(methodProfileData->size == methodProfileData->Size());
+    _ASSERTE(methodProfileData->size == methodProfileData->Size());
 
     // Link it to the per module list of profile data buffers
 
@@ -5026,10 +5022,12 @@ public:
             for (SectionList *pSec = pSectionList; pSec; pSec = pSec->next, secCount++)
             {
                 SIZE_T offset = profileMap->getCurrentOffset();
-                assert((offset & 0x3) == 0);
+                _ASSERTE((offset & 0x3) == 0);
+                _ASSERTE(offset <= DWORD_MAX);
 
                 SIZE_T actualSize  = pSec->profileMap.getCurrentOffset();
                 SIZE_T alignUpSize = AlignUp(actualSize, sizeof(DWORD));
+                _ASSERTE(alignUpSize <= DWORD_MAX);
 
                 profileMap->Allocate(alignUpSize);
 
@@ -5043,8 +5041,8 @@ public:
                 tableEntry = (CORBBTPROF_SECTION_TABLE_ENTRY *) profileMap->getOffsetPtr(tableEntryOffset);
                 tableEntry += secCount;
                 tableEntry->FormatID    = pSec->format;
-                tableEntry->Data.Offset = offset;
-                tableEntry->Data.Size   = alignUpSize;
+                tableEntry->Data.Offset = (DWORD)offset;
+                tableEntry->Data.Size   = (DWORD)alignUpSize;
             }
         }
 
@@ -5952,12 +5950,14 @@ static void ProfileDataAllocateScenarioInfo(ProfileEmitter * pEmitter, LPCSTR sc
             sHeaderOffset = profileMap->getCurrentOffset();
             sHeader = (CORBBTPROF_SCENARIO_HEADER *) profileMap->Allocate(sizeHeader.Value());
 
-            sHeader->size              = sHeaderSize.Value();
+            _ASSERTE(sHeaderSize.Value() <= DWORD_MAX);
+            _ASSERTE(cName.Value() <= DWORD_MAX);
+            sHeader->size              = (DWORD)sHeaderSize.Value();
             sHeader->scenario.ordinal  = 1;
             sHeader->scenario.mask     = 1;
             sHeader->scenario.priority = 0;
             sHeader->scenario.numRuns  = 1;
-            sHeader->scenario.cName    = cName.Value();
+            sHeader->scenario.cName    = (DWORD)cName.Value();
             wcscpy_s(sHeader->scenario.name, cName.Value(), pName);
         }
 
@@ -5968,10 +5968,12 @@ static void ProfileDataAllocateScenarioInfo(ProfileEmitter * pEmitter, LPCSTR sc
             CORBBTPROF_SCENARIO_RUN *sRun;
             sRun = (CORBBTPROF_SCENARIO_RUN *)  profileMap->Allocate(sizeRun.Value());
 
+            _ASSERTE(cCmdLine.Value() <= DWORD_MAX);
+            _ASSERTE(cSystemInfo.Value() <= DWORD_MAX);
             sRun->runTime     = runTime;
             sRun->mvid        = *pMvid;
-            sRun->cCmdLine    = cCmdLine.Value();
-            sRun->cSystemInfo = cSystemInfo.Value();
+            sRun->cCmdLine    = (DWORD)cCmdLine.Value();
+            sRun->cSystemInfo = (DWORD)cSystemInfo.Value();
             wcscpy_s(sRun->cmdLine, cCmdLine.Value(), pCmdLine);
             wcscpy_s(sRun->cmdLine+cCmdLine.Value(), cSystemInfo.Value(), pSystemInfo);
         }
@@ -5979,7 +5981,7 @@ static void ProfileDataAllocateScenarioInfo(ProfileEmitter * pEmitter, LPCSTR sc
         {
             CORBBTPROF_SCENARIO_HEADER * sHeader;
             sHeader = (CORBBTPROF_SCENARIO_HEADER *) profileMap->getOffsetPtr(sHeaderOffset);
-            assert(sHeader->size == sHeader->Size());
+            _ASSERTE(sHeader->size == sHeader->Size());
         }
 #endif
     }
@@ -6018,7 +6020,7 @@ static void ProfileDataAllocateMethodBlockCounts(ProfileEmitter * pEmitter, CORC
     {
         CORBBTPROF_METHOD_HEADER * pInfo = methodProfileList->GetInfo();
 
-        assert(pInfo->size == pInfo->Size());
+        _ASSERTE(pInfo->size == pInfo->Size());
 
         //
         // We set methodWasExecuted based upon the ExecutionCount of the very first block
@@ -6087,7 +6089,8 @@ static void ProfileDataAllocateMethodBlockCounts(ProfileEmitter * pEmitter, CORC
                     profileMap->Allocate(sizeof(CORBBTPROF_TOKEN_LIST_SECTION_HEADER) +
                                          pTokenArray->Size() * sizeof(CORBBTPROF_TOKEN_INFO));
 
-                header->NumTokens = pTokenArray->Size();
+                _ASSERTE(pTokenArray->Size() <= DWORD_MAX);
+                header->NumTokens = (DWORD)pTokenArray->Size();
                 memcpy( (header + 1), &((*pTokenArray)[0]), pTokenArray->Size() * sizeof(CORBBTPROF_TOKEN_INFO));
 
                 // Reset the collected tokens
@@ -6348,7 +6351,8 @@ HRESULT Module::WriteMethodProfileDataLogFile(bool cleanup)
             HandleHolder profileDataFile(OpenMethodProfileDataLogFile(mvid));
 
             ULONG count;
-            BOOL result = WriteFile(profileDataFile, profileImage.getOffsetPtr(0), profileImage.getCurrentOffset(), &count, NULL);
+            _ASSERTE(profileImage.getCurrentOffset() <= DWORD_MAX);
+            BOOL result = WriteFile(profileDataFile, profileImage.getOffsetPtr(0), (DWORD)profileImage.getCurrentOffset(), &count, NULL);
             if (!result || (count != profileImage.getCurrentOffset()))
             {
                 DWORD lasterror = GetLastError();
@@ -7848,10 +7852,6 @@ bool Module::HasReferenceByName(LPCUTF8 pModuleName)
     return false;
 }
 #endif
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif // _MSC_VER: warning C4244
 
 #if defined(_DEBUG) && !defined(DACCESS_COMPILE)
 NOINLINE void NgenForceFailure_AV()

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -1851,7 +1851,7 @@ void Module::FreeModuleIndex(ModuleIndex index)
     // add 1 before we free it.
     SIZE_T val = index.m_dwIndex + 1;
 
-    _ASSERTE(val <= DWORD_MAX);
+    _ASSERTE(val <= MAXDWORD);
     g_pModuleIndexDispenser->DisposeId((DWORD)val);
 }
 
@@ -5023,11 +5023,11 @@ public:
             {
                 SIZE_T offset = profileMap->getCurrentOffset();
                 _ASSERTE((offset & 0x3) == 0);
-                _ASSERTE(offset <= DWORD_MAX);
+                _ASSERTE(offset <= MAXDWORD);
 
                 SIZE_T actualSize  = pSec->profileMap.getCurrentOffset();
                 SIZE_T alignUpSize = AlignUp(actualSize, sizeof(DWORD));
-                _ASSERTE(alignUpSize <= DWORD_MAX);
+                _ASSERTE(alignUpSize <= MAXDWORD);
 
                 profileMap->Allocate(alignUpSize);
 
@@ -5950,8 +5950,8 @@ static void ProfileDataAllocateScenarioInfo(ProfileEmitter * pEmitter, LPCSTR sc
             sHeaderOffset = profileMap->getCurrentOffset();
             sHeader = (CORBBTPROF_SCENARIO_HEADER *) profileMap->Allocate(sizeHeader.Value());
 
-            _ASSERTE(sHeaderSize.Value() <= DWORD_MAX);
-            _ASSERTE(cName.Value() <= DWORD_MAX);
+            _ASSERTE(sHeaderSize.Value() <= MAXDWORD);
+            _ASSERTE(cName.Value() <= MAXDWORD);
             sHeader->size              = (DWORD)sHeaderSize.Value();
             sHeader->scenario.ordinal  = 1;
             sHeader->scenario.mask     = 1;
@@ -5968,8 +5968,8 @@ static void ProfileDataAllocateScenarioInfo(ProfileEmitter * pEmitter, LPCSTR sc
             CORBBTPROF_SCENARIO_RUN *sRun;
             sRun = (CORBBTPROF_SCENARIO_RUN *)  profileMap->Allocate(sizeRun.Value());
 
-            _ASSERTE(cCmdLine.Value() <= DWORD_MAX);
-            _ASSERTE(cSystemInfo.Value() <= DWORD_MAX);
+            _ASSERTE(cCmdLine.Value() <= MAXDWORD);
+            _ASSERTE(cSystemInfo.Value() <= MAXDWORD);
             sRun->runTime     = runTime;
             sRun->mvid        = *pMvid;
             sRun->cCmdLine    = (DWORD)cCmdLine.Value();
@@ -6089,7 +6089,7 @@ static void ProfileDataAllocateMethodBlockCounts(ProfileEmitter * pEmitter, CORC
                     profileMap->Allocate(sizeof(CORBBTPROF_TOKEN_LIST_SECTION_HEADER) +
                                          pTokenArray->Size() * sizeof(CORBBTPROF_TOKEN_INFO));
 
-                _ASSERTE(pTokenArray->Size() <= DWORD_MAX);
+                _ASSERTE(pTokenArray->Size() <= MAXDWORD);
                 header->NumTokens = (DWORD)pTokenArray->Size();
                 memcpy( (header + 1), &((*pTokenArray)[0]), pTokenArray->Size() * sizeof(CORBBTPROF_TOKEN_INFO));
 
@@ -6351,7 +6351,7 @@ HRESULT Module::WriteMethodProfileDataLogFile(bool cleanup)
             HandleHolder profileDataFile(OpenMethodProfileDataLogFile(mvid));
 
             ULONG count;
-            _ASSERTE(profileImage.getCurrentOffset() <= DWORD_MAX);
+            _ASSERTE(profileImage.getCurrentOffset() <= MAXDWORD);
             BOOL result = WriteFile(profileDataFile, profileImage.getOffsetPtr(0), (DWORD)profileImage.getCurrentOffset(), &count, NULL);
             if (!result || (count != profileImage.getCurrentOffset()))
             {

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -36,11 +36,6 @@
 #include "clrtocomcall.h"
 #endif
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4244)
-#endif // _MSC_VER
-
 #ifdef FEATURE_MINIMETADATA_IN_TRIAGEDUMPS
 GVAL_IMPL(DWORD, g_MiniMetaDataBuffMaxSize);
 GVAL_IMPL(TADDR, g_MiniMetaDataBuffAddress);
@@ -1730,7 +1725,7 @@ MethodDescChunk *MethodDescChunk::CreateChunk(LoaderHeap *pHeap, DWORD methodDes
 
     _ASSERTE((oneSize & MethodDesc::ALIGNMENT_MASK) == 0);
 
-    DWORD maxMethodDescsPerChunk = MethodDescChunk::MaxSizeOfMethodDescs / oneSize;
+    DWORD maxMethodDescsPerChunk = (DWORD)(MethodDescChunk::MaxSizeOfMethodDescs / oneSize);
 
     if (methodDescCount == 0)
         methodDescCount = maxMethodDescsPerChunk;
@@ -4113,7 +4108,3 @@ void MethodDesc::PrepareForUseAsAFunctionPointer()
     SetValueTypeParametersLoaded();
 }
 #endif //!DACCESS_COMPILE
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif // _MSC_VER: warning C4244

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -2260,7 +2260,7 @@ public:
         m_methodTable = pMT;
     }
 
-    inline void SetSizeAndCount(ULONG sizeOfMethodDescs, COUNT_T methodDescCount)
+    inline void SetSizeAndCount(SIZE_T sizeOfMethodDescs, COUNT_T methodDescCount)
     {
         LIMITED_METHOD_CONTRACT;
 

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -7053,7 +7053,7 @@ VOID MethodTableBuilder::AllocAndInitMethodDescChunk(COUNT_T startIndex, COUNT_T
     }
     _ASSERTE(offset == sizeof(MethodDescChunk) + sizeOfMethodDescs);
 
-    pChunk->SetSizeAndCount((ULONG)sizeOfMethodDescs, methodDescCount);
+    pChunk->SetSizeAndCount(sizeOfMethodDescs, methodDescCount);
 
     GetHalfBakedClass()->AddChunk(pChunk);
 }

--- a/src/coreclr/vm/typehash.cpp
+++ b/src/coreclr/vm/typehash.cpp
@@ -16,11 +16,6 @@
 #include "typekey.h"
 #include "dacenumerablehash.inl"
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4244)
-#endif // _MSC_VER
-
 #ifndef DACCESS_COMPILE
 
 // ============================================================================
@@ -168,7 +163,7 @@ static DWORD HashPossiblyInstantiatedType(mdTypeDef token, Instantiation inst)
         }
     }
 
-    return dwHash;
+    return (DWORD)dwHash;
 }
 
 // Calculate hash value for a function pointer type
@@ -187,7 +182,7 @@ static DWORD HashFnPtrType(BYTE callConv, DWORD numArgs, TypeHandle *retAndArgTy
         dwHash = ((dwHash << 5) + dwHash) ^ retAndArgTypes[i].AsTAddr();
     }
 
-    return dwHash;
+    return (DWORD)dwHash;
 }
 
 // Calculate hash value for an array/pointer/byref type
@@ -199,7 +194,7 @@ static DWORD HashParamType(CorElementType kind, TypeHandle typeParam)
     dwHash = ((dwHash << 5) + dwHash) ^ kind;
     dwHash = ((dwHash << 5) + dwHash) ^ typeParam.AsTAddr();
 
-    return dwHash;
+    return (DWORD)dwHash;
 }
 
 // Calculate hash value from type handle
@@ -234,10 +229,13 @@ static DWORD HashTypeHandle(TypeHandle t)
     else if (t.IsGenericVariable())
     {
         _ASSERTE(!"Generic variables are unexpected here.");
-        retVal = t.AsTAddr();
+        // Revisit the cast to DWORD if this path becomes viable.
+        retVal = (DWORD)t.AsTAddr();
     }
     else
+    {
         retVal = HashPossiblyInstantiatedType(t.GetCl(), Instantiation());
+    }
 
     return retVal;
 }
@@ -578,7 +576,3 @@ void EETypeHashEntry::SetTypeHandle(TypeHandle handle)
     m_data = handle.AsPtr();
 }
 #endif // !DACCESS_COMPILE
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif // _MSC_VER: warning C4244

--- a/src/coreclr/vm/typehash.cpp
+++ b/src/coreclr/vm/typehash.cpp
@@ -229,8 +229,7 @@ static DWORD HashTypeHandle(TypeHandle t)
     else if (t.IsGenericVariable())
     {
         _ASSERTE(!"Generic variables are unexpected here.");
-        // Revisit the cast to DWORD if this path becomes viable.
-        retVal = (DWORD)t.AsTAddr();
+        retVal = 0;
     }
     else
     {


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/66154

Reenable and fix MSVC compiler warnings under `coreclr/`.

/cc @GrabYourPitchforks @jkotas @janvorli 


