### PR TITLE
Remove _socket field from HttpConnection 

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -43,7 +43,6 @@ namespace System.Net.Http
         private static readonly ulong s_http11Bytes = BitConverter.ToUInt64(Encoding.ASCII.GetBytes("HTTP/1.1"));
 
         private readonly HttpConnectionPool _pool;
-        private readonly Socket? _socket; // used for polling; _stream should be used for all reading/writing. _stream owns disposal.
         private readonly Stream _stream;
         private readonly TransportContext? _transportContext;
         private readonly WeakReference<HttpConnection> _weakThisRef;
@@ -74,7 +73,6 @@ namespace System.Net.Http
 
         public HttpConnection(
             HttpConnectionPool pool,
-            Socket? socket,
             Stream stream,
             TransportContext? transportContext)
         {
@@ -83,7 +81,6 @@ namespace System.Net.Http
 
             _pool = pool;
             _stream = stream;
-            _socket = socket;
 
             _transportContext = transportContext;
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -158,13 +158,13 @@ namespace System.Net.Http
             // Check to see if we've received anything on the connection; if we have, that's
             // either erroneous data (we shouldn't have received anything yet) or the connection
             // has been closed; either way, we can't use it.
-            if (!async && _socket is not null)
+            if (!async && _stream is NetworkStream networkStream)
             {
                 // Directly poll the socket rather than doing an async read, so that we can
                 // issue an appropriate sync read when we actually need it.
                 try
                 {
-                    return !_socket.Poll(0, SelectMode.SelectRead);
+                    return !networkStream.Socket.Poll(0, SelectMode.SelectRead);
                 }
                 catch (Exception e) when (e is SocketException || e is ObjectDisposedException)
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1532,12 +1532,7 @@ namespace System.Net.Http
         private async ValueTask<HttpConnection> ConstructHttp11ConnectionAsync(bool async, Socket? socket, Stream stream, TransportContext? transportContext, HttpRequestMessage request, CancellationToken cancellationToken)
         {
             Stream newStream = await ApplyPlaintextFilterAsync(async, stream, HttpVersion.Version11, request, cancellationToken).ConfigureAwait(false);
-            if (newStream != stream)
-            {
-                // If a plaintext filter created a new stream, we can't trust that the socket is still applicable.
-                socket = null;
-            }
-            return new HttpConnection(this, socket, newStream, transportContext);
+            return new HttpConnection(this, newStream, transportContext);
         }
 
         private async ValueTask<Http2Connection> ConstructHttp2ConnectionAsync(Stream stream, HttpRequestMessage request, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1464,9 +1464,8 @@ namespace System.Net.Http
 
         internal async ValueTask<HttpConnection> CreateHttp11ConnectionAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
-            (Socket? socket, Stream stream, TransportContext? transportContext) = await ConnectAsync(request, async, cancellationToken).ConfigureAwait(false);
-
-            return await ConstructHttp11ConnectionAsync(async, socket, stream!, transportContext, request, cancellationToken).ConfigureAwait(false);
+            (Socket? _, Stream stream, TransportContext? transportContext) = await ConnectAsync(request, async, cancellationToken).ConfigureAwait(false);
+            return await ConstructHttp11ConnectionAsync(async, stream, transportContext, request, cancellationToken).ConfigureAwait(false);
         }
 
         private SslClientAuthenticationOptions GetSslOptionsForRequest(HttpRequestMessage request)
@@ -1527,12 +1526,6 @@ namespace System.Net.Http
             }
 
             return newStream;
-        }
-
-        // TODO: this goes away
-        private ValueTask<HttpConnection> ConstructHttp11ConnectionAsync(bool async, Socket? socket, Stream stream, TransportContext? transportContext, HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            return ConstructHttp11ConnectionAsync(async, stream, transportContext, request, cancellationToken);
         }
 
         private async ValueTask<HttpConnection> ConstructHttp11ConnectionAsync(bool async, Stream stream, TransportContext? transportContext, HttpRequestMessage request, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/63710

Also, contributes to https://github.com/dotnet/runtime/issues/66223 by simplifying the interaction between the connection pool and the connection.

