### PR TITLE
Set SocketsHttpHandler's default connect timeout to 15s

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/libraries/Common/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -27,6 +27,6 @@ namespace System.Net.Http
         public static readonly TimeSpan DefaultPooledConnectionLifetime = Timeout.InfiniteTimeSpan;
         public static readonly TimeSpan DefaultPooledConnectionIdleTimeout = TimeSpan.FromMinutes(1);
         public static readonly TimeSpan DefaultExpect100ContinueTimeout = TimeSpan.FromSeconds(1);
-        public static readonly TimeSpan DefaultConnectTimeout = Timeout.InfiniteTimeSpan;
+        public static readonly TimeSpan DefaultConnectTimeout = TimeSpan.FromSeconds(15);
     }
 }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1054,7 +1054,7 @@ namespace System.Net.Http.Functional.Tests
         {
             using (var handler = new SocketsHttpHandler())
             {
-                Assert.Equal(Timeout.InfiniteTimeSpan, handler.ConnectTimeout);
+                Assert.Equal(TimeSpan.FromSeconds(15), handler.ConnectTimeout);
             }
         }
 


### PR DESCRIPTION
Unifies default ConnectTimeout for Windows and Linux. The value is less than default Windows socket timeout (21s) to minimize the race between timeout exception and socket exception.

Fixes #66297