### PR TITLE
Update CancellationToken.cs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationToken.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationToken.cs
@@ -351,8 +351,6 @@ namespace System.Threading
         /// </code>
         /// </remarks>
         /// <exception cref="System.OperationCanceledException">The token has had cancellation requested.</exception>
-        /// <exception cref="System.ObjectDisposedException">The associated <see
-        /// cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see> has been disposed.</exception>
         public void ThrowIfCancellationRequested()
         {
             if (IsCancellationRequested)


### PR DESCRIPTION
Remove ObjectDisposedException from doc since the method doesn't throw the exception.

Fixes https://github.com/dotnet/runtime/issues/66369