### PR TITLE
Fix beginning fixups of captures after Regex span support

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Capture.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Capture.cs
@@ -19,17 +19,6 @@ namespace System.Text.RegularExpressions
         /// <summary>Returns the position in the original string where the first character of captured substring was found.</summary>
         public int Index { get; private protected set; }
 
-        /// <summary>
-        /// This method should only be called when the text for matching was sliced with a different beginning, so the resulting index of
-        /// the match is not from the start of the text, but instead the start of the slice. This method will add back that extra indices
-        /// to account for the original text beginning.
-        /// </summary>
-        /// <param name="beginning">The original text's beginning offset.</param>
-        internal void AddBeginningToIndex(int beginning)
-        {
-            Index += beginning;
-        }
-
         /// <summary>Returns the length of the captured substring.</summary>
         public int Length { get; private protected set; }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -570,13 +570,7 @@ namespace System.Text.RegularExpressions
                     return null;
                 }
 
-                match.Tidy(runner.runtextpos);
-
-                // If the passed in beginning was not 0 then we need to adjust the offsets on the match object.
-                if (beginning != 0)
-                {
-                    match.AddBeginningToIndex(beginning);
-                }
+                match.Tidy(runner.runtextpos, beginning);
 
                 return match;
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -184,7 +184,7 @@ namespace System.Text.RegularExpressions
                 }
 
                 runmatch = null;
-                match.Tidy(runtextpos);
+                match.Tidy(runtextpos, 0);
             }
             else
             {

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Groups.Tests.cs
@@ -961,22 +961,26 @@ namespace System.Text.RegularExpressions.Tests
                 return;
             }
 
-            Match match = regex.Match(input);
-
-            Assert.True(match.Success);
-            Assert.Equal(expectedGroups[0], match.Value);
-
-            Assert.Equal(expectedGroups.Length, match.Groups.Count);
-
-            int[] groupNumbers = regex.GetGroupNumbers();
-            string[] groupNames = regex.GetGroupNames();
-            for (int i = 0; i < expectedGroups.Length; i++)
+            foreach (string prefix in new[] { "", "IGNORETHIS" })
             {
-                Assert.Equal(expectedGroups[i], match.Groups[groupNumbers[i]].Value);
-                Assert.Equal(match.Groups[groupNumbers[i]], match.Groups[groupNames[i]]);
+                Match match = prefix.Length == 0 ?
+                    regex.Match(input) : // validate the original input
+                    regex.Match(prefix + input, prefix.Length, input.Length); // validate we handle groups and beginning/length correctly
 
-                Assert.Equal(groupNumbers[i], regex.GroupNumberFromName(groupNames[i]));
-                Assert.Equal(groupNames[i], regex.GroupNameFromNumber(groupNumbers[i]));
+                Assert.True(match.Success);
+                Assert.Equal(expectedGroups[0], match.Value);
+                Assert.Equal(expectedGroups.Length, match.Groups.Count);
+
+                int[] groupNumbers = regex.GetGroupNumbers();
+                string[] groupNames = regex.GetGroupNames();
+                for (int i = 0; i < expectedGroups.Length; i++)
+                {
+                    Assert.Equal(expectedGroups[i], match.Groups[groupNumbers[i]].Value);
+                    Assert.Equal(match.Groups[groupNumbers[i]], match.Groups[groupNames[i]]);
+
+                    Assert.Equal(groupNumbers[i], regex.GroupNumberFromName(groupNames[i]));
+                    Assert.Equal(groupNames[i], regex.GroupNameFromNumber(groupNumbers[i]));
+                }
             }
         }
 


### PR DESCRIPTION
The Regex span support changed the scanning infrastructure to always be based on spans.  That means that when a string is passed in by the caller, internally we still operate on it as a span.  That also means we can take advantage of slicing, and if the caller has specified via a beginning/length set of arguments that we should only process a substring, we can just slice to that substring.  That, however, then means that all offsets computed by the scanning implementation are 0-based rather than beginning-based.  The span change included a fixup for the overall match position, but not for the position of each individual capture, and that then meant that captures were providing the wrong values.  We unfortunately didn't have any tests for validating groups that also involved non-0 beginnings with string inputs.

Fixes https://github.com/dotnet/runtime/issues/66697