### PR TITLE
fix pal test

### DIFF
--- a/docs/workflow/testing/coreclr/unix-test-instructions.md
+++ b/docs/workflow/testing/coreclr/unix-test-instructions.md
@@ -156,6 +156,7 @@ To only run enabled tests for the platform the tests were built for:
 artifacts/bin/coreclr/$(uname).x64.Debug/paltests/runpaltests.sh $(pwd)/artifacts/bin/coreclr/$(uname).x64.Debug/paltests
 # on macOS, replace $(uname) with OSX
 ```
+To run only specific tests, edit paltestlist.txt locally to delete the ones you don't want to run.
 
 Test results will go into: `/tmp/PalTestOutput/default/pal_tests.xml`
 

--- a/src/coreclr/pal/tests/palsuite/file_io/GetSystemTime/test1/test.cpp
+++ b/src/coreclr/pal/tests/palsuite/file_io/GetSystemTime/test1/test.cpp
@@ -26,11 +26,6 @@ PALTEST(file_io_GetSystemTime_test1_paltest_getsystemtime_test1, "file_io/GetSys
     SYSTEMTIME firstTime;
     SYSTEMTIME secondTime;
 
-    WORD avgDeltaFileTime = 0;
-
-    int i=0; 
-
-
     if (0 != PAL_Initialize(argc,argv))
     {
         return FAIL;
@@ -100,24 +95,24 @@ PALTEST(file_io_GetSystemTime_test1_paltest_getsystemtime_test1, "file_io/GetSys
             "and it is currently showing %d.",TheTime.wMilliseconds);
     }
 
-    /* check if two consecutive calls to system time return */
-    /* correct time in ms after sleep() call. */
-    for (i = 0; i<5 ;i++)
-    { 
+    /* verify that two consecutive calls to system time return */
+    /* different values of seconds across sleep() call. */
+    /* do this 5 times in case we are super unlucky. */
+    float avgDeltaFileTime = 0;
+    for (int i = 0; i < 5; i++)
+    {
         GetSystemTime(&firstTime);
         Sleep(1000);
-        GetSystemTime(&secondTime);    
-        avgDeltaFileTime +=  abs(firstTime.wSecond - secondTime.wSecond );
-
-    }     
-
-    if( (avgDeltaFileTime/5) < 1.0)
-    {
-        Fail("ERROR: 2 calls for GetSystemTime interrupted"
-                " by a 1000 ms sleep failed Value[%f]", avgDeltaFileTime/5  );
+        GetSystemTime(&secondTime);
+        avgDeltaFileTime += abs(firstTime.wSecond - secondTime.wSecond);
     }
 
-    PAL_Terminate();  
+    if( (avgDeltaFileTime / 5) == 0)
+    {
+        Fail("ERROR: GetSystemTime always returning same value of seconds Value[%f]", avgDeltaFileTime / 5);
+    }
+
+    PAL_Terminate();
     return PASS;
 }
 


### PR DESCRIPTION
Fix #66630

It's checking that the abs seconds-number across a 1 second sleep differs. Because it is possible for the thread to be switched out for 60 seconds, it does this 5 times. However (a) it was using a short not a float and (b) it was checking that it was exactly 1 anyway. So it was making it 5 times more likely to have this problem.

It still seems a bit implausible, but it's at least possible this is why it failed.

Change to float and check that at least one iteration has a different value of seconds.