### PR TITLE
don't run WriteChars_VeryLargeArray_DoesNotOverflow test on 32 bit

### DIFF
--- a/src/libraries/System.IO/tests/BinaryWriter/BinaryWriter.EncodingTests.cs
+++ b/src/libraries/System.IO/tests/BinaryWriter/BinaryWriter.EncodingTests.cs
@@ -192,7 +192,7 @@ namespace System.IO.Tests
         }
 
         [OuterLoop("Allocates a lot of memory")]
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
         [SkipOnPlatform(TestPlatforms.Android, "OOM on Android could be uncatchable & kill the test runner")]
         public unsafe void WriteChars_VeryLargeArray_DoesNotOverflow()
         {


### PR DESCRIPTION
as it allocates more than 2GB and will always fail on 32 bit

fixes #66488

