### PR TITLE
A bunch of small regex tweaks

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -344,8 +344,8 @@ namespace System.Text.RegularExpressions.Generator
             Debug.Assert(minRequiredLength >= 0);
             string clause = (minRequiredLength, rtl) switch
                             {
-                                (0, false) => "if (pos <= inputSpan.Length)",
-                                (1, false) => "if (pos < inputSpan.Length)",
+                                (0, false) => "if ((uint)pos <= (uint)inputSpan.Length)",
+                                (1, false) => "if ((uint)pos < (uint)inputSpan.Length)",
                                 (_, false) => $"if (pos <= inputSpan.Length - {minRequiredLength})",
                                 (0, true) => "if (pos >= 0)",
                                 (1, true) => "if (pos > 0)",

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -2332,7 +2332,7 @@ namespace System.Text.RegularExpressions.Generator
                                 {
                                     WritePrefix();
                                     string sourceSpan = sliceStaticPos > 0 ? $"{sliceSpan}.Slice({sliceStaticPos})" : sliceSpan;
-                                    writer.Write($"!global::System.MemoryExtensions.StartsWith({sourceSpan}, {Literal(caseInsensitiveString)}, global::System.StringComparison.OrdinalIgnoreCase)");
+                                    writer.Write($"!{sourceSpan}.StartsWith({Literal(caseInsensitiveString)}, StringComparison.OrdinalIgnoreCase)");
                                     prevDescription = $"Match the string {Literal(caseInsensitiveString)} (ordinal case-insensitive)";
                                     wroteClauses = true;
 

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -434,12 +434,12 @@ namespace System.Text.RegularExpressions.Generator
                 {
                     case FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning:
                         writer.WriteLine("// The pattern leads with a beginning (\\A) anchor.");
-                        using (EmitBlock(writer, "if (pos != 0)"))
+                        using (EmitBlock(writer, "if (pos == 0)"))
                         {
-                            // If we're not currently at the beginning, we'll never be, so fail immediately.
-                            Goto(NoStartingPositionFound);
+                            // If we're at the beginning, we're at a possible match location.  Otherwise,
+                            // we'll never be, so fail immediately.
+                            writer.WriteLine("return true;");
                         }
-                        writer.WriteLine("return true;");
                         return true;
 
                     case FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Start:
@@ -450,13 +450,13 @@ namespace System.Text.RegularExpressions.Generator
                             writer.Write(" when processed right to left.");
                         }
                         writer.WriteLine(".");
-                        using (EmitBlock(writer, "if (pos != base.runtextstart)"))
+                        using (EmitBlock(writer, "if (pos == base.runtextstart)"))
                         {
-                            // For both left-to-right and right-to-left, if we're not currently at the starting (because
-                            // we've already moved beyond it), then we'll never be, so fail immediately.
-                            Goto(NoStartingPositionFound);
+                            // For both left-to-right and right-to-left, if we're  currently at the start,
+                            // we're at a possible match location.  Otherwise, because we've already moved
+                            // beyond it, we'll never be, so fail immediately.
+                            writer.WriteLine("return true;");
                         }
-                        writer.WriteLine("return true;");
                         return true;
 
                     case FindNextStartingPositionMode.LeadingAnchor_LeftToRight_EndZ:
@@ -495,24 +495,22 @@ namespace System.Text.RegularExpressions.Generator
 
                     case FindNextStartingPositionMode.LeadingAnchor_RightToLeft_EndZ:
                         writer.WriteLine("// The pattern leads with an end (\\Z) anchor when processed right to left.");
-                        using (EmitBlock(writer, "if (pos < inputSpan.Length - 1 || ((uint)pos < (uint)inputSpan.Length && inputSpan[pos] != '\\n'))"))
+                        using (EmitBlock(writer, "if (pos >= inputSpan.Length - 1 && ((uint)pos >= (uint)inputSpan.Length || inputSpan[pos] == '\\n'))"))
                         {
-                            // If we're not currently at the end, we'll never be (we're iterating from end to beginning),
-                            // so fail immediately.
-                            Goto(NoStartingPositionFound);
+                            // If we're currently at the end, we're at a valid position to try.  Otherwise,
+                            // we'll never be (we're iterating from end to beginning), so fail immediately.
+                            writer.WriteLine("return true;");
                         }
-                        writer.WriteLine("return true;");
                         return true;
 
                     case FindNextStartingPositionMode.LeadingAnchor_RightToLeft_End:
                         writer.WriteLine("// The pattern leads with an end (\\z) anchor when processed right to left.");
-                        using (EmitBlock(writer, "if (pos < inputSpan.Length)"))
+                        using (EmitBlock(writer, "if (pos >= inputSpan.Length)"))
                         {
-                            // If we're not currently at the end, we'll never be (we're iterating from end to beginning),
-                            // so fail immediately.
-                            Goto(NoStartingPositionFound);
+                            // If we're currently at the end, we're at a valid position to try.  Otherwise,
+                            // we'll never be (we're iterating from end to beginning), so fail immediately.
+                            writer.WriteLine("return true;");
                         }
-                        writer.WriteLine("return true;");
                         return true;
 
                     case FindNextStartingPositionMode.TrailingAnchor_FixedLength_LeftToRight_EndZ:

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -956,7 +956,7 @@ namespace System.Text.RegularExpressions.Generator
             // Declare some locals.
             string sliceSpan = "slice";
             writer.WriteLine("int pos = base.runtextpos;");
-            writer.WriteLine($"int original_pos = pos;");
+            writer.WriteLine($"int matchStart = pos;");
             bool hasTimeout = EmitLoopTimeoutCounterIfNeeded(writer, rm);
             bool hasTextInfo = EmitInitializeCultureForTryMatchAtCurrentPositionIfNecessary(writer, rm, analysis);
             writer.Flush();
@@ -997,7 +997,7 @@ namespace System.Text.RegularExpressions.Generator
                 EmitAdd(writer, "pos", sliceStaticPos); // TransferSliceStaticPosToPos would also slice, which isn't needed here
             }
             writer.WriteLine("base.runtextpos = pos;");
-            writer.WriteLine("base.Capture(0, original_pos, pos);");
+            writer.WriteLine("base.Capture(0, matchStart, pos);");
             writer.WriteLine("return true;");
 
             // We're done with the match.

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -921,7 +921,7 @@ namespace System.Text.RegularExpressions.Generator
             // in the input.  When we encounter a variable-length construct, we transfer the static value to
             // pos, slicing the inputSpan appropriately, and then zero out the static position.
             int sliceStaticPos = 0;
-            SliceInputSpan(writer, defineLocal: true);
+            SliceInputSpan(defineLocal: true);
             writer.WriteLine();
 
             // doneLabel starts out as the top-level label for the whole expression failing to match.  However,
@@ -1021,7 +1021,7 @@ namespace System.Text.RegularExpressions.Generator
             static bool IsCaseInsensitive(RegexNode node) => (node.Options & RegexOptions.IgnoreCase) != 0;
 
             // Slices the inputSpan starting at pos until end and stores it into slice.
-            void SliceInputSpan(IndentedTextWriter writer, bool defineLocal = false)
+            void SliceInputSpan(bool defineLocal = false)
             {
                 if (defineLocal)
                 {
@@ -1060,11 +1060,11 @@ namespace System.Text.RegularExpressions.Generator
                 {
                     EmitAdd(writer, "pos", sliceStaticPos);
                     sliceStaticPos = 0;
-                    SliceInputSpan(writer);
+                    SliceInputSpan();
                 }
                 else if (forceSliceReload)
                 {
-                    SliceInputSpan(writer);
+                    SliceInputSpan();
                 }
             }
 
@@ -1386,7 +1386,7 @@ namespace System.Text.RegularExpressions.Generator
                                 writer.WriteLine();
                                 MarkLabel(nextBranch!, emitSemicolon: false);
                                 writer.WriteLine($"pos = {startingPos};");
-                                SliceInputSpan(writer);
+                                SliceInputSpan();
                                 sliceStaticPos = startingSliceStaticPos;
                                 if (startingCapturePos is not null)
                                 {
@@ -1510,7 +1510,7 @@ namespace System.Text.RegularExpressions.Generator
 
                         writer.WriteLine();
                         writer.WriteLine($"pos += matchLength;");
-                        SliceInputSpan(writer);
+                        SliceInputSpan();
                     }
                     else
                     {
@@ -1759,7 +1759,7 @@ namespace System.Text.RegularExpressions.Generator
                 // Do not reset captures, which persist beyond the lookaround.
                 writer.WriteLine("// Condition matched:");
                 writer.WriteLine($"pos = {startingPos};");
-                SliceInputSpan(writer);
+                SliceInputSpan();
                 sliceStaticPos = startingSliceStaticPos;
                 writer.WriteLine();
 
@@ -1780,7 +1780,7 @@ namespace System.Text.RegularExpressions.Generator
                 writer.WriteLine("// Condition did not match:");
                 MarkLabel(expressionNotMatched, emitSemicolon: false);
                 writer.WriteLine($"pos = {startingPos};");
-                SliceInputSpan(writer);
+                SliceInputSpan();
                 sliceStaticPos = startingSliceStaticPos;
                 if (startingCapturePos is not null)
                 {
@@ -1968,7 +1968,7 @@ namespace System.Text.RegularExpressions.Generator
                 // Do not reset captures, which persist beyond the lookaround.
                 writer.WriteLine();
                 writer.WriteLine($"pos = {startingPos};");
-                SliceInputSpan(writer);
+                SliceInputSpan();
                 sliceStaticPos = startingSliceStaticPos;
             }
 
@@ -2023,7 +2023,7 @@ namespace System.Text.RegularExpressions.Generator
 
                 // After the child completes in failure (success for negative lookaround), reset the text positions.
                 writer.WriteLine($"pos = {startingPos};");
-                SliceInputSpan(writer);
+                SliceInputSpan();
                 sliceStaticPos = startingSliceStaticPos;
 
                 doneLabel = originalDoneLabel;
@@ -2040,7 +2040,7 @@ namespace System.Text.RegularExpressions.Generator
                     Debug.Assert(sliceStaticPos == 0, "This should be the first node and thus static position shouldn't have advanced.");
                     writer.WriteLine("// Skip loop already matched in TryFindNextPossibleStartingPosition.");
                     writer.WriteLine("pos = base.runtrackpos;");
-                    SliceInputSpan(writer);
+                    SliceInputSpan();
                     return;
                 }
 
@@ -2673,7 +2673,7 @@ namespace System.Text.RegularExpressions.Generator
 
                 if (!rtl)
                 {
-                    SliceInputSpan(writer);
+                    SliceInputSpan();
                 }
                 writer.WriteLine();
 
@@ -2775,7 +2775,7 @@ namespace System.Text.RegularExpressions.Generator
                 // just after the last character in this loop was matched, and we need to store the resulting position
                 // for the next time we backtrack.
                 writer.WriteLine($"pos = {startingPos};");
-                SliceInputSpan(writer);
+                SliceInputSpan();
                 EmitSingleChar(node);
                 TransferSliceStaticPosToPos();
 
@@ -2806,7 +2806,7 @@ namespace System.Text.RegularExpressions.Generator
                             Goto(doneLabel);
                         }
                         writer.WriteLine($"pos += {startingPos};");
-                        SliceInputSpan(writer);
+                        SliceInputSpan();
                     }
                     else if (iterationCount is null &&
                         node.Kind is RegexNodeKind.Setlazy &&
@@ -2830,7 +2830,7 @@ namespace System.Text.RegularExpressions.Generator
                             Goto(doneLabel);
                         }
                         writer.WriteLine($"pos += {startingPos};");
-                        SliceInputSpan(writer);
+                        SliceInputSpan();
                     }
                 }
 
@@ -3022,7 +3022,7 @@ namespace System.Text.RegularExpressions.Generator
                 {
                     EmitUncaptureUntil(StackPop());
                 }
-                SliceInputSpan(writer);
+                SliceInputSpan();
                 if (doneLabel == originalDoneLabel)
                 {
                     Goto(originalDoneLabel);
@@ -3514,7 +3514,7 @@ namespace System.Text.RegularExpressions.Generator
                 {
                     EmitUncaptureUntil(StackPop());
                 }
-                SliceInputSpan(writer);
+                SliceInputSpan();
 
                 if (minIterations > 0)
                 {

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -783,8 +783,11 @@ namespace System.Text.RegularExpressions.Generator
                     writer.WriteLine();
 
                     // We found the literal.  Walk backwards from it finding as many matches as we can against the loop.
-                    writer.WriteLine("int prev = i;");
-                    writer.WriteLine($"while ((uint)--prev < (uint)slice.Length && {MatchCharacterClass(hasTextInfo, options, "slice[prev]", target.LoopNode.Str!, caseInsensitive: false, negate: false, additionalDeclarations, requiredHelpers)});");
+                    writer.WriteLine("int prev = i - 1;");
+                    using (EmitBlock(writer, $"while ((uint)prev < (uint)slice.Length && {MatchCharacterClass(hasTextInfo, options, "slice[prev]", target.LoopNode.Str!, caseInsensitive: false, negate: false, additionalDeclarations, requiredHelpers)})"))
+                    {
+                        writer.WriteLine("prev--;");
+                    }
                     writer.WriteLine();
 
                     if (target.LoopNode.M > 0)

--- a/src/libraries/System.Text.RegularExpressions/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.RegularExpressions/src/Resources/Strings.resx
@@ -281,10 +281,6 @@
     <value>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</value>
     <comment>{Locked="RegexOptions.NonBacktracking"}</comment>
   </data>
-  <data name="NotSupported_NonBacktrackingConflictingOption" xml:space="preserve">
-    <value>RegexOptions.NonBacktracking is not supported in conjunction with RegexOptions.{0}.</value>
-    <comment>{Locked="RegexOptions.NonBacktracking"}</comment>
-  </data>
   <data name="NotSupported_NonBacktrackingConflictingExpression" xml:space="preserve">
     <value>RegexOptions.NonBacktracking is not supported in conjunction with expressions containing: '{0}'.</value>
     <comment>{Locked="RegexOptions.NonBacktracking"}</comment>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -137,7 +137,8 @@ namespace System.Text.RegularExpressions
         {
             const int MaxOptionShift = 11;
             if (((((uint)options) >> MaxOptionShift) != 0) ||
-                ((options & RegexOptions.ECMAScript) != 0 && (options & ~(RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled | RegexOptions.NonBacktracking | RegexOptions.CultureInvariant)) != 0))
+                ((options & RegexOptions.ECMAScript) != 0 && (options & ~(RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled | RegexOptions.CultureInvariant)) != 0) ||
+                ((options & RegexOptions.NonBacktracking) != 0 && (options & (RegexOptions.ECMAScript | RegexOptions.RightToLeft)) != 0))
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.options);
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -1445,6 +1445,17 @@ namespace System.Text.RegularExpressions
                     return Child(0);
             }
 
+            // If any node in the concatenation is a Nothing, the concatenation itself is a Nothing.
+            int childCount = ChildCount();
+            for (int i = 0; i < childCount; i++)
+            {
+                RegexNode child = Child(i);
+                if (child.Kind == RegexNodeKind.Nothing)
+                {
+                    return child;
+                }
+            }
+
             // Coalesce adjacent loops.  This helps to minimize work done by the interpreter, minimize code gen,
             // and also help to reduce catastrophic backtracking.
             ReduceConcatenationWithAdjacentLoops();

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
@@ -564,8 +564,10 @@ namespace System.Text.RegularExpressions
                 return null;
             }
 
-            // Find the first concatenation.
-            while ((node.Kind is RegexNodeKind.Atomic or RegexNodeKind.Capture) || (node.Kind is RegexNodeKind.Loop or RegexNodeKind.Lazyloop && node.M > 0))
+            // Find the first concatenation.  We traverse through atomic and capture nodes as they don't effect flow control.  (We don't
+            // want to explore loops, even if they have a guaranteed iteration, because we may use information about the node to then
+            // skip the node's execution in the matching algorithm, and we would need to special-case only skipping the first iteration.)
+            while (node.Kind is RegexNodeKind.Atomic or RegexNodeKind.Capture)
             {
                 node = node.Child(0);
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexRunnerFactory.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexRunnerFactory.cs
@@ -15,13 +15,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <summary>Initializes the factory.</summary>
         public SymbolicRegexRunnerFactory(RegexTree regexTree, RegexOptions options, TimeSpan matchTimeout, CultureInfo culture)
         {
-            // RightToLeft and ECMAScript are currently not supported in conjunction with NonBacktracking.
-            if ((options & (RegexOptions.RightToLeft | RegexOptions.ECMAScript)) != 0)
-            {
-                throw new NotSupportedException(
-                    SR.Format(SR.NotSupported_NonBacktrackingConflictingOption,
-                        (options & RegexOptions.RightToLeft) != 0 ? nameof(RegexOptions.RightToLeft) : nameof(RegexOptions.ECMAScript)));
-            }
+            Debug.Assert((options & (RegexOptions.RightToLeft | RegexOptions.ECMAScript)) == 0);
 
             var converter = new RegexNodeConverter(culture, regexTree.CaptureNumberSparseMapping);
             CharSetSolver solver = CharSetSolver.Instance;

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Ctor.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Ctor.Tests.cs
@@ -96,21 +96,6 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public static void Ctor_Invalid()
         {
-            if (PlatformDetection.IsNetCore)
-            {
-                // NonBacktracking option is not supported together with these other options
-                Assert.Throws<NotSupportedException>(() => new Regex("abc", RegexOptions.ECMAScript | RegexHelpers.RegexOptionNonBacktracking));
-                Assert.Throws<NotSupportedException>(() => new Regex("abc", RegexOptions.RightToLeft | RegexHelpers.RegexOptionNonBacktracking));
-
-                // NonBacktracking option is not supported for these constructs
-                Assert.Throws<NotSupportedException>(() => new Regex("(?=a)", RegexHelpers.RegexOptionNonBacktracking));
-                Assert.Throws<NotSupportedException>(() => new Regex("(?!a)", RegexHelpers.RegexOptionNonBacktracking));
-                Assert.Throws<NotSupportedException>(() => new Regex("(?<=a)", RegexHelpers.RegexOptionNonBacktracking));
-                Assert.Throws<NotSupportedException>(() => new Regex("(?<!a)", RegexHelpers.RegexOptionNonBacktracking));
-                Assert.Throws<NotSupportedException>(() => new Regex(@"(?(0)ab)", RegexHelpers.RegexOptionNonBacktracking));
-                Assert.Throws<NotSupportedException>(() => new Regex(@"([ab])\1", RegexHelpers.RegexOptionNonBacktracking));
-            }
-
             // Pattern is null
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => new Regex(null));
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => new Regex(null, RegexOptions.None));
@@ -132,49 +117,28 @@ namespace System.Text.RegularExpressions.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Singleline));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.IgnorePatternWhitespace));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", RegexOptions.ECMAScript | RegexHelpers.RegexOptionNonBacktracking));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", RegexOptions.RightToLeft | RegexHelpers.RegexOptionNonBacktracking));
 
             // MatchTimeout is invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("matchTimeout", () => new Regex("foo", RegexOptions.None, new TimeSpan(-1)));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("matchTimeout", () => new Regex("foo", RegexOptions.None, TimeSpan.Zero));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("matchTimeout", () => new Regex("foo", RegexOptions.None, TimeSpan.FromMilliseconds(int.MaxValue)));
-        }
 
-        /// <summary>
-        /// Nonsupported cases for the NonBacktracking option
-        /// </summary>
-        public static IEnumerable<object[]> Ctor_Invalid_NonBacktracking_Data()
-        {
-            yield return new object[] { @"(?<cat-0>cat)", RegexOptions.None, "balancing group" };
-            yield return new object[] { @"(?<cat>cat)\w+(?<dog-0>dog)", RegexOptions.None, "balancing group"};
-            yield return new object[] { @"(?<cat>cat)\w+(?<dog-cat>dog)", RegexOptions.None, "balancing group" };
-            yield return new object[] { @"abc", RegexOptions.RightToLeft, "RightToLeft" };
-            yield return new object[] { @"abc", RegexOptions.ECMAScript, "ECMAScript" };
-            yield return new object[] { @"^(a)?(?(1)a|b)+$", RegexOptions.None, "conditional" };
-            yield return new object[] { @"(abc)\1", RegexOptions.None, "backreference" };
-            yield return new object[] { @"a(?=d).", RegexOptions.None, "positive lookahead" };
-            yield return new object[] { @"a(?!b).", RegexOptions.None, "negative lookahead" };
-            yield return new object[] { @"(?<=a)b", RegexOptions.None, "positive lookbehind" };
-            yield return new object[] { @"(?<!c)b", RegexOptions.None, "negative lookbehind" };
-            yield return new object[] { @"(?>(abc)*).", RegexOptions.None, "atomic" };
-            yield return new object[] { @"\G(\w+\s?\w*),?", RegexOptions.None, "contiguous" };
-            yield return new object[] { @"(?>a*).", RegexOptions.None, "atomic" };
-            yield return new object[] { @"(?(A)B|C)", RegexOptions.None, "conditional" };
-        }
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Doesn't support NonBacktracking")]
-        [Theory]
-        [MemberData(nameof(Ctor_Invalid_NonBacktracking_Data))]
-        public void Ctor_Invalid_NonBacktracking(string pattern, RegexOptions options, string expected_word_in_error_message)
-        {
-            string actual = string.Empty;
-            try
+            if (PlatformDetection.IsNetCore)
             {
-                new Regex(pattern, options | RegexHelpers.RegexOptionNonBacktracking);
+                // Unsupported pattern constructs with specific options
+                Assert.Throws<NotSupportedException>(() => new Regex("(?=a)", RegexHelpers.RegexOptionNonBacktracking)); // NonBacktracking and positive lookaheads
+                Assert.Throws<NotSupportedException>(() => new Regex("(?!a)", RegexHelpers.RegexOptionNonBacktracking)); // NonBacktracking and negative lookaheads
+                Assert.Throws<NotSupportedException>(() => new Regex("(?<=a)", RegexHelpers.RegexOptionNonBacktracking)); // NonBacktracking and positive lookbehinds
+                Assert.Throws<NotSupportedException>(() => new Regex("(?<!a)", RegexHelpers.RegexOptionNonBacktracking)); // NonBacktracking and negative lookbehinds
+                Assert.Throws<NotSupportedException>(() => new Regex(@"(\w)\1", RegexHelpers.RegexOptionNonBacktracking)); // NonBacktracking and backreferences
+                Assert.Throws<NotSupportedException>(() => new Regex(@"(?(0)ab)", RegexHelpers.RegexOptionNonBacktracking)); // NonBacktracking and backreference conditionals
+                Assert.Throws<NotSupportedException>(() => new Regex(@"([ab])\1", RegexHelpers.RegexOptionNonBacktracking)); // NonBacktracking and expression conditionals
+                Assert.Throws<NotSupportedException>(() => new Regex(@"(?>a*)a", RegexHelpers.RegexOptionNonBacktracking)); // NonBacktracking and atomics
+                Assert.Throws<NotSupportedException>(() => new Regex(@"\Ga", RegexHelpers.RegexOptionNonBacktracking)); // NonBacktracking and start anchors
+                Assert.Throws<NotSupportedException>(() => new Regex(@"(?<C>A)(?<-C>B)$", RegexHelpers.RegexOptionNonBacktracking)); // NonBacktracking and balancing groups
             }
-            catch (NotSupportedException e)
-            {
-                actual = e.Message;
-            }
-            Assert.Contains(expected_word_in_error_message, actual);
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Groups.Tests.cs
@@ -955,7 +955,7 @@ namespace System.Text.RegularExpressions.Tests
             {
                 regex = await RegexHelpers.GetRegexAsync(engine, pattern, options);
             }
-            catch (NotSupportedException) when (RegexHelpers.IsNonBacktracking(engine))
+            catch (Exception e) when (e is NotSupportedException or ArgumentOutOfRangeException && RegexHelpers.IsNonBacktracking(engine))
             {
                 // Some constructs are not supported in NonBacktracking mode, such as: if-then-else, lookaround, and backreferences
                 return;

--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexReductionTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexReductionTests.cs
@@ -377,6 +377,9 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("(?:w*)+\\.", "(?>w*)+\\.")]
         [InlineData("(a[bcd]e*)*fg", "(a[bcd](?>e*))*fg")]
         [InlineData("(\\w[bcd]\\s*)*fg", "(\\w[bcd](?>\\s*))*fg")]
+        // Nothing handling
+        [InlineData(@"\wabc(?!)def", "(?!)")]
+        [InlineData(@"\wabc(?!)def|ghi(?!)", "(?!)")]
         // IgnoreCase set creation
         [InlineData("(?i)abcd", "[Aa][Bb][Cc][Dd]")]
         [InlineData("(?i)abcd|efgh", "[Aa][Bb][Cc][Dd]|[Ee][Ff][Gg][Hh]")]


### PR DESCRIPTION
I spent some time exploring combining all of the TryFindXx and TryMatchXx methods in RegexCompiler / source generator into just a single Scan.  It doesn't yet appear to be worth doing, but along the way I tweaked a bunch of things, and am submitting that as a PR separately.

Functional:
- We were throwing NotSupportedException when RegexOptions.NonBacktracking was used in combination with other supported options, but for existing incompatible options we throw ArgumentOutOfRangeException, so we should be doing the same there.  We should also do it in the helper where we validate options rather than in the NonBacktracking factory.

Performance:
- Given a pattern like "\w*-", we'll use our literal-after-loop find optimization where we search for the '-' and then walk backwards through the atomic loop looking for where it starts.  However, we then record that start-of-loop location as the starting position, and try to match from there, which means we end up then rematching that whole loop again.  If the loop is long, that can be non-trivial wasted work.  We now store the position after the loop into a field and use that from the matching logic to skip the loop as part of the match.
- We now emit specialized code in Scan for a few common structures, e.g. if the pattern begins with a beginning anchor, we don't need a scan loop at all.

Most everything else is for code readability / maintenance.