### PR TITLE
Fix register conflict between freeing large stack frames and fast tailcalls on arm32

### DIFF
--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1987,8 +1987,11 @@ void CodeGen::genFreeLclFrame(unsigned frameSize, /* IN OUT */ bool* pUnwindStar
     }
     else
     {
-        // R12 doesn't hold arguments or return values, so can be used as temp.
-        regNumber tmpReg = REG_R12;
+        // We always save LR for return address hijacking and it will be
+        // restored after this point, so it is available for use here. The
+        // other possibility is r12 but it is not available as it can be used
+        // for the target address for fast tailcalls.
+        regNumber tmpReg = REG_LR;
         instGen_Set_Reg_To_Imm(EA_PTRSIZE, tmpReg, frameSize);
         if (*pUnwindStarted)
         {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_66585/Runtime_66585.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_66585/Runtime_66585.cs
@@ -10,9 +10,10 @@ using System.Runtime.InteropServices;
 
 public unsafe class Runtime_66585
 {
-    public static unsafe void Main()
+    public static unsafe int Main()
     {
         GetCaller()(0, 1, 2, 3);
+        return 100;
     }
 
     private static SLarge s_s;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_66585/Runtime_66585.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_66585/Runtime_66585.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This test would segfault/AV in Caller on arm32 because it put the address of
+// Callee into r12, but then also tried to use r12 to unwind a large stack
+// frame.
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+public unsafe class Runtime_66585
+{
+    public static unsafe void Main()
+    {
+        GetCaller()(0, 1, 2, 3);
+    }
+
+    private static SLarge s_s;
+    public static void Caller(int r0, int r1, int r2, int r3)
+    {
+        SLarge s = s_s;
+        Consume(s);
+        Callee(r0, r1, r2, r3);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Callee(int r0, int r1, int r2, int r3)
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Consume(SLarge s)
+    {
+    }
+
+    // We cannot mark Caller as noinline because it inhibits tailcalling as well
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static delegate*<int, int, int, int, void> GetCaller()
+        => &Caller;
+
+    [StructLayout(LayoutKind.Sequential, Size = 0x1008)]
+    private struct SLarge
+    {
+        public int Value;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_66585/Runtime_66585.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_66585/Runtime_66585.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_66585/Runtime_66585.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_66585/Runtime_66585.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
Freeing large stack frames on ARM32 requires a helper register, so it is natural to use `r12` which is the only volatile non-argument register available. However this register is used for fast tailcalls as well resulting in a conflict.
Since we always spill `lr` and it will be restored after this point in the epilog we can use `lr` instead to free up the conflict. It already seems `lr` is the primary register used as a scratch register in codegen.

This did not repro in our own test runs but I found it in a Fuzzlyn test run.

Fix #66585

cc @dotnet/jit-contrib @clamp03 PTAL @BruceForstall 