### PR TITLE
Disable Xharness telemetry for wasm 

### DIFF
--- a/src/libraries/sendtohelix-wasm.targets
+++ b/src/libraries/sendtohelix-wasm.targets
@@ -26,7 +26,7 @@
     <NeedsToRunOnBrowser Condition="'$(NeedsToRunOnBrowser)' == '' and '$(IsWasmDebuggerTests)' == 'true'">true</NeedsToRunOnBrowser>
 
     <IncludeXHarnessCli>true</IncludeXHarnessCli>
-    <EnableXHarnessTelemetry>true</EnableXHarnessTelemetry>
+    <EnableXHarnessTelemetry>false</EnableXHarnessTelemetry>
     <IncludeNodePayload Condition="'$(NeedsEMSDKNode)' == 'true' and '$(NeedsEMSDK)' != 'true'">true</IncludeNodePayload>
   </PropertyGroup>
 
@@ -99,13 +99,13 @@
         <NeedsDotNetSdk>true</NeedsDotNetSdk>
         <UseDotNetCliVersionFromGlobalJson>true</UseDotNetCliVersionFromGlobalJson>
         <IncludeXHarnessCli>true</IncludeXHarnessCli>
-        <EnableXHarnessTelemetry>true</EnableXHarnessTelemetry>
+        <EnableXHarnessTelemetry>false</EnableXHarnessTelemetry>
       </PropertyGroup>
     </When>
     <When Condition="'$(NeedsEMSDKNode)' == 'true'">
       <PropertyGroup>
         <IncludeXHarnessCli>true</IncludeXHarnessCli>
-        <EnableXHarnessTelemetry>true</EnableXHarnessTelemetry>
+        <EnableXHarnessTelemetry>false</EnableXHarnessTelemetry>
       </PropertyGroup>
     </When>
   </Choose>


### PR DESCRIPTION
To prevent a trash log from getting into Wasm build log:
```
+ /usr/bin/python3 -u /datadisks/disk1/work/B43F097B/w/A1780928/u/xharness-event-processor.py
/usr/bin/python3: can't open file '/datadisks/disk1/work/B43F097B/w/A1780928/u/xharness-event-processor.py': [Errno 2] No such file or directory
```
This log is not the real error and might be confusing when examining the failure.

[Example of a log with this problem.](https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-heads-main-5c24d9c7df9d4d30b3/normal-Microsoft.Extensions.Logging.Generators.Roslyn3.11.Tests/1/console.fc780b6c.log?sv=2019-07-07&se=2022-03-30T21:54:41Z&sr=c&sp=rl&sig=zwASfdzVKHDhyq6jP%2BeQtflGCxr1VgzUaktAh5kKQWo%3D)

Reason for the missing file explained: https://github.com/dotnet/runtime/pull/66698#issuecomment-1068872012.