### PR TITLE
[mono] Less MonoClassField arithmetic and less direct offset access

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -7821,6 +7821,9 @@ static int get_static_field_value(MonoClassField* f, MonoClass* klass, MonoDomai
 	if (!is_ok(error))
 		return -1;
 
+	/* TODO: metadata-update.  implement support for added fields */
+	g_assert (!m_field_is_from_update (f));
+
 	if (CHECK_ICORDBG (TRUE))
 	{
 		void *src;
@@ -7828,13 +7831,13 @@ static int get_static_field_value(MonoClassField* f, MonoClass* klass, MonoDomai
 			return -1;
 		}
 
-		if (f->offset == -1) {
+		if (m_field_get_offset (f) == -1) {
 			/* Special static */
 			gpointer addr = mono_special_static_field_get_offset (f, error);
 			mono_error_assert_ok (error);
 			src = mono_get_special_static_data_for_thread (thread, GPOINTER_TO_UINT (addr));
 		} else {
-			src = (char*)mono_vtable_get_static_field_data (vtable) + f->offset;
+			src = (char*)mono_vtable_get_static_field_data (vtable) + m_field_get_offset (f);
 		}
 		buffer_add_value(buf, f->type, src, domain);
 	}
@@ -9659,6 +9662,8 @@ object_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 			if (!found)
 				goto invalid_fieldid;
 get_field_value:
+			/* TODO: metadata-update: implement support for added fields */
+			g_assert (!m_field_is_from_update (f));
 			if (f->type->attrs & FIELD_ATTRIBUTE_STATIC) {
 				guint8 *val;
 				MonoVTable *vtable;
@@ -9681,7 +9686,7 @@ get_field_value:
 				buffer_add_value (buf, f->type, val, obj->vtable->domain);
 				g_free (val);
 			} else {
-				void *field_value = (guint8*)obj + f->offset;
+				void *field_value = (guint8*)obj + m_field_get_offset (f);
 
 				buffer_add_value (buf, f->type, field_value, obj->vtable->domain);
 			}
@@ -9706,6 +9711,9 @@ get_field_value:
 			if (!found)
 				goto invalid_fieldid;
 
+			/* TODO: metadata-update: implement support for added fields. */
+			g_assert (!m_field_is_from_update (f));
+			
 			if (f->type->attrs & FIELD_ATTRIBUTE_STATIC) {
 				guint8 *val;
 				MonoVTable *vtable;
@@ -9729,7 +9737,7 @@ get_field_value:
 				mono_field_static_set_value_internal (vtable, f, val);
 				g_free (val);
 			} else {
-				err = decode_value (f->type, obj->vtable->domain, (guint8*)obj + f->offset, p, &p, end, TRUE);
+				err = decode_value (f->type, obj->vtable->domain, (guint8*)obj + m_field_get_offset (f), p, &p, end, TRUE);
 				if (err != ERR_NONE)
 					goto exit;
 			}

--- a/src/mono/mono/component/debugger-engine.c
+++ b/src/mono/mono/component/debugger-engine.c
@@ -1690,7 +1690,7 @@ get_async_method_builder (DbgEngineStackFrame *frame)
 		builder = mono_vtype_get_field_addr (*(guint8**)this_addr, builder_field);
 	} else {
 		this_obj = *(MonoObject**)this_addr;
-		builder = (char*)this_obj + builder_field->offset;
+		builder = (char*)this_obj + m_field_get_offset (builder_field);
 	}
 
 	return builder;

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -35,6 +35,7 @@
 #define ALLOW_CLASS_ADD
 #define ALLOW_METHOD_ADD
 #define ALLOW_FIELD_ADD
+#define ALLOW_INSTANCE_FIELD_ADD
 
 typedef struct _BaselineInfo BaselineInfo;
 typedef struct _DeltaInfo DeltaInfo;
@@ -121,7 +122,7 @@ static MonoMethod *
 hot_reload_find_method_by_name (MonoClass *klass, const char *name, int param_count, int flags, MonoError *error);
 
 static MonoClassMetadataUpdateField *
-metadata_update_field_setup_basic_info_and_resolve (MonoImage *image_base, BaselineInfo *base_info, uint32_t generation, DeltaInfo *delta_info, MonoClass *parent_klass, uint32_t fielddef_token, MonoError *error);
+metadata_update_field_setup_basic_info_and_resolve (MonoImage *image_base, BaselineInfo *base_info, uint32_t generation, DeltaInfo *delta_info, MonoClass *parent_klass, uint32_t fielddef_token, uint32_t field_flags, MonoError *error);
 
 static MonoComponentHotReload fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &hot_reload_available },
@@ -1842,12 +1843,14 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 			uint32_t mapped_token = hot_reload_relative_delta_index (image_dmeta, delta_info, log_token);
 			uint32_t field_flags = mono_metadata_decode_row_col (&image_dmeta->tables [MONO_TABLE_FIELD], mapped_token - 1, MONO_FIELD_FLAGS);
 
+#ifndef ALLOW_INSTANCE_FIELD_ADD
 			if ((field_flags & FIELD_ATTRIBUTE_STATIC) == 0) {
 				/* TODO: implement instance (and literal?) fields */
 				mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_METADATA_UPDATE, "Adding non-static fields isn't implemented yet (token 0x%08x, class %s.%s)", log_token, m_class_get_name_space (add_member_klass), m_class_get_name (add_member_klass));
 				mono_error_set_not_implemented (error, "Adding non-static fields isn't implemented yet (token 0x%08x, class %s.%s)", log_token, m_class_get_name_space (add_member_klass), m_class_get_name (add_member_klass));
 				return FALSE;
 			}
+#endif
 
 			add_field_to_baseline (base_info, delta_info, add_member_klass, log_token);
 
@@ -1855,7 +1858,7 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 			 * resolves MonoClassField:type and sets MonoClassField:offset to -1 to make
 			 * it easier to spot that the field is special.
 			 */
-			metadata_update_field_setup_basic_info_and_resolve (image_base, base_info, generation, delta_info, add_member_klass, log_token, error);
+			metadata_update_field_setup_basic_info_and_resolve (image_base, base_info, generation, delta_info, add_member_klass, log_token, field_flags, error);
 			if (!is_ok (error)) {
 				mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_METADATA_UPDATE, "Could not setup field (token 0x%08x) due to: %s", log_token, mono_error_get_message (error));
 				return FALSE;
@@ -2426,10 +2429,13 @@ hot_reload_get_field (MonoClass *klass, uint32_t fielddef_token) {
 
 
 static MonoClassMetadataUpdateField *
-metadata_update_field_setup_basic_info_and_resolve (MonoImage *image_base, BaselineInfo *base_info, uint32_t generation, DeltaInfo *delta_info, MonoClass *parent_klass, uint32_t fielddef_token, MonoError *error)
+metadata_update_field_setup_basic_info_and_resolve (MonoImage *image_base, BaselineInfo *base_info, uint32_t generation, DeltaInfo *delta_info, MonoClass *parent_klass, uint32_t fielddef_token, uint32_t field_flags, MonoError *error)
 {
 	// TODO: hang a "pending field" struct off the parent_klass if !parent_klass->fields
 	//   In that case we can do things simpler, maybe by just creating the MonoClassField array as usual, and just relying on the normal layout algorithm to make space for the instance.
+
+	if (!m_class_is_inited (parent_klass))
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "Adding fielddef 0x%08x to uninited class 0x%08x", fielddef_token, m_class_get_type_token (parent_klass));
 
 	MonoClassMetadataUpdateInfo *parent_info = mono_class_get_or_add_metadata_update_info (parent_klass);
 

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -35,7 +35,7 @@
 #define ALLOW_CLASS_ADD
 #define ALLOW_METHOD_ADD
 #define ALLOW_FIELD_ADD
-#define ALLOW_INSTANCE_FIELD_ADD
+#undef ALLOW_INSTANCE_FIELD_ADD
 
 typedef struct _BaselineInfo BaselineInfo;
 typedef struct _DeltaInfo DeltaInfo;

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -1951,6 +1951,11 @@ validate_struct_fields_overlaps (guint8 *layout_check, int layout_size, MonoClas
 		// try to call mono_class_setup_fields which is what we're doing already
 		field = &m_class_get_fields (klass) [i];
 		field_offset = field_offsets [i];
+		/*
+		 * metadata-update: adding fields to existing structs isn't supported; when a brand
+		 * new struct is added in an update, the fields will be in m_class_get_fields.  so
+		 * nothing new to do here.
+		 */
 
 		if (!field)
 			continue;

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -2490,7 +2490,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 				guint32 field_idx = first_field_idx + (field - p->fields);
 				if (MONO_TYPE_IS_REFERENCE (field->type) && mono_assembly_is_weak_field (p->image, field_idx + 1)) {
 					has_weak_fields = TRUE;
-					mono_trace_message (MONO_TRACE_TYPE, "Field %s:%s at offset %x is weak.", m_field_get_parent (field)->name, field->name, field->offset);
+					mono_trace_message (MONO_TRACE_TYPE, "Field %s:%s at offset %x is weak.", m_field_get_parent (field)->name, field->name, field->offset_);
 				}
 			}
 		}

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -2490,7 +2490,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 				guint32 field_idx = first_field_idx + (field - p->fields);
 				if (MONO_TYPE_IS_REFERENCE (field->type) && mono_assembly_is_weak_field (p->image, field_idx + 1)) {
 					has_weak_fields = TRUE;
-					mono_trace_message (MONO_TRACE_TYPE, "Field %s:%s at offset %x is weak.", m_field_get_parent (field)->name, field->name, field->offset_);
+					mono_trace_message (MONO_TRACE_TYPE, "Field %s:%s at offset %x is weak.", m_field_get_parent (field)->name, field->name, field->offset);
 				}
 			}
 		}

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -1587,7 +1587,7 @@ m_field_get_meta_flags (MonoClassField *field)
 	return (unsigned int)(field->parent_and_flags & MONO_CLASS_FIELD_META_FLAG_MASK);
 }
 
-static inline gboolean
+static inline int
 m_field_get_offset (MonoClassField *field)
 {
 	g_assert (m_class_is_fields_inited (m_field_get_parent (field)));

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -1569,7 +1569,7 @@ mono_class_find_enum_basetype (MonoClass *klass, MonoError *error)
 	first_field_idx = mono_class_get_first_field_idx (klass);
 	/*
 	 * metadata-update: adding new enum fields isn't supported, so when this code runs, all the
-	 * fields are cotiguous in metadata.
+	 * fields are contiguous in metadata.
 	 */
 	for (i = 0; i < top; i++){
 		const char *sig;

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -1567,6 +1567,10 @@ mono_class_find_enum_basetype (MonoClass *klass, MonoError *error)
 	 * Fetch all the field information.
 	 */
 	first_field_idx = mono_class_get_first_field_idx (klass);
+	/*
+	 * metadata-update: adding new enum fields isn't supported, so when this code runs, all the
+	 * fields are cotiguous in metadata.
+	 */
 	for (i = 0; i < top; i++){
 		const char *sig;
 		guint32 cols [MONO_FIELD_SIZE];
@@ -2468,17 +2472,14 @@ mono_class_get_field_from_name_full (MonoClass *klass, const char *name, MonoTyp
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	int i;
-
 	mono_class_setup_fields (klass);
 	if (mono_class_has_failure (klass))
 		return NULL;
 
 	while (klass) {
-		int fcount = mono_class_get_field_count (klass);
-		for (i = 0; i < fcount; ++i) {
-			MonoClassField *field = &m_class_get_fields (klass) [i];
-
+		gpointer iter = NULL;
+		MonoClassField *field;
+		while ((field = mono_class_get_fields_internal (klass, &iter))) {
 			if (strcmp (name, mono_field_get_name (field)) != 0)
 				continue;
 
@@ -2526,6 +2527,10 @@ mono_class_get_field_token (MonoClassField *field)
 				return mono_metadata_make_token (MONO_TABLE_FIELD, idx);
 			}
 		}
+		if (G_UNLIKELY (m_class_get_image (klass)->has_updates)) {
+			/* TODO: metadata-update: check if the field was added. */
+			g_assert_not_reached ();
+		}
 		klass = m_class_get_parent (klass);
 	}
 
@@ -2538,6 +2543,8 @@ mono_field_get_index (MonoClassField *field)
 {
 	int index = field - m_class_get_fields (m_field_get_parent (field));
 	g_assert (index >= 0 && index < mono_class_get_field_count (m_field_get_parent (field)));
+	/* TODO: metadata-update: check if the field was added */
+	g_assert (!m_class_get_image (m_field_get_parent (field))->has_updates);
 
 	return index;
 }
@@ -5033,6 +5040,7 @@ mono_class_get_fields_internal (MonoClass *klass, gpointer *iter)
 	MonoClassField* field;
 	if (!iter)
 		return NULL;
+	/* TODO: metadata-update - also iterate over the added fields */
 	if (!*iter) {
 		mono_class_setup_fields (klass);
 		if (mono_class_has_failure (klass))
@@ -5456,6 +5464,9 @@ mono_field_get_rva (MonoClassField *field, int swizzle)
 	MonoFieldDefaultValue *def_values;
 
 	g_assert (field->type->attrs & FIELD_ATTRIBUTE_HAS_FIELD_RVA);
+
+	/* TODO: metadata-update: make this work. */
+	g_assert (!m_field_is_from_update (field));
 
 	def_values = mono_class_get_field_def_values_with_swizzle (klass, swizzle);
 	if (!def_values) {
@@ -6512,6 +6523,9 @@ mono_field_resolve_type (MonoClassField *field, MonoError *error)
 static guint32
 mono_field_resolve_flags (MonoClassField *field)
 {
+	/* Fields in metadata updates are pre-resolved, so this method should not be called. */
+	g_assert (!m_field_is_from_update (field));
+
 	MonoClass *klass = m_field_get_parent (field);
 	MonoImage *image = m_class_get_image (klass);
 	MonoClass *gtd = mono_class_is_ginst (klass) ? mono_class_get_generic_type_definition (klass) : NULL;
@@ -6550,6 +6564,8 @@ mono_class_get_fields_lazy (MonoClass* klass, gpointer *iter)
 	MonoClassField* field;
 	if (!iter)
 		return NULL;
+	/* TODO: metadata-update: iterate over the added fields, too */
+	g_assert (!m_class_get_image (klass)->has_updates);
 	if (!*iter) {
 		mono_class_setup_basic_field_info (klass);
 		MonoClassField *klass_fields = m_class_get_fields (klass);

--- a/src/mono/mono/metadata/debug-helpers.c
+++ b/src/mono/mono/metadata/debug-helpers.c
@@ -1067,7 +1067,7 @@ static void
 print_field_value (const char *field_ptr, MonoClassField *field, int type_offset)
 {
 	MonoType *type;
-	g_print ("At %p (ofs: %2d) %s: ", field_ptr, field->offset + type_offset, mono_field_get_name (field));
+	g_print ("At %p (ofs: %2d) %s: ", field_ptr, m_field_is_from_update (field) ? -1 : (field->offset + type_offset), mono_field_get_name (field));
 	type = mono_type_get_underlying_type (field->type);
 
 	switch (type->type) {
@@ -1155,6 +1155,9 @@ objval_describe (MonoClass *klass, const char *addr)
 		while ((field = mono_class_get_fields_internal (p, &iter))) {
 			if (field->type->attrs & (FIELD_ATTRIBUTE_STATIC | FIELD_ATTRIBUTE_HAS_FIELD_RVA))
 				continue;
+			/* TODO: metadata-update: print something here */
+			if (m_field_is_from_update (field))
+				continue;
 
 			if (p != klass && !printed_header) {
 				const char *sep;
@@ -1229,7 +1232,11 @@ mono_class_describe_statics (MonoClass* klass)
 			if (!(field->type->attrs & (FIELD_ATTRIBUTE_STATIC | FIELD_ATTRIBUTE_HAS_FIELD_RVA)))
 				continue;
 
-			field_ptr = (const char*)addr + field->offset;
+			/* TODO: metadata-update: print something for added fields? */
+			if (m_field_is_from_update (field))
+				continue;
+			
+			field_ptr = (const char*)addr + m_field_get_offset (field);
 
 			print_field_value (field_ptr, field, 0);
 		}

--- a/src/mono/mono/metadata/handle.h
+++ b/src/mono/mono/metadata/handle.h
@@ -605,6 +605,8 @@ mono_handle_assign_raw (MonoObjectHandleOut dest, void *src)
 static inline gpointer
 mono_handle_unsafe_field_addr (MonoObjectHandle h, MonoClassField *field)
 {
+	/* TODO: metadata-update: fix all callers */
+	g_assert (!m_field_is_from_update (field));
 	return MONO_HANDLE_SUPPRESS (((gchar *)MONO_HANDLE_RAW (h)) + field->offset);
 }
 

--- a/src/mono/mono/metadata/marshal-ilgen.c
+++ b/src/mono/mono/metadata/marshal-ilgen.c
@@ -156,7 +156,7 @@ static int
 offset_of_first_nonstatic_field (MonoClass *klass)
 {
 	mono_class_setup_fields (klass);
-	gpointer iter;
+	gpointer iter = NULL;
 	MonoClassField *field;
 	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		if (!(field->type->attrs & FIELD_ATTRIBUTE_STATIC) && !mono_field_is_deleted (field)) {
@@ -165,7 +165,7 @@ offset_of_first_nonstatic_field (MonoClass *klass)
 			 * newly-added structs, the "from update" field won't be set.
 			 */
 			g_assert (!m_field_is_from_update (field));
-			return field->offset - MONO_ABI_SIZEOF (MonoObject);
+			return m_field_get_offset (field) - MONO_ABI_SIZEOF (MonoObject);
 		}
 	}
 
@@ -1140,10 +1140,10 @@ emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_obje
 		ntype = (MonoMarshalNative)mono_type_to_unmanaged (ftype, info->fields [i].mspec, TRUE, m_class_is_unicode (klass), &conv);
 
 		if (last_field) {
-			msize = m_class_get_instance_size (klass) - info->fields [i].field->offset;
+			msize = m_class_get_instance_size (klass) - m_field_get_offset (info->fields [i].field);
 			usize = info->native_size - info->fields [i].offset;
 		} else {
-			msize = info->fields [i + 1].field->offset - info->fields [i].field->offset;
+			msize = m_field_get_offset (info->fields [i + 1].field) - m_field_get_offset (info->fields [i].field);
 			usize = info->fields [i + 1].offset - info->fields [i].offset;
 		}
 

--- a/src/mono/mono/metadata/marshal-ilgen.c
+++ b/src/mono/mono/metadata/marshal-ilgen.c
@@ -155,13 +155,18 @@ mono_mb_emit_exception_marshal_directive (MonoMethodBuilder *mb, char *msg)
 static int
 offset_of_first_nonstatic_field (MonoClass *klass)
 {
-	int i;
-	int fcount = mono_class_get_field_count (klass);
 	mono_class_setup_fields (klass);
-	MonoClassField *klass_fields = m_class_get_fields (klass);
-	for (i = 0; i < fcount; i++) {
-		if (!(klass_fields[i].type->attrs & FIELD_ATTRIBUTE_STATIC) && !mono_field_is_deleted (&klass_fields[i]))
-			return klass_fields[i].offset - MONO_ABI_SIZEOF (MonoObject);
+	gpointer iter;
+	MonoClassField *field;
+	while ((field = mono_class_get_fields_internal (klass, &iter))) {
+		if (!(field->type->attrs & FIELD_ATTRIBUTE_STATIC) && !mono_field_is_deleted (field)) {
+			/*
+			 * metadata-update: adding fields to existing structs isn't supported.  In
+			 * newly-added structs, the "from update" field won't be set.
+			 */
+			g_assert (!m_field_is_from_update (field));
+			return field->offset - MONO_ABI_SIZEOF (MonoObject);
+		}
 	}
 
 	return 0;

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -5552,7 +5552,7 @@ mono_marshal_load_type_info (MonoClass* klass)
 			size = mono_marshal_type_size (field->type, info->fields [j].mspec,
 						       &align, TRUE, m_class_is_unicode (klass));
 			min_align = MAX (align, min_align);
-			info->fields [j].offset = field->offset - MONO_ABI_SIZEOF (MonoObject);
+			info->fields [j].offset = m_field_get_offset (field) - MONO_ABI_SIZEOF (MonoObject);
 			info->native_size = MAX (info->native_size, info->fields [j].offset + size);
 			break;
 		}

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -7596,6 +7596,10 @@ mono_metadata_get_corresponding_field_from_generic_type_definition (MonoClassFie
 	if (!mono_class_is_ginst (m_field_get_parent (field)))
 		return field;
 
+	/*
+	 * metadata-update: nothing to do. can't add fields to existing generic
+	 * classes; for new gtds added in updates, this is correct.
+	 */
 	gtd = mono_class_get_generic_class (m_field_get_parent (field))->container_class;
 	offset = field - m_class_get_fields (m_field_get_parent (field));
 	return m_class_get_fields (gtd) + offset;

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -852,11 +852,18 @@ compute_class_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int
 			if (m_type_is_byref (field->type))
 				break;
 
-			if (static_fields && field->offset == -1)
+			/* metadadta-update: added fields aren't stored in the object, don't
+			 * contribute to the GC descriptor. */
+			if (m_field_is_from_update (field))
+				continue;
+
+			int field_offset = m_field_get_offset (field);
+
+			if (static_fields && field_offset == -1)
 				/* special static */
 				continue;
 
-			pos = field->offset / TARGET_SIZEOF_VOID_P;
+			pos = field_offset / TARGET_SIZEOF_VOID_P;
 			pos += offset;
 
 			type = mono_type_get_underlying_type (field->type);
@@ -871,7 +878,7 @@ compute_class_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int
 			case MONO_TYPE_CLASS:
 			case MONO_TYPE_OBJECT:
 			case MONO_TYPE_ARRAY:
-				g_assert ((field->offset % wordsize) == 0);
+				g_assert ((m_field_get_offset (field) % wordsize) == 0);
 
 				g_assert (pos < size || pos <= max_size);
 				bitmap [pos / BITMAP_EL_SIZE] |= ((gsize)1) << (pos % BITMAP_EL_SIZE);
@@ -879,7 +886,7 @@ compute_class_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int
 				break;
 			case MONO_TYPE_GENERICINST:
 				if (!mono_type_generic_inst_is_valuetype (type)) {
-					g_assert ((field->offset % wordsize) == 0);
+					g_assert ((m_field_get_offset (field) % wordsize) == 0);
 
 					bitmap [pos / BITMAP_EL_SIZE] |= ((gsize)1) << (pos % BITMAP_EL_SIZE);
 					*max_set = MAX (*max_set, pos);
@@ -2073,6 +2080,9 @@ mono_class_create_runtime_vtable (MonoClass *klass, MonoError *error)
 			continue;
 		if (mono_field_is_deleted (field))
 			continue;
+		/* metadata-update: added fields are stored external to the object, and don't contribute to the bitmap */
+		if (m_field_is_from_update (field))
+			continue;
 		if (!(field->type->attrs & FIELD_ATTRIBUTE_LITERAL)) {
 			gint32 special_static = m_class_has_no_special_static_fields (klass) ? SPECIAL_STATIC_NONE : field_is_special_static (klass, field);
 			if (special_static != SPECIAL_STATIC_NONE) {
@@ -2757,7 +2767,10 @@ mono_field_set_value_internal (MonoObject *obj, MonoClassField *field, void *val
 	if ((field->type->attrs & FIELD_ATTRIBUTE_STATIC))
 		return;
 
-	dest = (char*)obj + field->offset;
+	/* TODO: metadata-update: implement support for added fields */
+	g_assert (!m_field_is_from_update (field));
+
+	dest = (char*)obj + m_field_get_offset (field);
 	mono_copy_value (field->type, dest, value, value && field->type->type == MONO_TYPE_PTR);
 }
 
@@ -2845,8 +2858,11 @@ mono_field_get_addr (MonoObject *obj, MonoVTable *vt, MonoClassField *field)
 
 	if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 		return mono_static_field_get_addr (vt, field);
-	else
-		return (guint8*)obj + field->offset;
+	else {
+		/* TODO: metadata-update: implement support for added fields */
+		g_assert (!m_field_is_from_update (field));
+		return (guint8*)obj + m_field_get_offset (field);
+	}
 }
 
 guint8*
@@ -2867,7 +2883,7 @@ mono_static_field_get_addr (MonoVTable *vt, MonoClassField *field)
 		mono_error_assert_ok (error);
 		src = (guint8 *)mono_get_special_static_data (GPOINTER_TO_UINT (addr));
 	} else {
-		src = (guint8*)mono_vtable_get_static_field_data (vt) + field->offset;
+		src = (guint8*)mono_vtable_get_static_field_data (vt) + m_field_get_offset (field);
 	}
 
 	return src;
@@ -2910,7 +2926,10 @@ mono_field_get_value_internal (MonoObject *obj, MonoClassField *field, void *val
 
 	g_return_if_fail (!(field->type->attrs & FIELD_ATTRIBUTE_STATIC));
 
-	src = (char*)obj + field->offset;
+	/* TODO: metadata-update: implement me */
+	g_assert (!m_field_is_from_update (field));
+
+	src = (char*)obj + m_field_get_offset (field);
 	mono_copy_value (field->type, value, src, TRUE);
 }
 
@@ -7786,7 +7805,8 @@ mono_class_value_size (MonoClass *klass, guint32 *align)
 gpointer
 mono_vtype_get_field_addr (gpointer vtype, MonoClassField *field)
 {
-	return ((char*)vtype) + field->offset - MONO_ABI_SIZEOF (MonoObject);
+	g_assert (!m_field_is_from_update (field));
+	return ((char*)vtype) + m_field_get_offset (field) - MONO_ABI_SIZEOF (MonoObject);
 }
 
 static GString *

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -2993,6 +2993,7 @@ mono_get_field_token (MonoClassField *field)
 	MonoClass *klass = m_field_get_parent (field);
 	int i;
 
+	g_assert (!m_field_is_from_update (field));
 	int fcount = mono_class_get_field_count (klass);
 	MonoClassField *klass_fields = m_class_get_fields (klass);
 	for (i = 0; i < fcount; ++i) {

--- a/src/mono/mono/mini/dwarfwriter.c
+++ b/src/mono/mono/mini/dwarfwriter.c
@@ -1094,9 +1094,9 @@ emit_class_dwarf_info (MonoDwarfWriter *w, MonoClass *klass, gboolean vtype)
 				p = buf;
 				*p ++= DW_OP_plus_uconst;
 				if (m_class_is_valuetype (klass) && vtype)
-					encode_uleb128 (field->offset - MONO_ABI_SIZEOF (MonoObject), p, &p);
+					encode_uleb128 (m_field_get_offset (field) - MONO_ABI_SIZEOF (MonoObject), p, &p);
 				else
-					encode_uleb128 (field->offset, p, &p);
+					encode_uleb128 (m_field_get_offset (field), p, &p);
 
 				emit_byte (w, p - buf);
 				emit_bytes (w, buf, p - buf);

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2002,11 +2002,11 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 			if (!mini_is_gsharedvt_variable_klass (param_class)) {
 				MonoClassField *length_field = mono_class_get_field_from_name_full (target_method->klass, "_length", NULL);
 				g_assert (length_field);
-				int offset_length = length_field->offset - sizeof (MonoObject);
+				int offset_length = m_field_get_offset (length_field) - sizeof (MonoObject);
 
 				MonoClassField *ptr_field = mono_class_get_field_from_name_full (target_method->klass, "_pointer", NULL);
 				g_assert (ptr_field);
-				int offset_pointer = ptr_field->offset - sizeof (MonoObject);
+				int offset_pointer = m_field_get_offset (ptr_field) - sizeof (MonoObject);
 
 				int size = mono_class_array_element_size (param_class);
 				interp_add_ins (td, MINT_GETITEM_SPAN);
@@ -2024,7 +2024,7 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 		} else if (!strcmp (tm, "get_Length")) {
 			MonoClassField *length_field = mono_class_get_field_from_name_full (target_method->klass, "_length", NULL);
 			g_assert (length_field);
-			int offset_length = length_field->offset - sizeof (MonoObject);
+			int offset_length = m_field_get_offset (length_field) - sizeof (MonoObject);
 			interp_add_ins (td, MINT_LDLEN_SPAN);
 			td->last_ins->data [0] = offset_length;
 			td->sp--;
@@ -5779,7 +5779,9 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 					goto_if_nok (error, exit);
 				} else {
 					td->sp--;
-					int foffset = m_class_is_valuetype (klass) ? field->offset - MONO_ABI_SIZEOF (MonoObject) : field->offset;
+					/* TODO: metadata-update: implement me. If it's an added field, emit a call to the helper method instead of MINT_LDFLDA_UNSAFE */
+					g_assert (!m_field_is_from_update (field));
+					int foffset = m_class_is_valuetype (klass) ? m_field_get_offset (field) - MONO_ABI_SIZEOF (MonoObject) : m_field_get_offset (field);
 					if (td->sp->type == STACK_TYPE_O) {
 						interp_add_ins (td, MINT_LDFLDA);
 						td->last_ins->data [0] = foffset;
@@ -5822,10 +5824,12 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 					interp_emit_sfld_access (td, field, field_klass, mt, TRUE, error);
 					goto_if_nok (error, exit);
 				} else if (td->sp [-1].type == STACK_TYPE_VT) {
+					/* TODO: metadata-update: implement me */
+					g_assert (!m_field_is_from_update (field));
 					int size = 0;
 					/* First we pop the vt object from the stack. Then we push the field */
 #ifdef NO_UNALIGNED_ACCESS
-					if (field->offset % SIZEOF_VOID_P != 0) {
+					if (m_field_get_offset (field) % SIZEOF_VOID_P != 0) {
 						if (mt == MINT_TYPE_I8 || mt == MINT_TYPE_R8)
 							size = 8;
 					}
@@ -5834,7 +5838,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 					g_assert (m_class_is_valuetype (klass));
 					td->sp--;
 					interp_ins_set_sreg (td->last_ins, td->sp [0].local);
-					td->last_ins->data [0] = field->offset - MONO_ABI_SIZEOF (MonoObject);
+					td->last_ins->data [0] = m_field_get_offset (field) - MONO_ABI_SIZEOF (MonoObject);
 					td->last_ins->data [1] = mt;
 					if (mt == MINT_TYPE_VT)
 						size = field_size;
@@ -5846,6 +5850,8 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 						push_type (td, stack_type [mt], field_klass);
 					interp_ins_set_dreg (td->last_ins, td->sp [-1].local);
 				} else {
+					/* TODO: metadata-update: implement me */
+					g_assert (!m_field_is_from_update (field));
 					int opcode = MINT_LDFLD_I1 + mt - MINT_TYPE_I1;
 #ifdef NO_UNALIGNED_ACCESS
 					if ((mt == MINT_TYPE_I8 || mt == MINT_TYPE_R8) && field->offset % SIZEOF_VOID_P != 0)
@@ -5854,7 +5860,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 					interp_add_ins (td, opcode);
 					td->sp--;
 					interp_ins_set_sreg (td->last_ins, td->sp [0].local);
-					td->last_ins->data [0] = m_class_is_valuetype (klass) ? field->offset - MONO_ABI_SIZEOF (MonoObject) : field->offset;
+					td->last_ins->data [0] = m_class_is_valuetype (klass) ? m_field_get_offset (field) - MONO_ABI_SIZEOF (MonoObject) : m_field_get_offset (field);
 					if (mt == MINT_TYPE_VT) {
 						int size = mono_class_value_size (field_klass, NULL);
 						g_assert (size < G_MAXUINT16);
@@ -5896,6 +5902,8 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 					mono_class_vtable_checked (field_klass, error);
 					goto_if_nok (error, exit);
 				} else {
+					/* TODO: metadata-update: implement me */
+					g_assert (!m_field_is_from_update (field));
 					int opcode = MINT_STFLD_I1 + mt - MINT_TYPE_I1;
 #ifdef NO_UNALIGNED_ACCESS
 					if ((mt == MINT_TYPE_I8 || mt == MINT_TYPE_R8) && field->offset % SIZEOF_VOID_P != 0)
@@ -5904,7 +5912,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 					interp_add_ins (td, opcode);
 					td->sp -= 2;
 					interp_ins_set_sregs2 (td->last_ins, td->sp [0].local, td->sp [1].local);
-					td->last_ins->data [0] = m_class_is_valuetype (klass) ? field->offset - MONO_ABI_SIZEOF (MonoObject) : field->offset;
+					td->last_ins->data [0] = m_class_is_valuetype (klass) ? m_field_get_offset (field) - MONO_ABI_SIZEOF (MonoObject) : m_field_get_offset (field);
 					if (mt == MINT_TYPE_VT) {
 						/* the vtable of the field might not be initialized at this point */
 						mono_class_vtable_checked (field_klass, error);

--- a/src/mono/mono/mini/memory-access.c
+++ b/src/mono/mono/mini/memory-access.c
@@ -250,7 +250,7 @@ create_write_barrier_bitmap (MonoCompile *cfg, MonoClass *klass, unsigned *wb_bi
 
 		if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 			continue;
-		foffset = m_class_is_valuetype (klass) ? field->offset - MONO_ABI_SIZEOF (MonoObject): field->offset;
+		foffset = m_class_is_valuetype (klass) ? m_field_get_offset (field) - MONO_ABI_SIZEOF (MonoObject): m_field_get_offset (field);
 		if (mini_type_is_reference (mono_field_get_type_internal (field))) {
 			g_assert ((foffset % TARGET_SIZEOF_VOID_P) == 0);
 			*wb_bitmap |= 1 << ((offset + foffset) / TARGET_SIZEOF_VOID_P);

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -9646,6 +9646,9 @@ calli_end:
 
 			if (is_instance)
 				g_assert (field->offset);
+			/* metadata-update: no hot reload in the JIT.  But if it was supported,
+			 * field->offset here could be wrong for added (m_field_is_from_update)
+			 * fields */
 			foffset = m_class_is_valuetype (klass) ? field->offset - MONO_ABI_SIZEOF (MonoObject): field->offset;
 			if (il_op == MONO_CEE_STFLD) {
 				sp [1] = convert_value (cfg, field->type, sp [1]);

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -400,15 +400,16 @@ collect_field_info_nested (MonoClass *klass, GArray *fields_array, int offset, g
 		while ((field = mono_class_get_fields_internal (klass, &iter))) {
 			if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 				continue;
+			g_assert (!m_field_is_from_update (field));
 			if (MONO_TYPE_ISSTRUCT (field->type)) {
-				collect_field_info_nested (mono_class_from_mono_type_internal (field->type), fields_array, field->offset - MONO_ABI_SIZEOF (MonoObject), pinvoke, unicode);
+				collect_field_info_nested (mono_class_from_mono_type_internal (field->type), fields_array, m_field_get_offset (field) - MONO_ABI_SIZEOF (MonoObject), pinvoke, unicode);
 			} else {
 				int align;
 				StructFieldInfo f;
 
 				f.type = field->type;
 				f.size = mono_type_size (field->type, &align);
-				f.offset = field->offset - MONO_ABI_SIZEOF (MonoObject) + offset;
+				f.offset = m_field_get_offset (field) - MONO_ABI_SIZEOF (MonoObject) + offset;
 
 				g_array_append_val (fields_array, f);
 			}

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -676,6 +676,12 @@ inflate_info (MonoMemoryManager *mem_manager, MonoRuntimeGenericContextInfoTempl
 		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
 		MonoClass *inflated_class = mono_class_from_mono_type_internal (inflated_type);
+		/*
+		 * metadata-update: no EnC with the JIT.  But even if ther was, adding fields to
+		 * generic types isn't supported, and fields in added generic types would be
+		 * contiguous.  So this is ok.
+		 */
+		g_assert (!m_field_is_from_update (field));
 		int i = field - m_class_get_fields (m_field_get_parent (field));
 		gpointer dummy = NULL;
 
@@ -1178,11 +1184,9 @@ get_wrapper_shared_vtype (MonoType *t)
 	if (m_class_get_type_token (klass) && mono_metadata_packing_from_typedef (m_class_get_image (klass), m_class_get_type_token (klass), NULL, NULL))
 		return NULL;
 
-	int num_fields = mono_class_get_field_count (klass);
-	MonoClassField *klass_fields = m_class_get_fields (klass);
-
-	for (int i = 0; i < num_fields; ++i) {
-		MonoClassField *field = &klass_fields [i];
+	gpointer iter = NULL;
+	MonoClassField *field;
+	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 
 		if (field->type->attrs & (FIELD_ATTRIBUTE_STATIC | FIELD_ATTRIBUTE_HAS_FIELD_RVA))
 			continue;

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -2335,9 +2335,9 @@ instantiate_info (MonoMemoryManager *mem_manager, MonoRuntimeGenericContextInfoT
 
 		/* The value is offset by 1 */
 		if (m_class_is_valuetype (m_field_get_parent (field)) && !(field->type->attrs & FIELD_ATTRIBUTE_STATIC))
-			return GUINT_TO_POINTER (field->offset - MONO_ABI_SIZEOF (MonoObject) + 1);
+			return GUINT_TO_POINTER (m_field_get_offset (field) - MONO_ABI_SIZEOF (MonoObject) + 1);
 		else
-			return GUINT_TO_POINTER (field->offset + 1);
+			return GUINT_TO_POINTER (m_field_get_offset (field) + 1);
 	}
 	case MONO_RGCTX_INFO_METHOD_RGCTX: {
 		MonoMethodInflated *method = (MonoMethodInflated *)data;

--- a/src/mono/mono/sgen/sgen-debug.c
+++ b/src/mono/mono/sgen/sgen-debug.c
@@ -966,13 +966,13 @@ check_reference_for_xdomain (GCObject **ptr, GCObject *obj, MonoDomain *domain)
 
 	field = NULL;
 	for (klass = obj->vtable->klass; klass; klass = m_class_get_parent (klass)) {
-		int i;
-
-		int fcount = mono_class_get_field_count (klass);
-		MonoClassField *klass_fields = m_class_get_fields (klass);
-		for (i = 0; i < fcount; ++i) {
-			if (klass_fields[i].offset == offset) {
-				field = &klass_fields[i];
+		gpointer iter = NULL;
+		MonoClassField *cur;
+		while ((cur = mono_class_get_fields_internal (klass, &iter))) {
+			/* metadata-update: there are no domains in .NET */
+			g_assert (!m_field_is_from_update (cur));
+			if (cur->offset == offset) {
+				field = cur;
 				break;
 			}
 		}

--- a/src/mono/mono/sgen/sgen-debug.c
+++ b/src/mono/mono/sgen/sgen-debug.c
@@ -971,7 +971,7 @@ check_reference_for_xdomain (GCObject **ptr, GCObject *obj, MonoDomain *domain)
 		while ((cur = mono_class_get_fields_internal (klass, &iter))) {
 			/* metadata-update: there are no domains in .NET */
 			g_assert (!m_field_is_from_update (cur));
-			if (cur->offset == offset) {
+			if (m_field_get_offset (cur) == offset) {
 				field = cur;
 				break;
 			}


### PR DESCRIPTION
This is in preparation for adding the ability for hot reload to add instance fields to existing classes.

Mostly the PR does 3 things:
* Add `/* TODO: metadata-update */` comments to places where we will need to do work
* Add `g_assert (!m_field_is_from_update (field))` to places where we either don't expect to see updated fields (for example the JIT or AOT compilers), or places where we will need to do work for hot reload.
* Switch from directly iterating over `MonoClass:fields` to using `mono_class_get_fields_internal`.  For hot reload we will update the iterator method to also return added fields.
* Avoid accessing `MonoClassField:offset` directly.  Go via `m_field_get_offset`.  This is primarily to make it easier to grep for all the places that access field offsets. (Hot reload added fields aren't stored with the object, so "offset" won't make sense - they will be in separate storage that is associated with the object instances)