### PR TITLE
Fix ReplaceModuleMapping for 32bit binary on 64bit kernel

### DIFF
--- a/src/coreclr/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/debug/createdump/crashinfo.cpp
@@ -412,8 +412,8 @@ CrashInfo::UnwindAllThreads()
 void
 CrashInfo::ReplaceModuleMapping(CLRDATA_ADDRESS baseAddress, ULONG64 size, const std::string& name)
 {
-    uint64_t start = (uint64_t)baseAddress;
-    uint64_t end = ((baseAddress + size) + (PAGE_SIZE - 1)) & PAGE_MASK;
+    ULONG_PTR start = (ULONG_PTR)baseAddress;
+    ULONG_PTR end = ((baseAddress + size) + (PAGE_SIZE - 1)) & PAGE_MASK;
     uint32_t flags = GetMemoryRegionFlags(start);
 
     // Make sure that the page containing the PE header for the managed asseblies is in the dump


### PR DESCRIPTION
During `dotnet-dump collect` on 32bit binary + 64bit kernel, `ReplaceModuleMapping` always fails due to address mismatch as follows.
```
W/STDOUT  ( 9535): EnumerateManagedModules: Module enumeration STARTED
W/STDOUT  ( 9535): MODULE: ffffffffefa4c000 dyn 0 inmem 0 file 0 pe 00e8cbd0 pdb 00000000GetMemoryRegionFlags: FAILED
W/STDOUT  ( 9535): MODULE: ADD ffffffffefa4c000 - fffffffff03fd000 (0009b1) 00000000 rwx--- 07 /usr/share/dotnet/shared/Microsoft.NETCore.App/6.0.0/System.Private.CoreLib.dll
W/STDOUT  ( 9535): MODULE: timestamp aa6efd46 size 009b1000 d22cb4e759db4fc3825a86706dba1fa9 /usr/share/dotnet/shared/Microsoft.NETCore.App/6.0.0/System.Private.CoreLib.dll
W/STDOUT  ( 9535): MODULE: fffffffff45fc000 dyn 0 inmem 0 file 1 pe 00e930e0 pdb 00000000GetMemoryRegionFlags: FAILED
W/STDOUT  ( 9535): MODULE: ADD fffffffff45fc000 - fffffffff45ff000 (000003) 00000000 rwx--- 07 /usr/share/dotnet.tizen/framework/Tizen.Runtime.dll
W/STDOUT  ( 9535): MODULE: timestamp 82a77f6e size 00008000 8e75eedb11d5453b8fac7729b8991ef1 /usr/share/dotnet.tizen/framework/Tizen.Runtime.dll
W/STDOUT  ( 9535): MODULE: fffffffff45c0000 dyn 0 inmem 0 file 0 pe 00e94d00 pdb 00000000GetMemoryRegionFlags: FAILED
W/STDOUT  ( 9535): MODULE: ADD fffffffff45c0000 - fffffffff45fc000 (00003c) 00000000 rwx--- 07 /usr/share/dotnet/shared/Microsoft.NETCore.App/6.0.0/System.Runtime.ni.dll
W/STDOUT  ( 9535): MODULE: timestamp c44f9ada size 0003c000 108a3f6230874a7fa0f3b090464402a1 /usr/share/dotnet/shared/Microsoft.NETCore.App/6.0.0/System.Runtime.ni.dll
```

Older impl in `coreclr` used to cast the address with `ULONG_PTR` and it fixes the problem.
https://github.com/dotnet/coreclr/blob/259ce7d4619478cfefe7b0c0f6fa765f765f7e37/src/debug/createdump/crashinfo.cpp#L794

