### PR TITLE
JIT: enable reading PGO data when switching to optimized

### DIFF
--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -521,6 +521,7 @@ void Compiler::fgSwitchToOptimized(const char* reason)
     opts.jitFlags->Clear(JitFlags::JIT_FLAG_TIER0);
     opts.jitFlags->Clear(JitFlags::JIT_FLAG_BBINSTR);
     opts.jitFlags->Clear(JitFlags::JIT_FLAG_OSR);
+    opts.jitFlags->Set(JitFlags::JIT_FLAG_BBOPT);
 
     // Leave a note for jit diagnostics
     compSwitchedToOptimized = true;


### PR DESCRIPTION
When QuickJitForLoops=0 (current default) and the JIT sees a Tier0 method with
a loop, it will switch to optimizing the method instead.

When this happens we should also have set `BBOPT` so that the JIT will read and
incorporate PGO data for the method and/or its inliees. But we were not doing that.

This change sets `BBOPT`.