### PR TITLE
Fix macOS ARM64 stack overflow detection

### DIFF
--- a/src/coreclr/pal/src/exception/machmessage.h
+++ b/src/coreclr/pal/src/exception/machmessage.h
@@ -21,7 +21,7 @@ using namespace CorUnix;
 
 #if HAVE_MACH_EXCEPTIONS
 
-#if defined(HOST_AMD64)
+#if defined(HOST_64BIT)
 #define MACH_EH_TYPE(x) mach_##x
 #else
 #define MACH_EH_TYPE(x) x


### PR DESCRIPTION
We were incorrectly using exception_data_type_t instead of mach_exception_data_type_t
in the PAL due to a missing change when we have added support for ARM64 macOS.

The wrong type was 32 bit and it caused the address of a hardware exception to have
the upper 32 bits cut off. That prevented us from detecting stack overflow correctly.

Close #66302