### PR TITLE
Add current-outgoing-connect-attempts counter to Sockets

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -1037,7 +1037,7 @@ namespace System.Net.Sockets
             }
             catch (Exception ex)
             {
-                SocketsTelemetry.AfterAccept(SocketError.Interrupted, ex.Message);
+                SocketsTelemetry.Log.AfterAccept(SocketError.Interrupted, ex.Message);
                 throw;
             }
 
@@ -1047,12 +1047,12 @@ namespace System.Net.Sockets
                 Debug.Assert(acceptedSocketHandle.IsInvalid);
                 UpdateAcceptSocketErrorForDisposed(ref errorCode);
 
-                SocketsTelemetry.AfterAccept(errorCode);
+                SocketsTelemetry.Log.AfterAccept(errorCode);
 
                 UpdateStatusAfterSocketErrorAndThrowException(errorCode);
             }
 
-            SocketsTelemetry.AfterAccept(SocketError.Success);
+            SocketsTelemetry.Log.AfterAccept(SocketError.Success);
 
             Debug.Assert(!acceptedSocketHandle.IsInvalid);
 
@@ -2618,7 +2618,7 @@ namespace System.Net.Sockets
             }
             catch (Exception ex)
             {
-                SocketsTelemetry.AfterAccept(SocketError.Interrupted, ex.Message);
+                SocketsTelemetry.Log.AfterAccept(SocketError.Interrupted, ex.Message);
 
                 // Clear in-use flag on event args object.
                 e.Complete();
@@ -2696,7 +2696,7 @@ namespace System.Net.Sockets
 
                 WildcardBindForConnectIfNecessary(endPointSnapshot.AddressFamily);
 
-                SocketsTelemetry.ConnectStart(e._socketAddress!);
+                SocketsTelemetry.Log.ConnectStart(e._socketAddress!);
 
                 // Prepare for the native call.
                 try
@@ -2706,7 +2706,7 @@ namespace System.Net.Sockets
                 }
                 catch (Exception ex)
                 {
-                    SocketsTelemetry.AfterConnect(SocketError.NotSocket, ex.Message);
+                    SocketsTelemetry.Log.AfterConnect(SocketError.NotSocket, ex.Message);
                     throw;
                 }
 
@@ -2722,7 +2722,7 @@ namespace System.Net.Sockets
                 }
                 catch (Exception ex)
                 {
-                    SocketsTelemetry.AfterConnect(SocketError.NotSocket, ex.Message);
+                    SocketsTelemetry.Log.AfterConnect(SocketError.NotSocket, ex.Message);
 
                     _localEndPoint = null;
 
@@ -3080,7 +3080,7 @@ namespace System.Net.Sockets
 
         private void DoConnect(EndPoint endPointSnapshot, Internals.SocketAddress socketAddress)
         {
-            SocketsTelemetry.ConnectStart(socketAddress);
+            SocketsTelemetry.Log.ConnectStart(socketAddress);
             SocketError errorCode;
             try
             {
@@ -3088,7 +3088,7 @@ namespace System.Net.Sockets
             }
             catch (Exception ex)
             {
-                SocketsTelemetry.AfterConnect(SocketError.NotSocket, ex.Message);
+                SocketsTelemetry.Log.AfterConnect(SocketError.NotSocket, ex.Message);
                 throw;
             }
 
@@ -3101,12 +3101,12 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, socketException);
 
-                SocketsTelemetry.AfterConnect(errorCode);
+                SocketsTelemetry.Log.AfterConnect(errorCode);
 
                 throw socketException;
             }
 
-            SocketsTelemetry.AfterConnect(SocketError.Success);
+            SocketsTelemetry.Log.AfterConnect(SocketError.Success);
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"connection to:{endPointSnapshot}");
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -1037,11 +1037,7 @@ namespace System.Net.Sockets
             }
             catch (Exception ex)
             {
-                if (SocketsTelemetry.Log.IsEnabled())
-                {
-                    SocketsTelemetry.Log.AfterAccept(SocketError.Interrupted, ex.Message);
-                }
-
+                SocketsTelemetry.AfterAccept(SocketError.Interrupted, ex.Message);
                 throw;
             }
 
@@ -1051,12 +1047,12 @@ namespace System.Net.Sockets
                 Debug.Assert(acceptedSocketHandle.IsInvalid);
                 UpdateAcceptSocketErrorForDisposed(ref errorCode);
 
-                if (SocketsTelemetry.Log.IsEnabled()) SocketsTelemetry.Log.AfterAccept(errorCode);
+                SocketsTelemetry.AfterAccept(errorCode);
 
                 UpdateStatusAfterSocketErrorAndThrowException(errorCode);
             }
 
-            if (SocketsTelemetry.Log.IsEnabled()) SocketsTelemetry.Log.AfterAccept(SocketError.Success);
+            SocketsTelemetry.AfterAccept(SocketError.Success);
 
             Debug.Assert(!acceptedSocketHandle.IsInvalid);
 
@@ -2622,10 +2618,7 @@ namespace System.Net.Sockets
             }
             catch (Exception ex)
             {
-                if (SocketsTelemetry.Log.IsEnabled())
-                {
-                    SocketsTelemetry.Log.AfterAccept(SocketError.Interrupted, ex.Message);
-                }
+                SocketsTelemetry.AfterAccept(SocketError.Interrupted, ex.Message);
 
                 // Clear in-use flag on event args object.
                 e.Complete();
@@ -2703,14 +2696,19 @@ namespace System.Net.Sockets
 
                 WildcardBindForConnectIfNecessary(endPointSnapshot.AddressFamily);
 
-                if (SocketsTelemetry.Log.IsEnabled())
-                {
-                    SocketsTelemetry.Log.ConnectStart(e._socketAddress!);
-                }
+                SocketsTelemetry.ConnectStart(e._socketAddress!);
 
                 // Prepare for the native call.
-                e.StartOperationCommon(this, SocketAsyncOperation.Connect);
-                e.StartOperationConnect(saeaMultiConnectCancelable: false, userSocket);
+                try
+                {
+                    e.StartOperationCommon(this, SocketAsyncOperation.Connect);
+                    e.StartOperationConnect(saeaMultiConnectCancelable: false, userSocket);
+                }
+                catch (Exception ex)
+                {
+                    SocketsTelemetry.AfterConnect(SocketError.NotSocket, ex.Message);
+                    throw;
+                }
 
                 // Make the native call.
                 try
@@ -2724,10 +2722,7 @@ namespace System.Net.Sockets
                 }
                 catch (Exception ex)
                 {
-                    if (SocketsTelemetry.Log.IsEnabled())
-                    {
-                        SocketsTelemetry.Log.AfterConnect(SocketError.NotSocket, ex.Message);
-                    }
+                    SocketsTelemetry.AfterConnect(SocketError.NotSocket, ex.Message);
 
                     _localEndPoint = null;
 
@@ -3085,8 +3080,7 @@ namespace System.Net.Sockets
 
         private void DoConnect(EndPoint endPointSnapshot, Internals.SocketAddress socketAddress)
         {
-            if (SocketsTelemetry.Log.IsEnabled()) SocketsTelemetry.Log.ConnectStart(socketAddress);
-
+            SocketsTelemetry.ConnectStart(socketAddress);
             SocketError errorCode;
             try
             {
@@ -3094,11 +3088,7 @@ namespace System.Net.Sockets
             }
             catch (Exception ex)
             {
-                if (SocketsTelemetry.Log.IsEnabled())
-                {
-                    SocketsTelemetry.Log.AfterConnect(SocketError.NotSocket, ex.Message);
-                }
-
+                SocketsTelemetry.AfterConnect(SocketError.NotSocket, ex.Message);
                 throw;
             }
 
@@ -3111,12 +3101,12 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, socketException);
 
-                if (SocketsTelemetry.Log.IsEnabled()) SocketsTelemetry.Log.AfterConnect(errorCode);
+                SocketsTelemetry.AfterConnect(errorCode);
 
                 throw socketException;
             }
 
-            if (SocketsTelemetry.Log.IsEnabled()) SocketsTelemetry.Log.AfterConnect(SocketError.Success);
+            SocketsTelemetry.AfterConnect(SocketError.Success);
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"connection to:{endPointSnapshot}");
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -201,6 +201,7 @@ namespace System.Net.Sockets
 
         private void OnCompletedInternal()
         {
+            // The following check checks if the operation was Accept (1) or Connect (2)
             if (LastOperation <= SocketAsyncOperation.Connect)
             {
                 AfterConnectAcceptTelemetry();
@@ -1006,6 +1007,7 @@ namespace System.Net.Sockets
                 FinishOperationSyncFailure(socketError, bytesTransferred, flags);
             }
 
+            // The following check checks if the operation was Accept (1) or Connect (2)
             if (LastOperation <= SocketAsyncOperation.Connect)
             {
                 AfterConnectAcceptTelemetry();

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -201,7 +201,10 @@ namespace System.Net.Sockets
 
         private void OnCompletedInternal()
         {
-            AfterConnectAcceptTelemetry();
+            if (LastOperation <= SocketAsyncOperation.Connect)
+            {
+                AfterConnectAcceptTelemetry();
+            }
 
             OnCompleted(this);
         }
@@ -216,11 +219,15 @@ namespace System.Net.Sockets
             switch (LastOperation)
             {
                 case SocketAsyncOperation.Accept:
-                    SocketsTelemetry.AfterAccept(SocketError);
+                    SocketsTelemetry.Log.AfterAccept(SocketError);
                     break;
 
                 case SocketAsyncOperation.Connect:
-                    SocketsTelemetry.AfterConnect(SocketError);
+                    SocketsTelemetry.Log.AfterConnect(SocketError);
+                    break;
+
+                default:
+                    Debug.Fail($"Callers should guard against calling this method for '{LastOperation}'");
                     break;
             }
         }
@@ -999,7 +1006,10 @@ namespace System.Net.Sockets
                 FinishOperationSyncFailure(socketError, bytesTransferred, flags);
             }
 
-            AfterConnectAcceptTelemetry();
+            if (LastOperation <= SocketAsyncOperation.Connect)
+            {
+                AfterConnectAcceptTelemetry();
+            }
         }
 
         private static void LogBytesTransferEvents(SocketType? socketType, SocketAsyncOperation operation, int bytesTransferred)

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -201,7 +201,7 @@ namespace System.Net.Sockets
 
         private void OnCompletedInternal()
         {
-            if (SocketsTelemetry.Log.IsEnabled()) AfterConnectAcceptTelemetry();
+            AfterConnectAcceptTelemetry();
 
             OnCompleted(this);
         }
@@ -216,11 +216,11 @@ namespace System.Net.Sockets
             switch (LastOperation)
             {
                 case SocketAsyncOperation.Accept:
-                    SocketsTelemetry.Log.AfterAccept(SocketError);
+                    SocketsTelemetry.AfterAccept(SocketError);
                     break;
 
                 case SocketAsyncOperation.Connect:
-                    SocketsTelemetry.Log.AfterConnect(SocketError);
+                    SocketsTelemetry.AfterConnect(SocketError);
                     break;
             }
         }
@@ -999,7 +999,7 @@ namespace System.Net.Sockets
                 FinishOperationSyncFailure(socketError, bytesTransferred, flags);
             }
 
-            if (SocketsTelemetry.Log.IsEnabled()) AfterConnectAcceptTelemetry();
+            AfterConnectAcceptTelemetry();
         }
 
         private static void LogBytesTransferEvents(SocketType? socketType, SocketAsyncOperation operation, int bytesTransferred)

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketsTelemetry.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketsTelemetry.cs
@@ -20,9 +20,9 @@ namespace System.Net.Sockets
         private PollingCounter? _datagramsReceivedCounter;
         private PollingCounter? _datagramsSentCounter;
 
-        private static long _currentOutgoingConnectAttempts;
-        private static long _outgoingConnectionsEstablished;
-        private static long _incomingConnectionsEstablished;
+        private long _currentOutgoingConnectAttempts;
+        private long _outgoingConnectionsEstablished;
+        private long _incomingConnectionsEstablished;
         private long _bytesReceived;
         private long _bytesSent;
         private long _datagramsReceived;
@@ -77,18 +77,18 @@ namespace System.Net.Sockets
         }
 
         [NonEvent]
-        public static void ConnectStart(Internals.SocketAddress address)
+        public void ConnectStart(Internals.SocketAddress address)
         {
             Interlocked.Increment(ref _currentOutgoingConnectAttempts);
 
-            if (Log.IsEnabled(EventLevel.Informational, EventKeywords.All))
+            if (IsEnabled(EventLevel.Informational, EventKeywords.All))
             {
-                Log.ConnectStart(address.ToString());
+                ConnectStart(address.ToString());
             }
         }
 
         [NonEvent]
-        public static void AfterConnect(SocketError error, string? exceptionMessage = null)
+        public void AfterConnect(SocketError error, string? exceptionMessage = null)
         {
             long newCount = Interlocked.Decrement(ref _currentOutgoingConnectAttempts);
             Debug.Assert(newCount >= 0);
@@ -100,10 +100,10 @@ namespace System.Net.Sockets
             }
             else
             {
-                Log.ConnectFailed(error, exceptionMessage);
+                ConnectFailed(error, exceptionMessage);
             }
 
-            Log.ConnectStop();
+            ConnectStop();
         }
 
         [NonEvent]
@@ -125,7 +125,7 @@ namespace System.Net.Sockets
         }
 
         [NonEvent]
-        public static void AfterAccept(SocketError error, string? exceptionMessage = null)
+        public void AfterAccept(SocketError error, string? exceptionMessage = null)
         {
             if (error == SocketError.Success)
             {
@@ -134,10 +134,10 @@ namespace System.Net.Sockets
             }
             else
             {
-                Log.AcceptFailed(error, exceptionMessage);
+                AcceptFailed(error, exceptionMessage);
             }
 
-            Log.AcceptStop();
+            AcceptStop();
         }
 
         [NonEvent]

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
@@ -112,6 +112,7 @@ namespace System.Net.Sockets.Tests
 
                     await WaitForEventAsync(events, "AcceptStop");
                     await WaitForEventAsync(events, "ConnectStop");
+                    await connectTask;
 
                     await WaitForEventCountersAsync(events);
                 });

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
@@ -104,11 +104,11 @@ namespace System.Net.Sockets.Tests
 
                     using var client = new Socket(SocketType.Stream, ProtocolType.Tcp);
 
-                    Task acceptTask = GetHelperBase(acceptMethod).AcceptAsync(server);
-                    await WaitForEventAsync(events, "AcceptStart");
+                    Task connectTask = GetHelperBase(connectMethod).ConnectAsync(client, server.LocalEndPoint);
+                    await WaitForEventAsync(events, "ConnectStart");
+                    await WaitForEventCountersAsync(events); // Wait for current-outgoing-connect-attempts = 1
 
-                    await GetHelperBase(connectMethod).ConnectAsync(client, server.LocalEndPoint);
-                    await acceptTask;
+                    await GetHelperBase(acceptMethod).AcceptAsync(server);
 
                     await WaitForEventAsync(events, "AcceptStop");
                     await WaitForEventAsync(events, "ConnectStop");
@@ -118,7 +118,7 @@ namespace System.Net.Sockets.Tests
 
                 VerifyEvents(events, connect: true, expectedCount: 1);
                 VerifyEvents(events, connect: false, expectedCount: 1);
-                VerifyEventCounters(events, connectCount: 1);
+                VerifyEventCounters(events, connectCount: 1, hasCurrentConnectCounter: true);
             }, connectMethod, acceptMethod).Dispose();
         }
 
@@ -445,7 +445,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        private static void VerifyEventCounters(ConcurrentQueue<(EventWrittenEventArgs Event, Guid ActivityId)> events, int connectCount, bool connectOnly = false, bool shouldHaveTransferedBytes = false, bool shouldHaveDatagrams = false)
+        private static void VerifyEventCounters(ConcurrentQueue<(EventWrittenEventArgs Event, Guid ActivityId)> events, int connectCount, bool hasCurrentConnectCounter = false, bool connectOnly = false, bool shouldHaveTransferedBytes = false, bool shouldHaveDatagrams = false)
         {
             Dictionary<string, double[]> eventCounters = events
                 .Where(e => e.Event.EventName == "EventCounters")
@@ -458,6 +458,13 @@ namespace System.Net.Sockets.Tests
 
             Assert.True(eventCounters.TryGetValue("incoming-connections-established", out double[] incomingConnections));
             Assert.Equal(connectOnly ? 0 : connectCount, incomingConnections[^1]);
+
+            Assert.True(eventCounters.TryGetValue("current-outgoing-connect-attempts", out double[] currentOutgoingConnectAttempts));
+            if (hasCurrentConnectCounter)
+            {
+                Assert.Contains(currentOutgoingConnectAttempts, c => c > 0);
+            }
+            Assert.Equal(0, currentOutgoingConnectAttempts[^1]);
 
             Assert.True(eventCounters.TryGetValue("bytes-received", out double[] bytesReceived));
             if (shouldHaveTransferedBytes)


### PR DESCRIPTION
Followup from https://github.com/dotnet/runtime/pull/66605#discussion_r826484834.


We have `current-requests` for HTTP, `current-tls-handshakes` for Security, and `current-dns-lookups` for name resolution, but we only have totals for Sockets.
`current-outgoing-connect-attempts` (feel free to suggest better names) would be the Sockets counterpart.

We also have `httpXX-connections-current-total`, `tlsXX-sessions-open` and `dns-lookups-requested` counters.
Any thoughts on adding something like that for Sockets (as in number of currently connected sockets for the process)?
Note that we don't currently distinguish between types of socket when counting `outgoing-connections-established`, even UDP socket connects count.