### PR TITLE
Support using the system version of brotli 

### DIFF
--- a/src/native/external/brotli.cmake
+++ b/src/native/external/brotli.cmake
@@ -1,4 +1,4 @@
-include_directories("${CMAKE_CURRENT_LIST_DIR}/brotli/include")
+include_directories(BEFORE "${CMAKE_CURRENT_LIST_DIR}/brotli/include")
 
 set (BROTLI_SOURCES_BASE
     common/constants.c

--- a/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
@@ -7,11 +7,20 @@ set(NATIVECOMPRESSION_SOURCES
 )
 
 if (NOT CLR_CMAKE_TARGET_BROWSER)
-    include(${CLR_SRC_NATIVE_DIR}/external/brotli.cmake)
+
+    if (CLR_CMAKE_USE_SYSTEM_BROTLI)
+        add_definitions(-DFEATURE_USE_SYSTEM_BROTLI)
+    else ()
+        include(${CLR_SRC_NATIVE_DIR}/external/brotli.cmake)
+
+        set (NATIVECOMPRESSION_SOURCES
+            ${NATIVECOMPRESSION_SOURCES}
+            ${BROTLI_SOURCES}
+        )
+    endif ()
 
     set (NATIVECOMPRESSION_SOURCES
         ${NATIVECOMPRESSION_SOURCES}
-        ${BROTLI_SOURCES}
         entrypoints.c
     )
 endif ()
@@ -60,14 +69,16 @@ if (CLR_CMAKE_TARGET_UNIX OR CLR_CMAKE_TARGET_BROWSER)
             set_property(TARGET System.IO.Compression.Native APPEND_STRING PROPERTY LINK_FLAGS ${EXPORTS_LINKER_OPTION})
             set_property(TARGET System.IO.Compression.Native APPEND_STRING PROPERTY LINK_DEPENDS ${EXPORTS_FILE})
 
-            add_custom_command(TARGET System.IO.Compression.Native POST_BUILD
-                COMMENT "Verifying System.IO.Compression.Native entry points against entrypoints.c "
-                COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../verify-entrypoints.sh
-                    $<TARGET_FILE:System.IO.Compression.Native>
-                    ${CMAKE_CURRENT_SOURCE_DIR}/entrypoints.c
-                    ${CMAKE_NM}
-                VERBATIM
-            )
+            if (NOT CLR_CMAKE_USE_SYSTEM_BROTLI)
+                add_custom_command(TARGET System.IO.Compression.Native POST_BUILD
+                    COMMENT "Verifying System.IO.Compression.Native entry points against entrypoints.c "
+                    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../verify-entrypoints.sh
+                        $<TARGET_FILE:System.IO.Compression.Native>
+                        ${CMAKE_CURRENT_SOURCE_DIR}/entrypoints.c
+                        ${CMAKE_NM}
+                    VERBATIM
+                )
+            endif ()
         endif ()
 
         install_with_stripped_symbols (System.IO.Compression.Native PROGRAMS .)

--- a/src/native/libs/System.IO.Compression.Native/entrypoints.c
+++ b/src/native/libs/System.IO.Compression.Native/entrypoints.c
@@ -5,10 +5,10 @@
 
 // Include System.IO.Compression.Native headers
 #include "pal_zlib.h"
-#include <external/brotli/include/brotli/decode.h>
-#include <external/brotli/include/brotli/encode.h>
-#include <external/brotli/include/brotli/port.h>
-#include <external/brotli/include/brotli/types.h>
+#include <brotli/decode.h>
+#include <brotli/encode.h>
+#include <brotli/port.h>
+#include <brotli/types.h>
 
 static const Entry s_compressionNative[] =
 {

--- a/src/native/libs/System.IO.Compression.Native/extra_libs.cmake
+++ b/src/native/libs/System.IO.Compression.Native/extra_libs.cmake
@@ -12,4 +12,11 @@ macro(append_extra_compression_libs NativeLibsExtra)
       find_package(ZLIB REQUIRED)
   endif ()
   list(APPEND ${NativeLibsExtra} ${ZLIB_LIBRARIES})
+
+  if (CLR_CMAKE_USE_SYSTEM_BROTLI)
+    find_library(BROTLIDEC brotlidec REQUIRED)
+    find_library(BROTLIENC brotlienc REQUIRED)
+
+    list(APPEND ${NativeLibsExtra} ${BROTLIDEC} ${BROTLIENC})
+  endif ()
 endmacro()


### PR DESCRIPTION
This is mainly motivated by the March 2022 release of .NET 5. .NET 5 was
found to be vulnerable to CVE-2020-8927, which was caused by the older
version of brotli built into .NET. .NET was vulernable even in
environments where a system-wide version of brotli was present and had
already received fixes for this CVE. We could have avoided a Remove Code
Execution vulnerability in such environments by using the system's
version of brotli.

This is similar to the existing support for disabling distro-agnostic
OpenSSL (except no OpenSSL is embedded) and libunwind (a copy of
libunwind is embedded this repo).