### PR TITLE
Load C++/CLI DLLs built against .NET 7.0+ in default ALC

### DIFF
--- a/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -117,7 +117,6 @@
   <!-- Sources -->
   <ItemGroup>
     <Compile Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\ComActivationContextInternal.cs" />
-    <Compile Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\InMemoryAssemblyLoader.cs" />
     <Compile Include="$(BclSourcesRoot)\System\__Canon.cs" />
     <Compile Include="$(BclSourcesRoot)\System\ArgIterator.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Array.CoreCLR.cs" />
@@ -285,10 +284,12 @@
     <Compile Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\ComActivator.PlatformNotSupported.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+    <Compile Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\InMemoryAssemblyLoader.PlatformNotSupported.cs" />
     <Compile Include="$(BclSourcesRoot)\Interop\Unix\Interop.Libraries.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Threading\LowLevelLifoSemaphore.Unix.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+    <Compile Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\InMemoryAssemblyLoader.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\OleAut32\Interop.VariantClear.cs">
       <Link>Common\Interop\Windows\OleAut32\Interop.VariantClear.cs</Link>
     </Compile>

--- a/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -117,6 +117,7 @@
   <!-- Sources -->
   <ItemGroup>
     <Compile Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\ComActivationContextInternal.cs" />
+    <Compile Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\ComponentActivator.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\__Canon.cs" />
     <Compile Include="$(BclSourcesRoot)\System\ArgIterator.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Array.CoreCLR.cs" />

--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -21,13 +21,6 @@
     <type fullname="System.SZArrayHelper">
       <method name=".ctor" />
     </type>
-
-    <!-- Enables the .NET IJW host to load an in-memory module as a .NET assembly.
-         These are always rooted to ensure native calls get trimmer related errors
-         but will be trimmed away by the related feature switch -->
-    <type fullname="Internal.Runtime.InteropServices.InMemoryAssemblyLoader">
-      <method name="LoadInMemoryAssembly" />
-    </type>
   </assembly>
 
   <!-- The private Event methods are accessed by private reflection in the base EventSource class. -->

--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Windows.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Windows.xml
@@ -11,11 +11,17 @@
       <method name="UnregisterClassForTypeInternal" />
     </type>
 
-    <!-- Enables the .NET IJW host to load an in-memory module as a .NET assembly.
+    <!-- Enables the .NET IJW host (before .NET 7.0) to load an in-memory module as a .NET assembly.
         These are always rooted to ensure native calls get trimmer related errors
         but will be trimmed away by the related feature switch -->
     <type fullname="Internal.Runtime.InteropServices.InMemoryAssemblyLoader">
       <method name="LoadInMemoryAssembly" />
+    </type>
+  </assembly>
+
+  <assembly fullname="System.Private.CoreLib" feature="System.Runtime.InteropServices.EnableCppCLIHostActivation" featurevalue="true">
+    <!-- Enables the .NET IJW host (.NET 7.0+) to load an in-memory module as a .NET assembly. -->
+    <type fullname="Internal.Runtime.InteropServices.InMemoryAssemblyLoader">
       <method name="LoadInMemoryAssemblyInContext" />
     </type>
   </assembly>

--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Windows.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Windows.xml
@@ -10,5 +10,13 @@
       <method name="RegisterClassForTypeInternal" />
       <method name="UnregisterClassForTypeInternal" />
     </type>
+
+    <!-- Enables the .NET IJW host to load an in-memory module as a .NET assembly.
+        These are always rooted to ensure native calls get trimmer related errors
+        but will be trimmed away by the related feature switch -->
+    <type fullname="Internal.Runtime.InteropServices.InMemoryAssemblyLoader">
+      <method name="LoadInMemoryAssembly" />
+      <method name="LoadInMemoryAssemblyInContext" />
+    </type>
   </assembly>
 </linker>

--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Windows.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Windows.xml
@@ -13,7 +13,7 @@
 
     <!-- Enables the .NET IJW host (before .NET 7.0) to load an in-memory module as a .NET assembly.
         These are always rooted to ensure native calls get trimmer related errors
-        but will be trimmed away by the related feature switch -->
+        but their bodies will be mostly trimmed away by the related feature switch -->
     <type fullname="Internal.Runtime.InteropServices.InMemoryAssemblyLoader">
       <method name="LoadInMemoryAssembly" />
     </type>

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.CoreCLR.cs
@@ -15,7 +15,7 @@ namespace Internal.Runtime.InteropServices
             if (!OperatingSystem.IsWindows())
                 return;
 
-            // Check for the exact type and method name used by ijwhost - see src/native/corehoste/ijwhost/ijwhost.cpp
+            // Check for the exact type and method name used by ijwhost - see src/native/corehost/ijwhost/ijwhost.cpp
             if (Marshal.PtrToStringUni(methodNameNative) == "LoadInMemoryAssemblyInContext"
                 && Marshal.PtrToStringUni(typeNameNative) == $"Internal.Runtime.InteropServices.{nameof(InMemoryAssemblyLoader)}, {CoreLib.Name}")
             {

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.CoreCLR.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Internal.Runtime.InteropServices
+{
+    public static partial class ComponentActivator
+    {
+        // This hook for when GetFunctionPointer is called when the feature is disabled allows us to
+        // provide error messages for known hosting scenarios such as C++/CLI.
+        private static void OnDisabledGetFunctionPointerCall(IntPtr typeNameNative, IntPtr methodNameNative)
+        {
+            if (!OperatingSystem.IsWindows())
+                return;
+
+            // Check for the exact type and method name used by ijwhost - see src/native/corehoste/ijwhost/ijwhost.cpp
+            if (Marshal.PtrToStringUni(methodNameNative) == "LoadInMemoryAssemblyInContext"
+                && Marshal.PtrToStringUni(typeNameNative) == $"Internal.Runtime.InteropServices.{nameof(InMemoryAssemblyLoader)}, {CoreLib.Name}")
+            {
+                throw new NotSupportedException(SR.NotSupported_CppCli);
+            }
+        }
+    }
+}

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/InMemoryAssemblyLoader.PlatformNotSupported.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/InMemoryAssemblyLoader.PlatformNotSupported.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Loader;
+
+namespace Internal.Runtime.InteropServices
+{
+    /// <summary>
+    /// This class enables the .NET IJW host to load an in-memory module as a .NET assembly
+    /// </summary>
+    public static class InMemoryAssemblyLoader
+    {
+        /// <summary>
+        /// Loads into an isolated AssemblyLoadContext an assembly that has already been loaded into memory by the OS loader as a native module.
+        /// </summary>
+        /// <param name="moduleHandle">The native module handle for the assembly.</param>
+        /// <param name="assemblyPath">The path to the assembly (as a pointer to a UTF-16 C string).</param>
+        public static unsafe void LoadInMemoryAssembly(IntPtr moduleHandle, IntPtr assemblyPath)
+            => throw new PlatformNotSupportedException();
+    }
+}

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/InMemoryAssemblyLoader.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/InMemoryAssemblyLoader.cs
@@ -27,7 +27,7 @@ namespace Internal.Runtime.InteropServices
         public static unsafe void LoadInMemoryAssembly(IntPtr moduleHandle, IntPtr assemblyPath)
         {
             if (!IsSupported)
-                throw new NotSupportedException("This API is not enabled in trimmed scenarios. see https://aka.ms/dotnet-illink/nativehost for more details");
+                throw new NotSupportedException(SR.NotSupported_CppCli);
 
 #pragma warning disable IL2026 // suppressed in ILLink.Suppressions.LibraryBuild.xml
             LoadInMemoryAssemblyInContextImpl(moduleHandle, assemblyPath);
@@ -44,10 +44,10 @@ namespace Internal.Runtime.InteropServices
         [UnmanagedCallersOnly]
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
             Justification = "The same C++/CLI feature switch applies to LoadInMemoryAssembly and this function. We rely on the warning from LoadInMemoryAssembly.")]
-        internal static unsafe void LoadInMemoryAssemblyInContext(IntPtr moduleHandle, IntPtr assemblyPath, IntPtr loadContext)
+        public static unsafe void LoadInMemoryAssemblyInContext(IntPtr moduleHandle, IntPtr assemblyPath, IntPtr loadContext)
         {
             if (!IsSupported)
-                throw new NotSupportedException("This API is not enabled in trimmed scenarios. see https://aka.ms/dotnet-illink/nativehost for more details");
+                throw new NotSupportedException(SR.NotSupported_CppCli);
 
             if (loadContext != IntPtr.Zero)
                 throw new ArgumentOutOfRangeException(nameof(loadContext));

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/InMemoryAssemblyLoader.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/InMemoryAssemblyLoader.cs
@@ -2,30 +2,30 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
+using System.Runtime.Versioning;
 
 namespace Internal.Runtime.InteropServices
 {
     /// <summary>
     /// This class enables the .NET IJW host to load an in-memory module as a .NET assembly
     /// </summary>
+    [SupportedOSPlatform("windows")]
     public static class InMemoryAssemblyLoader
     {
-#if TARGET_WINDOWS
         private static bool IsSupported { get; } = InitializeIsSupported();
-
         private static bool InitializeIsSupported() => AppContext.TryGetSwitch("System.Runtime.InteropServices.EnableCppCLIHostActivation", out bool isSupported) ? isSupported : true;
-#endif
 
         /// <summary>
         /// Loads into an isolated AssemblyLoadContext an assembly that has already been loaded into memory by the OS loader as a native module.
         /// </summary>
         /// <param name="moduleHandle">The native module handle for the assembly.</param>
         /// <param name="assemblyPath">The path to the assembly (as a pointer to a UTF-16 C string).</param>
+        [RequiresUnreferencedCode("C++/CLI is not trim-compatible", Url = "https://aka.ms/dotnet-illink/nativehost")]
         public static unsafe void LoadInMemoryAssembly(IntPtr moduleHandle, IntPtr assemblyPath)
         {
-#if TARGET_WINDOWS
             if (!IsSupported)
                 throw new NotSupportedException("This API is not enabled in trimmed scenarios. see https://aka.ms/dotnet-illink/nativehost for more details");
 
@@ -35,15 +35,23 @@ namespace Internal.Runtime.InteropServices
                 throw new ArgumentOutOfRangeException(nameof(assemblyPath));
             }
 
-            // We don't cache the ALCs here since each IJW assembly will call this method at most once
+            // We don't cache the resolvers here since each IJW assembly will call this method at most once
             // (the load process rewrites the stubs that call here to call the actual methods they're supposed to)
+            var resolver = new AssemblyDependencyResolver(assemblyPathString);
+            AssemblyLoadContext.Default.Resolving +=
+                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+                    Justification = "The trimmer warning is on the method that adds this handler")]
+                (context, assemblyName) =>
+                {
+                    string? assemblyPath = resolver.ResolveAssemblyToPath(assemblyName);
 #pragma warning disable IL2026 // suppressed in ILLink.Suppressions.LibraryBuild.xml
-            AssemblyLoadContext context = new IsolatedComponentLoadContext(assemblyPathString);
+                    return assemblyPath != null
+                        ? context.LoadFromAssemblyPath(assemblyPath)
+                        : null;
 #pragma warning restore IL2026
-            context.LoadFromInMemoryModule(moduleHandle);
-#else
-            throw new PlatformNotSupportedException();
-#endif
+                };
+
+            AssemblyLoadContext.Default.LoadFromInMemoryModule(moduleHandle);
         }
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/InMemoryAssemblyLoader.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/InMemoryAssemblyLoader.cs
@@ -24,13 +24,14 @@ namespace Internal.Runtime.InteropServices
         /// </summary>
         /// <param name="moduleHandle">The native module handle for the assembly.</param>
         /// <param name="assemblyPath">The path to the assembly (as a pointer to a UTF-16 C string).</param>
-        [RequiresUnreferencedCode("C++/CLI is not trim-compatible", Url = "https://aka.ms/dotnet-illink/nativehost")]
         public static unsafe void LoadInMemoryAssembly(IntPtr moduleHandle, IntPtr assemblyPath)
         {
             if (!IsSupported)
                 throw new NotSupportedException("This API is not enabled in trimmed scenarios. see https://aka.ms/dotnet-illink/nativehost for more details");
 
+#pragma warning disable IL2026 // suppressed in ILLink.Suppressions.LibraryBuild.xml
             LoadInMemoryAssemblyInContextImpl(moduleHandle, assemblyPath);
+#pragma warning restore IL2026
         }
 
         /// <summary>
@@ -41,7 +42,8 @@ namespace Internal.Runtime.InteropServices
         /// <param name="assemblyPath">The path to the assembly (as a pointer to a UTF-16 C string).</param>
         /// <param name="loadContext">Load context (currently must be IntPtr.Zero)</param>
         [UnmanagedCallersOnly]
-        [RequiresUnreferencedCode("C++/CLI is not trim-compatible", Url = "https://aka.ms/dotnet-illink/nativehost")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "The same C++/CLI feature switch applies to LoadInMemoryAssembly and this function. We rely on the warning from LoadInMemoryAssembly.")]
         internal static unsafe void LoadInMemoryAssemblyInContext(IntPtr moduleHandle, IntPtr assemblyPath, IntPtr loadContext)
         {
             if (!IsSupported)

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Ijwhost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Ijwhost.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             result.Should().Pass()
                 .And.HaveStdOutContaining("[C++/CLI] NativeEntryPoint: calling managed class")
-                .And.HaveStdOutContaining("[C++/CLI] ManagedClass: AssemblyLoadContext = \"IsolatedComponentLoadContext");
+                .And.HaveStdOutContaining("[C++/CLI] ManagedClass: AssemblyLoadContext = \"Default\" System.Runtime.Loader.DefaultAssemblyLoadContext");
         }
 
         [Theory]
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             result.Should().Pass()
                 .And.HaveStdOutContaining("[C++/CLI] NativeEntryPoint: calling managed class")
-                .And.HaveStdOutContaining("[C++/CLI] ManagedClass: AssemblyLoadContext = \"IsolatedComponentLoadContext")
+                .And.HaveStdOutContaining("[C++/CLI] ManagedClass: AssemblyLoadContext = \"Default\" System.Runtime.Loader.DefaultAssemblyLoadContext")
                 .And.HaveStdErrContaining($"Executing as a {(selfContained ? "self-contained" : "framework-dependent")} app");
         }
 

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -16,10 +16,16 @@
     -->
     <type fullname="Internal.Runtime.InteropServices.ComponentActivator">
       <method name="LoadAssemblyAndGetFunctionPointer" />
+    </type>
+  </assembly>
+
+  <assembly fullname="System.Private.CoreLib">
+    <!-- Rooting GetFunctionPointer allows for a reasonable error experience when using any form of native hosting on a trimmed app. -->
+    <type fullname="Internal.Runtime.InteropServices.ComponentActivator">
       <method name="GetFunctionPointer" />
     </type>
   </assembly>
-  
+
   <!-- Properties and methods used by a debugger. -->
   <assembly fullname="System.Private.CoreLib" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="true" featuredefault="true">
     <type fullname="System.Threading.Tasks.Task">
@@ -69,7 +75,7 @@
       <method name="GetActiveTaskFromId" />
     </type>
 
-     <!-- methods used by hot reload --> 
+     <!-- methods used by hot reload -->
     <type fullname="System.Reflection.Metadata.MetadataUpdater">
       <method name="GetCapabilities" />
     </type>

--- a/src/libraries/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.cs
@@ -117,7 +117,19 @@ namespace Internal.Runtime.InteropServices
             if (!IsSupported)
             {
 #if CORECLR
-                OnDisabledGetFunctionPointerCall(typeNameNative, methodNameNative);
+                try
+                {
+                    OnDisabledGetFunctionPointerCall(typeNameNative, methodNameNative);
+                }
+                catch (Exception e)
+                {
+                    // The callback can intentionally throw NotSupportedException to provide errors to consumers,
+                    // so we let that one through. Any other exceptions must not be leaked out.
+                    if (e is NotSupportedException)
+                        throw;
+
+                    return e.HResult;
+                }
 #endif
                 return HostFeatureDisabled;
             }

--- a/src/libraries/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.cs
@@ -11,7 +11,7 @@ using System.Runtime.Versioning;
 
 namespace Internal.Runtime.InteropServices
 {
-    public static class ComponentActivator
+    public static partial class ComponentActivator
     {
         private const string TrimIncompatibleWarningMessage = "Native hosting is not trim compatible and this warning will be seen if trimming is enabled.";
         private const string NativeAOTIncompatibleWarningMessage = "The native code for the method requested might not be available at runtime.";
@@ -115,7 +115,12 @@ namespace Internal.Runtime.InteropServices
                                                     IntPtr functionHandle)
         {
             if (!IsSupported)
+            {
+#if CORECLR
+                OnDisabledGetFunctionPointerCall(typeNameNative, methodNameNative);
+#endif
                 return HostFeatureDisabled;
+            }
 
             try
             {

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3727,6 +3727,9 @@
   <data name="NotSupported_COM" xml:space="preserve">
     <value>Built-in COM has been disabled via a feature switch. See https://aka.ms/dotnet-illink/com for more information.</value>
   </data>
+  <data name="NotSupported_CppCli" xml:space="preserve">
+    <value>C++/CLI activation has been disabled via a feature switch. See https://aka.ms/dotnet-illink/nativehost for more information.</value>
+  </data>
   <data name="InvalidOperation_EmptyQueue" xml:space="preserve">
     <value>Queue empty.</value>
   </data>

--- a/src/native/corehost/ijwhost/ijwhost.cpp
+++ b/src/native/corehost/ijwhost/ijwhost.cpp
@@ -46,7 +46,7 @@ pal::hresult_t get_load_in_memory_assembly_delegate(pal::dll_t handle, load_in_m
         return status;
 
     return get_function_pointer(
-        _X("Internal.Runtime.InteropServices.InMemoryAssemblyLoader"),
+        _X("Internal.Runtime.InteropServices.InMemoryAssemblyLoader, System.Private.CoreLib"),
         _X("LoadInMemoryAssemblyInContext"),
         UNMANAGEDCALLERSONLY_METHOD,
         nullptr, // load context

--- a/src/native/corehost/ijwhost/ijwhost.cpp
+++ b/src/native/corehost/ijwhost/ijwhost.cpp
@@ -2,14 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include "ijwhost.h"
-#include "hostfxr.h"
-#include "fxr_resolver.h"
-#include "pal.h"
-#include "trace.h"
-#include "error_codes.h"
-#include "utils.h"
+#include <coreclr_delegates.h>
+#include <hostfxr.h>
+#include <fxr_resolver.h>
+#include <pal.h>
+#include <trace.h>
+#include <error_codes.h>
+#include <utils.h>
 #include "bootstrap_thunk.h"
-
 
 #if defined(_WIN32)
 // IJW entry points are defined without the __declspec(dllexport) attribute.
@@ -22,8 +22,9 @@
 
 pal::hresult_t get_load_in_memory_assembly_delegate(pal::dll_t handle, load_in_memory_assembly_fn* delegate)
 {
-    return load_fxr_and_get_delegate(
-        hostfxr_delegate_type::hdt_load_in_memory_assembly,
+    get_function_pointer_fn get_function_pointer;
+    int status = load_fxr_and_get_delegate(
+        hostfxr_delegate_type::hdt_get_function_pointer,
         [handle](const pal::string_t& host_path, pal::string_t* config_path_out)
         {
             pal::string_t mod_path;
@@ -39,8 +40,18 @@ pal::hresult_t get_load_in_memory_assembly_delegate(pal::dll_t handle, load_in_m
 
             return StatusCode::Success;
         },
-        delegate
+        &get_function_pointer
     );
+    if (status != StatusCode::Success)
+        return status;
+
+    return get_function_pointer(
+        _X("Internal.Runtime.InteropServices.InMemoryAssemblyLoader"),
+        _X("LoadInMemoryAssemblyInContext"),
+        UNMANAGEDCALLERSONLY_METHOD,
+        nullptr, // load context
+        nullptr, // reserved
+        (void**)delegate);
 }
 
 IJW_API BOOL STDMETHODCALLTYPE _CorDllMain(HINSTANCE hInst,

--- a/src/native/corehost/ijwhost/ijwhost.h
+++ b/src/native/corehost/ijwhost/ijwhost.h
@@ -13,7 +13,7 @@ bool patch_vtable_entries(PEDecoder& decoder);
 void release_bootstrap_thunks(PEDecoder& decoder);
 bool are_thunks_installed_for_module(HMODULE instance);
 
-using load_in_memory_assembly_fn = void(STDMETHODCALLTYPE*)(pal::dll_t handle, const pal::char_t* path);
+using load_in_memory_assembly_fn = void(STDMETHODCALLTYPE*)(pal::dll_t handle, const pal::char_t* path, void* load_context);
 
 pal::hresult_t get_load_in_memory_assembly_delegate(pal::dll_t handle, load_in_memory_assembly_fn* delegate);
 

--- a/src/native/corehost/ijwhost/ijwthunk.cpp
+++ b/src/native/corehost/ijwhost/ijwthunk.cpp
@@ -34,7 +34,7 @@ namespace
 HANDLE g_heapHandle;
 
 bool patch_vtable_entries(PEDecoder& pe)
-{    
+{
     size_t numFixupRecords;
     IMAGE_COR_VTABLEFIXUP* pFixupTable = pe.GetVTableFixups(&numFixupRecords);
 
@@ -68,7 +68,7 @@ bool patch_vtable_entries(PEDecoder& pe)
     }
 
     trace::setup();
-    
+
     error_writer_scope_t writer_scope(swallow_trace);
 
     size_t currentThunk = 0;
@@ -115,7 +115,7 @@ extern "C" std::uintptr_t __stdcall start_runtime_and_get_target_address(std::ui
 {
     trace::setup();
     error_writer_scope_t writer_scope(swallow_trace);
-    
+
     bootstrap_thunk *pThunk = bootstrap_thunk::get_thunk_from_cookie(cookie);
     load_in_memory_assembly_fn loadInMemoryAssembly;
     pal::dll_t moduleHandle = pThunk->get_dll_handle();
@@ -145,7 +145,7 @@ extern "C" std::uintptr_t __stdcall start_runtime_and_get_target_address(std::ui
 #pragma warning (pop)
     }
 
-    loadInMemoryAssembly(moduleHandle, app_path.c_str());
+    loadInMemoryAssembly(moduleHandle, app_path.c_str(), nullptr);
 
     std::uintptr_t thunkAddress = *(pThunk->get_slot_address());
 

--- a/src/native/corehost/ijwhost/ijwthunk.cpp
+++ b/src/native/corehost/ijwhost/ijwthunk.cpp
@@ -128,7 +128,7 @@ extern "C" std::uintptr_t __stdcall start_runtime_and_get_target_address(std::ui
         // As we were taken here via an entry point with arbitrary signature,
         // there's no way of returning the error code so we just throw it.
 
-        trace::error(_X("Failed to start the .NET runtime. Error code %d"), status);
+        trace::error(_X("Failed to start the .NET runtime. Error code: %#x"), status);
 
 #pragma warning (push)
 #pragma warning (disable: 4297)


### PR DESCRIPTION
Make `ijwhost` load C++/CLI components into default ALC
  - Components targeting .NET 7.0+ (so using the updated `ijwhost`) will load in the default ALC
  - Older components (using older `ijwhost`) will keep their existing behaviour of loading into an isolated context.
  - No configuration to go back to using the isolated context in this change. We have the option of adding a check for a runtime config property that will allow each component to specify whether or not it should be loaded in the default ALC.
option

<details>
<summary>
Original context/description
</summary>

@vitek-karas @AaronRobinsonMSFT @agocke - I realized (re-discovered?) that the C++/CLI path is a bit more special than I thought. I had been thinking a new `load_assembly` API like @vitek-karas mentioned would be something like the below and fit all our component loads. 
```c
typedef int (CORECLR_DELEGATE_CALLTYPE *load_assembly_fn)(const char_t *assembly_path, void *load_context, void *reserved);
```

However, unlike other component hosting, C++/CLI loads using a module handle for a module that has already been loaded into memory (via an internal, coreclr, windows-only API), so it doesn't fit quite so nicely.

The changes in this PR just always load C++/CLI libraries into the default ALC.

Some options:
1. Always load into default ALC (current change)
    - C++/CLI library built using an older `ijwhost` would also be loaded in the default ALC when loaded in 7.0+ without a rebuild/retarget
      - For pre-7.0, they would have to have set `RollForward` to `Major` or `LatestMajor` (non-default values)
    - No way to override on a per-component basis
2. Overload the meaning / do some re-interpretation of the parameters (two `IntPtr`s) currently passed to `InMemoryAssemblyLoader`
    - For example, something like `IntPtr.Zero` for one (currently an invalid value) indicating that the other `IntPtr` should be interpreted as some struct with the info for what to load and in what ALC
    - Would allow C++/CLI libraries built with an older `ijwhost` to keep the old behaviour (isolated ALC)
    - Would allow overriding on a per-component basis
    - Feels weird/hacky
3. Add `load_assembly` and make `ijwhost` go through it, using the `void* reserved` parameter
    - Would allow C++/CLI libraries built with an older `ijwhost` to keep the old behaviour (isolated ALC)
    - Would allow overriding on a per-component basis
    - Not too keen on immediately making a new API use the reserved/extensibility parameter

Thoughts?
</details>