### PR TITLE
Dedup patterm/options/timeout in Regex source generator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -71,7 +71,7 @@ namespace System.Text.RegularExpressions.Generator
             writer.WriteLine($"internal sealed class {rm.GeneratedName} : Regex");
             writer.WriteLine($"{{");
             writer.WriteLine($"    /// <summary>Cached, thread-safe singleton instance.</summary>");
-            writer.WriteLine($"    internal static Regex Instance {{ get; }} = new({Literal(rm.Pattern)}, {Literal(rm.Options)}, {GetTimeoutExpression(rm.MatchTimeout)});");
+            writer.WriteLine($"    internal static readonly Regex Instance = new({Literal(rm.Pattern)}, {Literal(rm.Options)}, {GetTimeoutExpression(rm.MatchTimeout)});");
             writer.WriteLine($"}}");
         }
 
@@ -83,7 +83,7 @@ namespace System.Text.RegularExpressions.Generator
             writer.WriteLine($"internal sealed class {rm.GeneratedName} : Regex");
             writer.WriteLine($"{{");
             writer.WriteLine($"    /// <summary>Cached, thread-safe singleton instance.</summary>");
-            writer.WriteLine($"    internal static {rm.GeneratedName} Instance {{ get; }} = new();");
+            writer.WriteLine($"    internal static readonly {rm.GeneratedName} Instance = new();");
             writer.WriteLine($"");
             writer.WriteLine($"    /// <summary>Initializes the instance.</summary>");
             writer.WriteLine($"    private {rm.GeneratedName}()");

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -64,7 +64,7 @@ namespace System.Text.RegularExpressions.Generator
 
         /// <summary>Emits the Regex-derived type for a method where we're unable to generate custom code.</summary>
         private static void EmitRegexLimitedBoilerplate(
-            IndentedTextWriter writer, RegexMethod rm, int id, string reason)
+            IndentedTextWriter writer, RegexMethod rm, string reason)
         {
             writer.WriteLine($"/// <summary>Caches a <see cref=\"Regex\"/> instance for the {rm.MethodName} method.</summary>");
             writer.WriteLine($"/// <remarks>A custom Regex-derived type could not be generated because {reason}.</remarks>");
@@ -77,7 +77,7 @@ namespace System.Text.RegularExpressions.Generator
 
         /// <summary>Emits the Regex-derived type for a method whose RunnerFactory implementation was generated into <paramref name="runnerFactoryImplementation"/>.</summary>
         private static void EmitRegexDerivedImplementation(
-            IndentedTextWriter writer, RegexMethod rm, int id, string runnerFactoryImplementation)
+            IndentedTextWriter writer, RegexMethod rm, string runnerFactoryImplementation)
         {
             writer.WriteLine($"/// <summary>Custom <see cref=\"Regex\"/>-derived type for the {rm.MethodName} method.</summary>");
             writer.WriteLine($"internal sealed class {rm.GeneratedName} : Regex");

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
@@ -234,8 +234,8 @@ namespace System.Text.RegularExpressions.Generator
         /// <summary>A regex method.</summary>
         internal sealed record RegexMethod(RegexType DeclaringType, MethodDeclarationSyntax MethodSyntax, string MethodName, string Modifiers, string Pattern, RegexOptions Options, int MatchTimeout, RegexTree Tree)
         {
-            public int GeneratedId { get; set; }
-            public string GeneratedName => $"{MethodName}_{GeneratedId}";
+            public string GeneratedName { get; set; }
+            public bool IsDuplicate { get; set; }
         }
 
         /// <summary>A type holding a regex method.</summary>


### PR DESCRIPTION
If we end up with multiple identical pattern/options/timeout tuples in the same assembly, we don't need to emit unique code for each.  We can still emit the partial implementation for each, but emit a single implementation of the Regex they all share.