### PR TITLE
Add xarch `blsmsk`

### DIFF
--- a/src/coreclr/jit/instrsxarch.h
+++ b/src/coreclr/jit/instrsxarch.h
@@ -594,8 +594,8 @@ INST3(LAST_AVXVNNI_INSTRUCTION, "LAST_AVXVNNI_INSTRUCTION", IUM_WR, BAD_CODE, BA
 // BMI1
 INST3(FIRST_BMI_INSTRUCTION, "FIRST_BMI_INSTRUCTION", IUM_WR, BAD_CODE, BAD_CODE, BAD_CODE, INS_FLAGS_None)
 INST3(andn,             "andn",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF2),                             Resets_OF      | Writes_SF     | Writes_ZF     | Undefined_AF  | Undefined_PF  | Resets_CF     | INS_Flags_IsDstDstSrcAVXInstruction)    // Logical AND NOT
-INST3(blsi,             "blsi",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF3),                             Resets_OF      | Writes_SF     | Writes_ZF     | Undefined_AF  | Undefined_PF  | Writes_CF     | INS_Flags_IsDstDstSrcAVXInstruction)    // Extract Lowest Set Isolated Bit
-INST3(blsmsk,           "blsmsk",           IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF3),                             INS_Flags_IsDstDstSrcAVXInstruction)    // Get Mask Up to Lowest Set Bit
+INST3(blsi,				"blsi",				IUM_WR, BAD_CODE,	  BAD_CODE,		SSE38(0xF3),							 Resets_OF		| Writes_SF		| Writes_ZF		| Undefined_AF	| Undefined_PF	| Writes_CF		| INS_Flags_IsDstDstSrcAVXInstruction)    // Extract Lowest Set Isolated Bit
+INST3(blsmsk,			"blsmsk",			IUM_WR, BAD_CODE,	  BAD_CODE,		SSE38(0xF3),							 Resets_OF		| Writes_SF		| Writes_ZF		| Undefined_AF	| Undefined_PF	| Writes_CF		| INS_Flags_IsDstDstSrcAVXInstruction)    // Get Mask Up to Lowest Set Bit
 INST3(blsr,             "blsr",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF3),                             Resets_OF      | Writes_SF     | Writes_ZF     | Undefined_AF  | Undefined_PF  | Writes_CF     | INS_Flags_IsDstDstSrcAVXInstruction)    // Reset Lowest Set Bit
 INST3(bextr,            "bextr",            IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF7),                             INS_Flags_IsDstDstSrcAVXInstruction)    // Bit Field Extract
 

--- a/src/coreclr/jit/instrsxarch.h
+++ b/src/coreclr/jit/instrsxarch.h
@@ -595,7 +595,7 @@ INST3(LAST_AVXVNNI_INSTRUCTION, "LAST_AVXVNNI_INSTRUCTION", IUM_WR, BAD_CODE, BA
 INST3(FIRST_BMI_INSTRUCTION, "FIRST_BMI_INSTRUCTION", IUM_WR, BAD_CODE, BAD_CODE, BAD_CODE, INS_FLAGS_None)
 INST3(andn,             "andn",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF2),                             Resets_OF      | Writes_SF     | Writes_ZF     | Undefined_AF  | Undefined_PF  | Resets_CF     | INS_Flags_IsDstDstSrcAVXInstruction)    // Logical AND NOT
 INST3(blsi,				"blsi",				IUM_WR, BAD_CODE,	  BAD_CODE,		SSE38(0xF3),							 Resets_OF		| Writes_SF		| Writes_ZF		| Undefined_AF	| Undefined_PF	| Writes_CF		| INS_Flags_IsDstDstSrcAVXInstruction)    // Extract Lowest Set Isolated Bit
-INST3(blsmsk,			"blsmsk",			IUM_WR, BAD_CODE,	  BAD_CODE,		SSE38(0xF3),							 Resets_OF		| Writes_SF		| Writes_ZF		| Undefined_AF	| Undefined_PF	| Writes_CF		| INS_Flags_IsDstDstSrcAVXInstruction)    // Get Mask Up to Lowest Set Bit
+INST3(blsmsk,			"blsmsk",			IUM_WR, BAD_CODE,	  BAD_CODE,		SSE38(0xF3),							 Resets_OF		| Writes_SF		| Writes_ZF		| Undefined_AF	| Undefined_PF	| Resets_CF		| INS_Flags_IsDstDstSrcAVXInstruction)    // Get Mask Up to Lowest Set Bit
 INST3(blsr,             "blsr",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF3),                             Resets_OF      | Writes_SF     | Writes_ZF     | Undefined_AF  | Undefined_PF  | Writes_CF     | INS_Flags_IsDstDstSrcAVXInstruction)    // Reset Lowest Set Bit
 INST3(bextr,            "bextr",            IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF7),                             INS_Flags_IsDstDstSrcAVXInstruction)    // Bit Field Extract
 

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -351,6 +351,7 @@ private:
     GenTree* TryLowerAndOpToResetLowestSetBit(GenTreeOp* andNode);
     GenTree* TryLowerAndOpToExtractLowestSetBit(GenTreeOp* andNode);
     GenTree* TryLowerAndOpToAndNot(GenTreeOp* andNode);
+    GenTree* TryLowerXorOpToGetMaskUpToLowestSetBit(GenTreeOp* xorNode);
     void LowerBswapOp(GenTreeOp* node);
 #elif defined(TARGET_ARM64)
     bool IsValidConstForMovImm(GenTreeHWIntrinsic* node);

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -4149,9 +4149,9 @@ GenTree* Lowering::TryLowerXorOpToGetMaskUpToLowestSetBit(GenTreeOp* xorNode)
         return nullptr;
     }
 
-    // prevent decomposed 64 integer node parts in x86 from being recognised
-    if (((xorNode->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS) || ((negOp->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS) ||
-        ((negNode->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS))
+     // Subsequent nodes may rely on CPU flags set by these nodes in which case we cannot remove them
+    if (((xorNode->gtFlags & GTF_SET_FLAGS) != 0) || ((negOp->gtFlags & GTF_SET_FLAGS) !=0) ||
+        ((negNode->gtFlags & GTF_SET_FLAGS) != 0))
     {
         return nullptr;
     }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -4149,8 +4149,8 @@ GenTree* Lowering::TryLowerXorOpToGetMaskUpToLowestSetBit(GenTreeOp* xorNode)
         return nullptr;
     }
 
-     // Subsequent nodes may rely on CPU flags set by these nodes in which case we cannot remove them
-    if (((xorNode->gtFlags & GTF_SET_FLAGS) != 0) || ((negOp->gtFlags & GTF_SET_FLAGS) !=0) ||
+    // Subsequent nodes may rely on CPU flags set by these nodes in which case we cannot remove them
+    if (((xorNode->gtFlags & GTF_SET_FLAGS) != 0) || ((negOp->gtFlags & GTF_SET_FLAGS) != 0) ||
         ((negNode->gtFlags & GTF_SET_FLAGS) != 0))
     {
         return nullptr;

--- a/src/tests/JIT/Intrinsics/BMI1Intrinsics.cs
+++ b/src/tests/JIT/Intrinsics/BMI1Intrinsics.cs
@@ -12,15 +12,15 @@ namespace BMI1Intrinsics
             // bmi1 expression are folded to to hwintrinsics that return identical results
 
             var values = new (uint input1, uint input2, uint andnExpected, uint blsiExpected, uint blsrExpected, uint blmskExpected)[] {
-                (0, 0, 0, 0 ,0 ,0),
-                (1, 0, 1, 1 ,0 ,0xfffffffe),
-                (uint.MaxValue / 2, 0, 0x7fffffff, 0x1 ,0x7ffffffe ,0xfffffffe),
-                ((uint.MaxValue / 2) - 1,  0, 0x7FFFFFFE, 2 ,0x7FFFFFFC ,0xFFFFFFFC),
-                ((uint.MaxValue / 2) + 1, 0, 0x80000000, 0x80000000 ,0 ,0),
-                (uint.MaxValue - 1, 0, 0xFFFFFFFE, 2 ,0xFFFFFFFC ,0xFFFFFFFC),
-                (uint.MaxValue , 0, 0xFFFFFFFF, 1 ,0xFFFFFFFE ,0xFFFFFFFE),
-                (0xAAAAAAAA,0xAAAAAAAA,0,2,0xAAAAAAA8,0xFFFFFFFC),
-                (0xAAAAAAAA,0x55555555,0xAAAAAAAA,2,0xAAAAAAA8,0xFFFFFFFC),
+                (0, 0, 0, 0 ,0 ,0xFFFFFFFF),
+                (1, 0, 1, 1 ,0 ,1),
+                (uint.MaxValue / 2, 0, 0x7fffffff, 0x1 ,0x7ffffffe ,1),
+                ((uint.MaxValue / 2) - 1,  0, 0x7FFFFFFE, 2 ,0x7FFFFFFC ,3),
+                ((uint.MaxValue / 2) + 1, 0, 0x80000000, 0x80000000 ,0 ,0xFFFFFFFF),
+                (uint.MaxValue - 1, 0, 0xFFFFFFFE, 2 ,0xFFFFFFFC ,3),
+                (uint.MaxValue , 0, 0xFFFFFFFF, 1 ,0xFFFFFFFE ,1),
+                (0xAAAAAAAA,0xAAAAAAAA,0,2,0xAAAAAAA8,3),
+                (0xAAAAAAAA,0x55555555,0xAAAAAAAA,2,0xAAAAAAA8,3),
             };
 
             foreach (var value in values)
@@ -33,15 +33,15 @@ namespace BMI1Intrinsics
 
 
             var values2 = new (ulong input1, ulong input2, ulong andnExpected, ulong blsiExpected, ulong blsrExpected, ulong blmskExpected)[] {
-                (0,                                    0,                  0,                  0,                  0,                  0),
-                (1,                                    0,                  1,                  1,                  0,0xFFFFFFFF_FFFFFFFE),
-                (ulong.MaxValue / 2,                   0,0x7FFFFFFF_FFFFFFFF,                  1,0x7FFFFFFF_FFFFFFFE,0xFFFFFFFF_FFFFFFFE),
-                ((ulong.MaxValue / 2) - 1,             0,0x7FFFFFFF_FFFFFFFE,                  2,0x7FFFFFFF_FFFFFFFC,0xFFFFFFFF_FFFFFFFC),
-                ((ulong.MaxValue / 2) + 1,             0,0x80000000_00000000,0x80000000_00000000,                  0,                  0),
-                (ulong.MaxValue - 1,                   0,0xFFFFFFFF_FFFFFFFE,                  2,0xFFFFFFFF_FFFFFFFC,0xFFFFFFFF_FFFFFFFC),
-                (ulong.MaxValue,                       0,0xFFFFFFFF_FFFFFFFF,                  1,0xFFFFFFFF_FFFFFFFE,0xFFFFFFFF_FFFFFFFE),
-                (0xAAAAAAAA_AAAAAAAA,0xAAAAAAAA_AAAAAAAA,                  0,                  2,0xAAAAAAAA_AAAAAAA8,0xFFFFFFFF_FFFFFFFC),
-                (0xAAAAAAAA_AAAAAAAA,0x55555555_55555555,0xAAAAAAAA_AAAAAAAA,                  2,0xAAAAAAAA_AAAAAAA8,0xFFFFFFFF_FFFFFFFC),
+                (0,                                    0,                  0,                  0,                  0,0xFFFFFFFF_FFFFFFFF),
+                (1,                                    0,                  1,                  1,                  0,                  1),
+                (ulong.MaxValue / 2,                   0,0x7FFFFFFF_FFFFFFFF,                  1,0x7FFFFFFF_FFFFFFFE,                  1),
+                ((ulong.MaxValue / 2) - 1,             0,0x7FFFFFFF_FFFFFFFE,                  2,0x7FFFFFFF_FFFFFFFC,                  3),
+                ((ulong.MaxValue / 2) + 1,             0,0x80000000_00000000,0x80000000_00000000,                  0,0xFFFFFFFF_FFFFFFFF),
+                (ulong.MaxValue - 1,                   0,0xFFFFFFFF_FFFFFFFE,                  2,0xFFFFFFFF_FFFFFFFC,                  3),
+                (ulong.MaxValue,                       0,0xFFFFFFFF_FFFFFFFF,                  1,0xFFFFFFFF_FFFFFFFE,                  1),
+                (0xAAAAAAAA_AAAAAAAA,0xAAAAAAAA_AAAAAAAA,                  0,                  2,0xAAAAAAAA_AAAAAAA8,                  3),
+                (0xAAAAAAAA_AAAAAAAA,0x55555555_55555555,0xAAAAAAAA_AAAAAAAA,                  2,0xAAAAAAAA_AAAAAAA8,                  3),
             };
 
             foreach (var value in values2)
@@ -74,10 +74,10 @@ namespace BMI1Intrinsics
         private static ulong ResetLowestSetBit_64bit(ulong x) => x & (x - 1); // bmi1 blsr
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static uint GetMaskUpToLowestSetBit_32bit(uint x) => (uint)(x ^ (-x)); // bmi1 blmsk
+        private static uint GetMaskUpToLowestSetBit_32bit(uint x) => x ^ (x - 1); // bmi1 blsmsk
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static ulong GetMaskUpToLowestSetBit_64bit(ulong x) => x ^ (ulong)(-(long)x); // bmi1 blmsk
+        private static ulong GetMaskUpToLowestSetBit_64bit(ulong x) => x ^ (x - 1); // bmi1 blsmsk
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void Test(uint input, uint output, uint expected, string callerName)


### PR DESCRIPTION
This adds a lowering for the pattern XOR(x, x - 1) to the GetMaskUpToLowestSetSit hwintrinsic.
There are no uses of this pattern in the runtime. SPMI replay is clean. Test coverage is added by https://github.com/dotnet/runtime/pull/66193 and this PR is opened for completeness of the simple BMI1 intrinsic. 

/cc @dotnet/jit-contrib @AndyAyersMS 