### PR TITLE
Use values from TlsCipherSuiteData for SslConnectionInfo on Windows

### DIFF
--- a/src/libraries/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/libraries/System.Net.Security/src/System.Net.Security.csproj
@@ -31,6 +31,7 @@
     <Compile Include="System\Net\Security\SslCertificateTrust.cs" />
     <Compile Include="System\Net\Security\SslClientAuthenticationOptions.cs" />
     <Compile Include="System\Net\Security\SslClientHelloInfo.cs" />
+    <Compile Include="System\Net\Security\SslConnectionInfo.Unix.cs" />
     <Compile Include="System\Net\Security\SslServerAuthenticationOptions.cs" />
     <Compile Include="System\Net\Security\SecureChannel.cs" />
     <Compile Include="System\Net\Security\SslSessionsCache.cs" />
@@ -41,6 +42,7 @@
     <Compile Include="System\Net\Security\StreamSizes.cs" />
     <Compile Include="System\Net\Security\TlsAlertType.cs" />
     <Compile Include="System\Net\Security\TlsAlertMessage.cs" />
+    <Compile Include="System\Net\Security\TlsCipherSuiteData.cs" />
     <Compile Include="System\Net\Security\TlsFrameHelper.cs" />
     <!-- NegotiateStream -->
     <Compile Include="System\Net\NTAuthentication.cs" />
@@ -106,19 +108,12 @@
     </Compile>
     <None Include="System\Net\Security\TlsCipherSuiteNameParser.ttinclude" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != '' and '$(TargetPlatformIdentifier)' != 'windows'">
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != ''">
     <Compile Include="System\Net\Security\TlsCipherSuiteData.Lookup.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>TlsCipherSuiteData.Lookup.tt</DependentUpon>
     </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows'">
-    <None Include="System\Net\Security\TlsCipherSuiteData.Lookup.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>TlsCipherSuiteData.Lookup.tt</DependentUpon>
-    </None>
   </ItemGroup>
   <ItemGroup Condition="'$(AllowTlsCipherSuiteGeneration)' == 'true'">
     <None Include="System\Net\Security\TlsCipherSuite.tt">
@@ -257,8 +252,6 @@
              Link="Common\System\Net\Security\Unix\SecChannelBindings.cs" />
     <Compile Include="System\Net\Security\Pal.Managed\EndpointChannelBindingToken.cs" />
     <Compile Include="System\Net\Security\Pal.Managed\SafeChannelBindingHandle.cs" />
-    <Compile Include="System\Net\Security\SslConnectionInfo.Unix.cs" />
-    <Compile Include="System\Net\Security\TlsCipherSuiteData.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != '' and '$(TargetPlatformIdentifier)' != 'windows' and '$(TargetPlatformIdentifier)' != 'tvOS'">
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\GssSafeHandles.cs"

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslConnectionInfo.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslConnectionInfo.Windows.cs
@@ -8,14 +8,11 @@ namespace System.Net.Security
         public SslConnectionInfo(SecPkgContext_ConnectionInfo interopConnectionInfo, TlsCipherSuite cipherSuite)
         {
             Protocol = interopConnectionInfo.Protocol;
-            DataCipherAlg = interopConnectionInfo.DataCipherAlg;
-            DataKeySize = interopConnectionInfo.DataKeySize;
-            DataHashAlg = interopConnectionInfo.DataHashAlg;
-            DataHashKeySize = interopConnectionInfo.DataHashKeySize;
-            KeyExchangeAlg = interopConnectionInfo.KeyExchangeAlg;
-            KeyExchKeySize = interopConnectionInfo.KeyExchKeySize;
 
-            TlsCipherSuite = cipherSuite;
+            MapCipherSuite(cipherSuite);
+
+            // TlsCipherSuiteData does not provide KeyExchKeySize, but WinAPI does
+            KeyExchKeySize = interopConnectionInfo.KeyExchKeySize;
         }
     }
 }


### PR DESCRIPTION
Contributes to #37578

On Windows, the value returned from SChannel for the key exchange algorithm type cannot be mapped 1:1 to the `ExchangeAlgorithmType` enum. This PR makes `SslConnectionInfo` be retrieved from `TlsCipherSuiteData` like on Unix platforms for consistency.