### PR TITLE
Update Roslyn Testing SDK

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -165,7 +165,7 @@
     <MoqVersion>4.12.0</MoqVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
     <SdkVersionForWorkloadTesting>7.0.100-preview.3.22151.18</SdkVersionForWorkloadTesting>
-    <CompilerPlatformTestingVersion>1.1.1-beta1.22103.1</CompilerPlatformTestingVersion>
+    <CompilerPlatformTestingVersion>1.1.2-beta1.22122.4</CompilerPlatformTestingVersion>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>6.0.0-preview-20220104.1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
@@ -13,7 +13,7 @@ namespace LibraryImportGenerator.UnitTests
 {
     public class AdditionalAttributesOnStub
     {
-        [ConditionalFact]
+        [Fact]
         public async Task SkipLocalsInitAdded()
         {
             string source = @"
@@ -45,7 +45,7 @@ struct Native
             Assert.Contains(stubMethod.GetAttributes(), attr => attr.AttributeClass!.ToDisplayString() == typeof(SkipLocalsInitAttribute).FullName);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task SkipLocalsInitNotAddedOnForwardingStub()
         {
             string source = @"
@@ -64,7 +64,7 @@ partial class C
             Assert.DoesNotContain(stubMethod.GetAttributes(), attr => attr.AttributeClass!.ToDisplayString() == typeof(SkipLocalsInitAttribute).FullName);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task GeneratedCodeAdded()
         {
             string source = @"
@@ -96,7 +96,7 @@ struct Native
             Assert.Contains(stubMethod.GetAttributes(), attr => attr.AttributeClass!.ToDisplayString() == typeof(System.CodeDom.Compiler.GeneratedCodeAttribute).FullName);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task GeneratedCodeNotAddedOnForwardingStub()
         {
             string source = @"
@@ -125,7 +125,7 @@ partial class C
             yield return new object[] { TestTargetFramework.Framework, false };
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(GetDownlevelTargetFrameworks))]
         public async Task SkipLocalsInitOnDownlevelTargetFrameworks(TestTargetFramework targetFramework, bool expectSkipLocalsInit)
         {
@@ -154,7 +154,7 @@ partial class C
             }
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task SkipLocalsInitNotAddedWhenDefinedAtModuleLevel()
         {
             string source = @"
@@ -186,7 +186,7 @@ struct Native
             Assert.DoesNotContain(stubMethod.GetAttributes(), attr => attr.AttributeClass!.ToDisplayString() == typeof(SkipLocalsInitAttribute).FullName);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task SkipLocalsInitNotAddedWhenDefinedAtClassLevel()
         {
             string source = @"
@@ -218,7 +218,7 @@ struct Native
             Assert.DoesNotContain(stubMethod.GetAttributes(), attr => attr.AttributeClass!.ToDisplayString() == typeof(SkipLocalsInitAttribute).FullName);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task SkipLocalsInitNotAddedWhenDefinedOnMethodByUser()
         {
             string source = @"

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AttributeForwarding.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AttributeForwarding.cs
@@ -17,7 +17,7 @@ namespace LibraryImportGenerator.UnitTests
 {
     public class AttributeForwarding
     {
-        [ConditionalTheory]
+        [Theory]
         [InlineData("SuppressGCTransition", "System.Runtime.InteropServices.SuppressGCTransitionAttribute")]
         [InlineData("UnmanagedCallConv", "System.Runtime.InteropServices.UnmanagedCallConvAttribute")]
         public async Task KnownParameterlessAttribute(string attributeSourceName, string attributeMetadataName)
@@ -59,7 +59,7 @@ struct Native
                 attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, attributeType));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task UnmanagedCallConvAttribute_EmptyCallConvArray()
         {
             string source = @"
@@ -103,7 +103,7 @@ struct Native
                     && attr.NamedArguments[0].Value.Values.Length == 0);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task UnmanagedCallConvAttribute_SingleCallConvType()
         {
             string source = @"
@@ -150,7 +150,7 @@ struct Native
                         callConvType));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task UnmanagedCallConvAttribute_MultipleCallConvTypes()
         {
             string source = @"
@@ -201,7 +201,7 @@ struct Native
                         callConvType2));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task DefaultDllImportSearchPathsAttribute()
         {
             string source = @$"
@@ -245,7 +245,7 @@ struct Native
                     && expected == (DllImportSearchPath)attr.ConstructorArguments[0].Value!);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task OtherAttributeType()
         {
             string source = @"
@@ -290,7 +290,7 @@ struct Native
                 attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, attributeType));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task InOutAttributes_Forwarded_To_ForwardedParameter()
         {
             string source = @"
@@ -333,7 +333,7 @@ partial class C
                     }));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task MarshalAsAttribute_Forwarded_To_ForwardedParameter()
         {
             string source = @"
@@ -362,7 +362,7 @@ partial class C
                     }));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task MarshalAsAttribute_Forwarded_To_ForwardedParameter_Array()
         {
             string source = @"

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
@@ -121,7 +121,7 @@ namespace LibraryImportGenerator.UnitTests
             yield return new object[] { CodeSnippets.RefReturn("int"), 2, 2 };
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(CodeSnippetsToCompile))]
         public async Task ValidateSnippets(string source, int expectedGeneratorErrors, int expectedCompilerErrors)
         {
@@ -153,7 +153,7 @@ namespace LibraryImportGenerator.UnitTests
             yield return new object[] { CodeSnippets.IncorrectAttributeFieldType, 1, 1 };
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(CodeSnippetsToCompile_InvalidCode))]
         public async Task ValidateSnippets_InvalidCodeGracefulFailure(string source, int expectedGeneratorErrors, int expectedCompilerErrors)
         {

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
@@ -231,7 +231,7 @@ namespace LibraryImportGenerator.UnitTests
             yield return new[] { CodeSnippets.CollectionsOfCollectionsStress };
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(CodeSnippetsToCompile))]
         public async Task ValidateSnippets(string source)
         {
@@ -257,7 +257,7 @@ namespace LibraryImportGenerator.UnitTests
             yield return new object[] { CodeSnippets.PreprocessorIfAfterAttributeAroundFunctionAdditionalFunctionAfter("Foo"), Array.Empty<string>() };
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(CodeSnippetsToCompileWithPreprocessorSymbols))]
         public async Task ValidateSnippetsWithPreprocessorDefintions(string source, IEnumerable<string> preprocessorSymbols)
         {
@@ -303,7 +303,7 @@ namespace LibraryImportGenerator.UnitTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(CodeSnippetsToValidateFallbackForwarder))]
         public async Task ValidateSnippetsFallbackForwarder(string source, TestTargetFramework targetFramework, bool expectFallbackForwarder)
         {
@@ -340,7 +340,7 @@ namespace LibraryImportGenerator.UnitTests
             yield return new[] { CodeSnippets.BasicParameterByValue("int") };
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(FullyBlittableSnippetsToCompile))]
         public async Task ValidateSnippetsWithBlittableAutoForwarding(string source)
         {
@@ -374,7 +374,7 @@ namespace LibraryImportGenerator.UnitTests
             yield return new[] { CodeSnippets.SetLastErrorTrue<int>() };
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(SnippetsWithBlittableTypesButNonBlittableDataToCompile))]
         public async Task ValidateSnippetsWithBlittableTypesButNonBlittableMetadataDoNotAutoForward(string source)
         {
@@ -412,7 +412,7 @@ namespace LibraryImportGenerator.UnitTests
 #pragma warning disable xUnit1004 // Test methods should not be skipped.
                                   // If we have any new experimental APIs that we are implementing that have not been approved,
                                   // we will add new scenarios for this test.
-        [ConditionalTheory(Skip = "No current scenarios to test.")]
+        [Theory(Skip = "No current scenarios to test.")]
 #pragma warning restore
         [MemberData(nameof(CodeSnippetsToCompileWithMarshalType))]
         public async Task ValidateSnippetsWithMarshalType(string source)
@@ -444,7 +444,7 @@ namespace LibraryImportGenerator.UnitTests
             yield return new object[] { new[] { CodeSnippets.BasicParameterByValue("int[]", CodeSnippets.DisableRuntimeMarshalling), CodeSnippets.BasicParameterWithByRefModifier("ref", "int") } };
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(CodeSnippetsToCompileMultipleSources))]
         public async Task ValidateSnippetsWithMultipleSources(string[] sources)
         {

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/ConvertToLibraryImportAnalyzerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/ConvertToLibraryImportAnalyzerTests.cs
@@ -47,7 +47,7 @@ namespace LibraryImportGenerator.UnitTests
             new object[] { typeof(System.Text.StringBuilder) },
         };
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(MarshallingRequiredTypes))]
         [MemberData(nameof(NoMarshallingRequiredTypes))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/60909", typeof(PlatformDetection), nameof(PlatformDetection.IsArm64Process), nameof(PlatformDetection.IsWindows))]
@@ -64,7 +64,7 @@ namespace LibraryImportGenerator.UnitTests
                     .WithArguments("Method_Return"));
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(MarshallingRequiredTypes))]
         [MemberData(nameof(NoMarshallingRequiredTypes))]
         public async Task ByRef_ReportsDiagnostic(Type type)
@@ -97,7 +97,7 @@ unsafe partial class Test
                     .WithArguments("Method_Ref"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task SetLastErrorTrue_ReportsDiagnostic()
         {
             string source = @$"
@@ -121,7 +121,7 @@ partial class Test
                     .WithArguments("Method2"));
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(UnsupportedTypes))]
         public async Task UnsupportedType_NoDiagnostic(Type type)
         {
@@ -129,7 +129,7 @@ partial class Test
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [ConditionalTheory]
+        [Theory]
         [InlineData(UnmanagedType.Interface)]
         [InlineData(UnmanagedType.IDispatch)]
         [InlineData(UnmanagedType.IInspectable)]
@@ -152,7 +152,7 @@ unsafe partial class Test
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task LibraryImport_NoDiagnostic()
         {
             string source = @$"
@@ -171,7 +171,7 @@ partial class Test
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NotDllImport_NoDiagnostic()
         {
             string source = @$"

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/ConvertToLibraryImportFixerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/ConvertToLibraryImportFixerTests.cs
@@ -19,7 +19,7 @@ namespace LibraryImportGenerator.UnitTests
     {
         private const string ConvertToLibraryImportKey = "ConvertToLibraryImport";
 
-        [ConditionalFact]
+        [Fact]
         public async Task Basic()
         {
             string source = @$"
@@ -42,7 +42,7 @@ partial class Test
                 fixedSource);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task Comments()
         {
             string source = @$"
@@ -77,7 +77,7 @@ partial class Test
                 fixedSource);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task MultipleAttributes()
         {
             string source = @$"
@@ -110,7 +110,7 @@ partial class Test
                 fixedSource);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NamedArguments()
         {
             string source = @$"
@@ -139,7 +139,7 @@ partial class Test
                 fixedSource);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task RemoveableNamedArguments()
         {
             string source = @$"
@@ -186,7 +186,7 @@ partial class Test
                 fixedSource);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task ReplaceableExplicitPlatformDefaultCallingConvention()
         {
             string source = @$"
@@ -209,7 +209,7 @@ partial class Test
                 fixedSource);
         }
 
-        [ConditionalTheory]
+        [Theory]
         [InlineData(CallingConvention.Cdecl, typeof(CallConvCdecl))]
         [InlineData(CallingConvention.StdCall, typeof(CallConvStdcall))]
         [InlineData(CallingConvention.ThisCall, typeof(CallConvThiscall))]
@@ -237,7 +237,7 @@ partial class Test
                 fixedSource);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task PreferredAttributeOrder()
         {
             string source = @$"
@@ -262,7 +262,7 @@ partial class Test
 
         [InlineData(CharSet.Ansi, 'A')]
         [InlineData(CharSet.Unicode, 'W')]
-        [ConditionalTheory]
+        [Theory]
         public async Task ExactSpelling_False_NoAutoCharSet_Provides_No_Suffix_And_Suffix_Fix(CharSet charSet, char suffix)
         {
             string source = $@"
@@ -290,7 +290,7 @@ partial class Test
             await VerifyCS.VerifyCodeFixAsync(source, fixedSourceWithSuffix, $"{ConvertToLibraryImportKey}{suffix}");
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task ExactSpelling_False_AutoCharSet_Provides_No_Suffix_And_Both_Suffix_Fixes()
         {
             string source = $@"
@@ -326,7 +326,7 @@ partial class Test
             await VerifyCS.VerifyCodeFixAsync(source, fixedSourceWithWSuffix, $"{ConvertToLibraryImportKey}W");
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task ExactSpelling_False_ImplicitAnsiCharSet_Provides_No_Suffix_And_Suffix_Fix()
         {
             string source = $@"
@@ -354,7 +354,7 @@ partial class Test
             await VerifyCS.VerifyCodeFixAsync(source, fixedSourceWithASuffix, $"{ConvertToLibraryImportKey}A");
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task ExactSpelling_False_ConstantNonLiteralEntryPoint()
         {
             string source = $@"
@@ -376,7 +376,7 @@ partial class Test
             await VerifyCS.VerifyCodeFixAsync(source, fixedSourceWithASuffix, $"{ConvertToLibraryImportKey}A");
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task Implicit_ExactSpelling_False_Offers_Suffix_Fix()
         {
             string source = $@"
@@ -396,7 +396,7 @@ partial class Test
             await VerifyCS.VerifyCodeFixAsync(source, fixedSourceWithASuffix, $"{ConvertToLibraryImportKey}A");
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task ExactSpelling_False_NameOfEntryPoint()
         {
             string source = $@"
@@ -418,7 +418,7 @@ partial class Test
             await VerifyCS.VerifyCodeFixAsync(source, fixedSourceWithASuffix, $"{ConvertToLibraryImportKey}A");
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task ExactSpelling_False_ImplicitEntryPointName()
         {
             string source = $@"
@@ -438,7 +438,7 @@ partial class Test
             await VerifyCS.VerifyCodeFixAsync(source, fixedSourceWithASuffix, $"{ConvertToLibraryImportKey}A");
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task PreserveSigFalseSignatureModified()
         {
             string source = @"
@@ -481,7 +481,7 @@ partial class Test
                 fixedSource);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task MakeEnclosingTypesPartial()
         {
             string source = @"
@@ -544,7 +544,7 @@ partial class EnclosingPartial
                 fixedSource);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task BooleanMarshalAsAdded()
         {
             string source = @$"

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Diagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Diagnostics.cs
@@ -16,7 +16,7 @@ namespace LibraryImportGenerator.UnitTests
 {
     public class Diagnostics
     {
-        [ConditionalTheory]
+        [Theory]
         [InlineData(TestTargetFramework.Framework)]
         [InlineData(TestTargetFramework.Core)]
         [InlineData(TestTargetFramework.Standard)]
@@ -42,7 +42,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [ConditionalTheory]
+        [Theory]
         [InlineData(TestTargetFramework.Framework)]
         [InlineData(TestTargetFramework.Core)]
         [InlineData(TestTargetFramework.Standard)]
@@ -67,7 +67,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task ParameterTypeNotSupported_ReportsDiagnostic()
         {
             string source = @"
@@ -105,7 +105,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task ReturnTypeNotSupported_ReportsDiagnostic()
         {
             string source = @"
@@ -143,7 +143,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task ParameterTypeNotSupportedWithDetails_ReportsDiagnostic()
         {
             string source = @"
@@ -171,7 +171,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task ReturnTypeNotSupportedWithDetails_ReportsDiagnostic()
         {
             string source = @"
@@ -202,7 +202,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task ParameterConfigurationNotSupported_ReportsDiagnostic()
         {
             string source = @"
@@ -235,7 +235,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task ReturnConfigurationNotSupported_ReportsDiagnostic()
         {
             string source = @"
@@ -270,7 +270,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task MarshalAsUnmanagedTypeNotSupported_ReportsDiagnostic()
         {
             string source = @"
@@ -310,7 +310,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task MarshalAsFieldNotSupported_ReportsDiagnostic()
         {
             string source = @"
@@ -343,7 +343,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task StringMarshallingForwardingNotSupported_ReportsDiagnostic()
         {
             string source = @"
@@ -388,7 +388,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task InvalidStringMarshallingConfiguration_ReportsDiagnostic()
         {
             string source = @$"
@@ -426,7 +426,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NonPartialMethod_ReportsDiagnostic()
         {
             string source = @"
@@ -458,7 +458,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NonStaticMethod_ReportsDiagnostic()
         {
             string source = @"
@@ -485,7 +485,7 @@ partial class Test
             TestUtils.AssertPreSourceGeneratorCompilation(newComp);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task GenericMethod_ReportsDiagnostic()
         {
             string source = @"
@@ -518,7 +518,7 @@ partial class Test
             TestUtils.AssertPreSourceGeneratorCompilation(newComp);
         }
 
-        [ConditionalTheory]
+        [Theory]
         [InlineData("class")]
         [InlineData("struct")]
         [InlineData("record")]
@@ -551,7 +551,7 @@ using System.Runtime.InteropServices;
             TestUtils.AssertPreSourceGeneratorCompilation(newComp, additionalDiag);
         }
 
-        [ConditionalTheory]
+        [Theory]
         [InlineData("class")]
         [InlineData("struct")]
         [InlineData("record")]

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/IncrementalGenerationTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/IncrementalGenerationTests.cs
@@ -21,7 +21,7 @@ namespace LibraryImportGenerator.UnitTests
         public const string RequiresIncrementalSyntaxTreeModifySupport = "The GeneratorDriver treats all SyntaxTree replace operations on a Compilation as an Add/Remove operation instead of a Modify operation"
             + ", so all cached results based on that input are thrown out. As a result, we cannot validate that unrelated changes within the same SyntaxTree do not cause regeneration.";
 
-        [ConditionalFact]
+        [Fact]
         public async Task AddingNewUnrelatedType_DoesNotRegenerateSource()
         {
             string source = CodeSnippets.BasicParametersAndModifiers<int>();
@@ -45,7 +45,7 @@ namespace LibraryImportGenerator.UnitTests
                 });
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task AppendingUnrelatedSource_DoesNotRegenerateSource()
         {
             string source = $"namespace NS{{{CodeSnippets.BasicParametersAndModifiers<int>()}}}";
@@ -75,7 +75,7 @@ namespace LibraryImportGenerator.UnitTests
                 });
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task AddingFileWithNewLibraryImport_DoesNotRegenerateOriginalMethod()
         {
             string source = CodeSnippets.BasicParametersAndModifiers<int>();
@@ -105,7 +105,7 @@ namespace LibraryImportGenerator.UnitTests
                 });
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task ReplacingFileWithNewLibraryImport_DoesNotRegenerateStubsInOtherFiles()
         {
             Compilation comp1 = await TestUtils.CreateCompilation(new string[] { CodeSnippets.BasicParametersAndModifiers<int>(), CodeSnippets.BasicParametersAndModifiers<bool>() });
@@ -132,7 +132,7 @@ namespace LibraryImportGenerator.UnitTests
                 });
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task ChangingMarshallingStrategy_RegeneratesStub()
         {
             string stubSource = CodeSnippets.BasicParametersAndModifiers("CustomType");
@@ -171,7 +171,7 @@ namespace LibraryImportGenerator.UnitTests
                 });
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task ChangingMarshallingAttributes_SameStrategy_DoesNotRegenerate()
         {
             string source = CodeSnippets.BasicParametersAndModifiers<int>();

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/ManualTypeMarshallingAnalyzerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/ManualTypeMarshallingAnalyzerTests.cs
@@ -15,7 +15,7 @@ namespace LibraryImportGenerator.UnitTests
     [ActiveIssue("https://github.com/dotnet/runtime/issues/60650", TestRuntimes.Mono)]
     public class ManualTypeMarshallingAnalyzerTests
     {
-        [ConditionalFact]
+        [Fact]
         public async Task NullNativeType_ReportsDiagnostic()
         {
             string source = @"
@@ -31,7 +31,7 @@ struct S
                 VerifyCS.Diagnostic(NativeTypeMustBeNonNullRule).WithLocation(0).WithArguments("S"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NonNamedNativeType_ReportsDiagnostic()
         {
             string source = @"
@@ -47,7 +47,7 @@ struct S
                 VerifyCS.Diagnostic(NativeTypeMustHaveRequiredShapeRule).WithLocation(0).WithArguments("int*", "S"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NonBlittableNativeType_ReportsDiagnostic()
         {
             string source = @"
@@ -74,7 +74,7 @@ struct {|#0:Native|}
                 VerifyCS.Diagnostic(NativeTypeMustBeBlittableRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task ClassNativeType_ReportsDiagnostic()
         {
             string source = @"
@@ -101,7 +101,7 @@ class {|#0:Native|}
                 VerifyCS.Diagnostic(NativeTypeMustHaveRequiredShapeRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task BlittableNativeType_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -129,7 +129,7 @@ struct Native
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task BlittableNativeWithNonBlittableValueProperty_ReportsDiagnostic()
         {
             string source = @"
@@ -160,7 +160,7 @@ struct Native
                 VerifyCS.Diagnostic(NativeTypeMustBeBlittableRule).WithLocation(0).WithArguments("string", "S"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NonBlittableNativeTypeWithBlittableValueProperty_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -190,7 +190,7 @@ struct Native
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task ClassNativeTypeWithValueProperty_ReportsDiagnostic()
         {
             string source = @"
@@ -221,7 +221,7 @@ class {|#0:Native|}
                 VerifyCS.Diagnostic(NativeTypeMustHaveRequiredShapeRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NonBlittableGetPinnableReferenceReturnType_ReportsDiagnostic()
         {
             string source = @"
@@ -254,7 +254,7 @@ unsafe struct Native
                 VerifyCS.Diagnostic(GetPinnableReferenceReturnTypeBlittableRule).WithLocation(0));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task BlittableGetPinnableReferenceReturnType_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -286,7 +286,7 @@ unsafe struct Native
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NonBlittableMarshallerGetPinnableReferenceReturnType_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -318,7 +318,7 @@ unsafe struct Native
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task BlittableMarshallerGetPinnableReferenceReturnType_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -350,7 +350,7 @@ unsafe struct Native
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task TypeWithGetPinnableReferenceNonPointerReturnType_ReportsDiagnostic()
         {
             string source = @"
@@ -383,7 +383,7 @@ unsafe struct Native
                 VerifyCS.Diagnostic(NativeTypeMustBePointerSizedRule).WithLocation(0).WithArguments("int", "S"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task TypeWithGetPinnableReferencePointerReturnType_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -415,7 +415,7 @@ unsafe struct Native
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task TypeWithGetPinnableReferenceByRefValuePropertyType_ReportsDiagnostic()
         {
             string source = @"
@@ -446,7 +446,7 @@ unsafe struct Native
                 VerifyCS.Diagnostic(RefValuePropertyUnsupportedRule).WithLocation(0).WithArguments("Native"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NativeTypeWithGetPinnableReferenceByRefValuePropertyType_ReportsDiagnostic()
         {
             string source = @"
@@ -477,7 +477,7 @@ unsafe struct Native
                 VerifyCS.Diagnostic(RefValuePropertyUnsupportedRule).WithLocation(0).WithArguments("Native"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NativeTypeWithGetPinnableReferenceNoValueProperty_ReportsDiagnostic()
         {
             string source = @"
@@ -506,7 +506,7 @@ unsafe struct Native
                 VerifyCS.Diagnostic(MarshallerGetPinnableReferenceRequiresValuePropertyRule).WithLocation(0).WithArguments("Native"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NativeTypeWithGetPinnableReferenceWithNonPointerValueProperty_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -536,7 +536,7 @@ unsafe struct Native
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NativeTypeWithNoMarshallingMethods_ReportsDiagnostic()
         {
             string source = @"
@@ -557,7 +557,7 @@ struct {|#0:Native|}
                 VerifyCS.Diagnostic(NativeTypeMustHaveRequiredShapeRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task CollectionNativeTypeWithNoMarshallingMethods_ReportsDiagnostic()
         {
             string source = @"
@@ -579,7 +579,7 @@ struct {|#0:Native|}
                 VerifyCS.Diagnostic(CollectionNativeTypeMustHaveRequiredShapeRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task CollectionNativeTypeWithWrongConstructor_ReportsDiagnostic()
         {
             string source = @"
@@ -607,7 +607,7 @@ ref struct {|#0:Native|}
                 VerifyCS.Diagnostic(CollectionNativeTypeMustHaveRequiredShapeRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task CollectionNativeTypeWithCorrectConstructor_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -634,7 +634,7 @@ ref struct Native
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task CollectionNativeTypeWithIncorrectStackallocConstructor_ReportsDiagnostic()
         {
             string source = @"
@@ -664,7 +664,7 @@ ref struct {|#0:Native|}
                 VerifyCS.Diagnostic(CollectionNativeTypeMustHaveRequiredShapeRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task CollectionNativeTypeWithOnlyStackallocConstructor_ReportsDiagnostic()
         {
             string source = @"
@@ -694,7 +694,7 @@ ref struct {|#0:Native|}
                 VerifyCS.Diagnostic(CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task CollectionNativeTypeWithMissingManagedValuesProperty_ReportsDiagnostic()
         {
             string source = @"
@@ -721,7 +721,7 @@ ref struct {|#0:Native|}
                 VerifyCS.Diagnostic(CollectionNativeTypeMustHaveRequiredShapeRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task CollectionNativeTypeWithMissingNativeValueStorageProperty_ReportsDiagnostic()
         {
             string source = @"
@@ -748,7 +748,7 @@ ref struct {|#0:Native|}
                 VerifyCS.Diagnostic(CollectionNativeTypeMustHaveRequiredShapeRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NativeTypeWithOnlyConstructor_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -769,7 +769,7 @@ struct Native
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NativeTypeWithOnlyToManagedMethod_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -790,7 +790,7 @@ struct Native
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NativeTypeWithOnlyStackallocConstructor_ReportsDiagnostic()
         {
             string source = @"
@@ -814,7 +814,7 @@ struct {|#0:Native|}
                 VerifyCS.Diagnostic(CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackRule).WithLocation(0).WithArguments("Native"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task TypeWithOnlyNativeStackallocConstructorAndGetPinnableReference_ReportsDiagnostics()
         {
             string source = @"
@@ -842,7 +842,7 @@ struct {|#1:Native|}
                 VerifyCS.Diagnostic(GetPinnableReferenceShouldSupportAllocatingMarshallingFallbackRule).WithLocation(0).WithArguments("S", "Native"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NativeTypeWithConstructorAndSetOnlyValueProperty_ReportsDiagnostic()
         {
             string source = @"
@@ -866,7 +866,7 @@ struct Native
                 VerifyCS.Diagnostic(ValuePropertyMustHaveGetterRule).WithLocation(0).WithArguments("Native"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NativeTypeWithToManagedAndGetOnlyValueProperty_ReportsDiagnostic()
         {
             string source = @"
@@ -890,7 +890,7 @@ struct Native
                 VerifyCS.Diagnostic(ValuePropertyMustHaveSetterRule).WithLocation(0).WithArguments("Native"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task BlittableNativeTypeOnMarshalUsingParameter_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -924,7 +924,7 @@ static class Test
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NonBlittableNativeTypeOnMarshalUsingParameter_ReportsDiagnostic()
         {
             string source = @"
@@ -958,7 +958,7 @@ static class Test
                 VerifyCS.Diagnostic(NativeTypeMustBeBlittableRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NonBlittableNativeTypeOnMarshalUsingParameter_MultipleCompilations_ReportsDiagnostic_WithLocation()
         {
             string source1 = @"
@@ -1009,7 +1009,7 @@ static class Test
             await test.RunAsync();
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NonBlittableNativeTypeOnMarshalUsingReturn_ReportsDiagnostic()
         {
             string source = @"
@@ -1043,7 +1043,7 @@ static class Test
                 VerifyCS.Diagnostic(NativeTypeMustBeBlittableRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NonBlittableNativeTypeOnMarshalUsingField_ReportsDiagnostic()
         {
             string source = @"
@@ -1077,7 +1077,7 @@ struct Test
                 VerifyCS.Diagnostic(NativeTypeMustBeBlittableRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task GenericNativeTypeWithValueTypeValueProperty_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -1104,7 +1104,7 @@ struct Native<T>
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task GenericNativeTypeWithGenericMemberInstantiatedWithBlittable_DoesNotReportDiagnostic()
         {
 
@@ -1132,7 +1132,7 @@ struct Native<T>
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task UninstantiatedGenericNativeTypeOnNonGeneric_ReportsDiagnostic()
         {
 
@@ -1160,7 +1160,7 @@ struct Native<T>
             await VerifyCS.VerifyAnalyzerAsync(source, VerifyCS.Diagnostic(NativeGenericTypeMustBeClosedOrMatchArityRule).WithLocation(0).WithArguments("Native<>", "S"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task UninstantiatedGenericNativeTypeOnGenericWithArityMismatch_ReportsDiagnostic()
         {
             string source = @"
@@ -1187,7 +1187,7 @@ struct Native<T, U>
             await VerifyCS.VerifyAnalyzerAsync(source, VerifyCS.Diagnostic(NativeGenericTypeMustBeClosedOrMatchArityRule).WithLocation(0).WithArguments("Native<,>", "S<T>"));
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task UninstantiatedGenericNativeTypeOnGenericWithArityMatch_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -1214,7 +1214,7 @@ struct Native<T>
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [ConditionalFact]
+        [Fact]
         public async Task NativeTypeWithStackallocConstructorWithoutBufferSize_ReportsDiagnostic()
         {
             string source = @"

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/TestUtils.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/TestUtils.cs
@@ -220,26 +220,12 @@ namespace LibraryImportGenerator.UnitTests
                 optionsProvider: options,
                 driverOptions: driverOptions);
 
-        // The non-configurable test-packages folder may be incomplete/corrupt.
-        // - https://github.com/dotnet/roslyn-sdk/issues/487
-        // - https://github.com/dotnet/roslyn-sdk/issues/590
-        internal static void ThrowSkipExceptionIfPackagingException(Exception e)
-        {
-            if (e.GetType().FullName == "NuGet.Packaging.Core.PackagingException")
-                throw new SkipTestException($"Skipping test due to issue with test-packages ({e.Message}). See https://github.com/dotnet/roslyn-sdk/issues/590.");
-        }
-
         private static async Task<ImmutableArray<MetadataReference>> ResolveReferenceAssemblies(ReferenceAssemblies referenceAssemblies)
         {
             try
             {
                 ResolveRedirect.Instance.Start();
                 return await referenceAssemblies.ResolveAsync(LanguageNames.CSharp, CancellationToken.None);
-            }
-            catch (Exception e)
-            {
-                ThrowSkipExceptionIfPackagingException(e);
-                throw;
             }
             finally
             {

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Verifiers/CSharpCodeFixVerifier.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Verifiers/CSharpCodeFixVerifier.cs
@@ -143,19 +143,6 @@ namespace LibraryImportGenerator.UnitTests.Verifiers
                             return true;
                         }));
             }
-
-            protected override async Task RunImplAsync(CancellationToken cancellationToken)
-            {
-                try
-                {
-                    await base.RunImplAsync(cancellationToken);
-                }
-                catch (System.Exception e)
-                {
-                    TestUtils.ThrowSkipExceptionIfPackagingException(e);
-                    throw;
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Update the Roslyn testing SDK to pick up fixes for the NuGet package download that's part of the ReferenceAssemblies API.