### PR TITLE
Add additional trace to HttpConnectionPool

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -873,8 +873,10 @@ namespace System.Net.Http
                 {
                     quicConnection = await ConnectHelper.ConnectQuicAsync(request, Settings._quicImplementationProvider ?? QuicImplementationProviders.Default, new DnsEndPoint(authority.IdnHost, authority.Port), _sslOptionsHttp3!, cancellationToken).ConfigureAwait(false);
                 }
-                catch
+                catch (Exception e)
                 {
+                    if (NetEventSource.Log.IsEnabled()) Trace($"QUIC connection failed: {e}"));
+
                     // Disables HTTP/3 until server announces it can handle it via Alt-Svc.
                     BlocklistAuthority(authority);
                     throw;
@@ -1619,7 +1621,7 @@ namespace System.Net.Http
 
         private void HandleHttp11ConnectionFailure(HttpRequestMessage request, Exception e)
         {
-            if (NetEventSource.Log.IsEnabled()) Trace("HTTP/1.1 connection failed");
+            if (NetEventSource.Log.IsEnabled()) Trace($"HTTP/1.1 connection failed: {e}"));
 
             bool failRequest;
             TaskCompletionSourceWithCancellation<HttpConnection>? waiter;
@@ -1649,7 +1651,7 @@ namespace System.Net.Http
 
         private void HandleHttp2ConnectionFailure(HttpRequestMessage request, Exception e)
         {
-            if (NetEventSource.Log.IsEnabled()) Trace("HTTP2 connection failed");
+            if (NetEventSource.Log.IsEnabled()) Trace($"HTTP2 connection failed: {e}");
 
             bool failRequest;
             TaskCompletionSourceWithCancellation<Http2Connection?>? waiter;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -875,7 +875,7 @@ namespace System.Net.Http
                 }
                 catch (Exception e)
                 {
-                    if (NetEventSource.Log.IsEnabled()) Trace($"QUIC connection failed: {e}"));
+                    if (NetEventSource.Log.IsEnabled()) Trace($"QUIC connection failed: {e}");
 
                     // Disables HTTP/3 until server announces it can handle it via Alt-Svc.
                     BlocklistAuthority(authority);
@@ -1621,7 +1621,7 @@ namespace System.Net.Http
 
         private void HandleHttp11ConnectionFailure(HttpRequestMessage request, Exception e)
         {
-            if (NetEventSource.Log.IsEnabled()) Trace($"HTTP/1.1 connection failed: {e}"));
+            if (NetEventSource.Log.IsEnabled()) Trace($"HTTP/1.1 connection failed: {e}");
 
             bool failRequest;
             TaskCompletionSourceWithCancellation<HttpConnection>? waiter;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -478,6 +478,13 @@ namespace System.Net.Http
                 return;
             }
 
+            if (NetEventSource.Log.IsEnabled())
+            {
+                Trace($"Available HTTP/1.1 connections: {_availableHttp11Connections.Count}, Requests in the queue: {_http11RequestQueue.Count}, " +
+                    $"Pending HTTP/1.1 connections: {_pendingHttp11ConnectionCount}, Total associated HTTP/1.1 connections: {_associatedHttp11ConnectionCount}, " +
+                    $"Max HTTP/1.1 connection limit: {_maxHttp11Connections}.");
+            }
+
             // Determine if we can and should add a new connection to the pool.
             if (_availableHttp11Connections.Count == 0 &&                           // No available connections
                 _http11RequestQueue.Count > _pendingHttp11ConnectionCount &&        // More requests queued than pending connections


### PR DESCRIPTION
The additional trace should help troubleshoot hanged "pending" connection issues (i.e. the reasons why new connections were not created) in `HttpConnectionPool`.

The issue manifests as growing number of timeouted requests. It is not easy to link a timeouted request (esp. with a small timeout) to a connection that was created 3 minutes ago but still is not connected. There are no traces of the state of HttpConnectionPool, e.g. number of pending connections, so it is unclear from existing traces why the pool decided not to create a connection.

Related to #66297