### PR TITLE
Re-enable RevokeEndEntity_PolicyErrors_NotTimeValid

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
@@ -640,7 +640,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 
         [Theory]
         [MemberData(nameof(PolicyErrorsNotTimeValidData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/31249", PlatformSupport.AppleCrypto)]
         public static void RevokeEndEntity_PolicyErrors_NotTimeValid(bool policyErrors, bool notTimeValid)
         {
             SimpleTest(
@@ -673,7 +672,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 
                         // [ActiveIssue("https://github.com/dotnet/runtime/issues/31246")]
                         // Linux reports this code at more levels than Windows does.
-                        if (OperatingSystem.IsLinux())
+                        if (!OperatingSystem.IsWindows())
                         {
                             issuerExtraProblems |= X509ChainStatusFlags.NotValidForUsage;
                         }


### PR DESCRIPTION
I started looking at these tests again under Monterey, to see if anything has changed.

I noticed that `RevokeEndEntity_PolicyErrors_NotTimeValid` worked for me on macOS 12 with just a small change, so lets run it though CI and see what happens.

Contributes to #31249