### PR TITLE
Workaround NuGet error in Content_Types

### DIFF
--- a/src/libraries/Microsoft.XmlSerializer.Generator/src/Microsoft.XmlSerializer.Generator.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/src/Microsoft.XmlSerializer.Generator.csproj
@@ -22,8 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Set an empty PackagePath to place this file in the root of the package -->
     <None Include="build\prefercliruntime"
-          PackagePath="/"
+          PackagePath=""
           Pack="true" />
     <None Include="build\Microsoft.XmlSerializer.Generator.targets"
           PackagePath="build"


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/66584

With this change I see the `prefercliruntime` remains in the root of the package and the `[Content_Types].xml` changes as follows:
```diff
- <Override PartName="//prefercliruntime" ContentType="application/octet" />
+ <Override PartName="/prefercliruntime" ContentType="application/octet" />
```