### PR TITLE
Remove dotnet6 feeds

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -18,9 +18,6 @@
     <!-- TODO: Remove dotnet7 feeds when dependencies publish into dotnet8 feeds: https://github.com/dotnet/runtime/issues/63375. -->
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet7-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json" />
-    <!-- TODO: Remove dotnet6 feeds when dependencies publish into dotnet7 feeds: https://github.com/dotnet/runtime/issues/57716. -->
-    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
-    <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
     <!-- Used for the Rich Navigation indexing task -->
     <add key="richnav" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
   </packageSources>

--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -23,7 +23,7 @@
     <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
     <!-- Hardcode the apphost version until the SDK understands the net7.0 tfm. -->
-    <_AppHostBaselinePackVersion Condition="'$(UseLocalAppHostPack)' != 'true'">6.0.0-rc.1.21411.2</_AppHostBaselinePackVersion>
+    <_AppHostBaselinePackVersion Condition="'$(UseLocalAppHostPack)' != 'true'">7.0.0-preview.2.22152.2</_AppHostBaselinePackVersion>
   </PropertyGroup>
 
   <!-- Add Known* items if the SDK doesn't support the TargetFramework yet. -->

--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -23,7 +23,7 @@
     <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
     <!-- Hardcode the apphost version until the SDK understands the net7.0 tfm. -->
-    <_AppHostBaselinePackVersion Condition="'$(UseLocalAppHostPack)' != 'true'">7.0.0-preview.2.22152.2</_AppHostBaselinePackVersion>
+    <_AppHostBaselinePackVersion Condition="'$(UseLocalAppHostPack)' != 'true'">6.0.3</_AppHostBaselinePackVersion>
   </PropertyGroup>
 
   <!-- Add Known* items if the SDK doesn't support the TargetFramework yet. -->

--- a/src/installer/tests/Assets/TestUtils/TestProjects.targets
+++ b/src/installer/tests/Assets/TestUtils/TestProjects.targets
@@ -15,17 +15,17 @@
     <KnownFrameworkReference Include="Microsoft.NETCore.App"
                              TargetFramework="net7.0"
                              RuntimeFrameworkName="Microsoft.NETCore.App"
-                             DefaultRuntimeFrameworkVersion="6.0.0-rc.1.21411.2"
-                             LatestRuntimeFrameworkVersion="6.0.0-rc.1.21411.2"
+                             DefaultRuntimeFrameworkVersion="6.0.3"
+                             LatestRuntimeFrameworkVersion="6.0.3"
                              TargetingPackName="Microsoft.NETCore.App.Ref"
-                             TargetingPackVersion="6.0.0-rc.1.21411.2"
+                             TargetingPackVersion="6.0.3"
                              RuntimePackNamePatterns="Microsoft.NETCore.App.Runtime.**RID**"
                              RuntimePackRuntimeIdentifiers="linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86;linux-musl-arm;osx-arm64;maccatalyst-x64;maccatalyst-arm64" />
 
     <KnownAppHostPack Include="Microsoft.NETCore.App"
                       TargetFramework="net7.0"
                       AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
-                      AppHostPackVersion="6.0.0-rc.1.21411.2"
+                      AppHostPackVersion="6.0.3"
                       AppHostRuntimeIdentifiers="linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86;linux-musl-arm;osx-arm64" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj
@@ -73,7 +73,7 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(TargetOS)' == 'OSX'">
       <TargetTriple Condition="'$(TargetArchitecture)' == 'arm64'">arm64-apple-macos11</TargetTriple>
-      <TargetTriple Condition="'$(TargetArchitecture)' == 'x64'">x86_64-apple-macos10.13</TargetTriple>
+      <TargetTriple Condition="'$(TargetArchitecture)' == 'x64'">x86_64-apple-macos10.14</TargetTriple>
       <XCodeSdkName>macosx</XCodeSdkName>
     </PropertyGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/57716

The current main branch's corresponding feeds are the dotnet7 ones and the dotnet6 ones shouldn't be used.
Please see my comments below for packages that were missing.