### PR TITLE
Reenable a test in stress mode

### DIFF
--- a/src/tests/JIT/opt/OSR/tailrecursetry.csproj
+++ b/src/tests/JIT/opt/OSR/tailrecursetry.csproj
@@ -3,10 +3,6 @@
     <OutputType>Exe</OutputType>
     <DebugType />
     <Optimize>True</Optimize>
-    <!-- This test currently fails for TailcallStress. Disable for JIT stress modes until this is fixed.
-         Issue: https://github.com/dotnet/runtime/issues/35687
-    -->
-    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
The issue #35687 was closed in #59784 and I can confirm the original
repro mentioned there no longer reproduces with this test.

Fix #65934