### PR TITLE
JIT: Remove BB limit from importer_vectorization

### DIFF
--- a/src/coreclr/jit/importer_vectorization.cpp
+++ b/src/coreclr/jit/importer_vectorization.cpp
@@ -484,14 +484,6 @@ GenTree* Compiler::impExpandHalfConstEquals(GenTreeLclVar*   data,
         return nullptr;
     }
 
-    if ((compIsForInlining() ? (fgBBcount + impInlineRoot()->fgBBcount) : (fgBBcount)) > 20)
-    {
-        // We don't want to unroll too much and in big methods
-        // TODO-Unroll-CQ: come up with some better heuristic/budget
-        JITDUMP("impExpandHalfConstEquals: method has too many BBs (>20) - not profitable to expand.\n");
-        return nullptr;
-    }
-
     const genTreeOps cmpOp         = startsWith ? GT_GE : GT_EQ;
     GenTree*         elementsCount = gtNewIconNode(len);
     GenTree*         lenCheckNode;


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/66529 where due to large method size we end up with the following codegen for all `loweredValue.SequenceEqual("<literal>".AsSpan())`:
```asm
       mov       rdx,1FCA7409060	
       mov       rdx,[rdx]	
       lea       rcx,[rbp+4C0]	
       call      System.MemoryExtensions.AsSpan(System.String)	
       mov       [rbp+10],rbx	
       mov       [rbp+18],r14d	
       mov       rcx,[rbp+4C0]	
       mov       [rbp+20],rcx	
       mov       ecx,[rbp+4C8]	
       mov       [rbp+28],ecx	
       lea       rcx,[rbp+10]	
       lea       rdx,[rbp+20]	
       call      System.MemoryExtensions.SequenceEqual[[System.Char, System.Private.CoreLib]](System.Span`1<Char>, System.ReadOnlySpan`1<Char>)
```

so let's just unconditionally enable https://github.com/dotnet/runtime/pull/65288 - surprisingly, it makes code even smaller.

https://github.com/dotnet/runtime/issues/66529 Benchmark:

|                     Method |                   Toolchain |     Mean |    Error |   StdDev | Ratio |
|--------------------------- |---------------------------- |---------:|---------:|---------:|------:|
|                  SpanBlack | \Core_Root_base\corerun.exe | 49.13 ns | 0.048 ns | 0.037 ns |  3.05 |
|                  SpanBlack |   \Core_Root_PR\corerun.exe | 16.11 ns | 0.317 ns | 0.297 ns |  1.00 |
|                            |                             |          |          |          |       |
|  SpanLightGoldenrodYellowk | \Core_Root_base\corerun.exe | 65.72 ns | 0.150 ns | 0.126 ns |  2.08 |
|  SpanLightGoldenrodYellowk |   \Core_Root_PR\corerun.exe | 31.55 ns | 0.229 ns | 0.215 ns |  1.00 |

**2-3x improvement**

Codegen diff for `GetNamedColorSpan`: https://www.diffchecker.com/bFuRMHNP

SPMI Diffs are interesting - https://dev.azure.com/dnceng/public/_build/results?buildId=1660127&view=ms.vss-build-web.run-extensions-tab (I assume they caught all switches over string literals)
```
benchmarks.run.Linux.x64.checked.mch:
Total bytes of delta: -10162 (-0.06 % of base)

coreclr_tests.pmi.Linux.x64.checked.mch:
Total bytes of delta: -5643 (-0.00 % of base)

libraries.crossgen2.Linux.x64.checked.mch:
Total bytes of delta: 3730 (0.03 % of base)

libraries.pmi.Linux.x64.checked.mch:
Total bytes of delta: -30098 (-0.06 % of base)

libraries_tests.pmi.Linux.x64.checked.mch:
Total bytes of delta: -36095 (-0.03 % of base)
```