### PR TITLE
Fix for assert failure in distribute free regions

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -3957,9 +3957,9 @@ void region_allocator::move_highest_free_regions (int64_t n, bool small_region_p
         {
             uint32_t* index = current_index - (current_num_units - 1);
             heap_segment* region = get_region_info (region_address_of (index));
-            if (is_free_region (region))
+            if (is_free_region (region) && !region_free_list::is_on_free_list (region, to_free_list))
             {
-                if (n >= current_num_units && !region_free_list::is_on_free_list (region, to_free_list))
+                if (n >= current_num_units)
                 {
                     n -= current_num_units;
 

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -3959,7 +3959,7 @@ void region_allocator::move_highest_free_regions (int64_t n, bool small_region_p
             heap_segment* region = get_region_info (region_address_of (index));
             if (is_free_region (region))
             {
-                if (n >= current_num_units)
+                if (n >= current_num_units && !region_free_list::is_on_free_list (region, to_free_list))
                 {
                     n -= current_num_units;
 
@@ -12139,6 +12139,13 @@ void region_free_list::add_region_descending (heap_segment* region, region_free_
 {
     free_region_kind kind = get_region_kind (region);
     to_free_list[kind].add_region_in_descending_order (region);
+}
+
+bool region_free_list::is_on_free_list (heap_segment* region, region_free_list free_list[count_free_region_kinds])
+{
+    region_free_list* rfl = heap_segment_containing_free_list (region);
+    free_region_kind kind = get_region_kind (region);
+    return rfl == &free_list[kind];
 }
 
 void region_free_list::age_free_regions()

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1189,6 +1189,7 @@ public:
     void print (int hn, const char* msg="", int* ages=nullptr);
     static void print (region_free_list free_list[count_free_region_kinds], int hn, const char* msg="", int* ages=nullptr);
     void sort_by_committed_and_age();
+    static bool is_on_free_list (heap_segment* region, region_free_list free_list[count_free_region_kinds]):
 };
 #endif
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1189,7 +1189,7 @@ public:
     void print (int hn, const char* msg="", int* ages=nullptr);
     static void print (region_free_list free_list[count_free_region_kinds], int hn, const char* msg="", int* ages=nullptr);
     void sort_by_committed_and_age();
-    static bool is_on_free_list (heap_segment* region, region_free_list free_list[count_free_region_kinds]):
+    static bool is_on_free_list (heap_segment* region, region_free_list free_list[count_free_region_kinds]);
 };
 #endif
 


### PR DESCRIPTION
I had failed to take into account the case where we move a free region to the decommit list due to age, but it is among the free regions with the highest address, and so is encountered by move_highest_free_regions as well.

What happens then is that move_highest_free_regions removes it from the decommit list, and puts it on the decommit list again. No harm done, except that we didn't move as many regions to the decommit list as planned.

Fix is to check in move_highest_free_regions whether a region is already on the decommit list, and skip it in this case. I preferred this to loosening the assert because it makes sure we actually decommit as much as planned.

Fixes: https://github.com/dotnet/runtime/issues/66601