### PR TITLE
Add OSR to DacpTieredVersionData

### DIFF
--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -1152,6 +1152,9 @@ HRESULT ClrDataAccess::GetTieredVersions(
                 case NativeCodeVersion::OptimizationTier1:
                     nativeCodeAddrs[count].OptimizationTier = DacpTieredVersionData::OptimizationTier_OptimizedTier1;
                     break;
+                case NativeCodeVersion::OptimizationTier1OSR:
+                    nativeCodeAddrs[count].OptimizationTier = DacpTieredVersionData::OptimizationTier_OptimizedTier1OSR;
+                    break;
                 case NativeCodeVersion::OptimizationTierOptimized:
                     nativeCodeAddrs[count].OptimizationTier = DacpTieredVersionData::OptimizationTier_Optimized;
                     break;

--- a/src/coreclr/inc/dacprivate.h
+++ b/src/coreclr/inc/dacprivate.h
@@ -609,6 +609,7 @@ struct MSLAYOUT DacpTieredVersionData
         OptimizationTier_QuickJitted,
         OptimizationTier_OptimizedTier1,
         OptimizationTier_ReadyToRun,
+        OptimizationTier_OptimizedTier1OSR,
     };
 
     CLRDATA_ADDRESS NativeCodeAddr;


### PR DESCRIPTION
Older SOSs will continue to report OSR methods as "unknown tier" until that side is updated.