### PR TITLE
Run illink before ApiCompat

### DIFF
--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -10,7 +10,7 @@
   <PropertyGroup>
     <TargetsTriggeredByCompilation Condition="'$(DesignTimeBuild)' != 'true'">
       ILLinkTrimAssembly;
-      $(TargetsTriggeredByCompilation)      
+      $(TargetsTriggeredByCompilation)
     </TargetsTriggeredByCompilation>
   </PropertyGroup>
 

--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -9,8 +9,8 @@
 
   <PropertyGroup>
     <TargetsTriggeredByCompilation Condition="'$(DesignTimeBuild)' != 'true'">
-      $(TargetsTriggeredByCompilation);
-      ILLinkTrimAssembly
+      ILLinkTrimAssembly;
+      $(TargetsTriggeredByCompilation)      
     </TargetsTriggeredByCompilation>
   </PropertyGroup>
 

--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -1,17 +1,10 @@
 <Project>
   <PropertyGroup>
     <IsTrimmable Condition="'$(IsTrimmable)' == ''">true</IsTrimmable>
-    <PrepareResourcesDependsOn>
-      _EmbedILLinkXmls;
-      $(PrepareResourcesDependsOn)
-    </PrepareResourcesDependsOn>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <TargetsTriggeredByCompilation Condition="'$(DesignTimeBuild)' != 'true'">
-      ILLinkTrimAssembly;
-      $(TargetsTriggeredByCompilation)
-    </TargetsTriggeredByCompilation>
+    <PrepareResourcesDependsOn>_EmbedILLinkXmls;$(PrepareResourcesDependsOn)</PrepareResourcesDependsOn>
+    <TargetsTriggeredByCompilation Condition="'$(DesignTimeBuild)' != 'true'">$(TargetsTriggeredByCompilation);ILLinkTrimAssembly</TargetsTriggeredByCompilation>
+    <!-- ApiCompat should perform compatibility checks on the trimmed assemblies. -->
+    <ApiCompatDependsOn>$(ApiCompatDependsOn);ILLinkTrimAssembly</ApiCompatDependsOn>
   </PropertyGroup>
 
   <!-- Inputs and outputs of ILLinkTrimAssembly -->


### PR DESCRIPTION
As observed in https://github.com/dotnet/runtime/issues/66634#issuecomment-1068556981, illink currently runs after APICompat. This happens because nuget imports the ApiCompat targets earlier than the illink.targets is imported.

This should flag issues where illink removes interfaces even though it shouldn't in library mode.

cc @bartonjs @ericstj 