### PR TITLE
[wasm] Add vector measurements to the bench Sample

### DIFF
--- a/src/mono/sample/wasm/browser-bench/Console/Wasm.Console.Bench.Sample.csproj
+++ b/src/mono/sample/wasm/browser-bench/Console/Wasm.Console.Bench.Sample.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <WasmCopyAppZipToHelixTestDir Condition="'$(ArchiveTests)' == 'true'">true</WasmCopyAppZipToHelixTestDir>
     <WasmMainJSPath>$(MonoProjectRoot)\wasm\test-main.js</WasmMainJSPath>
     <WasmGenerateRunV8Script>true</WasmGenerateRunV8Script>

--- a/src/mono/sample/wasm/browser-bench/Program.cs
+++ b/src/mono/sample/wasm/browser-bench/Program.cs
@@ -18,6 +18,7 @@ namespace Sample
             new AppStartTask(),
             new ExceptionsTask(),
             new JsonTask(),
+            new VectorTask(),
             new WebSocketTask()
         };
         static Test instance = new Test();

--- a/src/mono/sample/wasm/browser-bench/Vector.cs
+++ b/src/mono/sample/wasm/browser-bench/Vector.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Intrinsics;
+
+namespace Sample
+{
+    class VectorTask : BenchTask
+    {
+        public override string Name => "Vector";
+        Measurement[] measurements;
+
+        public VectorTask()
+        {
+            measurements = new Measurement[] {
+                new Create(),
+                new Add(),
+                new Multiply(),
+            };
+        }
+
+        public override Measurement[] Measurements
+        {
+            get
+            {
+                return measurements;
+            }
+        }
+
+        public abstract class VectorMeasurement : BenchTask.Measurement
+        {
+            public override int InitialSamples => 100000;
+        }
+
+        class Create : VectorMeasurement
+        {
+            Vector128<int> vector;
+
+            public override string Name => "Create Vector128";
+
+            public override void RunStep() => vector = Vector128.Create(0x123456);
+        }
+
+        class Add : VectorMeasurement
+        {
+            Vector128<int> vector1, vector2, vector3;
+
+            public override string Name => "Add 2 Vector128's";
+
+            public Add()
+            {
+                vector1 = Vector128.Create(0x12345678);
+                vector2 = Vector128.Create(0x23456789);
+            }
+
+            public override void RunStep() => vector3 = vector1 + vector2;
+        }
+
+        class Multiply : VectorMeasurement
+        {
+            Vector128<int> vector1, vector2, vector3;
+
+            public override string Name => "Multiply 2 Vector128's";
+
+            public Multiply()
+            {
+                vector1 = Vector128.Create(0x12345678);
+                vector2 = Vector128.Create(0x23456789);
+            }
+
+            public override void RunStep() => vector3 = vector1 * vector2;
+        }
+    }
+}

--- a/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
+++ b/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <!-- don't need to run this on helix -->
     <WasmCopyAppZipToHelixTestDir>false</WasmCopyAppZipToHelixTestDir>
     <WasmMainJSPath>main.js</WasmMainJSPath>


### PR DESCRIPTION
Example output, chrome:

    | measurement | time |
    |-:|-:|
    |               Vector, Create Vector128 |     0.1340us |
    |              Vector, Add 2 Vector128's |     0.6261us |
    |         Vector, Multiply 2 Vector128's |     0.6257us |

v8:

    | measurement | time |
    |-:|-:|
    |               Vector, Create Vector128 |     0.3990us |
    |              Vector, Add 2 Vector128's |     0.9154us |
    |         Vector, Multiply 2 Vector128's |     0.9127us |