### PR TITLE
Eat cancellation exceptions from WaitAsync in Parallel.ForEachAsync

### DIFF
--- a/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.ForEachAsync.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.ForEachAsync.cs
@@ -229,7 +229,17 @@ namespace System.Threading.Tasks
                     {
                         // Get the next element from the enumerator.  This requires asynchronously locking around MoveNextAsync/Current.
                         TSource element;
-                        await state.Lock.WaitAsync(state.Cancellation.Token);
+                        try
+                        {
+                            // TODO https://github.com/dotnet/runtime/issues/22144:
+                            // Use a no-throwing await if/when one is available built-in.
+                            await state.Lock.WaitAsync(state.Cancellation.Token);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            break;
+                        }
+
                         try
                         {
                             if (!await state.Enumerator.MoveNextAsync())


### PR DESCRIPTION
We can safely ignore cancellation exceptions due to WaitAsync being canceled.  They do not represent work that was started and interrupted, and we know exactly the source of the exception (as compared to if the exception emerged from either MoveNextAsync or the loop body).

Fixes https://github.com/dotnet/runtime/issues/66695