### PR TITLE
WIP: Pack Stopwatch into a single long

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.cs
@@ -39,7 +39,11 @@ namespace System.Diagnostics
 
         public Stopwatch()
         {
-            Reset();
+        }
+
+        private Stopwatch(long initialState)
+        {
+            _state = initialState;
         }
 
         public void Start()
@@ -60,8 +64,8 @@ namespace System.Diagnostics
 
         public static Stopwatch StartNew()
         {
-            Stopwatch s = new Stopwatch();
-            s.Start();
+            long initialState = GetTimestamp();
+            Stopwatch s = new Stopwatch(initialState);
             return s;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.cs
@@ -71,7 +71,7 @@ namespace System.Diagnostics
             if (IsRunning)
             {
                 long endTimeStamp = GetTimestamp();
-                
+
                 // Subtract the old timestamp from the new timestamp
                 // so elapsedThisPeriod is already negative (which we need
                 // for _state).
@@ -80,13 +80,13 @@ namespace System.Diagnostics
                 long elapsedThisPeriod = _state - endTimeStamp;
 
                 // Buggy BIOS ir HAL can result in negative durations
-                // (which are POSITIVE elapsedThisPeriod values) clip 
+                // (which are POSITIVE elapsedThisPeriod values) clip
                 // to a zero in that case.
                 if (elapsedThisPeriod > 0)
                 {
                     elapsedThisPeriod = 0;
                 }
-                
+
                 _state = elapsedThisPeriod;
             }
         }


### PR DESCRIPTION
# This is work-in-progress

Rework [`System.Diagnostics.Stopwatch` ](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.stopwatch?view=net-6.0) to have a single `long` field, instead of the current 2 `long`s and a `bool`.

## Background

When profiling an application, I found a whole bunch of short-to-medium-lifetime `Stopwatch`s being created.  I ended up refactoring things to use a "ValueStopwatch," as that was a viable option (since these `Stopwatch`s weren't passed around as parameters).  In order to not inflate the types that had a `Stopwatch` field, I crammed everything into a single `long` using the below scheme.

After going through that exercise, I wonder if the actual `Stopwatch` class could be shrunk down the same way?

## The Scheme

Basically, use the sign bit on a `long` to distinguish between a running `Stopwatch` and a stopped one.

In either state, the rest of the bits in the `long` are available to store a number.  When running that number is a timestamp, when stopped that number is an elapsed time.

`Stopwatch` supports restarting a stopped stopwatch, which doesn't cleanly map to this scheme.  It is supported by _backdating_ the new start timestamp by the current elapsed time.  By choosing to use negative numbers for elapsed time we can accomplish this backdating with a simple addition.

## Benchmarks

[Benchmarks are off in this repo](https://github.com/kevin-montrose/StopwatchBenchmark).

The important one is the reduction in allocations in `StartNewStopBenchmark` - everything else is basically a wash IMO, although there's slight improvement the  "`StartNew()` followed by a `Stop()`" pattern and a slight regression in the "(reused) `new Stopwatch()` followed by (repeated) `Start()` followed by `Stop()` pattern.  Things are already pretty dang fast, note that the benchmarks all do 1,000 passes per iteration just to get something measureable.

All told, this is a (39-23)/39 == **~40% reduction in allocations** on 64-bit systems.

This matches expectations, since the total size of `Stopwatch` currently is 40 bytes (16 bytes for header and method table, and 24 bytes for 2 longs and a bool plus padding), and the new version is 24 bytes (16 bytes for header and method table again, and 8 bytes for the 1 long), and (40-24)/40 == 40%.

### ElapsedBenchmark

|  Method | LeaveRunning |      Mean |     Error |    StdDev | Ratio | Allocated |
|-------- |------------- |----------:|----------:|----------:|------:|----------:|
| **Current** |        **False** |  **2.556 μs** | **0.0188 μs** | **0.0166 μs** |  **1.00** |         **-** |
| Updated |        False |  2.566 μs | 0.0262 μs | 0.0245 μs |  1.00 |         - |
|         |              |           |           |           |       |           |
| **Current** |         **True** | **56.362 μs** | **0.0158 μs** | **0.0132 μs** |  **1.00** |         **-** |
| Updated |         True | 56.153 μs | 0.0370 μs | 0.0328 μs |  1.00 |         - |

### RandomizedElapsedBenchmark

|  Method |     Mean |     Error |    StdDev | Ratio | Allocated |
|-------- |---------:|----------:|----------:|------:|----------:|
| Current | 9.194 μs | 0.0050 μs | 0.0042 μs |  1.00 |         - |
| Updated | 9.202 μs | 0.0302 μs | 0.0283 μs |  1.00 |         - |

### StartNewStopBenchmark

|  Method |     Mean |    Error |   StdDev | Ratio |   Gen 0 | Allocated |
|-------- |---------:|---------:|---------:|------:|--------:|----------:|
| Current | 45.94 μs | 0.354 μs | 0.314 μs |  1.00 | 19.1040 |     39 KB |
| Updated | 44.76 μs | 0.078 μs | 0.069 μs |  0.97 | 11.4746 |     23 KB |

### StartStopBenchmark

|  Method |     Mean |    Error |   StdDev | Ratio | Allocated |
|-------- |---------:|---------:|---------:|------:|----------:|
| Current | 41.91 μs | 0.028 μs | 0.022 μs |  1.00 |         - |
| Updated | 44.33 μs | 0.144 μs | 0.135 μs |  1.06 |         - |

## Concerns

 - This does take a bit away from `Stopwatch`'s timestamps, which could be problematic
    * My understanding of the underlying APIs is that negative timestamps are practically unreachable, taking on the order of a century of uptime.
 - This scheme cannot distinguish between a `Stopwatch` that has been started and stopped within a single tick, and one which has never been started
    * I don't _think_ this matters, but I could be wrong.
 - Finally, any sort of change to `Stopwatch` is mildly terrifying - this thing is ancient and used everywhere.