### PR TITLE
Upgrading the version of Package Validation used in the repo to reduce Build flakiness when loading Roslyn

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -250,9 +250,9 @@
       <Uri>https://github.com/dotnet/roslyn-analyzers</Uri>
       <Sha>9a1f02eff42635a5a9934735f12c722c3bfba8e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Compatibility" Version="1.0.0-rc.2.21511.46">
+    <Dependency Name="Microsoft.DotNet.Compatibility" Version="1.1.0-preview.22164.17">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>f6028bc958dbab0094be39b94ba9e9c761cde13f</Sha>
+      <Sha>fa2be1406598f8e473af9061e07488ae0778ea11</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -39,7 +39,7 @@
     <MicrosoftCodeAnalysisCSharpVersion>3.10.0</MicrosoftCodeAnalysisCSharpVersion>
     <MicrosoftCodeAnalysisNetAnalyzersVersion>6.0.0-rtm.21514.4</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <!-- SDK dependencies -->
-    <MicrosoftDotNetCompatibilityVersion>1.0.0-rc.2.21511.46</MicrosoftDotNetCompatibilityVersion>
+    <MicrosoftDotNetCompatibilityVersion>1.1.0-preview.22164.17</MicrosoftDotNetCompatibilityVersion>
     <!-- Arcade dependencies -->
     <MicrosoftDotNetApiCompatVersion>6.0.0-beta.22161.1</MicrosoftDotNetApiCompatVersion>
     <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.22161.1</MicrosoftDotNetBuildTasksFeedVersion>

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -1,12 +1,6 @@
 <Project>
 
   <PropertyGroup>
-    <!--
-      Disable PackageValidation for non-CSProj since those will load only one roslyn assembly of the wrong
-      version causing the task to be in torn-state.  See https://github.com/dotnet/runtime/pull/61697.
-      https://github.com/dotnet/runtime/issues/60883 tracks fixing this in 6.0 and removing this condition.
-    -->
-    <EnablePackageValidation Condition="'$(MSBuildProjectExtension)' == '.csproj'">true</EnablePackageValidation>
     <!-- Don't restore prebuilt packages during sourcebuild. -->
     <DisablePackageBaselineValidation Condition="'$(DotNetBuildFromSource)' == 'true'">true</DisablePackageBaselineValidation>
     <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">6.0.0</PackageValidationBaselineVersion>


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/22353

cc: @ericstj @carlossanlop 

This version has both https://github.com/dotnet/sdk/pull/24339 and https://github.com/dotnet/sdk/pull/24362 fixes release 6.0