### PR TITLE
Always append the "dll" extension for native libraries loads on Windows

### DIFF
--- a/src/coreclr/vm/nativelibrary.cpp
+++ b/src/coreclr/vm/nativelibrary.cpp
@@ -581,7 +581,7 @@ namespace
         // or provide an absolute path.
         libNameVariations[varCount++] = NameFmt;
 
-        // The runtime will append the '.dll' extension if the path is relative and the name doesn't ends with a "."
+        // The runtime will append the '.dll' extension if the path is relative and the name doesn't end with a "."
         // or an existing known extension. This is done due to issues with case-sensitive file systems
         // on Windows. The Windows loader always appends ".DLL" as opposed to the more common ".dll".
         if (libNameIsRelativePath

--- a/src/coreclr/vm/nativelibrary.cpp
+++ b/src/coreclr/vm/nativelibrary.cpp
@@ -576,22 +576,19 @@ namespace
 
         int varCount = 0;
 
-        // The runtime will always append the '.dll' extension unless the path is relative, name ends with a "."
-        // or with an existing known extension. This is done due to issues with case-sensitive file systems
+        // Follow LoadLibrary rules in MSDN doc: https://docs.microsoft.com/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibrarya
+        // To prevent the function from appending ".DLL" to the module name, include a trailing point character (.) in the module name string
+        // or provide an absolute path.
+        libNameVariations[varCount++] = NameFmt;
+
+        // The runtime will append the '.dll' extension if the path is relative and the name doesn't ends with a "."
+        // or an existing known extension. This is done due to issues with case-sensitive file systems
         // on Windows. The Windows loader always appends ".DLL" as opposed to the more common ".dll".
-        if (!libNameIsRelativePath
-            || libName.EndsWith(W("."))
-            || libName.EndsWithCaseInsensitive(W(".dll"))
-            || libName.EndsWithCaseInsensitive(W(".exe")))
+        if (libNameIsRelativePath
+            && !libName.EndsWith(W("."))
+            && !libName.EndsWithCaseInsensitive(W(".dll"))
+            && !libName.EndsWithCaseInsensitive(W(".exe")))
         {
-            // Follow LoadLibrary rules in MSDN doc: https://docs.microsoft.com/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibrarya
-            // To prevent the function from appending ".DLL" to the module name, include a trailing point character (.) in the module name string
-            // or provide an absolute path.
-            libNameVariations[varCount++] = NameFmt;
-        }
-        else
-        {
-            libNameVariations[varCount++] = NameFmt;
             libNameVariations[varCount++] = NameSuffixFmt;
         }
 

--- a/src/coreclr/vm/nativelibrary.cpp
+++ b/src/coreclr/vm/nativelibrary.cpp
@@ -576,16 +576,17 @@ namespace
 
         int varCount = 0;
 
-        // The runtime will always append the '.dll' extension unless the name ends with a "."
+        // The runtime will always append the '.dll' extension unless the path is relative, name ends with a "."
         // or with an existing known extension. This is done due to issues with case-sensitive file systems
-        // on Windows that only search for ".DLL" as opposed to the more common ".dll".
-        auto it = libName.Begin();
-        if (libName.EndsWith(W("."))
+        // on Windows. The Windows loader always appends ".DLL" as opposed to the more common ".dll".
+        if (!libNameIsRelativePath
+            || libName.EndsWith(W("."))
             || libName.EndsWithCaseInsensitive(W(".dll"))
             || libName.EndsWithCaseInsensitive(W(".exe")))
         {
             // Follow LoadLibrary rules in MSDN doc: https://docs.microsoft.com/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibrarya
-            // To prevent the function from appending ".DLL" to the module name, include a trailing point character (.) in the module name string.
+            // To prevent the function from appending ".DLL" to the module name, include a trailing point character (.) in the module name string
+            // or provide an absolute path.
             libNameVariations[varCount++] = NameFmt;
         }
         else

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/LibraryNameVariation.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/LibraryNameVariation.Windows.cs
@@ -15,7 +15,8 @@ namespace System.Runtime.Loader
 
             yield return new LibraryNameVariation(string.Empty, string.Empty);
 
-            if (!libName.EndsWith(".", StringComparison.OrdinalIgnoreCase)
+            if (isRelativePath
+                && !libName.EndsWith(".", StringComparison.OrdinalIgnoreCase)
                 && !libName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
                 && !libName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/LibraryNameVariation.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/LibraryNameVariation.Windows.cs
@@ -15,10 +15,9 @@ namespace System.Runtime.Loader
 
             yield return new LibraryNameVariation(string.Empty, string.Empty);
 
-            // Follow LoadLibrary rules if forOSLoader is true
-            if (isRelativePath &&
-                !libName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) &&
-                !libName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+            if (!libName.EndsWith(".", StringComparison.OrdinalIgnoreCase)
+                && !libName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+                && !libName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
             {
                 yield return new LibraryNameVariation(string.Empty, LibraryNameSuffix);
             }

--- a/src/tests/Loader/AssemblyDependencyResolver/AssemblyDependencyResolverTests/NativeDependencyTests.cs
+++ b/src/tests/Loader/AssemblyDependencyResolver/AssemblyDependencyResolverTests/NativeDependencyTests.cs
@@ -51,21 +51,21 @@ namespace AssemblyDependencyResolverTests
         public void TestRelativeNameAndLibPrefixAndNoSuffix()
         {
             // The lib prefix is not added if the lookup is a relative path.
-            ValidateNativeLibraryWithRelativeLookupResolutions("lib{0}", "{0}", 0);
+            ValidateNativeLibraryWithRelativeLookupResolutions("lib{0}", "{0}", OS.None);
         }
 
         public void TestSimpleNameAndLibPrefixAndSuffix()
         {
-            ValidateNativeLibraryResolutions("lib{0}.dll", "{0}", 0);
+            ValidateNativeLibraryResolutions("lib{0}.dll", "{0}", OS.None);
             ValidateNativeLibraryResolutions("lib{0}.dylib", "{0}", OS.OSX);
             ValidateNativeLibraryResolutions("lib{0}.so", "{0}", OS.Linux);
         }
 
         public void TestNameWithSuffixAndNoPrefixAndNoSuffix()
         {
-            ValidateNativeLibraryResolutions("{0}", "{0}.dll", 0);
-            ValidateNativeLibraryResolutions("{0}", "{0}.dylib", 0);
-            ValidateNativeLibraryResolutions("{0}", "{0}.so", 0);
+            ValidateNativeLibraryResolutions("{0}", "{0}.dll", OS.None);
+            ValidateNativeLibraryResolutions("{0}", "{0}.dylib", OS.None);
+            ValidateNativeLibraryResolutions("{0}", "{0}.so", OS.None);
         }
 
         public void TestNameWithSuffixAndNoPrefixAndSuffix()
@@ -78,16 +78,16 @@ namespace AssemblyDependencyResolverTests
         public void TestNameWithSuffixAndNoPrefixAndDoubleSuffix()
         {
             // Unixes add the suffix even if one is already present.
-            ValidateNativeLibraryResolutions("{0}.dll.dll", "{0}.dll", 0);
+            ValidateNativeLibraryResolutions("{0}.dll.dll", "{0}.dll", OS.None);
             ValidateNativeLibraryResolutions("{0}.dylib.dylib", "{0}.dylib", OS.OSX);
             ValidateNativeLibraryResolutions("{0}.so.so", "{0}.so", OS.Linux);
         }
 
         public void TestNameWithSuffixAndPrefixAndNoSuffix()
         {
-            ValidateNativeLibraryResolutions("lib{0}", "{0}.dll", 0);
-            ValidateNativeLibraryResolutions("lib{0}", "{0}.dylib", 0);
-            ValidateNativeLibraryResolutions("lib{0}", "{0}.so", 0);
+            ValidateNativeLibraryResolutions("lib{0}", "{0}.dll", OS.None);
+            ValidateNativeLibraryResolutions("lib{0}", "{0}.dylib", OS.None);
+            ValidateNativeLibraryResolutions("lib{0}", "{0}.so", OS.None);
         }
 
         public void TestNameWithSuffixAndPrefixAndSuffix()
@@ -100,14 +100,14 @@ namespace AssemblyDependencyResolverTests
         public void TestRelativeNameWithSuffixAndPrefixAndSuffix()
         {
             // The lib prefix is not added if the lookup is a relative path
-            ValidateNativeLibraryWithRelativeLookupResolutions("lib{0}.dll", "{0}.dll", 0);
-            ValidateNativeLibraryWithRelativeLookupResolutions("lib{0}.dylib", "{0}.dylib", 0);
-            ValidateNativeLibraryWithRelativeLookupResolutions("lib{0}.so", "{0}.so", 0);
+            ValidateNativeLibraryWithRelativeLookupResolutions("lib{0}.dll", "{0}.dll", OS.None);
+            ValidateNativeLibraryWithRelativeLookupResolutions("lib{0}.dylib", "{0}.dylib", OS.None);
+            ValidateNativeLibraryWithRelativeLookupResolutions("lib{0}.so", "{0}.so", OS.None);
         }
 
         public void TestNameWithPrefixAndNoPrefixAndNoSuffix()
         {
-            ValidateNativeLibraryResolutions("{0}", "lib{0}", 0);
+            ValidateNativeLibraryResolutions("{0}", "lib{0}", OS.None);
         }
 
         public void TestNameWithPrefixAndPrefixAndNoSuffix()
@@ -117,9 +117,9 @@ namespace AssemblyDependencyResolverTests
 
         public void TestNameWithPrefixAndNoPrefixAndSuffix()
         {
-            ValidateNativeLibraryResolutions("{0}.dll", "lib{0}", 0);
-            ValidateNativeLibraryResolutions("{0}.dylib", "lib{0}", 0);
-            ValidateNativeLibraryResolutions("{0}.so", "lib{0}", 0);
+            ValidateNativeLibraryResolutions("{0}.dll", "lib{0}", OS.None);
+            ValidateNativeLibraryResolutions("{0}.dylib", "lib{0}", OS.None);
+            ValidateNativeLibraryResolutions("{0}.so", "lib{0}", OS.None);
         }
 
         public void TestNameWithPrefixAndPrefixAndSuffix()
@@ -136,10 +136,10 @@ namespace AssemblyDependencyResolverTests
 
         public void TestWindowsDoesntAddSuffixWhenExectubaleIsPresent()
         {
-            ValidateNativeLibraryResolutions("{0}.dll.dll", "{0}.dll", 0);
-            ValidateNativeLibraryResolutions("{0}.dll.exe", "{0}.dll", 0);
-            ValidateNativeLibraryResolutions("{0}.exe.dll", "{0}.exe", 0);
-            ValidateNativeLibraryResolutions("{0}.exe.exe", "{0}.exe", 0);
+            ValidateNativeLibraryResolutions("{0}.dll.dll", "{0}.dll", OS.None);
+            ValidateNativeLibraryResolutions("{0}.dll.exe", "{0}.dll", OS.None);
+            ValidateNativeLibraryResolutions("{0}.exe.dll", "{0}.exe", OS.None);
+            ValidateNativeLibraryResolutions("{0}.exe.exe", "{0}.exe", OS.None);
         }
 
         private void TestLookupWithSuffixPrefersUnmodifiedSuffixOnUnixes()
@@ -174,21 +174,22 @@ namespace AssemblyDependencyResolverTests
 
         public void TestFullPathLookupWithDifferentFileName()
         {
-            ValidateFullPathNativeLibraryResolutions("lib{0}", "{0}", 0);
-            ValidateFullPathNativeLibraryResolutions("{0}.dll", "{0}", OS.Windows);
-            ValidateFullPathNativeLibraryResolutions("{0}.dylib", "{0}", 0);
-            ValidateFullPathNativeLibraryResolutions("{0}.so", "{0}", 0);
-            ValidateFullPathNativeLibraryResolutions("lib{0}.dll", "{0}", 0);
-            ValidateFullPathNativeLibraryResolutions("lib{0}.dylib", "{0}", 0);
-            ValidateFullPathNativeLibraryResolutions("lib{0}.so", "{0}", 0);
-            ValidateFullPathNativeLibraryResolutions("lib{0}.dll", "{0}.dll", 0);
-            ValidateFullPathNativeLibraryResolutions("lib{0}.dylib", "{0}.dylib", 0);
-            ValidateFullPathNativeLibraryResolutions("lib{0}.so", "{0}.so", 0);
+            ValidateFullPathNativeLibraryResolutions("lib{0}", "{0}", OS.None);
+            ValidateFullPathNativeLibraryResolutions("{0}.dll", "{0}", OS.None);
+            ValidateFullPathNativeLibraryResolutions("{0}.dylib", "{0}", OS.None);
+            ValidateFullPathNativeLibraryResolutions("{0}.so", "{0}", OS.None);
+            ValidateFullPathNativeLibraryResolutions("lib{0}.dll", "{0}", OS.None);
+            ValidateFullPathNativeLibraryResolutions("lib{0}.dylib", "{0}", OS.None);
+            ValidateFullPathNativeLibraryResolutions("lib{0}.so", "{0}", OS.None);
+            ValidateFullPathNativeLibraryResolutions("lib{0}.dll", "{0}.dll", OS.None);
+            ValidateFullPathNativeLibraryResolutions("lib{0}.dylib", "{0}.dylib", OS.None);
+            ValidateFullPathNativeLibraryResolutions("lib{0}.so", "{0}.so", OS.None);
         }
 
         [Flags]
         private enum OS
         {
+            None = 0,
             Windows = 0x1,
             OSX = 0x2,
             Linux = 0x4

--- a/src/tests/Loader/AssemblyDependencyResolver/AssemblyDependencyResolverTests/NativeDependencyTests.cs
+++ b/src/tests/Loader/AssemblyDependencyResolver/AssemblyDependencyResolverTests/NativeDependencyTests.cs
@@ -175,7 +175,7 @@ namespace AssemblyDependencyResolverTests
         public void TestFullPathLookupWithDifferentFileName()
         {
             ValidateFullPathNativeLibraryResolutions("lib{0}", "{0}", 0);
-            ValidateFullPathNativeLibraryResolutions("{0}.dll", "{0}", 0);
+            ValidateFullPathNativeLibraryResolutions("{0}.dll", "{0}", OS.Windows);
             ValidateFullPathNativeLibraryResolutions("{0}.dylib", "{0}", 0);
             ValidateFullPathNativeLibraryResolutions("{0}.so", "{0}", 0);
             ValidateFullPathNativeLibraryResolutions("lib{0}.dll", "{0}", 0);


### PR DESCRIPTION
Fixes #66608 

Due to case-sensitive file systems on Windows the runtime will now always append the ".dll" extension unless the name contains a trailing "." or a known loadable extension. This is an attempt to mitigate the default Windows behavior that appends a ".DLL" which is rarely the casing used for Windows shared libraries.

Documentation PR to follow.

/cc @dotnet/interop-contrib 

