### PR TITLE
Revert "Remove 4267 suppression from mono (#66552)"

### DIFF
--- a/src/mono/cmake/config.h.in
+++ b/src/mono/cmake/config.h.in
@@ -8,6 +8,7 @@
 #pragma warning(disable:4090) // const problem
 #pragma warning(disable:4146) // unary minus operator applied to unsigned type, result still unsigned
 #pragma warning(disable:4244) // integer conversion, possible loss of data
+#pragma warning(disable:4267) // integer conversion, possible loss of data
 
 // promote warnings to errors
 #pragma warning(  error:4013) // function undefined; assuming extern returning int

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -529,7 +529,7 @@ is_debugger_thread (void)
 	if (!internal)
 		return FALSE;
 
-	return internal->debugger_thread ? TRUE : FALSE;
+	return internal->debugger_thread;
 }
 
 static int
@@ -1398,13 +1398,13 @@ transport_handshake (void)
 	sprintf (handshake_msg, "DWP-Handshake");
 
 	do {
-		res = transport_send (handshake_msg, (int)strlen (handshake_msg));
+		res = transport_send (handshake_msg, strlen (handshake_msg));
 	} while (res == -1 && get_last_sock_error () == MONO_EINTR);
 
 	g_assert (res != -1);
 
 	/* Read answer */
-	res = transport_recv (buf, (int)strlen (handshake_msg));
+	res = transport_recv (buf, strlen (handshake_msg));
 	if ((res != strlen (handshake_msg)) || (memcmp (buf, handshake_msg, strlen (handshake_msg)) != 0)) {
 		PRINT_ERROR_MSG ("debugger-agent: DWP handshake failed.\n");
 		return FALSE;
@@ -1619,7 +1619,7 @@ mono_init_debugger_agent_for_wasm (int log_level_parm, MonoProfilerHandle *prof)
 	mono_profiler_set_jit_done_callback (*prof, jit_done);
 }
 
-void
+void 
 mono_change_log_level (int new_log_level)
 {
 	log_level = new_log_level;
@@ -6982,7 +6982,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 		break;
 	}
 	case MDBGPROT_CMD_GET_ASSEMBLY_BY_NAME: {
-		size_t i;
+		int i;
 		char* assembly_name = decode_string (p, &p, end);
 		//we get 'foo.dll' but mono_assembly_load expects 'foo' so we strip the last dot
 		char *lookup_name = g_strdup (assembly_name);
@@ -8912,8 +8912,8 @@ thread_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 			buffer_add_int (buf, 0);
 		} else {
 			const size_t len = strlen (s);
-			buffer_add_int (buf, (guint32)len);
-			buffer_add_data (buf, (guint8*)s, (uint32_t)len);
+			buffer_add_int (buf, len);
+			buffer_add_data (buf, (guint8*)s, len);
 			g_free (s);
 		}
 		break;
@@ -9717,7 +9717,7 @@ get_field_value:
 
 			/* TODO: metadata-update: implement support for added fields. */
 			g_assert (!m_field_is_from_update (f));
-
+			
 			if (f->type->attrs & FIELD_ATTRIBUTE_STATIC) {
 				guint8 *val;
 				MonoVTable *vtable;

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -563,7 +563,7 @@ table_info_find_in_base (const MonoTableInfo *table, MonoImage **base_out, int *
 
 	if (tbl_index) {
 		size_t s = ALIGN_TO (sizeof (MonoTableInfo), sizeof (gpointer));
-		*tbl_index = (int)(((intptr_t) table - (intptr_t) base->tables) / s);
+		*tbl_index = ((intptr_t) table - (intptr_t) base->tables) / s;
 	}
 	return TRUE;
 }
@@ -2382,7 +2382,7 @@ hot_reload_metadata_linear_search (MonoImage *base_image, MonoTableInfo *base_ta
 	int tbl_index;
 	{
 		size_t s = ALIGN_TO (sizeof (MonoTableInfo), sizeof (gpointer));
-		tbl_index = (int)(((intptr_t) base_table - (intptr_t) base_image->tables) / s);
+		tbl_index = ((intptr_t) base_table - (intptr_t) base_image->tables) / s;
 	}
 
 	DeltaInfo *delta_info = NULL;

--- a/src/mono/mono/eglib/giconv.c
+++ b/src/mono/mono/eglib/giconv.c
@@ -551,7 +551,7 @@ eg_utf8_to_utf16_general (const gchar *str, glong len, glong *items_read, glong 
 			return NULL;
 		}
 
-		len = (glong)strlen (str);
+		len = strlen (str);
 	}
 
 	inptr = (char *) str;
@@ -582,7 +582,7 @@ eg_utf8_to_utf16_general (const gchar *str, glong len, glong *items_read, glong 
 		*items_read = inptr - str;
 
 	if (items_written)
-		*items_written = (glong)outlen;
+		*items_written = outlen;
 
 	if (G_LIKELY (!custom_alloc_func))
 		outptr = outbuf = g_malloc ((outlen + 1) * sizeof (gunichar2));
@@ -680,7 +680,7 @@ g_utf8_to_ucs4 (const gchar *str, glong len, glong *items_read, glong *items_wri
 	g_return_val_if_fail (str != NULL, NULL);
 
 	if (len < 0)
-		len = (glong)strlen (str);
+		len = strlen (str);
 
 	inptr = (char *) str;
 	inleft = len;
@@ -714,7 +714,7 @@ g_utf8_to_ucs4 (const gchar *str, glong len, glong *items_read, glong *items_wri
 	}
 
 	if (items_written)
-		*items_written = (glong)(outlen / 4);
+		*items_written = outlen / 4;
 
 	if (items_read)
 		*items_read = inptr - str;
@@ -798,7 +798,7 @@ eg_utf16_to_utf8_general (const gunichar2 *str, glong len, glong *items_read, gl
 		*items_read = (inptr - (char *) str) / 2;
 
 	if (items_written)
-		*items_written = (glong)outlen;
+		*items_written = outlen;
 
 	if (G_LIKELY (!custom_alloc_func))
 		outptr = outbuf = g_malloc (outlen + 1);
@@ -902,7 +902,7 @@ g_utf16_to_ucs4 (const gunichar2 *str, glong len, glong *items_read, glong *item
 		*items_read = (inptr - (char *) str) / 2;
 
 	if (items_written)
-		*items_written = (glong)(outlen / 4);
+		*items_written = outlen / 4;
 
 	outptr = outbuf = g_malloc (outlen + 4);
 	inptr = (char *) str;
@@ -978,7 +978,7 @@ g_ucs4_to_utf8 (const gunichar *str, glong len, glong *items_read, glong *items_
 	*outptr = 0;
 
 	if (items_written)
-		*items_written = (glong)outlen;
+		*items_written = outlen;
 
 	if (items_read)
 		*items_read = i;
@@ -1040,7 +1040,7 @@ g_ucs4_to_utf16 (const gunichar *str, glong len, glong *items_read, glong *items
 	*outptr = 0;
 
 	if (items_written)
-		*items_written = (glong)outlen;
+		*items_written = outlen;
 
 	if (items_read)
 		*items_read = i;

--- a/src/mono/mono/eglib/glib.h
+++ b/src/mono/mono/eglib/glib.h
@@ -1076,9 +1076,9 @@ gboolean   g_file_test (const gchar *filename, GFileTest test);
 #define g_write write
 #endif
 #ifdef G_OS_WIN32
-#define g_read(fd, buffer, buffer_size) _read(fd, buffer, (unsigned)buffer_size)
+#define g_read _read
 #else
-#define g_read(fd, buffer, buffer_size) (int)read(fd, buffer, buffer_size)
+#define g_read read
 #endif
 
 #define g_fopen fopen

--- a/src/mono/mono/eglib/gpath.c
+++ b/src/mono/mono/eglib/gpath.c
@@ -313,7 +313,7 @@ g_ensure_directory_exists (const gchar *filename)
 	if (!dir_utf8 || !dir_utf8 [0])
 		return FALSE;
 
-	dir_utf16 = g_utf8_to_utf16 (dir_utf8, (glong)strlen (dir_utf8), NULL, NULL, NULL);
+	dir_utf16 = g_utf8_to_utf16 (dir_utf8, strlen (dir_utf8), NULL, NULL, NULL);
 	g_free (dir_utf8);
 
 	if (!dir_utf16)

--- a/src/mono/mono/eglib/gstr.c
+++ b/src/mono/mono/eglib/gstr.c
@@ -928,7 +928,7 @@ g_str_from_file_region (int fd, guint64 offset, gsize size)
 		return NULL;
 	buffer [size] = 0;
 	do {
-		status = g_read (fd, buffer, size);
+		status = read (fd, buffer, size);
 	} while (status == -1 && errno == EINTR);
 	if (status == -1){
 		g_free (buffer);

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -4332,16 +4332,16 @@ mono_profiler_fire_buffered_gc_event_root_register (
 	uint8_t root_source = (uint8_t)source;
 	uintptr_t root_key = (uintptr_t)key;
 	const char *root_name = (name ? name : "");
-	size_t root_name_len = strlen (root_name) + 1;
+	uint32_t root_name_len = strlen (root_name) + 1;
 
 	MonoProfilerBufferedGCEvent gc_event_data;
 	gc_event_data.type = MONO_PROFILER_BUFFERED_GC_EVENT_ROOT_REGISTER;
-	gc_event_data.payload_size = (uint32_t)
-		(sizeof (root_id) +
+	gc_event_data.payload_size =
+		sizeof (root_id) +
 		sizeof (root_size) +
 		sizeof (root_source) +
 		sizeof (root_key) +
-		root_name_len);
+		root_name_len;
 
 	uint8_t * buffer = mono_profiler_buffered_gc_event_alloc (gc_event_data.payload_size);
 	if (buffer) {
@@ -4545,8 +4545,8 @@ mono_profiler_fire_buffered_gc_event_moves (
 	MonoProfilerBufferedGCEvent gc_event_data;
 	gc_event_data.type = MONO_PROFILER_BUFFERED_GC_EVENT_MOVES;
 	gc_event_data.payload_size =
-		(uint32_t)(sizeof (count) +
-		(count * (sizeof (uintptr_t) + sizeof (uintptr_t))));
+		sizeof (count) +
+		(count * (sizeof (uintptr_t) + sizeof (uintptr_t)));
 
 	uint8_t * buffer = mono_profiler_buffered_gc_event_alloc (gc_event_data.payload_size);
 	if (buffer) {
@@ -4612,8 +4612,8 @@ mono_profiler_fire_buffered_gc_event_roots (
 	MonoProfilerBufferedGCEvent gc_event_data;
 	gc_event_data.type = MONO_PROFILER_BUFFERED_GC_EVENT_ROOTS;
 	gc_event_data.payload_size =
-		(uint32_t)(sizeof (count) +
-		(count * (sizeof (uintptr_t) + sizeof (uintptr_t))));
+		sizeof (count) +
+		(count * (sizeof (uintptr_t) + sizeof (uintptr_t)));
 
 	uint8_t * buffer = mono_profiler_buffered_gc_event_alloc (gc_event_data.payload_size);
 	if (buffer) {

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -152,11 +152,11 @@ prefix_name ## _rt_ ## type_name ## _ ## func_name
 #define EP_RT_DEFINE_ARRAY_PREFIX(prefix_name, array_name, array_type, iterator_type, item_type) \
 	static inline void EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, array_name, alloc) (array_type *ep_array) { \
 		EP_ASSERT (ep_array != NULL); \
-		ep_array->array = g_array_new (FALSE, FALSE, (guint)sizeof (item_type)); \
+		ep_array->array = g_array_new (FALSE, FALSE, sizeof (item_type)); \
 	} \
 	static inline void EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, array_name, alloc_capacity) (array_type *ep_array, size_t capacity) { \
 		EP_ASSERT (ep_array != NULL); \
-		ep_array->array = g_array_sized_new (FALSE, FALSE, (guint)sizeof (item_type), (guint)capacity); \
+		ep_array->array = g_array_sized_new (FALSE, FALSE, sizeof (item_type), capacity); \
 	} \
 	static inline void EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, array_name, free) (array_type *ep_array) { \
 		EP_ASSERT (ep_array != NULL); \
@@ -188,11 +188,11 @@ prefix_name ## _rt_ ## type_name ## _ ## func_name
 #define EP_RT_DEFINE_LOCAL_ARRAY_PREFIX(prefix_name, array_name, array_type, iterator_type, item_type) \
 	static inline void EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, array_name, init) (array_type *ep_array) { \
 		EP_ASSERT (ep_array != NULL); \
-		ep_array->array = g_array_new (FALSE, FALSE, (guint)sizeof (item_type)); \
+		ep_array->array = g_array_new (FALSE, FALSE, sizeof (item_type)); \
 	} \
 	static inline void EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, array_name, init_capacity) (array_type *ep_array, size_t capacity) { \
 		EP_ASSERT (ep_array != NULL); \
-		ep_array->array = g_array_sized_new (FALSE, FALSE, (guint)sizeof (item_type), (guint)capacity); \
+		ep_array->array = g_array_sized_new (FALSE, FALSE, sizeof (item_type), capacity); \
 	} \
 	static inline void EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, array_name, fini) (array_type *ep_array) { \
 		EP_ASSERT (ep_array != NULL); \
@@ -1308,7 +1308,7 @@ ep_rt_thread_sleep (uint64_t ns)
 		mono_thread_info_yield ();
 	} else {
 		MONO_ENTER_GC_SAFE;
-		g_usleep ((gulong)(ns / 1000));
+		g_usleep (ns / 1000);
 		MONO_EXIT_GC_SAFE;
 	}
 }
@@ -1775,7 +1775,7 @@ ep_rt_utf8_to_utf16_string (
 	const ep_char8_t *str,
 	size_t len)
 {
-	return (ep_char16_t *)(g_utf8_to_utf16 ((const gchar *)str, (glong)len, NULL, NULL, NULL));
+	return (ep_char16_t *)(g_utf8_to_utf16 ((const gchar *)str, len, NULL, NULL, NULL));
 }
 
 static
@@ -1813,7 +1813,7 @@ ep_rt_utf16_to_utf8_string (
 	const ep_char16_t *str,
 	size_t len)
 {
-	return g_utf16_to_utf8 ((const gunichar2 *)str, (glong)len, NULL, NULL, NULL);
+	return g_utf16_to_utf8 ((const gunichar2 *)str, len, NULL, NULL, NULL);
 }
 
 static

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -634,7 +634,7 @@ real_load (gchar **search_path, const gchar *culture, const gchar *name, const M
 	gchar **path;
 	gchar *filename;
 	const gchar *local_culture;
-	size_t len;
+	gint len;
 
 	if (!culture || *culture == '\0') {
 		local_culture = "";

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -2137,9 +2137,10 @@ mono_assembly_request_load_from (MonoImage *image, const char *fname,
 #if defined (HOST_WIN32)
 	{
 		gchar *tmp_fn;
+		int i;
 
 		tmp_fn = g_strdup (fname);
-		for (size_t i = strlen (tmp_fn) - 1; i >= 0; i--) {
+		for (i = strlen (tmp_fn) - 1; i >= 0; i--) {
 			if (tmp_fn [i] == '/')
 				tmp_fn [i] = '\\';
 		}
@@ -2334,7 +2335,7 @@ parse_public_key (const gchar *key, gchar** pubkey, gboolean *is_ecma)
 	//both pubkey and is_ecma are required arguments
 	g_assert (pubkey && is_ecma);
 
-	keylen = (gint)strlen (key) >> 1;
+	keylen = strlen (key) >> 1;
 	if (keylen < 1)
 		return FALSE;
 
@@ -2366,7 +2367,7 @@ parse_public_key (const gchar *key, gchar** pubkey, gboolean *is_ecma)
 
 	/* We need the first 16 bytes
 	* to check whether this key is valid or not */
-	pkeylen = (gint)strlen (pkey) >> 1;
+	pkeylen = strlen (pkey) >> 1;
 	if (pkeylen < 16)
 		return FALSE;
 
@@ -2725,7 +2726,7 @@ unquote (const char *str)
 	if (str == NULL)
 		return NULL;
 
-	slen = (gint)strlen (str);
+	slen = strlen (str);
 	if (slen < 2)
 		return NULL;
 

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -1019,7 +1019,7 @@ mono_class_create_bounded_array (MonoClass *eclass, guint32 rank, gboolean bound
 	MonoClass *klass, *cached, *k;
 	MonoClass *parent = NULL;
 	GSList *list, *rootlist = NULL;
-	size_t nsize;
+	int nsize;
 	char *name;
 	MonoMemoryManager *mm;
 
@@ -1739,12 +1739,12 @@ mono_class_interface_match (const uint8_t *bitmap, int id)
 static char*
 concat_two_strings_with_zero (MonoImage *image, const char *s1, const char *s2)
 {
-	size_t null_length = strlen ("(null)");
-	size_t len = (s1 ? strlen (s1) : null_length) + (s2 ? strlen (s2) : null_length) + 2;
-	char *s = (char *)mono_image_alloc (image, (int)len);
+	int null_length = strlen ("(null)");
+	int len = (s1 ? strlen (s1) : null_length) + (s2 ? strlen (s2) : null_length) + 2;
+	char *s = (char *)mono_image_alloc (image, len);
 	int result;
 
-	result = g_snprintf (s, (glong)len, "%s%c%s", s1 ? s1 : "(null)", '\0', s2 ? s2 : "(null)");
+	result = g_snprintf (s, len, "%s%c%s", s1 ? s1 : "(null)", '\0', s2 ? s2 : "(null)");
 	g_assert (result == len - 1);
 
 	return s;
@@ -2708,7 +2708,7 @@ generic_array_methods (MonoClass *klass)
 
 		generic_array_method_info [i].array_method = m;
 
-		name = (gchar *)mono_image_alloc (mono_defaults.corlib, (guint)(strlen (iname) + strlen (mname) + 1));
+		name = (gchar *)mono_image_alloc (mono_defaults.corlib, strlen (iname) + strlen (mname) + 1);
 		strcpy (name, iname);
 		strcpy (name + strlen (iname), mname);
 		generic_array_method_info [i].name = name;

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -3285,7 +3285,7 @@ mono_class_from_name_checked_aux (MonoImage *image, const char* name_space, cons
 
 	if ((nested = (char*)strchr (name, '/'))) {
 		int pos = nested - name;
-		size_t len = strlen (name);
+		int len = strlen (name);
 		if (len > 1023)
 			return NULL;
 		memcpy (buf, name, len + 1);

--- a/src/mono/mono/metadata/cominterop.c
+++ b/src/mono/mono/metadata/cominterop.c
@@ -3110,7 +3110,7 @@ mono_ptr_to_ansibstr (const char *ptr, size_t slen)
 	char *s = (char *)mono_bstr_alloc ((slen + 1) * sizeof(char));
 	if (s == NULL)
 		return NULL;
-	*((guint32 *)s - 1) = (guint32)(slen * sizeof (char));
+	*((guint32 *)s - 1) = slen * sizeof (char);
 	if (ptr)
 		memcpy (s, ptr, slen * sizeof (char));
 	s [slen] = 0;

--- a/src/mono/mono/metadata/debug-helpers.c
+++ b/src/mono/mono/metadata/debug-helpers.c
@@ -569,7 +569,7 @@ mono_method_desc_full_match (MonoMethodDesc *desc, MonoMethod *method)
 		return FALSE;
 	if (!desc->klass)
 		return FALSE;
-	if (!match_class (desc, (int)strlen (desc->klass), method->klass))
+	if (!match_class (desc, strlen (desc->klass), method->klass))
 		return FALSE;
 
 	return mono_method_desc_match (desc, method);
@@ -715,11 +715,11 @@ dis_one (GString *str, MonoDisHelper *dh, MonoMethod *method, const unsigned cha
 
 				for (i = 0; i < len2; ++i)
 					buf [i] = GUINT16_FROM_LE (((guint16*)blob2) [i]);
-				s = g_utf16_to_utf8 (buf, (glong)len2, NULL, NULL, NULL);
+				s = g_utf16_to_utf8 (buf, len2, NULL, NULL, NULL);
 				g_free (buf);
 			}
 #else
-				s = g_utf16_to_utf8 ((gunichar2*)blob2, (glong)len2, NULL, NULL, NULL);
+				s = g_utf16_to_utf8 ((gunichar2*)blob2, len2, NULL, NULL, NULL);
 #endif
 
 			g_string_append_printf (str, "\"%s\"", s);
@@ -1235,7 +1235,7 @@ mono_class_describe_statics (MonoClass* klass)
 			/* TODO: metadata-update: print something for added fields? */
 			if (m_field_is_from_update (field))
 				continue;
-
+			
 			field_ptr = (const char*)addr + m_field_get_offset (field);
 
 			print_field_value (field_ptr, field, 0);

--- a/src/mono/mono/metadata/domain.c
+++ b/src/mono/mono/metadata/domain.c
@@ -818,7 +818,7 @@ get_runtime_by_version (const char *version)
 {
 	int n;
 	int max = G_N_ELEMENTS (supported_runtimes);
-	size_t vlen;
+	int vlen;
 
 	if (!version)
 		return NULL;

--- a/src/mono/mono/metadata/dynamic-stream.c
+++ b/src/mono/mono/metadata/dynamic-stream.c
@@ -51,7 +51,7 @@ mono_dynstream_insert_string (MonoDynamicStream *sh, const char *str)
 	MONO_REQ_GC_NEUTRAL_MODE;
 
 	guint32 idx;
-	size_t len;
+	guint32 len;
 	gpointer oldkey, oldval;
 
 	if (g_hash_table_lookup_extended (sh->hash, str, &oldkey, &oldval))
@@ -60,7 +60,7 @@ mono_dynstream_insert_string (MonoDynamicStream *sh, const char *str)
 	len = strlen (str) + 1;
 	idx = sh->index;
 
-	make_room_in_stream (sh, (int)(idx + len));
+	make_room_in_stream (sh, idx + len);
 
 	/*
 	 * We strdup the string even if we already copy them in sh->data
@@ -69,7 +69,7 @@ mono_dynstream_insert_string (MonoDynamicStream *sh, const char *str)
 	 */
 	g_hash_table_insert (sh->hash, g_strdup (str), GUINT_TO_POINTER (idx));
 	memcpy (sh->data + idx, str, len);
-	sh->index += (guint32)len;
+	sh->index += len;
 	return idx;
 }
 

--- a/src/mono/mono/metadata/exception.c
+++ b/src/mono/mono/metadata/exception.c
@@ -1079,7 +1079,7 @@ append_frame_and_continue (MonoMethod *method, gpointer ip, size_t native_offset
 	if (data->prefix)
 		g_string_append (data->text, data->prefix);
 	if (method) {
-		char *msg = mono_debug_print_stack_frame (method, (uint32_t)native_offset, NULL);
+		char *msg = mono_debug_print_stack_frame (method, native_offset, NULL);
 		g_string_append_printf (data->text, "%s\n", msg);
 		g_free (msg);
 	} else {

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -6782,7 +6782,7 @@ mono_add_internal_call_internal (const char *name, gconstpointer method)
 static int
 concat_class_name (char *buf, int bufsize, MonoClass *klass)
 {
-	size_t nspacelen, cnamelen;
+	int nspacelen, cnamelen;
 	nspacelen = strlen (m_class_get_name_space (klass));
 	cnamelen = strlen (m_class_get_name (klass));
 	if (nspacelen + cnamelen + 2 > bufsize)
@@ -6793,7 +6793,7 @@ concat_class_name (char *buf, int bufsize, MonoClass *klass)
 	}
 	memcpy (buf + nspacelen, m_class_get_name (klass), cnamelen);
 	buf [nspacelen + cnamelen] = 0;
-	return (int)(nspacelen + cnamelen);
+	return nspacelen + cnamelen;
 }
 
 static void
@@ -6818,8 +6818,7 @@ mono_lookup_internal_call_full_with_flags (MonoMethod *method, gboolean warn_on_
 	char *tmpsig = NULL;
 	char mname [2048];
 	char *classname = NULL;
-	int typelen = 0;
-	size_t mlen, siglen;
+	int typelen = 0, mlen, siglen;
 	gconstpointer res = NULL;
 	gboolean locked = FALSE;
 

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -597,9 +597,9 @@ mono_string_from_byvalwstr_impl (const gunichar2 *data, int max_len, MonoError *
 		return NULL_HANDLE_STRING;
 
 	// FIXME Check max_len while scanning data? mono_string_from_byvalstr does.
-	const size_t len = g_utf16_len (data);
+	const int len = g_utf16_len (data);
 
-	return mono_string_new_utf16_handle (data, (gint32)MIN (len, max_len), error);
+	return mono_string_new_utf16_handle (data, MIN (len, max_len), error);
 }
 
 gpointer
@@ -789,7 +789,7 @@ mono_string_utf16_to_builder_copy (MonoStringBuilderHandle sb, const gunichar2 *
 		g_assert (chunkOffset >= 0);
 		if (maxLength > 0 && chunkOffset < string_len) {
 			// Check that we will not overrun our boundaries.
-			int charsToCopy = (int)MIN (string_len - chunkOffset, maxLength);
+			int charsToCopy = MIN (string_len - chunkOffset, maxLength);
 			memcpy (MONO_HANDLE_RAW (chunkChars)->vector, text + chunkOffset, charsToCopy * sizeof (gunichar2));
 			MONO_HANDLE_SETVAL (chunk, chunkLength, int, charsToCopy);
 		} else {
@@ -809,7 +809,7 @@ mono_string_utf16_to_builder2_impl (const gunichar2 *text, MonoError *error)
 
 	const gsize len = g_utf16_len (text);
 
-	MonoStringBuilderHandle sb = mono_string_builder_new ((int)len, error);
+	MonoStringBuilderHandle sb = mono_string_builder_new (len, error);
 	return_val_if_nok (error, NULL_HANDLE_STRING_BUILDER);
 
 	mono_string_utf16len_to_builder (sb, text, len, error);
@@ -826,7 +826,7 @@ mono_string_utf8len_to_builder (MonoStringBuilderHandle sb, const char *text, gs
 
 	GError *gerror = NULL;
 	glong copied;
-	gunichar2* ut = g_utf8_to_utf16 (text, (glong)len, NULL, &copied, &gerror);
+	gunichar2* ut = g_utf8_to_utf16 (text, len, NULL, &copied, &gerror);
 	int capacity = mono_string_builder_capacity (sb);
 
 	if (copied > capacity)
@@ -857,7 +857,7 @@ mono_string_utf8_to_builder2_impl (const char *text, MonoError *error)
 
 	const gsize len = strlen (text);
 
-	MonoStringBuilderHandle sb = mono_string_builder_new ((int)len, error);
+	MonoStringBuilderHandle sb = mono_string_builder_new (len, error);
 	return_val_if_nok (error, NULL_HANDLE_STRING_BUILDER);
 
 	mono_string_utf8len_to_builder (sb, text, len, error);
@@ -1110,7 +1110,7 @@ mono_string_to_byvalstr_impl (char *dst, MonoStringHandle src, int size, MonoErr
 
 	char *s = mono_string_handle_to_utf8 (src, error);
 	return_if_nok (error);
-	size_t len = MIN (size, strlen (s));
+	int len = MIN (size, strlen (s));
 	len -= (len >= size);
 	memcpy (dst, s, len);
 	dst [len] = 0;

--- a/src/mono/mono/metadata/mempool.c
+++ b/src/mono/mono/metadata/mempool.c
@@ -357,13 +357,14 @@ char*
 mono_mempool_strdup (MonoMemPool *pool,
 					 const char *s)
 {
+	int l;
 	char *res;
 
 	if (s == NULL)
 		return NULL;
 
-	size_t l = strlen (s);
-	res = (char *)mono_mempool_alloc (pool, (guint)l + 1);
+	l = strlen (s);
+	res = (char *)mono_mempool_alloc (pool, l + 1);
 	memcpy (res, s, l + 1);
 
 	return res;
@@ -379,7 +380,7 @@ mono_mempool_strdup_vprintf (MonoMemPool *pool, const char *format, va_list args
 	int len = vsnprintf (NULL, 0, format, args2);
 	va_end (args2);
 
-	if (len >= 0 && (buf = (char*)mono_mempool_alloc (pool, (guint)(buflen = (size_t) (len + 1)))) != NULL) {
+	if (len >= 0 && (buf = (char*)mono_mempool_alloc (pool, (buflen = (size_t) (len + 1)))) != NULL) {
 		vsnprintf (buf, buflen, format, args);
 	} else {
 		buf = NULL;

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -2043,7 +2043,7 @@ alloc_type_with_cmods (MonoImage *m, gboolean transient, int count)
 	g_assert (count > 0);
 	MonoType *type;
 	size_t size = mono_sizeof_type_with_mods (count, FALSE);
-	type = transient ? (MonoType *)g_malloc0 (size) : (MonoType *)mono_image_alloc0 (m, (guint)size);
+	type = transient ? (MonoType *)g_malloc0 (size) : (MonoType *)mono_image_alloc0 (m, size);
 	type->has_cmods = TRUE;
 
 	MonoCustomModContainer *cmods = mono_type_get_cmods (type);
@@ -2426,18 +2426,18 @@ static MonoMethodSignature*
 mono_metadata_signature_dup_internal (MonoImage *image, MonoMemPool *mp, MonoMemoryManager *mem_manager,
 									  MonoMethodSignature *sig, size_t padding)
 {
-	size_t sigsize, sig_header_size;
+	int sigsize, sig_header_size;
 	MonoMethodSignature *ret;
 	sigsize = sig_header_size = MONO_SIZEOF_METHOD_SIGNATURE + sig->param_count * sizeof (MonoType *) + padding;
 	if (sig->ret)
 		sigsize += mono_sizeof_type (sig->ret);
 
 	if (image) {
-		ret = (MonoMethodSignature *)mono_image_alloc (image, (guint)sigsize);
+		ret = (MonoMethodSignature *)mono_image_alloc (image, sigsize);
 	} else if (mp) {
-		ret = (MonoMethodSignature *)mono_mempool_alloc (mp, (unsigned int)sigsize);
+		ret = (MonoMethodSignature *)mono_mempool_alloc (mp, sigsize);
 	} else if (mem_manager) {
-		ret = (MonoMethodSignature *)mono_mem_manager_alloc (mem_manager, (guint)sigsize);
+		ret = (MonoMethodSignature *)mono_mem_manager_alloc (mem_manager, sigsize);
 	} else {
 		ret = (MonoMethodSignature *)g_malloc (sigsize);
 	}
@@ -3459,7 +3459,7 @@ mono_metadata_get_canonical_aggregate_modifiers (MonoAggregateModContainer *cand
 	MonoAggregateModContainer *amods = (MonoAggregateModContainer *)g_hash_table_lookup (mm->aggregate_modifiers_cache, candidate);
 	if (!amods) {
 		size_t size = mono_sizeof_aggregate_modifiers (candidate->count);
-		amods = (MonoAggregateModContainer *)mono_mem_manager_alloc0 (mm, (guint)size);
+		amods = (MonoAggregateModContainer *)mono_mem_manager_alloc0 (mm, size);
 		amods->count = candidate->count;
 		for (int i = 0; i < candidate->count; ++i) {
 			amods->modifiers [i].required = candidate->modifiers [i].required;
@@ -5974,7 +5974,7 @@ do_metadata_type_dup_append_cmods (MonoImage *image, const MonoType *o, const Mo
 		uint8_t total_cmods = o_cmods->count + extra_cmods->count;
 		gboolean aggregate = FALSE;
 		size_t sizeof_dup = mono_sizeof_type_with_mods (total_cmods, aggregate);
-		MonoType *r = image ? (MonoType *)mono_image_alloc0 (image, (guint)sizeof_dup) : (MonoType *)g_malloc0 (sizeof_dup);
+		MonoType *r = image ? (MonoType *)mono_image_alloc0 (image, sizeof_dup) : (MonoType *)g_malloc0 (sizeof_dup);
 
 		mono_type_with_mods_init (r, total_cmods, aggregate);
 
@@ -6018,7 +6018,7 @@ do_metadata_type_dup_append_cmods (MonoImage *image, const MonoType *o, const Mo
 		/* FIXME: if image, and the images of the custom modifiers from
 		 * o and cmods_source are all different, we need an image
 		 * set... */
-		MonoType *r = image ? (MonoType *)mono_image_alloc0 (image, (guint)sizeof_dup) : (MonoType*)g_malloc0 (sizeof_dup);
+		MonoType *r = image ? (MonoType *)mono_image_alloc0 (image, sizeof_dup) : (MonoType*)g_malloc0 (sizeof_dup);
 
 		mono_type_with_mods_init (r, total_cmods, aggregate);
 
@@ -6067,7 +6067,7 @@ mono_metadata_type_dup_with_cmods (MonoImage *image, const MonoType *o, const Mo
 	gboolean aggregate = mono_type_is_aggregate_mods (o) || mono_type_is_aggregate_mods (cmods_source);
 	size_t sizeof_r = mono_sizeof_type_with_mods (num_mods, aggregate);
 
-	r = image ? (MonoType *)mono_image_alloc0 (image, (guint)sizeof_r) : (MonoType *)g_malloc0 (sizeof_r);
+	r = image ? (MonoType *)mono_image_alloc0 (image, sizeof_r) : (MonoType *)g_malloc0 (sizeof_r);
 
 	if (cmods_source->has_cmods) {
 		/* FIXME: if it's aggregate what do we assert here? */

--- a/src/mono/mono/metadata/method-builder-ilgen.c
+++ b/src/mono/mono/metadata/method-builder-ilgen.c
@@ -131,8 +131,8 @@ create_method_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *signature, int 
 		MonoType *type = (MonoType*)l->data;
 		if (mb->mem_manager) {
 			/* Allocated in mono_mb_add_local () */
-			size_t size = mono_sizeof_type (type);
-			header->locals [i] = mono_mem_manager_alloc0 (mb->mem_manager, (guint)size);
+			int size = mono_sizeof_type (type);
+			header->locals [i] = mono_mem_manager_alloc0 (mb->mem_manager, size);
 			memcpy (header->locals [i], type, size);
 			g_free (type);
 		} else {

--- a/src/mono/mono/metadata/monitor.c
+++ b/src/mono/mono/metadata/monitor.c
@@ -222,7 +222,7 @@ lock_word_decrement_nest (LockWord lw)
 static gint32
 lock_word_get_owner (LockWord lw)
 {
-	return (gint32)(lw.lock_word >> LOCK_WORD_OWNER_SHIFT);
+	return lw.lock_word >> LOCK_WORD_OWNER_SHIFT;
 }
 
 static LockWord
@@ -407,7 +407,7 @@ mon_new (gsize id)
 	new_ = monitor_freelist;
 	monitor_freelist = (MonoThreadsSync *)new_->data;
 
-	new_->status = mon_status_set_owner (0, (guint32)id);
+	new_->status = mon_status_set_owner (0, id);
 	new_->status = mon_status_init_entry_count (new_->status);
 	new_->nest = 1;
 	new_->data = NULL;

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -1794,14 +1794,14 @@ mono_method_add_generic_virtual_invocation (MonoVTable *vtable,
 		gpointer imt_trampoline = NULL;
 
 		if ((gpointer)vtable_slot < (gpointer)vtable) {
-			size_t displacement = (gpointer*)vtable_slot - (gpointer*)vtable;
-			size_t imt_slot = MONO_IMT_SIZE + displacement;
+			int displacement = (gpointer*)vtable_slot - (gpointer*)vtable;
+			int imt_slot = MONO_IMT_SIZE + displacement;
 
 			/* Force the rebuild of the trampoline at the next call */
-			imt_trampoline = callbacks.get_imt_trampoline (vtable, (int)imt_slot);
+			imt_trampoline = callbacks.get_imt_trampoline (vtable, imt_slot);
 			*vtable_slot = imt_trampoline;
 		} else {
-			vtable_trampoline = callbacks.get_vtable_trampoline ? callbacks.get_vtable_trampoline (vtable, (int)((gpointer*)vtable_slot - (gpointer*)vtable->vtable)) : NULL;
+			vtable_trampoline = callbacks.get_vtable_trampoline ? callbacks.get_vtable_trampoline (vtable, (gpointer*)vtable_slot - (gpointer*)vtable->vtable) : NULL;
 
 			entries = get_generic_virtual_entries (mem_manager, vtable_slot);
 
@@ -1920,7 +1920,7 @@ alloc_vtable (MonoClass *klass, size_t vtable_size, size_t imt_table_bytes)
 		alloc_offset = 0;
 	}
 
-	return (gpointer*) ((char*)m_class_alloc0 (klass, (guint)vtable_size) + alloc_offset);
+	return (gpointer*) ((char*)m_class_alloc0 (klass, vtable_size) + alloc_offset);
 }
 
 static MonoVTable *
@@ -2011,12 +2011,12 @@ mono_class_create_runtime_vtable (MonoClass *klass, MonoError *error)
 		if (use_interpreter)
 			imt_table_bytes *= 2;
 		UnlockedIncrement (&mono_stats.imt_number_of_tables);
-		UnlockedAdd (&mono_stats.imt_tables_size, (gint32)imt_table_bytes);
+		UnlockedAdd (&mono_stats.imt_tables_size, imt_table_bytes);
 	} else {
 		imt_table_bytes = 0;
 	}
 
-	vtable_size = (guint32)(imt_table_bytes + MONO_SIZEOF_VTABLE + vtable_slots * sizeof (gpointer));
+	vtable_size = imt_table_bytes + MONO_SIZEOF_VTABLE + vtable_slots * sizeof (gpointer);
 
 	UnlockedIncrement (&mono_stats.used_class_count);
 	UnlockedAdd (&mono_stats.class_vtable_size, vtable_size);
@@ -5700,9 +5700,9 @@ mono_array_new_full_checked (MonoClass *array_class, uintptr_t *lengths, intptr_
 
 	if (bounds_size) {
 		for (i = 0; i < array_class_rank; ++i) {
-			bounds [i].length = (mono_array_size_t)lengths [i];
+			bounds [i].length = lengths [i];
 			if (lower_bounds)
-				bounds [i].lower_bound = (mono_array_lower_bound_t)lower_bounds [i];
+				bounds [i].lower_bound = lower_bounds [i];
 		}
 	}
 
@@ -6018,9 +6018,9 @@ mono_string_new_utf32_checked (const mono_unichar4 *text, gint32 len, MonoError 
 	error_init (error);
 	utf16_output = g_ucs4_to_utf16 (text, len, NULL, NULL, NULL);
 
-	size_t utf16_len = g_utf16_len (utf16_output);
+	gint32 utf16_len = g_utf16_len (utf16_output);
 
-	s = mono_string_new_size_checked ((gint32)utf16_len, error);
+	s = mono_string_new_size_checked (utf16_len, error);
 	goto_if_nok (error, exit);
 
 	memcpy (mono_string_chars_internal (s), utf16_output, utf16_len * 2);
@@ -6217,10 +6217,13 @@ mono_string_new_checked (const char *text, MonoError *error)
 	MonoString *o = NULL;
 	gunichar2 *ut;
 	glong items_written;
+	int len;
 
 	error_init (error);
 
-	ut = g_utf8_to_utf16 (text, (glong)strlen (text), NULL, &items_written, &eg_error);
+	len = strlen (text);
+
+	ut = g_utf8_to_utf16 (text, len, NULL, &items_written, &eg_error);
 
 	if (!eg_error)
 		o = mono_string_new_utf16_checked (ut, items_written, error);
@@ -6510,7 +6513,7 @@ mono_object_get_size_internal (MonoObject* o)
 			size &= ~3;
 			size += sizeof (MonoArrayBounds) * o->vtable->rank;
 		}
-		return (guint)size;
+		return size;
 	} else {
 		return mono_class_instance_size (klass);
 	}
@@ -6736,7 +6739,7 @@ mono_string_get_pinned (MonoStringHandle str, MonoError *error)
 
 	MONO_EXIT_NO_SAFEPOINTS;
 
-	MONO_HANDLE_SETVAL (news, length, int, (int)length);
+	MONO_HANDLE_SETVAL (news, length, int, length);
 	return news;
 }
 
@@ -6925,7 +6928,7 @@ mono_ldstr_metadata_sig (const char* sig, MonoStringHandleOut string_handle, Mon
 
 	// FIXMEcoop excess handle, use mono_string_new_utf16_checked and string_handle parameter
 
-	MonoStringHandle o = mono_string_new_utf16_handle ((gunichar2*)sig, (gint32)len, error);
+	MonoStringHandle o = mono_string_new_utf16_handle ((gunichar2*)sig, len, error);
 	return_if_nok (error);
 
 #if G_BYTE_ORDER != G_LITTLE_ENDIAN
@@ -6960,7 +6963,7 @@ mono_ldstr_utf8 (MonoImage *image, guint32 idx, MonoError *error)
 	len2 = mono_metadata_decode_blob_size (str, &str);
 	len2 >>= 1;
 
-	as = g_utf16_to_utf8 ((gunichar2*)str, (glong)len2, NULL, &written, &gerror);
+	as = g_utf16_to_utf8 ((gunichar2*)str, len2, NULL, &written, &gerror);
 	if (gerror) {
 		mono_error_set_argument (error, "string", gerror->message);
 		g_error_free (gerror);
@@ -7022,7 +7025,7 @@ mono_utf16_to_utf8len (const gunichar2 *s, gsize slength, gsize *utf8_length, Mo
 	if (!slength)
 		return g_strdup ("");
 
-	as = g_utf16_to_utf8 (s, (glong)slength, NULL, &written, &gerror);
+	as = g_utf16_to_utf8 (s, slength, NULL, &written, &gerror);
 	*utf8_length = written;
 	if (gerror) {
 		mono_error_set_argument (error, "string", gerror->message);
@@ -7232,7 +7235,7 @@ mono_string_from_utf16_checked (const gunichar2 *data, MonoError *error)
 	error_init (error);
 	if (!data)
 		return NULL;
-	return mono_string_new_utf16_checked (data, (gint32)g_utf16_len (data), error);
+	return mono_string_new_utf16_checked (data, g_utf16_len (data), error);
 }
 
 /**
@@ -7291,7 +7294,7 @@ mono_string_to_utf8_internal (MonoMemPool *mp, MonoImage *image, MonoString *s, 
 
 	char *r;
 	char *mp_s;
-	size_t len;
+	int len;
 
 	r = mono_string_to_utf8_checked_internal (s, error);
 	if (!is_ok (error))
@@ -7302,9 +7305,9 @@ mono_string_to_utf8_internal (MonoMemPool *mp, MonoImage *image, MonoString *s, 
 
 	len = strlen (r) + 1;
 	if (mp)
-		mp_s = (char *)mono_mempool_alloc (mp, (unsigned int)len);
+		mp_s = (char *)mono_mempool_alloc (mp, len);
 	else
-		mp_s = (char *)mono_image_alloc (image, (guint)len);
+		mp_s = (char *)mono_image_alloc (image, len);
 
 	memcpy (mp_s, r, len);
 

--- a/src/mono/mono/metadata/sre.c
+++ b/src/mono/mono/metadata/sre.c
@@ -1381,7 +1381,7 @@ add_custom_modifiers_to_type (MonoType *without_mods, MonoArrayHandle req_array,
 		return without_mods;
 
 	MonoTypeWithModifiers *result;
-	result = mono_image_g_malloc0 (image, (guint)mono_sizeof_type_with_mods (total_mods, FALSE));
+	result = mono_image_g_malloc0 (image, mono_sizeof_type_with_mods (total_mods, FALSE));
 	memcpy (result, without_mods, MONO_SIZEOF_TYPE);
 	result->unmodified.has_cmods = 1;
 	MonoCustomModContainer *cmods = mono_type_get_cmods ((MonoType *)result);
@@ -2043,7 +2043,7 @@ handle_enum:
 		break;
 	case MONO_TYPE_STRING: {
 		char *str;
-		size_t slen;
+		guint32 slen;
 		if (!arg) {
 MONO_DISABLE_WARNING(4309) // truncation of constant
 			*p++ = 0xFF;
@@ -2056,12 +2056,12 @@ MONO_RESTORE_WARNING
 		if ((p-buffer) + 10 + slen >= *buflen) {
 			char *newbuf;
 			*buflen *= 2;
-			*buflen += (guint32)slen;
+			*buflen += slen;
 			newbuf = (char *)g_realloc (buffer, *buflen);
 			p = newbuf + (p-buffer);
 			buffer = newbuf;
 		}
-		mono_metadata_encode_value ((uint32_t)slen, p, &p);
+		mono_metadata_encode_value (slen, p, &p);
 		memcpy (p, str, slen);
 		p += slen;
 		g_free (str);
@@ -2082,7 +2082,7 @@ handle_type:
 		return_if_nok (error);
 
 		str = type_get_qualified_name (arg_type, NULL);
-		slen = (guint32)strlen (str);
+		slen = strlen (str);
 		if ((p-buffer) + 10 + slen >= *buflen) {
 			char *newbuf;
 			*buflen *= 2;
@@ -2198,7 +2198,7 @@ MONO_RESTORE_WARNING
 			break;
 		}
 		str = type_get_qualified_name (m_class_get_byval_arg (klass), NULL);
-		slen = (guint32)strlen (str);
+		slen = strlen (str);
 		if ((p-buffer) + 10 + slen >= *buflen) {
 			char *newbuf;
 			*buflen *= 2;
@@ -2226,14 +2226,14 @@ encode_field_or_prop_type (MonoType *type, char *p, char **retp)
 {
 	if (type->type == MONO_TYPE_VALUETYPE && type->data.klass->enumtype) {
 		char *str = type_get_qualified_name (type, NULL);
-		size_t slen = strlen (str);
+		int slen = strlen (str);
 
 		*p++ = 0x55;
 		/*
 		 * This seems to be optional...
 		 * *p++ = 0x80;
 		 */
-		mono_metadata_encode_value ((uint32_t)slen, p, &p);
+		mono_metadata_encode_value (slen, p, &p);
 		memcpy (p, str, slen);
 		p += slen;
 		g_free (str);
@@ -2256,7 +2256,7 @@ encode_field_or_prop_type (MonoType *type, char *p, char **retp)
 static void
 encode_named_val (MonoReflectionAssembly *assembly, char *buffer, char *p, char **retbuffer, char **retp, guint32 *buflen, MonoType *type, char *name, MonoObject *value, MonoError *error)
 {
-	size_t len;
+	int len;
 
 	error_init (error);
 
@@ -2277,7 +2277,7 @@ encode_named_val (MonoReflectionAssembly *assembly, char *buffer, char *p, char 
 	if ((p-buffer) + 20 + len >= *buflen) {
 		char *newbuf;
 		*buflen *= 2;
-		*buflen += (guint32)len;
+		*buflen += len;
 		newbuf = (char *)g_realloc (buffer, *buflen);
 		p = newbuf + (p-buffer);
 		buffer = newbuf;
@@ -2286,7 +2286,7 @@ encode_named_val (MonoReflectionAssembly *assembly, char *buffer, char *p, char 
 	encode_field_or_prop_type (type, p, &p);
 
 	len = strlen (name);
-	mono_metadata_encode_value ((uint32_t)len, p, &p);
+	mono_metadata_encode_value (len, p, &p);
 	memcpy (p, name, len);
 	p += len;
 	encode_cattr_value (assembly->assembly, buffer, p, &buffer, &p, buflen, type, value, NULL, error);
@@ -3564,7 +3564,7 @@ typebuilder_setup_one_field (MonoDynamicImage *dynamic_image, MonoClass *klass, 
 		if ((fb->attrs & FIELD_ATTRIBUTE_HAS_FIELD_RVA) && (rva_data = fb->rva_data)) {
 			char *base = mono_array_addr_internal (rva_data, char, 0);
 			size_t size = mono_array_length_internal (rva_data);
-			char *data = (char *)mono_image_alloc (klass->image, (guint)size);
+			char *data = (char *)mono_image_alloc (klass->image, size);
 			memcpy (data, base, size);
 			def_value_out->data = data;
 		}

--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -1887,7 +1887,7 @@ mono_thread_set_name (MonoInternalThread *this_obj,
 
 	if (name8) {
 		this_obj->name.chars = (char*)name8;
-		this_obj->name.length = (gint32)name8_length;
+		this_obj->name.length = name8_length;
 		this_obj->name.free = !constant;
 		if (flags & MonoSetThreadNameFlag_Permanent)
 			this_obj->flags |= MONO_THREAD_FLAG_NAME_SET;

--- a/src/mono/mono/metadata/w32handle.c
+++ b/src/mono/mono/metadata/w32handle.c
@@ -214,7 +214,7 @@ retry:
 				mono_coop_mutex_init (&handle_data->signal_mutex);
 
 				if (handle_specific)
-					handle_data->specific = g_memdup (handle_specific, (guint)mono_w32handle_ops_typesize (type));
+					handle_data->specific = g_memdup (handle_specific, mono_w32handle_ops_typesize (type));
 
 				return handle_data;
 			}
@@ -508,7 +508,9 @@ mono_w32handle_ops_prewait (MonoW32Handle *handle_data)
 static void
 mono_w32handle_unlock_handles (MonoW32Handle **handles_data, gsize nhandles)
 {
-	for (gsize i = nhandles - 1; i >= 0; i--) {
+	gint i;
+
+	for (i = nhandles - 1; i >= 0; i--) {
 		if (!handles_data [i])
 			continue;
 		mono_w32handle_unlock (handles_data [i]);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -816,7 +816,7 @@ static void
 emit_string_symbol (MonoAotCompile *acfg, const char *name, const char *value)
 {
 	if (acfg->llvm) {
-		mono_llvm_emit_aot_data (name, (guint8*)value, (int)strlen (value) + 1);
+		mono_llvm_emit_aot_data (name, (guint8*)value, strlen (value) + 1);
 		return;
 	}
 
@@ -940,7 +940,7 @@ encode_int16 (guint16 val, guint8 *buf, guint8 **endbuf)
 static void
 encode_string (const char *s, guint8 *buf, guint8 **endbuf)
 {
-	size_t len = strlen (s);
+	int len = strlen (s);
 
 	memcpy (buf, s, len + 1);
 	*endbuf = buf + len + 1;
@@ -3806,8 +3806,8 @@ encode_method_ref (MonoAotCompile *acfg, MonoMethod *method, guint8 *buf, guint8
 			} else if (info->subtype == WRAPPER_SUBTYPE_GENERIC_ARRAY_HELPER) {
 				encode_klass_ref (acfg, info->d.generic_array_helper.klass, p, &p);
 				encode_method_ref (acfg, info->d.generic_array_helper.method, p, &p);
-				size_t len = strlen (info->d.generic_array_helper.name) + 1;
-				guint32 idx = add_to_blob (acfg, (guint8*)info->d.generic_array_helper.name, (guint32)len);
+				int len = strlen (info->d.generic_array_helper.name);
+				guint32 idx = add_to_blob (acfg, (guint8*)info->d.generic_array_helper.name, len + 1);
 				encode_value (idx, p, &p);
 			} else {
 				g_assert_not_reached ();
@@ -6578,7 +6578,7 @@ static char*
 sanitize_symbol (MonoAotCompile *acfg, char *s)
 {
 	gboolean process = FALSE;
-	size_t i, len;
+	int i, len;
 	GString *gs;
 	char *res;
 
@@ -6623,7 +6623,7 @@ static char*
 get_debug_sym (MonoMethod *method, const char *prefix, GHashTable *cache)
 {
 	char *name1, *name2, *cached;
-	size_t i, j, len, count;
+	int i, j, len, count;
 	MonoMethod *cached_method;
 
 	name1 = mono_method_full_name (method, TRUE);
@@ -6666,7 +6666,7 @@ get_debug_sym (MonoMethod *method, const char *prefix, GHashTable *cache)
 		cached_method = (MonoMethod *)g_hash_table_lookup (cache, name2);
 		if (!(cached_method && cached_method != method))
 			break;
-		sprintf (name2 + j, "_%zu", count);
+		sprintf (name2 + j, "_%d", count);
 		count ++;
 	}
 
@@ -6822,13 +6822,13 @@ encode_patch (MonoAotCompile *acfg, MonoJumpInfo *patch_info, guint8 *buf, guint
 	case MONO_PATCH_INFO_JIT_ICALL_ID:
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR:
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR_NOCALL:
-		encode_value ((guint32)patch_info->data.jit_icall_id, p, &p);
+		encode_value (patch_info->data.jit_icall_id, p, &p);
 		break;
 	case MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR:
-		encode_value ((guint32)patch_info->data.uindex, p, &p);
+		encode_value (patch_info->data.uindex, p, &p);
 		break;
 	case MONO_PATCH_INFO_LDSTR_LIT: {
-		guint32 len = (guint32)strlen (patch_info->data.name);
+		guint32 len = strlen (patch_info->data.name);
 		encode_value (len, p, &p);
 		memcpy (p, patch_info->data.name, len + 1);
 		p += len + 1;
@@ -8073,7 +8073,7 @@ emit_trampolines (MonoAotCompile *acfg)
 static gboolean
 str_begins_with (const char *str1, const char *str2)
 {
-	size_t len = strlen (str2);
+	int len = strlen (str2);
 	return strncmp (str1, str2, len) == 0;
 }
 
@@ -8083,8 +8083,9 @@ mono_aot_readonly_field_override (MonoClassField *field)
 	ReadOnlyValue *rdv;
 	for (rdv = readonly_values; rdv; rdv = rdv->next) {
 		char *p = rdv->name;
+		int len;
 		MonoClass *field_parent = m_field_get_parent (field);
-		size_t len = strlen (m_class_get_name_space (field_parent));
+		len = strlen (m_class_get_name_space (field_parent));
 		if (strncmp (p, m_class_get_name_space (field_parent), len))
 			continue;
 		p += len;
@@ -8172,7 +8173,7 @@ clean_path (gchar * path)
 static const gchar *
 wrap_path (const gchar * path)
 {
-	size_t len;
+	int len;
 	if (!path)
 		return NULL;
 
@@ -9430,7 +9431,7 @@ append_mangled_type (GString *s, MonoType *t)
 		GString *temp;
 		char *temps;
 		gboolean is_system = FALSE;
-		size_t i, len;
+		int i, len;
 
 		len = strlen ("System.");
 		if (strncmp (fullname, "System.", len) == 0) {
@@ -11172,7 +11173,7 @@ emit_class_name_table (MonoAotCompile *acfg)
 static void
 emit_image_table (MonoAotCompile *acfg)
 {
-	size_t i, buf_size;
+	int i, buf_size;
 	guint8 *buf, *p;
 
 	/*
@@ -11252,7 +11253,7 @@ emit_weak_field_indexes (MonoAotCompile *acfg)
 
 	encode_int (0, p, &p);
 	emit_aot_data (acfg, MONO_AOT_TABLE_WEAK_FIELD_INDEXES, "weak_field_indexes", buf, p - buf);
-#endif
+#endif	
 }
 
 static void
@@ -12243,7 +12244,7 @@ emit_unwind_info_sections_win32 (MonoAotCompile *acfg, const char *function_star
 {
 	char *pdata_section_label = NULL;
 
-	size_t temp_prefix_len = (acfg->temp_prefix != NULL) ? strlen (acfg->temp_prefix) : 0;
+	int temp_prefix_len = (acfg->temp_prefix != NULL) ? strlen (acfg->temp_prefix) : 0;
 	if (strncmp (function_start, acfg->temp_prefix, temp_prefix_len)) {
 		temp_prefix_len = 0;
 	}
@@ -12722,7 +12723,9 @@ static guint8
 profread_byte (FILE *infile)
 {
 	guint8 i;
-	size_t res = fread (&i, 1, 1, infile);
+	int res;
+
+	res = fread (&i, 1, 1, infile);
 	g_assert (res == 1);
 	return i;
 }
@@ -12730,9 +12733,9 @@ profread_byte (FILE *infile)
 static int
 profread_int (FILE *infile)
 {
-	int i;
-	size_t res = fread (&i, 4, 1, infile);
+	int i, res;
 
+	res = fread (&i, 4, 1, infile);
 	g_assert (res == 1);
 	return i;
 }
@@ -12740,8 +12743,7 @@ profread_int (FILE *infile)
 static char*
 profread_string (FILE *infile)
 {
-	int len;
-	size_t res;
+	int len, res;
 	char *pbuf;
 
 	len = profread_int (infile);
@@ -12757,8 +12759,7 @@ load_profile_file (MonoAotCompile *acfg, char *filename)
 {
 	FILE *infile;
 	char buf [1024];
-	size_t res, len;
-	int version;
+	int res, len, version;
 	char magic [32];
 
 	infile = fopen (filename, "rb");
@@ -13711,7 +13712,7 @@ mono_read_method_cache (MonoAotCompile *acfg)
 	size_t offset;
 	offset = 0;
 
-	while (fgets (&bulk [offset], (int)(fileLength - offset), cache)) {
+	while (fgets (&bulk [offset], fileLength - offset, cache)) {
 		// strip newline
 		char *line = &bulk [offset];
 		size_t len = strlen (line);
@@ -14138,7 +14139,7 @@ mono_compile_assembly (MonoAssembly *ass, guint32 opts, const char *aot_options,
 		if (!acfg->aot_opts.asm_only && acfg->llvm_owriter_supported) {
 			acfg->llvm_owriter = TRUE;
 		} else if (acfg->aot_opts.llvm_outfile) {
-			size_t len = strlen (acfg->aot_opts.llvm_outfile);
+			int len = strlen (acfg->aot_opts.llvm_outfile);
 
 			if (len >= 2 && acfg->aot_opts.llvm_outfile [len - 2] == '.' && acfg->aot_opts.llvm_outfile [len - 1] == 'o')
 				acfg->llvm_owriter = TRUE;
@@ -14506,7 +14507,7 @@ emit_aot_image (MonoAotCompile *acfg)
 		 * in another.
 		 */
 		const char *gc_name = mono_gc_get_gc_name ();
-		acfg->gc_name_offset = add_to_blob (acfg, (guint8*)gc_name, (guint32)strlen (gc_name) + 1);
+		acfg->gc_name_offset = add_to_blob (acfg, (guint8*)gc_name, strlen (gc_name) + 1);
 	}
 
 	emit_blob (acfg);

--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -253,7 +253,7 @@ static MonoGraphOptions
 mono_parse_graph_options (const char* p)
 {
 	const char *n;
-	size_t i, len;
+	int i, len;
 
 	for (i = 0; i < G_N_ELEMENTS (graph_names); ++i) {
 		n = graph_names [i].name;

--- a/src/mono/mono/mini/dwarfwriter.c
+++ b/src/mono/mono/mini/dwarfwriter.c
@@ -202,8 +202,10 @@ emit_byte (MonoDwarfWriter *w, guint8 val)
 static void
 emit_escaped_string (MonoDwarfWriter *w, char *value)
 {
-	size_t len = (int)strlen (value);
-	for (int i = 0; i < len; ++i) {
+	int i, len;
+
+	len = strlen (value);
+	for (i = 0; i < len; ++i) {
 		char c = value [i];
 		if (!(isalnum (c))) {
 			switch (c) {
@@ -617,8 +619,7 @@ mono_dwarf_escape_path (const char *name)
 {
 	if (strchr (name, '\\')) {
 		char *s;
-		size_t len;
-		int i, j;
+		int len, i, j;
 
 		len = strlen (name);
 		s = (char *)g_malloc0 ((len + 1) * 2);

--- a/src/mono/mono/mini/exceptions-amd64.c
+++ b/src/mono/mono/mini/exceptions-amd64.c
@@ -1413,7 +1413,7 @@ mono_arch_unwindinfo_insert_range_in_table (const gpointer code_block, gsize blo
 			new_entry->handle = NULL;
 			new_entry->begin_range = begin_range;
 			new_entry->end_range = end_range;
-			new_entry->rt_funcs_max_count = (DWORD)((block_size / MONO_UNWIND_INFO_RT_FUNC_SIZE) + 1);
+			new_entry->rt_funcs_max_count = (block_size / MONO_UNWIND_INFO_RT_FUNC_SIZE) + 1;
 			new_entry->rt_funcs_current_count = 0;
 			new_entry->rt_funcs = g_new0 (RUNTIME_FUNCTION, new_entry->rt_funcs_max_count);
 
@@ -1660,11 +1660,11 @@ mono_arch_unwindinfo_insert_rt_func_in_table (const gpointer code, gsize code_si
 		PRUNTIME_FUNCTION current_rt_funcs = found_entry->rt_funcs;
 
 		RUNTIME_FUNCTION new_rt_func_data;
-		new_rt_func_data.BeginAddress = (DWORD)code_offset;
-		new_rt_func_data.EndAddress = (DWORD)(code_offset + code_size);
+		new_rt_func_data.BeginAddress = code_offset;
+		new_rt_func_data.EndAddress = code_offset + code_size;
 
 		gsize aligned_unwind_data = ALIGN_TO(end_range, sizeof(host_mgreg_t));
-		new_rt_func_data.UnwindData = (DWORD)(aligned_unwind_data - found_entry->begin_range);
+		new_rt_func_data.UnwindData = aligned_unwind_data - found_entry->begin_range;
 
 		g_assert_checked (new_rt_func_data.UnwindData == ALIGN_TO(new_rt_func_data.EndAddress, sizeof (host_mgreg_t)));
 
@@ -1708,8 +1708,8 @@ mono_arch_unwindinfo_insert_rt_func_in_table (const gpointer code, gsize code_si
 		}
 
 		// Update the stats for current entry.
-		found_entry->rt_funcs_current_count = (DWORD)entry_count;
-		found_entry->rt_funcs_max_count = (DWORD)max_entry_count;
+		found_entry->rt_funcs_current_count = entry_count;
+		found_entry->rt_funcs_max_count = max_entry_count;
 
 		if (new_rt_funcs == NULL && g_rtl_grow_function_table != NULL) {
 			// No new table just report increase in use.

--- a/src/mono/mono/mini/graph.c
+++ b/src/mono/mono/mini/graph.c
@@ -21,7 +21,7 @@
 static char *
 convert_name (const char *str)
 {
-	size_t i, j, len = strlen (str);
+	int i, j, len = strlen (str);
 	char *res = (char *)g_malloc (len * 2);
 
 	j = 0;

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -3405,7 +3405,7 @@ get_basic_blocks (TransformData *td, MonoMethodHeader *header, gboolean make_lis
 	guint cli_addr;
 	const MonoOpcode *opcode;
 
-	td->offset_to_bb = (InterpBasicBlock**)mono_mempool_alloc0 (td->mempool, (unsigned int)(sizeof (InterpBasicBlock*) * (end - start + 1)));
+	td->offset_to_bb = (InterpBasicBlock**)mono_mempool_alloc0 (td->mempool, sizeof (InterpBasicBlock*) * (end - start + 1));
 	get_bb (td, start, make_list);
 
 	for (i = 0; i < header->num_clauses; i++) {

--- a/src/mono/mono/mini/lldb.c
+++ b/src/mono/mono/mini/lldb.c
@@ -206,14 +206,14 @@ buffer_add_data (Buffer *buf, guint8 *data, int len)
 static void
 buffer_add_string (Buffer *buf, const char *str)
 {
-	size_t len;
+	int len;
 
 	if (str == NULL) {
 		buffer_add_int (buf, 0);
 	} else {
 		len = strlen (str);
-		buffer_add_int (buf, (int)len);
-		buffer_add_data (buf, (guint8*)str, (int)len);
+		buffer_add_int (buf, len);
+		buffer_add_data (buf, (guint8*)str, len);
 	}
 }
 

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -4373,7 +4373,7 @@ mini_emit_array_store (MonoCompile *cfg, MonoClass *klass, MonoInst **sp, gboole
 		} else if (sp [1]->opcode == OP_ICONST) {
 			int array_reg = sp [0]->dreg;
 			int index_reg = sp [1]->dreg;
-			size_t offset = (mono_class_array_element_size (klass) * sp [1]->inst_c0) + MONO_STRUCT_OFFSET (MonoArray, vector);
+			int offset = (mono_class_array_element_size (klass) * sp [1]->inst_c0) + MONO_STRUCT_OFFSET (MonoArray, vector);
 
 			if (SIZEOF_REGISTER == 8 && COMPILE_LLVM (cfg) && sp [1]->inst_c0 < 0)
 				MONO_EMIT_NEW_UNALU (cfg, OP_ZEXT_I4, index_reg, index_reg);
@@ -10273,7 +10273,7 @@ field_access_end:
 			} else if (sp [1]->opcode == OP_ICONST) {
 				int array_reg = sp [0]->dreg;
 				int index_reg = sp [1]->dreg;
-				size_t offset = (mono_class_array_element_size (klass) * sp [1]->inst_c0) + MONO_STRUCT_OFFSET (MonoArray, vector);
+				int offset = (mono_class_array_element_size (klass) * sp [1]->inst_c0) + MONO_STRUCT_OFFSET (MonoArray, vector);
 
 				if (SIZEOF_REGISTER == 8 && COMPILE_LLVM (cfg))
 					MONO_EMIT_NEW_UNALU (cfg, OP_ZEXT_I4, index_reg, index_reg);

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -1754,7 +1754,7 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 		offset = 0;
 	}
 
-	cfg->arch.saved_iregs = (guint32)cfg->used_int_regs;
+	cfg->arch.saved_iregs = cfg->used_int_regs;
 	if (cfg->method->save_lmf) {
 		/* Save all callee-saved registers normally (except RBP, if not already used), and restore them when unwinding through an LMF */
 		guint32 iregs_to_save = AMD64_CALLEE_SAVED_REGS & ~(1<<AMD64_RBP);

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -829,7 +829,7 @@ mono_get_generic_info_from_stack_frame (MonoJitInfo *ji, MonoContext *ctx)
 	 * its prolog.
 	 */
 	if (gi->nlocs) {
-		size_t offset = (gsize)MONO_CONTEXT_GET_IP (ctx) - (gsize)ji->code_start;
+		int offset = (gsize)MONO_CONTEXT_GET_IP (ctx) - (gsize)ji->code_start;
 		int i;
 
 		for (i = 0; i < gi->nlocs; ++i) {
@@ -1935,7 +1935,7 @@ handle_exception_first_pass (MonoContext *ctx, MonoObject *obj, gint32 *out_filt
 			dynamic_methods = g_slist_prepend (dynamic_methods, method);
 
 		if (stack_overflow) {
-			free_stack = (guint32)((guint8*)(MONO_CONTEXT_GET_SP (ctx)) - (guint8*)(MONO_CONTEXT_GET_SP (&initial_ctx)));
+			free_stack = (guint8*)(MONO_CONTEXT_GET_SP (ctx)) - (guint8*)(MONO_CONTEXT_GET_SP (&initial_ctx));
 		} else {
 			free_stack = 0xffffff;
 		}
@@ -2368,7 +2368,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 		//printf ("[%d] %s.\n", frame_count, mono_method_full_name (method, TRUE));
 
 		if (stack_overflow) {
-			free_stack = (guint32)((guint8*)(MONO_CONTEXT_GET_SP (ctx)) - (guint8*)(MONO_CONTEXT_GET_SP (&initial_ctx)));
+			free_stack = (guint8*)(MONO_CONTEXT_GET_SP (ctx)) - (guint8*)(MONO_CONTEXT_GET_SP (&initial_ctx));
 		} else {
 			free_stack = 0xffffff;
 		}

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -1128,7 +1128,7 @@ tramp_info_hash (gconstpointer key)
 {
 	GSharedVtTrampInfo *tramp = (GSharedVtTrampInfo *)key;
 
-	return (guint)(gsize)tramp->addr;
+	return (gsize)tramp->addr;
 }
 
 static gboolean
@@ -4038,7 +4038,7 @@ get_shared_gparam_name (MonoTypeEnum constraint, const char *name)
 		memset (&t, 0, sizeof (t));
 		t.type = constraint;
 		tname = mono_type_full_name (&t);
-		size_t len = strlen (tname);
+		int len = strlen (tname);
 		for (int i = 0; i < len; ++i)
 			tname [i] = toupper (tname [i]);
 		res = g_strdup_printf ("%s_%s", name, tname);

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -1205,7 +1205,7 @@ mono_patch_info_hash (gconstpointer data)
 	case MONO_PATCH_INFO_DECLSEC:
 		return hash | ji->data.token->token;
 	case MONO_PATCH_INFO_TYPE_FROM_HANDLE:
-		return (guint)(hash | ji->data.token->token | (ji->data.token->has_context ? (gsize)ji->data.token->context.class_inst : 0));
+		return hash | ji->data.token->token | (ji->data.token->has_context ? (gsize)ji->data.token->context.class_inst : 0);
 	case MONO_PATCH_INFO_OBJC_SELECTOR_REF: // Hash on the selector name
 	case MONO_PATCH_INFO_LDSTR_LIT:
 		return g_str_hash (ji->data.name);
@@ -1255,7 +1255,7 @@ mono_patch_info_hash (gconstpointer data)
 	case MONO_PATCH_INFO_SPECIFIC_TRAMPOLINES_GOT_SLOTS_BASE:
 		return hash;
 	case MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR:
-		return (guint)(hash | ji->data.uindex);
+		return hash | ji->data.uindex;
 	case MONO_PATCH_INFO_JIT_ICALL_ID:
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR:
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR_NOCALL:
@@ -1266,7 +1266,7 @@ mono_patch_info_hash (gconstpointer data)
 	case MONO_PATCH_INFO_GSHAREDVT_METHOD:
 		return hash | (gssize)ji->data.gsharedvt_method->method;
 	case MONO_PATCH_INFO_DELEGATE_TRAMPOLINE:
-		return (guint)(hash | (gsize)ji->data.del_tramp->klass | (gsize)ji->data.del_tramp->method | (gsize)ji->data.del_tramp->is_virtual);
+		return hash | (gsize)ji->data.del_tramp->klass | (gsize)ji->data.del_tramp->method | (gsize)ji->data.del_tramp->is_virtual;
 	case MONO_PATCH_INFO_VIRT_METHOD: {
 		MonoJumpInfoVirtMethod *info = ji->data.virt_method;
 
@@ -1667,10 +1667,11 @@ mono_resolve_patch_target_ext (MonoMemoryManager *mem_manager, MonoMethod *metho
 		break;
 	}
 	case MONO_PATCH_INFO_LDSTR_LIT: {
+		int len;
 		char *s;
-		size_t len = strlen ((const char *)patch_info->data.target);
 
-		s = (char *)mono_mem_manager_alloc0 (mem_manager, (guint)len + 1);
+		len = strlen ((const char *)patch_info->data.target);
+		s = (char *)mono_mem_manager_alloc0 (mem_manager, len + 1);
 		memcpy (s, patch_info->data.target, len);
 		target = s;
 
@@ -4186,7 +4187,7 @@ class_method_pair_hash (gconstpointer data)
 {
 	const MonoClassMethodPair *pair = (const MonoClassMethodPair *)data;
 
-	return (guint)((gsize)pair->klass ^ (gsize)pair->method);
+	return (gsize)pair->klass ^ (gsize)pair->method;
 }
 
 static void

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -1867,7 +1867,7 @@ mono_add_var_location (MonoCompile *cfg, MonoInst *var, gboolean is_reg, int reg
 static void
 mono_apply_volatile (MonoInst *inst, MonoBitSet *set, gsize index)
 {
-	inst->flags |= mono_bitset_test_safe (set, (guint32)index) ? MONO_INST_VOLATILE : 0;
+	inst->flags |= mono_bitset_test_safe (set, index) ? MONO_INST_VOLATILE : 0;
 }
 
 static void
@@ -2633,7 +2633,7 @@ create_jit_info (MonoCompile *cfg, MonoMethod *method_to_compile)
 		jinfo->unwind_info = unwind_desc;
 		g_free (unwind_info);
 	} else {
-		jinfo->unwind_info = (guint32)cfg->used_int_regs;
+		jinfo->unwind_info = cfg->used_int_regs;
 	}
 
 	return jinfo;

--- a/src/mono/mono/mini/monovm.c
+++ b/src/mono/mono/mini/monovm.c
@@ -61,7 +61,7 @@ parse_trusted_platform_assemblies (const char *assemblies_paths)
 	a->basename_lens = g_new0 (uint32_t, asm_count + 1);
 	for (int i = 0; i < asm_count; ++i) {
 		a->basenames [i] = g_path_get_basename (a->assembly_filepaths [i]);
-		a->basename_lens [i] = (uint32_t)strlen (a->basenames [i]);
+		a->basename_lens [i] = strlen (a->basenames [i]);
 	}
 	a->basenames [asm_count] = NULL;
 	a->basename_lens [asm_count] = 0;

--- a/src/mono/mono/profiler/aot.c
+++ b/src/mono/mono/profiler/aot.c
@@ -445,10 +445,10 @@ emit_int32 (MonoProfiler *prof, gint32 value)
 static void
 emit_string (MonoProfiler *prof, const char *str)
 {
-	size_t len = strlen (str);
+	int len = strlen (str);
 
-	emit_int32 (prof, (gint32)len);
-	emit_bytes (prof, (guint8*)str, (int)len);
+	emit_int32 (prof, len);
+	emit_bytes (prof, (guint8*)str, len);
 }
 
 static void
@@ -640,7 +640,7 @@ prof_save (MonoProfiler *prof, FILE* file)
 
 	gint32 version = (AOT_PROFILER_MAJOR_VERSION << 16) | AOT_PROFILER_MINOR_VERSION;
 	sprintf (magic, AOT_PROFILER_MAGIC);
-	emit_bytes (prof, (guint8*)magic, (int)strlen (magic));
+	emit_bytes (prof, (guint8*)magic, strlen (magic));
 	emit_int32 (prof, version);
 
 	GHashTable *all_methods = g_hash_table_new (NULL, NULL);

--- a/src/mono/mono/sgen/sgen-gc.c
+++ b/src/mono/mono/sgen/sgen-gc.c
@@ -1636,7 +1636,7 @@ workers_finish_callback (void)
 		psj->scan_job.gc_thread_gray_queue = NULL;
 		psj->job_index = i;
 		psj->job_split_count = split_count;
-		psj->data = (int)(num_major_sections / split_count);
+		psj->data = num_major_sections / split_count;
 		sgen_workers_enqueue_job (GENERATION_OLD, &psj->scan_job.job, TRUE);
 	}
 
@@ -1678,7 +1678,7 @@ enqueue_scan_remembered_set_jobs (SgenGrayQueue *gc_thread_gray_queue, SgenObjec
 		psj->scan_job.gc_thread_gray_queue = gc_thread_gray_queue;
 		psj->job_index = i;
 		psj->job_split_count = split_count;
-		psj->data = (int)(num_major_sections / split_count);
+		psj->data = num_major_sections / split_count;
 		sgen_workers_enqueue_deferred_job (GENERATION_NURSERY, &psj->scan_job.job, is_parallel);
 
 		psj = (ParallelScanJob*)sgen_thread_pool_job_alloc ("scan LOS remsets", job_scan_los_card_table, sizeof (ParallelScanJob));
@@ -1707,7 +1707,7 @@ sgen_iterate_all_block_ranges (sgen_cardtable_block_callback callback, gboolean 
 		pjob = (ParallelIterateBlockRangesJob*)sgen_thread_pool_job_alloc ("iterate major block ranges", job_major_collector_iterate_block_ranges, sizeof (ParallelIterateBlockRangesJob));
 		pjob->job_index = i;
 		pjob->job_split_count = split_count;
-		pjob->data = (int)(num_major_sections / split_count);
+		pjob->data = num_major_sections / split_count;
 		pjob->callback = callback;
 		sgen_workers_enqueue_deferred_job (GENERATION_NURSERY, &pjob->job, is_parallel);
 
@@ -2207,7 +2207,7 @@ major_copy_or_mark_from_roots (SgenGrayQueue *gc_thread_gray_queue, size_t *old_
 			psj->scan_job.gc_thread_gray_queue = gc_thread_gray_queue;
 			psj->job_index = i;
 			psj->job_split_count = split_count;
-			psj->data = (int)(num_major_sections / split_count);
+			psj->data = num_major_sections / split_count;
 			sgen_workers_enqueue_job (GENERATION_OLD, &psj->scan_job.job, parallel);
 
 			psj = (ParallelScanJob*)sgen_thread_pool_job_alloc ("scan LOS mod union cardtable", job_scan_los_mod_union_card_table, sizeof (ParallelScanJob));

--- a/src/mono/mono/sgen/sgen-internal.c
+++ b/src/mono/mono/sgen/sgen-internal.c
@@ -281,7 +281,7 @@ sgen_init_internal_allocator (void)
 		fixed_type_allocator_indexes [i] = -1;
 
 	for (i = 0; i < NUM_ALLOCATORS; ++i) {
-		allocator_block_sizes [i] = (int)block_size (allocator_sizes [i]);
+		allocator_block_sizes [i] = block_size (allocator_sizes [i]);
 		mono_lock_free_allocator_init_size_class (&size_classes [i], allocator_sizes [i], allocator_block_sizes [i]);
 		mono_lock_free_allocator_init_allocator (&allocators [i], &size_classes [i], MONO_MEM_ACCOUNT_SGEN_INTERNAL);
 	}

--- a/src/mono/mono/sgen/sgen-marksweep.c
+++ b/src/mono/mono/sgen/sgen-marksweep.c
@@ -1807,7 +1807,7 @@ static void
 sweep_job_func (void *thread_data_untyped, SgenThreadPoolJob *job)
 {
 	guint32 block_index;
-	guint32 num_blocks = (guint32)num_major_sections_before_sweep;
+	guint32 num_blocks = num_major_sections_before_sweep;
 
 	SGEN_ASSERT (0, sweep_in_progress (), "Sweep thread called with wrong state");
 	SGEN_ASSERT (0, num_blocks <= allocated_blocks.next_slot, "How did we lose blocks?");
@@ -2186,7 +2186,7 @@ major_free_swept_blocks (size_t section_reserve)
 #endif
 
 	{
-		size_t i, num_empty_blocks_orig, num_blocks, arr_length;
+		int i, num_empty_blocks_orig, num_blocks, arr_length;
 		void *block;
 		void **empty_block_arr;
 		void **rebuild_next;

--- a/src/mono/mono/sgen/sgen-protocol.c
+++ b/src/mono/mono/sgen/sgen-protocol.c
@@ -232,7 +232,7 @@ binary_protocol_flush_buffer (BinaryProtocolBuffer *buffer)
 	while (binary_protocol_file != invalid_file_value && written < to_write) {
 #if defined(HOST_WIN32)
 		DWORD tmp_written;
-		if (WriteFile (binary_protocol_file, buffer->buffer + written, (DWORD)(to_write - written), &tmp_written, NULL))
+		if (WriteFile (binary_protocol_file, buffer->buffer + written, to_write - written, &tmp_written, NULL))
 			written += tmp_written;
 #elif defined(HAVE_UNISTD_H)
 		ssize_t ret = write (binary_protocol_file, buffer->buffer + written, to_write - written);

--- a/src/mono/mono/utils/hazard-pointer.c
+++ b/src/mono/mono/utils/hazard-pointer.c
@@ -89,8 +89,8 @@ mono_thread_small_id_alloc (void)
 		MonoBitSet *new_table;
 		if (small_id_table->size * 2 >= (1 << 16))
 			g_assert_not_reached ();
-		new_table = mono_bitset_clone (small_id_table, (gint32)small_id_table->size * 2);
-		id = mono_bitset_find_first_unset (new_table, (gint)small_id_table->size - 1);
+		new_table = mono_bitset_clone (small_id_table, small_id_table->size * 2);
+		id = mono_bitset_find_first_unset (new_table, small_id_table->size - 1);
 
 		mono_bitset_free (small_id_table);
 		small_id_table = new_table;

--- a/src/mono/mono/utils/lock-free-array-queue.c
+++ b/src/mono/mono/utils/lock-free-array-queue.c
@@ -45,9 +45,10 @@ static Chunk*
 alloc_chunk (MonoLockFreeArray *arr)
 {
 	int size = mono_pagesize ();
+	int num_entries = (size - (sizeof (Chunk) - arr->entry_size * MONO_ZERO_LEN_ARRAY)) / arr->entry_size;
 	Chunk *chunk = (Chunk *) mono_valloc (NULL, size, MONO_MMAP_READ | MONO_MMAP_WRITE, arr->account_type);
 	g_assert (chunk);
-	chunk->num_entries = (gint32)((size - (sizeof (Chunk) - arr->entry_size * MONO_ZERO_LEN_ARRAY)) / arr->entry_size);
+	chunk->num_entries = num_entries;
 	return chunk;
 }
 

--- a/src/mono/mono/utils/mono-dl-windows.c
+++ b/src/mono/mono/utils/mono-dl-windows.c
@@ -50,7 +50,7 @@ mono_dl_open_file (const char *file, int flags)
 {
 	gpointer hModule = NULL;
 	if (file) {
-		gunichar2* file_utf16 = g_utf8_to_utf16 (file, (glong)strlen (file), NULL, NULL, NULL);
+		gunichar2* file_utf16 = g_utf8_to_utf16 (file, strlen (file), NULL, NULL, NULL);
 
 #if HAVE_API_SUPPORT_WIN32_SET_ERROR_MODE
 		guint last_sem = SetErrorMode (SEM_FAILCRITICALERRORS);

--- a/src/mono/mono/utils/mono-dl.c
+++ b/src/mono/mono/utils/mono-dl.c
@@ -455,7 +455,8 @@ dl_build_path (const char *directory, const char *name, void **iter, dl_library_
 	const char *prefix;
 	const char *suffix;
 	gboolean need_prefix = TRUE, need_suffix = TRUE;
-	size_t prlen, suffixlen;
+	int prlen;
+	int suffixlen;
 	char *res;
 	int iteration;
 

--- a/src/mono/mono/utils/mono-md5.c
+++ b/src/mono/mono/utils/mono-md5.c
@@ -397,7 +397,7 @@ mono_md5_get_digest_from_file (const gchar *filename, guchar digest[16])
 		return;
 	}
 
-	while ((nb_bytes_read = (gint)fread (tmp_buf, sizeof (guchar), 1024, fp)) > 0)
+	while ((nb_bytes_read = fread (tmp_buf, sizeof (guchar), 1024, fp)) > 0)
 		mono_md5_update (&ctx, tmp_buf, nb_bytes_read);
 
 	if (ferror(fp)) {

--- a/src/mono/mono/utils/mono-path.c
+++ b/src/mono/mono/utils/mono-path.c
@@ -95,7 +95,7 @@ mono_path_canonicalize (const char *path)
 	 * since we'll return an empty string, so re-append a dir separator if there is none in the
 	 * result */
 	if (strchr (abspath, G_DIR_SEPARATOR) == NULL) {
-		size_t len = strlen (abspath);
+		int len = strlen (abspath);
 		abspath = (gchar *) g_realloc (abspath, len + 2);
 		abspath [len] = G_DIR_SEPARATOR;
 		abspath [len+1] = 0;

--- a/src/mono/mono/utils/mono-sha1.c
+++ b/src/mono/mono/utils/mono-sha1.c
@@ -320,7 +320,7 @@ mono_sha1_get_digest_from_file (const gchar *filename, guchar digest [20])
 		return;
 	}
 
-	while ((nb_bytes_read = (gint)fread (tmp_buf, sizeof (guchar), 1024, fp)) > 0)
+	while ((nb_bytes_read = fread (tmp_buf, sizeof (guchar), 1024, fp)) > 0)
 		mono_sha1_update (&ctx, tmp_buf, nb_bytes_read);
 
 	if (ferror(fp)) {

--- a/src/mono/mono/utils/mono-sigcontext.h
+++ b/src/mono/mono/utils/mono-sigcontext.h
@@ -449,7 +449,7 @@
 
 #ifndef UCONTEXT_REG_SET_PC
 #define UCONTEXT_REG_SET_PC(ctx, val) do { \
-	UCONTEXT_REG_PC (ctx) = (__uint64_t)(val); \
+	UCONTEXT_REG_PC (ctx) = (val); \
 	 } while (0)
 #endif
 #ifndef UCONTEXT_REG_SET_SP

--- a/src/mono/mono/utils/mono-stdlib.c
+++ b/src/mono/mono/utils/mono-stdlib.c
@@ -32,7 +32,7 @@ mono_mkstemp (char *templ)
 	int ret;
 	int count = 27; /* Windows doc. */
 	char *t;
-	size_t len;
+	int len;
 
 	len = strlen (templ);
 	do {

--- a/src/mono/mono/utils/mono-threads-windows.c
+++ b/src/mono/mono/utils/mono-threads-windows.c
@@ -583,7 +583,7 @@ mono_threads_platform_yield (void)
 void
 mono_threads_platform_exit (gsize exit_code)
 {
-	ExitThread ((DWORD)exit_code);
+	ExitThread (exit_code);
 }
 
 int

--- a/src/mono/mono/utils/mono-threads.c
+++ b/src/mono/mono/utils/mono-threads.c
@@ -310,7 +310,7 @@ gboolean
 mono_threads_wait_pending_operations (void)
 {
 	int i;
-	size_t c = pending_suspends;
+	int c = pending_suspends;
 
 	/* Wait threads to park */
 	THREADS_SUSPEND_DEBUG ("[INITIATOR-WAIT-COUNT] %d\n", c);

--- a/src/mono/mono/utils/mono-utility-thread.c
+++ b/src/mono/mono/utils/mono-utility-thread.c
@@ -90,7 +90,7 @@ mono_utility_thread_launch (size_t payload_size, MonoUtilityThreadCallbacks *cal
 	thread->callbacks = *callbacks;
 
 	mono_lock_free_queue_init (&thread->work_queue);
-	mono_lock_free_allocator_init_size_class (&thread->message_size_class, (unsigned int)entry_size, (unsigned int)thread->message_block_size);
+	mono_lock_free_allocator_init_size_class (&thread->message_size_class, entry_size, thread->message_block_size);
 	mono_lock_free_allocator_init_allocator (&thread->message_allocator, &thread->message_size_class, accountType);
 	mono_os_sem_init (&thread->work_queue_sem, 0);
 	mono_atomic_store_i32 (&thread->run_thread, 1);

--- a/src/mono/mono/utils/monobitset.c
+++ b/src/mono/mono/utils/monobitset.c
@@ -187,7 +187,7 @@ mono_bitset_invert (MonoBitSet *set) {
  */
 guint32
 mono_bitset_size (const MonoBitSet *set) {
-	return (guint32)set->size;
+	return set->size;
 }
 
 /*
@@ -444,7 +444,7 @@ mono_bitset_find_last (const MonoBitSet *set, gint pos) {
 	int j, bit, result, i;
 
 	if (pos < 0)
-		pos = (gint)(set->size - 1);
+		pos = set->size - 1;
 
 	j = pos / BITS_PER_CHUNK;
 	bit = pos % BITS_PER_CHUNK;
@@ -512,8 +512,8 @@ mono_bitset_clone (const MonoBitSet *set, guint32 new_size) {
 	MonoBitSet *result;
 
 	if (!new_size)
-		new_size = (guint32)set->size;
-	result = mono_bitset_new (new_size, (guint32)set->flags);
+		new_size = set->size;
+	result = mono_bitset_new (new_size, set->flags);
 	result->flags &= ~MONO_BITSET_DONT_FREE;
 	memcpy (result->data, set->data, set->size / 8);
 	return result;
@@ -542,8 +542,7 @@ mono_bitset_copyto (const MonoBitSet *src, MonoBitSet *dest) {
  */
 void
 mono_bitset_union (MonoBitSet *dest, const MonoBitSet *src) {
-	int i;
-	size_t size;
+	int i, size;
 
 	g_assert (src->size <= dest->size);
 
@@ -561,8 +560,7 @@ mono_bitset_union (MonoBitSet *dest, const MonoBitSet *src) {
  */
 void
 mono_bitset_intersection (MonoBitSet *dest, const MonoBitSet *src) {
-	int i;
-	size_t size;
+	int i, size;
 
 	g_assert (src->size <= dest->size);
 
@@ -581,8 +579,7 @@ mono_bitset_intersection (MonoBitSet *dest, const MonoBitSet *src) {
  */
 void
 mono_bitset_intersection_2 (MonoBitSet *dest, const MonoBitSet *src1, const MonoBitSet *src2) {
-	int i;
-	size_t size;
+	int i, size;
 
 	g_assert (src1->size <= dest->size);
 	g_assert (src2->size <= dest->size);
@@ -601,8 +598,7 @@ mono_bitset_intersection_2 (MonoBitSet *dest, const MonoBitSet *src1, const Mono
  */
 void
 mono_bitset_sub (MonoBitSet *dest, const MonoBitSet *src) {
-	int i;
-	size_t size;
+	int i, size;
 
 	g_assert (src->size <= dest->size);
 

--- a/src/mono/mono/utils/monobitset.h
+++ b/src/mono/mono/utils/monobitset.h
@@ -49,16 +49,18 @@ enum {
 #define mono_bitset_union_fast(dest,src) do { \
     MonoBitSet *tmp_src = (src); \
     MonoBitSet *tmp_dest = (dest); \
-	size_t size = (tmp_dest->size / MONO_BITSET_BITS_PER_CHUNK); \
-	for (size_t i = 0; i < size; ++i) \
+    int i, size; \
+	size = tmp_dest->size / MONO_BITSET_BITS_PER_CHUNK; \
+	for (i = 0; i < size; ++i) \
 		tmp_dest->data [i] |= tmp_src->data [i]; \
 } while (0)
 
 #define mono_bitset_sub_fast(dest,src) do { \
     MonoBitSet *tmp_src = (src); \
     MonoBitSet *tmp_dest = (dest); \
-    size_t size = tmp_dest->size / MONO_BITSET_BITS_PER_CHUNK; \
-	for (size_t i = 0; i < size; ++i) \
+    int i, size; \
+	size = tmp_dest->size / MONO_BITSET_BITS_PER_CHUNK; \
+	for (i = 0; i < size; ++i) \
 		tmp_dest->data [i] &= ~tmp_src->data [i]; \
 } while (0)
 

--- a/src/mono/mono/utils/options.c
+++ b/src/mono/mono/utils/options.c
@@ -122,16 +122,16 @@ mono_options_parse_options (const char **argv, int argc, int *out_argc, MonoErro
 		/* Compute flag name */
 		char *arg_copy = g_strdup (arg);
 		char *optname = arg_copy;
-		size_t len = strlen (arg);
+		int len = strlen (arg);
 		int equals_sign_index = -1;
 		/* Handle no- prefix */
 		if (optname [0] == 'n' && optname [1] == 'o' && optname [2] == '-') {
 			optname += 3;
 		} else {
 			/* Handle option=value */
-			for (size_t i = 0; i < len; ++i) {
+			for (int i = 0; i < len; ++i) {
 				if (optname [i] == '=') {
-					equals_sign_index = (int)i;
+					equals_sign_index = i;
 					optname [i] = '\0';
 					break;
 				}

--- a/src/mono/mono/utils/parse.c
+++ b/src/mono/mono/utils/parse.c
@@ -29,8 +29,7 @@ gboolean
 mono_gc_parse_environment_string_extract_number (const char *str, size_t *out)
 {
 	char *endptr;
-	size_t len = strlen (str);
-	int shift = 0;
+	int len = strlen (str), shift = 0;
 	size_t val;
 	gboolean is_suffix = FALSE;
 	char suffix;


### PR DESCRIPTION
This reverts commit c3dbdea91835d67cc461b22125e652ad5063d746.

This caused `mono-aot-cross.exe` to crash on windows, breaking all the
windows/AOT tests.
Corresponding issue: https://github.com/dotnet/runtime/issues/66718