### PR TITLE
Arm64: Always use SIMD features 

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2666,8 +2666,12 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
 #endif // DEBUG
 
 #ifdef FEATURE_SIMD
+
+#ifndef TARGET_ARM64
     // Minimum bar for availing SIMD benefits is SSE2 on AMD64/x86.
     featureSIMD = jitFlags->IsSet(JitFlags::JIT_FLAG_FEATURE_SIMD);
+#endif
+
     setUsesSIMDTypes(false);
 #endif // FEATURE_SIMD
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8856,8 +8856,10 @@ private:
 
 #ifdef FEATURE_SIMD
 
+#ifndef TARGET_ARM64
     // Should we support SIMD intrinsics?
     bool featureSIMD;
+#endif
 
     // Should we recognize SIMD types?
     // We always do this on ARM64 to support HVA types.

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -574,7 +574,7 @@ GenTree* Compiler::addRangeCheckForHWIntrinsic(GenTree* immOp, int immLowerBound
 //    true iff the given instruction set is enabled via configuration (environment variables, etc.).
 bool Compiler::compSupportsHWIntrinsic(CORINFO_InstructionSet isa)
 {
-    return compHWIntrinsicDependsOn(isa) && (featureSIMD || HWIntrinsicInfo::isScalarIsa(isa)) &&
+    return compHWIntrinsicDependsOn(isa) && (supportSIMDTypes() || HWIntrinsicInfo::isScalarIsa(isa)) &&
            (
 #ifdef DEBUG
                JitConfig.EnableIncompleteISAClass() ||
@@ -766,7 +766,7 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
     var_types              retType         = JITtype2varType(sig->retType);
     CorInfoType            simdBaseJitType = CORINFO_TYPE_UNDEF;
 
-    if ((retType == TYP_STRUCT) && featureSIMD)
+    if ((retType == TYP_STRUCT) && supportSIMDTypes())
     {
         unsigned int sizeBytes;
         simdBaseJitType = getBaseJitTypeAndSizeOfSIMDType(sig->retTypeSigClass, &sizeBytes);
@@ -805,7 +805,7 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
         }
         else
         {
-            assert(featureSIMD);
+            assert(supportSIMDTypes());
             unsigned int sizeBytes;
 
             simdBaseJitType = getBaseJitTypeAndSizeOfSIMDType(clsHnd, &sizeBytes);

--- a/src/coreclr/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/jit/hwintrinsicarm64.cpp
@@ -325,7 +325,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
     assert(category != HW_Category_Scalar);
     assert(!HWIntrinsicInfo::isScalarIsa(HWIntrinsicInfo::lookupIsa(intrinsic)));
 
-    if (!featureSIMD || !IsBaselineSimdIsaSupported())
+    if (!supportSIMDTypes() || !IsBaselineSimdIsaSupported())
     {
         return nullptr;
     }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -8916,7 +8916,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
         }
 
 #ifdef FEATURE_SIMD
-        if (featureSIMD)
+        if (supportSIMDTypes())
         {
             call = impSIMDIntrinsic(opcode, newobjThis, clsHnd, methHnd, sig, mflags, pResolvedToken->token);
             if (call != nullptr)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5260,7 +5260,7 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
     }
 
 #ifdef FEATURE_SIMD
-    if (featureSIMD && varTypeIsStruct(elemTyp) && structSizeMightRepresentSIMDType(elemSize))
+    if (supportSIMDTypes() && varTypeIsStruct(elemTyp) && structSizeMightRepresentSIMDType(elemSize))
     {
         // If this is a SIMD type, this is the point at which we lose the type information,
         // so we need to set the correct type on the GT_IND.

--- a/src/coreclr/jit/simd.cpp
+++ b/src/coreclr/jit/simd.cpp
@@ -950,7 +950,7 @@ const SIMDIntrinsicInfo* Compiler::getSIMDIntrinsicInfo(CORINFO_CLASS_HANDLE* in
                                                         CorInfoType*          simdBaseJitType,
                                                         unsigned*             sizeBytes)
 {
-    assert(featureSIMD);
+    assert(supportSIMDTypes());
     assert(simdBaseJitType != nullptr);
     assert(sizeBytes != nullptr);
 
@@ -1798,7 +1798,7 @@ GenTree* Compiler::createAddressNodeForSIMDInit(GenTree* tree, unsigned simdSize
 
 void Compiler::impMarkContiguousSIMDFieldAssignments(Statement* stmt)
 {
-    if (!featureSIMD || opts.OptimizationDisabled())
+    if (!supportSIMDTypes() || opts.OptimizationDisabled())
     {
         return;
     }
@@ -1891,7 +1891,7 @@ GenTree* Compiler::impSIMDIntrinsic(OPCODE                opcode,
                                     unsigned              methodFlags,
                                     int                   memberRef)
 {
-    assert(featureSIMD);
+    assert(supportSIMDTypes());
 
     // Exit early if we are not in one of the SIMD types.
     if (!isSIMDClass(clsHnd))

--- a/src/coreclr/jit/simdashwintrinsic.cpp
+++ b/src/coreclr/jit/simdashwintrinsic.cpp
@@ -170,7 +170,7 @@ GenTree* Compiler::impSimdAsHWIntrinsic(NamedIntrinsic        intrinsic,
                                         CORINFO_SIG_INFO*     sig,
                                         GenTree*              newobjThis)
 {
-    if (!featureSIMD)
+    if (!supportSIMDTypes())
     {
         // We can't support SIMD intrinsics if the JIT doesn't support the feature
         return nullptr;
@@ -356,7 +356,7 @@ GenTree* Compiler::impSimdAsHWIntrinsicSpecial(NamedIntrinsic       intrinsic,
 {
     var_types simdBaseType = JitType2PreciseVarType(simdBaseJitType);
 
-    assert(featureSIMD);
+    assert(supportSIMDTypes());
     assert(retType != TYP_UNKNOWN);
     assert(varTypeIsArithmetic(simdBaseType));
     assert(simdSize != 0);


### PR DESCRIPTION
On Arm64, we always support SIMD types but in the code base, we were sometimes relying on `featureSIMD` flag which can be `false` in case `COMPlus_FeatureSIMD=0` and doesn't work on Arm64. On Arm64, we always need SIMD features to support ABI handling. Modified all the usages to instead use `supportSIMDTypes()`.

Will fix https://github.com/dotnet/runtime/issues/64972

Thanks @tannergooding for your the references:

- https://github.com/dotnet/runtime/issues/66206
- https://github.com/dotnet/runtime/issues/11701
- https://github.com/dotnet/runtime/issues/9473.