### PR TITLE
Dedup SymbolicRegexMatcher construction

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/BitVector64Algebra.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/BitVector64Algebra.cs
@@ -7,20 +7,20 @@ using System.Diagnostics;
 namespace System.Text.RegularExpressions.Symbolic
 {
     /// <summary>Provides an <see cref="ICharAlgebra{Int64}"/> over bit vectors up to 64 bits in length.</summary>
-    internal sealed class BitVector64Algebra : ICharAlgebra<ulong>
+    internal sealed class UInt64Algebra : ICharAlgebra<ulong>
     {
         private readonly BDD[] _minterms;
         private readonly MintermGenerator<ulong> _mintermGenerator;
         internal readonly MintermClassifier _classifier;
 
-        public BitVector64Algebra(CharSetSolver solver, BDD[] minterms)
+        public UInt64Algebra(BDD[] minterms)
         {
             Debug.Assert(minterms.Length <= 64);
 
             _minterms = minterms;
 
             _mintermGenerator = new MintermGenerator<ulong>(this);
-            _classifier = new MintermClassifier(solver, minterms);
+            _classifier = new MintermClassifier(minterms);
 
             True = minterms.Length == 64 ? ulong.MaxValue : ulong.MaxValue >> (64 - minterms.Length);
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/BitVectorAlgebra.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/BitVectorAlgebra.cs
@@ -14,11 +14,11 @@ namespace System.Text.RegularExpressions.Symbolic
         internal readonly MintermClassifier _classifier;
         private readonly BitVector[] _mintermVectors;
 
-        public BitVectorAlgebra(CharSetSolver solver, BDD[] minterms)
+        public BitVectorAlgebra(BDD[] minterms)
         {
             _minterms = minterms;
 
-            _classifier = new MintermClassifier(solver, minterms);
+            _classifier = new MintermClassifier(minterms);
             _mintermGenerator = new MintermGenerator<BitVector>(this);
 
             var singleBitVectors = new BitVector[minterms.Length];

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/MintermClassifier.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/MintermClassifier.cs
@@ -33,11 +33,12 @@ namespace System.Text.RegularExpressions.Symbolic
         private readonly BDD _nonAscii;
 
         /// <summary>Create a classifier that maps a character to the ID of its associated minterm.</summary>
-        /// <param name="solver">Character algebra</param>
         /// <param name="minterms">A BDD for classifying all characters (ASCII and non-ASCII) to their corresponding minterm IDs.</param>
-        public MintermClassifier(CharSetSolver solver, BDD[] minterms)
+        public MintermClassifier(BDD[] minterms)
         {
             Debug.Assert(minterms.Length > 0, "Requires at least");
+
+            CharSetSolver solver = CharSetSolver.Instance;
 
             if (minterms.Length == 1)
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeConverter.cs
@@ -26,11 +26,11 @@ namespace System.Text.RegularExpressions.Symbolic
         private Dictionary<(bool IgnoreCase, string Set), BDD>? _setBddCache;
 
         /// <summary>Constructs a regex to symbolic finite automata converter</summary>
-        public RegexNodeConverter(CultureInfo culture, Hashtable? captureSparseMapping)
+        public RegexNodeConverter(SymbolicRegexBuilder<BDD> builder, CultureInfo culture, Hashtable? captureSparseMapping)
         {
+            _builder = builder;
             _culture = culture;
             _captureSparseMapping = captureSparseMapping;
-            _builder = new SymbolicRegexBuilder<BDD>(CharSetSolver.Instance);
         }
 
         /// <summary>Converts a <see cref="RegexNode"/> into its corresponding <see cref="SymbolicRegexNode{S}"/>.</summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
@@ -371,7 +371,7 @@ namespace System.Text.RegularExpressions.Symbolic
             return SymbolicRegexNode<TElement>.CreateDisableBacktrackingSimulation(this, child);
         }
 
-        internal SymbolicRegexNode<T> Transform<T>(SymbolicRegexNode<TElement> sr, SymbolicRegexBuilder<T> builder, Func<TElement, T> predicateTransformer) where T : notnull
+        internal SymbolicRegexNode<T> Transform<T>(SymbolicRegexNode<TElement> sr, SymbolicRegexBuilder<T> builder, Func<SymbolicRegexBuilder<T>, TElement, T> predicateTransformer) where T : notnull
         {
             if (!StackHelper.TryEnsureSufficientExecutionStack())
             {
@@ -412,7 +412,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
                 case SymbolicRegexNodeKind.Singleton:
                     Debug.Assert(sr._set is not null);
-                    return builder.CreateSingleton(predicateTransformer(sr._set));
+                    return builder.CreateSingleton(predicateTransformer(builder, sr._set));
 
                 case SymbolicRegexNodeKind.Loop:
                     Debug.Assert(sr._left is not null);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -144,32 +144,55 @@ namespace System.Text.RegularExpressions.Symbolic
             return _builder._minterms[_mintermClassifier.GetMintermID(c)];
         }
 
-        /// <summary>Constructs matcher for given symbolic regex.</summary>
-        internal SymbolicRegexMatcher(SymbolicRegexNode<TSetType> sr, RegexTree regexTree, BDD[] minterms, TimeSpan matchTimeout)
+        /// <summary>Creates a new <see cref="SymbolicRegexMatcher{TSetType}"/>.</summary>
+        /// <param name="captureCount">The number of captures in the regular expression.</param>
+        /// <param name="findOptimizations">The find optimizations computed from the expression.</param>
+        /// <param name="bddBuilder">The <see cref="BDD"/>-based builder.</param>
+        /// <param name="rootBddNode">The root <see cref="BDD"/>-based node from the pattern.</param>
+        /// <param name="algebra">The algebra to use.</param>
+        /// <param name="matchTimeout">The match timeout to use.</param>
+        public static SymbolicRegexMatcher<TSetType> Create(
+            int captureCount, RegexFindOptimizations findOptimizations,
+            SymbolicRegexBuilder<BDD> bddBuilder, SymbolicRegexNode<BDD> rootBddNode, ICharAlgebra<TSetType> algebra,
+            TimeSpan matchTimeout)
         {
-            Debug.Assert(sr._builder._solver is BitVector64Algebra or BitVectorAlgebra or CharSetSolver, $"Unsupported algebra: {sr._builder._solver}");
+            // Use BitVector to represent a predicate
+            var builder = new SymbolicRegexBuilder<TSetType>(algebra)
+            {
+                // The default constructor sets the following predicates to False; this update happens after the fact.
+                // It depends on whether anchors where used in the regex whether the predicates are actually different from False.
+                _wordLetterPredicateForAnchors = algebra.ConvertFromCharSet(CharSetSolver.Instance, bddBuilder._wordLetterPredicateForAnchors),
+                _newLinePredicate = algebra.ConvertFromCharSet(CharSetSolver.Instance, bddBuilder._newLinePredicate)
+            };
 
-            _pattern = sr;
-            _builder = sr._builder;
+            // Convert the BDD-based AST to TSetType-based AST
+            SymbolicRegexNode<TSetType> rootNode = bddBuilder.Transform(rootBddNode, builder, static (builder, bdd) => builder._solver.ConvertFromCharSet(CharSetSolver.Instance, bdd));
+            return new SymbolicRegexMatcher<TSetType>(rootNode, captureCount, findOptimizations, matchTimeout);
+        }
+
+        /// <summary>Constructs matcher for given symbolic regex.</summary>
+        private SymbolicRegexMatcher(SymbolicRegexNode<TSetType> rootNode, int captureCount, RegexFindOptimizations findOptimizations, TimeSpan matchTimeout)
+        {
+            Debug.Assert(rootNode._builder._solver is UInt64Algebra or BitVectorAlgebra, $"Unsupported algebra: {rootNode._builder._solver}");
+
+            _pattern = rootNode;
+            _builder = rootNode._builder;
             _checkTimeout = Regex.InfiniteMatchTimeout != matchTimeout;
             _timeout = (int)(matchTimeout.TotalMilliseconds + 0.5); // Round up, so it will be at least 1ms
-            _mintermClassifier = _builder._solver switch
-            {
-                BitVector64Algebra bv64 => bv64._classifier,
-                BitVectorAlgebra bv => bv._classifier,
-                _ => new MintermClassifier((CharSetSolver)(object)_builder._solver, minterms),
-            };
-            _capsize = regexTree.CaptureCount;
+            _mintermClassifier = _builder._solver is UInt64Algebra bv64 ?
+                bv64._classifier :
+                ((BitVectorAlgebra)(object)_builder._solver)._classifier;
+            _capsize = captureCount;
 
-            if (regexTree.FindOptimizations.MinRequiredLength == regexTree.FindOptimizations.MaxPossibleLength)
+            if (findOptimizations.MinRequiredLength == findOptimizations.MaxPossibleLength)
             {
-                _fixedMatchLength = regexTree.FindOptimizations.MinRequiredLength;
+                _fixedMatchLength = findOptimizations.MinRequiredLength;
             }
 
-            if (regexTree.FindOptimizations.FindMode != FindNextStartingPositionMode.NoSearch &&
-                regexTree.FindOptimizations.LeadingAnchor == 0) // If there are any anchors, we're better off letting the DFA quickly do its job of determining whether there's a match.
+            if (findOptimizations.FindMode != FindNextStartingPositionMode.NoSearch &&
+                findOptimizations.LeadingAnchor == 0) // If there are any anchors, we're better off letting the DFA quickly do its job of determining whether there's a match.
             {
-                _findOpts = regexTree.FindOptimizations;
+                _findOpts = findOptimizations;
             }
 
             // Determine the number of initial states. If there's no anchor, only the default previous

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexRunnerFactory.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexRunnerFactory.cs
@@ -23,43 +23,15 @@ namespace System.Text.RegularExpressions.Symbolic
                         (options & RegexOptions.RightToLeft) != 0 ? nameof(RegexOptions.RightToLeft) : nameof(RegexOptions.ECMAScript)));
             }
 
-            var converter = new RegexNodeConverter(culture, regexTree.CaptureNumberSparseMapping);
-            CharSetSolver solver = CharSetSolver.Instance;
-            SymbolicRegexNode<BDD> root = converter.ConvertToSymbolicRegexNode(regexTree.Root, tryCreateFixedLengthMarker: true);
+            var bddBuilder = new SymbolicRegexBuilder<BDD>(CharSetSolver.Instance);
+            var converter = new RegexNodeConverter(bddBuilder, culture, regexTree.CaptureNumberSparseMapping);
 
-            BDD[] minterms = root.ComputeMinterms();
-            if (minterms.Length > 64)
-            {
-                // Use BitVector to represent a predicate
-                var algebra = new BitVectorAlgebra(solver, minterms);
-                var builder = new SymbolicRegexBuilder<BitVector>(algebra)
-                {
-                    // The default constructor sets the following predicates to False; this update happens after the fact.
-                    // It depends on whether anchors where used in the regex whether the predicates are actually different from False.
-                    _wordLetterPredicateForAnchors = algebra.ConvertFromCharSet(solver, converter._builder._wordLetterPredicateForAnchors),
-                    _newLinePredicate = algebra.ConvertFromCharSet(solver, converter._builder._newLinePredicate)
-                };
+            SymbolicRegexNode<BDD> rootNode = converter.ConvertToSymbolicRegexNode(regexTree.Root, tryCreateFixedLengthMarker: true);
+            BDD[] minterms = rootNode.ComputeMinterms();
 
-                // Convert the BDD-based AST to BitVector-based AST
-                SymbolicRegexNode<BitVector> rootNode = converter._builder.Transform(root, builder, bdd => builder._solver.ConvertFromCharSet(solver, bdd));
-                _matcher = new SymbolicRegexMatcher<BitVector>(rootNode, regexTree, minterms, matchTimeout);
-            }
-            else
-            {
-                // Use ulong to represent a predicate
-                var algebra = new BitVector64Algebra(solver, minterms);
-                var builder = new SymbolicRegexBuilder<ulong>(algebra)
-                {
-                    // The default constructor sets the following predicates to False, this update happens after the fact
-                    // It depends on whether anchors where used in the regex whether the predicates are actually different from False
-                    _wordLetterPredicateForAnchors = algebra.ConvertFromCharSet(solver, converter._builder._wordLetterPredicateForAnchors),
-                    _newLinePredicate = algebra.ConvertFromCharSet(solver, converter._builder._newLinePredicate)
-                };
-
-                // Convert the BDD-based AST to ulong-based AST
-                SymbolicRegexNode<ulong> rootNode = converter._builder.Transform(root, builder, bdd => builder._solver.ConvertFromCharSet(solver, bdd));
-                _matcher = new SymbolicRegexMatcher<ulong>(rootNode, regexTree, minterms, matchTimeout);
-            }
+            _matcher = minterms.Length > 64 ?
+                SymbolicRegexMatcher<BitVector>.Create(regexTree.CaptureCount, regexTree.FindOptimizations, bddBuilder, rootNode, new BitVectorAlgebra(minterms), matchTimeout) :
+                SymbolicRegexMatcher<ulong>.Create(regexTree.CaptureCount, regexTree.FindOptimizations, bddBuilder, rootNode, new UInt64Algebra(minterms), matchTimeout);
         }
 
         /// <summary>Creates a <see cref="RegexRunner"/> object.</summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSet.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSet.cs
@@ -402,12 +402,12 @@ namespace System.Text.RegularExpressions.Symbolic
             }
         }
 
-        internal SymbolicRegexSet<T> Transform<T>(SymbolicRegexBuilder<T> builderT, Func<S, T> predicateTransformer) where T : notnull
+        internal SymbolicRegexSet<T> Transform<T>(SymbolicRegexBuilder<T> builderT, Func<SymbolicRegexBuilder<T>, S, T> predicateTransformer) where T : notnull
         {
             // This function is mutually recursive with the one in SymbolicRegexBuilder, which has stack overflow avoidance
             return SymbolicRegexSet<T>.CreateMulti(builderT, TransformElements(builderT, predicateTransformer), _kind);
 
-            IEnumerable<SymbolicRegexNode<T>> TransformElements(SymbolicRegexBuilder<T> builderT, Func<S, T> predicateTransformer)
+            IEnumerable<SymbolicRegexNode<T>> TransformElements(SymbolicRegexBuilder<T> builderT, Func<SymbolicRegexBuilder<T>, S, T> predicateTransformer)
             {
                 foreach (SymbolicRegexNode<S> sr in this)
                 {


### PR DESCRIPTION
SymbolicRegexRunnerFactory has two code paths for creating a matcher, with duplicated code based on the exact element type used.  We can create a generic routine to deduplicate that.  Renamed a few other things along the way.