### PR TITLE
Fold *(size_t*)&obj to a raw class handle

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -16787,6 +16787,10 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* pIsExact, b
                 {
                     assert(sig.retType == CORINFO_TYPE_CLASS);
                     objClass = sig.retTypeClass;
+                    if ((objClass != NO_CLASS_HANDLE) && impIsClassExact(objClass))
+                    {
+                        *pIsExact = true;
+                    }
                 }
             }
             else if (call->gtCallType == CT_HELPER)

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -16787,10 +16787,6 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* pIsExact, b
                 {
                     assert(sig.retType == CORINFO_TYPE_CLASS);
                     objClass = sig.retTypeClass;
-                    if ((objClass != NO_CLASS_HANDLE) && impIsClassExact(objClass))
-                    {
-                        *pIsExact = true;
-                    }
                 }
             }
             else if (call->gtCallType == CT_HELPER)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12460,12 +12460,13 @@ DONE_MORPHING_CHILDREN:
             }
 
             // Fold *(size_t*)&obj to a raw class handle if we know the exact obj's type
-            if (indir->TypeIs(TYP_I_IMPL) && indir->Addr()->TypeIs(TYP_REF) && !gtIsActiveCSE_Candidate(indir->Addr()))
+            if (indir->TypeIs(TYP_I_IMPL) && !gtIsActiveCSE_Candidate(indir->Addr()))
             {
                 bool                 isExact   = false;
                 bool                 isNonNull = false;
                 CORINFO_CLASS_HANDLE objCls    = gtGetClassHandle(indir->Addr(), &isExact, &isNonNull);
-                if ((objCls != NO_CLASS_HANDLE) && isExact)
+                if ((objCls != NO_CLASS_HANDLE) && isExact &&
+                    (info.compCompHnd->compareTypesForEquality(objCls, objCls) == TypeCompareState::Must))
                 {
                     GenTree* clsNode = gtNewIconEmbClsHndNode(objCls);
                     if (!isNonNull)


### PR DESCRIPTION
If we see IND(obj) and we know obj's exact type we can fold it to a raw class handle.

Closes https://github.com/dotnet/runtime/issues/52370