### PR TITLE
Fix stepping issues with ReadyToRun and TieredCompilation

### DIFF
--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -1306,8 +1306,8 @@ bool DebuggerController::BindPatch(DebuggerControllerPatch *patch,
             return false;
         }
 
-        LOG((LF_CORDB,LL_INFO10000, "DC::BindPa: For startAddr 0x%x, got DJI "
-             "0x%x, from 0x%x size: 0x%x\n", startAddr, info, info->m_addrOfCode, info->m_sizeOfCode));
+        LOG((LF_CORDB,LL_INFO10000, "DC::BindPa: For startAddr 0x%p, got DJI "
+             "0x%p, from 0x%p size: 0x%x\n", startAddr, info, info->m_addrOfCode, info->m_sizeOfCode));
     }
 
     LOG((LF_CORDB, LL_INFO10000, "DC::BP:Trying to bind patch in %s::%s version %d\n",
@@ -6410,7 +6410,8 @@ void DebuggerStepper::TrapStepOut(ControllerStackInfo *info, bool fForceTraditio
                     continue;
 
                 dji = info->m_activeFrame.GetJitInfoFromFrame();
-                _ASSERTE(dji != NULL);
+                if (dji == NULL)
+                   continue;
 
                 // Note: we used to pass in the IP from the active frame to GetJitInfo, but there seems to be no value
                 // in that, and it was causing problems creating a stepper while sitting in ndirect stubs after we'd
@@ -7173,7 +7174,7 @@ TP_RESULT DebuggerStepper::TriggerPatch(DebuggerControllerPatch *patch,
                 else
                 {
                     LOG((LF_CORDB, LL_INFO10000,
-                         "TSO for TRACE_MGR_PUSH case."));
+                         "TSO for TRACE_MGR_PUSH case. RetAddr: 0x%p\n", traceManagerRetAddr));
 
                     // We'd better have a valid return address.
                     _ASSERTE(traceManagerRetAddr != NULL);
@@ -7184,14 +7185,32 @@ TP_RESULT DebuggerStepper::TriggerPatch(DebuggerControllerPatch *patch,
                         DebuggerJitInfo *dji;
                         dji = g_pDebugger->GetJitInfoFromAddr((TADDR) traceManagerRetAddr);
 
-                        MethodDesc * mdNative = (dji == NULL) ?
-                            g_pEEInterface->GetNativeCodeMethodDesc(dac_cast<PCODE>(traceManagerRetAddr)) : dji->m_nativeCodeVersion.GetMethodDesc();
-                        _ASSERTE(mdNative != NULL);
+                        MethodDesc* mdNative = NULL;
+                        PCODE pcodeNative = NULL;
+                        if (dji != NULL)
+                        {
+                            mdNative = dji->m_nativeCodeVersion.GetMethodDesc();
+                            pcodeNative = dji->m_nativeCodeVersion.GetNativeCode();
+                        }
+                        else
+                        {
+                            // Find the method that the return is to.
+                            mdNative = g_pEEInterface->GetNativeCodeMethodDesc(dac_cast<PCODE>(traceManagerRetAddr));
+                            _ASSERTE(g_pEEInterface->GetFunctionAddress(mdNative) != NULL);
+                            pcodeNative = g_pEEInterface->GetFunctionAddress(mdNative);
+                        }
 
-                        // Find the method that the return is to.
-                        _ASSERTE(g_pEEInterface->GetFunctionAddress(mdNative) != NULL);
-                        SIZE_T offsetRet = dac_cast<TADDR>(traceManagerRetAddr -
-                            g_pEEInterface->GetFunctionAddress(mdNative));
+                        _ASSERTE(mdNative != NULL && pcodeNative != NULL);
+                        SIZE_T offsetRet = dac_cast<TADDR>(traceManagerRetAddr - pcodeNative);
+                        LOG((LF_CORDB, LL_INFO10000,
+                             "DS::TP: Before normally managed code AddPatch"
+                             " in %s::%s \n\tmd=0x%p, offset 0x%x, pcode=0x%p, dji=0x%p\n",
+                             mdNative->m_pszDebugClassName,
+                             mdNative->m_pszDebugMethodName,
+                             mdNative,
+                             offsetRet,
+                             pcodeNative,
+                             dji));
 
                         // Place the patch.
                         AddBindAndActivateNativeManagedPatch(mdNative,
@@ -7199,13 +7218,6 @@ TP_RESULT DebuggerStepper::TriggerPatch(DebuggerControllerPatch *patch,
                                  offsetRet,
                                  LEAF_MOST_FRAME,
                                  NULL);
-
-                        LOG((LF_CORDB, LL_INFO10000,
-                             "DS::TP: normally managed code AddPatch"
-                             " in %s::%s, offset 0x%x\n",
-                             mdNative->m_pszDebugClassName,
-                             mdNative->m_pszDebugMethodName,
-                             offsetRet));
                     }
                     else
                     {

--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -6414,8 +6414,7 @@ void DebuggerStepper::TrapStepOut(ControllerStackInfo *info, bool fForceTraditio
                     continue;
 
                 dji = info->m_activeFrame.GetJitInfoFromFrame();
-                if (dji == NULL)
-                   continue;
+                _ASSERTE(dji != NULL);
 
                 // Note: we used to pass in the IP from the active frame to GetJitInfo, but there seems to be no value
                 // in that, and it was causing problems creating a stepper while sitting in ndirect stubs after we'd

--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -1946,6 +1946,10 @@ BOOL DebuggerController::AddILPatch(AppDomain * pAppDomain, Module *module,
     BOOL fOk = FALSE;
 
     DebuggerMethodInfo *dmi = g_pDebugger->GetOrCreateMethodInfo(module, md); // throws
+    LOG((LF_CORDB,LL_INFO10000,"DC::AILP: dmi:0x%p, mdToken:0x%x, mdFilter:0x%p, "
+            "encVer:%zu, offset:0x%zx <- isIL:%d, Mod:0x%p\n",
+            dmi, md, pMethodDescFilter, encVersion, offset, offsetIsIL, module));
+
     if (dmi == NULL)
     {
         return false;

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -2711,10 +2711,14 @@ DebuggerJitInfo *Debugger::GetJitInfoWorker(MethodDesc *fd, const BYTE *pbAddr, 
         return NULL;
     }
 
-    if (pbAddr != NULL)
+    if (pbAddr == NULL)
+    {
+        dji = dmi->GetLatestJitInfo(fd);
+    }
+#ifndef DACCESS_COMPILE
+    else
     {
         PCODE startAddr = g_pEEInterface->GetNativeCodeStartAddress((PCODE)pbAddr);
-#ifndef DACCESS_COMPILE
         if (startAddr == NULL)
         {
             LOG((LF_CORDB,LL_INFO1000,"D::GJIW: Couldn't find a DJI by address 0x%p, "
@@ -2743,13 +2747,8 @@ DebuggerJitInfo *Debugger::GetJitInfoWorker(MethodDesc *fd, const BYTE *pbAddr, 
         {
             dji = dmi->FindOrCreateInitAndAddJitInfo(fd, startAddr);
         }
+    }
 #endif // !DACCESS_COMPILE
-    }
-
-    if (dji == NULL)
-    {
-        dji = dmi->GetLatestJitInfo(fd);
-    }
 
     if (pMethInfo)
     {

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -2665,37 +2665,37 @@ DebuggerJitInfo *Debugger::GetJitInfo(MethodDesc *fd, const BYTE *pbAddr, Debugg
 // Internal worker to GetJitInfo. Doesn't validate parameters.
 DebuggerJitInfo *Debugger::GetJitInfoWorker(MethodDesc *fd, const BYTE *pbAddr, DebuggerMethodInfo **pMethInfo)
 {
+    CONTRACTL
+    {
+        THROWS;
+        GC_NOTRIGGER;
+        PRECONDITION(!g_pDebugger->HasDebuggerDataLock());
+    }
+    CONTRACTL_END;
 
     DebuggerMethodInfo *dmi = NULL;
     DebuggerJitInfo *dji = NULL;
 
-    // If we have a null MethodDesc - we're not going to get a jit-info. Do this check once at the top
-    // rather than littered throughout the rest of this function.
-    if (fd == NULL)
-    {
-        LOG((LF_CORDB, LL_EVERYTHING, "Debugger::GetJitInfo, addr=0x%p - null fd - returning null\n", pbAddr));
-        return NULL;
-    }
-    else
-    {
-        CONSISTENCY_CHECK_MSGF(!fd->IsWrapperStub(), ("Can't get Jit-info for wrapper MDesc,'%s'", fd->m_pszDebugMethodName));
-    }
-
-    // The debugger doesn't track Lightweight-codegen methods b/c they have no metadata.
-    if (fd->IsDynamicMethod())
-    {
-        return NULL;
-    }
-
-
-    // initialize our out param
     if (pMethInfo)
     {
         *pMethInfo = NULL;
     }
 
-    LOG((LF_CORDB, LL_EVERYTHING, "Debugger::GetJitInfo called\n"));
-    //    CHECK_DJI_TABLE_DEBUGGER;
+    // If we have a null MethodDesc - we're not going to get a jit-info. Do this check once at the top
+    // rather than littered throughout the rest of this function.
+    if (fd == NULL)
+    {
+        LOG((LF_CORDB, LL_EVERYTHING, "D::GJIW: addr=0x%p - null fd - returning null\n", pbAddr));
+        return NULL;
+    }
+
+    CONSISTENCY_CHECK_MSGF(!fd->IsWrapperStub(), ("Can't get Jit-info for wrapper MDesc,'%s'", fd->m_pszDebugMethodName));
+
+    // The debugger doesn't track dynamic methods b/c they have no metadata.
+    if (fd->IsDynamicMethod())
+    {
+        return NULL;
+    }
 
     // Find the DJI via the DMI
     //
@@ -2704,80 +2704,57 @@ DebuggerJitInfo *Debugger::GetJitInfoWorker(MethodDesc *fd, const BYTE *pbAddr, 
     // struct.  After all, we never want to have a MethodInfo in the table without an
     // associated JitInfo, and this should bring us back very close to the old situation
     // in terms of perf.  But correctness comes first, and perf later...
-    //        CHECK_DMI_TABLE;
     dmi = GetOrCreateMethodInfo(fd->GetModule(), fd->GetMemberDef());
-
     if (dmi == NULL)
     {
         // If we can't create the DMI, we won't be able to create the DJI.
         return NULL;
     }
 
-    // TODO: Currently, this method does not handle code versioning properly (at least in some profiler scenarios), it may need
-    // to take pbAddr into account and lazily create a DJI for that particular version of the method.
-
-    // This may take the lock and lazily create an entry, so we do it up front.
-    dji = dmi->GetLatestJitInfo(fd);
-
+    if (pbAddr != NULL)
     {
-        DebuggerDataLockHolder debuggerDataLockHolder(this);
-
-        // Note the call to GetLatestJitInfo() will lazily create the first DJI if we don't already have one.
-        for (; dji != NULL; dji = dji->m_prevJitInfo)
-        {
-            if (PTR_TO_TADDR(dji->m_nativeCodeVersion.GetMethodDesc()) == PTR_HOST_TO_TADDR(fd))
-            {
-                break;
-            }
-        }
-
-        LOG((LF_CORDB, LL_INFO1000, "D::GJI: for md:0x%p (%s::%s), got dmi:0x%p, dji:0x%p, latest dji:0x%p, latest fd:0x%p, prev dji:0x%p\n",
-            fd, fd->m_pszDebugClassName, fd->m_pszDebugMethodName,
-            dmi, dji, (dmi ? dmi->GetLatestJitInfo_NoCreate() : 0),
-            ((dmi && dmi->GetLatestJitInfo_NoCreate()) ? dmi->GetLatestJitInfo_NoCreate()->m_nativeCodeVersion.GetMethodDesc():0),
-            (dji?dji->m_prevJitInfo:0)));
-
-        if ((dji != NULL) && (pbAddr != NULL))
-        {
-            dji = dji->GetJitInfoByAddress(pbAddr);
-        }
-    }
-
-    // dac doesn't support stub tracing so this just results in not-impl exceptions.
+        PCODE startAddr = g_pEEInterface->GetNativeCodeStartAddress((PCODE)pbAddr);
 #ifndef DACCESS_COMPILE
-    if (dji == NULL) //may have been given address of a thunk
-    {
-        LOG((LF_CORDB,LL_INFO1000,"Couldn't find a DJI by address 0x%p, "
-            "so it might be a stub or thunk\n", pbAddr));
-        TraceDestination trace;
-
-        g_pEEInterface->TraceStub((const BYTE *)pbAddr, &trace);
-
-        if ((trace.GetTraceType() == TRACE_MANAGED) && (pbAddr != (const BYTE *)trace.GetAddress()))
+        if (startAddr == NULL)
         {
-            LOG((LF_CORDB,LL_INFO1000,"Address thru thunk"
-                ": 0x%p\n", trace.GetAddress()));
-            dji = GetJitInfo(fd, dac_cast<PTR_CBYTE>(trace.GetAddress()));
-        }
+            LOG((LF_CORDB,LL_INFO1000,"D::GJIW: Couldn't find a DJI by address 0x%p, "
+                "so it might be a stub or thunk\n", pbAddr));
+
+            // if the address wasn't in jitted code we'll also check to see if it is a stub that leads to jitted code
+            TraceDestination trace;
+            (void)g_pEEInterface->TraceStub(pbAddr, &trace);
+            if(trace.GetTraceType() == TRACE_MANAGED && (PCODE)pbAddr != trace.GetAddress())
+            {
+                startAddr = trace.GetAddress();
+                LOG((LF_CORDB,LL_INFO1000,"D::GJIW: Address thru thunk: 0x%p\n", startAddr));
+            }
 #ifdef LOGGING
-        else
-        {
-            _ASSERTE(trace.GetTraceType() != TRACE_UNJITTED_METHOD ||
-                (fd == trace.GetMethodDesc()));
-            LOG((LF_CORDB,LL_INFO1000,"Address not thunked - "
-                "must be to unJITted method, or normal managed "
-                "method lacking a DJI!\n"));
+            else
+            {
+                _ASSERTE(trace.GetTraceType() != TRACE_UNJITTED_METHOD || (fd == trace.GetMethodDesc()));
+                LOG((LF_CORDB,LL_INFO1000,"D::GJIW: Address not thunked - "
+                    "must be to unJITted method, or normal managed "
+                    "method lacking a DJI!\n"));
+            }
+#endif // LOGGING
         }
-#endif //LOGGING
+
+        if (startAddr != NULL)
+        {
+            dji = dmi->FindOrCreateInitAndAddJitInfo(fd, startAddr);
+        }
+#endif // !DACCESS_COMPILE
     }
-#endif // #ifndef DACCESS_COMPILE
+
+    if (dji == NULL)
+    {
+        dji = dmi->GetLatestJitInfo(fd);
+    }
 
     if (pMethInfo)
     {
         *pMethInfo = dmi;
     }
-
-    // DebuggerDataLockHolder out of scope - release implied
 
     return dji;
 }
@@ -2813,7 +2790,7 @@ DebuggerMethodInfo *Debugger::GetOrCreateMethodInfo(Module *pModule, mdMethodDef
     {
         info = CreateMethodInfo(pModule, token);
 
-        LOG((LF_CORDB, LL_INFO1000, "D::GOCMI: created DMI for mdToken:0x%x, dmi:0x%x\n",
+        LOG((LF_CORDB, LL_INFO1000, "D::GOCMI: created DMI for mdToken:0x%x, dmi:0x%p\n",
             token, info));
     }
 #endif // #ifndef DACCESS_COMPILE
@@ -13962,7 +13939,7 @@ Debugger::InsertToMethodInfoList( DebuggerMethodInfo *dmi )
     }
     CONTRACTL_END;
 
-    LOG((LF_CORDB,LL_INFO10000,"D:IAHOL DMI: dmi:0x%08x\n", dmi));
+    LOG((LF_CORDB,LL_INFO10000,"D:IAHOL DMI: dmi:0x%p\n", dmi));
 
     HRESULT hr = S_OK;
 
@@ -13982,7 +13959,7 @@ Debugger::InsertToMethodInfoList( DebuggerMethodInfo *dmi )
 
     _ASSERTE((dmiPrev == NULL) || ((dmi->m_token == dmiPrev->m_token) && (dmi->m_module == dmiPrev->m_module)));
 
-    LOG((LF_CORDB,LL_INFO10000,"D:IAHOL: current head of dmi list:0x%08x\n",dmiPrev));
+    LOG((LF_CORDB,LL_INFO10000,"D:IAHOL: current head of dmi list:0x%p\n",dmiPrev));
 
     if (dmiPrev != NULL)
     {
@@ -14007,7 +13984,7 @@ Debugger::InsertToMethodInfoList( DebuggerMethodInfo *dmi )
     }
 #ifdef _DEBUG
     dmiPrev = m_pMethodInfos->GetMethodInfo(dmi->m_module, dmi->m_token);
-    LOG((LF_CORDB,LL_INFO10000,"D:IAHOL: new head of dmi list:0x%08x\n",
+    LOG((LF_CORDB,LL_INFO10000,"D:IAHOL: new head of dmi list:0x%p\n",
         dmiPrev));
 #endif //_DEBUG
 

--- a/src/coreclr/debug/ee/debugger.h
+++ b/src/coreclr/debug/ee/debugger.h
@@ -1604,10 +1604,6 @@ public:
                               DWORD *which,
                               BOOL skipPrologs=FALSE);
 
-    // If a method has multiple copies of code (because of EnC or code-pitching),
-    // this returns the DJI corresponding to 'pbAddr'
-    DebuggerJitInfo *GetJitInfoByAddress(const BYTE *pbAddr );
-
     void Init(TADDR newAddress);
 
 #if defined(FEATURE_EH_FUNCLETS)

--- a/src/coreclr/debug/ee/frameinfo.cpp
+++ b/src/coreclr/debug/ee/frameinfo.cpp
@@ -601,7 +601,6 @@ DebuggerJitInfo * FrameInfo::GetJitInfoFromFrame() const
 
     DebuggerJitInfo *ji = NULL;
 
-    // @todo - we shouldn't need both a MD and an IP here.
     EX_TRY
     {
         _ASSERTE(this->md != NULL);

--- a/src/coreclr/debug/ee/frameinfo.cpp
+++ b/src/coreclr/debug/ee/frameinfo.cpp
@@ -606,8 +606,7 @@ DebuggerJitInfo * FrameInfo::GetJitInfoFromFrame() const
     {
         _ASSERTE(this->md != NULL);
         ji = g_pDebugger->GetJitInfo(this->md, (const BYTE*)GetControlPC(&(this->registers)));
-        _ASSERTE(ji != NULL);
-        _ASSERTE(ji->m_nativeCodeVersion.GetMethodDesc() == this->md);
+        _ASSERTE(ji == NULL || ji->m_nativeCodeVersion.GetMethodDesc() == this->md);
     }
     EX_CATCH
     {

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -2326,12 +2326,13 @@ void DebuggerMethodInfoTable::DeleteEntryDMI(DebuggerMethodInfoEntry *entry)
 
 #endif // #ifndef DACCESS_COMPILE
 
-DebuggerJitInfo *DebuggerJitInfo::GetJitInfoByAddress(const BYTE *pbAddr )
+DebuggerJitInfo *DebuggerJitInfo::GetJitInfoByAddress(const BYTE *pbAddr)
 {
     CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
+        PRECONDITION(g_pDebugger->HasDebuggerDataLock());
     }
     CONTRACTL_END;
 

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -2333,44 +2333,6 @@ void DebuggerMethodInfoTable::DeleteEntryDMI(DebuggerMethodInfoEntry *entry)
 
 #endif // #ifndef DACCESS_COMPILE
 
-DebuggerJitInfo *DebuggerJitInfo::GetJitInfoByAddress(const BYTE *pbAddr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        PRECONDITION(g_pDebugger->HasDebuggerDataLock());
-    }
-    CONTRACTL_END;
-
-    DebuggerJitInfo *dji = this;
-
-#ifdef LOGGING
-    LOG((LF_CORDB,LL_INFO10000,"DJI:GJIBA finding DJI "
-            "corresponding to addr 0x%p, starting with 0x%p\n", pbAddr, dji));
-#endif //LOGGING
-
-    // If it's not NULL, but not in the range m_addrOfCode to end of function,
-    //  then get the previous one.
-    while( dji != NULL &&
-           !CodeRegionInfo::GetCodeRegionInfo(dji).IsMethodAddress(pbAddr))
-    {
-        LOG((LF_CORDB,LL_INFO10000,"DJI:GJIBA: pbAddr 0x%p is not in code "
-            "0x%p (size:0x%p)\n", pbAddr, dji->m_addrOfCode,
-            dji->m_sizeOfCode));
-        dji = dji->m_prevJitInfo;
-    }
-
-#ifdef LOGGING
-    if (dji == NULL)
-    {
-        LOG((LF_CORDB,LL_INFO10000,"DJI:GJIBA couldn't find a DJI "
-            "corresponding to addr 0x%p\n", pbAddr));
-    }
-#endif //LOGGING
-    return dji;
-}
-
 PTR_DebuggerJitInfo DebuggerMethodInfo::GetLatestJitInfo(MethodDesc *mdesc)
 {
     // dac checks ngen'ed image content first, so

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -280,7 +280,7 @@ DebuggerJitInfo::DebuggerJitInfo(DebuggerMethodInfo *minfo, NativeCodeVersion na
     _ASSERTE(minfo);
     m_encVersion = minfo->GetCurrentEnCVersion();
     _ASSERTE(m_encVersion >= CorDB_DEFAULT_ENC_FUNCTION_VERSION);
-    LOG((LF_CORDB,LL_EVERYTHING, "DJI::DJI : created at 0x%x\n", this));
+    LOG((LF_CORDB,LL_EVERYTHING, "DJI::DJI : created at 0x%p\n", this));
 
     // Debugger doesn't track LightWeight codegen methods.
     // We should never even be creating a DJI for one.
@@ -892,7 +892,7 @@ void DebuggerJitInfo::LazyInitBounds()
         PRECONDITION(!g_pDebugger->HasDebuggerDataLock());
     } CONTRACTL_END;
 
-    LOG((LF_CORDB, LL_EVERYTHING, "DJI::LazyInitBounds: this=0x%x m_fAttemptInit %s\n", this, m_fAttemptInit == true ? "true": "false"));
+    LOG((LF_CORDB, LL_EVERYTHING, "DJI::LazyInitBounds: this=0x%p m_fAttemptInit %s\n", this, m_fAttemptInit == true ? "true": "false"));
 
     // Only attempt lazy-init once
     if (m_fAttemptInit)
@@ -902,7 +902,7 @@ void DebuggerJitInfo::LazyInitBounds()
 
     EX_TRY
     {
-        LOG((LF_CORDB, LL_EVERYTHING, "DJI::LazyInitBounds: this=0x%x Initing\n", this));
+        LOG((LF_CORDB, LL_EVERYTHING, "DJI::LazyInitBounds: this=0x%p Initing\n", this));
 
         // Should have already been jitted
         _ASSERTE(this->m_jitComplete);
@@ -927,7 +927,7 @@ void DebuggerJitInfo::LazyInitBounds()
             &cMap, &pMap,
             &cVars, &pVars);
 
-        LOG((LF_CORDB,LL_EVERYTHING, "DJI::LazyInitBounds: this=0x%x GetBoundariesAndVars success=0x%x\n", this, fSuccess));
+        LOG((LF_CORDB,LL_EVERYTHING, "DJI::LazyInitBounds: this=0x%p GetBoundariesAndVars success=0x%x\n", this, fSuccess));
 
         // SetBoundaries uses the CodeVersionManager, need to take it now for lock ordering reasons
         CodeVersionManager::LockHolder codeVersioningLockHolder;
@@ -2073,6 +2073,7 @@ void DebuggerMethodInfo::CreateDJIsForMethodDesc(MethodDesc * pMethodDesc)
     }
     CONTRACTL_END;
 
+   LOG((LF_CORDB, LL_INFO10000, "DMI::CDJIFMD pMethodDesc:0x%p\n", pMethodDesc));
 
     // The debugger doesn't track Lightweight-codegen methods b/c they have no metadata.
     if (pMethodDesc->IsDynamicMethod())
@@ -2087,19 +2088,25 @@ void DebuggerMethodInfo::CreateDJIsForMethodDesc(MethodDesc * pMethodDesc)
         CodeVersionManager::LockHolder codeVersioningLockHolder;
         NativeCodeVersionCollection nativeCodeVersions = pCodeVersionManager->GetNativeCodeVersions(pMethodDesc);
 
+#ifdef LOGGING
+        int count = 0;
+#endif // LOGGING
         for (NativeCodeVersionIterator itr = nativeCodeVersions.Begin(), end = nativeCodeVersions.End(); itr != end; itr++)
         {
             // Some versions may not be compiled yet - skip those for now
             // if they compile later the JitCompiled callback will add a DJI to our cache at that time
             PCODE codeAddr = itr->GetNativeCode();
+            LOG((LF_CORDB, LL_INFO10000, "DMI::CDJIFMD (%d) Native code for DJI - 0x%p\n", ++count, codeAddr));
             if (codeAddr)
             {
                 // The DJI may already be populated in the cache, if so CreateInitAndAdd is
                 // a no-op and that is fine.
                 BOOL unusedDjiWasCreated;
                 CreateInitAndAddJitInfo(*itr, codeAddr, &unusedDjiWasCreated);
+                LOG((LF_CORDB, LL_INFO10000, "DMI::CDJIFMD Was DJI created? 0x%d\n", unusedDjiWasCreated));
             }
         }
+        LOG((LF_CORDB, LL_INFO10000, "DMI::CDJIFMD NativeCodeVersion total %d for md=0x%p\n", count, pMethodDesc));
     }
 #else
     // We just ask for the DJI to ensure that it's lazily created.


### PR DESCRIPTION
Fixes #52768 

Fix stepping issues with ReadyToRun assemblies and TieredCompilation in Debug/Checked builds of coreclr.

Narrow the scope of the DebuggerDataLock to only when the JIT info dictionary is being enumerated.

Get the correct PCODE version for ReadyToRun methods when the StubManager is computing the address to step to.

/cc @noahfalk @dotnet/dotnet-diag 