### PR TITLE
Merged wrapper support for test exclusion lists

### DIFF
--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -306,6 +306,8 @@ $__Command msbuild $CORE_ROOT/wasm-test-runner/WasmTestRunner.proj /p:NetCoreApp
     <![CDATA[
 $(BashLinkerTestLaunchCmds)
 
+export TestExclusionListPath=$CORE_ROOT/TestExclusionList.txt
+
 _DebuggerArgsSeparator=
 if [[ "$_DebuggerFullPath" == *lldb* ]];
 then

--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -301,6 +301,8 @@ COPY /y %CORE_ROOT%\CoreShim.dll .
 $(BatchLinkerTestLaunchCmds)
 $(BatchCopyCoreShimLocalCmds)
 
+set TestExclusionListPath=%CORE_ROOT%\TestExclusionList.txt
+
 IF NOT "%CLRCustomTestLauncher%"=="" (
   set LAUNCHER=call %CLRCustomTestLauncher% %scriptPath%
 ) ELSE (

--- a/src/tests/Common/XHarnessRunnerLibrary/GeneratedTestRunner.cs
+++ b/src/tests/Common/XHarnessRunnerLibrary/GeneratedTestRunner.cs
@@ -14,11 +14,17 @@ public sealed class GeneratedTestRunner : TestRunner
     string _assemblyName;
     TestFilter.ISearchClause? _filter;
     Func<TestFilter?, TestSummary> _runTestsCallback;
-    public GeneratedTestRunner(LogWriter logger, Func<TestFilter?, TestSummary> runTestsCallback, string assemblyName)
+    HashSet<string> _testExclusionList;
+    public GeneratedTestRunner(
+        LogWriter logger, 
+        Func<TestFilter?, TestSummary> runTestsCallback, 
+        string assemblyName,
+        HashSet<string> testExclusionList)
         :base(logger)
     {
         _assemblyName = assemblyName;
         _runTestsCallback = runTestsCallback;
+        _testExclusionList = testExclusionList;
         ResultsFileName = $"{_assemblyName}.testResults.xml";
     }
 
@@ -28,7 +34,7 @@ public sealed class GeneratedTestRunner : TestRunner
 
     public override Task Run(IEnumerable<TestAssemblyInfo> testAssemblies)
     {
-        LastTestRun = _runTestsCallback(_filter is not null ? new TestFilter(_filter) : null);
+        LastTestRun = _runTestsCallback(new TestFilter(_filter, _testExclusionList));
         PassedTests = LastTestRun.PassedTests;
         FailedTests = LastTestRun.FailedTests;
         SkippedTests = LastTestRun.SkippedTests;

--- a/src/tests/Common/XHarnessRunnerLibrary/RunnerEntryPoint.cs
+++ b/src/tests/Common/XHarnessRunnerLibrary/RunnerEntryPoint.cs
@@ -9,20 +9,25 @@ namespace XHarnessRunnerLibrary;
 
 public static class RunnerEntryPoint
 {
-    public static async Task<int> RunTests(Func<TestFilter?, TestSummary> runTestsCallback, string assemblyName, string? filter)
+    public static async Task<int> RunTests(
+        Func<TestFilter?,
+        TestSummary> runTestsCallback,
+        string assemblyName,
+        string? filter,
+        HashSet<string> testExclusionList)
     {
         ApplicationEntryPoint? entryPoint = null;
         if (OperatingSystem.IsAndroid())
         {
-            entryPoint = new AndroidEntryPoint(new SimpleDevice(assemblyName), runTestsCallback, assemblyName, filter);
+            entryPoint = new AndroidEntryPoint(new SimpleDevice(assemblyName), runTestsCallback, assemblyName, filter, testExclusionList);
         }
         if (OperatingSystem.IsMacCatalyst() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsWatchOS())
         {
-            entryPoint = new AppleEntryPoint(new SimpleDevice(assemblyName), runTestsCallback, assemblyName, filter);
+            entryPoint = new AppleEntryPoint(new SimpleDevice(assemblyName), runTestsCallback, assemblyName, filter, testExclusionList);
         }
         if (OperatingSystem.IsBrowser())
         {
-            entryPoint = new WasmEntryPoint(runTestsCallback, assemblyName, filter);
+            entryPoint = new WasmEntryPoint(runTestsCallback, assemblyName, filter, testExclusionList);
         }
         if (entryPoint is null)
         {
@@ -36,16 +41,23 @@ public static class RunnerEntryPoint
 
     sealed class AppleEntryPoint : iOSApplicationEntryPointBase
     {
-        private Func<TestFilter?, TestSummary> _runTestsCallback;
-        private string _assemblyName;
-        private string? _methodNameToRun;
+        private readonly Func<TestFilter?, TestSummary> _runTestsCallback;
+        private readonly string _assemblyName;
+        private readonly string? _methodNameToRun;
+        private readonly HashSet<string> _testExclusionList;
 
-        public AppleEntryPoint(IDevice device, Func<TestFilter?, TestSummary> runTestsCallback, string assemblyName, string? methodNameToRun)
+        public AppleEntryPoint(
+            IDevice device,
+            Func<TestFilter?, TestSummary> runTestsCallback,
+            string assemblyName,
+            string? methodNameToRun,
+            HashSet<string> testExclusionList)
         {
             Device = device;
             _runTestsCallback = runTestsCallback;
             _assemblyName = assemblyName;
             _methodNameToRun = methodNameToRun;
+            _testExclusionList = testExclusionList;
         }
 
         protected override IDevice? Device { get; }
@@ -53,7 +65,7 @@ public static class RunnerEntryPoint
         protected override bool IsXunit => true;
         protected override TestRunner GetTestRunner(LogWriter logWriter)
         {
-            var runner = new GeneratedTestRunner(logWriter, _runTestsCallback, _assemblyName);
+            var runner = new GeneratedTestRunner(logWriter, _runTestsCallback, _assemblyName, _testExclusionList);
             if (_methodNameToRun is not null)
             {
                 runner.SkipMethod(_methodNameToRun, isExcluded: false);
@@ -67,16 +79,23 @@ public static class RunnerEntryPoint
 
     sealed class AndroidEntryPoint : AndroidApplicationEntryPointBase
     {
-        private Func<TestFilter?, TestSummary> _runTestsCallback;
-        private string _assemblyName;
-        private string? _methodNameToRun;
+        private readonly Func<TestFilter?, TestSummary> _runTestsCallback;
+        private readonly string _assemblyName;
+        private readonly string? _methodNameToRun;
+        private readonly HashSet<string> _testExclusionList;
 
-        public AndroidEntryPoint(IDevice device, Func<TestFilter?, TestSummary> runTestsCallback, string assemblyName, string? methodNameToRun)
+        public AndroidEntryPoint(
+            IDevice device,
+            Func<TestFilter?, TestSummary> runTestsCallback,
+            string assemblyName,
+            string? methodNameToRun,
+            HashSet<string> testExclusionList)
         {
             Device = device;
             _runTestsCallback = runTestsCallback;
             _assemblyName = assemblyName;
             _methodNameToRun = methodNameToRun;
+            _testExclusionList = testExclusionList;
         }
 
         protected override IDevice? Device { get; }
@@ -84,7 +103,7 @@ public static class RunnerEntryPoint
         protected override bool IsXunit => true;
         protected override TestRunner GetTestRunner(LogWriter logWriter)
         {
-            var runner = new GeneratedTestRunner(logWriter, _runTestsCallback, _assemblyName);
+            var runner = new GeneratedTestRunner(logWriter, _runTestsCallback, _assemblyName, _testExclusionList);
             if (_methodNameToRun is not null)
             {
                 runner.SkipMethod(_methodNameToRun, isExcluded: false);
@@ -112,22 +131,27 @@ public static class RunnerEntryPoint
 
     sealed class WasmEntryPoint : WasmApplicationEntryPointBase
     {
-        private Func<TestFilter?, TestSummary> _runTestsCallback;
-        private string _assemblyName;
+        private readonly Func<TestFilter?, TestSummary> _runTestsCallback;
+        private readonly string _assemblyName;
+        private readonly string? _methodNameToRun;
+        private readonly HashSet<string> _testExclusionList;
 
-        private string? _methodNameToRun;
-
-        public WasmEntryPoint(Func<TestFilter?, TestSummary> runTestsCallback, string assemblyName, string? methodNameToRun)
+        public WasmEntryPoint(
+            Func<TestFilter?, TestSummary> runTestsCallback,
+            string assemblyName,
+            string? methodNameToRun,
+            HashSet<string> testExclusionList)
         {
             _runTestsCallback = runTestsCallback;
             _assemblyName = assemblyName;
             _methodNameToRun = methodNameToRun;
+            _testExclusionList = testExclusionList;
         }
         protected override int? MaxParallelThreads => 1;
         protected override bool IsXunit => true;
         protected override TestRunner GetTestRunner(LogWriter logWriter)
         {
-            var runner = new GeneratedTestRunner(logWriter, _runTestsCallback, _assemblyName);
+            var runner = new GeneratedTestRunner(logWriter, _runTestsCallback, _assemblyName, _testExclusionList);
             if (_methodNameToRun is not null)
             {
                 runner.SkipMethod(_methodNameToRun, isExcluded: false);
@@ -136,7 +160,6 @@ public static class RunnerEntryPoint
         }
 
         protected override IEnumerable<TestAssemblyInfo> GetTestAssemblies() => Array.Empty<TestAssemblyInfo>();
-
     }
 
     class SimpleDevice : IDevice

--- a/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
@@ -345,6 +345,10 @@ sealed class WrapperLibraryTestSummaryReporting : ITestReporterWrapper
         builder.AppendLine("}");
 
         builder.AppendLine("}");
+        builder.AppendLine("else");
+        builder.AppendLine("{");
+        builder.AppendLine(GenerateSkippedTestReporting(test));
+        builder.AppendLine("}");
         return builder.ToString();
     }
 

--- a/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
@@ -90,6 +90,12 @@ public class TestFilter
     }
 
     private readonly ISearchClause? _filter;
+
+    // Test exclusion list is a compatibility measure allowing for a smooth migration
+    // away from the legacy issues.targets issue tracking system. Before we migrate
+    // all tests to the new model, it's easier to keep bug exclusions in the existing
+    // issues.targets file as a split model would be very confusing for developers
+    // and test monitors.
     private readonly HashSet<string>? _testExclusionList;
 
     public TestFilter(string? filterString, HashSet<string>? testExclusionList)

--- a/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 namespace XUnitWrapperLibrary;
 
@@ -88,21 +89,49 @@ public class TestFilter
         public bool IsMatch(string fullyQualifiedName, string displayName, string[] traits) => !_inner.IsMatch(fullyQualifiedName, displayName, traits);
     }
 
-    private ISearchClause? _filter;
+    private readonly ISearchClause? _filter;
+    private readonly HashSet<string>? _testExclusionList;
 
-    public TestFilter(string filterString)
+    public TestFilter(string? filterString, HashSet<string>? testExclusionList)
     {
-        if (filterString.IndexOfAny(new[] { '!', '(', ')', '~', '=' }) != -1)
+        if (filterString is not null)
         {
-            throw new ArgumentException("Complex test filter expressions are not supported today. The only filters supported today are the simple form supported in 'dotnet test --filter' (substrings of the test's fully qualified name). If further filtering options are desired, file an issue on dotnet/runtime for support.", nameof(filterString));
+            if (filterString.IndexOfAny(new[] { '!', '(', ')', '~', '=' }) != -1)
+            {
+                throw new ArgumentException("Complex test filter expressions are not supported today. The only filters supported today are the simple form supported in 'dotnet test --filter' (substrings of the test's fully qualified name). If further filtering options are desired, file an issue on dotnet/runtime for support.", nameof(filterString));
+            }
+            _filter = new NameClause(TermKind.FullyQualifiedName, filterString, substring: true);
         }
-        _filter = new NameClause(TermKind.FullyQualifiedName, filterString, substring: true);
+        _testExclusionList = testExclusionList;
     }
 
-    public TestFilter(ISearchClause filter)
+    public TestFilter(ISearchClause? filter, HashSet<string>? testExclusionList)
     {
         _filter = filter;
+        _testExclusionList = testExclusionList;
     }
 
-    public bool ShouldRunTest(string fullyQualifiedName, string displayName, string[]? traits = null) => _filter is null ? true : _filter.IsMatch(fullyQualifiedName, displayName, traits ?? Array.Empty<string>());
+    public bool ShouldRunTest(string fullyQualifiedName, string displayName, string[]? traits = null)
+    {
+        if (_testExclusionList is not null && _testExclusionList.Contains(displayName))
+        {
+            return false;
+        }
+        if (_filter is null)
+        {
+            return true;
+        }
+        return _filter.IsMatch(fullyQualifiedName, displayName, traits ?? Array.Empty<string>());
+    }
+    
+    public static HashSet<string> LoadTestExclusionList()
+    {
+        HashSet<string> output = new ();
+        string? testExclusionListPath = Environment.GetEnvironmentVariable("TestExclusionListPath");
+        if (!string.IsNullOrEmpty(testExclusionListPath))
+        {
+            output.UnionWith(File.ReadAllLines(testExclusionListPath));
+        }
+        return output;
+    }
 }

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -107,7 +107,6 @@
     <HaveExcludes Condition="'$(__Exclude)' != ''">True</HaveExcludes>
   </PropertyGroup>
 
-
   <Target Name="MonoAotCompileTests" DependsOnTargets="GetListOfTestCmds;FindCmdDirectories">
     <ItemGroup>
       <AllTestScripts Include="%(TestDirectories.Identity)\**\*.sh" />
@@ -502,7 +501,13 @@
   <Target Name="GenerateLayout"
       DependsOnTargets="CreateTestOverlay"
       AfterTargets="ManagedBuild;RestorePackages"
-      Condition="'$(__BuildTestWrappersOnly)' != '1' and '$(__CopyNativeTestBinaries)' != '1' and '$(__SkipGenerateLayout)' != '1' and !$(MonoAot) and !$(MonoFullAot)" />
+      Condition="'$(__BuildTestWrappersOnly)' != '1' and '$(__CopyNativeTestBinaries)' != '1' and '$(__SkipGenerateLayout)' != '1' and !$(MonoAot) and !$(MonoFullAot)">
+
+    <MSBuild
+      Projects="$(MSBuildProjectFile)"
+      Targets="EmitTestExclusionList"
+      Properties="XunitTestBinBase=$(XunitTestBinBase)" />
+  </Target>
 
   <Target Name="BuildTestWrappers"
       DependsOnTargets="CreateAllWrappers"
@@ -583,5 +588,23 @@
     <MSBuild Projects="$(CoreCLRBuildIntegrationDir)/BuildFrameworkNativeObjects.proj"
       Targets="CreateLib"
       Properties="@(CreateLibProperty)" />
+  </Target>
+
+  <Target Name="EmitTestExclusionList">
+    <PropertyGroup>
+      <TestExclusionListPath>$(CORE_ROOT)\TestExclusionList.txt</TestExclusionListPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <FilteredExcludeList
+        Include="$([System.IO.Path]::GetRelativePath('$(XunitTestBinBase)', '%(ExcludeList.FullPath)'))"
+        Condition="'%(ExcludeList.Extension)' == '.dll'" />
+    </ItemGroup>
+
+    <WriteLinesToFile
+        File="$(TestExclusionListPath)"
+        Lines="@(FilteredExcludeList)"
+        Overwrite="true"
+        Encoding="Unicode" />
   </Target>
 </Project>


### PR DESCRIPTION
According to our design discussions we have decided to keep
the 'issues.targets' file for disabling tests before the
test refactoring has been completed as otherwise we would
have a subset of issue exclusions in 'issues.targets' and
the rest in 'ActiveIssue' test annotations making it very
hard to understand for developers and test monitors.

Moreover today implementation of ActiveIssue is not rich enough
to express all conditional test disabling clauses in issues.targets
so the bug migration will require a bit of additional design work
and we don't want to block the migration on that. This simple change
uses the existing infrastructure to emit a "test exclusion list"
under CORE_ROOT for the particular targeting OS, architecture and
build mode that gets subsequently consumed by the merged test
wrapper in Helix and used to skip the blocked tests.

Thanks

Tomas

/cc @dotnet/runtime-infrastructure 