### PR TITLE
Add withAssert flag in getTierName method

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4086,7 +4086,7 @@ const char* Compiler::compGetTieringName(bool wantShortName) const
         // If 'compMinOptsIsSet' is not set, just return here. Otherwise, if this method is called
         // by the assertAbort(), we would recursively call assert while trying to get MinOpts()
         // and eventually stackoverflow.
-        return opts.compDbgCode ? "Debug" : "Optimization-Level-Not-Yet-Set";
+        return "Optimization-Level-Not-Yet-Set";
     }
 
     assert(!tier0 || !tier1); // We don't expect multiple TIER flags to be set at one time.

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4080,6 +4080,15 @@ const char* Compiler::compGetTieringName(bool wantShortName) const
 {
     const bool tier0 = opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER0);
     const bool tier1 = opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER1);
+
+    if (!opts.compMinOptsIsSet)
+    {
+        // If 'compMinOptsIsSet' is not set, just return here. Otherwise, if this method is called
+        // by the assertAbort(), we would recursively call assert while trying to get MinOpts()
+        // and eventually stackoverflow.
+        return opts.compDbgCode ? "Debug" : "Optimization-Level-Not-Yet-Set";
+    }
+
     assert(!tier0 || !tier1); // We don't expect multiple TIER flags to be set at one time.
 
     if (tier0)


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/66107, we included `tierName` and `compMethodHash` in the assert message. But if any assert was triggered before setting up the `minopts` flag (which happens in `compSetOptimizationLevel()`), we would recursively call the assert and stackoverflow.

The fix is to skip the asserts inside `getTierName` method if we are calling it from `assert`.