### PR TITLE
Fix System.Text.Json tests affected by DST

### DIFF
--- a/src/libraries/Common/tests/System/DateTimeTestHelpers.cs
+++ b/src/libraries/Common/tests/System/DateTimeTestHelpers.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace System
+{
+    // Provide date/time test helpers
+    public static class DateTimeTestHelpers
+    {
+        // Fixed DateTimeOffset, to avoid the use of DateTimeOffset.(Utc)Now in situations that simply require a value be present.
+        public static DateTimeOffset FixedDateTimeOffsetValue => new DateTimeOffset(2001, 2, 3, 4, 5, 6, 789, TimeSpan.Zero);
+
+        // Fixed DateTime, to avoid the use of DateTime.(Utc)Now in situations that simply require a value be present.
+        public static DateTime FixedDateTimeValue => FixedDateTimeOffsetValue.UtcDateTime;
+    }
+
+}

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -376,8 +376,8 @@ namespace System.Text.Json.Serialization.Tests
             point.SecondInt = 348943;
             point.FirstString = "934sdkjfskdfssf";
             point.SecondString = "sdad9434243242";
-            point.FirstDateTime = DateTime.UtcNow;
-            point.SecondDateTime = DateTime.UtcNow.AddHours(1).AddYears(1);
+            point.FirstDateTime = DateTimeTestHelpers.FixedDateTimeValue;
+            point.SecondDateTime = DateTimeTestHelpers.FixedDateTimeValue.AddHours(1).AddYears(1);
 
             point.X = 234235;
             point.Y = 912874;
@@ -387,8 +387,8 @@ namespace System.Text.Json.Serialization.Tests
             point.FourthInt = 348943;
             point.ThirdString = "934sdkjfskdfssf";
             point.FourthString = "sdad9434243242";
-            point.ThirdDateTime = DateTime.UtcNow;
-            point.FourthDateTime = DateTime.UtcNow.AddHours(1).AddYears(1);
+            point.ThirdDateTime = DateTimeTestHelpers.FixedDateTimeValue;
+            point.FourthDateTime = DateTimeTestHelpers.FixedDateTimeValue.AddHours(1).AddYears(1);
 
             string json = await JsonSerializerWrapperForString.SerializeWrapper(point);
 
@@ -421,15 +421,15 @@ namespace System.Text.Json.Serialization.Tests
             point.SecondInt = 348943;
             point.FirstString = "934sdkjfskdfssf";
             point.SecondString = "sdad9434243242";
-            point.FirstDateTime = DateTime.UtcNow;
-            point.SecondDateTime = DateTime.UtcNow.AddHours(1).AddYears(1);
+            point.FirstDateTime = DateTimeTestHelpers.FixedDateTimeValue;
+            point.SecondDateTime = DateTimeTestHelpers.FixedDateTimeValue.AddHours(1).AddYears(1);
 
             point.ThirdInt = 348943;
             point.FourthInt = 348943;
             point.ThirdString = "934sdkjfskdfssf";
             point.FourthString = "sdad9434243242";
-            point.ThirdDateTime = DateTime.UtcNow;
-            point.FourthDateTime = DateTime.UtcNow.AddHours(1).AddYears(1);
+            point.ThirdDateTime = DateTimeTestHelpers.FixedDateTimeValue;
+            point.FourthDateTime = DateTimeTestHelpers.FixedDateTimeValue.AddHours(1).AddYears(1);
 
             string json = await JsonSerializerWrapperForString.SerializeWrapper(point);
 
@@ -462,15 +462,15 @@ namespace System.Text.Json.Serialization.Tests
             point.SecondInt = 348943;
             point.FirstString = "934sdkjfskdfssf";
             point.SecondString = "sdad9434243242";
-            point.FirstDateTime = DateTime.UtcNow;
-            point.SecondDateTime = DateTime.UtcNow.AddHours(1).AddYears(1);
+            point.FirstDateTime = DateTimeTestHelpers.FixedDateTimeValue;
+            point.SecondDateTime = DateTimeTestHelpers.FixedDateTimeValue.AddHours(1).AddYears(1);
 
             point.ThirdInt = 348943;
             point.FourthInt = 348943;
             point.ThirdString = "934sdkjfskdfssf";
             point.FourthString = "sdad9434243242";
-            point.ThirdDateTime = DateTime.UtcNow;
-            point.FourthDateTime = DateTime.UtcNow.AddHours(1).AddYears(1);
+            point.ThirdDateTime = DateTimeTestHelpers.FixedDateTimeValue;
+            point.FourthDateTime = DateTimeTestHelpers.FixedDateTimeValue.AddHours(1).AddYears(1);
 
             string json = await JsonSerializerWrapperForString.SerializeWrapper(point);
 

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -376,8 +376,8 @@ namespace System.Text.Json.Serialization.Tests
             point.SecondInt = 348943;
             point.FirstString = "934sdkjfskdfssf";
             point.SecondString = "sdad9434243242";
-            point.FirstDateTime = DateTime.Now;
-            point.SecondDateTime = DateTime.Now.AddHours(1).AddYears(1);
+            point.FirstDateTime = DateTime.UtcNow;
+            point.SecondDateTime = DateTime.UtcNow.AddHours(1).AddYears(1);
 
             point.X = 234235;
             point.Y = 912874;
@@ -387,8 +387,8 @@ namespace System.Text.Json.Serialization.Tests
             point.FourthInt = 348943;
             point.ThirdString = "934sdkjfskdfssf";
             point.FourthString = "sdad9434243242";
-            point.ThirdDateTime = DateTime.Now;
-            point.FourthDateTime = DateTime.Now.AddHours(1).AddYears(1);
+            point.ThirdDateTime = DateTime.UtcNow;
+            point.FourthDateTime = DateTime.UtcNow.AddHours(1).AddYears(1);
 
             string json = await JsonSerializerWrapperForString.SerializeWrapper(point);
 
@@ -421,15 +421,15 @@ namespace System.Text.Json.Serialization.Tests
             point.SecondInt = 348943;
             point.FirstString = "934sdkjfskdfssf";
             point.SecondString = "sdad9434243242";
-            point.FirstDateTime = DateTime.Now;
-            point.SecondDateTime = DateTime.Now.AddHours(1).AddYears(1);
+            point.FirstDateTime = DateTime.UtcNow;
+            point.SecondDateTime = DateTime.UtcNow.AddHours(1).AddYears(1);
 
             point.ThirdInt = 348943;
             point.FourthInt = 348943;
             point.ThirdString = "934sdkjfskdfssf";
             point.FourthString = "sdad9434243242";
-            point.ThirdDateTime = DateTime.Now;
-            point.FourthDateTime = DateTime.Now.AddHours(1).AddYears(1);
+            point.ThirdDateTime = DateTime.UtcNow;
+            point.FourthDateTime = DateTime.UtcNow.AddHours(1).AddYears(1);
 
             string json = await JsonSerializerWrapperForString.SerializeWrapper(point);
 
@@ -462,15 +462,15 @@ namespace System.Text.Json.Serialization.Tests
             point.SecondInt = 348943;
             point.FirstString = "934sdkjfskdfssf";
             point.SecondString = "sdad9434243242";
-            point.FirstDateTime = DateTime.Now;
-            point.SecondDateTime = DateTime.Now.AddHours(1).AddYears(1);
+            point.FirstDateTime = DateTime.UtcNow;
+            point.SecondDateTime = DateTime.UtcNow.AddHours(1).AddYears(1);
 
             point.ThirdInt = 348943;
             point.FourthInt = 348943;
             point.ThirdString = "934sdkjfskdfssf";
             point.FourthString = "sdad9434243242";
-            point.ThirdDateTime = DateTime.Now;
-            point.FourthDateTime = DateTime.Now.AddHours(1).AddYears(1);
+            point.ThirdDateTime = DateTime.UtcNow;
+            point.FourthDateTime = DateTime.UtcNow.AddHours(1).AddYears(1);
 
             string json = await JsonSerializerWrapperForString.SerializeWrapper(point);
 

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -833,7 +833,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public async Task ArgumentDeserialization_Honors_JsonInclude()
         {
-            Point_MembersHave_JsonInclude point = new Point_MembersHave_JsonInclude(1, 2,3);
+            Point_MembersHave_JsonInclude point = new Point_MembersHave_JsonInclude(1, 2, 3);
 
             string json = await JsonSerializerWrapperForString.SerializeWrapper(point);
             Assert.Contains(@"""X"":1", json);

--- a/src/libraries/System.Text.Json/tests/Common/TestClasses/TestClasses.Constructor.cs
+++ b/src/libraries/System.Text.Json/tests/Common/TestClasses/TestClasses.Constructor.cs
@@ -1308,7 +1308,8 @@ namespace System.Text.Json.Serialization.Tests
             Int56 = int56; Int57 = int57; Int58 = int58; Int59 = int59; Int60 = int60; Int61 = int61; Int62 = int62; Int63 = int63;
         }
 
-        public static string Json {
+        public static string Json
+        {
             get
             {
                 StringBuilder sb = new StringBuilder();
@@ -2282,7 +2283,7 @@ namespace System.Text.Json.Serialization.Tests
     {
         public int X { get; }
         public int Y { get; }
-        public int Z { get; set;  }
+        public int Z { get; set; }
 
         [JsonConstructor]
         public Point_With_Property(int x, int y)

--- a/src/libraries/System.Text.Json/tests/Common/TestClasses/TestClasses.Constructor.cs
+++ b/src/libraries/System.Text.Json/tests/Common/TestClasses/TestClasses.Constructor.cs
@@ -2326,18 +2326,18 @@ namespace System.Text.Json.Serialization.Tests
             = new MyEventsListerItem
             {
                 Campaign = "A very nice campaign",
-                EndDate = DateTime.UtcNow.AddDays(7),
+                EndDate = DateTimeTestHelpers.FixedDateTimeValue.AddDays(7),
                 EventId = 321,
                 EventName = "wonderful name",
                 Organization = "Local Animal Shelter",
-                StartDate = DateTime.UtcNow.AddDays(-7),
+                StartDate = DateTimeTestHelpers.FixedDateTimeValue.AddDays(-7),
                 TimeZone = TimeZoneInfo.Utc.DisplayName,
                 VolunteerCount = 15,
                 Tasks = Enumerable.Repeat(
                     new MyEventsListerItemTask
                     {
-                        StartDate = DateTime.UtcNow,
-                        EndDate = DateTime.UtcNow.AddDays(1),
+                        StartDate = DateTimeTestHelpers.FixedDateTimeValue,
+                        EndDate = DateTimeTestHelpers.FixedDateTimeValue.AddDays(1),
                         Name = "A very nice task to have"
                     }, 4).ToList()
             };

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
@@ -396,10 +396,10 @@ namespace System.Text.Json.SourceGeneration.Tests
                 CampaignManagedOrganizerName = "Name FamilyName",
                 CampaignName = "The very new campaign",
                 Description = "The .NET Foundation works with Microsoft and the broader industry to increase the exposure of open source projects in the .NET community and the .NET Foundation. The .NET Foundation provides access to these resources to projects and looks to promote the activities of our communities.",
-                EndDate = DateTime.UtcNow.AddYears(1),
+                EndDate = DateTimeTestHelpers.FixedDateTimeValue.AddYears(1),
                 Name = "Just a name",
                 ImageUrl = "https://www.dotnetfoundation.org/theme/img/carousel/foundation-diagram-content.png",
-                StartDate = DateTime.UtcNow,
+                StartDate = DateTimeTestHelpers.FixedDateTimeValue,
                 Offset = TimeSpan.FromHours(2)
             };
         }
@@ -460,10 +460,10 @@ namespace System.Text.Json.SourceGeneration.Tests
                         CampaignManagedOrganizerName = "Name FamilyName",
                         CampaignName = "The very new campaign",
                         Description = "The .NET Foundation works with Microsoft and the broader industry to increase the exposure of open source projects in the .NET community and the .NET Foundation. The .NET Foundation provides access to these resources to projects and looks to promote the activities of our communities.",
-                        EndDate = DateTime.UtcNow.AddYears(1),
+                        EndDate = DateTimeTestHelpers.FixedDateTimeValue.AddYears(1),
                         Name = "Just a name",
                         ImageUrl = "https://www.dotnetfoundation.org/theme/img/carousel/foundation-diagram-content.png",
-                        StartDate = DateTime.UtcNow
+                        StartDate = DateTimeTestHelpers.FixedDateTimeValue
                     },
                     count: 20).ToList()
             };

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Tests.targets
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Tests.targets
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)System\DateTimeTestHelpers.cs" Link="CommonTest\System\DateTimeTestHelpers.cs" />
     <Compile Include="..\Common\CollectionTests\CollectionTests.AsyncEnumerable.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\CollectionTests\CollectionTests.AsyncEnumerable.cs" />
     <Compile Include="..\Common\CollectionTests\CollectionTests.Concurrent.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\CollectionTests\CollectionTests.Concurrent.cs" />
     <Compile Include="..\Common\CollectionTests\CollectionTests.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\CollectionTests\CollectionTests.cs" />

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NullableTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NullableTests.cs
@@ -22,7 +22,7 @@ namespace System.Text.Json.Serialization.Tests
                 dictOfDictWithNull: new Dictionary<string, Dictionary<string, float?>> { { "key", dictWithFloatNull } },
                 42.0f);
 
-            DateTime now = DateTime.Now;
+            DateTime now = DateTime.UtcNow;
             Dictionary<string, DateTime?> dictWithDateTimeValue = new Dictionary<string, DateTime?> { { "key", now } };
             Dictionary<string, DateTime?> dictWithDateTimeNull = new Dictionary<string, DateTime?> { { "key", null } };
             TestDictionaryWithNullableValue<Dictionary<string, DateTime?>, Dictionary<string, Dictionary<string, DateTime?>>, DateTime?>(
@@ -205,7 +205,7 @@ namespace System.Text.Json.Serialization.Tests
                 enumerableOfEnumerableWithNull: new List<IEnumerable<float?>> { ieWithFloatNull },
                 42.0f);
 
-            DateTime now = DateTime.Now;
+            DateTime now = DateTime.UtcNow;
             IEnumerable<DateTime?> ieWithDateTimeValue = new List<DateTime?> { now };
             IEnumerable<DateTime?> ieWithDateTimeNull = new List<DateTime?> { null };
             TestEnumerableWithNullableValue<IEnumerable<DateTime?>, IEnumerable<IEnumerable<DateTime?>>, DateTime?>(

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NullableTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NullableTests.cs
@@ -22,7 +22,7 @@ namespace System.Text.Json.Serialization.Tests
                 dictOfDictWithNull: new Dictionary<string, Dictionary<string, float?>> { { "key", dictWithFloatNull } },
                 42.0f);
 
-            DateTime now = DateTime.UtcNow;
+            DateTime now = DateTimeTestHelpers.FixedDateTimeValue;
             Dictionary<string, DateTime?> dictWithDateTimeValue = new Dictionary<string, DateTime?> { { "key", now } };
             Dictionary<string, DateTime?> dictWithDateTimeNull = new Dictionary<string, DateTime?> { { "key", null } };
             TestDictionaryWithNullableValue<Dictionary<string, DateTime?>, Dictionary<string, Dictionary<string, DateTime?>>, DateTime?>(
@@ -205,7 +205,7 @@ namespace System.Text.Json.Serialization.Tests
                 enumerableOfEnumerableWithNull: new List<IEnumerable<float?>> { ieWithFloatNull },
                 42.0f);
 
-            DateTime now = DateTime.UtcNow;
+            DateTime now = DateTimeTestHelpers.FixedDateTimeValue;
             IEnumerable<DateTime?> ieWithDateTimeValue = new List<DateTime?> { now };
             IEnumerable<DateTime?> ieWithDateTimeNull = new List<DateTime?> { null };
             TestEnumerableWithNullableValue<IEnumerable<DateTime?>, IEnumerable<IEnumerable<DateTime?>>, DateTime?>(

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NumberHandlingTests.cs
@@ -256,7 +256,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void NonNumber_AsBoxed_Property()
         {
-            DateTime dateTime = DateTime.UtcNow;
+            DateTime dateTime = DateTimeTestHelpers.FixedDateTimeValue;
             Guid? nullableGuid = Guid.NewGuid();
 
             string expected = @$"{{""MyDateTime"":{JsonSerializer.Serialize(dateTime)},""MyNullableGuid"":{JsonSerializer.Serialize(nullableGuid)}}}";
@@ -293,7 +293,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void NonNumber_AsBoxed_CollectionRootType_Element()
         {
-            DateTime dateTime = DateTime.UtcNow;
+            DateTime dateTime = DateTimeTestHelpers.FixedDateTimeValue;
             Guid? nullableGuid = Guid.NewGuid();
 
             string expected = @$"[{JsonSerializer.Serialize(dateTime)}]";
@@ -324,7 +324,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void NonNumber_AsBoxed_CollectionProperty_Element()
         {
-            DateTime dateTime = DateTime.UtcNow;
+            DateTime dateTime = DateTimeTestHelpers.FixedDateTimeValue;
             Guid? nullableGuid = Guid.NewGuid();
 
             string expected = @$"{{""MyDateTimes"":[{JsonSerializer.Serialize(dateTime)}],""MyNullableGuids"":[{JsonSerializer.Serialize(nullableGuid)}]}}";

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NumberHandlingTests.cs
@@ -256,7 +256,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void NonNumber_AsBoxed_Property()
         {
-            DateTime dateTime = DateTime.Now;
+            DateTime dateTime = DateTime.UtcNow;
             Guid? nullableGuid = Guid.NewGuid();
 
             string expected = @$"{{""MyDateTime"":{JsonSerializer.Serialize(dateTime)},""MyNullableGuid"":{JsonSerializer.Serialize(nullableGuid)}}}";
@@ -293,7 +293,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void NonNumber_AsBoxed_CollectionRootType_Element()
         {
-            DateTime dateTime = DateTime.Now;
+            DateTime dateTime = DateTime.UtcNow;
             Guid? nullableGuid = Guid.NewGuid();
 
             string expected = @$"[{JsonSerializer.Serialize(dateTime)}]";
@@ -324,7 +324,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void NonNumber_AsBoxed_CollectionProperty_Element()
         {
-            DateTime dateTime = DateTime.Now;
+            DateTime dateTime = DateTime.UtcNow;
             Guid? nullableGuid = Guid.NewGuid();
 
             string expected = @$"{{""MyDateTimes"":[{JsonSerializer.Serialize(dateTime)}],""MyNullableGuids"":[{JsonSerializer.Serialize(nullableGuid)}]}}";

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\IO\WrappedMemoryStream.cs" Link="CommonTest\System\IO\WrappedMemoryStream.cs" />
+    <Compile Include="$(CommonTestPath)System\DateTimeTestHelpers.cs" Link="CommonTest\System\DateTimeTestHelpers.cs" />
     <Compile Include="..\Common\CollectionTests\CollectionTests.AsyncEnumerable.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\CollectionTests\CollectionTests.AsyncEnumerable.cs" />
     <Compile Include="..\Common\CollectionTests\CollectionTests.Concurrent.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\CollectionTests\CollectionTests.Concurrent.cs" />
     <Compile Include="..\Common\CollectionTests\CollectionTests.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\CollectionTests\CollectionTests.cs" />

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonWriterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonWriterTests.cs
@@ -6195,7 +6195,7 @@ namespace System.Text.Json.Tests
                 var output = new ArrayBufferWriter<byte>(1024);
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteStartObject();
-                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteString(key, DateTime.UtcNow));
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteString(key, DateTimeTestHelpers.FixedDateTimeValue));
                 Assert.Equal(0, output.WrittenCount);
             }
 
@@ -6304,7 +6304,7 @@ namespace System.Text.Json.Tests
         [Fact]
         public void WriteDateTime_TrimsFractionCorrectly_SerializerRoundtrip()
         {
-            DateTime utcNow = DateTime.UtcNow;
+            DateTime utcNow = DateTimeTestHelpers.FixedDateTimeValue;
             Assert.Equal(utcNow, JsonSerializer.Deserialize(JsonSerializer.SerializeToUtf8Bytes(utcNow), typeof(DateTime)));
         }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonWriterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonWriterTests.cs
@@ -6195,7 +6195,7 @@ namespace System.Text.Json.Tests
                 var output = new ArrayBufferWriter<byte>(1024);
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteStartObject();
-                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteString(key, DateTime.Now));
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteString(key, DateTime.UtcNow));
                 Assert.Equal(0, output.WrittenCount);
             }
 


### PR DESCRIPTION
Fixes #66555 

Does so by switching all remaining references to `DateTime.Now` to `DateTime.UtcNow`.