### PR TITLE
Revert "[Mono] Enable emitting intrinsics for System.Numerics.Vector<T> on arm64"

### DIFF
--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -3694,10 +3694,6 @@ mono_emit_simd_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 	if (!strcmp (class_ns, "System.Numerics") && !strcmp (class_name, "Vector")){
 		return emit_sri_vector (cfg, cmethod, fsig, args);
 	}
-
-	if (!strcmp (class_ns, "System.Numerics") && !strcmp (class_name, "Vector`1")){
-		return emit_vector64_vector128_t (cfg, cmethod, fsig, args);
-	}
 #endif // defined(TARGET_ARM64)
 
 	return emit_simd_intrinsics (class_ns, class_name, cfg, cmethod, fsig, args);


### PR DESCRIPTION
Reverts dotnet/runtime#66476

Fixes #66556
Fixes #66583