### PR TITLE
Address a few TODOs on S.S.C.Cose. 

### DIFF
--- a/src/libraries/System.Security.Cryptography.Cose/ref/System.Security.Cryptography.Cose.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/ref/System.Security.Cryptography.Cose.cs
@@ -61,7 +61,7 @@ namespace System.Security.Cryptography.Cose
     {
         internal CoseSign1Message() { }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
-        public static byte[] Sign(byte[] content, System.Security.Cryptography.Cose.CoseHeaderMap protectedHeaders, System.Security.Cryptography.Cose.CoseHeaderMap unprotectedHeaders, System.Security.Cryptography.AsymmetricAlgorithm key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, bool isDetached = false) { throw null; }
+        public static byte[] Sign(byte[] content, System.Security.Cryptography.AsymmetricAlgorithm key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Cose.CoseHeaderMap? protectedHeaders = null, System.Security.Cryptography.Cose.CoseHeaderMap? unprotectedHeaders = null, bool isDetached = false) { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static byte[] Sign(byte[] content, System.Security.Cryptography.ECDsa key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, bool isDetached = false) { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]

--- a/src/libraries/System.Security.Cryptography.Cose/src/System.Security.Cryptography.Cose.csproj
+++ b/src/libraries/System.Security.Cryptography.Cose/src/System.Security.Cryptography.Cose.csproj
@@ -34,6 +34,7 @@
     <Reference Include="System.Security.Cryptography.Primitives" />
     <Reference Include="System.Security.Cryptography.Algorithms" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.Numerics" />
   </ItemGroup>
   
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">

--- a/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseHeaderMap.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseHeaderMap.cs
@@ -12,6 +12,8 @@ namespace System.Security.Cryptography.Cose
     public sealed class CoseHeaderMap : IEnumerable<(CoseHeaderLabel Label, ReadOnlyMemory<byte> EncodedValue)>
     {
         private static readonly byte[] s_emptyBstrEncoded = new byte[] { 0x40 };
+        private static readonly CoseHeaderMap s_emptyMap = new CoseHeaderMap(isReadOnly: true);
+
         public bool IsReadOnly { get; internal set; }
 
         private readonly Dictionary<CoseHeaderLabel, ReadOnlyMemory<byte>> _headerParameters = new Dictionary<CoseHeaderLabel, ReadOnlyMemory<byte>>();
@@ -190,16 +192,17 @@ namespace System.Security.Cryptography.Cose
             }
         }
 
-        internal byte[] Encode(bool mustReturnEmptyBstrIfEmpty = false, int? algHeaderValueToSlip = null)
+        internal static byte[] Encode(CoseHeaderMap? map, bool mustReturnEmptyBstrIfEmpty = false, int? algHeaderValueToSlip = null)
         {
+            map ??= s_emptyMap;
             bool shouldSlipAlgHeader = algHeaderValueToSlip.HasValue;
 
-            if (_headerParameters.Count == 0 && mustReturnEmptyBstrIfEmpty && !shouldSlipAlgHeader)
+            if (map._headerParameters.Count == 0 && mustReturnEmptyBstrIfEmpty && !shouldSlipAlgHeader)
             {
                 return s_emptyBstrEncoded;
             }
 
-            int mapLength = _headerParameters.Count;
+            int mapLength = map._headerParameters.Count;
             if (shouldSlipAlgHeader)
             {
                 mapLength++;
@@ -210,14 +213,13 @@ namespace System.Security.Cryptography.Cose
 
             if (shouldSlipAlgHeader)
             {
-                Debug.Assert(!TryGetEncodedValue(CoseHeaderLabel.Algorithm, out _));
+                Debug.Assert(!map.TryGetEncodedValue(CoseHeaderLabel.Algorithm, out _));
                 writer.WriteInt32(KnownHeaders.Alg);
                 writer.WriteInt32(algHeaderValueToSlip!.Value);
             }
 
-            foreach ((CoseHeaderLabel Label, ReadOnlyMemory<byte> EncodedValue) header in this)
+            foreach ((CoseHeaderLabel label, ReadOnlyMemory<byte> encodedValue) in map)
             {
-                CoseHeaderLabel label = header.Label;
                 if (label.LabelAsString == null)
                 {
                     writer.WriteInt32(label.LabelAsInt32);
@@ -226,7 +228,7 @@ namespace System.Security.Cryptography.Cose
                 {
                     writer.WriteTextString(label.LabelAsString);
                 }
-                writer.WriteEncodedValue(header.EncodedValue.Span);
+                writer.WriteEncodedValue(encodedValue.Span);
             }
             writer.WriteEndMap();
             return writer.Encode();

--- a/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseMessage.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseMessage.cs
@@ -175,8 +175,13 @@ namespace System.Security.Cryptography.Cose
         }
 
         // Validate duplicate labels https://datatracker.ietf.org/doc/html/rfc8152#section-3.
-        internal static void ThrowIfDuplicateLabels(CoseHeaderMap protectedHeaders, CoseHeaderMap unprotectedHeaders)
+        internal static void ThrowIfDuplicateLabels(CoseHeaderMap? protectedHeaders, CoseHeaderMap? unprotectedHeaders)
         {
+            if (protectedHeaders == null || unprotectedHeaders == null)
+            {
+                return;
+            }
+
             foreach ((CoseHeaderLabel Label, ReadOnlyMemory<byte>) header in protectedHeaders)
             {
                 if (unprotectedHeaders.TryGetEncodedValue(header.Label, out _))

--- a/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseSign1Message.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseSign1Message.cs
@@ -34,7 +34,7 @@ namespace System.Security.Cryptography.Cose
         }
 
         [UnsupportedOSPlatform("browser")]
-        public static byte[] Sign(byte[] content!!, CoseHeaderMap protectedHeaders!!, CoseHeaderMap unprotectedHeaders!!, AsymmetricAlgorithm key!!, HashAlgorithmName hashAlgorithm, bool isDetached = false)
+        public static byte[] Sign(byte[] content!!, AsymmetricAlgorithm key!!, HashAlgorithmName hashAlgorithm, CoseHeaderMap? protectedHeaders = null, CoseHeaderMap? unprotectedHeaders = null, bool isDetached = false)
         {
             KeyType keyType = key switch
             {
@@ -47,7 +47,7 @@ namespace System.Security.Cryptography.Cose
 
             int? algHeaderValueToSlip = ValidateOrSlipAlgorithmHeader(protectedHeaders, unprotectedHeaders, keyType, hashAlgorithm);
 
-            byte[] encodedProtetedHeaders = protectedHeaders.Encode(mustReturnEmptyBstrIfEmpty: true, algHeaderValueToSlip);
+            byte[] encodedProtetedHeaders = CoseHeaderMap.Encode(protectedHeaders, mustReturnEmptyBstrIfEmpty: true, algHeaderValueToSlip);
             byte[] toBeSigned = CreateToBeSigned(SigStructureCoxtextSign1, encodedProtetedHeaders, content);
 
             byte[] signature;
@@ -60,7 +60,7 @@ namespace System.Security.Cryptography.Cose
                 signature = SignWithRSA((RSA)key, toBeSigned, hashAlgorithm);
             }
 
-            return SignCore(encodedProtetedHeaders, unprotectedHeaders.Encode(), signature, content, isDetached);
+            return SignCore(encodedProtetedHeaders, CoseHeaderMap.Encode(unprotectedHeaders), signature, content, isDetached);
         }
 
         private static byte[] SignCore(
@@ -177,20 +177,20 @@ namespace System.Security.Cryptography.Cose
         // If we Validate: The caller did specify a COSE Algorithm, we will make sure it matches the specified key and hash algorithm.
         // If we Slip: The caller did not specify a COSE Algorithm, we will write the header for them, rather than throw.
         private static int? ValidateOrSlipAlgorithmHeader(
-            CoseHeaderMap protectedHeaders,
-            CoseHeaderMap unprotectedHeaders,
+            CoseHeaderMap? protectedHeaders,
+            CoseHeaderMap? unprotectedHeaders,
             KeyType keyType,
             HashAlgorithmName hashAlgorithm)
         {
             int algHeaderValue = GetCoseAlgorithmHeaderFromKeyTypeAndHashAlgorithm(keyType, hashAlgorithm);
 
-            if (protectedHeaders.TryGetEncodedValue(CoseHeaderLabel.Algorithm, out ReadOnlyMemory<byte> encodedAlg))
+            if (protectedHeaders != null && protectedHeaders.TryGetEncodedValue(CoseHeaderLabel.Algorithm, out ReadOnlyMemory<byte> encodedAlg))
             {
                 ValidateAlgorithmHeader(encodedAlg, algHeaderValue, keyType, hashAlgorithm);
                 return null;
             }
 
-            if (unprotectedHeaders.TryGetEncodedValue(CoseHeaderLabel.Algorithm, out _))
+            if (unprotectedHeaders != null && unprotectedHeaders.TryGetEncodedValue(CoseHeaderLabel.Algorithm, out _))
             {
                 throw new CryptographicException(SR.Sign1SignAlgMustBeProtected);
             }

--- a/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/KnownCoseAlgorithms.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/KnownCoseAlgorithms.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Numerics;
+
 namespace System.Security.Cryptography.Cose
 {
     // https://www.iana.org/assignments/cose/cose.xhtml#algorithms
@@ -15,13 +17,19 @@ namespace System.Security.Cryptography.Cose
         internal const int PS384 = -38;
         internal const int PS512 = -39;
 
-        internal static void ThrowIfNotSupported(int alg)
+        internal static void ThrowIfNotSupported(long alg)
         {
             if (alg != ES256 && alg > ES384 && alg < PS512)
             {
                 throw new CryptographicException(SR.Format(SR.Sign1UnknownCoseAlgorithm, alg));
             }
         }
+
+        internal static void ThrowUnsignedIntegerNotSupported(ulong alg) // All algorithm valid values are negatives.
+            => throw new CryptographicException(SR.Format(SR.Sign1UnknownCoseAlgorithm, alg));
+
+        internal static void ThrowCborNegativeIntegerNotSupported(ulong alg) // Cbor Negative Integer Representation is too big.
+            => throw new CryptographicException(SR.Format(SR.Sign1UnknownCoseAlgorithm, BigInteger.MinusOne - new BigInteger(alg)));
 
         internal static int FromString(string algString)
         {

--- a/src/libraries/System.Security.Cryptography.Cose/tests/CoseSign1MessageTests.Sign.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/tests/CoseSign1MessageTests.Sign.cs
@@ -53,7 +53,7 @@ namespace System.Security.Cryptography.Cose.Tests
             ECDsa key = ECDsaKeys[algorithm];
             HashAlgorithmName hashAlgorithm = GetHashAlgorithmNameFromCoseAlgorithm((int)algorithm);
 
-            byte[] message = CoseSign1Message.Sign(s_sampleContent, protectedHeaders, unprotectedHeaders, key, hashAlgorithm);
+            byte[] message = CoseSign1Message.Sign(s_sampleContent, key, hashAlgorithm, protectedHeaders, unprotectedHeaders);
             Assert.True(CoseMessage.DecodeSign1(message).Verify(key));
         }
 
@@ -62,7 +62,7 @@ namespace System.Security.Cryptography.Cose.Tests
         {
             Assert.Throws<ArgumentNullException>(() => CoseSign1Message.Sign(null!, DefaultKey, HashAlgorithmName.SHA256));
             Assert.Throws<ArgumentNullException>(() => CoseSign1Message.Sign(null!, RSAKey, HashAlgorithmName.SHA256));
-            Assert.Throws<ArgumentNullException>(() => CoseSign1Message.Sign(null!, GetHeaderMapWithAlgorithm(), GetEmptyHeaderMap(), DefaultKey, DefaultHash));
+            Assert.Throws<ArgumentNullException>(() => CoseSign1Message.Sign(null!, DefaultKey, DefaultHash, GetHeaderMapWithAlgorithm(), GetEmptyHeaderMap()));
         }
 
         [Theory]
@@ -77,7 +77,9 @@ namespace System.Security.Cryptography.Cose.Tests
 
             AssertSign1Message(CoseSign1Message.Sign(content, RSAKey, DefaultHash), content, RSAKey, GetExpectedProtectedHeaders((int)RSAAlgorithm.PS256));
 
-            AssertSign1Message(CoseSign1Message.Sign(content, GetHeaderMapWithAlgorithm(), GetEmptyHeaderMap(), DefaultKey, DefaultHash), content, DefaultKey);
+            AssertSign1Message(CoseSign1Message.Sign(content, DefaultKey, DefaultHash, GetHeaderMapWithAlgorithm(), GetEmptyHeaderMap()), content, DefaultKey);
+
+            AssertSign1Message(CoseSign1Message.Sign(content, DefaultKey, DefaultHash, protectedHeaders: null, unprotectedHeaders: null), content, DefaultKey);
         }
 
         [Fact]
@@ -86,7 +88,7 @@ namespace System.Security.Cryptography.Cose.Tests
             byte[] content = GetDummyContent(ContentTestCase.Small);
             Assert.Throws<ArgumentNullException>(() => CoseSign1Message.Sign(content, (ECDsa)null!, HashAlgorithmName.SHA256));
             Assert.Throws<ArgumentNullException>(() => CoseSign1Message.Sign(content, (RSA)null!, HashAlgorithmName.SHA256));
-            Assert.Throws<ArgumentNullException>(() => CoseSign1Message.Sign(content, GetHeaderMapWithAlgorithm(), GetEmptyHeaderMap(), null!, GetHashAlgorithmNameFromCoseAlgorithm((int)ECDsaAlgorithm.ES256)));
+            Assert.Throws<ArgumentNullException>(() => CoseSign1Message.Sign(content, (AsymmetricAlgorithm)null!, GetHashAlgorithmNameFromCoseAlgorithm((int)ECDsaAlgorithm.ES256)));
         }
 
         [Theory]
@@ -114,7 +116,7 @@ namespace System.Security.Cryptography.Cose.Tests
                 key = RSAKeyWithoutPrivateKey;
             }
 
-            Assert.ThrowsAny<CryptographicException>(() => CoseSign1Message.Sign(content, GetHeaderMapWithAlgorithm(algorithm), GetEmptyHeaderMap(), key, hashAlgorithm));
+            Assert.ThrowsAny<CryptographicException>(() => CoseSign1Message.Sign(content, key, hashAlgorithm, GetHeaderMapWithAlgorithm(algorithm), GetEmptyHeaderMap()));
         }
 
         [Fact]
@@ -122,7 +124,7 @@ namespace System.Security.Cryptography.Cose.Tests
         {
             AsymmetricAlgorithm key = ECDiffieHellman.Create();
             // Header still says that a supported combination of key-algorithm will be used.
-            Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(GetDummyContent(ContentTestCase.Small), GetHeaderMapWithAlgorithm(), GetEmptyHeaderMap(), key, DefaultHash));
+            Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(GetDummyContent(ContentTestCase.Small), key, DefaultHash, GetHeaderMapWithAlgorithm(), GetEmptyHeaderMap()));
         }
 
         [Theory]
@@ -134,7 +136,7 @@ namespace System.Security.Cryptography.Cose.Tests
 
             Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(GetDummyContent(ContentTestCase.Small), DefaultKey, new HashAlgorithmName(hashAlgorithm)));
             Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(GetDummyContent(ContentTestCase.Small), RSAKey, new HashAlgorithmName(hashAlgorithm)));
-            Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(GetDummyContent(ContentTestCase.Small), GetHeaderMapWithAlgorithm(-47 /*ES256K*/), GetEmptyHeaderMap(), DefaultKey, DefaultHash));
+            Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(GetDummyContent(ContentTestCase.Small), DefaultKey, DefaultHash, GetHeaderMapWithAlgorithm(-47 /*ES256K*/), GetEmptyHeaderMap()));
         }
 
         [Theory]
@@ -163,7 +165,7 @@ namespace System.Security.Cryptography.Cose.Tests
                 AssertSign1Message(CoseSign1Message.Sign(content, RSAKey, hashAlgorithm), content, key, expectedProtectedHeaders);
             }
 
-            AssertSign1Message(CoseSign1Message.Sign(content, GetHeaderMapWithAlgorithm(algorithm), GetEmptyHeaderMap(), key, hashAlgorithm), content, key, expectedProtectedHeaders);
+            AssertSign1Message(CoseSign1Message.Sign(content, key, hashAlgorithm, GetHeaderMapWithAlgorithm(algorithm), GetEmptyHeaderMap()), content, key, expectedProtectedHeaders);
         }
 
         [Theory]
@@ -199,7 +201,7 @@ namespace System.Security.Cryptography.Cose.Tests
             byte[] content = GetDummyContent(ContentTestCase.Small);
             CoseHeaderMap protectedHeaders = GetEmptyHeaderMap();
 
-            AssertSign1Message(CoseSign1Message.Sign(GetDummyContent(ContentTestCase.Small), protectedHeaders, GetEmptyHeaderMap(), DefaultKey, DefaultHash), content, DefaultKey);
+            AssertSign1Message(CoseSign1Message.Sign(GetDummyContent(ContentTestCase.Small), DefaultKey, DefaultHash, protectedHeaders, GetEmptyHeaderMap()), content, DefaultKey);
             Assert.Equal(0, protectedHeaders.Count());
         }
 
@@ -210,7 +212,7 @@ namespace System.Security.Cryptography.Cose.Tests
             CoseHeaderMap protectedHeaders = GetEmptyHeaderMap();
             CoseHeaderMap unprotectedHeaders = GetHeaderMapWithAlgorithm();
 
-            Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(content, protectedHeaders, unprotectedHeaders, DefaultKey, DefaultHash));
+            Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(content, DefaultKey, DefaultHash, protectedHeaders, unprotectedHeaders));
         }
 
         [Fact]
@@ -220,7 +222,31 @@ namespace System.Security.Cryptography.Cose.Tests
             CoseHeaderMap protectedHeaders = GetHeaderMapWithAlgorithm(); 
             CoseHeaderMap unprotectedHeaders = GetEmptyHeaderMap();
 
-            AssertSign1Message(CoseSign1Message.Sign(content, protectedHeaders, unprotectedHeaders, DefaultKey, DefaultHash), content, DefaultKey);
+            AssertSign1Message(CoseSign1Message.Sign(content, DefaultKey, DefaultHash, protectedHeaders, unprotectedHeaders), content, DefaultKey);
+        }
+        [Fact]
+        public void SignWithNullHeaderMaps()
+        {
+            byte[] content = GetDummyContent(ContentTestCase.Small);
+            AssertSign1Message(CoseSign1Message.Sign(GetDummyContent(ContentTestCase.Small), DefaultKey, DefaultHash, null, null), content, DefaultKey);
+        }
+
+        [Fact]
+        public void SignWithNullProtectedHeaderMap()
+        {
+            byte[] content = GetDummyContent(ContentTestCase.Small);
+            CoseHeaderMap unprotectedHeaders = GetHeaderMapWithAlgorithm();
+
+            Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(content, DefaultKey, DefaultHash, null, unprotectedHeaders));
+        }
+
+        [Fact]
+        public void SignWithNullUnprotectedHeaderMap()
+        {
+            byte[] content = GetDummyContent(ContentTestCase.Small);
+            CoseHeaderMap protectedHeaders = GetHeaderMapWithAlgorithm();
+
+            AssertSign1Message(CoseSign1Message.Sign(content, DefaultKey, DefaultHash, protectedHeaders, null), content, DefaultKey);
         }
 
         [Theory]
@@ -239,7 +265,7 @@ namespace System.Security.Cryptography.Cose.Tests
             mapForCustomHeader.SetValue(myLabel, myValue);
             AddEncoded(listForCustomHeader, myLabel, myValue);
 
-            AssertSign1Message(CoseSign1Message.Sign(content, protectedHeaders, unprotectedHeaders, DefaultKey, DefaultHash),
+            AssertSign1Message(CoseSign1Message.Sign(content, DefaultKey, DefaultHash, protectedHeaders, unprotectedHeaders),
                 content, DefaultKey, expectedProtectedHeaders, expectedUnprotectedHeaders);
 
 
@@ -249,7 +275,7 @@ namespace System.Security.Cryptography.Cose.Tests
             mapForCustomHeader.SetValue(myLabel, myValue);
             AddEncoded(listForCustomHeader, myLabel, myValue);
 
-            AssertSign1Message(CoseSign1Message.Sign(content, protectedHeaders, unprotectedHeaders, DefaultKey, DefaultHash),
+            AssertSign1Message(CoseSign1Message.Sign(content, DefaultKey, DefaultHash, protectedHeaders, unprotectedHeaders),
                 content, DefaultKey, expectedProtectedHeaders, expectedUnprotectedHeaders);
 
             void Initialize()
@@ -275,27 +301,27 @@ namespace System.Security.Cryptography.Cose.Tests
             InitializeHeaders();
             // @protected.SetValue(CoseHeaderLabel.Algorithm, (int)ECDsaAlgorithm.ES256); // We don't need to Set Algorithm header as InitHeader does it for us.
             unprotectedHeaders.SetValue(CoseHeaderLabel.Algorithm, (int)ECDsaAlgorithm.ES256);
-            Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(content, protectedHeaders, unprotectedHeaders, DefaultKey, DefaultHash));
+            Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(content, DefaultKey, DefaultHash, protectedHeaders, unprotectedHeaders));
 
             // other known header is duplicate.
             InitializeHeaders();
             protectedHeaders.SetValue(CoseHeaderLabel.ContentType, ContentTypeDummyValue);
             unprotectedHeaders.SetValue(CoseHeaderLabel.ContentType, ContentTypeDummyValue);
-            Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(content, protectedHeaders, unprotectedHeaders, DefaultKey, DefaultHash));
+            Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(content, DefaultKey, DefaultHash, protectedHeaders, unprotectedHeaders));
 
             // not-known int header is duplicate.
             InitializeHeaders();
             var myLabel = new CoseHeaderLabel(42);
             protectedHeaders.SetValue(myLabel, 42);
             unprotectedHeaders.SetValue(myLabel, 42);
-            Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(content, protectedHeaders, unprotectedHeaders, DefaultKey, DefaultHash));
+            Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(content, DefaultKey, DefaultHash, protectedHeaders, unprotectedHeaders));
 
             // not-known tstr header is duplicate.
             InitializeHeaders();
             myLabel = new CoseHeaderLabel("42");
             protectedHeaders.SetValue(myLabel, 42);
             unprotectedHeaders.SetValue(myLabel, 42);
-            Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(content, protectedHeaders, unprotectedHeaders, DefaultKey, DefaultHash));
+            Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(content, DefaultKey, DefaultHash, protectedHeaders, unprotectedHeaders));
 
             void InitializeHeaders()
             {
@@ -319,7 +345,7 @@ namespace System.Security.Cryptography.Cose.Tests
             List<(CoseHeaderLabel, ReadOnlyMemory<byte>)> expectedUnprotectedHeaders = GetEmptyExpectedHeaders();
             (useProtectedMap ? expectedProtectedHeaders : expectedUnprotectedHeaders).Add((myLabel, encodedValue)); 
 
-            byte[] encodedMessage = CoseSign1Message.Sign(content, protectedHeaders, unprotectedHeaders, DefaultKey, DefaultHash);
+            byte[] encodedMessage = CoseSign1Message.Sign(content, DefaultKey, DefaultHash, protectedHeaders, unprotectedHeaders);
             AssertSign1Message(encodedMessage, content, DefaultKey, expectedProtectedHeaders, expectedUnprotectedHeaders);
 
             // Verify it is transported correctly.

--- a/src/libraries/System.Security.Cryptography.Cose/tests/CoseSign1MessageTests.Sign.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/tests/CoseSign1MessageTests.Sign.cs
@@ -474,5 +474,60 @@ namespace System.Security.Cryptography.Cose.Tests
                 return new object[] { useProtectedMap, encodedValue };
             }
         }
+
+        [Theory]
+        [InlineData(0L)]
+        [InlineData(long.MaxValue)]
+        [InlineData(long.MinValue)]
+        [InlineData(int.MinValue - 1L)]
+        [InlineData(int.MaxValue + 1L)]
+        public void SignWithInt64AlgorithmHeaderValue(long value)
+        {
+            var writer = new CborWriter();
+            writer.WriteInt64(value);
+
+            byte[] encodedValue = writer.Encode();
+
+            CoseHeaderMap protectedHeaders = new CoseHeaderMap();
+            protectedHeaders.SetEncodedValue(CoseHeaderLabel.Algorithm, encodedValue);
+
+            Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(s_sampleContent, DefaultKey, DefaultHash, protectedHeaders));
+        }
+
+        [Theory]
+        [InlineData(0UL)]
+        [InlineData(ulong.MaxValue)]
+        [InlineData(long.MaxValue + 1UL)]
+        [InlineData(long.MaxValue - 1UL)]
+        public void SignWithUInt64AlgorithmHeaderValue(ulong value)
+        {
+            var writer = new CborWriter();
+            writer.WriteUInt64(value);
+
+            byte[] encodedValue = writer.Encode();
+
+            CoseHeaderMap protectedHeaders = new CoseHeaderMap();
+            protectedHeaders.SetEncodedValue(CoseHeaderLabel.Algorithm, encodedValue);
+
+            Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(s_sampleContent, DefaultKey, DefaultHash, protectedHeaders));
+        }
+
+        [Theory]
+        [InlineData(0UL)]
+        [InlineData(ulong.MaxValue)]
+        [InlineData(long.MaxValue + 1UL)]
+        [InlineData(long.MaxValue - 1UL)]
+        public void SignWithCborNegativeIntegerRepresentationAlgorithmHeaderValue(ulong value)
+        {
+            var writer = new CborWriter();
+            writer.WriteCborNegativeIntegerRepresentation(value);
+
+            byte[] encodedValue = writer.Encode();
+
+            CoseHeaderMap protectedHeaders = new CoseHeaderMap();
+            protectedHeaders.SetEncodedValue(CoseHeaderLabel.Algorithm, encodedValue);
+
+            Assert.Throws<CryptographicException>(() => CoseSign1Message.Sign(s_sampleContent, DefaultKey, DefaultHash, protectedHeaders));
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Cose/tests/CoseSign1MessageTests.Verify.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/tests/CoseSign1MessageTests.Verify.cs
@@ -129,14 +129,14 @@ namespace System.Security.Cryptography.Cose.Tests
         {
             var protectedHeaders = GetHeaderMapWithAlgorithm();
             protectedHeaders.SetValue(CoseHeaderLabel.Critical, ReadOnlySpan<byte>.Empty);
-            byte[] encodedMsg = CoseSign1Message.Sign(s_sampleContent, protectedHeaders, GetEmptyHeaderMap(), DefaultKey, DefaultHash);
+            byte[] encodedMsg = CoseSign1Message.Sign(s_sampleContent, DefaultKey, DefaultHash, protectedHeaders, GetEmptyHeaderMap());
 
             CoseSign1Message msg = CoseMessage.DecodeSign1(encodedMsg);
             Assert.Throws<NotSupportedException>(() => msg.Verify(DefaultKey));
 
             var unprotectedHeaders = GetEmptyHeaderMap();
             unprotectedHeaders.SetValue(CoseHeaderLabel.Critical, ReadOnlySpan<byte>.Empty);
-            encodedMsg = CoseSign1Message.Sign(s_sampleContent, GetHeaderMapWithAlgorithm(), unprotectedHeaders, DefaultKey, DefaultHash);
+            encodedMsg = CoseSign1Message.Sign(s_sampleContent, DefaultKey, DefaultHash, GetHeaderMapWithAlgorithm(), unprotectedHeaders);
 
             msg = CoseMessage.DecodeSign1(encodedMsg);
             Assert.Throws<NotSupportedException>(() => msg.Verify(DefaultKey));
@@ -148,14 +148,14 @@ namespace System.Security.Cryptography.Cose.Tests
             var protectedHeaders = GetHeaderMapWithAlgorithm();
             protectedHeaders.SetValue(CoseHeaderLabel.CounterSignature, ReadOnlySpan<byte>.Empty);
 
-            byte[] encodedMsg = CoseSign1Message.Sign(s_sampleContent, protectedHeaders, GetEmptyHeaderMap(), DefaultKey, DefaultHash);
+            byte[] encodedMsg = CoseSign1Message.Sign(s_sampleContent, DefaultKey, DefaultHash, protectedHeaders, GetEmptyHeaderMap());
             CoseSign1Message msg = CoseMessage.DecodeSign1(encodedMsg);
 
             Assert.Throws<NotSupportedException>(() => msg.Verify(DefaultKey));
 
             var unprotectedHeaders = GetEmptyHeaderMap();
             unprotectedHeaders.SetValue(CoseHeaderLabel.CounterSignature, ReadOnlySpan<byte>.Empty);
-            encodedMsg = CoseSign1Message.Sign(s_sampleContent, GetHeaderMapWithAlgorithm(), unprotectedHeaders, DefaultKey, DefaultHash);
+            encodedMsg = CoseSign1Message.Sign(s_sampleContent, DefaultKey, DefaultHash, GetHeaderMapWithAlgorithm(), unprotectedHeaders);
 
             msg = CoseMessage.DecodeSign1(encodedMsg);
             Assert.Throws<NotSupportedException>(() => msg.Verify(DefaultKey));


### PR DESCRIPTION
Follow up on https://github.com/dotnet/runtime/pull/64461 TODOs:

* [CoseHeaderMap parameters should be allowed to be null](https://github.com/dotnet/runtime/pull/64461#discussion_r799721571).
  * https://github.com/dotnet/runtime/commit/531c4d9e8f8728450e6f5c3bb9dee3b8cda03761
* [Improve handling of alg header values larger/smaller than int32](https://github.com/dotnet/runtime/pull/64461#discussion_r794959940).
  * https://github.com/dotnet/runtime/commit/e937c1a606dd829a7a379779bc96e09057c060ee

Unaddressed TODOs: Re-evaluate places where we should use Span/Memory/byte[] & Add stream support for content. 
They will be addressed in separates PRs respectively. 

