### PR TITLE
[wasm] Use `npm` from emsdk when running `sanitize.py`

### DIFF
--- a/src/mono/wasm/sanitize.py
+++ b/src/mono/wasm/sanitize.py
@@ -38,7 +38,7 @@ upgrade = True
 
 # Add the local node bin directory to the path so that
 # npm can find it when doing the updating or pruning
-os.environ["PATH"] += os.pathsep + os.path.join(node_paths[0], "bin")
+os.environ["PATH"] = os.path.join(node_paths[0], "bin") + os.pathsep + os.environ["PATH"]
 
 def update_npm(path):
     try:


### PR DESCRIPTION
The issue manifests are build errors:
`UnhandledPromiseRejectionWarning: Error: Cannot find module 'is-fullwidth-code-point'`

.. eventually failing the build:
`*** No rule to make target 'src/cjs/runtime.cjs.iffe.js', needed by 'dotnet.js'`