### PR TITLE
Port Access violation occurring in System.DirectoryServices.ActiveDirectory.ForestTrustRelationshipInformation fix from .netfx to .net-core

### DIFF
--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ForestTrustRelationshipInformation.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ForestTrustRelationshipInformation.cs
@@ -15,6 +15,7 @@ namespace System.DirectoryServices.ActiveDirectory
         private StringCollection _excludedNames = new StringCollection();
         private ForestTrustDomainInfoCollection _domainInfo = new ForestTrustDomainInfoCollection();
         private ArrayList _binaryData = new ArrayList();
+        private ArrayList _binaryRecordType = new ArrayList();
         private Hashtable _excludedNameTime = new Hashtable();
         private ArrayList _binaryDataTime = new ArrayList();
         internal bool retrieved;
@@ -97,20 +98,14 @@ namespace System.DirectoryServices.ActiveDirectory
             int toplevelNamesCount = TopLevelNames.Count;
             int excludedNamesCount = ExcludedTopLevelNames.Count;
             int trustedDomainCount = TrustedDomainInformation.Count;
-            int binaryDataCount = 0;
+            int binaryDataCount = _binaryData.Count;
 
             checked
             {
                 count += toplevelNamesCount;
                 count += excludedNamesCount;
                 count += trustedDomainCount;
-                if (_binaryData.Count != 0)
-                {
-                    binaryDataCount = _binaryData.Count;
-                    // for the ForestTrustRecordTypeLast record
-                    count++;
-                    count += binaryDataCount;
-                }
+                count += binaryDataCount;
 
                 // allocate the memory for all the records
                 records = Marshal.AllocHGlobal(count * IntPtr.Size);
@@ -212,43 +207,31 @@ namespace System.DirectoryServices.ActiveDirectory
                         currentCount++;
                     }
 
-                    if (binaryDataCount > 0)
+                    for (int i = 0; i < binaryDataCount; i++)
                     {
-                        // now begin to construct ForestTrustRecordTypeLast
-                        LSA_FOREST_TRUST_RECORD lastRecord = new LSA_FOREST_TRUST_RECORD();
-                        lastRecord.Flags = 0;
-                        lastRecord.ForestTrustType = LSA_FOREST_TRUST_RECORD_TYPE.ForestTrustRecordTypeLast;
+                        LSA_FOREST_TRUST_RECORD record = new LSA_FOREST_TRUST_RECORD();
+                        record.Flags = 0;
+                        record.Time = (LARGE_INTEGER)_binaryDataTime[i]!;
+                        record.Data.Length = ((byte[])_binaryData[i]!).Length;
+                        record.ForestTrustType = (LSA_FOREST_TRUST_RECORD_TYPE)_binaryRecordType[i];
+                        record.Data = new LSA_FOREST_TRUST_BINARY_DATA();
+                        if (record.Data.Length == 0)
+                        {
+                            record.Data.Buffer = (IntPtr)0;
+                        }
+                        else
+                        {
+                            record.Data.Buffer = Marshal.AllocHGlobal(record.Data.Length);
+                            ptrList.Add(record.Data.Buffer);
+                            Marshal.Copy((byte[])_binaryData[i]!, 0, record.Data.Buffer, record.Data.Length);
+                        }
                         tmpPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(LSA_FOREST_TRUST_RECORD)));
                         ptrList.Add(tmpPtr);
-                        Marshal.StructureToPtr(lastRecord, tmpPtr, false);
+                        Marshal.StructureToPtr(record, tmpPtr, false);
+
                         Marshal.WriteIntPtr(records, IntPtr.Size * currentCount, tmpPtr);
+
                         currentCount++;
-
-                        for (int i = 0; i < binaryDataCount; i++)
-                        {
-                            // now begin to construct excluded top leve name record
-                            LSA_FOREST_TRUST_RECORD record = new LSA_FOREST_TRUST_RECORD();
-                            record.Flags = 0;
-                            record.Time = (LARGE_INTEGER)_binaryDataTime[i]!;
-                            record.Data.Length = ((byte[])_binaryData[i]!).Length;
-                            if (record.Data.Length == 0)
-                            {
-                                record.Data.Buffer = (IntPtr)0;
-                            }
-                            else
-                            {
-                                record.Data.Buffer = Marshal.AllocHGlobal(record.Data.Length);
-                                ptrList.Add(record.Data.Buffer);
-                                Marshal.Copy((byte[])_binaryData[i]!, 0, record.Data.Buffer, record.Data.Length);
-                            }
-                            tmpPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(LSA_FOREST_TRUST_RECORD)));
-                            ptrList.Add(tmpPtr);
-                            Marshal.StructureToPtr(record, tmpPtr, false);
-
-                            Marshal.WriteIntPtr(records, IntPtr.Size * currentCount, tmpPtr);
-
-                            currentCount++;
-                        }
                     }
 
                     // finally construct the LSA_FOREST_TRUST_INFORMATION
@@ -350,6 +333,7 @@ namespace System.DirectoryServices.ActiveDirectory
             ArrayList tmpBinaryData = new ArrayList();
             Hashtable tmpExcludedNameTime = new Hashtable();
             ArrayList tmpBinaryDataTime = new ArrayList();
+            ArrayList tmpBinaryRecordType = new ArrayList();
 
             try
             {
@@ -412,16 +396,15 @@ namespace System.DirectoryServices.ActiveDirectory
                                 }
                                 else if (record.ForestTrustType == LSA_FOREST_TRUST_RECORD_TYPE.ForestTrustDomainInfo)
                                 {
+                                    IntPtr myPtr = IntPtr.Add(addr, 16);
+                                    Marshal.PtrToStructure(myPtr, record.DomainInfo);
                                     ForestTrustDomainInformation dom = new ForestTrustDomainInformation(record.Flags, record.DomainInfo!, record.Time);
                                     tmpDomainInformation.Add(dom);
                                 }
-                                else if (record.ForestTrustType == LSA_FOREST_TRUST_RECORD_TYPE.ForestTrustRecordTypeLast)
-                                {
-                                    // enumeration is done, but we might still have some unrecognized entries after that
-                                    continue;
-                                }
                                 else
                                 {
+                                    IntPtr myPtr = IntPtr.Add(addr, 16);
+                                    Marshal.PtrToStructure(myPtr, record.Data);
                                     int length = record.Data.Length;
                                     byte[] byteArray = new byte[length];
                                     if ((record.Data.Buffer != (IntPtr)0) && (length != 0))
@@ -430,6 +413,7 @@ namespace System.DirectoryServices.ActiveDirectory
                                     }
                                     tmpBinaryData.Add(byteArray);
                                     tmpBinaryDataTime.Add(record.Time);
+                                    tmpBinaryRecordType.Add((int)record.ForestTrustType);
                                 }
                             }
                         }
@@ -446,6 +430,7 @@ namespace System.DirectoryServices.ActiveDirectory
                     _binaryData = tmpBinaryData;
                     _excludedNameTime = tmpExcludedNameTime;
                     _binaryDataTime = tmpBinaryDataTime;
+                    _binaryRecordType = tmpBinaryRecordType;
 
                     // mark it as retrieved
                     retrieved = true;

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ForestTrustRelationshipInformation.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ForestTrustRelationshipInformation.cs
@@ -213,7 +213,7 @@ namespace System.DirectoryServices.ActiveDirectory
                         record.Flags = 0;
                         record.Time = (LARGE_INTEGER)_binaryDataTime[i]!;
                         record.Data.Length = ((byte[])_binaryData[i]!).Length;
-                        record.ForestTrustType = (LSA_FOREST_TRUST_RECORD_TYPE)_binaryRecordType[i];
+                        record.ForestTrustType = (LSA_FOREST_TRUST_RECORD_TYPE)_binaryRecordType[i]!;
                         record.Data = new LSA_FOREST_TRUST_BINARY_DATA();
                         if (record.Data.Length == 0)
                         {
@@ -397,7 +397,7 @@ namespace System.DirectoryServices.ActiveDirectory
                                 else if (record.ForestTrustType == LSA_FOREST_TRUST_RECORD_TYPE.ForestTrustDomainInfo)
                                 {
                                     IntPtr myPtr = IntPtr.Add(addr, 16);
-                                    Marshal.PtrToStructure(myPtr, record.DomainInfo);
+                                    Marshal.PtrToStructure(myPtr, record.DomainInfo!);
                                     ForestTrustDomainInformation dom = new ForestTrustDomainInformation(record.Flags, record.DomainInfo!, record.Time);
                                     tmpDomainInformation.Add(dom);
                                 }


### PR DESCRIPTION
- Description: Access violation occurring in System.DirectoryServices.ActiveDirectory.ForestTrustRelationshipInformation.GetForestTrustInfoHelper
- Customer Impact: None yet, customer had an issue in .netfx because they were using .netfx to fetch forest trust information. If any customer uses .netcore to do something similar then this fix should mitigate the issue. None of the customers have reported any issues with .netcore yet.
- Regression: Yes, The issue was introduced when windows 1B security fixes were released. We missed the corresponding fix in ,net code and hence this pr.
- Risk: Very low
- Original Issue: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1465335
- Original PR: https://vstfdevdiv/DevDiv2/DevDiv/_versionControl/changeset/1764922