### PR TITLE
Add flags checks to BMI1 intrinsic lowering

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3789,9 +3789,9 @@ GenTree* Lowering::TryLowerAndOpToResetLowestSetBit(GenTreeOp* andNode)
         return nullptr;
     }
 
-    // prevent decomposed 64 integer node parts in x86 from being recognised
-    if (((addOp1->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS) || ((addOp2->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS) ||
-        ((op2->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS) || ((andNode->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS))
+    // Subsequent nodes may rely on CPU flags set by these nodes in which case we cannot remove them
+    if (((addOp2->gtFlags & GTF_SET_FLAGS) != 0) || ((op2->gtFlags & GTF_SET_FLAGS) != 0) ||
+        ((andNode->gtFlags & GTF_SET_FLAGS) != 0))
     {
         return nullptr;
     }
@@ -3875,8 +3875,8 @@ GenTree* Lowering::TryLowerAndOpToExtractLowestSetBit(GenTreeOp* andNode)
         return nullptr;
     }
 
-    // prevent decomposed 64 integer node parts in x86 from being recognised
-    if (((opNode->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS) || ((negNode->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS))
+    // Subsequent nodes may rely on CPU flags set by these nodes in which case we cannot remove them
+    if (((opNode->gtFlags & GTF_SET_FLAGS) != 0) || ((negNode->gtFlags & GTF_SET_FLAGS) != 0))
     {
         return nullptr;
     }
@@ -3960,8 +3960,8 @@ GenTree* Lowering::TryLowerAndOpToAndNot(GenTreeOp* andNode)
         return nullptr;
     }
 
-    // prevent decomposed 64 integer node parts in x86 from being recognised
-    if (((andNode->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS) || ((notNode->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS))
+    // Subsequent nodes may rely on CPU flags set by these nodes in which case we cannot remove them
+    if (((andNode->gtFlags & GTF_SET_FLAGS) != 0) || ((notNode->gtFlags & GTF_SET_FLAGS) != 0))
     {
         return nullptr;
     }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3789,6 +3789,13 @@ GenTree* Lowering::TryLowerAndOpToResetLowestSetBit(GenTreeOp* andNode)
         return nullptr;
     }
 
+    // prevent decomposed 64 integer node parts in x86 from being recognised
+    if (((addOp1->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS) || ((addOp2->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS) ||
+        ((op2->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS) || ((andNode->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS))
+    {
+        return nullptr;
+    }
+
     NamedIntrinsic intrinsic;
     if (op1->TypeIs(TYP_LONG) && comp->compOpportunisticallyDependsOn(InstructionSet_BMI1_X64))
     {
@@ -3868,6 +3875,12 @@ GenTree* Lowering::TryLowerAndOpToExtractLowestSetBit(GenTreeOp* andNode)
         return nullptr;
     }
 
+    // prevent decomposed 64 integer node parts in x86 from being recognised
+    if (((opNode->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS) || ((negNode->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS))
+    {
+        return nullptr;
+    }
+
     NamedIntrinsic intrinsic;
     if (andNode->TypeIs(TYP_LONG) && comp->compOpportunisticallyDependsOn(InstructionSet_BMI1_X64))
     {
@@ -3943,6 +3956,12 @@ GenTree* Lowering::TryLowerAndOpToAndNot(GenTreeOp* andNode)
     // We want to avoid using "andn" when one of the operands is both a source and the destination and is also coming
     // from memory. In this scenario, we will get smaller and likely faster code by using the RMW encoding of `and`
     if (IsBinOpInRMWStoreInd(andNode))
+    {
+        return nullptr;
+    }
+
+    // prevent decomposed 64 integer node parts in x86 from being recognised
+    if (((andNode->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS) || ((notNode->gtFlags & GTF_SET_FLAGS) == GTF_SET_FLAGS))
     {
         return nullptr;
     }

--- a/src/tests/JIT/Intrinsics/BMI1Intrinsics.cs
+++ b/src/tests/JIT/Intrinsics/BMI1Intrinsics.cs
@@ -25,29 +25,76 @@ namespace BMI1Intrinsics
 
             foreach (var value in values)
             {
-                Test(value.input1, AndNot(value.input1, value.input2), value.andnExpected, nameof(AndNot));
-                Test(value.input1, ExtractLowestSetIsolatedBit(value.input1), value.blsiExpected, nameof(ExtractLowestSetIsolatedBit));
-                Test(value.input1, ResetLowestSetBit(value.input1), value.blsrExpected, nameof(ResetLowestSetBit));
-                Test(value.input1, GetMaskUpToLowestSetBit(value.input1), value.blmskExpected, nameof(GetMaskUpToLowestSetBit));
+                Test(value.input1, AndNot_32bit(value.input1, value.input2), value.andnExpected, nameof(AndNot_32bit));
+                Test(value.input1, ExtractLowestSetIsolatedBit_32bit(value.input1), value.blsiExpected, nameof(ExtractLowestSetIsolatedBit_32bit));
+                Test(value.input1, ResetLowestSetBit_32bit(value.input1), value.blsrExpected, nameof(ResetLowestSetBit_32bit));
+                Test(value.input1, GetMaskUpToLowestSetBit_32bit(value.input1), value.blmskExpected, nameof(GetMaskUpToLowestSetBit_32bit));
+            }
+
+
+            var values2 = new (ulong input1, ulong input2, ulong andnExpected, ulong blsiExpected, ulong blsrExpected, ulong blmskExpected)[] {
+                (0,                                    0,                  0,                  0,                  0,                  0),
+                (1,                                    0,                  1,                  1,                  0,0xFFFFFFFF_FFFFFFFE),
+                (ulong.MaxValue / 2,                   0,0x7FFFFFFF_FFFFFFFF,                  1,0x7FFFFFFF_FFFFFFFE,0xFFFFFFFF_FFFFFFFE),
+                ((ulong.MaxValue / 2) - 1,             0,0x7FFFFFFF_FFFFFFFE,                  2,0x7FFFFFFF_FFFFFFFC,0xFFFFFFFF_FFFFFFFC),
+                ((ulong.MaxValue / 2) + 1,             0,0x80000000_00000000,0x80000000_00000000,                  0,                  0),
+                (ulong.MaxValue - 1,                   0,0xFFFFFFFF_FFFFFFFE,                  2,0xFFFFFFFF_FFFFFFFC,0xFFFFFFFF_FFFFFFFC),
+                (ulong.MaxValue,                       0,0xFFFFFFFF_FFFFFFFF,                  1,0xFFFFFFFF_FFFFFFFE,0xFFFFFFFF_FFFFFFFE),
+                (0xAAAAAAAA_AAAAAAAA,0xAAAAAAAA_AAAAAAAA,                  0,                  2,0xAAAAAAAA_AAAAAAA8,0xFFFFFFFF_FFFFFFFC),
+                (0xAAAAAAAA_AAAAAAAA,0x55555555_55555555,0xAAAAAAAA_AAAAAAAA,                  2,0xAAAAAAAA_AAAAAAA8,0xFFFFFFFF_FFFFFFFC),
+            };
+
+            foreach (var value in values2)
+            {
+                Test(value.input1, AndNot_64bit(value.input1, value.input2), value.andnExpected, nameof(AndNot_64bit));
+                Test(value.input1, ExtractLowestSetIsolatedBit_64bit(value.input1), value.blsiExpected, nameof(ExtractLowestSetIsolatedBit_64bit));
+                Test(value.input1, ResetLowestSetBit_64bit(value.input1), value.blsrExpected, nameof(ResetLowestSetBit_64bit));
+                Test(value.input1, GetMaskUpToLowestSetBit_64bit(value.input1), value.blmskExpected, nameof(GetMaskUpToLowestSetBit_64bit));
             }
 
             return _errorCode;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static uint AndNot(uint x, uint y) => x & (~y); // bmi1 andn
+        private static uint AndNot_32bit(uint x, uint y) => x & (~y); // bmi1 andn
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static uint ExtractLowestSetIsolatedBit(uint x) => (uint)(x & (-x)); // bmi1 blsi
+        private static ulong AndNot_64bit(ulong x, ulong y) => x & (~y); // bmi1 andn
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static uint ResetLowestSetBit(uint x) => x & (x - 1); // bmi1 blsr
+        private static uint ExtractLowestSetIsolatedBit_32bit(uint x) => (uint)(x & (-x)); // bmi1 blsi
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static uint GetMaskUpToLowestSetBit(uint x) => (uint)(x ^ (-x)); // bmi1 blmsk
+        private static ulong ExtractLowestSetIsolatedBit_64bit(ulong x) => x & (ulong)(-(long)x); // bmi1 blsi
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void Test(uint input, uint output, uint expected,string callerName)
+        private static uint ResetLowestSetBit_32bit(uint x) => x & (x - 1); // bmi1 blsr
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ulong ResetLowestSetBit_64bit(ulong x) => x & (x - 1); // bmi1 blsr
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static uint GetMaskUpToLowestSetBit_32bit(uint x) => (uint)(x ^ (-x)); // bmi1 blmsk
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ulong GetMaskUpToLowestSetBit_64bit(ulong x) => x ^ (ulong)(-(long)x); // bmi1 blmsk
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void Test(uint input, uint output, uint expected, string callerName)
+        {
+            if (output != expected)
+            {
+                Console.WriteLine($"{callerName} failed.");
+                Console.WriteLine($"Input:    {input:X}");
+                Console.WriteLine($"Output:   {output:X}");
+                Console.WriteLine($"Expected: {expected:X}");
+
+                _errorCode++;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void Test(ulong input, ulong output, ulong expected, string callerName)
         {
             if (output != expected)
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/66709

On x86 longs are decomposed into two integer nodes. This bug was caused by one of those integer nodes being recognised as part of the `blsi` pattern, `x & -x` and transformed without the second node being included. On x86 the 64 bit version of the intrinsic is not available so the lowering of a 64 bit operation to the intrinsic is not possible.

This PR adds in flags checks on all nodes being removed to see if they have side effect and if they have the lowering is not attempted. 

I have added the same checks to `blsr` and `andn` even though I have confirmed that they do not suffer from the same bug. This seemed prudent to me in case future jit changes expose a situation where it does become possible for those lowering to be affected.

/cc @dotnet/jit-contrib 