### PR TITLE
Ensure the generic math interfaces are implemented implicitly where possible

### DIFF
--- a/src/libraries/System.Data.Odbc/src/System.Data.Odbc.csproj
+++ b/src/libraries/System.Data.Odbc/src/System.Data.Odbc.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-FreeBSD;$(NetCoreAppCurrent)-illumos;$(NetCoreAppCurrent)-Solaris;$(NetCoreAppCurrent)-Linux;$(NetCoreAppCurrent)-OSX;$(NetCoreAppCurrent)-iOS;$(NetCoreAppCurrent)-tvOS;$(NetCoreAppCurrent);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum)-FreeBSD;$(NetCoreAppMinimum)-Linux;$(NetCoreAppMinimum)-OSX;$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
-    <NoWarn>$(NoWarn);CA2249;CA1838</NoWarn>
+    <NoWarn>$(NoWarn);CA2249;CA1838;CA1846</NoWarn>
     <!-- Suppress CA1845: Use span-based 'string.Concat' and 'AsSpan' instead of 'Substring' to avoid ifdefs. -->
     <NoWarn>$(NoWarn);CA1845</NoWarn>
     <Nullable>enable</Nullable>

--- a/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcConnection.cs
+++ b/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcConnection.cs
@@ -223,7 +223,7 @@ namespace System.Data.Odbc
                     {
                         try
                         {   // mdac 89269: driver may return malformatted string
-                            ProviderInfo.IsV3Driver = (int.Parse(ProviderInfo.DriverVersion.AsSpan(0, 2), CultureInfo.InvariantCulture) >= 3);
+                            ProviderInfo.IsV3Driver = (int.Parse(ProviderInfo.DriverVersion.Substring(0, 2), CultureInfo.InvariantCulture) >= 3);
                         }
                         catch (System.FormatException e)
                         {

--- a/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcConnection.cs
+++ b/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcConnection.cs
@@ -223,7 +223,7 @@ namespace System.Data.Odbc
                     {
                         try
                         {   // mdac 89269: driver may return malformatted string
-                            ProviderInfo.IsV3Driver = (int.Parse(ProviderInfo.DriverVersion.Substring(0, 2), CultureInfo.InvariantCulture) >= 3);
+                            ProviderInfo.IsV3Driver = (int.Parse(ProviderInfo.DriverVersion.AsSpan(0, 2), CultureInfo.InvariantCulture) >= 3);
                         }
                         catch (System.FormatException e)
                         {

--- a/src/libraries/System.Private.CoreLib/src/System/Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Byte.cs
@@ -31,6 +31,18 @@ namespace System
         // The minimum value that a Byte may represent: 0.
         public const byte MinValue = 0;
 
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        public const byte AdditiveIdentity = 0;
+
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        public const byte MultiplicativeIdentity = 1;
+
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        public const byte One = 1;
+
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        public const byte Zero = 0;
+
         // Compares this object to another object, returning an integer that
         // indicates the relationship.
         // Returns a value less than zero if this  object
@@ -285,169 +297,174 @@ namespace System
         // IAdditionOperators
         //
 
-        static byte IAdditionOperators<byte, byte, byte>.operator +(byte left, byte right)
-            => (byte)(left + right);
+        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        static byte IAdditionOperators<byte, byte, byte>.operator +(byte left, byte right) => (byte)(left + right);
 
-        // static checked byte IAdditionOperators<byte, byte, byte>.operator +(byte left, byte right)
-        //     => checked((byte)(left + right));
+        // /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_CheckedAddition(TSelf, TOther)" />
+        // static byte IAdditionOperators<byte, byte, byte>.operator checked +(byte left, byte right) => checked((byte)(left + right));
 
         //
         // IAdditiveIdentity
         //
 
-        static byte IAdditiveIdentity<byte, byte>.AdditiveIdentity => 0;
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        static byte IAdditiveIdentity<byte, byte>.AdditiveIdentity => AdditiveIdentity;
 
         //
         // IBinaryInteger
         //
 
-        static byte IBinaryInteger<byte>.LeadingZeroCount(byte value)
-            => (byte)(BitOperations.LeadingZeroCount(value) - 24);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.LeadingZeroCount(TSelf)" />
+        public static byte LeadingZeroCount(byte value) => (byte)(BitOperations.LeadingZeroCount(value) - 24);
 
-        static byte IBinaryInteger<byte>.PopCount(byte value)
-            => (byte)BitOperations.PopCount(value);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.PopCount(TSelf)" />
+        public static byte PopCount(byte value) => (byte)BitOperations.PopCount(value);
 
-        static byte IBinaryInteger<byte>.RotateLeft(byte value, int rotateAmount)
-            => (byte)((value << (rotateAmount & 7)) | (value >> ((8 - rotateAmount) & 7)));
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateLeft(TSelf, int)" />
+        public static byte RotateLeft(byte value, int rotateAmount) => (byte)((value << (rotateAmount & 7)) | (value >> ((8 - rotateAmount) & 7)));
 
-        static byte IBinaryInteger<byte>.RotateRight(byte value, int rotateAmount)
-            => (byte)((value >> (rotateAmount & 7)) | (value << ((8 - rotateAmount) & 7)));
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateRight(TSelf, int)" />
+        public static byte RotateRight(byte value, int rotateAmount) => (byte)((value >> (rotateAmount & 7)) | (value << ((8 - rotateAmount) & 7)));
 
-        static byte IBinaryInteger<byte>.TrailingZeroCount(byte value)
-            => (byte)(BitOperations.TrailingZeroCount(value << 24) - 24);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.TrailingZeroCount(TSelf)" />
+        public static byte TrailingZeroCount(byte value) => (byte)(BitOperations.TrailingZeroCount(value << 24) - 24);
 
         //
         // IBinaryNumber
         //
 
-        static bool IBinaryNumber<byte>.IsPow2(byte value)
-            => BitOperations.IsPow2((uint)value);
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
+        public static bool IsPow2(byte value) => BitOperations.IsPow2((uint)value);
 
-        static byte IBinaryNumber<byte>.Log2(byte value)
-            => (byte)BitOperations.Log2(value);
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />
+        public static byte Log2(byte value) => (byte)BitOperations.Log2(value);
 
         //
         // IBitwiseOperators
         //
 
-        static byte IBitwiseOperators<byte, byte, byte>.operator &(byte left, byte right)
-            => (byte)(left & right);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseAnd(TSelf, TOther)" />
+        static byte IBitwiseOperators<byte, byte, byte>.operator &(byte left, byte right) => (byte)(left & right);
 
-        static byte IBitwiseOperators<byte, byte, byte>.operator |(byte left, byte right)
-            => (byte)(left | right);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseOr(TSelf, TOther)" />
+        static byte IBitwiseOperators<byte, byte, byte>.operator |(byte left, byte right) => (byte)(left | right);
 
-        static byte IBitwiseOperators<byte, byte, byte>.operator ^(byte left, byte right)
-            => (byte)(left ^ right);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_ExclusiveOr(TSelf, TOther)" />
+        static byte IBitwiseOperators<byte, byte, byte>.operator ^(byte left, byte right) => (byte)(left ^ right);
 
-        static byte IBitwiseOperators<byte, byte, byte>.operator ~(byte value)
-            => (byte)(~value);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_OnesComplement(TSelf)" />
+        static byte IBitwiseOperators<byte, byte, byte>.operator ~(byte value) => (byte)(~value);
 
         //
         // IComparisonOperators
         //
 
-        static bool IComparisonOperators<byte, byte>.operator <(byte left, byte right)
-            => left < right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
+        static bool IComparisonOperators<byte, byte>.operator <(byte left, byte right) => left < right;
 
-        static bool IComparisonOperators<byte, byte>.operator <=(byte left, byte right)
-            => left <= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<byte, byte>.operator <=(byte left, byte right) => left <= right;
 
-        static bool IComparisonOperators<byte, byte>.operator >(byte left, byte right)
-            => left > right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
+        static bool IComparisonOperators<byte, byte>.operator >(byte left, byte right) => left > right;
 
-        static bool IComparisonOperators<byte, byte>.operator >=(byte left, byte right)
-            => left >= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<byte, byte>.operator >=(byte left, byte right) => left >= right;
 
         //
         // IDecrementOperators
         //
 
-        static byte IDecrementOperators<byte>.operator --(byte value)
-            => --value;
+        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        static byte IDecrementOperators<byte>.operator --(byte value) => --value;
 
-        // static checked byte IDecrementOperators<byte>.operator --(byte value)
-        //     => checked(--value);
+        // /// <inheritdoc cref="IDecrementOperators{TSelf}.op_CheckedDecrement(TSelf)" />
+        // static byte IDecrementOperators<byte>.operator checked --(byte value) => checked(--value);
 
         //
         // IDivisionOperators
         //
 
-        static byte IDivisionOperators<byte, byte, byte>.operator /(byte left, byte right)
-            => (byte)(left / right);
+        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
+        static byte IDivisionOperators<byte, byte, byte>.operator /(byte left, byte right) => (byte)(left / right);
 
-        // static checked byte IDivisionOperators<byte, byte, byte>.operator /(byte left, byte right)
-        //     => checked((byte)(left / right));
+        // /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
+        // static byte IDivisionOperators<byte, byte, byte>.operator checked /(byte left, byte right) => checked((byte)(left / right));
 
         //
         // IEqualityOperators
         //
 
-        static bool IEqualityOperators<byte, byte>.operator ==(byte left, byte right)
-            => left == right;
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Equality(TSelf, TOther)" />
+        static bool IEqualityOperators<byte, byte>.operator ==(byte left, byte right) => left == right;
 
-        static bool IEqualityOperators<byte, byte>.operator !=(byte left, byte right)
-            => left != right;
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Inequality(TSelf, TOther)" />
+        static bool IEqualityOperators<byte, byte>.operator !=(byte left, byte right) => left != right;
 
         //
         // IIncrementOperators
         //
 
-        static byte IIncrementOperators<byte>.operator ++(byte value)
-            => ++value;
+        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_Increment(TSelf)" />
+        static byte IIncrementOperators<byte>.operator ++(byte value) => ++value;
 
-        // static checked byte IIncrementOperators<byte>.operator ++(byte value)
-        //     => checked(++value);
+        // /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
+        // static byte IIncrementOperators<byte>.operator checked ++(byte value) => checked(++value);
 
         //
         // IMinMaxValue
         //
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MinValue" />
         static byte IMinMaxValue<byte>.MinValue => MinValue;
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MaxValue" />
         static byte IMinMaxValue<byte>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        static byte IModulusOperators<byte, byte, byte>.operator %(byte left, byte right)
-            => (byte)(left % right);
-
-        // static checked byte IModulusOperators<byte, byte, byte>.operator %(byte left, byte right)
-        //     => checked((byte)(left % right));
+        /// <inheritdoc cref="IModulusOperators{TSelf, TOther, TResult}.op_Modulus(TSelf, TOther)" />
+        static byte IModulusOperators<byte, byte, byte>.operator %(byte left, byte right) => (byte)(left % right);
 
         //
         // IMultiplicativeIdentity
         //
 
-        static byte IMultiplicativeIdentity<byte, byte>.MultiplicativeIdentity => 1;
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        static byte IMultiplicativeIdentity<byte, byte>.MultiplicativeIdentity => MultiplicativeIdentity;
 
         //
         // IMultiplyOperators
         //
 
-        static byte IMultiplyOperators<byte, byte, byte>.operator *(byte left, byte right)
-            => (byte)(left * right);
+        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
+        static byte IMultiplyOperators<byte, byte, byte>.operator *(byte left, byte right) => (byte)(left * right);
 
-        // static checked byte IMultiplyOperators<byte, byte, byte>.operator *(byte left, byte right)
-        //     => checked((byte)(left * right));
+        // /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
+        // static byte IMultiplyOperators<byte, byte, byte>.operator checked *(byte left, byte right) => checked((byte)(left * right));
 
         //
         // INumber
         //
 
-        static byte INumber<byte>.One => 1;
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        static byte INumber<byte>.One => One;
 
-        static byte INumber<byte>.Zero => 0;
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        static byte INumber<byte>.Zero => Zero;
 
-        static byte INumber<byte>.Abs(byte value)
-            => value;
+        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
+        public static byte Abs(byte value) => value;
 
-        static byte INumber<byte>.Clamp(byte value, byte min, byte max)
-            => Math.Clamp(value, min, max);
+        /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
+        public static byte Clamp(byte value, byte min, byte max) => Math.Clamp(value, min, max);
 
+        /// <inheritdoc cref="INumber{TSelf}.Create{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static byte INumber<byte>.Create<TOther>(TOther value)
+        public static byte Create<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -512,8 +529,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static byte INumber<byte>.CreateSaturating<TOther>(TOther value)
+        public static byte CreateSaturating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -598,8 +617,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static byte INumber<byte>.CreateTruncating<TOther>(TOther value)
+        public static byte CreateTruncating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -664,26 +685,22 @@ namespace System
             }
         }
 
-        static (byte Quotient, byte Remainder) INumber<byte>.DivRem(byte left, byte right)
-            => Math.DivRem(left, right);
+        /// <inheritdoc cref="INumber{TSelf}.DivRem(TSelf, TSelf)" />
+        public static (byte Quotient, byte Remainder) DivRem(byte left, byte right) => Math.DivRem(left, right);
 
-        static byte INumber<byte>.Max(byte x, byte y)
-            => Math.Max(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static byte Max(byte x, byte y) => Math.Max(x, y);
 
-        static byte INumber<byte>.Min(byte x, byte y)
-            => Math.Min(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static byte Min(byte x, byte y) => Math.Min(x, y);
 
-        static byte INumber<byte>.Parse(string s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static byte Sign(byte value) => (byte)((value == 0) ? 0 : 1);
 
-        static byte INumber<byte>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
-
-        static byte INumber<byte>.Sign(byte value)
-            => (byte)((value == 0) ? 0 : 1);
-
+        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool INumber<byte>.TryCreate<TOther>(TOther value, out byte result)
+        public static bool TryCreate<TOther>(TOther value, out byte result)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -867,73 +884,64 @@ namespace System
             }
         }
 
-        static bool INumber<byte>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out byte result)
-            => TryParse(s, style, provider, out result);
-
-        static bool INumber<byte>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out byte result)
-            => TryParse(s, style, provider, out result);
-
         //
         // IParseable
         //
 
-        static byte IParseable<byte>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider);
-
-        static bool IParseable<byte>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out byte result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
+        /// <inheritdoc cref="IParseable{TSelf}.TryParse(string?, IFormatProvider?, out TSelf)" />
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out byte result) => TryParse(s, NumberStyles.Integer, provider, out result);
 
         //
         // IShiftOperators
         //
 
-        static byte IShiftOperators<byte, byte>.operator <<(byte value, int shiftAmount)
-            => (byte)(value << shiftAmount);
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_LeftShift(TSelf, int)" />
+        static byte IShiftOperators<byte, byte>.operator <<(byte value, int shiftAmount) => (byte)(value << shiftAmount);
 
-        static byte IShiftOperators<byte, byte>.operator >>(byte value, int shiftAmount)
-            => (byte)(value >> shiftAmount);
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_RightShift(TSelf, int)" />
+        static byte IShiftOperators<byte, byte>.operator >>(byte value, int shiftAmount) => (byte)(value >> shiftAmount);
 
-        // static byte IShiftOperators<byte, byte, byte>.operator >>>(byte value, int shiftAmount)
-        //     => (byte)(value >> shiftAmount);
+        // /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_UnsignedRightShift(TSelf, int)" />
+        // static byte IShiftOperators<byte, byte>.operator >>>(byte value, int shiftAmount) => (byte)(value >> shiftAmount);
 
         //
         // ISpanParseable
         //
 
-        static byte ISpanParseable<byte>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, NumberStyles.Integer, provider);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
+        public static byte Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, NumberStyles.Integer, provider);
 
-        static bool ISpanParseable<byte>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out byte result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out byte result) => TryParse(s, NumberStyles.Integer, provider, out result);
 
         //
         // ISubtractionOperators
         //
 
-        static byte ISubtractionOperators<byte, byte, byte>.operator -(byte left, byte right)
-            => (byte)(left - right);
+        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_Subtraction(TSelf, TOther)" />
+        static byte ISubtractionOperators<byte, byte, byte>.operator -(byte left, byte right) => (byte)(left - right);
 
-        // static checked byte ISubtractionOperators<byte, byte, byte>.operator -(byte left, byte right)
-        //     => checked((byte)(left - right));
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static byte ISubtractionOperators<byte, byte, byte>.operator checked -(byte left, byte right) => checked((byte)(left - right));
 
         //
         // IUnaryNegationOperators
         //
 
-        static byte IUnaryNegationOperators<byte, byte>.operator -(byte value)
-            => (byte)(-value);
+        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_UnaryNegation(TSelf)" />
+        static byte IUnaryNegationOperators<byte, byte>.operator -(byte value) => (byte)(-value);
 
-        // static checked byte IUnaryNegationOperators<byte, byte>.operator -(byte value)
-        //     => checked((byte)(-value));
+        // /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
+        // static byte IUnaryNegationOperators<byte, byte>.operator checked -(byte value) => checked((byte)(-value));
 
         //
         // IUnaryPlusOperators
         //
 
-        static byte IUnaryPlusOperators<byte, byte>.operator +(byte value)
-            => (byte)(+value);
+        /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_UnaryPlus(TSelf)" />
+        static byte IUnaryPlusOperators<byte, byte>.operator +(byte value) => (byte)(+value);
 
-        // static checked byte IUnaryPlusOperators<byte, byte>.operator +(byte value)
-        //     => checked((byte)(+value));
+        // /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_CheckedUnaryPlus(TSelf)" />
+        // static byte IUnaryPlusOperators<byte, byte>.operator checked +(byte value) => checked((byte)(+value));
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Byte.cs
@@ -31,16 +31,16 @@ namespace System
         // The minimum value that a Byte may represent: 0.
         public const byte MinValue = 0;
 
-        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        /// <summary>Represents the additive identity (0).</summary>
         public const byte AdditiveIdentity = 0;
 
-        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        /// <summary>Represents the multiplicative identity (1).</summary>
         public const byte MultiplicativeIdentity = 1;
 
-        /// <inheritdoc cref="INumber{TSelf}.One" />
+        /// <summary>Represents the number one (1).</summary>
         public const byte One = 1;
 
-        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        /// <summary>Represents the number zero (0).</summary>
         public const byte Zero = 0;
 
         // Compares this object to another object, returning an integer that

--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -24,7 +24,7 @@ namespace System
 {
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct Char
         : IComparable,
           IComparable<char>,
@@ -125,7 +125,7 @@ namespace System
             return m_value == ((char)obj).m_value;
         }
 
-        [System.Runtime.Versioning.NonVersionable]
+        [NonVersionable]
         public bool Equals(char obj)
         {
             return m_value == obj;
@@ -1065,169 +1065,174 @@ namespace System
         // IAdditionOperators
         //
 
-        static char IAdditionOperators<char, char, char>.operator +(char left, char right)
-            => (char)(left + right);
+        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        static char IAdditionOperators<char, char, char>.operator +(char left, char right) => (char) (left + right);
 
-        // static checked char IAdditionOperators<char, char, char>.operator +(char left, char right)
-        //     => checked((char)(left + right));
+        // /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        // static char IAdditionOperators<char, char, char>.operator checked +(char left, char right) => checked((char)(left + right));
 
         //
         // IAdditiveIdentity
         //
 
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
         static char IAdditiveIdentity<char, char>.AdditiveIdentity => (char)0;
 
         //
         // IBinaryInteger
         //
 
-        static char IBinaryInteger<char>.LeadingZeroCount(char value)
-            => (char)(BitOperations.LeadingZeroCount(value) - 16);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.LeadingZeroCount(TSelf)" />
+        public static char LeadingZeroCount(char value) => (char)(BitOperations.LeadingZeroCount(value) - 16);
 
-        static char IBinaryInteger<char>.PopCount(char value)
-            => (char)BitOperations.PopCount(value);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.PopCount(TSelf)" />
+        public static char PopCount(char value) => (char)BitOperations.PopCount(value);
 
-        static char IBinaryInteger<char>.RotateLeft(char value, int rotateAmount)
-            => (char)((value << (rotateAmount & 15)) | (value >> ((16 - rotateAmount) & 15)));
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateLeft(TSelf, int)" />
+        public static char RotateLeft(char value, int rotateAmount) => (char)((value << (rotateAmount & 15)) | (value >> ((16 - rotateAmount) & 15)));
 
-        static char IBinaryInteger<char>.RotateRight(char value, int rotateAmount)
-            => (char)((value >> (rotateAmount & 15)) | (value << ((16 - rotateAmount) & 15)));
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateRight(TSelf, int)" />
+        public static char RotateRight(char value, int rotateAmount) => (char)((value >> (rotateAmount & 15)) | (value << ((16 - rotateAmount) & 15)));
 
-        static char IBinaryInteger<char>.TrailingZeroCount(char value)
-            => (char)(BitOperations.TrailingZeroCount(value << 16) - 16);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.TrailingZeroCount(TSelf)" />
+        public static char TrailingZeroCount(char value) => (char)(BitOperations.TrailingZeroCount(value << 16) - 16);
 
         //
         // IBinaryNumber
         //
 
-        static bool IBinaryNumber<char>.IsPow2(char value)
-            => BitOperations.IsPow2((uint)value);
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
+        public static bool IsPow2(char value) => BitOperations.IsPow2((uint)value);
 
-        static char IBinaryNumber<char>.Log2(char value)
-            => (char)BitOperations.Log2(value);
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />
+        public static char Log2(char value) => (char)BitOperations.Log2(value);
 
         //
         // IBitwiseOperators
         //
 
-        static char IBitwiseOperators<char, char, char>.operator &(char left, char right)
-            => (char)(left & right);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseAnd(TSelf, TOther)" />
+        static char IBitwiseOperators<char, char, char>.operator &(char left, char right) => (char)(left & right);
 
-        static char IBitwiseOperators<char, char, char>.operator |(char left, char right)
-            => (char)(left | right);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseOr(TSelf, TOther)" />
+        static char IBitwiseOperators<char, char, char>.operator |(char left, char right) => (char)(left | right);
 
-        static char IBitwiseOperators<char, char, char>.operator ^(char left, char right)
-            => (char)(left ^ right);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_ExclusiveOr(TSelf, TOther)" />
+        static char IBitwiseOperators<char, char, char>.operator ^(char left, char right) => (char)(left ^ right);
 
-        static char IBitwiseOperators<char, char, char>.operator ~(char value)
-            => (char)(~value);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_OnesComplement(TSelf)" />
+        static char IBitwiseOperators<char, char, char>.operator ~(char value) => (char)(~value);
 
         //
         // IComparisonOperators
         //
 
-        static bool IComparisonOperators<char, char>.operator <(char left, char right)
-            => left < right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
+        static bool IComparisonOperators<char, char>.operator <(char left, char right) => left < right;
 
-        static bool IComparisonOperators<char, char>.operator <=(char left, char right)
-            => left <= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<char, char>.operator <=(char left, char right) => left <= right;
 
-        static bool IComparisonOperators<char, char>.operator >(char left, char right)
-            => left > right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
+        static bool IComparisonOperators<char, char>.operator >(char left, char right) => left > right;
 
-        static bool IComparisonOperators<char, char>.operator >=(char left, char right)
-            => left >= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<char, char>.operator >=(char left, char right) => left >= right;
 
         //
         // IDecrementOperators
         //
 
-        static char IDecrementOperators<char>.operator --(char value)
-            => --value;
+        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        static char IDecrementOperators<char>.operator --(char value) => --value;
 
-        // static checked char IDecrementOperators<char>.operator --(char value)
-        //     => checked(--value);
+        // /// <inheritdoc cref="IDecrementOperators{TSelf}.op_CheckedDecrement(TSelf)" />
+        // static char IDecrementOperators<char>.operator checked --(char value) => checked(--value);
 
         //
         // IDivisionOperators
         //
 
-        static char IDivisionOperators<char, char, char>.operator /(char left, char right)
-            => (char)(left / right);
+        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
+        static char IDivisionOperators<char, char, char>.operator /(char left, char right) => (char)(left / right);
 
-        // static checked char IDivisionOperators<char, char, char>.operator /(char left, char right)
-        //     => checked((char)(left / right));
+        // /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
+        // static char IDivisionOperators<char, char, char>.operator /(char left, char right) => checked((char)(left / right));
 
         //
         // IEqualityOperators
         //
 
-        static bool IEqualityOperators<char, char>.operator ==(char left, char right)
-            => left == right;
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Equality(TSelf, TOther)" />
+        static bool IEqualityOperators<char, char>.operator ==(char left, char right) => left == right;
 
-        static bool IEqualityOperators<char, char>.operator !=(char left, char right)
-            => left != right;
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Inequality(TSelf, TOther)" />
+        static bool IEqualityOperators<char, char>.operator !=(char left, char right) => left != right;
 
         //
         // IIncrementOperators
         //
 
-        static char IIncrementOperators<char>.operator ++(char value)
-            => ++value;
+        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_Increment(TSelf)" />
+        static char IIncrementOperators<char>.operator ++(char value) => ++value;
 
-        // static checked char IIncrementOperators<char>.operator ++(char value)
-        //     => checked(++value);
+        // /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
+        // static char IIncrementOperators<char>.operator checked ++(char value) => checked(++value);
 
         //
         // IMinMaxValue
         //
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MinValue" />
         static char IMinMaxValue<char>.MinValue => MinValue;
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MaxValue" />
         static char IMinMaxValue<char>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        static char IModulusOperators<char, char, char>.operator %(char left, char right)
-            => (char)(left % right);
-
-        // static checked char IModulusOperators<char, char, char>.operator %(char left, char right)
-        //     => checked((char)(left % right));
+        /// <inheritdoc cref="IModulusOperators{TSelf, TOther, TResult}.op_Modulus(TSelf, TOther)" />
+        static char IModulusOperators<char, char, char>.operator %(char left, char right) => (char)(left % right);
 
         //
         // IMultiplicativeIdentity
         //
 
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
         static char IMultiplicativeIdentity<char, char>.MultiplicativeIdentity => (char)1;
 
         //
         // IMultiplyOperators
         //
 
-        static char IMultiplyOperators<char, char, char>.operator *(char left, char right)
-            => (char)(left * right);
+        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
+        static char IMultiplyOperators<char, char, char>.operator *(char left, char right) => (char)(left * right);
 
-        // static checked char IMultiplyOperators<char, char, char>.operator *(char left, char right)
-        //     => checked((char)(left * right));
+        // /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
+        // static char IMultiplyOperators<char, char, char>.operator checked *(char left, char right) => checked((char)(left * right));
 
         //
         // INumber
         //
 
+        /// <inheritdoc cref="INumber{TSelf}.One" />
         static char INumber<char>.One => (char)1;
 
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
         static char INumber<char>.Zero => (char)0;
 
-        static char INumber<char>.Abs(char value)
-            => value;
+        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
+        public static char Abs(char value) => value;
 
-        static char INumber<char>.Clamp(char value, char min, char max)
-            => (char)Math.Clamp(value, min, max);
+        /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
+        public static char Clamp(char value, char min, char max) => (char)Math.Clamp(value, min, max);
 
+        /// <inheritdoc cref="INumber{TSelf}.Create{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static char INumber<char>.Create<TOther>(TOther value)
+        public static char Create<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1292,8 +1297,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static char INumber<char>.CreateSaturating<TOther>(TOther value)
+        public static char CreateSaturating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1375,8 +1382,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static char INumber<char>.CreateTruncating<TOther>(TOther value)
+        public static char CreateTruncating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1441,32 +1450,22 @@ namespace System
             }
         }
 
-        static (char Quotient, char Remainder) INumber<char>.DivRem(char left, char right)
-            => ((char, char))Math.DivRem(left, right);
+        /// <inheritdoc cref="INumber{TSelf}.DivRem(TSelf, TSelf)" />
+        public static (char Quotient, char Remainder) DivRem(char left, char right) => ((char, char))Math.DivRem(left, right);
 
-        static char INumber<char>.Max(char x, char y)
-            => (char)Math.Max(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static char Max(char x, char y) => (char)Math.Max(x, y);
 
-        static char INumber<char>.Min(char x, char y)
-            => (char)Math.Min(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static char Min(char x, char y) => (char)Math.Min(x, y);
 
-        static char INumber<char>.Parse(string s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s);
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static char Sign(char value) => (char)((value == 0) ? 0 : 1);
 
-        static char INumber<char>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
-        {
-            if (s.Length != 1)
-            {
-                throw new FormatException(SR.Format_NeedSingleChar);
-            }
-            return s[0];
-        }
-
-        static char INumber<char>.Sign(char value)
-            => (char)((value == 0) ? 0 : 1);
-
+        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool INumber<char>.TryCreate<TOther>(TOther value, out char result)
+        public static bool TryCreate<TOther>(TOther value, out char result)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1642,8 +1641,18 @@ namespace System
             }
         }
 
-        static bool INumber<char>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out char result)
-            => TryParse(s, out result);
+        static char INumber<char>.Parse(string s, NumberStyles style, IFormatProvider? provider) => Parse(s);
+
+        static char INumber<char>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
+        {
+            if (s.Length != 1)
+            {
+                throw new FormatException(SR.Format_NeedSingleChar);
+            }
+            return s[0];
+        }
+
+        static bool INumber<char>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out char result) => TryParse(s, out result);
 
         static bool INumber<char>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out char result)
         {
@@ -1660,24 +1669,22 @@ namespace System
         // IParseable
         //
 
-        static char IParseable<char>.Parse(string s, IFormatProvider? provider)
-            => Parse(s);
+        static char IParseable<char>.Parse(string s, IFormatProvider? provider) => Parse(s);
 
-        static bool IParseable<char>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out char result)
-            => TryParse(s, out result);
+        static bool IParseable<char>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out char result) => TryParse(s, out result);
 
         //
         // IShiftOperators
         //
 
-        static char IShiftOperators<char, char>.operator <<(char value, int shiftAmount)
-            => (char)(value << shiftAmount);
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_LeftShift(TSelf, int)" />
+        static char IShiftOperators<char, char>.operator <<(char value, int shiftAmount) => (char)(value << shiftAmount);
 
-        static char IShiftOperators<char, char>.operator >>(char value, int shiftAmount)
-            => (char)(value >> shiftAmount);
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_RightShift(TSelf, int)" />
+        static char IShiftOperators<char, char>.operator >>(char value, int shiftAmount) => (char)(value >> shiftAmount);
 
-        // static char IShiftOperators<char, char, char>.operator >>>(char value, int shiftAmount)
-        //     => (char)(value >> shiftAmount);
+        // /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_UnsignedRightShift(TSelf, int)" />
+        // static char IShiftOperators<char, char>.operator >>>(char value, int shiftAmount) => (char)(value >> shiftAmount);
 
         //
         // ISpanParseable
@@ -1707,30 +1714,30 @@ namespace System
         // ISubtractionOperators
         //
 
-        static char ISubtractionOperators<char, char, char>.operator -(char left, char right)
-            => (char)(left - right);
+        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_Subtraction(TSelf, TOther)" />
+        static char ISubtractionOperators<char, char, char>.operator -(char left, char right) => (char)(left - right);
 
-        // static checked char ISubtractionOperators<char, char, char>.operator -(char left, char right)
-        //     => checked((char)(left - right));
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static char ISubtractionOperators<char, char, char>.operator checked -(char left, char right) => checked((char)(left - right));
 
         //
         // IUnaryNegationOperators
         //
 
-        static char IUnaryNegationOperators<char, char>.operator -(char value)
-            => (char)(-value);
+        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_UnaryNegation(TSelf)" />
+        static char IUnaryNegationOperators<char, char>.operator -(char value) => (char)(-value);
 
-        // static checked char IUnaryNegationOperators<char, char>.operator -(char value)
-        //     => checked((char)(-value));
+        // /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
+        // static char IUnaryNegationOperators<char, char>.operator checked -(char value) => checked((char)(-value));
 
         //
         // IUnaryPlusOperators
         //
 
-        static char IUnaryPlusOperators<char, char>.operator +(char value)
-            => (char)(+value);
+        /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_UnaryPlus(TSelf)" />
+        static char IUnaryPlusOperators<char, char>.operator +(char value) => (char)(+value);
 
-        // static checked char IUnaryPlusOperators<char, char>.operator +(char value)
-        //     => checked((char)(+value));
+        // /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_CheckedUnaryPlus(TSelf)" />
+        // static byte IUnaryPlusOperators<char, char>.operator checked +(byte value) => checked((char)(+value));
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/DateOnly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateOnly.cs
@@ -163,6 +163,7 @@ namespace System
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns>true if left is later than right; otherwise, false.</returns>
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
         public static bool operator >(DateOnly left, DateOnly right) => left._dayNumber > right._dayNumber;
 
         /// <summary>
@@ -171,6 +172,7 @@ namespace System
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns>true if left is the same as or later than right; otherwise, false.</returns>
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
         public static bool operator >=(DateOnly left, DateOnly right) => left._dayNumber >= right._dayNumber;
 
         /// <summary>
@@ -179,6 +181,7 @@ namespace System
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns>true if left is earlier than right; otherwise, false.</returns>
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
         public static bool operator <(DateOnly left, DateOnly right) => left._dayNumber < right._dayNumber;
 
         /// <summary>
@@ -187,6 +190,7 @@ namespace System
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns>true if left is the same as or earlier than right; otherwise, false.</returns>
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
         public static bool operator <=(DateOnly left, DateOnly right) => left._dayNumber <= right._dayNumber;
 
         /// <summary>
@@ -830,57 +834,23 @@ namespace System
         }
 
         //
-        // IComparisonOperators
-        //
-
-        static bool IComparisonOperators<DateOnly, DateOnly>.operator <(DateOnly left, DateOnly right)
-            => left < right;
-
-        static bool IComparisonOperators<DateOnly, DateOnly>.operator <=(DateOnly left, DateOnly right)
-            => left <= right;
-
-        static bool IComparisonOperators<DateOnly, DateOnly>.operator >(DateOnly left, DateOnly right)
-            => left > right;
-
-        static bool IComparisonOperators<DateOnly, DateOnly>.operator >=(DateOnly left, DateOnly right)
-            => left >= right;
-
-        //
-        // IEqualityOperators
-        //
-
-        static bool IEqualityOperators<DateOnly, DateOnly>.operator ==(DateOnly left, DateOnly right)
-            => left == right;
-
-        static bool IEqualityOperators<DateOnly, DateOnly>.operator !=(DateOnly left, DateOnly right)
-            => left != right;
-
-        //
-        // IMinMaxValue
-        //
-
-        static DateOnly IMinMaxValue<DateOnly>.MinValue => MinValue;
-
-        static DateOnly IMinMaxValue<DateOnly>.MaxValue => MaxValue;
-
-        //
         // IParseable
         //
 
-        static DateOnly IParseable<DateOnly>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider, DateTimeStyles.None);
+        /// <inheritdoc cref="IParseable{TSelf}.Parse(string, IFormatProvider?)" />
+        public static DateOnly Parse(string s, IFormatProvider? provider) => Parse(s, provider, DateTimeStyles.None);
 
-        static bool IParseable<DateOnly>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out DateOnly result)
-            => TryParse(s, provider, DateTimeStyles.None, out result);
+        /// <inheritdoc cref="IParseable{TSelf}.TryParse(string?, IFormatProvider?, out TSelf)" />
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out DateOnly result) => TryParse(s, provider, DateTimeStyles.None, out result);
 
         //
         // ISpanParseable
         //
 
-        static DateOnly ISpanParseable<DateOnly>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, provider, DateTimeStyles.None);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
+        public static DateOnly Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, provider, DateTimeStyles.None);
 
-        static bool ISpanParseable<DateOnly>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out DateOnly result)
-            => TryParse(s, provider, DateTimeStyles.None, out result);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out DateOnly result) => TryParse(s, provider, DateTimeStyles.None, out result);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -43,7 +43,7 @@ namespace System
     //
     [StructLayout(LayoutKind.Auto)]
     [Serializable]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly partial struct DateTime
         : IComparable,
           ISpanFormattable,
@@ -1391,12 +1391,16 @@ namespace System
 
         public static bool operator !=(DateTime d1, DateTime d2) => !(d1 == d2);
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
         public static bool operator <(DateTime t1, DateTime t2) => t1.Ticks < t2.Ticks;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
         public static bool operator <=(DateTime t1, DateTime t2) => t1.Ticks <= t2.Ticks;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
         public static bool operator >(DateTime t1, DateTime t2) => t1.Ticks > t2.Ticks;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
         public static bool operator >=(DateTime t1, DateTime t2) => t1.Ticks >= t2.Ticks;
 
         // Returns a string array containing all of the known date and time options for the
@@ -1506,44 +1510,15 @@ namespace System
         // IAdditionOperators
         //
 
-        static DateTime IAdditionOperators<DateTime, TimeSpan, DateTime>.operator +(DateTime left, TimeSpan right)
-            => left + right;
-
-        // static checked DateTime IAdditionOperators<DateTime, TimeSpan, DateTime>.operator +(DateTime left, TimeSpan right)
-        //     => checked(left + right);
+        // /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        // static DateTime IAdditionOperators<DateTime, TimeSpan, DateTime>.operator checked +(DateTime left, TimeSpan right) => checked(left + right);
 
         //
         // IAdditiveIdentity
         //
 
-        static TimeSpan IAdditiveIdentity<DateTime, TimeSpan>.AdditiveIdentity
-            => default;
-
-        //
-        // IComparisonOperators
-        //
-
-        static bool IComparisonOperators<DateTime, DateTime>.operator <(DateTime left, DateTime right)
-            => left < right;
-
-        static bool IComparisonOperators<DateTime, DateTime>.operator <=(DateTime left, DateTime right)
-            => left <= right;
-
-        static bool IComparisonOperators<DateTime, DateTime>.operator >(DateTime left, DateTime right)
-            => left > right;
-
-        static bool IComparisonOperators<DateTime, DateTime>.operator >=(DateTime left, DateTime right)
-            => left >= right;
-
-        //
-        // IEqualityOperators
-        //
-
-        static bool IEqualityOperators<DateTime, DateTime>.operator ==(DateTime left, DateTime right)
-            => left == right;
-
-        static bool IEqualityOperators<DateTime, DateTime>.operator !=(DateTime left, DateTime right)
-            => left != right;
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        public static TimeSpan AdditiveIdentity => default;
 
         //
         // IMinMaxValue
@@ -1557,36 +1532,27 @@ namespace System
         // IParseable
         //
 
-        static DateTime IParseable<DateTime>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider);
-
-        static bool IParseable<DateTime>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out DateTime result)
-            => TryParse(s, provider, DateTimeStyles.None, out result);
+        /// <inheritdoc cref="IParseable{TSelf}.TryParse(string?, IFormatProvider?, out TSelf)" />
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out DateTime result) => TryParse(s, provider, DateTimeStyles.None, out result);
 
         //
         // ISpanParseable
         //
 
-        static DateTime ISpanParseable<DateTime>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, provider, DateTimeStyles.None);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
+        public static DateTime Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, provider, DateTimeStyles.None);
 
-        static bool ISpanParseable<DateTime>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out DateTime result)
-            => TryParse(s, provider, DateTimeStyles.None, out result);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out DateTime result) => TryParse(s, provider, DateTimeStyles.None, out result);
 
         //
         // ISubtractionOperators
         //
 
-        static DateTime ISubtractionOperators<DateTime, TimeSpan, DateTime>.operator -(DateTime left, TimeSpan right)
-            => left - right;
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static DateTime ISubtractionOperators<DateTime, TimeSpan, DateTime>.operator checked -(DateTime left, TimeSpan right) => checked(left - right);
 
-        // static checked DateTime ISubtractionOperators<DateTime, TimeSpan, DateTime>.operator -(DateTime left, TimeSpan right)
-        //     => checked(left - right);
-
-        static TimeSpan ISubtractionOperators<DateTime, DateTime, TimeSpan>.operator -(DateTime left, DateTime right)
-            => left - right;
-
-        // static checked TimeSpan ISubtractionOperators<DateTime, DateTime, TimeSpan>.operator -(DateTime left, DateTime right)
-        //     => checked(left - right);
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static TimeSpan ISubtractionOperators<DateTime, DateTime, TimeSpan>.operator checked -(DateTime left, DateTime right) => checked(left - right);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Runtime.Versioning;
@@ -31,7 +32,7 @@ namespace System
 
     [StructLayout(LayoutKind.Auto)]
     [Serializable]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct DateTimeOffset
         : IComparable,
           ISpanFormattable,
@@ -845,15 +846,19 @@ namespace System
         public static bool operator !=(DateTimeOffset left, DateTimeOffset right) =>
             left.UtcDateTime != right.UtcDateTime;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
         public static bool operator <(DateTimeOffset left, DateTimeOffset right) =>
             left.UtcDateTime < right.UtcDateTime;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
         public static bool operator <=(DateTimeOffset left, DateTimeOffset right) =>
             left.UtcDateTime <= right.UtcDateTime;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
         public static bool operator >(DateTimeOffset left, DateTimeOffset right) =>
             left.UtcDateTime > right.UtcDateTime;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
         public static bool operator >=(DateTimeOffset left, DateTimeOffset right) =>
             left.UtcDateTime >= right.UtcDateTime;
 
@@ -861,43 +866,15 @@ namespace System
         // IAdditionOperators
         //
 
-        static DateTimeOffset IAdditionOperators<DateTimeOffset, TimeSpan, DateTimeOffset>.operator +(DateTimeOffset left, TimeSpan right)
-            => left + right;
-
-        // static checked DateTimeOffset IAdditionOperators<DateTimeOffset, TimeSpan, DateTimeOffset>.operator +(DateTimeOffset left, TimeSpan right)
-        //     => checked(left + right);
+        // /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        // static DateTimeOffset IAdditionOperators<DateTimeOffset, TimeSpan, DateTimeOffset>.operator checked +(DateTimeOffset left, TimeSpan right) => checked(left + right);
 
         //
         // IAdditiveIdentity
         //
 
-        static TimeSpan IAdditiveIdentity<DateTimeOffset, TimeSpan>.AdditiveIdentity => default;
-
-        //
-        // IComparisonOperators
-        //
-
-        static bool IComparisonOperators<DateTimeOffset, DateTimeOffset>.operator <(DateTimeOffset left, DateTimeOffset right)
-            => left < right;
-
-        static bool IComparisonOperators<DateTimeOffset, DateTimeOffset>.operator <=(DateTimeOffset left, DateTimeOffset right)
-            => left <= right;
-
-        static bool IComparisonOperators<DateTimeOffset, DateTimeOffset>.operator >(DateTimeOffset left, DateTimeOffset right)
-            => left > right;
-
-        static bool IComparisonOperators<DateTimeOffset, DateTimeOffset>.operator >=(DateTimeOffset left, DateTimeOffset right)
-            => left >= right;
-
-        //
-        // IEqualityOperators
-        //
-
-        static bool IEqualityOperators<DateTimeOffset, DateTimeOffset>.operator ==(DateTimeOffset left, DateTimeOffset right)
-            => left == right;
-
-        static bool IEqualityOperators<DateTimeOffset, DateTimeOffset>.operator !=(DateTimeOffset left, DateTimeOffset right)
-            => left != right;
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        public static TimeSpan AdditiveIdentity => default;
 
         //
         // IMinMaxValue
@@ -911,36 +888,27 @@ namespace System
         // IParseable
         //
 
-        static DateTimeOffset IParseable<DateTimeOffset>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider);
-
-        static bool IParseable<DateTimeOffset>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out DateTimeOffset result)
-            => TryParse(s, provider, DateTimeStyles.None, out result);
+        /// <inheritdoc cref="IParseable{TSelf}.TryParse(string?, IFormatProvider?, out TSelf)" />
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out DateTimeOffset result) => TryParse(s, provider, DateTimeStyles.None, out result);
 
         //
         // ISpanParseable
         //
 
-        static DateTimeOffset ISpanParseable<DateTimeOffset>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, provider, DateTimeStyles.None);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
+        public static DateTimeOffset Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, provider, DateTimeStyles.None);
 
-        static bool ISpanParseable<DateTimeOffset>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out DateTimeOffset result)
-            => TryParse(s, provider, DateTimeStyles.None, out result);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out DateTimeOffset result) => TryParse(s, provider, DateTimeStyles.None, out result);
 
         //
         // ISubtractionOperators
         //
 
-        static DateTimeOffset ISubtractionOperators<DateTimeOffset, TimeSpan, DateTimeOffset>.operator -(DateTimeOffset left, TimeSpan right)
-            => left - right;
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static DateTimeOffset ISubtractionOperators<DateTimeOffset, TimeSpan, DateTimeOffset>.operator checked -(DateTimeOffset left, TimeSpan right) => checked(left - right);
 
-        // static checked DateTimeOffset ISubtractionOperators<DateTimeOffset, TimeSpan, DateTimeOffset>.operator -(DateTimeOffset left, TimeSpan right)
-        //     => checked(left - right);
-
-        static TimeSpan ISubtractionOperators<DateTimeOffset, DateTimeOffset, TimeSpan>.operator -(DateTimeOffset left, DateTimeOffset right)
-            => left - right;
-
-        // static checked TimeSpan ISubtractionOperators<DateTimeOffset, DateTimeOffset, TimeSpan>.operator -(DateTimeOffset left, DateTimeOffset right)
-        //     => checked(left - right);
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static TimeSpan ISubtractionOperators<DateTimeOffset, DateTimeOffset, TimeSpan>.operator checked -(DateTimeOffset left, DateTimeOffset right) => checked(left - right);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
@@ -102,13 +102,13 @@ namespace System
         // this constant is -79,228,162,514,264,337,593,543,950,335.
         public const decimal MinValue = -79228162514264337593543950335m;
 
-        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        /// <summary>Represents the additive identity (0).</summary>
         public const decimal AdditiveIdentity = 0m;
 
-        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        /// <summary>Represents the multiplicative identity (1).</summary>
         public const decimal MultiplicativeIdentity = 1m;
 
-        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        /// <summary>Represents the number negative one (-1).</summary>
         public const decimal NegativeOne = -1m;
 
         // The lo, mid, hi, and flags fields contain the representation of the

--- a/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
@@ -56,8 +56,8 @@ namespace System
     // the range of the Decimal type.
     [StructLayout(LayoutKind.Sequential)]
     [Serializable]
-    [System.Runtime.Versioning.NonVersionable] // This only applies to field layout
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    [NonVersionable] // This only applies to field layout
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly partial struct Decimal
         : ISpanFormattable,
           IComparable,
@@ -101,6 +101,15 @@ namespace System
         // Constant representing the smallest possible Decimal value. The value of
         // this constant is -79,228,162,514,264,337,593,543,950,335.
         public const decimal MinValue = -79228162514264337593543950335m;
+
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        public const decimal AdditiveIdentity = 0m;
+
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        public const decimal MultiplicativeIdentity = 1m;
+
+        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        public const decimal NegativeOne = -1m;
 
         // The lo, mid, hi, and flags fields contain the representation of the
         // Decimal value. The lo, mid, and hi fields contain the 96-bit integer
@@ -333,15 +342,6 @@ namespace System
         /// Gets the scaling factor of the decimal, which is a number from 0 to 28 that represents the number of decimal digits.
         /// </summary>
         public byte Scale => (byte)(_flags >> ScaleShift);
-
-        // Returns the absolute value of the given Decimal. If d is
-        // positive, the result is d. If d is negative, the result
-        // is -d.
-        //
-        internal static decimal Abs(in decimal d)
-        {
-            return new decimal(in d, d._flags & ~SignMask);
-        }
 
         // Adds two Decimal values.
         //
@@ -614,20 +614,6 @@ namespace System
             int hi = BinaryPrimitives.ReadInt32LittleEndian(span.Slice(8));
             int flags = BinaryPrimitives.ReadInt32LittleEndian(span.Slice(12));
             return new decimal(lo, mid, hi, flags);
-        }
-
-        // Returns the larger of two Decimal values.
-        //
-        internal static ref readonly decimal Max(in decimal d1, in decimal d2)
-        {
-            return ref DecCalc.VarDecCmp(in d1, in d2) >= 0 ? ref d1 : ref d2;
-        }
-
-        // Returns the smaller of two Decimal values.
-        //
-        internal static ref readonly decimal Min(in decimal d1, in decimal d2)
-        {
-            return ref DecCalc.VarDecCmp(in d1, in d2) < 0 ? ref d1 : ref d2;
         }
 
         public static decimal Remainder(decimal d1, decimal d2)
@@ -952,8 +938,10 @@ namespace System
 
         public static decimal operator -(decimal d) => new decimal(in d, d._flags ^ SignMask);
 
+        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_Increment(TSelf)" />
         public static decimal operator ++(decimal d) => Add(d, One);
 
+        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
         public static decimal operator --(decimal d) => Subtract(d, One);
 
         public static decimal operator +(decimal d1, decimal d2)
@@ -968,34 +956,43 @@ namespace System
             return d1;
         }
 
+        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
         public static decimal operator *(decimal d1, decimal d2)
         {
             DecCalc.VarDecMul(ref AsMutable(ref d1), ref AsMutable(ref d2));
             return d1;
         }
 
+        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
         public static decimal operator /(decimal d1, decimal d2)
         {
             DecCalc.VarDecDiv(ref AsMutable(ref d1), ref AsMutable(ref d2));
             return d1;
         }
 
+        /// <inheritdoc cref="IModulusOperators{TSelf, TOther, TResult}.op_Modulus(TSelf, TOther)" />
         public static decimal operator %(decimal d1, decimal d2)
         {
             DecCalc.VarDecMod(ref AsMutable(ref d1), ref AsMutable(ref d2));
             return d1;
         }
 
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Equality(TSelf, TOther)" />
         public static bool operator ==(decimal d1, decimal d2) => DecCalc.VarDecCmp(in d1, in d2) == 0;
 
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Inequality(TSelf, TOther)" />
         public static bool operator !=(decimal d1, decimal d2) => DecCalc.VarDecCmp(in d1, in d2) != 0;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
         public static bool operator <(decimal d1, decimal d2) => DecCalc.VarDecCmp(in d1, in d2) < 0;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
         public static bool operator <=(decimal d1, decimal d2) => DecCalc.VarDecCmp(in d1, in d2) <= 0;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
         public static bool operator >(decimal d1, decimal d2) => DecCalc.VarDecCmp(in d1, in d2) > 0;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
         public static bool operator >=(decimal d1, decimal d2) => DecCalc.VarDecCmp(in d1, in d2) >= 0;
 
         //
@@ -1086,121 +1083,81 @@ namespace System
         // IAdditionOperators
         //
 
-        static decimal IAdditionOperators<decimal, decimal, decimal>.operator +(decimal left, decimal right)
-            => checked(left + right);
-
-        // static checked decimal IAdditionOperators<decimal, decimal, decimal>.operator +(decimal left, decimal right)
-        //     => checked(left + right);
+        // /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        // static decimal IAdditionOperators<decimal, decimal, decimal>.operator checked +(decimal left, decimal right) => checked(left + right);
 
         //
         // IAdditiveIdentity
         //
 
-        static decimal IAdditiveIdentity<decimal, decimal>.AdditiveIdentity => 0.0m;
-
-        //
-        // IComparisonOperators
-        //
-
-        static bool IComparisonOperators<decimal, decimal>.operator <(decimal left, decimal right)
-            => left < right;
-
-        static bool IComparisonOperators<decimal, decimal>.operator <=(decimal left, decimal right)
-            => left <= right;
-
-        static bool IComparisonOperators<decimal, decimal>.operator >(decimal left, decimal right)
-            => left > right;
-
-        static bool IComparisonOperators<decimal, decimal>.operator >=(decimal left, decimal right)
-            => left >= right;
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        static decimal IAdditiveIdentity<decimal, decimal>.AdditiveIdentity => AdditiveIdentity;
 
         //
         // IDecrementOperators
         //
 
-        static decimal IDecrementOperators<decimal>.operator --(decimal value)
-            => --value;
-
-        // static checked decimal IDecrementOperators<decimal>.operator --(decimal value)
-        //     => checked(--value);
+        // /// <inheritdoc cref="IDecrementOperators{TSelf}.op_CheckedDecrement(TSelf)" />
+        // static decimal IDecrementOperators<decimal>.operator checked --(decimal value) => checked(--value);
 
         //
         // IDivisionOperators
         //
 
-        static decimal IDivisionOperators<decimal, decimal, decimal>.operator /(decimal left, decimal right)
-            => left / right;
-
-        // static checked decimal IDivisionOperators<decimal, decimal, decimal>.operator /(decimal left, decimal right)
-        //     => checked(left / right);
-
-        //
-        // IEqualityOperators
-        //
-
-        static bool IEqualityOperators<decimal, decimal>.operator ==(decimal left, decimal right)
-            => left == right;
-
-        static bool IEqualityOperators<decimal, decimal>.operator !=(decimal left, decimal right)
-            => left != right;
+        // /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
+        // static decimal IDivisionOperators<decimal, decimal, decimal>.operator checked /(decimal left, decimal right) => checked(left / right);
 
         //
         // IIncrementOperators
         //
 
-        static decimal IIncrementOperators<decimal>.operator ++(decimal value)
-            => ++value;
-
-        // static checked decimal IIncrementOperators<decimal>.operator ++(decimal value)
-        //     => checked(++value);
+        // /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
+        // static decimal IIncrementOperators<decimal>.operator checked ++(decimal value) => checked(++value);
 
         //
         // IMinMaxValue
         //
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MinValue" />
         static decimal IMinMaxValue<decimal>.MinValue => MinValue;
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MaxValue" />
         static decimal IMinMaxValue<decimal>.MaxValue => MaxValue;
-
-        //
-        // IModulusOperators
-        //
-
-        static decimal IModulusOperators<decimal, decimal, decimal>.operator %(decimal left, decimal right)
-            => left % right;
-
-        // static checked decimal IModulusOperators<decimal, decimal, decimal>.operator %(decimal left, decimal right)
-        //     => checked(left % right);
 
         //
         // IMultiplicativeIdentity
         //
 
-        static decimal IMultiplicativeIdentity<decimal, decimal>.MultiplicativeIdentity => 1.0m;
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        static decimal IMultiplicativeIdentity<decimal, decimal>.MultiplicativeIdentity => MultiplicativeIdentity;
 
         //
         // IMultiplyOperators
         //
 
-        static decimal IMultiplyOperators<decimal, decimal, decimal>.operator *(decimal left, decimal right)
-            => left * right;
-
-        // static checked decimal IMultiplyOperators<decimal, decimal, decimal>.operator *(decimal left, decimal right)
-        //     => checked(left * right);
+        // /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
+        // public static decimal operator checked *(decimal left, decimal right) => checked(left * right);
 
         //
         // INumber
         //
 
-        static decimal INumber<decimal>.One => 1.0m;
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        static decimal INumber<decimal>.One => One;
 
-        static decimal INumber<decimal>.Zero => 0.0m;
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        static decimal INumber<decimal>.Zero => Zero;
 
-        static decimal INumber<decimal>.Abs(decimal value)
-            => Math.Abs(value);
+        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
+        public static decimal Abs(decimal value)
+        {
+            return new decimal(in value, value._flags & ~SignMask);
+        }
 
+        /// <inheritdoc cref="INumber{TSelf}.Create{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static decimal INumber<decimal>.Create<TOther>(TOther value)
+        public static decimal Create<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1265,8 +1222,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static decimal INumber<decimal>.CreateSaturating<TOther>(TOther value)
+        public static decimal CreateSaturating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1331,8 +1290,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static decimal INumber<decimal>.CreateTruncating<TOther>(TOther value)
+        public static decimal CreateTruncating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1397,29 +1358,31 @@ namespace System
             }
         }
 
-        static decimal INumber<decimal>.Clamp(decimal value, decimal min, decimal max)
-            => Math.Clamp(value, min, max);
+        /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
+        public static decimal Clamp(decimal value, decimal min, decimal max) => Math.Clamp(value, min, max);
 
-        static (decimal Quotient, decimal Remainder) INumber<decimal>.DivRem(decimal left, decimal right)
-            => (left / right, left % right);
+        /// <inheritdoc cref="INumber{TSelf}.DivRem(TSelf, TSelf)" />
+        public static (decimal Quotient, decimal Remainder) DivRem(decimal left, decimal right) => (left / right, left % right);
 
-        static decimal INumber<decimal>.Max(decimal x, decimal y)
-            => Math.Max(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static decimal Max(decimal x, decimal y)
+        {
+            return DecCalc.VarDecCmp(in x, in y) >= 0 ? x : y;
+        }
 
-        static decimal INumber<decimal>.Min(decimal x, decimal y)
-            => Math.Min(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static decimal Min(decimal x, decimal y)
+        {
+            return DecCalc.VarDecCmp(in x, in y) < 0 ? x : y;
+        }
 
-        static decimal INumber<decimal>.Parse(string s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        static decimal INumber<decimal>.Sign(decimal value) => Math.Sign(value);
 
-        static decimal INumber<decimal>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
-
-        static decimal INumber<decimal>.Sign(decimal value)
-            => Math.Sign(value);
-
+        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool INumber<decimal>.TryCreate<TOther>(TOther value, out decimal result)
+        public static bool TryCreate<TOther>(TOther value, out decimal result)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1499,66 +1462,48 @@ namespace System
             }
         }
 
-        static bool INumber<decimal>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out decimal result)
-            => TryParse(s, style, provider, out result);
-
-        static bool INumber<decimal>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out decimal result)
-            => TryParse(s, style, provider, out result);
-
         //
         // IParseable
         //
 
-        static decimal IParseable<decimal>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider);
-
-        static bool IParseable<decimal>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out decimal result)
-            => TryParse(s, NumberStyles.Number, provider, out result);
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out decimal result) => TryParse(s, NumberStyles.Number, provider, out result);
 
         //
         // ISignedNumber
         //
 
-        static decimal ISignedNumber<decimal>.NegativeOne => -1;
+        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        static decimal ISignedNumber<decimal>.NegativeOne => NegativeOne;
 
         //
         // ISpanParseable
         //
 
-        static decimal ISpanParseable<decimal>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, NumberStyles.Number, provider);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
+        public static decimal Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, NumberStyles.Number, provider);
 
-        static bool ISpanParseable<decimal>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out decimal result)
-            => TryParse(s, NumberStyles.Number, provider, out result);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out decimal result) => TryParse(s, NumberStyles.Number, provider, out result);
 
         //
         // ISubtractionOperators
         //
 
-        static decimal ISubtractionOperators<decimal, decimal, decimal>.operator -(decimal left, decimal right)
-            => left - right;
-
-        // static checked decimal ISubtractionOperators<decimal, decimal, decimal>.operator -(decimal left, decimal right)
-        //     => checked(left - right);
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static decimal ISubtractionOperators<decimal, decimal, decimal>.operator checked -(decimal left, decimal right) => checked(left - right);
 
         //
         // IUnaryNegationOperators
         //
 
-        static decimal IUnaryNegationOperators<decimal, decimal>.operator -(decimal value)
-            => -value;
-
-        // static checked decimal IUnaryNegationOperators<decimal, decimal>.operator -(decimal value)
-        //     => checked(-value);
+        // /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
+        // static decimal IUnaryNegationOperators<decimal, decimal>.operator checked -(decimal value) => checked(-value);
 
         //
         // IUnaryPlusOperators
         //
 
-        static decimal IUnaryPlusOperators<decimal, decimal>.operator +(decimal value)
-            => +value;
-
-        // static checked decimal IUnaryPlusOperators<decimal, decimal>.operator +(decimal value)
-        //     => checked(+value);
+        // /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_CheckedUnaryPlus(TSelf)" />
+        // static decimal IUnaryPlusOperators<decimal, decimal>.operator checked +(decimal value) => checked(+value);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 /*============================================================
@@ -46,31 +46,34 @@ namespace System
         public const double PositiveInfinity = (double)1.0 / (double)(0.0);
         public const double NaN = (double)0.0 / (double)0.0;
 
-        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        /// <summary>Represents the additive identity (0).</summary>
         public const double AdditiveIdentity = 0.0;
 
-        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        /// <summary>Represents the multiplicative identity (1).</summary>
         public const double MultiplicativeIdentity = 1.0;
 
-        /// <inheritdoc cref="INumber{TSelf}.One" />
+        /// <summary>Represents the number one (1).</summary>
         public const double One = 1.0;
 
-        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        /// <summary>Represents the number zero (0).</summary>
         public const double Zero = 0.0;
 
-        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        /// <summary>Represents the number negative one (-1).</summary>
         public const double NegativeOne = -1.0;
 
-        /// <inheritdoc cref="IFloatingPoint{TSelf}.NegativeZero" />
+        /// <summary>Represents the number negative zero (-0).</summary>
         public const double NegativeZero = -0.0;
 
-        /// <inheritdoc cref="IFloatingPoint{TSelf}.E" />
+        /// <summary>Represents the natural logarithmic base, specified by the constant, e.</summary>
+        /// <remarks>Euler's number is approximately 2.7182818284590452354.</remarks>
         public const double E = Math.E;
 
-        /// <inheritdoc cref="IFloatingPoint{TSelf}.Pi" />
+        /// <summary>Represents the ratio of the circumference of a circle to its diameter, specified by the constant, π.</summary>
+        /// <remarks>Pi is approximately 3.1415926535897932385.</remarks>
         public const double Pi = Math.PI;
 
-        /// <inheritdoc cref="IFloatingPoint{TSelf}.Tau" />
+        /// <summary>Represents the number of radians in one turn, specified by the constant, τ.</summary>
+        /// <remarks>Tau is approximately 6.2831853071795864769.</remarks>
         public const double Tau = Math.Tau;
 
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -46,8 +46,32 @@ namespace System
         public const double PositiveInfinity = (double)1.0 / (double)(0.0);
         public const double NaN = (double)0.0 / (double)0.0;
 
-        // We use this explicit definition to avoid the confusion between 0.0 and -0.0.
-        internal const double NegativeZero = -0.0;
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        public const double AdditiveIdentity = 0.0;
+
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        public const double MultiplicativeIdentity = 1.0;
+
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        public const double One = 1.0;
+
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        public const double Zero = 0.0;
+
+        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        public const double NegativeOne = -1.0;
+
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.NegativeZero" />
+        public const double NegativeZero = -0.0;
+
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.E" />
+        public const double E = Math.E;
+
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Pi" />
+        public const double Pi = Math.PI;
+
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Tau" />
+        public const double Tau = Math.Tau;
 
         //
         // Constants for manipulating the private bit-representation
@@ -217,21 +241,27 @@ namespace System
             return IsNaN(temp) && IsNaN(m_value);
         }
 
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Equality(TSelf, TOther)" />
         [NonVersionable]
         public static bool operator ==(double left, double right) => left == right;
 
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Inequality(TSelf, TOther)" />
         [NonVersionable]
         public static bool operator !=(double left, double right) => left != right;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
         [NonVersionable]
         public static bool operator <(double left, double right) => left < right;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
         [NonVersionable]
         public static bool operator >(double left, double right) => left > right;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
         [NonVersionable]
         public static bool operator <=(double left, double right) => left <= right;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
         [NonVersionable]
         public static bool operator >=(double left, double right) => left >= right;
 
@@ -454,23 +484,25 @@ namespace System
         // IAdditionOperators
         //
 
-        static double IAdditionOperators<double, double, double>.operator +(double left, double right)
-            => left + right;
+        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        static double IAdditionOperators<double, double, double>.operator +(double left, double right) => left + right;
 
-        // static checked double IAdditionOperators<double, double, double>.operator +(double left, double right)
-        //     => checked(left + right);
+        // /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        // static double IAdditionOperators<double, double, double>.operator checked +(double left, double right) => checked(left + right);
 
         //
         // IAdditiveIdentity
         //
 
-        static double IAdditiveIdentity<double, double>.AdditiveIdentity => 0.0;
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        static double IAdditiveIdentity<double, double>.AdditiveIdentity => AdditiveIdentity;
 
         //
         // IBinaryNumber
         //
 
-        static bool IBinaryNumber<double>.IsPow2(double value)
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
+        public static bool IsPow2(double value)
         {
             ulong bits = BitConverter.DoubleToUInt64Bits(value);
 
@@ -482,31 +514,35 @@ namespace System
                 && (significand == MinSignificand);
         }
 
-        static double IBinaryNumber<double>.Log2(double value)
-            => Math.Log2(value);
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />
+        public static double Log2(double value) => Math.Log2(value);
 
         //
         // IBitwiseOperators
         //
 
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseAnd(TSelf, TOther)" />
         static double IBitwiseOperators<double, double, double>.operator &(double left, double right)
         {
             ulong bits = BitConverter.DoubleToUInt64Bits(left) & BitConverter.DoubleToUInt64Bits(right);
             return BitConverter.UInt64BitsToDouble(bits);
         }
 
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseOr(TSelf, TOther)" />
         static double IBitwiseOperators<double, double, double>.operator |(double left, double right)
         {
             ulong bits = BitConverter.DoubleToUInt64Bits(left) | BitConverter.DoubleToUInt64Bits(right);
             return BitConverter.UInt64BitsToDouble(bits);
         }
 
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_ExclusiveOr(TSelf, TOther)" />
         static double IBitwiseOperators<double, double, double>.operator ^(double left, double right)
         {
             ulong bits = BitConverter.DoubleToUInt64Bits(left) ^ BitConverter.DoubleToUInt64Bits(right);
             return BitConverter.UInt64BitsToDouble(bits);
         }
 
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_OnesComplement(TSelf)" />
         static double IBitwiseOperators<double, double, double>.operator ~(double value)
         {
             ulong bits = ~BitConverter.DoubleToUInt64Bits(value);
@@ -514,324 +550,297 @@ namespace System
         }
 
         //
-        // IComparisonOperators
-        //
-
-        static bool IComparisonOperators<double, double>.operator <(double left, double right)
-            => left < right;
-
-        static bool IComparisonOperators<double, double>.operator <=(double left, double right)
-            => left <= right;
-
-        static bool IComparisonOperators<double, double>.operator >(double left, double right)
-            => left > right;
-
-        static bool IComparisonOperators<double, double>.operator >=(double left, double right)
-            => left >= right;
-
-        //
         // IDecrementOperators
         //
 
-        static double IDecrementOperators<double>.operator --(double value)
-            => --value;
+        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        static double IDecrementOperators<double>.operator --(double value) => --value;
 
-        // static checked double IDecrementOperators<double>.operator --(double value)
-        //     => checked(--value);
+        // /// <inheritdoc cref="IDecrementOperators{TSelf}.op_CheckedDecrement(TSelf)" />
+        // static double IDecrementOperators<double>.operator checked --(double value) => checked(--value);
 
         //
         // IDivisionOperators
         //
 
-        static double IDivisionOperators<double, double, double>.operator /(double left, double right)
-            => left / right;
+        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
+        static double IDivisionOperators<double, double, double>.operator /(double left, double right) => left / right;
 
-        // static checked double IDivisionOperators<double, double, double>.operator /(double left, double right)
-        //     => checked(left / right);
-
-        //
-        // IEqualityOperators
-        //
-
-        static bool IEqualityOperators<double, double>.operator ==(double left, double right)
-            => left == right;
-
-        static bool IEqualityOperators<double, double>.operator !=(double left, double right)
-            => left != right;
+        // /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
+        // static double IDivisionOperators<double, double, double>.operator checked /(double left, double right) => checked(left / right);
 
         //
         // IFloatingPoint
         //
 
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.E" />
         static double IFloatingPoint<double>.E => Math.E;
 
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Epsilon" />
         static double IFloatingPoint<double>.Epsilon => Epsilon;
 
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.NaN" />
         static double IFloatingPoint<double>.NaN => NaN;
 
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.NegativeInfinity" />
         static double IFloatingPoint<double>.NegativeInfinity => NegativeInfinity;
 
-        static double IFloatingPoint<double>.NegativeZero => -0.0;
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.NegativeZero" />
+        static double IFloatingPoint<double>.NegativeZero => NegativeZero;
 
-        static double IFloatingPoint<double>.Pi => Math.PI;
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Pi" />
+        static double IFloatingPoint<double>.Pi => Pi;
 
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.PositiveInfinity" />
         static double IFloatingPoint<double>.PositiveInfinity => PositiveInfinity;
 
-        static double IFloatingPoint<double>.Tau => Math.Tau;
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Tau" />
+        static double IFloatingPoint<double>.Tau => Tau;
 
-        static double IFloatingPoint<double>.Acos(double x)
-            => Math.Acos(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Acos(TSelf)" />
+        public static double Acos(double x) => Math.Acos(x);
 
-        static double IFloatingPoint<double>.Acosh(double x)
-            => Math.Acosh(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Acosh(TSelf)" />
+        public static double Acosh(double x) => Math.Acosh(x);
 
-        static double IFloatingPoint<double>.Asin(double x)
-            => Math.Asin(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Asin(TSelf)" />
+        public static double Asin(double x) => Math.Asin(x);
 
-        static double IFloatingPoint<double>.Asinh(double x)
-            => Math.Asinh(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Asinh(TSelf)" />
+        public static double Asinh(double x) => Math.Asinh(x);
 
-        static double IFloatingPoint<double>.Atan(double x)
-            => Math.Atan(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Atan(TSelf)" />
+        public static double Atan(double x) => Math.Atan(x);
 
-        static double IFloatingPoint<double>.Atan2(double y, double x)
-            => Math.Atan2(y, x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Atan2(TSelf, TSelf)" />
+        public static double Atan2(double y, double x) => Math.Atan2(y, x);
 
-        static double IFloatingPoint<double>.Atanh(double x)
-            => Math.Atanh(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Atanh(TSelf)" />
+        public static double Atanh(double x) => Math.Atanh(x);
 
-        static double IFloatingPoint<double>.BitIncrement(double x)
-            => Math.BitIncrement(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.BitIncrement(TSelf)" />
+        public static double BitIncrement(double x) => Math.BitIncrement(x);
 
-        static double IFloatingPoint<double>.BitDecrement(double x)
-            => Math.BitDecrement(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.BitDecrement(TSelf)" />
+        public static double BitDecrement(double x) => Math.BitDecrement(x);
 
-        static double IFloatingPoint<double>.Cbrt(double x)
-            => Math.Cbrt(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Cbrt(TSelf)" />
+        public static double Cbrt(double x) => Math.Cbrt(x);
 
-        static double IFloatingPoint<double>.Ceiling(double x)
-            => Math.Ceiling(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Ceiling(TSelf)" />
+        public static double Ceiling(double x) => Math.Ceiling(x);
 
-        static double IFloatingPoint<double>.CopySign(double x, double y)
-            => Math.CopySign(x, y);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.CopySign(TSelf, TSelf)" />
+        public static double CopySign(double x, double y) => Math.CopySign(x, y);
 
-        static double IFloatingPoint<double>.Cos(double x)
-            => Math.Cos(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Cos(TSelf)" />
+        public static double Cos(double x) => Math.Cos(x);
 
-        static double IFloatingPoint<double>.Cosh(double x)
-            => Math.Cosh(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Cosh(TSelf)" />
+        public static double Cosh(double x) => Math.Cosh(x);
 
-        static double IFloatingPoint<double>.Exp(double x)
-            => Math.Exp(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Exp" />
+        public static double Exp(double x) => Math.Exp(x);
 
-        static double IFloatingPoint<double>.Floor(double x)
-            => Math.Floor(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Floor(TSelf)" />
+        public static double Floor(double x) => Math.Floor(x);
 
-        static double IFloatingPoint<double>.FusedMultiplyAdd(double left, double right, double addend)
-            => Math.FusedMultiplyAdd(left, right, addend);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.FusedMultiplyAdd(TSelf, TSelf, TSelf)" />
+        public static double FusedMultiplyAdd(double left, double right, double addend) => Math.FusedMultiplyAdd(left, right, addend);
 
-        static double IFloatingPoint<double>.IEEERemainder(double left, double right)
-            => Math.IEEERemainder(left, right);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.IEEERemainder(TSelf, TSelf)" />
+        public static double IEEERemainder(double left, double right) => Math.IEEERemainder(left, right);
 
-        static TInteger IFloatingPoint<double>.ILogB<TInteger>(double x)
-            => TInteger.Create(Math.ILogB(x));
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.ILogB{TInteger}(TSelf)" />
+        public static TInteger ILogB<TInteger>(double x)
+            where TInteger : IBinaryInteger<TInteger> => TInteger.Create(Math.ILogB(x));
 
-        static double IFloatingPoint<double>.Log(double x)
-            => Math.Log(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Log(TSelf)" />
+        public static double Log(double x) => Math.Log(x);
 
-        static double IFloatingPoint<double>.Log(double x, double newBase)
-            => Math.Log(x, newBase);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Log(TSelf, TSelf)" />
+        public static double Log(double x, double newBase) => Math.Log(x, newBase);
 
-        static double IFloatingPoint<double>.Log2(double x)
-            => Math.Log2(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Log10(TSelf)" />
+        public static double Log10(double x) => Math.Log10(x);
 
-        static double IFloatingPoint<double>.Log10(double x)
-            => Math.Log10(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        public static double MaxMagnitude(double x, double y) => Math.MaxMagnitude(x, y);
 
-        static double IFloatingPoint<double>.MaxMagnitude(double x, double y)
-            => Math.MaxMagnitude(x, y);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        public static double MinMagnitude(double x, double y) => Math.MinMagnitude(x, y);
 
-        static double IFloatingPoint<double>.MinMagnitude(double x, double y)
-            => Math.MinMagnitude(x, y);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Pow(TSelf, TSelf)" />
+        public static double Pow(double x, double y) => Math.Pow(x, y);
 
-        static double IFloatingPoint<double>.Pow(double x, double y)
-            => Math.Pow(x, y);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Round(TSelf)" />
+        public static double Round(double x) => Math.Round(x);
 
-        static double IFloatingPoint<double>.Round(double x)
-            => Math.Round(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Round{TInteger}(TSelf, TInteger)" />
+        public static double Round<TInteger>(double x, TInteger digits)
+            where TInteger : IBinaryInteger<TInteger> => Math.Round(x, int.Create(digits));
 
-        static double IFloatingPoint<double>.Round<TInteger>(double x, TInteger digits)
-            => Math.Round(x, int.Create(digits));
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Round(TSelf, MidpointRounding)" />
+        public static double Round(double x, MidpointRounding mode) => Math.Round(x, mode);
 
-        static double IFloatingPoint<double>.Round(double x, MidpointRounding mode)
-            => Math.Round(x, mode);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Round{TInteger}(TSelf, TInteger, MidpointRounding)" />
+        public static double Round<TInteger>(double x, TInteger digits, MidpointRounding mode)
+            where TInteger : IBinaryInteger<TInteger> => Math.Round(x, int.Create(digits), mode);
 
-        static double IFloatingPoint<double>.Round<TInteger>(double x, TInteger digits, MidpointRounding mode)
-            => Math.Round(x, int.Create(digits), mode);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.ScaleB{TInteger}(TSelf, TInteger)" />
+        public static double ScaleB<TInteger>(double x, TInteger n)
+            where TInteger : IBinaryInteger<TInteger> => Math.ScaleB(x, int.Create(n));
 
-        static double IFloatingPoint<double>.ScaleB<TInteger>(double x, TInteger n)
-            => Math.ScaleB(x, int.Create(n));
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Sin(TSelf)" />
+        public static double Sin(double x) => Math.Sin(x);
 
-        static double IFloatingPoint<double>.Sin(double x)
-            => Math.Sin(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Sinh(TSelf)" />
+        public static double Sinh(double x) => Math.Sinh(x);
 
-        static double IFloatingPoint<double>.Sinh(double x)
-            => Math.Sinh(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Sqrt(TSelf)" />
+        public static double Sqrt(double x) => Math.Sqrt(x);
 
-        static double IFloatingPoint<double>.Sqrt(double x)
-            => Math.Sqrt(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Tan(TSelf)" />
+        public static double Tan(double x) => Math.Tan(x);
 
-        static double IFloatingPoint<double>.Tan(double x)
-            => Math.Tan(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Tanh(TSelf)" />
+        public static double Tanh(double x) => Math.Tanh(x);
 
-        static double IFloatingPoint<double>.Tanh(double x)
-            => Math.Tanh(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Truncate(TSelf)" />
+        public static double Truncate(double x) => Math.Truncate(x);
 
-        static double IFloatingPoint<double>.Truncate(double x)
-            => Math.Truncate(x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.AcosPi(TSelf)" />
+        // public static double AcosPi(double x) => Math.AcosPi(x);
 
-        static bool IFloatingPoint<double>.IsFinite(double d) => IsFinite(d);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.AsinPi(TSelf)" />
+        // public static double AsinPi(double x) => Math.AsinPi(x);
 
-        static bool IFloatingPoint<double>.IsInfinity(double d) => IsInfinity(d);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.AtanPi(TSelf)" />
+        // public static double AtanPi(double x) => Math.AtanPi(x);
 
-        static bool IFloatingPoint<double>.IsNaN(double d) => IsNaN(d);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Atan2Pi(TSelf)" />
+        // public static double Atan2Pi(double y, double x) => Math.Atan2Pi(y, x);
 
-        static bool IFloatingPoint<double>.IsNegative(double d) => IsNegative(d);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Compound(TSelf, TSelf)" />
+        // public static double Compound(double x, double n) => Math.Compound(x, n);
 
-        static bool IFloatingPoint<double>.IsNegativeInfinity(double d) => IsNegativeInfinity(d);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.CosPi(TSelf)" />
+        // public static double CosPi(double x) => Math.CosPi(x);
 
-        static bool IFloatingPoint<double>.IsNormal(double d) => IsNormal(d);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.ExpM1(TSelf)" />
+        // public static double ExpM1(double x) => Math.ExpM1(x);
 
-        static bool IFloatingPoint<double>.IsPositiveInfinity(double d) => IsPositiveInfinity(d);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Exp2(TSelf)" />
+        // public static double Exp2(double x) => Math.Exp2(x);
 
-        static bool IFloatingPoint<double>.IsSubnormal(double d) => IsSubnormal(d);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Exp2M1(TSelf)" />
+        // public static double Exp2M1(double x) => Math.Exp2M1(x);
 
-        // static double IFloatingPoint<double>.AcosPi(double x)
-        //     => Math.AcosPi(x);
-        //
-        // static double IFloatingPoint<double>.AsinPi(double x)
-        //     => Math.AsinPi(x);
-        //
-        // static double IFloatingPoint<double>.AtanPi(double x)
-        //     => Math.AtanPi(x);
-        //
-        // static double IFloatingPoint<double>.Atan2Pi(double y, double x)
-        //     => Math.Atan2Pi(y, x);
-        //
-        // static double IFloatingPoint<double>.Compound(double x, double n)
-        //     => Math.Compound(x, n);
-        //
-        // static double IFloatingPoint<double>.CosPi(double x)
-        //     => Math.CosPi(x);
-        //
-        // static double IFloatingPoint<double>.ExpM1(double x)
-        //     => Math.ExpM1(x);
-        //
-        // static double IFloatingPoint<double>.Exp2(double x)
-        //     => Math.Exp2(x);
-        //
-        // static double IFloatingPoint<double>.Exp2M1(double x)
-        //     => Math.Exp2M1(x);
-        //
-        // static double IFloatingPoint<double>.Exp10(double x)
-        //     => Math.Exp10(x);
-        //
-        // static double IFloatingPoint<double>.Exp10M1(double x)
-        //     => Math.Exp10M1(x);
-        //
-        // static double IFloatingPoint<double>.Hypot(double x, double y)
-        //     => Math.Hypot(x, y);
-        //
-        // static double IFloatingPoint<double>.LogP1(double x)
-        //     => Math.LogP1(x);
-        //
-        // static double IFloatingPoint<double>.Log2P1(double x)
-        //     => Math.Log2P1(x);
-        //
-        // static double IFloatingPoint<double>.Log10P1(double x)
-        //     => Math.Log10P1(x);
-        //
-        // static double IFloatingPoint<double>.MaxMagnitudeNumber(double x, double y)
-        //     => Math.MaxMagnitudeNumber(x, y);
-        //
-        // static double IFloatingPoint<double>.MaxNumber(double x, double y)
-        //     => Math.MaxNumber(x, y);
-        //
-        // static double IFloatingPoint<double>.MinMagnitudeNumber(double x, double y)
-        //     => Math.MinMagnitudeNumber(x, y);
-        //
-        // static double IFloatingPoint<double>.MinNumber(double x, double y)
-        //     => Math.MinNumber(x, y);
-        //
-        // static double IFloatingPoint<double>.Root(double x, double n)
-        //     => Math.Root(x, n);
-        //
-        // static double IFloatingPoint<double>.SinPi(double x)
-        //     => Math.SinPi(x, y);
-        //
-        // static double TanPi(double x)
-        //     => Math.TanPi(x, y);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Exp10(TSelf)" />
+        // public static double Exp10(double x) => Math.Exp10(x);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Exp10M1(TSelf)" />
+        // public static double Exp10M1(double x) => Math.Exp10M1(x);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Hypot(TSelf, TSelf)" />
+        // public static double Hypot(double x, double y) => Math.Hypot(x, y);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.LogP1(TSelf)" />
+        // public static double LogP1(double x) => Math.LogP1(x);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Log2P1(TSelf)" />
+        // public static double Log2P1(double x) => Math.Log2P1(x);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Log10P1(TSelf)" />
+        // public static double Log10P1(double x) => Math.Log10P1(x);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        // public static double MaxMagnitudeNumber(double x, double y) => Math.MaxMagnitudeNumber(x, y);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.MaxNumber(TSelf, TSelf)" />
+        // public static double MaxNumber(double x, double y) => Math.MaxNumber(x, y);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        // public static double MinMagnitudeNumber(double x, double y) => Math.MinMagnitudeNumber(x, y);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.MinNumber(TSelf, TSelf)" />
+        // public static double MinNumber(double x, double y) => Math.MinNumber(x, y);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Root(TSelf, TSelf)" />
+        // public static double Root(double x, double n) => Math.Root(x, n);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.SinPi(TSelf)" />
+        // public static double SinPi(double x) => Math.SinPi(x, y);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.TanPi(TSelf)" />
+        // public static double TanPi(double x) => Math.TanPi(x, y);
 
         //
         // IIncrementOperators
         //
 
-        static double IIncrementOperators<double>.operator ++(double value)
-            => ++value;
+        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_Increment(TSelf)" />
+        static double IIncrementOperators<double>.operator ++(double value) => ++value;
 
-        // static checked double IIncrementOperators<double>.operator ++(double value)
-        //     => checked(++value);
+        // /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
+        // static double IIncrementOperators<double>.operator checked ++(double value) => checked(++value);
 
         //
         // IMinMaxValue
         //
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MinValue" />
         static double IMinMaxValue<double>.MinValue => MinValue;
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MaxValue" />
         static double IMinMaxValue<double>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        static double IModulusOperators<double, double, double>.operator %(double left, double right)
-            => left % right;
+        /// <inheritdoc cref="IModulusOperators{TSelf, TOther, TResult}.op_Modulus(TSelf, TOther)" />
+        static double IModulusOperators<double, double, double>.operator %(double left, double right) => left % right;
 
-        // static checked double IModulusOperators<double, double, double>.operator %(double left, double right)
-        //     => checked(left % right);
+        // static checked double IModulusOperators<double, double, double>.operator %(double left, double right) => checked(left % right);
 
         //
         // IMultiplicativeIdentity
         //
 
-        static double IMultiplicativeIdentity<double, double>.MultiplicativeIdentity => 1.0;
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        static double IMultiplicativeIdentity<double, double>.MultiplicativeIdentity => MultiplicativeIdentity;
 
         //
         // IMultiplyOperators
         //
 
-        static double IMultiplyOperators<double, double, double>.operator *(double left, double right)
-            => (double)(left * right);
+        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
+        static double IMultiplyOperators<double, double, double>.operator *(double left, double right) => (double)(left * right);
 
-        // static checked double IMultiplyOperators<double, double, double>.operator *(double left, double right)
-        //     => checked((double)(left * right));
+        // /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
+        // static double IMultiplyOperators<double, double, double>.operator checked *(double left, double right) => checked((double)(left * right));
 
         //
         // INumber
         //
 
-        static double INumber<double>.One => 1.0;
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        static double INumber<double>.One => One;
 
-        static double INumber<double>.Zero => 0.0;
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        static double INumber<double>.Zero => Zero;
 
-        static double INumber<double>.Abs(double value)
-            => Math.Abs(value);
+        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
+        public static double Abs(double value) => Math.Abs(value);
 
-        static double INumber<double>.Clamp(double value, double min, double max)
-            => Math.Clamp(value, min, max);
+        /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
+        public static double Clamp(double value, double min, double max) => Math.Clamp(value, min, max);
 
+        /// <inheritdoc cref="INumber{TSelf}.Create{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static double INumber<double>.Create<TOther>(TOther value)
+        public static double Create<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -896,8 +905,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static double INumber<double>.CreateSaturating<TOther>(TOther value)
+        public static double CreateSaturating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -962,8 +973,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static double INumber<double>.CreateTruncating<TOther>(TOther value)
+        public static double CreateTruncating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1028,26 +1041,22 @@ namespace System
             }
         }
 
-        static (double Quotient, double Remainder) INumber<double>.DivRem(double left, double right)
-            => (left / right, left % right);
+        /// <inheritdoc cref="INumber{TSelf}.DivRem(TSelf, TSelf)" />
+        public static (double Quotient, double Remainder) DivRem(double left, double right) => (left / right, left % right);
 
-        static double INumber<double>.Max(double x, double y)
-            => Math.Max(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static double Max(double x, double y) => Math.Max(x, y);
 
-        static double INumber<double>.Min(double x, double y)
-            => Math.Min(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static double Min(double x, double y) => Math.Min(x, y);
 
-        static double INumber<double>.Parse(string s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static double Sign(double value) => Math.Sign(value);
 
-        static double INumber<double>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
-
-        static double INumber<double>.Sign(double value)
-            => Math.Sign(value);
-
+        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool INumber<double>.TryCreate<TOther>(TOther value, out double result)
+        public static bool TryCreate<TOther>(TOther value, out double result)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1127,66 +1136,57 @@ namespace System
             }
         }
 
-        static bool INumber<double>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out double result)
-            => TryParse(s, style, provider, out result);
-
-        static bool INumber<double>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out double result)
-            => TryParse(s, style, provider, out result);
-
         //
         // IParseable
         //
 
-        static double IParseable<double>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider);
-
-        static bool IParseable<double>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out double result)
-            => TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out double result) => TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
 
         //
         // ISignedNumber
         //
 
-        static double ISignedNumber<double>.NegativeOne => -1;
+        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        static double ISignedNumber<double>.NegativeOne => NegativeOne;
 
         //
         // ISpanParseable
         //
 
-        static double ISpanParseable<double>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
+        public static double Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider);
 
-        static bool ISpanParseable<double>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out double result)
-            => TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out double result) => TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
 
         //
         // ISubtractionOperators
         //
 
-        static double ISubtractionOperators<double, double, double>.operator -(double left, double right)
-            => (double)(left - right);
+        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_Subtraction(TSelf, TOther)" />
+        static double ISubtractionOperators<double, double, double>.operator -(double left, double right) => (double)(left - right);
 
-        // static checked double ISubtractionOperators<double, double, double>.operator -(double left, double right)
-        //     => checked((double)(left - right));
-
-        //
-        // IUnaryNegationOperators
-        //
-
-        static double IUnaryNegationOperators<double, double>.operator -(double value)
-            => (double)(-value);
-
-        // static checked double IUnaryNegationOperators<double, double>.operator -(double value)
-        //     => checked((double)(-value));
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static double ISubtractionOperators<double, double, double>.operator checked -(double left, double right) => checked((double)(left - right));
 
         //
         // IUnaryNegationOperators
         //
 
-        static double IUnaryPlusOperators<double, double>.operator +(double value)
-            => (double)(+value);
+        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_UnaryNegation(TSelf)" />
+        static double IUnaryNegationOperators<double, double>.operator -(double value) => (double)(-value);
 
-        // static checked double IUnaryPlusOperators<double, double>.operator +(double value)
-        //     => checked((double)(+value));
+        // /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
+        // static double IUnaryNegationOperators<double, double>.operator checked -(double value) => checked((double)(-value));
+
+        //
+        // IUnaryPlusOperators
+        //
+
+        /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_UnaryPlus(TSelf)" />
+        static double IUnaryPlusOperators<double, double>.operator +(double value) => (double)(+value);
+
+        // /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_CheckedUnaryPlus(TSelf)" />
+        // static double IUnaryPlusOperators<double, double>.operator checked +(double value) => checked((double)(+value));
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -1221,7 +1221,8 @@ namespace System
         // IComparisonOperators
         //
 
-        static bool IComparisonOperators<Guid, Guid>.operator <(Guid left, Guid right)
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
+        public static bool operator <(Guid left, Guid right)
         {
             if (left._a != right._a)
             {
@@ -1281,7 +1282,8 @@ namespace System
             return false;
         }
 
-        static bool IComparisonOperators<Guid, Guid>.operator <=(Guid left, Guid right)
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
+        public static bool operator <=(Guid left, Guid right)
         {
             if (left._a != right._a)
             {
@@ -1341,7 +1343,8 @@ namespace System
             return true;
         }
 
-        static bool IComparisonOperators<Guid, Guid>.operator >(Guid left, Guid right)
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
+        public static bool operator >(Guid left, Guid right)
         {
             if (left._a != right._a)
             {
@@ -1401,7 +1404,8 @@ namespace System
             return false;
         }
 
-        static bool IComparisonOperators<Guid, Guid>.operator >=(Guid left, Guid right)
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
+        public static bool operator >=(Guid left, Guid right)
         {
             if (left._a != right._a)
             {
@@ -1460,35 +1464,25 @@ namespace System
 
             return true;
         }
-
-        //
-        // IEqualityOperators
-        //
-
-        static bool IEqualityOperators<Guid, Guid>.operator ==(Guid left, Guid right)
-            => left == right;
-
-        static bool IEqualityOperators<Guid, Guid>.operator !=(Guid left, Guid right)
-            => left != right;
 
         //
         // IParseable
         //
 
-        static Guid IParseable<Guid>.Parse(string s, IFormatProvider? provider)
-            => Parse(s);
+        /// <inheritdoc cref="IParseable{TSelf}.Parse(string, IFormatProvider?)" />
+        public static Guid Parse(string s, IFormatProvider? provider) => Parse(s);
 
-        static bool IParseable<Guid>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out Guid result)
-            => TryParse(s, out result);
+        /// <inheritdoc cref="IParseable{TSelf}.TryParse(string?, IFormatProvider?, out TSelf)" />
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out Guid result) => TryParse(s, out result);
 
         //
         // ISpanParseable
         //
 
-        static Guid ISpanParseable<Guid>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
+        public static Guid Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s);
 
-        static bool ISpanParseable<Guid>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Guid result)
-            => TryParse(s, out result);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Guid result) => TryParse(s, out result);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -64,6 +64,13 @@ namespace System
         private const ushort MinValueBits = 0xFBFF;
         private const ushort MaxValueBits = 0x7BFF;
 
+        private const ushort PositiveOneBits = 0x3C00;
+        private const ushort NegativeOneBits = 0xBC00;
+
+        private const ushort EBits = 0x4170;
+        private const ushort PiBits = 0x4248;
+        private const ushort TauBits = 0x4648;
+
         // Well-defined and commonly used values
 
         public static Half Epsilon => new Half(EpsilonBits);                        //  5.9604645E-08
@@ -74,13 +81,11 @@ namespace System
 
         public static Half NaN => new Half(NegativeQNaNBits);                       //  0.0 / 0.0
 
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
         public static Half MinValue => new Half(MinValueBits);                      // -65504
 
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
         public static Half MaxValue => new Half(MaxValueBits);                      //  65504
-
-        // We use these explicit definitions to avoid the confusion between 0.0 and -0.0.
-        private static readonly Half PositiveZero = new Half(PositiveZeroBits);            //  0.0
-        private static readonly Half NegativeZero = new Half(NegativeZeroBits);            // -0.0
 
         private readonly ushort _value;
 
@@ -89,8 +94,7 @@ namespace System
             _value = value;
         }
 
-        private Half(bool sign, ushort exp, ushort sig)
-            => _value = (ushort)(((sign ? 1 : 0) << SignShift) + (exp << ExponentShift) + sig);
+        private Half(bool sign, ushort exp, ushort sig) => _value = (ushort)(((sign ? 1 : 0) << SignShift) + (exp << ExponentShift) + sig);
 
         private sbyte Exponent
         {
@@ -108,6 +112,7 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
         public static bool operator <(Half left, Half right)
         {
             if (IsNaN(left) || IsNaN(right))
@@ -129,11 +134,13 @@ namespace System
             return (left._value != right._value) && ((left._value < right._value) ^ leftIsNegative);
         }
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
         public static bool operator >(Half left, Half right)
         {
             return right < left;
         }
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
         public static bool operator <=(Half left, Half right)
         {
             if (IsNaN(left) || IsNaN(right))
@@ -155,11 +162,13 @@ namespace System
             return (left._value == right._value) || ((left._value < right._value) ^ leftIsNegative);
         }
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
         public static bool operator >=(Half left, Half right)
         {
             return right <= left;
         }
 
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Equality(TSelf, TOther)" />
         public static bool operator ==(Half left, Half right)
         {
             if (IsNaN(left) || IsNaN(right))
@@ -172,6 +181,7 @@ namespace System
             return (left._value == right._value) || AreZero(left, right);
         }
 
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Inequality(TSelf, TOther)" />
         public static bool operator !=(Half left, Half right)
         {
             return !(left == right);
@@ -668,11 +678,9 @@ namespace System
         // If any bits are lost by shifting, "jam" them into the LSB.
         // if dist > bit count, Will be 1 or 0 depending on i
         // (unlike bitwise operators that masks the lower 5 bits)
-        private static uint ShiftRightJam(uint i, int dist)
-            => dist < 31 ? (i >> dist) | (i << (-dist & 31) != 0 ? 1U : 0U) : (i != 0 ? 1U : 0U);
+        private static uint ShiftRightJam(uint i, int dist) => dist < 31 ? (i >> dist) | (i << (-dist & 31) != 0 ? 1U : 0U) : (i != 0 ? 1U : 0U);
 
-        private static ulong ShiftRightJam(ulong l, int dist)
-            => dist < 63 ? (l >> dist) | (l << (-dist & 63) != 0 ? 1UL : 0UL) : (l != 0 ? 1UL : 0UL);
+        private static ulong ShiftRightJam(ulong l, int dist) => dist < 63 ? (l >> dist) | (l << (-dist & 63) != 0 ? 1UL : 0UL) : (l != 0 ? 1UL : 0UL);
 
         private static float CreateSingleNaN(bool sign, ulong significand)
         {
@@ -694,11 +702,9 @@ namespace System
             return BitConverter.UInt64BitsToDouble(signInt | NaNBits | sigInt);
         }
 
-        private static float CreateSingle(bool sign, byte exp, uint sig)
-            => BitConverter.UInt32BitsToSingle(((sign ? 1U : 0U) << float.SignShift) + ((uint)exp << float.ExponentShift) + sig);
+        private static float CreateSingle(bool sign, byte exp, uint sig) => BitConverter.UInt32BitsToSingle(((sign ? 1U : 0U) << float.SignShift) + ((uint)exp << float.ExponentShift) + sig);
 
-        private static double CreateDouble(bool sign, ushort exp, ulong sig)
-            => BitConverter.UInt64BitsToDouble(((sign ? 1UL : 0UL) << double.SignShift) + ((ulong)exp << double.ExponentShift) + sig);
+        private static double CreateDouble(bool sign, ushort exp, ulong sig) => BitConverter.UInt64BitsToDouble(((sign ? 1UL : 0UL) << double.SignShift) + ((ulong)exp << double.ExponentShift) + sig);
 
         #endregion
 
@@ -706,59 +712,65 @@ namespace System
         // IAdditionOperators
         //
 
-        static Half IAdditionOperators<Half, Half, Half>.operator +(Half left, Half right)
-            => (Half)((float)left + (float)right);
+        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        public static Half operator +(Half left, Half right) => (Half)((float)left + (float)right);
 
-        // static checked Half IAdditionOperators<Half, Half, Half>.operator +(Half left, Half right)
-        //     => checked((Half)((float)left + (float)right));
+        // /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        // static Half IAdditionOperators<Half, Half, Half>.operator checked +(Half left, Half right) => checked((Half)((float)left + (float)right));
 
         //
         // IAdditiveIdentity
         //
 
-        static Half IAdditiveIdentity<Half, Half>.AdditiveIdentity => PositiveZero;
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        public static Half AdditiveIdentity => new Half(PositiveZeroBits);
 
         //
         // IBinaryNumber
         //
 
-        static bool IBinaryNumber<Half>.IsPow2(Half value)
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
+        public static bool IsPow2(Half value)
         {
             uint bits = BitConverter.HalfToUInt16Bits(value);
 
             uint exponent = (bits >> ExponentShift) & ShiftedExponentMask;
             uint significand = bits & SignificandMask;
 
-            return (value > PositiveZero)
+            return (value > Zero)
                 && (exponent != MinExponent) && (exponent != MaxExponent)
                 && (significand == MinSignificand);
         }
 
-        static Half IBinaryNumber<Half>.Log2(Half value)
-            => (Half)MathF.Log2((float)value);
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />
+        public static Half Log2(Half value) => (Half)MathF.Log2((float)value);
 
         //
         // IBitwiseOperators
         //
 
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseAnd(TSelf, TOther)" />
         static Half IBitwiseOperators<Half, Half, Half>.operator &(Half left, Half right)
         {
             ushort bits = (ushort)(BitConverter.HalfToUInt16Bits(left) & BitConverter.HalfToUInt16Bits(right));
             return BitConverter.UInt16BitsToHalf(bits);
         }
 
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseOr(TSelf, TOther)" />
         static Half IBitwiseOperators<Half, Half, Half>.operator |(Half left, Half right)
         {
             ushort bits = (ushort)(BitConverter.HalfToUInt16Bits(left) | BitConverter.HalfToUInt16Bits(right));
             return BitConverter.UInt16BitsToHalf(bits);
         }
 
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_ExclusiveOr(TSelf, TOther)" />
         static Half IBitwiseOperators<Half, Half, Half>.operator ^(Half left, Half right)
         {
             ushort bits = (ushort)(BitConverter.HalfToUInt16Bits(left) ^ BitConverter.HalfToUInt16Bits(right));
             return BitConverter.UInt16BitsToHalf(bits);
         }
 
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_OnesComplement(TSelf)" />
         static Half IBitwiseOperators<Half, Half, Half>.operator ~(Half value)
         {
             ushort bits = (ushort)(~BitConverter.HalfToUInt16Bits(value));
@@ -766,33 +778,19 @@ namespace System
         }
 
         //
-        // IComparisonOperators
-        //
-
-        static bool IComparisonOperators<Half, Half>.operator <(Half left, Half right)
-            => left < right;
-
-        static bool IComparisonOperators<Half, Half>.operator <=(Half left, Half right)
-            => left <= right;
-
-        static bool IComparisonOperators<Half, Half>.operator >(Half left, Half right)
-            => left > right;
-
-        static bool IComparisonOperators<Half, Half>.operator >=(Half left, Half right)
-            => left >= right;
-
-        //
         // IDecrementOperators
         //
 
-        static Half IDecrementOperators<Half>.operator --(Half value)
+        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        public static Half operator --(Half value)
         {
             var tmp = (float)value;
             --tmp;
             return (Half)tmp;
         }
 
-        // static checked Half IDecrementOperators<Half>.operator --(Half value)
+        // /// <inheritdoc cref="IDecrementOperators{TSelf}.op_CheckedDecrement(TSelf)" />
+        // static Half IDecrementOperators<Half>.operator checked --(Half value)
         // {
         //     var tmp = (float)value;
         //     --tmp;
@@ -800,295 +798,223 @@ namespace System
         // }
 
         //
-        // IEqualityOperators
-        //
-
-        static bool IEqualityOperators<Half, Half>.operator ==(Half left, Half right)
-            => left == right;
-
-        static bool IEqualityOperators<Half, Half>.operator !=(Half left, Half right)
-            => left != right;
-
-        //
         // IDivisionOperators
         //
 
-        static Half IDivisionOperators<Half, Half, Half>.operator /(Half left, Half right)
-            => (Half)((float)left / (float)right);
+        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
+        public static Half operator /(Half left, Half right) => (Half)((float)left / (float)right);
 
-        // static checked Half IDivisionOperators<Half, Half, Half>.operator /(Half left, Half right)
-        //     => checked((Half)((float)left / (float)right));
+        // /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
+        // static Half IDivisionOperators<Half, Half, Half>.operator checked /(Half left, Half right) => checked((Half)((float)left / (float)right));
 
         //
         // IFloatingPoint
         //
 
-        static Half IFloatingPoint<Half>.E => (Half)MathF.E;
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.E" />
+        public static Half E => new Half(EBits);
 
-        static Half IFloatingPoint<Half>.Epsilon => Epsilon;
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.NegativeZero" />
+        public static Half NegativeZero => new Half(NegativeZeroBits);
 
-        static Half IFloatingPoint<Half>.NaN => NaN;
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Pi" />
+        public static Half Pi => new Half(PiBits);
 
-        static Half IFloatingPoint<Half>.NegativeInfinity => NegativeInfinity;
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Tau" />
+        public static Half Tau => new Half(TauBits);
 
-        static Half IFloatingPoint<Half>.NegativeZero => NegativeZero;
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Acos(TSelf)" />
+        public static Half Acos(Half x) => (Half)MathF.Acos((float)x);
 
-        static Half IFloatingPoint<Half>.Pi => (Half)MathF.PI;
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Acosh(TSelf)" />
+        public static Half Acosh(Half x) => (Half)MathF.Acosh((float)x);
 
-        static Half IFloatingPoint<Half>.PositiveInfinity => PositiveInfinity;
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Asin(TSelf)" />
+        public static Half Asin(Half x) => (Half)MathF.Asin((float)x);
 
-        static Half IFloatingPoint<Half>.Tau => (Half)MathF.Tau;
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Asinh(TSelf)" />
+        public static Half Asinh(Half x) => (Half)MathF.Asinh((float)x);
 
-        static Half IFloatingPoint<Half>.Acos(Half x)
-            => (Half)MathF.Acos((float)x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Atan(TSelf)" />
+        public static Half Atan(Half x) => (Half)MathF.Atan((float)x);
 
-        static Half IFloatingPoint<Half>.Acosh(Half x)
-            => (Half)MathF.Acosh((float)x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Atan2(TSelf, TSelf)" />
+        public static Half Atan2(Half y, Half x) => (Half)MathF.Atan2((float)y, (float)x);
 
-        static Half IFloatingPoint<Half>.Asin(Half x)
-            => (Half)MathF.Asin((float)x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Atanh(TSelf)" />
+        public static Half Atanh(Half x) => (Half)MathF.Atanh((float)x);
 
-        static Half IFloatingPoint<Half>.Asinh(Half x)
-            => (Half)MathF.Asinh((float)x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.BitIncrement(TSelf)" />
+        public static Half BitIncrement(Half x) => (Half)MathF.BitIncrement((float)x);
 
-        static Half IFloatingPoint<Half>.Atan(Half x)
-            => (Half)MathF.Atan((float)x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.BitDecrement(TSelf)" />
+        public static Half BitDecrement(Half x) => (Half)MathF.BitDecrement((float)x);
 
-        static Half IFloatingPoint<Half>.Atan2(Half y, Half x)
-            => (Half)MathF.Atan2((float)y, (float)x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Cbrt(TSelf)" />
+        public static Half Cbrt(Half x) => (Half)MathF.Cbrt((float)x);
 
-        static Half IFloatingPoint<Half>.Atanh(Half x)
-            => (Half)MathF.Atanh((float)x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Ceiling(TSelf)" />
+        public static Half Ceiling(Half x) => (Half)MathF.Ceiling((float)x);
 
-        static Half IFloatingPoint<Half>.BitIncrement(Half x)
-        {
-            ushort bits = BitConverter.HalfToUInt16Bits(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.CopySign(TSelf, TSelf)" />
+        public static Half CopySign(Half x, Half y) => (Half)MathF.CopySign((float)x, (float)y);
 
-            if ((bits & ExponentMask) >= ExponentMask)
-            {
-                // NaN returns NaN
-                // -Infinity returns float.MinValue
-                // +Infinity returns +Infinity
-                return (bits == (ExponentMask | SignMask)) ? MinValue : x;
-            }
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Cos(TSelf)" />
+        public static Half Cos(Half x) => (Half)MathF.Cos((float)x);
 
-            if (bits == NegativeZeroBits)
-            {
-                // -0.0 returns float.Epsilon
-                return Epsilon;
-            }
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Cosh(TSelf)" />
+        public static Half Cosh(Half x) => (Half)MathF.Cosh((float)x);
 
-            // Negative values need to be decremented
-            // Positive values need to be incremented
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Exp" />
+        public static Half Exp(Half x) => (Half)MathF.Exp((float)x);
 
-            bits += unchecked((ushort)((bits < 0) ? -1 : +1));
-            return BitConverter.UInt16BitsToHalf(bits);
-        }
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Floor(TSelf)" />
+        public static Half Floor(Half x) => (Half)MathF.Floor((float)x);
 
-        static Half IFloatingPoint<Half>.BitDecrement(Half x)
-        {
-            ushort bits = BitConverter.HalfToUInt16Bits(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.FusedMultiplyAdd(TSelf, TSelf, TSelf)" />
+        public static Half FusedMultiplyAdd(Half left, Half right, Half addend) => (Half)MathF.FusedMultiplyAdd((float)left, (float)right, (float)addend);
 
-            if ((bits & ExponentMask) >= ExponentMask)
-            {
-                // NaN returns NaN
-                // -Infinity returns -Infinity
-                // +Infinity returns float.MaxValue
-                return (bits == ExponentMask) ? MaxValue : x;
-            }
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.IEEERemainder(TSelf, TSelf)" />
+        public static Half IEEERemainder(Half left, Half right) => (Half)MathF.IEEERemainder((float)left, (float)right);
 
-            if (bits == PositiveZeroBits)
-            {
-                // +0.0 returns -float.Epsilon
-                return new Half(EpsilonBits | SignMask);
-            }
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.ILogB{TInteger}(TSelf)" />
+        public static TInteger ILogB<TInteger>(Half x)
+            where TInteger : IBinaryInteger<TInteger> => TInteger.Create(MathF.ILogB((float)x));
 
-            // Negative values need to be incremented
-            // Positive values need to be decremented
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Log(TSelf)" />
+        public static Half Log(Half x) => (Half)MathF.Log((float)x);
 
-            bits += (ushort)((bits < 0) ? +1 : -1);
-            return BitConverter.UInt16BitsToHalf(bits);
-        }
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Log(TSelf, TSelf)" />
+        public static Half Log(Half x, Half newBase) => (Half)MathF.Log((float)x, (float)newBase);
 
-        static Half IFloatingPoint<Half>.Cbrt(Half x)
-            => (Half)MathF.Cbrt((float)x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Log10(TSelf)" />
+        public static Half Log10(Half x) => (Half)MathF.Log10((float)x);
 
-        static Half IFloatingPoint<Half>.Ceiling(Half x)
-            => (Half)MathF.Ceiling((float)x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        public static Half MaxMagnitude(Half x, Half y) => (Half)MathF.MaxMagnitude((float)x, (float)y);
 
-        static Half IFloatingPoint<Half>.CopySign(Half x, Half y)
-            => (Half)MathF.CopySign((float)x, (float)y);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        public static Half MinMagnitude(Half x, Half y) => (Half)MathF.MinMagnitude((float)x, (float)y);
 
-        static Half IFloatingPoint<Half>.Cos(Half x)
-            => (Half)MathF.Cos((float)x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Pow(TSelf, TSelf)" />
+        public static Half Pow(Half x, Half y) => (Half)MathF.Pow((float)x, (float)y);
 
-        static Half IFloatingPoint<Half>.Cosh(Half x)
-            => (Half)MathF.Cosh((float)x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Round(TSelf)" />
+        public static Half Round(Half x) => (Half)MathF.Round((float)x);
 
-        static Half IFloatingPoint<Half>.Exp(Half x)
-            => (Half)MathF.Exp((float)x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Round{TInteger}(TSelf, TInteger)" />
+        public static Half Round<TInteger>(Half x, TInteger digits)
+            where TInteger : IBinaryInteger<TInteger> => (Half)MathF.Round((float)x, int.Create(digits));
 
-        static Half IFloatingPoint<Half>.Floor(Half x)
-            => (Half)MathF.Floor((float)x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Round(TSelf, MidpointRounding)" />
+        public static Half Round(Half x, MidpointRounding mode) => (Half)MathF.Round((float)x, mode);
 
-        static Half IFloatingPoint<Half>.FusedMultiplyAdd(Half left, Half right, Half addend)
-            => (Half)MathF.FusedMultiplyAdd((float)left, (float)right, (float)addend);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Round{TInteger}(TSelf, TInteger, MidpointRounding)" />
+        public static Half Round<TInteger>(Half x, TInteger digits, MidpointRounding mode)
+            where TInteger : IBinaryInteger<TInteger> => (Half)MathF.Round((float)x, int.Create(digits), mode);
 
-        static Half IFloatingPoint<Half>.IEEERemainder(Half left, Half right)
-            => (Half)MathF.IEEERemainder((float)left, (float)right);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.ScaleB{TInteger}(TSelf, TInteger)" />
+        public static Half ScaleB<TInteger>(Half x, TInteger n)
+            where TInteger : IBinaryInteger<TInteger> => (Half)MathF.ScaleB((float)x, int.Create(n));
 
-        static TInteger IFloatingPoint<Half>.ILogB<TInteger>(Half x)
-            => TInteger.Create(MathF.ILogB((float)x));
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Sin(TSelf)" />
+        public static Half Sin(Half x) => (Half)MathF.Sin((float)x);
 
-        static Half IFloatingPoint<Half>.Log(Half x)
-            => (Half)MathF.Log((float)x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Sinh(TSelf)" />
+        public static Half Sinh(Half x) => (Half)MathF.Sinh((float)x);
 
-        static Half IFloatingPoint<Half>.Log(Half x, Half newBase)
-            => (Half)MathF.Log((float)x, (float)newBase);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Sqrt(TSelf)" />
+        public static Half Sqrt(Half x) => (Half)MathF.Sqrt((float)x);
 
-        static Half IFloatingPoint<Half>.Log2(Half x)
-            => (Half)MathF.Log2((float)x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Tan(TSelf)" />
+        public static Half Tan(Half x) => (Half)MathF.Tan((float)x);
 
-        static Half IFloatingPoint<Half>.Log10(Half x)
-            => (Half)MathF.Log10((float)x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Tanh(TSelf)" />
+        public static Half Tanh(Half x) => (Half)MathF.Tanh((float)x);
 
-        static Half IFloatingPoint<Half>.MaxMagnitude(Half x, Half y)
-            => (Half)MathF.MaxMagnitude((float)x, (float)y);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Truncate(TSelf)" />
+        public static Half Truncate(Half x) => (Half)MathF.Truncate((float)x);
 
-        static Half IFloatingPoint<Half>.MinMagnitude(Half x, Half y)
-            => (Half)MathF.MinMagnitude((float)x, (float)y);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.AcosPi(TSelf)" />
+        // public static Half AcosPi(Half x) => (Half)MathF.AcosPi((float)x);
 
-        static Half IFloatingPoint<Half>.Pow(Half x, Half y)
-            => (Half)MathF.Pow((float)x, (float)y);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.AsinPi(TSelf)" />
+        // public static Half AsinPi(Half x) => (Half)MathF.AsinPi((float)x);
 
-        static Half IFloatingPoint<Half>.Round(Half x)
-            => (Half)MathF.Round((float)x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.AtanPi(TSelf)" />
+        // public static Half AtanPi(Half x) => (Half)MathF.AtanPi((float)x);
 
-        static Half IFloatingPoint<Half>.Round<TInteger>(Half x, TInteger digits)
-            => (Half)MathF.Round((float)x, int.Create(digits));
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Atan2Pi(TSelf)" />
+        // public static Half Atan2Pi(Half y, Half x) => (Half)MathF.Atan2Pi((float)y, (float)x);
 
-        static Half IFloatingPoint<Half>.Round(Half x, MidpointRounding mode)
-            => (Half)MathF.Round((float)x, mode);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Compound(TSelf, TSelf)" />
+        // public static Half Compound(Half x, Half n) => (Half)MathF.Compound((float)x, (float)n);
 
-        static Half IFloatingPoint<Half>.Round<TInteger>(Half x, TInteger digits, MidpointRounding mode)
-            => (Half)MathF.Round((float)x, int.Create(digits), mode);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.CosPi(TSelf)" />
+        // public static Half CosPi(Half x) => (Half)MathF.CosPi((float)x);
 
-        static Half IFloatingPoint<Half>.ScaleB<TInteger>(Half x, TInteger n)
-            => (Half)MathF.ScaleB((float)x, int.Create(n));
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.ExpM1(TSelf)" />
+        // public static Half ExpM1(Half x) => (Half)MathF.ExpM1((float)x);
 
-        static Half IFloatingPoint<Half>.Sin(Half x)
-            => (Half)MathF.Sin((float)x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Exp2(TSelf)" />
+        // public static Half Exp2(Half x) => (Half)MathF.Exp2((float)x);
 
-        static Half IFloatingPoint<Half>.Sinh(Half x)
-            => (Half)MathF.Sinh((float)x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Exp2M1(TSelf)" />
+        // public static Half Exp2M1(Half x) => (Half)MathF.Exp2M1((float)x);
 
-        static Half IFloatingPoint<Half>.Sqrt(Half x)
-            => (Half)MathF.Sqrt((float)x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Exp10(TSelf)" />
+        // public static Half Exp10(Half x) => (Half)MathF.Exp10((float)x);
 
-        static Half IFloatingPoint<Half>.Tan(Half x)
-            => (Half)MathF.Tan((float)x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Exp10M1(TSelf)" />
+        // public static Half Exp10M1(Half x) => (Half)MathF.Exp10M1((float)x);
 
-        static Half IFloatingPoint<Half>.Tanh(Half x)
-            => (Half)MathF.Tanh((float)x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Hypot(TSelf, TSelf)" />
+        // public static Half Hypot(Half x, Half y) => (Half)MathF.Hypot((float)x, (float)y);
 
-        static Half IFloatingPoint<Half>.Truncate(Half x)
-            => (Half)MathF.Truncate((float)x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.LogP1(TSelf)" />
+        // public static Half LogP1(Half x) => (Half)MathF.LogP1((float)x);
 
-        static bool IFloatingPoint<Half>.IsFinite(Half x) => IsFinite(x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Log2P1(TSelf)" />
+        // public static Half Log2P1(Half x) => (Half)MathF.Log2P1((float)x);
 
-        static bool IFloatingPoint<Half>.IsInfinity(Half x) => IsInfinity(x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Log10P1(TSelf)" />
+        // public static Half Log10P1(Half x) => (Half)MathF.Log10P1((float)x);
 
-        static bool IFloatingPoint<Half>.IsNaN(Half x) => IsNaN(x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        // public static Half MaxMagnitudeNumber(Half x, Half y) => (Half)MathF.MaxMagnitudeNumber((float)x, (float)y);
 
-        static bool IFloatingPoint<Half>.IsNegative(Half x) => IsNegative(x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.MaxNumber(TSelf, TSelf)" />
+        // public static Half MaxNumber(Half x, Half y) => (Half)MathF.MaxNumber((float)x, (float)y);
 
-        static bool IFloatingPoint<Half>.IsNegativeInfinity(Half x) => IsNegativeInfinity(x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        // public static Half MinMagnitudeNumber(Half x, Half y) => (Half)MathF.MinMagnitudeNumber((float)x, (float)y);
 
-        static bool IFloatingPoint<Half>.IsNormal(Half x) => IsNormal(x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.MinNumber(TSelf, TSelf)" />
+        // public static Half MinNumber(Half x, Half y) => (Half)MathF.MinNumber((float)x, (float)y);
 
-        static bool IFloatingPoint<Half>.IsPositiveInfinity(Half x) => IsPositiveInfinity(x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Root(TSelf, TSelf)" />
+        // public static Half Root(Half x, Half n) => (Half)MathF.Root((float)x, (float)n);
 
-        static bool IFloatingPoint<Half>.IsSubnormal(Half x) => IsSubnormal(x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.SinPi(TSelf)" />
+        // public static Half SinPi(Half x) => (Half)MathF.SinPi((float)x, (float)y);
 
-
-        // static Half IFloatingPoint<Half>.AcosPi(Half x)
-        //     => (Half)MathF.AcosPi((float)x);
-        //
-        // static Half IFloatingPoint<Half>.AsinPi(Half x)
-        //     => (Half)MathF.AsinPi((float)x);
-        //
-        // static Half IFloatingPoint<Half>.AtanPi(Half x)
-        //     => (Half)MathF.AtanPi((float)x);
-        //
-        // static Half IFloatingPoint<Half>.Atan2Pi(Half y, Half x)
-        //     => (Half)MathF.Atan2Pi((float)y, (float)x);
-        //
-        // static Half IFloatingPoint<Half>.Compound(Half x, Half n)
-        //     => (Half)MathF.Compound((float)x, (float)n);
-        //
-        // static Half IFloatingPoint<Half>.CosPi(Half x)
-        //     => (Half)MathF.CosPi((float)x);
-        //
-        // static Half IFloatingPoint<Half>.ExpM1(Half x)
-        //     => (Half)MathF.ExpM1((float)x);
-        //
-        // static Half IFloatingPoint<Half>.Exp2(Half x)
-        //     => (Half)MathF.Exp2((float)x);
-        //
-        // static Half IFloatingPoint<Half>.Exp2M1(Half x)
-        //     => (Half)MathF.Exp2M1((float)x);
-        //
-        // static Half IFloatingPoint<Half>.Exp10(Half x)
-        //     => (Half)MathF.Exp10((float)x);
-        //
-        // static Half IFloatingPoint<Half>.Exp10M1(Half x)
-        //     => (Half)MathF.Exp10M1((float)x);
-        //
-        // static Half IFloatingPoint<Half>.Hypot(Half x, Half y)
-        //     => (Half)MathF.Hypot((float)x, (float)y);
-        //
-        // static Half IFloatingPoint<Half>.LogP1(Half x)
-        //     => (Half)MathF.LogP1((float)x);
-        //
-        // static Half IFloatingPoint<Half>.Log2P1(Half x)
-        //     => (Half)MathF.Log2P1((float)x);
-        //
-        // static Half IFloatingPoint<Half>.Log10P1(Half x)
-        //     => (Half)MathF.Log10P1((float)x);
-        //
-        // static Half IFloatingPoint<Half>.MaxMagnitudeNumber(Half x, Half y)
-        //     => (Half)MathF.MaxMagnitudeNumber((float)x, (float)y);
-        //
-        // static Half IFloatingPoint<Half>.MaxNumber(Half x, Half y)
-        //     => (Half)MathF.MaxNumber((float)x, (float)y);
-        //
-        // static Half IFloatingPoint<Half>.MinMagnitudeNumber(Half x, Half y)
-        //     => (Half)MathF.MinMagnitudeNumber((float)x, (float)y);
-        //
-        // static Half IFloatingPoint<Half>.MinNumber(Half x, Half y)
-        //     => (Half)MathF.MinNumber((float)x, (float)y);
-        //
-        // static Half IFloatingPoint<Half>.Root(Half x, Half n)
-        //     => (Half)MathF.Root((float)x, (float)n);
-        //
-        // static Half IFloatingPoint<Half>.SinPi(Half x)
-        //     => (Half)MathF.SinPi((float)x, (float)y);
-        //
-        // static Half TanPi(Half x)
-        //     => (Half)MathF.TanPi((float)x, (float)y);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.TanPi(TSelf)" />
+        // public static Half TanPi(Half x) => (Half)MathF.TanPi((float)x, (float)y);
 
         //
         // IIncrementOperators
         //
 
-        static Half IIncrementOperators<Half>.operator ++(Half value)
+        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_Increment(TSelf)" />
+        public static Half operator ++(Half value)
         {
             var tmp = (float)value;
             ++tmp;
             return (Half)tmp;
         }
 
-        // static checked Half IIncrementOperators<Half>.operator ++(Half value)
+        // /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
+        // static Half IIncrementOperators<Half>.operator checked ++(Half value)
         // {
         //     var tmp = (float)value;
         //     ++tmp;
@@ -1096,55 +1022,49 @@ namespace System
         // }
 
         //
-        // IMinMaxValue
-        //
-
-        static Half IMinMaxValue<Half>.MinValue => MinValue;
-
-        static Half IMinMaxValue<Half>.MaxValue => MaxValue;
-
-        //
         // IModulusOperators
         //
 
-        static Half IModulusOperators<Half, Half, Half>.operator %(Half left, Half right)
-            => (Half)((float)left % (float)right);
-
-        // static checked Half IModulusOperators<Half, Half, Half>.operator %(Half left, Half right)
-        //     => checked((Half)((float)left % (float)right));
+        /// <inheritdoc cref="IModulusOperators{TSelf, TOther, TResult}.op_Modulus(TSelf, TOther)" />
+        public static Half operator %(Half left, Half right) => (Half)((float)left % (float)right);
 
         //
         // IMultiplicativeIdentity
         //
 
-        static Half IMultiplicativeIdentity<Half, Half>.MultiplicativeIdentity => (Half)1.0f;
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        public static Half MultiplicativeIdentity => new Half(PositiveOneBits);
 
         //
         // IMultiplyOperators
         //
 
-        static Half IMultiplyOperators<Half, Half, Half>.operator *(Half left, Half right)
-            => (Half)((float)left * (float)right);
+        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
+        public static Half operator *(Half left, Half right) => (Half)((float)left * (float)right);
 
-        // static checked Half IMultiplyOperators<Half, Half, Half>.operator *(Half left, Half right)
-        //     => checked((Half)((float)left * (float)right));
+        // /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
+        // static Half IMultiplyOperators<Half, Half, Half>.operator checked *(Half left, Half right) => checked((Half)((float)left * (float)right));
 
         //
         // INumber
         //
 
-        static Half INumber<Half>.One => (Half)1.0f;
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        public static Half One => new Half(PositiveOneBits);
 
-        static Half INumber<Half>.Zero => PositiveZero;
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        public static Half Zero => new Half(PositiveZeroBits);
 
-        static Half INumber<Half>.Abs(Half value)
-            => (Half)MathF.Abs((float)value);
+        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
+        public static Half Abs(Half value) => (Half)MathF.Abs((float)value);
 
-        static Half INumber<Half>.Clamp(Half value, Half min, Half max)
-            => (Half)Math.Clamp((float)value, (float)min, (float)max);
+        /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
+        public static Half Clamp(Half value, Half min, Half max) => (Half)Math.Clamp((float)value, (float)min, (float)max);
 
+        /// <inheritdoc cref="INumber{TSelf}.Create{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static Half INumber<Half>.Create<TOther>(TOther value)
+        public static Half Create<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1209,8 +1129,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static Half INumber<Half>.CreateSaturating<TOther>(TOther value)
+        public static Half CreateSaturating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1275,8 +1197,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static Half INumber<Half>.CreateTruncating<TOther>(TOther value)
+        public static Half CreateTruncating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1341,26 +1265,22 @@ namespace System
             }
         }
 
-        static (Half Quotient, Half Remainder) INumber<Half>.DivRem(Half left, Half right)
-            => ((Half, Half))((float)left / (float)right, (float)left % (float)right);
+        /// <inheritdoc cref="INumber{TSelf}.DivRem(TSelf, TSelf)" />
+        public static (Half Quotient, Half Remainder) DivRem(Half left, Half right) => ((Half, Half))((float)left / (float)right, (float)left % (float)right);
 
-        static Half INumber<Half>.Max(Half x, Half y)
-            => (Half)MathF.Max((float)x, (float)y);
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static Half Max(Half x, Half y) => (Half)MathF.Max((float)x, (float)y);
 
-        static Half INumber<Half>.Min(Half x, Half y)
-            => (Half)MathF.Min((float)x, (float)y);
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static Half Min(Half x, Half y) => (Half)MathF.Min((float)x, (float)y);
 
-        static Half INumber<Half>.Parse(string s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static Half Sign(Half value) => (Half)MathF.Sign((float)value);
 
-        static Half INumber<Half>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
-
-        static Half INumber<Half>.Sign(Half value)
-            => (Half)MathF.Sign((float)value);
-
+        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool INumber<Half>.TryCreate<TOther>(TOther value, out Half result)
+        public static bool TryCreate<TOther>(TOther value, out Half result)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1440,66 +1360,57 @@ namespace System
             }
         }
 
-        static bool INumber<Half>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out Half result)
-            => TryParse(s, style, provider, out result);
-
-        static bool INumber<Half>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out Half result)
-            => TryParse(s, style, provider, out result);
-
         //
         // IParseable
         //
 
-        static Half IParseable<Half>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider);
-
-        static bool IParseable<Half>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out Half result)
-            => TryParse(s, DefaultParseStyle, provider, out result);
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out Half result) => TryParse(s, DefaultParseStyle, provider, out result);
 
         //
         // ISignedNumber
         //
 
-        static Half ISignedNumber<Half>.NegativeOne => (Half)(-1.0f);
+        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        public static Half NegativeOne => new Half(NegativeOneBits);
 
         //
         // ISpanParseable
         //
 
-        static Half ISpanParseable<Half>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, DefaultParseStyle, provider);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
+        public static Half Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, DefaultParseStyle, provider);
 
-        static bool ISpanParseable<Half>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Half result)
-            => TryParse(s, DefaultParseStyle, provider, out result);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Half result) => TryParse(s, DefaultParseStyle, provider, out result);
 
         //
         // ISubtractionOperators
         //
 
-        static Half ISubtractionOperators<Half, Half, Half>.operator -(Half left, Half right)
-            => (Half)((float)left - (float)right);
+        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_Subtraction(TSelf, TOther)" />
+        public static Half operator -(Half left, Half right) => (Half)((float)left - (float)right);
 
-        // static checked Half ISubtractionOperators<Half, Half, Half>.operator -(Half left, Half right)
-        //     => checked((Half)((float)left - (float)right));
-
-        //
-        // IUnaryNegationOperators
-        //
-
-        static Half IUnaryNegationOperators<Half, Half>.operator -(Half value)
-            => (Half)(-(float)value);
-
-        // static checked Half IUnaryNegationOperators<Half, Half>.operator -(Half value)
-        //     => checked((Half)(-(float)value));
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static Half ISubtractionOperators<Half, Half, Half>.operator checked -(Half left, Half right) => checked((Half)((float)left - (float)right));
 
         //
         // IUnaryNegationOperators
         //
 
-        static Half IUnaryPlusOperators<Half, Half>.operator +(Half value)
-            => value;
+        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_UnaryNegation(TSelf)" />
+        public static Half operator -(Half value) => (Half)(-(float)value);
 
-        // static checked Half IUnaryPlusOperators<Half, Half>.operator +(Half value)
-        //     => checked(value);
+        // /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
+        // static Half IUnaryNegationOperators<Half, Half>.operator checked -(Half value) => checked((Half)(-(float)value));
+
+        //
+        // IUnaryPlusOperators
+        //
+
+        /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_UnaryPlus(TSelf)" />
+        public static Half operator +(Half value) => value;
+
+        // /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_CheckedUnaryPlus(TSelf)" />
+        // static Half IUnaryPlusOperators<Half, Half>.operator checked +(Half value) => checked(value);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Int16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int16.cs
@@ -28,6 +28,21 @@ namespace System
         public const short MaxValue = (short)0x7FFF;
         public const short MinValue = unchecked((short)0x8000);
 
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        public const short AdditiveIdentity = 0;
+
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        public const short MultiplicativeIdentity = 1;
+
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        public const short One = 1;
+
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        public const short Zero = 0;
+
+        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        public const short NegativeOne = -1;
+
         // Compares this object to another object, returning an integer that
         // indicates the relationship.
         // Returns a value less than zero if this  object
@@ -288,45 +303,47 @@ namespace System
         // IAdditionOperators
         //
 
-        static short IAdditionOperators<short, short, short>.operator +(short left, short right)
-            => (short)(left + right);
+        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        static short IAdditionOperators<short, short, short>.operator +(short left, short right) => (short)(left + right);
 
-        // static checked short IAdditionOperators<short, short, short>.operator +(short left, short right)
-        //     => checked((short)(left + right));
+        // /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        // static short IAdditionOperators<short, short, short>.operator checked +(short left, short right) => checked((short)(left + right));
 
         //
         // IAdditiveIdentity
         //
 
-        static short IAdditiveIdentity<short, short>.AdditiveIdentity => 0;
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        static short IAdditiveIdentity<short, short>.AdditiveIdentity => AdditiveIdentity;
 
         //
         // IBinaryInteger
         //
 
-        static short IBinaryInteger<short>.LeadingZeroCount(short value)
-            => (short)(BitOperations.LeadingZeroCount((ushort)value) - 16);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.LeadingZeroCount(TSelf)" />
+        public static short LeadingZeroCount(short value) => (short)(BitOperations.LeadingZeroCount((ushort)value) - 16);
 
-        static short IBinaryInteger<short>.PopCount(short value)
-            => (short)BitOperations.PopCount((ushort)value);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.PopCount(TSelf)" />
+        public static short PopCount(short value) => (short)BitOperations.PopCount((ushort)value);
 
-        static short IBinaryInteger<short>.RotateLeft(short value, int rotateAmount)
-            => (short)((value << (rotateAmount & 15)) | ((ushort)value >> ((16 - rotateAmount) & 15)));
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateLeft(TSelf, int)" />
+        public static short RotateLeft(short value, int rotateAmount) => (short)((value << (rotateAmount & 15)) | ((ushort)value >> ((16 - rotateAmount) & 15)));
 
-        static short IBinaryInteger<short>.RotateRight(short value, int rotateAmount)
-            => (short)(((ushort)value >> (rotateAmount & 15)) | (value << ((16 - rotateAmount) & 15)));
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateRight(TSelf, int)" />
+        public static short RotateRight(short value, int rotateAmount) => (short)(((ushort)value >> (rotateAmount & 15)) | (value << ((16 - rotateAmount) & 15)));
 
-        static short IBinaryInteger<short>.TrailingZeroCount(short value)
-            => (byte)(BitOperations.TrailingZeroCount(value << 16) - 16);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.TrailingZeroCount(TSelf)" />
+        public static short TrailingZeroCount(short value) => (byte)(BitOperations.TrailingZeroCount(value << 16) - 16);
 
         //
         // IBinaryNumber
         //
 
-        static bool IBinaryNumber<short>.IsPow2(short value)
-            => BitOperations.IsPow2(value);
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
+        public static bool IsPow2(short value) => BitOperations.IsPow2(value);
 
-        static short IBinaryNumber<short>.Log2(short value)
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />
+        public static short Log2(short value)
         {
             if (value < 0)
             {
@@ -339,124 +356,128 @@ namespace System
         // IBitwiseOperators
         //
 
-        static short IBitwiseOperators<short, short, short>.operator &(short left, short right)
-            => (short)(left & right);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseAnd(TSelf, TOther)" />
+        static short IBitwiseOperators<short, short, short>.operator &(short left, short right) => (short)(left & right);
 
-        static short IBitwiseOperators<short, short, short>.operator |(short left, short right)
-            => (short)(left | right);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseOr(TSelf, TOther)" />
+        static short IBitwiseOperators<short, short, short>.operator |(short left, short right) => (short)(left | right);
 
-        static short IBitwiseOperators<short, short, short>.operator ^(short left, short right)
-            => (short)(left ^ right);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_ExclusiveOr(TSelf, TOther)" />
+        static short IBitwiseOperators<short, short, short>.operator ^(short left, short right) => (short)(left ^ right);
 
-        static short IBitwiseOperators<short, short, short>.operator ~(short value)
-            => (short)(~value);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_OnesComplement(TSelf)" />
+        static short IBitwiseOperators<short, short, short>.operator ~(short value) => (short)(~value);
 
         //
         // IComparisonOperators
         //
 
-        static bool IComparisonOperators<short, short>.operator <(short left, short right)
-            => left < right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
+        static bool IComparisonOperators<short, short>.operator <(short left, short right) => left < right;
 
-        static bool IComparisonOperators<short, short>.operator <=(short left, short right)
-            => left <= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<short, short>.operator <=(short left, short right) => left <= right;
 
-        static bool IComparisonOperators<short, short>.operator >(short left, short right)
-            => left > right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
+        static bool IComparisonOperators<short, short>.operator >(short left, short right) => left > right;
 
-        static bool IComparisonOperators<short, short>.operator >=(short left, short right)
-            => left >= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<short, short>.operator >=(short left, short right) => left >= right;
 
         //
         // IDecrementOperators
         //
 
-        static short IDecrementOperators<short>.operator --(short value)
-            => --value;
+        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        static short IDecrementOperators<short>.operator --(short value) => --value;
 
-        // static checked short IDecrementOperators<short>.operator --(short value)
-        //     => checked(--value);
+        // /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        // static short IDecrementOperators<short>.operator checked --(short value) => checked(--value);
 
         //
         // IDivisionOperators
         //
 
-        static short IDivisionOperators<short, short, short>.operator /(short left, short right)
-            => (short)(left / right);
+        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
+        static short IDivisionOperators<short, short, short>.operator /(short left, short right) => (short)(left / right);
 
-        // static checked short IDivisionOperators<short, short, short>.operator /(short left, short right)
-        //     => checked((short)(left / right));
+        // /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
+        // static short IDivisionOperators<short, short, short>.operator checked /(short left, short right) => checked((short)(left / right));
 
         //
         // IEqualityOperators
         //
 
-        static bool IEqualityOperators<short, short>.operator ==(short left, short right)
-            => left == right;
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Equality(TSelf, TOther)" />
+        static bool IEqualityOperators<short, short>.operator ==(short left, short right) => left == right;
 
-        static bool IEqualityOperators<short, short>.operator !=(short left, short right)
-            => left != right;
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Inequality(TSelf, TOther)" />
+        static bool IEqualityOperators<short, short>.operator !=(short left, short right) => left != right;
 
         //
         // IIncrementOperators
         //
 
-        static short IIncrementOperators<short>.operator ++(short value)
-            => ++value;
+        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_Increment(TSelf)" />
+        static short IIncrementOperators<short>.operator ++(short value) => ++value;
 
-        // static checked short IIncrementOperators<short>.operator ++(short value)
-        //     => checked(++value);
+        // /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
+        // static short IIncrementOperators<short>.operator checked ++(short value) => checked(++value);
 
         //
         // IMinMaxValue
         //
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MinValue" />
         static short IMinMaxValue<short>.MinValue => MinValue;
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MaxValue" />
         static short IMinMaxValue<short>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        static short IModulusOperators<short, short, short>.operator %(short left, short right)
-            => (short)(left % right);
-
-        // static checked short IModulusOperators<short, short, short>.operator %(short left, short right)
-        //     => checked((short)(left % right));
+        /// <inheritdoc cref="IModulusOperators{TSelf, TOther, TResult}.op_Modulus(TSelf, TOther)" />
+        static short IModulusOperators<short, short, short>.operator %(short left, short right) => (short)(left % right);
 
         //
         // IMultiplicativeIdentity
         //
 
-        static short IMultiplicativeIdentity<short, short>.MultiplicativeIdentity => 1;
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        static short IMultiplicativeIdentity<short, short>.MultiplicativeIdentity => MultiplicativeIdentity;
 
         //
         // IMultiplyOperators
         //
 
-        static short IMultiplyOperators<short, short, short>.operator *(short left, short right)
-            => (short)(left * right);
+        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
+        static short IMultiplyOperators<short, short, short>.operator *(short left, short right) => (short)(left * right);
 
-        // static checked short IMultiplyOperators<short, short, short>.operator *(short left, short right)
-        //     => checked((short)(left * right));
+        // /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
+        // static short IMultiplyOperators<short, short, short>.operator checked *(short left, short right) => checked((short)(left * right));
 
         //
         // INumber
         //
 
-        static short INumber<short>.One => 1;
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        static short INumber<short>.One => One;
 
-        static short INumber<short>.Zero => 0;
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        static short INumber<short>.Zero => Zero;
 
-        static short INumber<short>.Abs(short value)
-            => Math.Abs(value);
+        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
+        public static short Abs(short value) => Math.Abs(value);
 
-        static short INumber<short>.Clamp(short value, short min, short max)
-            => Math.Clamp(value, min, max);
+        /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
+        public static short Clamp(short value, short min, short max) => Math.Clamp(value, min, max);
 
+        /// <inheritdoc cref="INumber{TSelf}.Create{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static short INumber<short>.Create<TOther>(TOther value)
+        public static short Create<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -521,8 +542,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static short INumber<short>.CreateSaturating<TOther>(TOther value)
+        public static short CreateSaturating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -604,8 +627,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static short INumber<short>.CreateTruncating<TOther>(TOther value)
+        public static short CreateTruncating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -670,26 +695,22 @@ namespace System
             }
         }
 
-        static (short Quotient, short Remainder) INumber<short>.DivRem(short left, short right)
-            => Math.DivRem(left, right);
+        /// <inheritdoc cref="INumber{TSelf}.DivRem(TSelf, TSelf)" />
+        public static (short Quotient, short Remainder) DivRem(short left, short right) => Math.DivRem(left, right);
 
-        static short INumber<short>.Max(short x, short y)
-            => Math.Max(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static short Max(short x, short y) => Math.Max(x, y);
 
-        static short INumber<short>.Min(short x, short y)
-            => Math.Min(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static short Min(short x, short y) => Math.Min(x, y);
 
-        static short INumber<short>.Parse(string s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static short Sign(short value) => (short)Math.Sign(value);
 
-        static short INumber<short>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
-
-        static short INumber<short>.Sign(short value)
-            => (short)Math.Sign(value);
-
+        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool INumber<short>.TryCreate<TOther>(TOther value, out short result)
+        public static bool TryCreate<TOther>(TOther value, out short result)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -857,79 +878,70 @@ namespace System
             }
         }
 
-        static bool INumber<short>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out short result)
-            => TryParse(s, style, provider, out result);
-
-        static bool INumber<short>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out short result)
-            => TryParse(s, style, provider, out result);
-
         //
         // IParseable
         //
 
-        static short IParseable<short>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider);
-
-        static bool IParseable<short>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out short result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out short result) => TryParse(s, NumberStyles.Integer, provider, out result);
 
         //
         // IShiftOperators
         //
 
-        static short IShiftOperators<short, short>.operator <<(short value, int shiftAmount)
-            => (short)(value << shiftAmount);
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_LeftShift(TSelf, int)" />
+        static short IShiftOperators<short, short>.operator <<(short value, int shiftAmount) => (short)(value << shiftAmount);
 
-        static short IShiftOperators<short, short>.operator >>(short value, int shiftAmount)
-            => (short)(value >> shiftAmount);
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_RightShift(TSelf, int)" />
+        static short IShiftOperators<short, short>.operator >>(short value, int shiftAmount) => (short)(value >> shiftAmount);
 
-        // static short IShiftOperators<short, short>.operator >>>(short value, int shiftAmount)
-        //     => (short)((ushort)value >> shiftAmount);
+        // /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_UnsignedRightShift(TSelf, int)" />
+        // static short IShiftOperators<short, short>.operator >>>(short value, int shiftAmount) => (short)((ushort)value >> shiftAmount);
 
         //
         // ISignedNumber
         //
 
-        static short ISignedNumber<short>.NegativeOne => -1;
+        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        static short ISignedNumber<short>.NegativeOne => NegativeOne;
 
         //
         // ISpanParseable
         //
 
-        static short ISpanParseable<short>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, NumberStyles.Integer, provider);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
+        public static short Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, NumberStyles.Integer, provider);
 
-        static bool ISpanParseable<short>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out short result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out short result) => TryParse(s, NumberStyles.Integer, provider, out result);
 
         //
         // ISubtractionOperators
         //
 
-        static short ISubtractionOperators<short, short, short>.operator -(short left, short right)
-            => (short)(left - right);
+        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_Subtraction(TSelf, TOther)" />
+        static short ISubtractionOperators<short, short, short>.operator -(short left, short right) => (short)(left - right);
 
-        // static checked short ISubtractionOperators<short, short, short>.operator -(short left, short right)
-        //     => checked((short)(left - right));
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static short ISubtractionOperators<short, short, short>.operator checked -(short left, short right) => checked((short)(left - right));
 
         //
         // IUnaryNegationOperators
         //
 
-        static short IUnaryNegationOperators<short, short>.operator -(short value)
-            => (short)(-value);
+        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_UnaryNegation(TSelf)" />
+        static short IUnaryNegationOperators<short, short>.operator -(short value) => (short)(-value);
 
-        // static checked short IUnaryNegationOperators<short, short>.operator -(short value)
-        //     => checked((short)(-value));
+        // /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
+        // static short IUnaryNegationOperators<short, short>.operator checked -(short value) => checked((short)(-value));
 
         //
         // IUnaryPlusOperators
         //
 
-        static short IUnaryPlusOperators<short, short>.operator +(short value)
-            => (short)(+value);
+        /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_UnaryPlus(TSelf)" />
+        static short IUnaryPlusOperators<short, short>.operator +(short value) => (short)(+value);
 
-        // static checked short IUnaryPlusOperators<short, short>.operator +(short value)
-        //     => checked((short)(+value));
+        // /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_CheckedUnaryPlus(TSelf)" />
+        // static short IUnaryPlusOperators<short, short>.operator checked +(short value) => checked((short)(+value));
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Int16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int16.cs
@@ -28,19 +28,19 @@ namespace System
         public const short MaxValue = (short)0x7FFF;
         public const short MinValue = unchecked((short)0x8000);
 
-        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        /// <summary>Represents the additive identity (0).</summary>
         public const short AdditiveIdentity = 0;
 
-        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        /// <summary>Represents the multiplicative identity (1).</summary>
         public const short MultiplicativeIdentity = 1;
 
-        /// <inheritdoc cref="INumber{TSelf}.One" />
+        /// <summary>Represents the number one (1).</summary>
         public const short One = 1;
 
-        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        /// <summary>Represents the number zero (0).</summary>
         public const short Zero = 0;
 
-        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        /// <summary>Represents the number negative one (-1).</summary>
         public const short NegativeOne = -1;
 
         // Compares this object to another object, returning an integer that

--- a/src/libraries/System.Private.CoreLib/src/System/Int32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int32.cs
@@ -28,19 +28,19 @@ namespace System
         public const int MaxValue = 0x7fffffff;
         public const int MinValue = unchecked((int)0x80000000);
 
-        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        /// <summary>Represents the additive identity (0).</summary>
         public const int AdditiveIdentity = 0;
 
-        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        /// <summary>Represents the multiplicative identity (1).</summary>
         public const int MultiplicativeIdentity = 1;
 
-        /// <inheritdoc cref="INumber{TSelf}.One" />
+        /// <summary>Represents the number one (1).</summary>
         public const int One = 1;
 
-        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        /// <summary>Represents the number zero (0).</summary>
         public const int Zero = 0;
 
-        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        /// <summary>Represents the number negative one (-1).</summary>
         public const int NegativeOne = -1;
 
         // Compares this object to another object, returning an integer that

--- a/src/libraries/System.Private.CoreLib/src/System/Int32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int32.cs
@@ -28,6 +28,21 @@ namespace System
         public const int MaxValue = 0x7fffffff;
         public const int MinValue = unchecked((int)0x80000000);
 
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        public const int AdditiveIdentity = 0;
+
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        public const int MultiplicativeIdentity = 1;
+
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        public const int One = 1;
+
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        public const int Zero = 0;
+
+        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        public const int NegativeOne = -1;
+
         // Compares this object to another object, returning an integer that
         // indicates the relationship.
         // Returns :
@@ -280,45 +295,47 @@ namespace System
         // IAdditionOperators
         //
 
-        static int IAdditionOperators<int, int, int>.operator +(int left, int right)
-            => left + right;
+        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        static int IAdditionOperators<int, int, int>.operator +(int left, int right) => left + right;
 
-        // static checked int IAdditionOperators<int, int, int>.operator +(int left, int right)
-        //     => checked(left + right);
+        // /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        // static int IAdditionOperators<int, int, int>.operator checked +(int left, int right) => checked(left + right);
 
         //
         // IAdditiveIdentity
         //
 
-        static int IAdditiveIdentity<int, int>.AdditiveIdentity => 0;
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        static int IAdditiveIdentity<int, int>.AdditiveIdentity => AdditiveIdentity;
 
         //
         // IBinaryInteger
         //
 
-        static int IBinaryInteger<int>.LeadingZeroCount(int value)
-            => BitOperations.LeadingZeroCount((uint)value);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.LeadingZeroCount(TSelf)" />
+        public static int LeadingZeroCount(int value) => BitOperations.LeadingZeroCount((uint)value);
 
-        static int IBinaryInteger<int>.PopCount(int value)
-            => BitOperations.PopCount((uint)value);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.PopCount(TSelf)" />
+        public static int PopCount(int value) => BitOperations.PopCount((uint)value);
 
-        static int IBinaryInteger<int>.RotateLeft(int value, int rotateAmount)
-            => (int)BitOperations.RotateLeft((uint)value, rotateAmount);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateLeft(TSelf, int)" />
+        public static int RotateLeft(int value, int rotateAmount) => (int)BitOperations.RotateLeft((uint)value, rotateAmount);
 
-        static int IBinaryInteger<int>.RotateRight(int value, int rotateAmount)
-            => (int)BitOperations.RotateRight((uint)value, rotateAmount);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateRight(TSelf, int)" />
+        public static int RotateRight(int value, int rotateAmount) => (int)BitOperations.RotateRight((uint)value, rotateAmount);
 
-        static int IBinaryInteger<int>.TrailingZeroCount(int value)
-            => BitOperations.TrailingZeroCount(value);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.TrailingZeroCount(TSelf)" />
+        public static int TrailingZeroCount(int value) => BitOperations.TrailingZeroCount(value);
 
         //
         // IBinaryNumber
         //
 
-        static bool IBinaryNumber<int>.IsPow2(int value)
-            => BitOperations.IsPow2(value);
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
+        public static bool IsPow2(int value) => BitOperations.IsPow2(value);
 
-        static int IBinaryNumber<int>.Log2(int value)
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />
+        public static int Log2(int value)
         {
             if (value < 0)
             {
@@ -331,123 +348,127 @@ namespace System
         // IBitwiseOperators
         //
 
-        static int IBitwiseOperators<int, int, int>.operator &(int left, int right)
-            => left & right;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseAnd(TSelf, TOther)" />
+        static int IBitwiseOperators<int, int, int>.operator &(int left, int right) => left & right;
 
-        static int IBitwiseOperators<int, int, int>.operator |(int left, int right)
-            => left | right;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseOr(TSelf, TOther)" />
+        static int IBitwiseOperators<int, int, int>.operator |(int left, int right) => left | right;
 
-        static int IBitwiseOperators<int, int, int>.operator ^(int left, int right)
-            => left ^ right;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_ExclusiveOr(TSelf, TOther)" />
+        static int IBitwiseOperators<int, int, int>.operator ^(int left, int right) => left ^ right;
 
-        static int IBitwiseOperators<int, int, int>.operator ~(int value)
-            => ~value;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_OnesComplement(TSelf)" />
+        static int IBitwiseOperators<int, int, int>.operator ~(int value) => ~value;
 
         //
         // IComparisonOperators
         //
 
-        static bool IComparisonOperators<int, int>.operator <(int left, int right)
-            => left < right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
+        static bool IComparisonOperators<int, int>.operator <(int left, int right) => left < right;
 
-        static bool IComparisonOperators<int, int>.operator <=(int left, int right)
-            => left <= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<int, int>.operator <=(int left, int right) => left <= right;
 
-        static bool IComparisonOperators<int, int>.operator >(int left, int right)
-            => left > right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
+        static bool IComparisonOperators<int, int>.operator >(int left, int right) => left > right;
 
-        static bool IComparisonOperators<int, int>.operator >=(int left, int right)
-            => left >= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<int, int>.operator >=(int left, int right) => left >= right;
 
         //
         // IDecrementOperators
         //
 
-        static int IDecrementOperators<int>.operator --(int value)
-            => --value;
+        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        static int IDecrementOperators<int>.operator --(int value) => --value;
 
-        // static checked int IDecrementOperators<int>.operator --(int value)
-        //     => checked(--value);
+        // /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        // static int IDecrementOperators<int>.operator checked --(int value) => checked(--value);
 
         //
         // IDivisionOperators
         //
 
-        static int IDivisionOperators<int, int, int>.operator /(int left, int right)
-            => left / right;
+        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
+        static int IDivisionOperators<int, int, int>.operator /(int left, int right) => left / right;
 
-        // static checked int IDivisionOperators<int, int, int>.operator /(int left, int right)
-        //     => checked(left / right);
+        // /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
+        // static int IDivisionOperators<int, int, int>.operator checked /(int left, int right) => checked(left / right);
 
         //
         // IEqualityOperators
         //
 
-        static bool IEqualityOperators<int, int>.operator ==(int left, int right)
-            => left == right;
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Equality(TSelf, TOther)" />
+        static bool IEqualityOperators<int, int>.operator ==(int left, int right) => left == right;
 
-        static bool IEqualityOperators<int, int>.operator !=(int left, int right)
-            => left != right;
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Inequality(TSelf, TOther)" />
+        static bool IEqualityOperators<int, int>.operator !=(int left, int right) => left != right;
 
         //
         // IIncrementOperators
         //
 
-        static int IIncrementOperators<int>.operator ++(int value)
-            => ++value;
+        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_Increment(TSelf)" />
+        static int IIncrementOperators<int>.operator ++(int value) => ++value;
 
-        // static checked int IIncrementOperators<int>.operator ++(int value)
-        //     => checked(++value);
+        // /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
+        // static int IIncrementOperators<int>.operator checked ++(int value) => checked(++value);
 
         //
         // IMinMaxValue
         //
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MinValue" />
         static int IMinMaxValue<int>.MinValue => MinValue;
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MaxValue" />
         static int IMinMaxValue<int>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        static int IModulusOperators<int, int, int>.operator %(int left, int right)
-            => left % right;
-
-        // static checked int IModulusOperators<int, int, int>.operator %(int left, int right)
-        //     => checked(left % right);
+        /// <inheritdoc cref="IModulusOperators{TSelf, TOther, TResult}.op_Modulus(TSelf, TOther)" />
+        static int IModulusOperators<int, int, int>.operator %(int left, int right) => left % right;
 
         //
         // IMultiplicativeIdentity
         //
 
-        static int IMultiplicativeIdentity<int, int>.MultiplicativeIdentity => 1;
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        static int IMultiplicativeIdentity<int, int>.MultiplicativeIdentity => MultiplicativeIdentity;
 
         //
         // IMultiplyOperators
         //
 
-        static int IMultiplyOperators<int, int, int>.operator *(int left, int right)
-            => left * right;
+        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
+        static int IMultiplyOperators<int, int, int>.operator *(int left, int right) => left * right;
 
-        // static checked int IMultiplyOperators<int, int, int>.operator *(int left, int right)
-        //     => checked(left * right);
+        // /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
+        // static int IMultiplyOperators<int, int, int>.operator checked *(int left, int right) => checked(left * right);
 
         //
         // INumber
         //
 
-        static int INumber<int>.One => 1;
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        static int INumber<int>.One => One;
 
-        static int INumber<int>.Zero => 0;
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        static int INumber<int>.Zero => Zero;
 
-        static int INumber<int>.Abs(int value)
-            => Math.Abs(value);
+        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
+        public static int Abs(int value) => Math.Abs(value);
 
-        static int INumber<int>.Clamp(int value, int min, int max)
-            => Math.Clamp(value, min, max);
+        /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
+        public static int Clamp(int value, int min, int max) => Math.Clamp(value, min, max);
 
-        internal static int Create<TOther>(TOther value)
+        /// <inheritdoc cref="INumber{TSelf}.Create{TOther}(TOther)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Create<TOther>(TOther value)
             where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
@@ -513,12 +534,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static int INumber<int>.Create<TOther>(TOther value)
-            => Create(value);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static int INumber<int>.CreateSaturating<TOther>(TOther value)
+        public static int CreateSaturating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -596,8 +615,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static int INumber<int>.CreateTruncating<TOther>(TOther value)
+        public static int CreateTruncating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -662,26 +683,22 @@ namespace System
             }
         }
 
-        static (int Quotient, int Remainder) INumber<int>.DivRem(int left, int right)
-            => Math.DivRem(left, right);
+        /// <inheritdoc cref="INumber{TSelf}.DivRem(TSelf, TSelf)" />
+        public static (int Quotient, int Remainder) DivRem(int left, int right) => Math.DivRem(left, right);
 
-        static int INumber<int>.Max(int x, int y)
-            => Math.Max(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static int Max(int x, int y) => Math.Max(x, y);
 
-        static int INumber<int>.Min(int x, int y)
-            => Math.Min(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static int Min(int x, int y) => Math.Min(x, y);
 
-        static int INumber<int>.Parse(string s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static int Sign(int value) => Math.Sign(value);
 
-        static int INumber<int>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
-
-        static int INumber<int>.Sign(int value)
-            => Math.Sign(value);
-
+        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool INumber<int>.TryCreate<TOther>(TOther value, out int result)
+        public static bool TryCreate<TOther>(TOther value, out int result)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -825,79 +842,70 @@ namespace System
             }
         }
 
-        static bool INumber<int>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out int result)
-            => TryParse(s, style, provider, out result);
-
-        static bool INumber<int>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out int result)
-            => TryParse(s, style, provider, out result);
-
         //
         // IParseable
         //
 
-        static int IParseable<int>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider);
-
-        static bool IParseable<int>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out int result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out int result) => TryParse(s, NumberStyles.Integer, provider, out result);
 
         //
         // IShiftOperators
         //
 
-        static int IShiftOperators<int, int>.operator <<(int value, int shiftAmount)
-            => value << shiftAmount;
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_LeftShift(TSelf, int)" />
+        static int IShiftOperators<int, int>.operator <<(int value, int shiftAmount) => value << shiftAmount;
 
-        static int IShiftOperators<int, int>.operator >>(int value, int shiftAmount)
-            => value >> shiftAmount;
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_RightShift(TSelf, int)" />
+        static int IShiftOperators<int, int>.operator >>(int value, int shiftAmount) => value >> shiftAmount;
 
-        // static int IShiftOperators<int, int>.operator >>>(int value, int shiftAmount)
-        //     => (int)((uint)value >> shiftAmount);
+        // /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_UnsignedRightShift(TSelf, int)" />
+        // static int IShiftOperators<int, int>.operator >>>(int value, int shiftAmount) => (int)((uint)value >> shiftAmount);
 
         //
         // ISignedNumber
         //
 
-        static int ISignedNumber<int>.NegativeOne => -1;
+        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        static int ISignedNumber<int>.NegativeOne => NegativeOne;
 
         //
         // ISpanParseable
         //
 
-        static int ISpanParseable<int>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, NumberStyles.Integer, provider);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
+        public static int Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, NumberStyles.Integer, provider);
 
-        static bool ISpanParseable<int>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out int result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out int result) => TryParse(s, NumberStyles.Integer, provider, out result);
 
         //
         // ISubtractionOperators
         //
 
-        static int ISubtractionOperators<int, int, int>.operator -(int left, int right)
-            => left - right;
+        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_Subtraction(TSelf, TOther)" />
+        static int ISubtractionOperators<int, int, int>.operator -(int left, int right) => left - right;
 
-        // static checked int ISubtractionOperators<int, int, int>.operator -(int left, int right)
-        //     => checked(left - right);
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static int ISubtractionOperators<int, int, int>.operator checked -(int left, int right) => checked(left - right);
 
         //
         // IUnaryNegationOperators
         //
 
-        static int IUnaryNegationOperators<int, int>.operator -(int value)
-            => -value;
+        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_UnaryNegation(TSelf)" />
+        static int IUnaryNegationOperators<int, int>.operator -(int value) => -value;
 
-        // static checked int IUnaryNegationOperators<int, int>.operator -(int value)
-        //     => checked(-value);
+        // /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
+        // static int IUnaryNegationOperators<int, int>.operator checked -(int value) => checked(-value);
 
         //
         // IUnaryPlusOperators
         //
 
-        static int IUnaryPlusOperators<int, int>.operator +(int value)
-            => +value;
+        /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_UnaryPlus(TSelf)" />
+        static int IUnaryPlusOperators<int, int>.operator +(int value) => +value;
 
-        // static checked int IUnaryPlusOperators<int, int>.operator +(int value)
-        //     => checked(+value);
+        // /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_CheckedUnaryPlus(TSelf)" />
+        // static int IUnaryPlusOperators<int, int>.operator checked +(int value) => checked(+value);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Int64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int64.cs
@@ -28,19 +28,19 @@ namespace System
         public const long MaxValue = 0x7fffffffffffffffL;
         public const long MinValue = unchecked((long)0x8000000000000000L);
 
-        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        /// <summary>Represents the additive identity (0).</summary>
         public const long AdditiveIdentity = 0;
 
-        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        /// <summary>Represents the multiplicative identity (1).</summary>
         public const long MultiplicativeIdentity = 1;
 
-        /// <inheritdoc cref="INumber{TSelf}.One" />
+        /// <summary>Represents the number one (1).</summary>
         public const long One = 1;
 
-        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        /// <summary>Represents the number zero (0).</summary>
         public const long Zero = 0;
 
-        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        /// <summary>Represents the number negative one (-1).</summary>
         public const long NegativeOne = -1;
 
         // Compares this object to another object, returning an integer that

--- a/src/libraries/System.Private.CoreLib/src/System/Int64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int64.cs
@@ -28,6 +28,21 @@ namespace System
         public const long MaxValue = 0x7fffffffffffffffL;
         public const long MinValue = unchecked((long)0x8000000000000000L);
 
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        public const long AdditiveIdentity = 0;
+
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        public const long MultiplicativeIdentity = 1;
+
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        public const long One = 1;
+
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        public const long Zero = 0;
+
+        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        public const long NegativeOne = -1;
+
         // Compares this object to another object, returning an integer that
         // indicates the relationship.
         // Returns a value less than zero if this  object
@@ -267,45 +282,47 @@ namespace System
         // IAdditionOperators
         //
 
-        static long IAdditionOperators<long, long, long>.operator +(long left, long right)
-            => left + right;
+        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        static long IAdditionOperators<long, long, long>.operator +(long left, long right) => left + right;
 
-        // static checked long IAdditionOperators<long, long, long>.operator +(long left, long right)
-        //     => checked(left + right);
+        // /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        // static long IAdditionOperators<long, long, long>.operator checked +(long left, long right) => checked(left + right);
 
         //
         // IAdditiveIdentity
         //
 
-        static long IAdditiveIdentity<long, long>.AdditiveIdentity => 0;
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        static long IAdditiveIdentity<long, long>.AdditiveIdentity => AdditiveIdentity;
 
         //
         // IBinaryInteger
         //
 
-        static long IBinaryInteger<long>.LeadingZeroCount(long value)
-            => BitOperations.LeadingZeroCount((ulong)value);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.LeadingZeroCount(TSelf)" />
+        public static long LeadingZeroCount(long value) => BitOperations.LeadingZeroCount((ulong)value);
 
-        static long IBinaryInteger<long>.PopCount(long value)
-            => BitOperations.PopCount((ulong)value);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.PopCount(TSelf)" />
+        public static long PopCount(long value) => BitOperations.PopCount((ulong)value);
 
-        static long IBinaryInteger<long>.RotateLeft(long value, int rotateAmount)
-            => (long)BitOperations.RotateLeft((ulong)value, rotateAmount);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateLeft(TSelf, int)" />
+        public static long RotateLeft(long value, int rotateAmount) => (long)BitOperations.RotateLeft((ulong)value, rotateAmount);
 
-        static long IBinaryInteger<long>.RotateRight(long value, int rotateAmount)
-            => (long)BitOperations.RotateRight((ulong)value, rotateAmount);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateRight(TSelf, int)" />
+        public static long RotateRight(long value, int rotateAmount) => (long)BitOperations.RotateRight((ulong)value, rotateAmount);
 
-        static long IBinaryInteger<long>.TrailingZeroCount(long value)
-            => BitOperations.TrailingZeroCount(value);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.TrailingZeroCount(TSelf)" />
+        public static long TrailingZeroCount(long value) => BitOperations.TrailingZeroCount(value);
 
         //
         // IBinaryNumber
         //
 
-        static bool IBinaryNumber<long>.IsPow2(long value)
-            => BitOperations.IsPow2(value);
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
+        public static bool IsPow2(long value) => BitOperations.IsPow2(value);
 
-        static long IBinaryNumber<long>.Log2(long value)
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />
+        public static long Log2(long value)
         {
             if (value < 0)
             {
@@ -318,124 +335,128 @@ namespace System
         // IBitwiseOperators
         //
 
-        static long IBitwiseOperators<long, long, long>.operator &(long left, long right)
-            => left & right;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseAnd(TSelf, TOther)" />
+        static long IBitwiseOperators<long, long, long>.operator &(long left, long right) => left & right;
 
-        static long IBitwiseOperators<long, long, long>.operator |(long left, long right)
-            => left | right;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseOr(TSelf, TOther)" />
+        static long IBitwiseOperators<long, long, long>.operator |(long left, long right) => left | right;
 
-        static long IBitwiseOperators<long, long, long>.operator ^(long left, long right)
-            => left ^ right;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_ExclusiveOr(TSelf, TOther)" />
+        static long IBitwiseOperators<long, long, long>.operator ^(long left, long right) => left ^ right;
 
-        static long IBitwiseOperators<long, long, long>.operator ~(long value)
-            => ~value;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_OnesComplement(TSelf)" />
+        static long IBitwiseOperators<long, long, long>.operator ~(long value) => ~value;
 
         //
         // IComparisonOperators
         //
 
-        static bool IComparisonOperators<long, long>.operator <(long left, long right)
-            => left < right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
+        static bool IComparisonOperators<long, long>.operator <(long left, long right) => left < right;
 
-        static bool IComparisonOperators<long, long>.operator <=(long left, long right)
-            => left <= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<long, long>.operator <=(long left, long right) => left <= right;
 
-        static bool IComparisonOperators<long, long>.operator >(long left, long right)
-            => left > right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
+        static bool IComparisonOperators<long, long>.operator >(long left, long right) => left > right;
 
-        static bool IComparisonOperators<long, long>.operator >=(long left, long right)
-            => left >= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<long, long>.operator >=(long left, long right) => left >= right;
 
         //
         // IDecrementOperators
         //
 
-        static long IDecrementOperators<long>.operator --(long value)
-            => --value;
+        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        static long IDecrementOperators<long>.operator --(long value) => --value;
 
-        // static checked long IDecrementOperators<long>.operator --(long value)
-        //     => checked(--value);
+        // /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        // static long IDecrementOperators<long>.operator checked --(long value) => checked(--value);
 
         //
         // IDivisionOperators
         //
 
-        static long IDivisionOperators<long, long, long>.operator /(long left, long right)
-            => left / right;
+        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
+        static long IDivisionOperators<long, long, long>.operator /(long left, long right) => left / right;
 
-        // static checked long IDivisionOperators<long, long, long>.operator /(long left, long right)
-        //     => checked(left / right);
+        // /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
+        // static long IDivisionOperators<long, long, long>.operator checked /(long left, long right) => checked(left / right);
 
         //
         // IEqualityOperators
         //
 
-        static bool IEqualityOperators<long, long>.operator ==(long left, long right)
-            => left == right;
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Equality(TSelf, TOther)" />
+        static bool IEqualityOperators<long, long>.operator ==(long left, long right) => left == right;
 
-        static bool IEqualityOperators<long, long>.operator !=(long left, long right)
-            => left != right;
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Inequality(TSelf, TOther)" />
+        static bool IEqualityOperators<long, long>.operator !=(long left, long right) => left != right;
 
         //
         // IIncrementOperators
         //
 
-        static long IIncrementOperators<long>.operator ++(long value)
-            => ++value;
+        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_Increment(TSelf)" />
+        static long IIncrementOperators<long>.operator ++(long value) => ++value;
 
-        // static checked long IIncrementOperators<long>.operator ++(long value)
-        //     => checked(++value);
+        // /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
+        // static long IIncrementOperators<long>.operator checked ++(long value) => checked(++value);
 
         //
         // IMinMaxValue
         //
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MinValue" />
         static long IMinMaxValue<long>.MinValue => MinValue;
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MaxValue" />
         static long IMinMaxValue<long>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        static long IModulusOperators<long, long, long>.operator %(long left, long right)
-            => left % right;
-
-        // static checked long IModulusOperators<long, long, long>.operator %(long left, long right)
-        //     => checked(left % right);
+        /// <inheritdoc cref="IModulusOperators{TSelf, TOther, TResult}.op_Modulus(TSelf, TOther)" />
+        static long IModulusOperators<long, long, long>.operator %(long left, long right) => left % right;
 
         //
         // IMultiplicativeIdentity
         //
 
-        static long IMultiplicativeIdentity<long, long>.MultiplicativeIdentity => 1;
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        static long IMultiplicativeIdentity<long, long>.MultiplicativeIdentity => MultiplicativeIdentity;
 
         //
         // IMultiplyOperators
         //
 
-        static long IMultiplyOperators<long, long, long>.operator *(long left, long right)
-            => left * right;
+        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
+        static long IMultiplyOperators<long, long, long>.operator *(long left, long right) => left * right;
 
-        // static checked long IMultiplyOperators<long, long, long>.operator *(long left, long right)
-        //     => checked(left * right);
+        // /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
+        // static long IMultiplyOperators<long, long, long>.operator checked *(long left, long right) => checked(left * right);
 
         //
         // INumber
         //
 
-        static long INumber<long>.One => 1;
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        static long INumber<long>.One => One;
 
-        static long INumber<long>.Zero => 0;
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        static long INumber<long>.Zero => Zero;
 
-        static long INumber<long>.Abs(long value)
-            => Math.Abs(value);
+        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
+        public static long Abs(long value) => Math.Abs(value);
 
-        static long INumber<long>.Clamp(long value, long min, long max)
-            => Math.Clamp(value, min, max);
+        /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
+        public static long Clamp(long value, long min, long max) => Math.Clamp(value, min, max);
 
+        /// <inheritdoc cref="INumber{TSelf}.Create{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static long INumber<long>.Create<TOther>(TOther value)
+        public static long Create<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -500,8 +521,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static long INumber<long>.CreateSaturating<TOther>(TOther value)
+        public static long CreateSaturating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -574,8 +597,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static long INumber<long>.CreateTruncating<TOther>(TOther value)
+        public static long CreateTruncating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -640,26 +665,22 @@ namespace System
             }
         }
 
-        static (long Quotient, long Remainder) INumber<long>.DivRem(long left, long right)
-            => Math.DivRem(left, right);
+        /// <inheritdoc cref="INumber{TSelf}.DivRem(TSelf, TSelf)" />
+        public static (long Quotient, long Remainder) DivRem(long left, long right) => Math.DivRem(left, right);
 
-        static long INumber<long>.Max(long x, long y)
-            => Math.Max(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static long Max(long x, long y) => Math.Max(x, y);
 
-        static long INumber<long>.Min(long x, long y)
-            => Math.Min(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static long Min(long x, long y) => Math.Min(x, y);
 
-        static long INumber<long>.Parse(string s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static long Sign(long value) => Math.Sign(value);
 
-        static long INumber<long>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
-
-        static long INumber<long>.Sign(long value)
-            => Math.Sign(value);
-
+        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool INumber<long>.TryCreate<TOther>(TOther value, out long result)
+        public static bool TryCreate<TOther>(TOther value, out long result)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -779,79 +800,70 @@ namespace System
             }
         }
 
-        static bool INumber<long>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out long result)
-            => TryParse(s, style, provider, out result);
-
-        static bool INumber<long>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out long result)
-            => TryParse(s, style, provider, out result);
-
         //
         // IParseable
         //
 
-        static long IParseable<long>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider);
-
-        static bool IParseable<long>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out long result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out long result) => TryParse(s, NumberStyles.Integer, provider, out result);
 
         //
         // IShiftOperators
         //
 
-        static long IShiftOperators<long, long>.operator <<(long value, int shiftAmount)
-            => value << (int)shiftAmount;
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_LeftShift(TSelf, int)" />
+        static long IShiftOperators<long, long>.operator <<(long value, int shiftAmount) => value << (int)shiftAmount;
 
-        static long IShiftOperators<long, long>.operator >>(long value, int shiftAmount)
-            => value >> (int)shiftAmount;
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_RightShift(TSelf, int)" />
+        static long IShiftOperators<long, long>.operator >>(long value, int shiftAmount) => value >> (int)shiftAmount;
 
-        // static long IShiftOperators<long, long>.operator >>>(long value, int shiftAmount)
-        //     => (long)((ulong)value >> (int)shiftAmount);
+        // /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_UnsignedRightShift(TSelf, int)" />
+        // static long IShiftOperators<long, long>.operator >>>(long value, int shiftAmount) => (long)((ulong)value >> (int)shiftAmount);
 
         //
         // ISignedNumber
         //
 
-        static long ISignedNumber<long>.NegativeOne => -1;
+        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        static long ISignedNumber<long>.NegativeOne => NegativeOne;
 
         //
         // ISpanParseable
         //
 
-        static long ISpanParseable<long>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, NumberStyles.Integer, provider);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
+        public static long Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, NumberStyles.Integer, provider);
 
-        static bool ISpanParseable<long>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out long result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out long result) => TryParse(s, NumberStyles.Integer, provider, out result);
 
         //
         // ISubtractionOperators
         //
 
-        static long ISubtractionOperators<long, long, long>.operator -(long left, long right)
-            => left - right;
+        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_Subtraction(TSelf, TOther)" />
+        static long ISubtractionOperators<long, long, long>.operator -(long left, long right) => left - right;
 
-        // static checked long ISubtractionOperators<long, long, long>.operator -(long left, long right)
-        //     => checked(left - right);
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static long ISubtractionOperators<long, long, long>.operator checked -(long left, long right) => checked(left - right);
 
         //
         // IUnaryNegationOperators
         //
 
-        static long IUnaryNegationOperators<long, long>.operator -(long value)
-            => -value;
+        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_UnaryNegation(TSelf)" />
+        static long IUnaryNegationOperators<long, long>.operator -(long value) => -value;
 
-        // static checked long IUnaryNegationOperators<long, long>.operator -(long value)
-        //     => checked(-value);
+        // /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
+        // static long IUnaryNegationOperators<long, long>.operator checked -(long value) => checked(-value);
 
         //
         // IUnaryPlusOperators
         //
 
-        static long IUnaryPlusOperators<long, long>.operator +(long value)
-            => +value;
+        /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_UnaryPlus(TSelf)" />
+        static long IUnaryPlusOperators<long, long>.operator +(long value) => +value;
 
-        // static checked long IUnaryPlusOperators<long, long>.operator +(long value)
-        //     => checked(+value);
+        // /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_CheckedUnaryPlus(TSelf)" />
+        // static long IUnaryPlusOperators<long, long>.operator checked +(long value) => checked((long)(+value));
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
@@ -22,7 +22,7 @@ namespace System
 {
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct IntPtr
         : IEquatable<nint>,
           IComparable,
@@ -176,12 +176,14 @@ namespace System
         [NonVersionable]
         public unsafe void* ToPointer() => _value;
 
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
         public static IntPtr MaxValue
         {
             [NonVersionable]
             get => (IntPtr)nint_t.MaxValue;
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
         public static IntPtr MinValue
         {
             [NonVersionable]
@@ -222,12 +224,19 @@ namespace System
         public static IntPtr Parse(string s, NumberStyles style) => (IntPtr)nint_t.Parse(s, style);
         public static IntPtr Parse(string s, IFormatProvider? provider) => (IntPtr)nint_t.Parse(s, provider);
         public static IntPtr Parse(string s, NumberStyles style, IFormatProvider? provider) => (IntPtr)nint_t.Parse(s, style, provider);
+        public static IntPtr Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => (IntPtr)nint_t.Parse(s, provider);
         public static IntPtr Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null) => (IntPtr)nint_t.Parse(s, style, provider);
 
         public static bool TryParse([NotNullWhen(true)] string? s, out IntPtr result)
         {
             Unsafe.SkipInit(out result);
             return nint_t.TryParse(s, out Unsafe.As<IntPtr, nint_t>(ref result));
+        }
+
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out IntPtr result)
+        {
+            Unsafe.SkipInit(out result);
+            return nint_t.TryParse(s, provider, out Unsafe.As<IntPtr, nint_t>(ref result));
         }
 
         public static bool TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out IntPtr result)
@@ -242,6 +251,12 @@ namespace System
             return nint_t.TryParse(s, out Unsafe.As<IntPtr, nint_t>(ref result));
         }
 
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out IntPtr result)
+        {
+            Unsafe.SkipInit(out result);
+            return nint_t.TryParse(s, provider, out Unsafe.As<IntPtr, nint_t>(ref result));
+        }
+
         public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out IntPtr result)
         {
             Unsafe.SkipInit(out result);
@@ -252,22 +267,24 @@ namespace System
         // IAdditionOperators
         //
 
-        static nint IAdditionOperators<nint, nint, nint>.operator +(nint left, nint right)
-            => left + right;
+        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        static nint IAdditionOperators<nint, nint, nint>.operator +(nint left, nint right) => left + right;
 
-        // static checked nint IAdditionOperators<nint, nint, nint>.operator +(nint left, nint right)
-        //     => checked(left + right);
+        // /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        // static nint IAdditionOperators<nint, nint, nint>.operator checked +(nint left, nint right) => checked(left + right);
 
         //
         // IAdditiveIdentity
         //
 
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
         static nint IAdditiveIdentity<nint, nint>.AdditiveIdentity => 0;
 
         //
         // IBinaryInteger
         //
 
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.LeadingZeroCount(TSelf)" />
         static nint IBinaryInteger<nint>.LeadingZeroCount(nint value)
         {
             if (Environment.Is64BitProcess)
@@ -280,6 +297,7 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.PopCount(TSelf)" />
         static nint IBinaryInteger<nint>.PopCount(nint value)
         {
             if (Environment.Is64BitProcess)
@@ -292,6 +310,7 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateLeft(TSelf, int)" />
         static nint IBinaryInteger<nint>.RotateLeft(nint value, int rotateAmount)
         {
             if (Environment.Is64BitProcess)
@@ -304,8 +323,8 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateRight(TSelf, int)" />
         static nint IBinaryInteger<nint>.RotateRight(nint value, int rotateAmount)
-
         {
             if (Environment.Is64BitProcess)
             {
@@ -317,6 +336,7 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.TrailingZeroCount(TSelf)" />
         static nint IBinaryInteger<nint>.TrailingZeroCount(nint value)
         {
             if (Environment.Is64BitProcess)
@@ -333,9 +353,10 @@ namespace System
         // IBinaryNumber
         //
 
-        static bool IBinaryNumber<nint>.IsPow2(nint value)
-            => BitOperations.IsPow2(value);
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
+        static bool IBinaryNumber<nint>.IsPow2(nint value) => BitOperations.IsPow2(value);
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />
         static nint IBinaryNumber<nint>.Log2(nint value)
         {
             if (value < 0)
@@ -357,122 +378,115 @@ namespace System
         // IBitwiseOperators
         //
 
-        static nint IBitwiseOperators<nint, nint, nint>.operator &(nint left, nint right)
-            => left & right;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseAnd(TSelf, TOther)" />
+        static nint IBitwiseOperators<nint, nint, nint>.operator &(nint left, nint right) => left & right;
 
-        static nint IBitwiseOperators<nint, nint, nint>.operator |(nint left, nint right)
-            => left | right;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseOr(TSelf, TOther)" />
+        static nint IBitwiseOperators<nint, nint, nint>.operator |(nint left, nint right) => left | right;
 
-        static nint IBitwiseOperators<nint, nint, nint>.operator ^(nint left, nint right)
-            => left ^ right;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_ExclusiveOr(TSelf, TOther)" />
+        static nint IBitwiseOperators<nint, nint, nint>.operator ^(nint left, nint right) => left ^ right;
 
-        static nint IBitwiseOperators<nint, nint, nint>.operator ~(nint value)
-            => ~value;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_OnesComplement(TSelf)" />
+        static nint IBitwiseOperators<nint, nint, nint>.operator ~(nint value) => ~value;
 
         //
         // IComparisonOperators
         //
 
-        static bool IComparisonOperators<nint, nint>.operator <(nint left, nint right)
-            => left < right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
+        static bool IComparisonOperators<nint, nint>.operator <(nint left, nint right) => left < right;
 
-        static bool IComparisonOperators<nint, nint>.operator <=(nint left, nint right)
-            => left <= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<nint, nint>.operator <=(nint left, nint right) => left <= right;
 
-        static bool IComparisonOperators<nint, nint>.operator >(nint left, nint right)
-            => left > right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
+        static bool IComparisonOperators<nint, nint>.operator >(nint left, nint right) => left > right;
 
-        static bool IComparisonOperators<nint, nint>.operator >=(nint left, nint right)
-            => left >= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<nint, nint>.operator >=(nint left, nint right) => left >= right;
 
         //
         // IDecrementOperators
         //
 
-        static nint IDecrementOperators<nint>.operator --(nint value)
-            => --value;
+        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        static nint IDecrementOperators<nint>.operator --(nint value) => --value;
 
-        // static checked nint IDecrementOperators<nint>.operator --(nint value)
-        //     => checked(--value);
+        // /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        // static nint IDecrementOperators<nint>.operator checked --(nint value) => checked(--value);
 
         //
         // IDivisionOperators
         //
 
-        static nint IDivisionOperators<nint, nint, nint>.operator /(nint left, nint right)
-            => left / right;
+        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
+        static nint IDivisionOperators<nint, nint, nint>.operator /(nint left, nint right) => left / right;
 
-        // static checked nint IDivisionOperators<nint, nint, nint>.operator /(nint left, nint right)
-        //     => checked(left / right);
-
-        //
-        // IEqualityOperators
-        //
-
-        static bool IEqualityOperators<nint, nint>.operator ==(nint left, nint right)
-            => left == right;
-
-        static bool IEqualityOperators<nint, nint>.operator !=(nint left, nint right)
-            => left != right;
+        // /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
+        // static nint IDivisionOperators<nint, nint, nint>.operator checked /(nint left, nint right) => checked(left / right);
 
         //
         // IIncrementOperators
         //
 
-        static nint IIncrementOperators<nint>.operator ++(nint value)
-            => ++value;
+        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_Increment(TSelf)" />
+        static nint IIncrementOperators<nint>.operator ++(nint value) => ++value;
 
-        // static checked nint IIncrementOperators<nint>.operator ++(nint value)
-        //     => checked(++value);
+        // /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
+        // static nint IIncrementOperators<nint>.operator checked ++(nint value) => checked(++value);
 
         //
         // IMinMaxValue
         //
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MinValue" />
         static nint IMinMaxValue<nint>.MinValue => MinValue;
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MaxValue" />
         static nint IMinMaxValue<nint>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        static nint IModulusOperators<nint, nint, nint>.operator %(nint left, nint right)
-            => left % right;
-
-        // static checked nint IModulusOperators<nint, nint, nint>.operator %(nint left, nint right)
-        //     => checked(left % right);
+        /// <inheritdoc cref="IModulusOperators{TSelf, TOther, TResult}.op_Modulus(TSelf, TOther)" />
+        static nint IModulusOperators<nint, nint, nint>.operator %(nint left, nint right) => left % right;
 
         //
         // IMultiplicativeIdentity
         //
 
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
         static nint IMultiplicativeIdentity<nint, nint>.MultiplicativeIdentity => 1;
 
         //
         // IMultiplyOperators
         //
 
-        static nint IMultiplyOperators<nint, nint, nint>.operator *(nint left, nint right)
-            => left * right;
+        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
+        static nint IMultiplyOperators<nint, nint, nint>.operator *(nint left, nint right) => left * right;
 
-        // static checked nint IMultiplyOperators<nint, nint, nint>.operator *(nint left, nint right)
-        //     => checked(left * right);
+        // /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
+        // static nint IMultiplyOperators<nint, nint, nint>.operator checked *(nint left, nint right) => checked(left * right);
 
         //
         // INumber
         //
 
+        /// <inheritdoc cref="INumber{TSelf}.One" />
         static nint INumber<nint>.One => 1;
 
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
         static nint INumber<nint>.Zero => 0;
 
-        static nint INumber<nint>.Abs(nint value)
-            => Math.Abs(value);
+        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
+        static nint INumber<nint>.Abs(nint value) => Math.Abs(value);
 
-        static nint INumber<nint>.Clamp(nint value, nint min, nint max)
-            => Math.Clamp(value, min, max);
+        /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
+        static nint INumber<nint>.Clamp(nint value, nint min, nint max) => Math.Clamp(value, min, max);
 
+        /// <inheritdoc cref="INumber{TSelf}.Create{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static nint INumber<nint>.Create<TOther>(TOther value)
         {
@@ -539,6 +553,7 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static nint INumber<nint>.CreateSaturating<TOther>(TOther value)
         {
@@ -616,6 +631,7 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static nint INumber<nint>.CreateTruncating<TOther>(TOther value)
         {
@@ -682,24 +698,19 @@ namespace System
             }
         }
 
-        static (nint Quotient, nint Remainder) INumber<nint>.DivRem(nint left, nint right)
-            => Math.DivRem(left, right);
+        /// <inheritdoc cref="INumber{TSelf}.DivRem(TSelf, TSelf)" />
+        static (nint Quotient, nint Remainder) INumber<nint>.DivRem(nint left, nint right) => Math.DivRem(left, right);
 
-        static nint INumber<nint>.Max(nint x, nint y)
-            => Math.Max(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        static nint INumber<nint>.Max(nint x, nint y) => Math.Max(x, y);
 
-        static nint INumber<nint>.Min(nint x, nint y)
-            => Math.Min(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        static nint INumber<nint>.Min(nint x, nint y) => Math.Min(x, y);
 
-        static nint INumber<nint>.Parse(string s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        static nint INumber<nint>.Sign(nint value) => Math.Sign(value);
 
-        static nint INumber<nint>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
-
-        static nint INumber<nint>.Sign(nint value)
-            => Math.Sign(value);
-
+        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool INumber<nint>.TryCreate<TOther>(TOther value, out nint result)
         {
@@ -837,79 +848,54 @@ namespace System
             }
         }
 
-        static bool INumber<nint>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out nint result)
-            => TryParse(s, style, provider, out result);
-
-        static bool INumber<nint>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out nint result)
-            => TryParse(s, style, provider, out result);
-
-        //
-        // IParseable
-        //
-
-        static nint IParseable<nint>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider);
-
-        static bool IParseable<nint>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out nint result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
-
         //
         // IShiftOperators
         //
 
-        static nint IShiftOperators<nint, nint>.operator <<(nint value, int shiftAmount)
-            => value << (int)shiftAmount;
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_LeftShift(TSelf, int)" />
+        static nint IShiftOperators<nint, nint>.operator <<(nint value, int shiftAmount) => value << (int)shiftAmount;
 
-        static nint IShiftOperators<nint, nint>.operator >>(nint value, int shiftAmount)
-            => value >> (int)shiftAmount;
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_RightShift(TSelf, int)" />
+        static nint IShiftOperators<nint, nint>.operator >>(nint value, int shiftAmount) => value >> (int)shiftAmount;
 
-        // static nint IShiftOperators<nint, nint>.operator >>>(nint value, int shiftAmount)
-        //     => (nint)((nuint)value >> (int)shiftAmount);
+        // /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_UnsignedRightShift(TSelf, int)" />
+        // static nint IShiftOperators<nint, nint>.operator >>>(nint value, int shiftAmount) => (nint)((nuint)value >> (int)shiftAmount);
 
         //
         // ISignedNumber
         //
 
+        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
         static nint ISignedNumber<nint>.NegativeOne => -1;
-
-        //
-        // ISpanParseable
-        //
-
-        static nint ISpanParseable<nint>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, NumberStyles.Integer, provider);
-
-        static bool ISpanParseable<nint>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out nint result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
 
         //
         // ISubtractionOperators
         //
 
-        static nint ISubtractionOperators<nint, nint, nint>.operator -(nint left, nint right)
-            => left - right;
+        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_Subtraction(TSelf, TOther)" />
+        static nint ISubtractionOperators<nint, nint, nint>.operator -(nint left, nint right) => left - right;
 
-        // static checked nint ISubtractionOperators<nint, nint, nint>.operator -(nint left, nint right)
-        //     => checked(left - right);
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static nint ISubtractionOperators<nint, nint, nint>.operator checked -(nint left, nint right) => checked(left - right);
 
         //
         // IUnaryNegationOperators
         //
 
-        static nint IUnaryNegationOperators<nint, nint>.operator -(nint value)
-            => -value;
+        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_UnaryNegation(TSelf)" />
+        static nint IUnaryNegationOperators<nint, nint>.operator -(nint value) => -value;
 
-        // static checked nint IUnaryNegationOperators<nint, nint>.operator -(nint value)
-        //     => checked(-value);
+        // /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
+        // static nint IUnaryNegationOperators<nint, nint>.operator checked -(nint value) => checked(-value);
 
         //
         // IUnaryPlusOperators
         //
 
-        static nint IUnaryPlusOperators<nint, nint>.operator +(nint value)
-            => +value;
+        /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_UnaryPlus(TSelf)" />
+        static nint IUnaryPlusOperators<nint, nint>.operator +(nint value) => +value;
 
-        // static checked nint IUnaryPlusOperators<nint, nint>.operator +(nint value)
-        //     => checked(+value);
+        // /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_CheckedUnaryPlus(TSelf)" />
+        // static nint IUnaryPlusOperators<nint, nint>.operator checked +(nint value) => checked(+value);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SByte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SByte.cs
@@ -32,19 +32,19 @@ namespace System
         // The minimum value that a Byte may represent: -128.
         public const sbyte MinValue = unchecked((sbyte)0x80);
 
-        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        /// <summary>Represents the additive identity (0).</summary>
         public const sbyte AdditiveIdentity = 0;
 
-        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        /// <summary>Represents the multiplicative identity (1).</summary>
         public const sbyte MultiplicativeIdentity = 1;
 
-        /// <inheritdoc cref="INumber{TSelf}.One" />
+        /// <summary>Represents the number one (1).</summary>
         public const sbyte One = 1;
 
-        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        /// <summary>Represents the number zero (0).</summary>
         public const sbyte Zero = 0;
 
-        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        /// <summary>Represents the number negative one (-1).</summary>
         public const sbyte NegativeOne = -1;
 
         // Compares this object to another object, returning an integer that

--- a/src/libraries/System.Private.CoreLib/src/System/SByte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SByte.cs
@@ -32,6 +32,20 @@ namespace System
         // The minimum value that a Byte may represent: -128.
         public const sbyte MinValue = unchecked((sbyte)0x80);
 
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        public const sbyte AdditiveIdentity = 0;
+
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        public const sbyte MultiplicativeIdentity = 1;
+
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        public const sbyte One = 1;
+
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        public const sbyte Zero = 0;
+
+        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        public const sbyte NegativeOne = -1;
 
         // Compares this object to another object, returning an integer that
         // indicates the relationship.
@@ -297,45 +311,47 @@ namespace System
         // IAdditionOperators
         //
 
-        static sbyte IAdditionOperators<sbyte, sbyte, sbyte>.operator +(sbyte left, sbyte right)
-            => (sbyte)(left + right);
+        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        static sbyte IAdditionOperators<sbyte, sbyte, sbyte>.operator +(sbyte left, sbyte right) => (sbyte)(left + right);
 
-        // static checked sbyte IAdditionOperators<sbyte, sbyte, sbyte>.operator +(sbyte left, sbyte right)
-        //     => checked((sbyte)(left + right));
+        // /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        // static sbyte IAdditionOperators<sbyte, sbyte, sbyte>.operator checked +(sbyte left, sbyte right) => checked((sbyte)(left + right));
 
         //
         // IAdditiveIdentity
         //
 
-        static sbyte IAdditiveIdentity<sbyte, sbyte>.AdditiveIdentity => 0;
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        static sbyte IAdditiveIdentity<sbyte, sbyte>.AdditiveIdentity => AdditiveIdentity;
 
         //
         // IBinaryInteger
         //
 
-        static sbyte IBinaryInteger<sbyte>.LeadingZeroCount(sbyte value)
-            => (sbyte)(BitOperations.LeadingZeroCount((byte)value) - 24);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.LeadingZeroCount(TSelf)" />
+        public static sbyte LeadingZeroCount(sbyte value) => (sbyte)(BitOperations.LeadingZeroCount((byte)value) - 24);
 
-        static sbyte IBinaryInteger<sbyte>.PopCount(sbyte value)
-            => (sbyte)BitOperations.PopCount((byte)value);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.PopCount(TSelf)" />
+        public static sbyte PopCount(sbyte value) => (sbyte)BitOperations.PopCount((byte)value);
 
-        static sbyte IBinaryInteger<sbyte>.RotateLeft(sbyte value, int rotateAmount)
-            => (sbyte)((value << (rotateAmount & 7)) | ((byte)value >> ((8 - rotateAmount) & 7)));
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateLeft(TSelf, int)" />
+        public static sbyte RotateLeft(sbyte value, int rotateAmount) => (sbyte)((value << (rotateAmount & 7)) | ((byte)value >> ((8 - rotateAmount) & 7)));
 
-        static sbyte IBinaryInteger<sbyte>.RotateRight(sbyte value, int rotateAmount)
-            => (sbyte)(((byte)value >> (rotateAmount & 7)) | (value << ((8 - rotateAmount) & 7)));
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateRight(TSelf, int)" />
+        public static sbyte RotateRight(sbyte value, int rotateAmount) => (sbyte)(((byte)value >> (rotateAmount & 7)) | (value << ((8 - rotateAmount) & 7)));
 
-        static sbyte IBinaryInteger<sbyte>.TrailingZeroCount(sbyte value)
-            => (sbyte)(BitOperations.TrailingZeroCount(value << 24) - 24);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.TrailingZeroCount(TSelf)" />
+        public static sbyte TrailingZeroCount(sbyte value) => (sbyte)(BitOperations.TrailingZeroCount(value << 24) - 24);
 
         //
         // IBinaryNumber
         //
 
-        static bool IBinaryNumber<sbyte>.IsPow2(sbyte value)
-            => BitOperations.IsPow2(value);
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
+        public static bool IsPow2(sbyte value) => BitOperations.IsPow2(value);
 
-        static sbyte IBinaryNumber<sbyte>.Log2(sbyte value)
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />
+        public static sbyte Log2(sbyte value)
         {
             if (value < 0)
             {
@@ -348,124 +364,128 @@ namespace System
         // IBitwiseOperators
         //
 
-        static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator &(sbyte left, sbyte right)
-            => (sbyte)(left & right);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseAnd(TSelf, TOther)" />
+        static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator &(sbyte left, sbyte right) => (sbyte)(left & right);
 
-        static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator |(sbyte left, sbyte right)
-            => (sbyte)(left | right);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseOr(TSelf, TOther)" />
+        static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator |(sbyte left, sbyte right) => (sbyte)(left | right);
 
-        static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator ^(sbyte left, sbyte right)
-            => (sbyte)(left ^ right);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_ExclusiveOr(TSelf, TOther)" />
+        static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator ^(sbyte left, sbyte right) => (sbyte)(left ^ right);
 
-        static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator ~(sbyte value)
-            => (sbyte)(~value);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_OnesComplement(TSelf)" />
+        static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator ~(sbyte value) => (sbyte)(~value);
 
         //
         // IComparisonOperators
         //
 
-        static bool IComparisonOperators<sbyte, sbyte>.operator <(sbyte left, sbyte right)
-            => left < right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
+        static bool IComparisonOperators<sbyte, sbyte>.operator <(sbyte left, sbyte right) => left < right;
 
-        static bool IComparisonOperators<sbyte, sbyte>.operator <=(sbyte left, sbyte right)
-            => left <= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<sbyte, sbyte>.operator <=(sbyte left, sbyte right) => left <= right;
 
-        static bool IComparisonOperators<sbyte, sbyte>.operator >(sbyte left, sbyte right)
-            => left > right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
+        static bool IComparisonOperators<sbyte, sbyte>.operator >(sbyte left, sbyte right) => left > right;
 
-        static bool IComparisonOperators<sbyte, sbyte>.operator >=(sbyte left, sbyte right)
-            => left >= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<sbyte, sbyte>.operator >=(sbyte left, sbyte right) => left >= right;
 
         //
         // IDecrementOperators
         //
 
-        static sbyte IDecrementOperators<sbyte>.operator --(sbyte value)
-            => --value;
+        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        static sbyte IDecrementOperators<sbyte>.operator --(sbyte value) => --value;
 
-        // static checked sbyte IDecrementOperators<sbyte>.operator --(sbyte value)
-        //     => checked(--value);
+        // /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        // static sbyte IDecrementOperators<sbyte>.operator checked --(sbyte value) => checked(--value);
 
         //
         // IDivisionOperators
         //
 
-        static sbyte IDivisionOperators<sbyte, sbyte, sbyte>.operator /(sbyte left, sbyte right)
-            => (sbyte)(left / right);
+        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
+        static sbyte IDivisionOperators<sbyte, sbyte, sbyte>.operator /(sbyte left, sbyte right) => (sbyte)(left / right);
 
-        // static checked sbyte IDivisionOperators<sbyte, sbyte, sbyte>.operator /(sbyte left, sbyte right)
-        //     => checked((sbyte)(left / right));
+        // /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
+        // static sbyte IDivisionOperators<sbyte, sbyte, sbyte>.operator checked /(sbyte left, sbyte right) => checked((sbyte)(left / right));
 
         //
         // IEqualityOperators
         //
 
-        static bool IEqualityOperators<sbyte, sbyte>.operator ==(sbyte left, sbyte right)
-            => left == right;
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Equality(TSelf, TOther)" />
+        static bool IEqualityOperators<sbyte, sbyte>.operator ==(sbyte left, sbyte right) => left == right;
 
-        static bool IEqualityOperators<sbyte, sbyte>.operator !=(sbyte left, sbyte right)
-            => left != right;
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Inequality(TSelf, TOther)" />
+        static bool IEqualityOperators<sbyte, sbyte>.operator !=(sbyte left, sbyte right) => left != right;
 
         //
         // IIncrementOperators
         //
 
-        static sbyte IIncrementOperators<sbyte>.operator ++(sbyte value)
-            => ++value;
+        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_Increment(TSelf)" />
+        static sbyte IIncrementOperators<sbyte>.operator ++(sbyte value) => ++value;
 
-        // static checked sbyte IIncrementOperators<sbyte>.operator ++(sbyte value)
-        //     => checked(++value);
+        // /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
+        // static sbyte IIncrementOperators<sbyte>.operator checked ++(sbyte value) => checked(++value);
 
         //
         // IMinMaxValue
         //
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MinValue" />
         static sbyte IMinMaxValue<sbyte>.MinValue => MinValue;
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MaxValue" />
         static sbyte IMinMaxValue<sbyte>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        static sbyte IModulusOperators<sbyte, sbyte, sbyte>.operator %(sbyte left, sbyte right)
-            => (sbyte)(left % right);
-
-        // static checked sbyte IModulusOperators<sbyte, sbyte, sbyte>.operator %(sbyte left, sbyte right)
-        //     => checked((sbyte)(left % right));
+        /// <inheritdoc cref="IModulusOperators{TSelf, TOther, TResult}.op_Modulus(TSelf, TOther)" />
+        static sbyte IModulusOperators<sbyte, sbyte, sbyte>.operator %(sbyte left, sbyte right) => (sbyte)(left % right);
 
         //
         // IMultiplicativeIdentity
         //
 
-        static sbyte IMultiplicativeIdentity<sbyte, sbyte>.MultiplicativeIdentity => 1;
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        static sbyte IMultiplicativeIdentity<sbyte, sbyte>.MultiplicativeIdentity => MultiplicativeIdentity;
 
         //
         // IMultiplyOperators
         //
 
-        static sbyte IMultiplyOperators<sbyte, sbyte, sbyte>.operator *(sbyte left, sbyte right)
-            => (sbyte)(left * right);
+        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
+        static sbyte IMultiplyOperators<sbyte, sbyte, sbyte>.operator *(sbyte left, sbyte right) => (sbyte)(left * right);
 
-        // static checked sbyte IMultiplyOperators<sbyte, sbyte, sbyte>.operator *(sbyte left, sbyte right)
-        //     => checked((sbyte)(left * right));
+        // /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
+        // static sbyte IMultiplyOperators<sbyte, sbyte, sbyte>.operator checked *(sbyte left, sbyte right) => checked((sbyte)(left * right));
 
         //
         // INumber
         //
 
-        static sbyte INumber<sbyte>.One => 1;
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        static sbyte INumber<sbyte>.One => One;
 
-        static sbyte INumber<sbyte>.Zero => 0;
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        static sbyte INumber<sbyte>.Zero => Zero;
 
-        static sbyte INumber<sbyte>.Abs(sbyte value)
-            => Math.Abs(value);
+        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
+        public static sbyte Abs(sbyte value) => Math.Abs(value);
 
-        static sbyte INumber<sbyte>.Clamp(sbyte value, sbyte min, sbyte max)
-            => Math.Clamp(value, min, max);
+        /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
+        public static sbyte Clamp(sbyte value, sbyte min, sbyte max) => Math.Clamp(value, min, max);
 
+        /// <inheritdoc cref="INumber{TSelf}.Create{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static sbyte INumber<sbyte>.Create<TOther>(TOther value)
+        public static sbyte Create<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -530,8 +550,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static sbyte INumber<sbyte>.CreateSaturating<TOther>(TOther value)
+        public static sbyte CreateSaturating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -616,8 +638,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static sbyte INumber<sbyte>.CreateTruncating<TOther>(TOther value)
+        public static sbyte CreateTruncating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -682,26 +706,22 @@ namespace System
             }
         }
 
-        static (sbyte Quotient, sbyte Remainder) INumber<sbyte>.DivRem(sbyte left, sbyte right)
-            => Math.DivRem(left, right);
+        /// <inheritdoc cref="INumber{TSelf}.DivRem(TSelf, TSelf)" />
+        public static (sbyte Quotient, sbyte Remainder) DivRem(sbyte left, sbyte right) => Math.DivRem(left, right);
 
-        static sbyte INumber<sbyte>.Max(sbyte x, sbyte y)
-            => Math.Max(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static sbyte Max(sbyte x, sbyte y) => Math.Max(x, y);
 
-        static sbyte INumber<sbyte>.Min(sbyte x, sbyte y)
-            => Math.Min(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static sbyte Min(sbyte x, sbyte y) => Math.Min(x, y);
 
-        static sbyte INumber<sbyte>.Parse(string s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static sbyte Sign(sbyte value) => (sbyte)Math.Sign(value);
 
-        static sbyte INumber<sbyte>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
-
-        static sbyte INumber<sbyte>.Sign(sbyte value)
-            => (sbyte)Math.Sign(value);
-
+        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool INumber<sbyte>.TryCreate<TOther>(TOther value, out sbyte result)
+        public static bool TryCreate<TOther>(TOther value, out sbyte result)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -885,79 +905,70 @@ namespace System
             }
         }
 
-        static bool INumber<sbyte>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out sbyte result)
-            => TryParse(s, style, provider, out result);
-
-        static bool INumber<sbyte>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out sbyte result)
-            => TryParse(s, style, provider, out result);
-
         //
         // IParseable
         //
 
-        static sbyte IParseable<sbyte>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider);
-
-        static bool IParseable<sbyte>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out sbyte result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out sbyte result) => TryParse(s, NumberStyles.Integer, provider, out result);
 
         //
         // IShiftOperators
         //
 
-        static sbyte IShiftOperators<sbyte, sbyte>.operator <<(sbyte value, int shiftAmount)
-            => (sbyte)(value << shiftAmount);
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_LeftShift(TSelf, int)" />
+        static sbyte IShiftOperators<sbyte, sbyte>.operator <<(sbyte value, int shiftAmount) => (sbyte)(value << shiftAmount);
 
-        static sbyte IShiftOperators<sbyte, sbyte>.operator >>(sbyte value, int shiftAmount)
-            => (sbyte)(value >> shiftAmount);
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_RightShift(TSelf, int)" />
+        static sbyte IShiftOperators<sbyte, sbyte>.operator >>(sbyte value, int shiftAmount) => (sbyte)(value >> shiftAmount);
 
-        // static sbyte IShiftOperators<sbyte, sbyte>.operator >>>(sbyte value, int shiftAmount)
-        //     => (sbyte)((byte)value >> shiftAmount);
+        // /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_UnsignedRightShift(TSelf, int)" />
+        // static sbyte IShiftOperators<sbyte, sbyte>.operator >>>(sbyte value, int shiftAmount) => (sbyte)((byte)value >> shiftAmount);
 
         //
         // ISignedNumber
         //
 
-        static sbyte ISignedNumber<sbyte>.NegativeOne => -1;
+        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        static sbyte ISignedNumber<sbyte>.NegativeOne => NegativeOne;
 
         //
         // ISpanParseable
         //
 
-        static sbyte ISpanParseable<sbyte>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, NumberStyles.Integer, provider);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
+        public static sbyte Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, NumberStyles.Integer, provider);
 
-        static bool ISpanParseable<sbyte>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out sbyte result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out sbyte result) => TryParse(s, NumberStyles.Integer, provider, out result);
 
         //
         // ISubtractionOperators
         //
 
-        static sbyte ISubtractionOperators<sbyte, sbyte, sbyte>.operator -(sbyte left, sbyte right)
-            => (sbyte)(left - right);
+        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_Subtraction(TSelf, TOther)" />
+        static sbyte ISubtractionOperators<sbyte, sbyte, sbyte>.operator -(sbyte left, sbyte right) => (sbyte)(left - right);
 
-        // static checked sbyte ISubtractionOperators<sbyte, sbyte, sbyte>.operator -(sbyte left, sbyte right)
-        //     => checked((sbyte)(left - right));
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static sbyte ISubtractionOperators<sbyte, sbyte, sbyte>.operator checked -(sbyte left, sbyte right) => checked((sbyte)(left - right));
 
         //
         // IUnaryNegationOperators
         //
 
-        static sbyte IUnaryNegationOperators<sbyte, sbyte>.operator -(sbyte value)
-            => (sbyte)(-value);
+        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_UnaryNegation(TSelf)" />
+        static sbyte IUnaryNegationOperators<sbyte, sbyte>.operator -(sbyte value) => (sbyte)(-value);
 
-        // static checked sbyte IUnaryNegationOperators<sbyte, sbyte>.operator -(sbyte value)
-        //     => checked((sbyte)(-value));
+        // /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
+        // static sbyte IUnaryNegationOperators<sbyte, sbyte>.operator checked -(sbyte value) => checked((sbyte)(-value));
 
         //
         // IUnaryPlusOperators
         //
 
-        static sbyte IUnaryPlusOperators<sbyte, sbyte>.operator +(sbyte value)
-            => (sbyte)(+value);
+        /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_UnaryPlus(TSelf)" />
+        static sbyte IUnaryPlusOperators<sbyte, sbyte>.operator +(sbyte value) => (sbyte)(+value);
 
-        // static checked sbyte IUnaryPlusOperators<sbyte, sbyte>.operator +(sbyte value)
-        //     => checked((sbyte)(+value));
+        // /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_CheckedUnaryPlus(TSelf)" />
+        // static sbyte IUnaryPlusOperators<sbyte, sbyte>.operator checked +(sbyte value) => checked((sbyte)(+value));
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -36,14 +36,41 @@ namespace System
         // Public constants
         //
         public const float MinValue = (float)-3.40282346638528859e+38;
-        public const float Epsilon = (float)1.4e-45;
         public const float MaxValue = (float)3.40282346638528859e+38;
-        public const float PositiveInfinity = (float)1.0 / (float)0.0;
+
+        // Note Epsilon should be a float whose hex representation is 0x1
+        // on little endian machines.
+        public const float Epsilon = (float)1.4e-45;
         public const float NegativeInfinity = (float)-1.0 / (float)0.0;
+        public const float PositiveInfinity = (float)1.0 / (float)0.0;
         public const float NaN = (float)0.0 / (float)0.0;
 
-        // We use this explicit definition to avoid the confusion between 0.0 and -0.0.
-        internal const float NegativeZero = (float)-0.0;
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        public const float AdditiveIdentity = 0.0f;
+
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        public const float MultiplicativeIdentity = 1.0f;
+
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        public const float One = 1.0f;
+
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        public const float Zero = 0.0f;
+
+        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        public const float NegativeOne = -1.0f;
+
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.NegativeZero" />
+        public const float NegativeZero = -0.0f;
+
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.E" />
+        public const float E = MathF.E;
+
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Pi" />
+        public const float Pi = MathF.PI;
+
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Tau" />
+        public const float Tau = MathF.Tau;
 
         //
         // Constants for manipulating the private bit-representation
@@ -195,21 +222,27 @@ namespace System
                 return 1;
         }
 
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Equality(TSelf, TOther)" />
         [NonVersionable]
         public static bool operator ==(float left, float right) => left == right;
 
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Inequality(TSelf, TOther)" />
         [NonVersionable]
         public static bool operator !=(float left, float right) => left != right;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
         [NonVersionable]
         public static bool operator <(float left, float right) => left < right;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
         [NonVersionable]
         public static bool operator >(float left, float right) => left > right;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
         [NonVersionable]
         public static bool operator <=(float left, float right) => left <= right;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
         [NonVersionable]
         public static bool operator >=(float left, float right) => left >= right;
 
@@ -446,23 +479,25 @@ namespace System
         // IAdditionOperators
         //
 
-        static float IAdditionOperators<float, float, float>.operator +(float left, float right)
-            => left + right;
+        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        static float IAdditionOperators<float, float, float>.operator +(float left, float right) => left + right;
 
-        // static checked float IAdditionOperators<float, float, float>.operator +(float left, float right)
-        //     => checked(left + right);
+        // /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        // static float IAdditionOperators<float, float, float>.operator checked +(float left, float right) => checked(left + right);
 
         //
         // IAdditiveIdentity
         //
 
-        static float IAdditiveIdentity<float, float>.AdditiveIdentity => 0.0f;
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        static float IAdditiveIdentity<float, float>.AdditiveIdentity => AdditiveIdentity;
 
         //
         // IBinaryNumber
         //
 
-        static bool IBinaryNumber<float>.IsPow2(float value)
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
+        public static bool IsPow2(float value)
         {
             uint bits = BitConverter.SingleToUInt32Bits(value);
 
@@ -474,31 +509,35 @@ namespace System
                 && (significand == MinSignificand);
         }
 
-        static float IBinaryNumber<float>.Log2(float value)
-            => MathF.Log2(value);
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />
+        public static float Log2(float value) => MathF.Log2(value);
 
         //
         // IBitwiseOperators
         //
 
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseAnd(TSelf, TOther)" />
         static float IBitwiseOperators<float, float, float>.operator &(float left, float right)
         {
             uint bits = BitConverter.SingleToUInt32Bits(left) & BitConverter.SingleToUInt32Bits(right);
             return BitConverter.UInt32BitsToSingle(bits);
         }
 
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseOr(TSelf, TOther)" />
         static float IBitwiseOperators<float, float, float>.operator |(float left, float right)
         {
             uint bits = BitConverter.SingleToUInt32Bits(left) | BitConverter.SingleToUInt32Bits(right);
             return BitConverter.UInt32BitsToSingle(bits);
         }
 
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_ExclusiveOr(TSelf, TOther)" />
         static float IBitwiseOperators<float, float, float>.operator ^(float left, float right)
         {
             uint bits = BitConverter.SingleToUInt32Bits(left) ^ BitConverter.SingleToUInt32Bits(right);
             return BitConverter.UInt32BitsToSingle(bits);
         }
 
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_OnesComplement(TSelf)" />
         static float IBitwiseOperators<float, float, float>.operator ~(float value)
         {
             uint bits = ~BitConverter.SingleToUInt32Bits(value);
@@ -506,324 +545,297 @@ namespace System
         }
 
         //
-        // IComparisonOperators
-        //
-
-        static bool IComparisonOperators<float, float>.operator <(float left, float right)
-            => left < right;
-
-        static bool IComparisonOperators<float, float>.operator <=(float left, float right)
-            => left <= right;
-
-        static bool IComparisonOperators<float, float>.operator >(float left, float right)
-            => left > right;
-
-        static bool IComparisonOperators<float, float>.operator >=(float left, float right)
-            => left >= right;
-
-        //
         // IDecrementOperators
         //
 
-        static float IDecrementOperators<float>.operator --(float value)
-            => --value;
+        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        static float IDecrementOperators<float>.operator --(float value) => --value;
 
-        // static checked float IDecrementOperators<float>.operator --(float value)
-        //     => checked(--value);
+        // /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        // static float IDecrementOperators<float>.operator checked --(float value) => checked(--value);
 
         //
         // IDivisionOperators
         //
 
-        static float IDivisionOperators<float, float, float>.operator /(float left, float right)
-            => left / right;
+        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
+        static float IDivisionOperators<float, float, float>.operator /(float left, float right) => left / right;
 
-        // static checked float IDivisionOperators<float, float, float>.operator /(float left, float right)
-        //     => checked(left / right);
-
-        //
-        // IEqualityOperators
-        //
-
-        static bool IEqualityOperators<float, float>.operator ==(float left, float right)
-            => left == right;
-
-        static bool IEqualityOperators<float, float>.operator !=(float left, float right)
-            => left != right;
+        // /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
+        // static float IDivisionOperators<float, float, float>.operator checked /(float left, float right) => checked(left / right);
 
         //
         // IFloatingPoint
         //
 
-        static float IFloatingPoint<float>.E => MathF.E;
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.E" />
+        static float IFloatingPoint<float>.E => E;
 
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Epsilon" />
         static float IFloatingPoint<float>.Epsilon => Epsilon;
 
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.NaN" />
         static float IFloatingPoint<float>.NaN => NaN;
 
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.NegativeInfinity" />
         static float IFloatingPoint<float>.NegativeInfinity => NegativeInfinity;
 
-        static float IFloatingPoint<float>.NegativeZero => -0.0f;
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.NegativeZero" />
+        static float IFloatingPoint<float>.NegativeZero => NegativeZero;
 
-        static float IFloatingPoint<float>.Pi => MathF.PI;
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Pi" />
+        static float IFloatingPoint<float>.Pi => Pi;
 
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.PositiveInfinity" />
         static float IFloatingPoint<float>.PositiveInfinity => PositiveInfinity;
 
-        static float IFloatingPoint<float>.Tau => MathF.Tau;
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Tau" />
+        static float IFloatingPoint<float>.Tau => Tau;
 
-        static float IFloatingPoint<float>.Acos(float x)
-            => MathF.Acos(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Acos(TSelf)" />
+        public static float Acos(float x) => MathF.Acos(x);
 
-        static float IFloatingPoint<float>.Acosh(float x)
-            => MathF.Acosh(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Acosh(TSelf)" />
+        public static float Acosh(float x) => MathF.Acosh(x);
 
-        static float IFloatingPoint<float>.Asin(float x)
-            => MathF.Asin(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Asin(TSelf)" />
+        public static float Asin(float x) => MathF.Asin(x);
 
-        static float IFloatingPoint<float>.Asinh(float x)
-            => MathF.Asinh(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Asinh(TSelf)" />
+        public static float Asinh(float x) => MathF.Asinh(x);
 
-        static float IFloatingPoint<float>.Atan(float x)
-            => MathF.Atan(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Atan(TSelf)" />
+        public static float Atan(float x) => MathF.Atan(x);
 
-        static float IFloatingPoint<float>.Atan2(float y, float x)
-            => MathF.Atan2(y, x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Atan2(TSelf, TSelf)" />
+        public static float Atan2(float y, float x) => MathF.Atan2(y, x);
 
-        static float IFloatingPoint<float>.Atanh(float x)
-            => MathF.Atanh(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Atanh(TSelf)" />
+        public static float Atanh(float x) => MathF.Atanh(x);
 
-        static float IFloatingPoint<float>.BitIncrement(float x)
-            => MathF.BitIncrement(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.BitIncrement(TSelf)" />
+        public static float BitIncrement(float x) => MathF.BitIncrement(x);
 
-        static float IFloatingPoint<float>.BitDecrement(float x)
-            => MathF.BitDecrement(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.BitDecrement(TSelf)" />
+        public static float BitDecrement(float x) => MathF.BitDecrement(x);
 
-        static float IFloatingPoint<float>.Cbrt(float x)
-            => MathF.Cbrt(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Cbrt(TSelf)" />
+        public static float Cbrt(float x) => MathF.Cbrt(x);
 
-        static float IFloatingPoint<float>.Ceiling(float x)
-            => MathF.Ceiling(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Ceiling(TSelf)" />
+        public static float Ceiling(float x) => MathF.Ceiling(x);
 
-        static float IFloatingPoint<float>.CopySign(float x, float y)
-            => MathF.CopySign(x, y);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.CopySign(TSelf, TSelf)" />
+        public static float CopySign(float x, float y) => MathF.CopySign(x, y);
 
-        static float IFloatingPoint<float>.Cos(float x)
-            => MathF.Cos(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Cos(TSelf)" />
+        public static float Cos(float x) => MathF.Cos(x);
 
-        static float IFloatingPoint<float>.Cosh(float x)
-            => MathF.Cosh(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Cosh(TSelf)" />
+        public static float Cosh(float x) => MathF.Cosh(x);
 
-        static float IFloatingPoint<float>.Exp(float x)
-            => MathF.Exp(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Exp" />
+        public static float Exp(float x) => MathF.Exp(x);
 
-        static float IFloatingPoint<float>.Floor(float x)
-            => MathF.Floor(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Floor(TSelf)" />
+        public static float Floor(float x) => MathF.Floor(x);
 
-        static float IFloatingPoint<float>.FusedMultiplyAdd(float left, float right, float addend)
-            => MathF.FusedMultiplyAdd(left, right, addend);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.FusedMultiplyAdd(TSelf, TSelf, TSelf)" />
+        public static float FusedMultiplyAdd(float left, float right, float addend) => MathF.FusedMultiplyAdd(left, right, addend);
 
-        static float IFloatingPoint<float>.IEEERemainder(float left, float right)
-            => MathF.IEEERemainder(left, right);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.IEEERemainder(TSelf, TSelf)" />
+        public static float IEEERemainder(float left, float right) => MathF.IEEERemainder(left, right);
 
-        static TInteger IFloatingPoint<float>.ILogB<TInteger>(float x)
-            => TInteger.Create(MathF.ILogB(x));
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.ILogB{TInteger}(TSelf)" />
+        public static TInteger ILogB<TInteger>(float x)
+            where TInteger : IBinaryInteger<TInteger> => TInteger.Create(MathF.ILogB(x));
 
-        static float IFloatingPoint<float>.Log(float x)
-            => MathF.Log(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Log(TSelf)" />
+        public static float Log(float x) => MathF.Log(x);
 
-        static float IFloatingPoint<float>.Log(float x, float newBase)
-            => MathF.Log(x, newBase);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Log(TSelf, TSelf)" />
+        public static float Log(float x, float newBase) => MathF.Log(x, newBase);
 
-        static float IFloatingPoint<float>.Log2(float x)
-            => MathF.Log2(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Log10(TSelf)" />
+        public static float Log10(float x) => MathF.Log10(x);
 
-        static float IFloatingPoint<float>.Log10(float x)
-            => MathF.Log10(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.MaxMagnitude(TSelf, TSelf)" />
+        public static float MaxMagnitude(float x, float y) => MathF.MaxMagnitude(x, y);
 
-        static float IFloatingPoint<float>.MaxMagnitude(float x, float y)
-            => MathF.MaxMagnitude(x, y);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.MinMagnitude(TSelf, TSelf)" />
+        public static float MinMagnitude(float x, float y) => MathF.MinMagnitude(x, y);
 
-        static float IFloatingPoint<float>.MinMagnitude(float x, float y)
-            => MathF.MinMagnitude(x, y);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Pow(TSelf, TSelf)" />
+        public static float Pow(float x, float y) => MathF.Pow(x, y);
 
-        static float IFloatingPoint<float>.Pow(float x, float y)
-            => MathF.Pow(x, y);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Round(TSelf)" />
+        public static float Round(float x) => MathF.Round(x);
 
-        static float IFloatingPoint<float>.Round(float x)
-            => MathF.Round(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Round{TInteger}(TSelf, TInteger)" />
+        public static float Round<TInteger>(float x, TInteger digits)
+            where TInteger : IBinaryInteger<TInteger> => MathF.Round(x, int.Create(digits));
 
-        static float IFloatingPoint<float>.Round<TInteger>(float x, TInteger digits)
-            => MathF.Round(x, int.Create(digits));
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Round(TSelf, MidpointRounding)" />
+        public static float Round(float x, MidpointRounding mode) => MathF.Round(x, mode);
 
-        static float IFloatingPoint<float>.Round(float x, MidpointRounding mode)
-            => MathF.Round(x, mode);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Round{TInteger}(TSelf, TInteger, MidpointRounding)" />
+        public static float Round<TInteger>(float x, TInteger digits, MidpointRounding mode)
+            where TInteger : IBinaryInteger<TInteger> => MathF.Round(x, int.Create(digits), mode);
 
-        static float IFloatingPoint<float>.Round<TInteger>(float x, TInteger digits, MidpointRounding mode)
-            => MathF.Round(x, int.Create(digits), mode);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.ScaleB{TInteger}(TSelf, TInteger)" />
+        public static float ScaleB<TInteger>(float x, TInteger n)
+            where TInteger : IBinaryInteger<TInteger> => MathF.ScaleB(x, int.Create(n));
 
-        static float IFloatingPoint<float>.ScaleB<TInteger>(float x, TInteger n)
-            => MathF.ScaleB(x, int.Create(n));
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Sin(TSelf)" />
+        public static float Sin(float x) => MathF.Sin(x);
 
-        static float IFloatingPoint<float>.Sin(float x)
-            => MathF.Sin(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Sinh(TSelf)" />
+        public static float Sinh(float x) => MathF.Sinh(x);
 
-        static float IFloatingPoint<float>.Sinh(float x)
-            => MathF.Sinh(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Sqrt(TSelf)" />
+        public static float Sqrt(float x) => MathF.Sqrt(x);
 
-        static float IFloatingPoint<float>.Sqrt(float x)
-            => MathF.Sqrt(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Tan(TSelf)" />
+        public static float Tan(float x) => MathF.Tan(x);
 
-        static float IFloatingPoint<float>.Tan(float x)
-            => MathF.Tan(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Tanh(TSelf)" />
+        public static float Tanh(float x) => MathF.Tanh(x);
 
-        static float IFloatingPoint<float>.Tanh(float x)
-            => MathF.Tanh(x);
+        /// <inheritdoc cref="IFloatingPoint{TSelf}.Truncate(TSelf)" />
+        public static float Truncate(float x) => MathF.Truncate(x);
 
-        static float IFloatingPoint<float>.Truncate(float x)
-            => MathF.Truncate(x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.AcosPi(TSelf)" />
+        // public static float AcosPi(float x) => MathF.AcosPi(x);
 
-        static bool IFloatingPoint<float>.IsFinite(float x) => IsFinite(x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.AsinPi(TSelf)" />
+        // public static float AsinPi(float x) => MathF.AsinPi(x);
 
-        static bool IFloatingPoint<float>.IsInfinity(float x) => IsInfinity(x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.AtanPi(TSelf)" />
+        // public static float AtanPi(float x) => MathF.AtanPi(x);
 
-        static bool IFloatingPoint<float>.IsNaN(float x) => IsNaN(x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Atan2Pi(TSelf)" />
+        // public static float Atan2Pi(float y, float x) => MathF.Atan2Pi(y, x);
 
-        static bool IFloatingPoint<float>.IsNegative(float x) => IsNegative(x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Compound(TSelf, TSelf)" />
+        // public static float Compound(float x, float n) => MathF.Compound(x, n);
 
-        static bool IFloatingPoint<float>.IsNegativeInfinity(float x) => IsNegativeInfinity(x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.CosPi(TSelf)" />
+        // public static float CosPi(float x) => MathF.CosPi(x);
 
-        static bool IFloatingPoint<float>.IsNormal(float x) => IsNormal(x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.ExpM1(TSelf)" />
+        // public static float ExpM1(float x) => MathF.ExpM1(x);
 
-        static bool IFloatingPoint<float>.IsPositiveInfinity(float x) => IsPositiveInfinity(x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Exp2(TSelf)" />
+        // public static float Exp2(float x) => MathF.Exp2(x);
 
-        static bool IFloatingPoint<float>.IsSubnormal(float x) => IsSubnormal(x);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Exp2M1(TSelf)" />
+        // public static float Exp2M1(float x) => MathF.Exp2M1(x);
 
-        // static float IFloatingPoint<float>.AcosPi(float x)
-        //     => MathF.AcosPi(x);
-        //
-        // static float IFloatingPoint<float>.AsinPi(float x)
-        //     => MathF.AsinPi(x);
-        //
-        // static float IFloatingPoint<float>.AtanPi(float x)
-        //     => MathF.AtanPi(x);
-        //
-        // static float IFloatingPoint<float>.Atan2Pi(float y, float x)
-        //     => MathF.Atan2Pi(y, x);
-        //
-        // static float IFloatingPoint<float>.Compound(float x, float n)
-        //     => MathF.Compound(x, n);
-        //
-        // static float IFloatingPoint<float>.CosPi(float x)
-        //     => MathF.CosPi(x);
-        //
-        // static float IFloatingPoint<float>.ExpM1(float x)
-        //     => MathF.ExpM1(x);
-        //
-        // static float IFloatingPoint<float>.Exp2(float x)
-        //     => MathF.Exp2(x);
-        //
-        // static float IFloatingPoint<float>.Exp2M1(float x)
-        //     => MathF.Exp2M1(x);
-        //
-        // static float IFloatingPoint<float>.Exp10(float x)
-        //     => MathF.Exp10(x);
-        //
-        // static float IFloatingPoint<float>.Exp10M1(float x)
-        //     => MathF.Exp10M1(x);
-        //
-        // static float IFloatingPoint<float>.Hypot(float x, float y)
-        //     => MathF.Hypot(x, y);
-        //
-        // static float IFloatingPoint<float>.LogP1(float x)
-        //     => MathF.LogP1(x);
-        //
-        // static float IFloatingPoint<float>.Log2P1(float x)
-        //     => MathF.Log2P1(x);
-        //
-        // static float IFloatingPoint<float>.Log10P1(float x)
-        //     => MathF.Log10P1(x);
-        //
-        // static float IFloatingPoint<float>.MaxMagnitudeNumber(float x, float y)
-        //     => MathF.MaxMagnitudeNumber(x, y);
-        //
-        // static float IFloatingPoint<float>.MaxNumber(float x, float y)
-        //     => MathF.MaxNumber(x, y);
-        //
-        // static float IFloatingPoint<float>.MinMagnitudeNumber(float x, float y)
-        //     => MathF.MinMagnitudeNumber(x, y);
-        //
-        // static float IFloatingPoint<float>.MinNumber(float x, float y)
-        //     => MathF.MinNumber(x, y);
-        //
-        // static float IFloatingPoint<float>.Root(float x, float n)
-        //     => MathF.Root(x, n);
-        //
-        // static float IFloatingPoint<float>.SinPi(float x)
-        //     => MathF.SinPi(x, y);
-        //
-        // static float TanPi(float x)
-        //     => MathF.TanPi(x, y);
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Exp10(TSelf)" />
+        // public static float Exp10(float x) => MathF.Exp10(x);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Exp10M1(TSelf)" />
+        // public static float Exp10M1(float x) => MathF.Exp10M1(x);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Hypot(TSelf, TSelf)" />
+        // public static float Hypot(float x, float y) => MathF.Hypot(x, y);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.LogP1(TSelf)" />
+        // public static float LogP1(float x) => MathF.LogP1(x);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Log2P1(TSelf)" />
+        // public static float Log2P1(float x) => MathF.Log2P1(x);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Log10P1(TSelf)" />
+        // public static float Log10P1(float x) => MathF.Log10P1(x);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        // public static float MaxMagnitudeNumber(float x, float y) => MathF.MaxMagnitudeNumber(x, y);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.MaxNumber(TSelf, TSelf)" />
+        // public static float MaxNumber(float x, float y) => MathF.MaxNumber(x, y);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        // public static float MinMagnitudeNumber(float x, float y) => MathF.MinMagnitudeNumber(x, y);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.MinNumber(TSelf, TSelf)" />
+        // public static float MinNumber(float x, float y) => MathF.MinNumber(x, y);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.Root(TSelf, TSelf)" />
+        // public static float Root(float x, float n) => MathF.Root(x, n);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.SinPi(TSelf)" />
+        // public static float SinPi(float x) => MathF.SinPi(x, y);
+
+        // /// <inheritdoc cref="IFloatingPoint{TSelf}.TanPi(TSelf)" />
+        // public static float TanPi(float x) => MathF.TanPi(x, y);
 
         //
         // IIncrementOperators
         //
 
-        static float IIncrementOperators<float>.operator ++(float value)
-            => ++value;
+        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_Increment(TSelf)" />
+        static float IIncrementOperators<float>.operator ++(float value) => ++value;
 
-        // static checked float IIncrementOperators<float>.operator ++(float value)
-        //     => checked(++value);
+        // /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
+        // static float IIncrementOperators<float>.operator checked ++(float value) => checked(++value);
 
         //
         // IMinMaxValue
         //
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MinValue" />
         static float IMinMaxValue<float>.MinValue => MinValue;
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MaxValue" />
         static float IMinMaxValue<float>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        static float IModulusOperators<float, float, float>.operator %(float left, float right)
-            => left % right;
+        /// <inheritdoc cref="IModulusOperators{TSelf, TOther, TResult}.op_Modulus(TSelf, TOther)" />
+        static float IModulusOperators<float, float, float>.operator %(float left, float right) => left % right;
 
-        // static checked float IModulusOperators<float, float, float>.operator %(float left, float right)
-        //     => checked(left % right);
+        // static checked float IModulusOperators<float, float, float>.operator %(float left, float right) => checked(left % right);
 
         //
         // IMultiplicativeIdentity
         //
 
-        static float IMultiplicativeIdentity<float, float>.MultiplicativeIdentity => 1.0f;
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        static float IMultiplicativeIdentity<float, float>.MultiplicativeIdentity => MultiplicativeIdentity;
 
         //
         // IMultiplyOperators
         //
 
-        static float IMultiplyOperators<float, float, float>.operator *(float left, float right)
-            => (float)(left * right);
+        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
+        static float IMultiplyOperators<float, float, float>.operator *(float left, float right) => (float)(left * right);
 
-        // static checked float IMultiplyOperators<float, float, float>.operator *(float left, float right)
-        //     => checked((float)(left * right));
+        // /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
+        // static float IMultiplyOperators<float, float, float>.operator checked *(float left, float right) => checked((float)(left * right));
 
         //
         // INumber
         //
 
-        static float INumber<float>.One => 1.0f;
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        static float INumber<float>.One => One;
 
-        static float INumber<float>.Zero => 0.0f;
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        static float INumber<float>.Zero => Zero;
 
-        static float INumber<float>.Abs(float value)
-            => MathF.Abs(value);
+        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
+        public static float Abs(float value) => MathF.Abs(value);
 
-        static float INumber<float>.Clamp(float value, float min, float max)
-            => Math.Clamp(value, min, max);
+        /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
+        public static float Clamp(float value, float min, float max) => Math.Clamp(value, min, max);
 
+        /// <inheritdoc cref="INumber{TSelf}.Create{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static float INumber<float>.Create<TOther>(TOther value)
+        public static float Create<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -888,8 +900,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static float INumber<float>.CreateSaturating<TOther>(TOther value)
+        public static float CreateSaturating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -954,8 +968,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static float INumber<float>.CreateTruncating<TOther>(TOther value)
+        public static float CreateTruncating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1020,26 +1036,22 @@ namespace System
             }
         }
 
-        static (float Quotient, float Remainder) INumber<float>.DivRem(float left, float right)
-            => (left / right, left % right);
+        /// <inheritdoc cref="INumber{TSelf}.DivRem(TSelf, TSelf)" />
+        public static (float Quotient, float Remainder) DivRem(float left, float right) => (left / right, left % right);
 
-        static float INumber<float>.Max(float x, float y)
-            => MathF.Max(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static float Max(float x, float y) => MathF.Max(x, y);
 
-        static float INumber<float>.Min(float x, float y)
-            => MathF.Min(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static float Min(float x, float y) => MathF.Min(x, y);
 
-        static float INumber<float>.Parse(string s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static float Sign(float value) => MathF.Sign(value);
 
-        static float INumber<float>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
-
-        static float INumber<float>.Sign(float value)
-            => MathF.Sign(value);
-
+        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool INumber<float>.TryCreate<TOther>(TOther value, out float result)
+        public static bool TryCreate<TOther>(TOther value, out float result)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -1119,62 +1131,57 @@ namespace System
             }
         }
 
-        static bool INumber<float>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out float result)
-            => TryParse(s, style, provider, out result);
-
-        static bool INumber<float>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out float result)
-            => TryParse(s, style, provider, out result);
-
         //
         // IParseable
         //
 
-        static float IParseable<float>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider);
-
-        static bool IParseable<float>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out float result)
-            => TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out float result) => TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
 
         //
         // ISignedNumber
         //
 
-        static float ISignedNumber<float>.NegativeOne => -1;
+        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        static float ISignedNumber<float>.NegativeOne => NegativeOne;
 
         //
         // ISpanParseable
         //
 
-        static float ISpanParseable<float>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
+        public static float Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider);
 
-        static bool ISpanParseable<float>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out float result)
-            => TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out float result) => TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
 
         //
         // ISubtractionOperators
         //
 
-        static float ISubtractionOperators<float, float, float>.operator -(float left, float right)
-            => (float)(left - right);
+        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_Subtraction(TSelf, TOther)" />
+        static float ISubtractionOperators<float, float, float>.operator -(float left, float right) => (float)(left - right);
 
-        // static checked float ISubtractionOperators<float, float, float>.operator -(float left, float right)
-        //     => checked((float)(left - right));
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static float ISubtractionOperators<float, float, float>.operator checked -(float left, float right) => checked((float)(left - right));
 
         //
         // IUnaryNegationOperators
         //
 
+        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_UnaryNegation(TSelf)" />
         static float IUnaryNegationOperators<float, float>.operator -(float value) => (float)(-value);
 
-        // static checked float IUnaryNegationOperators<float, float>.operator -(float value) => checked((float)(-value));
+        // /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
+        // static float IUnaryNegationOperators<float, float>.operator checked -(float value) => checked((float)(-value));
 
         //
-        // IUnaryNegationOperators
+        // IUnaryPlusOperators
         //
 
+        /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_UnaryPlus(TSelf)" />
         static float IUnaryPlusOperators<float, float>.operator +(float value) => (float)(+value);
 
-        // static checked float IUnaryPlusOperators<float, float>.operator +(float value) => checked((float)(+value));
+        // /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_CheckedUnaryPlus(TSelf)" />
+        // static float IUnaryPlusOperators<float, float>.operator checked +(float value) => checked(value);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 /*============================================================
@@ -45,31 +45,34 @@ namespace System
         public const float PositiveInfinity = (float)1.0 / (float)0.0;
         public const float NaN = (float)0.0 / (float)0.0;
 
-        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        /// <summary>Represents the additive identity (0).</summary>
         public const float AdditiveIdentity = 0.0f;
 
-        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        /// <summary>Represents the multiplicative identity (1).</summary>
         public const float MultiplicativeIdentity = 1.0f;
 
-        /// <inheritdoc cref="INumber{TSelf}.One" />
+        /// <summary>Represents the number one (1).</summary>
         public const float One = 1.0f;
 
-        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        /// <summary>Represents the number zero (0).</summary>
         public const float Zero = 0.0f;
 
-        /// <inheritdoc cref="ISignedNumber{TSelf}.NegativeOne" />
+        /// <summary>Represents the number negative one (-1).</summary>
         public const float NegativeOne = -1.0f;
 
-        /// <inheritdoc cref="IFloatingPoint{TSelf}.NegativeZero" />
+        /// <summary>Represents the number negative zero (-0).</summary>
         public const float NegativeZero = -0.0f;
 
-        /// <inheritdoc cref="IFloatingPoint{TSelf}.E" />
+        /// <summary>Represents the natural logarithmic base, specified by the constant, e.</summary>
+        /// <remarks>This is known as Euler's number and is approximately 2.7182818284590452354.</remarks>
         public const float E = MathF.E;
 
-        /// <inheritdoc cref="IFloatingPoint{TSelf}.Pi" />
+        /// <summary>Represents the ratio of the circumference of a circle to its diameter, specified by the constant, π.</summary>
+        /// <remarks>Pi is approximately 3.1415926535897932385.</remarks>
         public const float Pi = MathF.PI;
 
-        /// <inheritdoc cref="IFloatingPoint{TSelf}.Tau" />
+        /// <summary>Represents the number of radians in one turn, specified by the constant, τ.</summary>
+        /// <remarks>Tau is approximately 6.2831853071795864769.</remarks>
         public const float Tau = MathF.Tau;
 
         //

--- a/src/libraries/System.Private.CoreLib/src/System/TimeOnly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeOnly.cs
@@ -33,11 +33,13 @@ namespace System
         /// <summary>
         /// Represents the smallest possible value of TimeOnly.
         /// </summary>
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
         public static TimeOnly MinValue => new TimeOnly((ulong)MinTimeTicks);
 
         /// <summary>
         /// Represents the largest possible value of TimeOnly.
         /// </summary>
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
         public static TimeOnly MaxValue => new TimeOnly((ulong)MaxTimeTicks);
 
         /// <summary>
@@ -204,6 +206,7 @@ namespace System
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns>true if left and right represent the same time; otherwise, false.</returns>
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Equality(TSelf, TOther)" />
         public static bool operator ==(TimeOnly left, TimeOnly right) => left._ticks == right._ticks;
 
         /// <summary>
@@ -212,6 +215,7 @@ namespace System
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns>true if left and right do not represent the same time; otherwise, false.</returns>
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Inequality(TSelf, TOther)" />
         public static bool operator !=(TimeOnly left, TimeOnly right) => left._ticks != right._ticks;
 
         /// <summary>
@@ -220,6 +224,7 @@ namespace System
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns>true if left is later than right; otherwise, false.</returns>
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
         public static bool operator >(TimeOnly left, TimeOnly right) => left._ticks > right._ticks;
 
         /// <summary>
@@ -228,6 +233,7 @@ namespace System
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns>true if left is the same as or later than right; otherwise, false.</returns>
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
         public static bool operator >=(TimeOnly left, TimeOnly right) => left._ticks >= right._ticks;
 
         /// <summary>
@@ -236,6 +242,7 @@ namespace System
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns>true if left is earlier than right; otherwise, false.</returns>
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
         public static bool operator <(TimeOnly left, TimeOnly right) => left._ticks < right._ticks;
 
         /// <summary>
@@ -244,6 +251,7 @@ namespace System
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns>true if left is the same as or earlier than right; otherwise, false.</returns>
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
         public static bool operator <=(TimeOnly left, TimeOnly right) => left._ticks <= right._ticks;
 
         /// <summary>
@@ -343,6 +351,7 @@ namespace System
         /// <param name="provider">An object that supplies culture-specific format information about s.</param>
         /// <param name="style">A bitwise combination of enumeration values that indicates the permitted format of s. A typical value to specify is None.</param>
         /// <returns>An object that is equivalent to the time contained in s, as specified by provider and styles.</returns>
+        /// <inheritdoc cref="ISpanParseable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
         public static TimeOnly Parse(ReadOnlySpan<char> s, IFormatProvider? provider = default, DateTimeStyles style = DateTimeStyles.None)
         {
             ParseFailureKind result = TryParseInternal(s, provider, style, out TimeOnly timeOnly);
@@ -491,6 +500,7 @@ namespace System
         /// <param name="style">A bitwise combination of enumeration values that indicates the permitted format of s. A typical value to specify is None.</param>
         /// <param name="result">When this method returns, contains the TimeOnly value equivalent to the time contained in s, if the conversion succeeded, or MinValue if the conversion failed. The conversion fails if the s parameter is empty string, or does not contain a valid string representation of a date. This parameter is passed uninitialized.</param>
         /// <returns>true if the s parameter was converted successfully; otherwise, false.</returns>
+        /// <inheritdoc cref="ISpanParseable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
         public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, DateTimeStyles style, out TimeOnly result) =>
                             TryParseInternal(s, provider, style, out result) == ParseFailureKind.None;
         private static ParseFailureKind TryParseInternal(ReadOnlySpan<char> s, IFormatProvider? provider, DateTimeStyles style, out TimeOnly result)
@@ -905,63 +915,29 @@ namespace System
         }
 
         //
-        // IComparisonOperators
+        // IMinMaxValue
         //
 
-        static bool IComparisonOperators<TimeOnly, TimeOnly>.operator <(TimeOnly left, TimeOnly right)
-            => left < right;
+        static TimeOnly IMinMaxValue<TimeOnly>.MinValue => MinValue;
 
-        static bool IComparisonOperators<TimeOnly, TimeOnly>.operator <=(TimeOnly left, TimeOnly right)
-            => left <= right;
-
-        static bool IComparisonOperators<TimeOnly, TimeOnly>.operator >(TimeOnly left, TimeOnly right)
-            => left > right;
-
-        static bool IComparisonOperators<TimeOnly, TimeOnly>.operator >=(TimeOnly left, TimeOnly right)
-            => left >= right;
-
-        //
-        // IEqualityOperators
-        //
-
-        static bool IEqualityOperators<TimeOnly, TimeOnly>.operator ==(TimeOnly left, TimeOnly right)
-            => left == right;
-
-        static bool IEqualityOperators<TimeOnly, TimeOnly>.operator !=(TimeOnly left, TimeOnly right)
-            => left != right;
+        static TimeOnly IMinMaxValue<TimeOnly>.MaxValue => MaxValue;
 
         //
         // IParseable
         //
 
-        static TimeOnly IParseable<TimeOnly>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider, DateTimeStyles.None);
+        public static TimeOnly Parse(string s, IFormatProvider? provider) => Parse(s, provider, DateTimeStyles.None);
 
-        static bool IParseable<TimeOnly>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out TimeOnly result)
-            => TryParse(s, provider, DateTimeStyles.None, out result);
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out TimeOnly result) => TryParse(s, provider, DateTimeStyles.None, out result);
 
         //
         // ISpanParseable
         //
 
-        static TimeOnly ISpanParseable<TimeOnly>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, provider, DateTimeStyles.None);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
+        public static TimeOnly Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, provider, DateTimeStyles.None);
 
-        static bool ISpanParseable<TimeOnly>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out TimeOnly result)
-            => TryParse(s, provider, DateTimeStyles.None, out result);
-
-        //
-        // ISubtractionOperators
-        //
-
-        static TimeSpan ISubtractionOperators<TimeOnly, TimeOnly, TimeSpan>.operator -(TimeOnly left, TimeOnly right)
-            => left - right;
-
-        // static checked TimeSpan ISubtractionOperators<TimeOnly, TimeOnly, TimeSpan>.operator -(TimeOnly left, TimeOnly right)
-        //     => checked(left - right);
-
-        static TimeOnly IMinMaxValue<TimeOnly>.MinValue => MinValue;
-
-        static TimeOnly IMinMaxValue<TimeOnly>.MaxValue => MaxValue;
+        /// <inheritdoc cref="ISpanParseable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out TimeOnly result) => TryParse(s, provider, DateTimeStyles.None, out result);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
@@ -460,6 +460,7 @@ namespace System
 
         public static TimeSpan operator +(TimeSpan t1, TimeSpan t2) => t1.Add(t2);
 
+        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
         public static TimeSpan operator *(TimeSpan timeSpan, double factor)
         {
             if (double.IsNaN(factor))
@@ -473,8 +474,10 @@ namespace System
             return IntervalFromDoubleTicks(ticks);
         }
 
+        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
         public static TimeSpan operator *(double factor, TimeSpan timeSpan) => timeSpan * factor;
 
+        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
         public static TimeSpan operator /(TimeSpan timeSpan, double divisor)
         {
             if (double.IsNaN(divisor))
@@ -490,77 +493,50 @@ namespace System
         // if we consider TimeSpan.FromHours(1) / TimeSpan.Zero asks how many zero-second intervals there are in
         // an hour for which infinity is the mathematic correct answer. Having TimeSpan.Zero / TimeSpan.Zero return NaN
         // is perhaps less useful, but no less useful than an exception.
+        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
         public static double operator /(TimeSpan t1, TimeSpan t2) => t1.Ticks / (double)t2.Ticks;
 
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Equality(TSelf, TOther)" />
         public static bool operator ==(TimeSpan t1, TimeSpan t2) => t1._ticks == t2._ticks;
 
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Inequality(TSelf, TOther)" />
         public static bool operator !=(TimeSpan t1, TimeSpan t2) => t1._ticks != t2._ticks;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
         public static bool operator <(TimeSpan t1, TimeSpan t2) => t1._ticks < t2._ticks;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
         public static bool operator <=(TimeSpan t1, TimeSpan t2) => t1._ticks <= t2._ticks;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
         public static bool operator >(TimeSpan t1, TimeSpan t2) => t1._ticks > t2._ticks;
 
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
         public static bool operator >=(TimeSpan t1, TimeSpan t2) => t1._ticks >= t2._ticks;
 
         //
         // IAdditionOperators
         //
 
-        static TimeSpan IAdditionOperators<TimeSpan, TimeSpan, TimeSpan>.operator +(TimeSpan left, TimeSpan right)
-            => left + right;
-
-        // static checked TimeSpan IAdditionOperators<TimeSpan, TimeSpan, TimeSpan>.operator +(TimeSpan left, TimeSpan right)
-        //     => checked(left + right);
+        // /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        // static TimeSpan IAdditionOperators<TimeSpan, TimeSpan, TimeSpan>.operator checked +(TimeSpan left, TimeSpan right) => checked(left + right);
 
         //
         // IAdditiveIdentity
         //
 
-        static TimeSpan IAdditiveIdentity<TimeSpan, TimeSpan>.AdditiveIdentity => default;
-
-        //
-        // IComparisonOperators
-        //
-
-        static bool IComparisonOperators<TimeSpan, TimeSpan>.operator <(TimeSpan left, TimeSpan right)
-            => left<right;
-
-        static bool IComparisonOperators<TimeSpan, TimeSpan>.operator <=(TimeSpan left, TimeSpan right)
-            => left <= right;
-
-        static bool IComparisonOperators<TimeSpan, TimeSpan>.operator >(TimeSpan left, TimeSpan right)
-            => left > right;
-
-        static bool IComparisonOperators<TimeSpan, TimeSpan>.operator >=(TimeSpan left, TimeSpan right)
-            => left >= right;
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        public static TimeSpan AdditiveIdentity => default;
 
         //
         // IDivisionOperators
         //
 
-        static TimeSpan IDivisionOperators<TimeSpan, double, TimeSpan>.operator /(TimeSpan left, double right)
-            => left / right;
+        // /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
+        // static TimeSpan IDivisionOperators<TimeSpan, double, TimeSpan>.operator checked /(TimeSpan left, double right) => checked(left / right);
 
-        // static checked TimeSpan IDivisionOperators<TimeSpan, double, TimeSpan>.operator /(TimeSpan left, double right)
-        //     => checked(left / right);
-
-        static double IDivisionOperators<TimeSpan, TimeSpan, double>.operator /(TimeSpan left, TimeSpan right)
-            => left / right;
-
-        // static checked double IDivisionOperators<TimeSpan, TimeSpan, double>.operator /(TimeSpan left, TimeSpan right)
-        //     => checked(left / right);
-
-        //
-        // IEqualityOperators
-        //
-
-        static bool IEqualityOperators<TimeSpan, TimeSpan>.operator ==(TimeSpan left, TimeSpan right)
-            => left == right;
-
-        static bool IEqualityOperators<TimeSpan, TimeSpan>.operator !=(TimeSpan left, TimeSpan right)
-            => left != right;
+        // /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
+        // static double IDivisionOperators<TimeSpan, TimeSpan, double>.operator checked /(TimeSpan left, TimeSpan right) => checked(left / right);
 
         //
         // IMinMaxValue
@@ -574,66 +550,34 @@ namespace System
         // IMultiplicativeIdentity
         //
 
-        static double IMultiplicativeIdentity<TimeSpan, double>.MultiplicativeIdentity => 1.0;
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        public static double MultiplicativeIdentity => 1.0;
 
         //
         // IMultiplyOperators
         //
 
-        static TimeSpan IMultiplyOperators<TimeSpan, double, TimeSpan>.operator *(TimeSpan left, double right)
-            => left * right;
-
-        // static checked TimeSpan IMultiplyOperators<TimeSpan, double, TimeSpan>.operator *(TimeSpan left, double right)
-        //     => checked(left * right);
-
-        //
-        // IParseable
-        //
-
-        static TimeSpan IParseable<TimeSpan>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider);
-
-        static bool IParseable<TimeSpan>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out TimeSpan result)
-            => TryParse(s, provider, out result);
-
-        //
-        // ISpanParseable
-        //
-
-        static TimeSpan ISpanParseable<TimeSpan>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, provider);
-
-        static bool ISpanParseable<TimeSpan>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out TimeSpan result)
-            => TryParse(s, provider, out result);
+        // /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
+        // static TimeSpan IMultiplyOperators<TimeSpan, double, TimeSpan>.operator checked *(TimeSpan left, double right) => checked(left * right);
 
         //
         // ISubtractionOperators
         //
 
-        static TimeSpan ISubtractionOperators<TimeSpan, TimeSpan, TimeSpan>.operator -(TimeSpan left, TimeSpan right)
-            => left - right;
-
-        // static checked TimeSpan ISubtractionOperators<TimeSpan, TimeSpan, TimeSpan>.operator -(TimeSpan left, TimeSpan right)
-        //     => checked(left - right);
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static TimeSpan ISubtractionOperators<TimeSpan, TimeSpan, TimeSpan>.operator checked -(TimeSpan left, TimeSpan right) => checked(left - right);
 
         //
         // IUnaryNegationOperators
         //
 
-        static TimeSpan IUnaryNegationOperators<TimeSpan, TimeSpan>.operator -(TimeSpan value)
-            => -value;
-
-        // static checked TimeSpan IUnaryNegationOperators<TimeSpan, TimeSpan>.operator -(TimeSpan value)
-        //     => checked(-value);
+        // /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
+        // static TimeSpan IUnaryNegationOperators<TimeSpan, TimeSpan>.operator checked -(TimeSpan value) => checked(-value);
 
         //
-        // IUnaryNegationOperators
+        // IUnaryPlusOperators
         //
 
-        static TimeSpan IUnaryPlusOperators<TimeSpan, TimeSpan>.operator +(TimeSpan value)
-            => +value;
-
-        // static checked TimeSpan IUnaryPlusOperators<TimeSpan, TimeSpan>.operator +(TimeSpan value)
-        //     => checked(+value);
+        // static checked TimeSpan IUnaryPlusOperators<TimeSpan, TimeSpan>.operator +(TimeSpan value) => checked(+value);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
@@ -29,6 +29,18 @@ namespace System
         public const ushort MaxValue = (ushort)0xFFFF;
         public const ushort MinValue = 0;
 
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        public const ushort AdditiveIdentity = 0;
+
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        public const ushort MultiplicativeIdentity = 1;
+
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        public const ushort One = 1;
+
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        public const ushort Zero = 0;
+
         // Compares this object to another object, returning an integer that
         // indicates the relationship.
         // Returns a value less than zero if this  object
@@ -279,169 +291,174 @@ namespace System
         // IAdditionOperators
         //
 
-        static ushort IAdditionOperators<ushort, ushort, ushort>.operator +(ushort left, ushort right)
-            => (ushort)(left + right);
+        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        static ushort IAdditionOperators<ushort, ushort, ushort>.operator +(ushort left, ushort right) => (ushort)(left + right);
 
-        // static checked ushort IAdditionOperators<ushort, ushort, ushort>.operator +(ushort left, ushort right)
-        //     => checked((ushort)(left + right));
+        // /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        // static ushort IAdditionOperators<ushort, ushort, ushort>.operator checked +(ushort left, ushort right) => checked((ushort)(left + right));
 
         //
         // IAdditiveIdentity
         //
 
-        static ushort IAdditiveIdentity<ushort, ushort>.AdditiveIdentity => 0;
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        static ushort IAdditiveIdentity<ushort, ushort>.AdditiveIdentity => AdditiveIdentity;
 
         //
         // IBinaryInteger
         //
 
-        static ushort IBinaryInteger<ushort>.LeadingZeroCount(ushort value)
-            => (ushort)(BitOperations.LeadingZeroCount(value) - 16);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.LeadingZeroCount(TSelf)" />
+        public static ushort LeadingZeroCount(ushort value) => (ushort)(BitOperations.LeadingZeroCount(value) - 16);
 
-        static ushort IBinaryInteger<ushort>.PopCount(ushort value)
-            => (ushort)BitOperations.PopCount(value);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.PopCount(TSelf)" />
+        public static ushort PopCount(ushort value) => (ushort)BitOperations.PopCount(value);
 
-        static ushort IBinaryInteger<ushort>.RotateLeft(ushort value, int rotateAmount)
-            => (ushort)((value << (rotateAmount & 15)) | (value >> ((16 - rotateAmount) & 15)));
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateLeft(TSelf, int)" />
+        public static ushort RotateLeft(ushort value, int rotateAmount) => (ushort)((value << (rotateAmount & 15)) | (value >> ((16 - rotateAmount) & 15)));
 
-        static ushort IBinaryInteger<ushort>.RotateRight(ushort value, int rotateAmount)
-            => (ushort)((value >> (rotateAmount & 15)) | (value << ((16 - rotateAmount) & 15)));
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateRight(TSelf, int)" />
+        public static ushort RotateRight(ushort value, int rotateAmount) => (ushort)((value >> (rotateAmount & 15)) | (value << ((16 - rotateAmount) & 15)));
 
-        static ushort IBinaryInteger<ushort>.TrailingZeroCount(ushort value)
-            => (ushort)(BitOperations.TrailingZeroCount(value << 16) - 16);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.TrailingZeroCount(TSelf)" />
+        public static ushort TrailingZeroCount(ushort value) => (ushort)(BitOperations.TrailingZeroCount(value << 16) - 16);
 
         //
         // IBinaryNumber
         //
 
-        static bool IBinaryNumber<ushort>.IsPow2(ushort value)
-            => BitOperations.IsPow2((uint)value);
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
+        public static bool IsPow2(ushort value) => BitOperations.IsPow2((uint)value);
 
-        static ushort IBinaryNumber<ushort>.Log2(ushort value)
-            => (ushort)BitOperations.Log2(value);
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />
+        public static ushort Log2(ushort value) => (ushort)BitOperations.Log2(value);
 
         //
         // IBitwiseOperators
         //
 
-        static ushort IBitwiseOperators<ushort, ushort, ushort>.operator &(ushort left, ushort right)
-            => (ushort)(left & right);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseAnd(TSelf, TOther)" />
+        static ushort IBitwiseOperators<ushort, ushort, ushort>.operator &(ushort left, ushort right) => (ushort)(left & right);
 
-        static ushort IBitwiseOperators<ushort, ushort, ushort>.operator |(ushort left, ushort right)
-            => (ushort)(left | right);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseOr(TSelf, TOther)" />
+        static ushort IBitwiseOperators<ushort, ushort, ushort>.operator |(ushort left, ushort right) => (ushort)(left | right);
 
-        static ushort IBitwiseOperators<ushort, ushort, ushort>.operator ^(ushort left, ushort right)
-            => (ushort)(left ^ right);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_ExclusiveOr(TSelf, TOther)" />
+        static ushort IBitwiseOperators<ushort, ushort, ushort>.operator ^(ushort left, ushort right) => (ushort)(left ^ right);
 
-        static ushort IBitwiseOperators<ushort, ushort, ushort>.operator ~(ushort value)
-            => (ushort)(~value);
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_OnesComplement(TSelf)" />
+        static ushort IBitwiseOperators<ushort, ushort, ushort>.operator ~(ushort value) => (ushort)(~value);
 
         //
         // IComparisonOperators
         //
 
-        static bool IComparisonOperators<ushort, ushort>.operator <(ushort left, ushort right)
-            => left < right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
+        static bool IComparisonOperators<ushort, ushort>.operator <(ushort left, ushort right) => left < right;
 
-        static bool IComparisonOperators<ushort, ushort>.operator <=(ushort left, ushort right)
-            => left <= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<ushort, ushort>.operator <=(ushort left, ushort right) => left <= right;
 
-        static bool IComparisonOperators<ushort, ushort>.operator >(ushort left, ushort right)
-            => left > right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
+        static bool IComparisonOperators<ushort, ushort>.operator >(ushort left, ushort right) => left > right;
 
-        static bool IComparisonOperators<ushort, ushort>.operator >=(ushort left, ushort right)
-            => left >= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<ushort, ushort>.operator >=(ushort left, ushort right) => left >= right;
 
         //
         // IDecrementOperators
         //
 
-        static ushort IDecrementOperators<ushort>.operator --(ushort value)
-            => --value;
+        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        static ushort IDecrementOperators<ushort>.operator --(ushort value) => --value;
 
-        // static checked ushort IDecrementOperators<ushort>.operator --(ushort value)
-        //     => checked(--value);
+        // /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        // static ushort IDecrementOperators<ushort>.operator checked --(ushort value) => checked(--value);
 
         //
         // IDivisionOperators
         //
 
-        static ushort IDivisionOperators<ushort, ushort, ushort>.operator /(ushort left, ushort right)
-            => (ushort)(left / right);
+        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
+        static ushort IDivisionOperators<ushort, ushort, ushort>.operator /(ushort left, ushort right) => (ushort)(left / right);
 
-        // static checked ushort IDivisionOperators<ushort, ushort, ushort>.operator /(ushort left, ushort right)
-        //     => checked((ushort)(left / right));
+        // /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
+        // static ushort IDivisionOperators<ushort, ushort, ushort>.operator checked /(ushort left, ushort right) => checked((ushort)(left / right));
 
         //
         // IEqualityOperators
         //
 
-        static bool IEqualityOperators<ushort, ushort>.operator ==(ushort left, ushort right)
-            => left == right;
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Equality(TSelf, TOther)" />
+        static bool IEqualityOperators<ushort, ushort>.operator ==(ushort left, ushort right) => left == right;
 
-        static bool IEqualityOperators<ushort, ushort>.operator !=(ushort left, ushort right)
-            => left != right;
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Inequality(TSelf, TOther)" />
+        static bool IEqualityOperators<ushort, ushort>.operator !=(ushort left, ushort right) => left != right;
 
         //
         // IIncrementOperators
         //
 
-        static ushort IIncrementOperators<ushort>.operator ++(ushort value)
-            => ++value;
+        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_Increment(TSelf)" />
+        static ushort IIncrementOperators<ushort>.operator ++(ushort value) => ++value;
 
-        // static checked ushort IIncrementOperators<ushort>.operator ++(ushort value)
-        //     => checked(++value);
+        // /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
+        // static ushort IIncrementOperators<ushort>.operator checked ++(ushort value) => checked(++value);
 
         //
         // IMinMaxValue
         //
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MinValue" />
         static ushort IMinMaxValue<ushort>.MinValue => MinValue;
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MaxValue" />
         static ushort IMinMaxValue<ushort>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        static ushort IModulusOperators<ushort, ushort, ushort>.operator %(ushort left, ushort right)
-            => (ushort)(left % right);
-
-        // static checked ushort IModulusOperators<ushort, ushort, ushort>.operator %(ushort left, ushort right)
-        //     => checked((ushort)(left % right));
+        /// <inheritdoc cref="IModulusOperators{TSelf, TOther, TResult}.op_Modulus(TSelf, TOther)" />
+        static ushort IModulusOperators<ushort, ushort, ushort>.operator %(ushort left, ushort right) => (ushort)(left % right);
 
         //
         // IMultiplicativeIdentity
         //
 
-        static ushort IMultiplicativeIdentity<ushort, ushort>.MultiplicativeIdentity => 1;
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        static ushort IMultiplicativeIdentity<ushort, ushort>.MultiplicativeIdentity => MultiplicativeIdentity;
 
         //
         // IMultiplyOperators
         //
 
-        static ushort IMultiplyOperators<ushort, ushort, ushort>.operator *(ushort left, ushort right)
-            => (ushort)(left * right);
+        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
+        static ushort IMultiplyOperators<ushort, ushort, ushort>.operator *(ushort left, ushort right) => (ushort)(left * right);
 
-        // static checked ushort IMultiplyOperators<ushort, ushort, ushort>.operator *(ushort left, ushort right)
-        //     => checked((ushort)(left * right));
+        // /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
+        // static ushort IMultiplyOperators<ushort, ushort, ushort>.operator checked *(ushort left, ushort right) => checked((ushort)(left * right));
 
         //
         // INumber
         //
 
-        static ushort INumber<ushort>.One => 1;
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        static ushort INumber<ushort>.One => One;
 
-        static ushort INumber<ushort>.Zero => 0;
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        static ushort INumber<ushort>.Zero => Zero;
 
-        static ushort INumber<ushort>.Abs(ushort value)
-            => value;
+        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
+        public static ushort Abs(ushort value) => value;
 
-        static ushort INumber<ushort>.Clamp(ushort value, ushort min, ushort max)
-            => Math.Clamp(value, min, max);
+        /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
+        public static ushort Clamp(ushort value, ushort min, ushort max) => Math.Clamp(value, min, max);
 
+        /// <inheritdoc cref="INumber{TSelf}.Create{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static ushort INumber<ushort>.Create<TOther>(TOther value)
+        public static ushort Create<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -506,8 +523,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static ushort INumber<ushort>.CreateSaturating<TOther>(TOther value)
+        public static ushort CreateSaturating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -589,8 +608,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static ushort INumber<ushort>.CreateTruncating<TOther>(TOther value)
+        public static ushort CreateTruncating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -655,26 +676,22 @@ namespace System
             }
         }
 
-        static (ushort Quotient, ushort Remainder) INumber<ushort>.DivRem(ushort left, ushort right)
-            => Math.DivRem(left, right);
+        /// <inheritdoc cref="INumber{TSelf}.DivRem(TSelf, TSelf)" />
+        public static (ushort Quotient, ushort Remainder) DivRem(ushort left, ushort right) => Math.DivRem(left, right);
 
-        static ushort INumber<ushort>.Max(ushort x, ushort y)
-            => Math.Max(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static ushort Max(ushort x, ushort y) => Math.Max(x, y);
 
-        static ushort INumber<ushort>.Min(ushort x, ushort y)
-            => Math.Min(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static ushort Min(ushort x, ushort y) => Math.Min(x, y);
 
-        static ushort INumber<ushort>.Parse(string s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static ushort Sign(ushort value) => (ushort)((value == 0) ? 0 : 1);
 
-        static ushort INumber<ushort>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
-
-        static ushort INumber<ushort>.Sign(ushort value)
-            => (ushort)((value == 0) ? 0 : 1);
-
+        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool INumber<ushort>.TryCreate<TOther>(TOther value, out ushort result)
+        public static bool TryCreate<TOther>(TOther value, out ushort result)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -842,73 +859,63 @@ namespace System
             }
         }
 
-        static bool INumber<ushort>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out ushort result)
-            => TryParse(s, style, provider, out result);
-
-        static bool INumber<ushort>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out ushort result)
-            => TryParse(s, style, provider, out result);
-
         //
         // IParseable
         //
 
-        static ushort IParseable<ushort>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider);
-
-        static bool IParseable<ushort>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out ushort result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out ushort result) => TryParse(s, NumberStyles.Integer, provider, out result);
 
         //
         // IShiftOperators
         //
 
-        static ushort IShiftOperators<ushort, ushort>.operator <<(ushort value, int shiftAmount)
-            => (ushort)(value << shiftAmount);
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_LeftShift(TSelf, int)" />
+        static ushort IShiftOperators<ushort, ushort>.operator <<(ushort value, int shiftAmount) => (ushort)(value << shiftAmount);
 
-        static ushort IShiftOperators<ushort, ushort>.operator >>(ushort value, int shiftAmount)
-            => (ushort)(value >> shiftAmount);
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_RightShift(TSelf, int)" />
+        static ushort IShiftOperators<ushort, ushort>.operator >>(ushort value, int shiftAmount) => (ushort)(value >> shiftAmount);
 
-        // static ushort IShiftOperators<ushort, ushort>.operator >>>(ushort value, int shiftAmount)
-        //     => (ushort)(value >> shiftAmount);
+        // /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_UnsignedRightShift(TSelf, int)" />
+        // static ushort IShiftOperators<ushort, ushort>.operator >>>(ushort value, int shiftAmount) => (ushort)(value >> shiftAmount);
 
         //
         // ISpanParseable
         //
 
-        static ushort ISpanParseable<ushort>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, NumberStyles.Integer, provider);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
+        public static ushort Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, NumberStyles.Integer, provider);
 
-        static bool ISpanParseable<ushort>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out ushort result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out ushort result) => TryParse(s, NumberStyles.Integer, provider, out result);
 
         //
         // ISubtractionOperators
         //
 
-        static ushort ISubtractionOperators<ushort, ushort, ushort>.operator -(ushort left, ushort right)
-            => (ushort)(left - right);
+        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_Subtraction(TSelf, TOther)" />
+        static ushort ISubtractionOperators<ushort, ushort, ushort>.operator -(ushort left, ushort right) => (ushort)(left - right);
 
-        // static checked ushort ISubtractionOperators<ushort, ushort, ushort>.operator -(ushort left, ushort right)
-        //     => checked((ushort)(left - right));
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static ushort ISubtractionOperators<ushort, ushort, ushort>.operator checked -(ushort left, ushort right) => checked((ushort)(left - right));
 
         //
         // IUnaryNegationOperators
         //
 
-        static ushort IUnaryNegationOperators<ushort, ushort>.operator -(ushort value)
-            => (ushort)(-value);
+        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_UnaryNegation(TSelf)" />
+        static ushort IUnaryNegationOperators<ushort, ushort>.operator -(ushort value) => (ushort)(-value);
 
-        // static checked ushort IUnaryNegationOperators<ushort, ushort>.operator -(ushort value)
-        //     => checked((ushort)(-value));
+        // /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
+        // static ushort IUnaryNegationOperators<ushort, ushort>.operator checked -(ushort value) => checked((ushort)(-value));
 
         //
         // IUnaryPlusOperators
         //
 
-        static ushort IUnaryPlusOperators<ushort, ushort>.operator +(ushort value)
-            => (ushort)(+value);
+        /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_UnaryPlus(TSelf)" />
+        static ushort IUnaryPlusOperators<ushort, ushort>.operator +(ushort value) => (ushort)(+value);
 
-        // static checked ushort IUnaryPlusOperators<ushort, ushort>.operator +(ushort value)
-        //     => checked((ushort)(+value));
+        // /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_CheckedUnaryPlus(TSelf)" />
+        // static ushort IUnaryPlusOperators<ushort, ushort>.operator checked +(ushort value) => checked((ushort)(+value));
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
@@ -29,16 +29,16 @@ namespace System
         public const ushort MaxValue = (ushort)0xFFFF;
         public const ushort MinValue = 0;
 
-        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        /// <summary>Represents the additive identity (0).</summary>
         public const ushort AdditiveIdentity = 0;
 
-        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        /// <summary>Represents the multiplicative identity (1).</summary>
         public const ushort MultiplicativeIdentity = 1;
 
-        /// <inheritdoc cref="INumber{TSelf}.One" />
+        /// <summary>Represents the number one (1).</summary>
         public const ushort One = 1;
 
-        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        /// <summary>Represents the number zero (0).</summary>
         public const ushort Zero = 0;
 
         // Compares this object to another object, returning an integer that

--- a/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
@@ -29,16 +29,16 @@ namespace System
         public const uint MaxValue = (uint)0xffffffff;
         public const uint MinValue = 0U;
 
-        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        /// <summary>Represents the additive identity (0).</summary>
         public const uint AdditiveIdentity = 0;
 
-        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        /// <summary>Represents the multiplicative identity (1).</summary>
         public const uint MultiplicativeIdentity = 1;
 
-        /// <inheritdoc cref="INumber{TSelf}.One" />
+        /// <summary>Represents the number one (1).</summary>
         public const uint One = 1;
 
-        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        /// <summary>Represents the number zero (0).</summary>
         public const uint Zero = 0;
 
         // Compares this object to another object, returning an integer that

--- a/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
@@ -29,6 +29,18 @@ namespace System
         public const uint MaxValue = (uint)0xffffffff;
         public const uint MinValue = 0U;
 
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        public const uint AdditiveIdentity = 0;
+
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        public const uint MultiplicativeIdentity = 1;
+
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        public const uint One = 1;
+
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        public const uint Zero = 0;
+
         // Compares this object to another object, returning an integer that
         // indicates the relationship.
         // Returns a value less than zero if this  object
@@ -265,169 +277,174 @@ namespace System
         // IAdditionOperators
         //
 
-        static uint IAdditionOperators<uint, uint, uint>.operator +(uint left, uint right)
-            => left + right;
+        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        static uint IAdditionOperators<uint, uint, uint>.operator +(uint left, uint right) => left + right;
 
-        // static checked uint IAdditionOperators<uint, uint, uint>.operator +(uint left, uint right)
-        //     => checked(left + right);
+        // /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        // static uint IAdditionOperators<uint, uint, uint>.operator checked +(uint left, uint right) => checked(left + right);
 
         //
         // IAdditiveIdentity
         //
 
-        static uint IAdditiveIdentity<uint, uint>.AdditiveIdentity => 0;
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        static uint IAdditiveIdentity<uint, uint>.AdditiveIdentity => AdditiveIdentity;
 
         //
         // IBinaryInteger
         //
 
-        static uint IBinaryInteger<uint>.LeadingZeroCount(uint value)
-            => (uint)BitOperations.LeadingZeroCount(value);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.LeadingZeroCount(TSelf)" />
+        public static uint LeadingZeroCount(uint value) => (uint)BitOperations.LeadingZeroCount(value);
 
-        static uint IBinaryInteger<uint>.PopCount(uint value)
-            => (uint)BitOperations.PopCount(value);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.PopCount(TSelf)" />
+        public static uint PopCount(uint value) => (uint)BitOperations.PopCount(value);
 
-        static uint IBinaryInteger<uint>.RotateLeft(uint value, int rotateAmount)
-            => BitOperations.RotateLeft(value, rotateAmount);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateLeft(TSelf, int)" />
+        public static uint RotateLeft(uint value, int rotateAmount) => BitOperations.RotateLeft(value, rotateAmount);
 
-        static uint IBinaryInteger<uint>.RotateRight(uint value, int rotateAmount)
-            => BitOperations.RotateRight(value, rotateAmount);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateRight(TSelf, int)" />
+        public static uint RotateRight(uint value, int rotateAmount) => BitOperations.RotateRight(value, rotateAmount);
 
-        static uint IBinaryInteger<uint>.TrailingZeroCount(uint value)
-            => (uint)BitOperations.TrailingZeroCount(value);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.TrailingZeroCount(TSelf)" />
+        public static uint TrailingZeroCount(uint value) => (uint)BitOperations.TrailingZeroCount(value);
 
         //
         // IBinaryNumber
         //
 
-        static bool IBinaryNumber<uint>.IsPow2(uint value)
-            => BitOperations.IsPow2(value);
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
+        public static bool IsPow2(uint value) => BitOperations.IsPow2(value);
 
-        static uint IBinaryNumber<uint>.Log2(uint value)
-            => (uint)BitOperations.Log2(value);
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />
+        public static uint Log2(uint value) => (uint)BitOperations.Log2(value);
 
         //
         // IBitwiseOperators
         //
 
-        static uint IBitwiseOperators<uint, uint, uint>.operator &(uint left, uint right)
-            => left & right;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseAnd(TSelf, TOther)" />
+        static uint IBitwiseOperators<uint, uint, uint>.operator &(uint left, uint right) => left & right;
 
-        static uint IBitwiseOperators<uint, uint, uint>.operator |(uint left, uint right)
-            => left | right;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseOr(TSelf, TOther)" />
+        static uint IBitwiseOperators<uint, uint, uint>.operator |(uint left, uint right) => left | right;
 
-        static uint IBitwiseOperators<uint, uint, uint>.operator ^(uint left, uint right)
-            => left ^ right;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_ExclusiveOr(TSelf, TOther)" />
+        static uint IBitwiseOperators<uint, uint, uint>.operator ^(uint left, uint right) => left ^ right;
 
-        static uint IBitwiseOperators<uint, uint, uint>.operator ~(uint value)
-            => ~value;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_OnesComplement(TSelf)" />
+        static uint IBitwiseOperators<uint, uint, uint>.operator ~(uint value) => ~value;
 
         //
         // IComparisonOperators
         //
 
-        static bool IComparisonOperators<uint, uint>.operator <(uint left, uint right)
-            => left < right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
+        static bool IComparisonOperators<uint, uint>.operator <(uint left, uint right) => left < right;
 
-        static bool IComparisonOperators<uint, uint>.operator <=(uint left, uint right)
-            => left <= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<uint, uint>.operator <=(uint left, uint right) => left <= right;
 
-        static bool IComparisonOperators<uint, uint>.operator >(uint left, uint right)
-            => left > right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
+        static bool IComparisonOperators<uint, uint>.operator >(uint left, uint right) => left > right;
 
-        static bool IComparisonOperators<uint, uint>.operator >=(uint left, uint right)
-            => left >= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<uint, uint>.operator >=(uint left, uint right) => left >= right;
 
         //
         // IDecrementOperators
         //
 
-        static uint IDecrementOperators<uint>.operator --(uint value)
-            => --value;
+        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        static uint IDecrementOperators<uint>.operator --(uint value) => --value;
 
-        // static checked uint IDecrementOperators<uint>.operator --(uint value)
-        //     => checked(--value);
+        // /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        // static uint IDecrementOperators<uint>.operator checked --(uint value) => checked(--value);
 
         //
         // IDivisionOperators
         //
 
-        static uint IDivisionOperators<uint, uint, uint>.operator /(uint left, uint right)
-            => left / right;
+        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
+        static uint IDivisionOperators<uint, uint, uint>.operator /(uint left, uint right) => left / right;
 
-        // static checked uint IDivisionOperators<uint, uint, uint>.operator /(uint left, uint right)
-        //     => checked(left / right);
+        // /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
+        // static uint IDivisionOperators<uint, uint, uint>.operator checked /(uint left, uint right) => checked(left / right);
 
         //
         // IEqualityOperators
         //
 
-        static bool IEqualityOperators<uint, uint>.operator ==(uint left, uint right)
-            => left == right;
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Equality(TSelf, TOther)" />
+        static bool IEqualityOperators<uint, uint>.operator ==(uint left, uint right) => left == right;
 
-        static bool IEqualityOperators<uint, uint>.operator !=(uint left, uint right)
-            => left != right;
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Inequality(TSelf, TOther)" />
+        static bool IEqualityOperators<uint, uint>.operator !=(uint left, uint right) => left != right;
 
         //
         // IIncrementOperators
         //
 
-        static uint IIncrementOperators<uint>.operator ++(uint value)
-            => ++value;
+        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_Increment(TSelf)" />
+        static uint IIncrementOperators<uint>.operator ++(uint value) => ++value;
 
-        // static checked uint IIncrementOperators<uint>.operator ++(uint value)
-        //     => checked(++value);
+        // /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
+        // static uint IIncrementOperators<uint>.operator checked ++(uint value) => checked(++value);
 
         //
         // IMinMaxValue
         //
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MinValue" />
         static uint IMinMaxValue<uint>.MinValue => MinValue;
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MaxValue" />
         static uint IMinMaxValue<uint>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        static uint IModulusOperators<uint, uint, uint>.operator %(uint left, uint right)
-            => left % right;
-
-        // static checked uint IModulusOperators<uint, uint, uint>.operator %(uint left, uint right)
-        //     => checked(left % right);
+        /// <inheritdoc cref="IModulusOperators{TSelf, TOther, TResult}.op_Modulus(TSelf, TOther)" />
+        static uint IModulusOperators<uint, uint, uint>.operator %(uint left, uint right) => left % right;
 
         //
         // IMultiplicativeIdentity
         //
 
-        static uint IMultiplicativeIdentity<uint, uint>.MultiplicativeIdentity => 1;
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        static uint IMultiplicativeIdentity<uint, uint>.MultiplicativeIdentity => MultiplicativeIdentity;
 
         //
         // IMultiplyOperators
         //
 
-        static uint IMultiplyOperators<uint, uint, uint>.operator *(uint left, uint right)
-            => left * right;
+        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
+        static uint IMultiplyOperators<uint, uint, uint>.operator *(uint left, uint right) => left * right;
 
-        // static checked uint IMultiplyOperators<uint, uint, uint>.operator *(uint left, uint right)
-        //     => checked(left * right);
+        // /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
+        // static uint IMultiplyOperators<uint, uint, uint>.operator checked *(uint left, uint right) => checked(left * right);
 
         //
         // INumber
         //
 
-        static uint INumber<uint>.One => 1;
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        static uint INumber<uint>.One => One;
 
-        static uint INumber<uint>.Zero => 0;
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        static uint INumber<uint>.Zero => Zero;
 
-        static uint INumber<uint>.Abs(uint value)
-            => value;
+        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
+        public static uint Abs(uint value) => value;
 
-        static uint INumber<uint>.Clamp(uint value, uint min, uint max)
-            => Math.Clamp(value, min, max);
+        /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
+        public static uint Clamp(uint value, uint min, uint max) => Math.Clamp(value, min, max);
 
+        /// <inheritdoc cref="INumber{TSelf}.Create{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static uint INumber<uint>.Create<TOther>(TOther value)
+        public static uint Create<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -492,8 +509,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static uint INumber<uint>.CreateSaturating<TOther>(TOther value)
+        public static uint CreateSaturating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -573,8 +592,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static uint INumber<uint>.CreateTruncating<TOther>(TOther value)
+        public static uint CreateTruncating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -639,26 +660,22 @@ namespace System
             }
         }
 
-        static (uint Quotient, uint Remainder) INumber<uint>.DivRem(uint left, uint right)
-            => Math.DivRem(left, right);
+        /// <inheritdoc cref="INumber{TSelf}.DivRem(TSelf, TSelf)" />
+        public static (uint Quotient, uint Remainder) DivRem(uint left, uint right) => Math.DivRem(left, right);
 
-        static uint INumber<uint>.Max(uint x, uint y)
-            => Math.Max(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static uint Max(uint x, uint y) => Math.Max(x, y);
 
-        static uint INumber<uint>.Min(uint x, uint y)
-            => Math.Min(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static uint Min(uint x, uint y) => Math.Min(x, y);
 
-        static uint INumber<uint>.Parse(string s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static uint Sign(uint value) => (uint)((value == 0) ? 0 : 1);
 
-        static uint INumber<uint>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
-
-        static uint INumber<uint>.Sign(uint value)
-            => (uint)((value == 0) ? 0 : 1);
-
+        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool INumber<uint>.TryCreate<TOther>(TOther value, out uint result)
+        public static bool TryCreate<TOther>(TOther value, out uint result)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -818,73 +835,63 @@ namespace System
             }
         }
 
-        static bool INumber<uint>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out uint result)
-            => TryParse(s, style, provider, out result);
-
-        static bool INumber<uint>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out uint result)
-            => TryParse(s, style, provider, out result);
-
         //
         // IParseable
         //
 
-        static uint IParseable<uint>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider);
-
-        static bool IParseable<uint>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out uint result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out uint result) => TryParse(s, NumberStyles.Integer, provider, out result);
 
         //
         // IShiftOperators
         //
 
-        static uint IShiftOperators<uint, uint>.operator <<(uint value, int shiftAmount)
-            => value << (int)shiftAmount;
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_LeftShift(TSelf, int)" />
+        static uint IShiftOperators<uint, uint>.operator <<(uint value, int shiftAmount) => value << (int)shiftAmount;
 
-        static uint IShiftOperators<uint, uint>.operator >>(uint value, int shiftAmount)
-            => value >> (int)shiftAmount;
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_RightShift(TSelf, int)" />
+        static uint IShiftOperators<uint, uint>.operator >>(uint value, int shiftAmount) => value >> (int)shiftAmount;
 
-        // static uint IShiftOperators<uint, uint>.operator >>>(uint value, int shiftAmount)
-        //     => value >> (int)shiftAmount;
+        // /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_UnsignedRightShift(TSelf, int)" />
+        // static uint IShiftOperators<uint, uint>.operator >>>(uint value, int shiftAmount) => value >> (int)shiftAmount;
 
         //
         // ISpanParseable
         //
 
-        static uint ISpanParseable<uint>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, NumberStyles.Integer, provider);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
+        public static uint Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, NumberStyles.Integer, provider);
 
-        static bool ISpanParseable<uint>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out uint result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out uint result) => TryParse(s, NumberStyles.Integer, provider, out result);
 
         //
         // ISubtractionOperators
         //
 
-        static uint ISubtractionOperators<uint, uint, uint>.operator -(uint left, uint right)
-            => left - right;
+        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_Subtraction(TSelf, TOther)" />
+        static uint ISubtractionOperators<uint, uint, uint>.operator -(uint left, uint right) => left - right;
 
-        // static checked uint ISubtractionOperators<uint, uint, uint>.operator -(uint left, uint right)
-        //     => checked(left - right);
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static uint ISubtractionOperators<uint, uint, uint>.operator checked -(uint left, uint right) => checked(left - right);
 
         //
         // IUnaryNegationOperators
         //
 
-        static uint IUnaryNegationOperators<uint, uint>.operator -(uint value)
-            => 0u - value;
+        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_UnaryNegation(TSelf)" />
+        static uint IUnaryNegationOperators<uint, uint>.operator -(uint value) => 0u - value;
 
-        // static checked uint IUnaryNegationOperators<uint, uint>.operator -(uint value)
-        //     => checked(0u - value);
+        // /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
+        // static uint IUnaryNegationOperators<uint, uint>.operator checked -(uint value) => checked(0u - value);
 
         //
         // IUnaryPlusOperators
         //
 
-        static uint IUnaryPlusOperators<uint, uint>.operator +(uint value)
-            => +value;
+        /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_UnaryPlus(TSelf)" />
+        static uint IUnaryPlusOperators<uint, uint>.operator +(uint value) => +value;
 
-        // static checked uint IUnaryPlusOperators<uint, uint>.operator +(uint value)
-        //     => checked(+value);
+        // /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_CheckedUnaryPlus(TSelf)" />
+        // static uint IUnaryPlusOperators<uint, uint>.operator checked +(uint value) => checked(+value);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
@@ -29,16 +29,16 @@ namespace System
         public const ulong MaxValue = (ulong)0xffffffffffffffffL;
         public const ulong MinValue = 0x0;
 
-        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        /// <summary>Represents the additive identity (0).</summary>
         public const ulong AdditiveIdentity = 0;
 
-        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        /// <summary>Represents the multiplicative identity (1).</summary>
         public const ulong MultiplicativeIdentity = 1;
 
-        /// <inheritdoc cref="INumber{TSelf}.One" />
+        /// <summary>Represents the number one (1).</summary>
         public const ulong One = 1;
 
-        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        /// <summary>Represents the number zero (0).</summary>
         public const ulong Zero = 0;
 
         // Compares this object to another object, returning an integer that

--- a/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
@@ -29,6 +29,18 @@ namespace System
         public const ulong MaxValue = (ulong)0xffffffffffffffffL;
         public const ulong MinValue = 0x0;
 
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        public const ulong AdditiveIdentity = 0;
+
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        public const ulong MultiplicativeIdentity = 1;
+
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        public const ulong One = 1;
+
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        public const ulong Zero = 0;
+
         // Compares this object to another object, returning an integer that
         // indicates the relationship.
         // Returns a value less than zero if this  object
@@ -264,169 +276,174 @@ namespace System
         // IAdditionOperators
         //
 
-        static ulong IAdditionOperators<ulong, ulong, ulong>.operator +(ulong left, ulong right)
-            => left + right;
+        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        static ulong IAdditionOperators<ulong, ulong, ulong>.operator +(ulong left, ulong right) => left + right;
 
-        // static checked ulong IAdditionOperators<ulong, ulong, ulong>.operator +(ulong left, ulong right)
-        //     => checked(left + right);
+        // /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        // static ulong IAdditionOperators<ulong, ulong, ulong>.operator checked +(ulong left, ulong right) => checked(left + right);
 
         //
         // IAdditiveIdentity
         //
 
-        static ulong IAdditiveIdentity<ulong, ulong>.AdditiveIdentity => 0;
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
+        static ulong IAdditiveIdentity<ulong, ulong>.AdditiveIdentity => AdditiveIdentity;
 
         //
         // IBinaryInteger
         //
 
-        static ulong IBinaryInteger<ulong>.LeadingZeroCount(ulong value)
-            => (ulong)BitOperations.LeadingZeroCount(value);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.LeadingZeroCount(TSelf)" />
+        public static ulong LeadingZeroCount(ulong value) => (ulong)BitOperations.LeadingZeroCount(value);
 
-        static ulong IBinaryInteger<ulong>.PopCount(ulong value)
-            => (ulong)BitOperations.PopCount(value);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.PopCount(TSelf)" />
+        public static ulong PopCount(ulong value) => (ulong)BitOperations.PopCount(value);
 
-        static ulong IBinaryInteger<ulong>.RotateLeft(ulong value, int rotateAmount)
-            => BitOperations.RotateLeft(value, rotateAmount);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateLeft(TSelf, int)" />
+        public static ulong RotateLeft(ulong value, int rotateAmount) => BitOperations.RotateLeft(value, rotateAmount);
 
-        static ulong IBinaryInteger<ulong>.RotateRight(ulong value, int rotateAmount)
-            => BitOperations.RotateRight(value, rotateAmount);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateRight(TSelf, int)" />
+        public static ulong RotateRight(ulong value, int rotateAmount) => BitOperations.RotateRight(value, rotateAmount);
 
-        static ulong IBinaryInteger<ulong>.TrailingZeroCount(ulong value)
-            => (ulong)BitOperations.TrailingZeroCount(value);
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.TrailingZeroCount(TSelf)" />
+        public static ulong TrailingZeroCount(ulong value) => (ulong)BitOperations.TrailingZeroCount(value);
 
         //
         // IBinaryNumber
         //
 
-        static bool IBinaryNumber<ulong>.IsPow2(ulong value)
-            => BitOperations.IsPow2(value);
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
+        public static bool IsPow2(ulong value) => BitOperations.IsPow2(value);
 
-        static ulong IBinaryNumber<ulong>.Log2(ulong value)
-            => (ulong)BitOperations.Log2(value);
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />
+        public static ulong Log2(ulong value) => (ulong)BitOperations.Log2(value);
 
         //
         // IBitwiseOperators
         //
 
-        static ulong IBitwiseOperators<ulong, ulong, ulong>.operator &(ulong left, ulong right)
-            => left & right;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseAnd(TSelf, TOther)" />
+        static ulong IBitwiseOperators<ulong, ulong, ulong>.operator &(ulong left, ulong right) => left & right;
 
-        static ulong IBitwiseOperators<ulong, ulong, ulong>.operator |(ulong left, ulong right)
-            => left | right;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseOr(TSelf, TOther)" />
+        static ulong IBitwiseOperators<ulong, ulong, ulong>.operator |(ulong left, ulong right) => left | right;
 
-        static ulong IBitwiseOperators<ulong, ulong, ulong>.operator ^(ulong left, ulong right)
-            => left ^ right;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_ExclusiveOr(TSelf, TOther)" />
+        static ulong IBitwiseOperators<ulong, ulong, ulong>.operator ^(ulong left, ulong right) => left ^ right;
 
-        static ulong IBitwiseOperators<ulong, ulong, ulong>.operator ~(ulong value)
-            => ~value;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_OnesComplement(TSelf)" />
+        static ulong IBitwiseOperators<ulong, ulong, ulong>.operator ~(ulong value) => ~value;
 
         //
         // IComparisonOperators
         //
 
-        static bool IComparisonOperators<ulong, ulong>.operator <(ulong left, ulong right)
-            => left < right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
+        static bool IComparisonOperators<ulong, ulong>.operator <(ulong left, ulong right) => left < right;
 
-        static bool IComparisonOperators<ulong, ulong>.operator <=(ulong left, ulong right)
-            => left <= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<ulong, ulong>.operator <=(ulong left, ulong right) => left <= right;
 
-        static bool IComparisonOperators<ulong, ulong>.operator >(ulong left, ulong right)
-            => left > right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
+        static bool IComparisonOperators<ulong, ulong>.operator >(ulong left, ulong right) => left > right;
 
-        static bool IComparisonOperators<ulong, ulong>.operator >=(ulong left, ulong right)
-            => left >= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<ulong, ulong>.operator >=(ulong left, ulong right) => left >= right;
 
         //
         // IDecrementOperators
         //
 
-        static ulong IDecrementOperators<ulong>.operator --(ulong value)
-            => --value;
+        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        static ulong IDecrementOperators<ulong>.operator --(ulong value) => --value;
 
-        // static checked ulong IDecrementOperators<ulong>.operator --(ulong value)
-        //     => checked(--value);
+        // /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        // static ulong IDecrementOperators<ulong>.operator checked --(ulong value) => checked(--value);
 
         //
         // IDivisionOperators
         //
 
-        static ulong IDivisionOperators<ulong, ulong, ulong>.operator /(ulong left, ulong right)
-            => left / right;
+        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
+        static ulong IDivisionOperators<ulong, ulong, ulong>.operator /(ulong left, ulong right) => left / right;
 
-        // static checked ulong IDivisionOperators<ulong, ulong, ulong>.operator /(ulong left, ulong right)
-        //     => checked(left / right);
+        // /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
+        // static ulong IDivisionOperators<ulong, ulong, ulong>.operator checked /(ulong left, ulong right) => checked(left / right);
 
         //
         // IEqualityOperators
         //
 
-        static bool IEqualityOperators<ulong, ulong>.operator ==(ulong left, ulong right)
-            => left == right;
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Equality(TSelf, TOther)" />
+        static bool IEqualityOperators<ulong, ulong>.operator ==(ulong left, ulong right) => left == right;
 
-        static bool IEqualityOperators<ulong, ulong>.operator !=(ulong left, ulong right)
-            => left != right;
+        /// <inheritdoc cref="IEqualityOperators{TSelf, TOther}.op_Inequality(TSelf, TOther)" />
+        static bool IEqualityOperators<ulong, ulong>.operator !=(ulong left, ulong right) => left != right;
 
         //
         // IIncrementOperators
         //
 
-        static ulong IIncrementOperators<ulong>.operator ++(ulong value)
-            => ++value;
+        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_Increment(TSelf)" />
+        static ulong IIncrementOperators<ulong>.operator ++(ulong value) => ++value;
 
-        // static checked ulong IIncrementOperators<ulong>.operator ++(ulong value)
-        //     => checked(++value);
+        // /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
+        // static ulong IIncrementOperators<ulong>.operator checked ++(ulong value) => checked(++value);
 
         //
         // IMinMaxValue
         //
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MinValue" />
         static ulong IMinMaxValue<ulong>.MinValue => MinValue;
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MaxValue" />
         static ulong IMinMaxValue<ulong>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        static ulong IModulusOperators<ulong, ulong, ulong>.operator %(ulong left, ulong right)
-            => left % right;
-
-        // static checked ulong IModulusOperators<ulong, ulong, ulong>.operator %(ulong left, ulong right)
-        //     => checked(left % right);
+        /// <inheritdoc cref="IModulusOperators{TSelf, TOther, TResult}.op_Modulus(TSelf, TOther)" />
+        static ulong IModulusOperators<ulong, ulong, ulong>.operator %(ulong left, ulong right) => left % right;
 
         //
         // IMultiplicativeIdentity
         //
 
-        static ulong IMultiplicativeIdentity<ulong, ulong>.MultiplicativeIdentity => 1;
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
+        static ulong IMultiplicativeIdentity<ulong, ulong>.MultiplicativeIdentity => MultiplicativeIdentity;
 
         //
         // IMultiplyOperators
         //
 
-        static ulong IMultiplyOperators<ulong, ulong, ulong>.operator *(ulong left, ulong right)
-            => left * right;
+        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
+        static ulong IMultiplyOperators<ulong, ulong, ulong>.operator *(ulong left, ulong right) => left * right;
 
-        // static checked ulong IMultiplyOperators<ulong, ulong, ulong>.operator *(ulong left, ulong right)
-        //     => checked(left * right);
+        // /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
+        // static ulong IMultiplyOperators<ulong, ulong, ulong>.operator checked *(ulong left, ulong right) => checked(left * right);
 
         //
         // INumber
         //
 
-        static ulong INumber<ulong>.One => 1;
+        /// <inheritdoc cref="INumber{TSelf}.One" />
+        static ulong INumber<ulong>.One => One;
 
-        static ulong INumber<ulong>.Zero => 0;
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
+        static ulong INumber<ulong>.Zero => Zero;
 
-        static ulong INumber<ulong>.Abs(ulong value)
-            => value;
+        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
+        public static ulong Abs(ulong value) => value;
 
-        static ulong INumber<ulong>.Clamp(ulong value, ulong min, ulong max)
-            => Math.Clamp(value, min, max);
+        /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
+        public static ulong Clamp(ulong value, ulong min, ulong max) => Math.Clamp(value, min, max);
 
+        /// <inheritdoc cref="INumber{TSelf}.Create{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static ulong INumber<ulong>.Create<TOther>(TOther value)
+        public static ulong Create<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -491,8 +508,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static ulong INumber<ulong>.CreateSaturating<TOther>(TOther value)
+        public static ulong CreateSaturating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -568,8 +587,10 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static ulong INumber<ulong>.CreateTruncating<TOther>(TOther value)
+        public static ulong CreateTruncating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -634,26 +655,22 @@ namespace System
             }
         }
 
-        static (ulong Quotient, ulong Remainder) INumber<ulong>.DivRem(ulong left, ulong right)
-            => Math.DivRem(left, right);
+        /// <inheritdoc cref="INumber{TSelf}.DivRem(TSelf, TSelf)" />
+        public static (ulong Quotient, ulong Remainder) DivRem(ulong left, ulong right) => Math.DivRem(left, right);
 
-        static ulong INumber<ulong>.Max(ulong x, ulong y)
-            => Math.Max(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        public static ulong Max(ulong x, ulong y) => Math.Max(x, y);
 
-        static ulong INumber<ulong>.Min(ulong x, ulong y)
-            => Math.Min(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        public static ulong Min(ulong x, ulong y) => Math.Min(x, y);
 
-        static ulong INumber<ulong>.Parse(string s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        public static ulong Sign(ulong value) => (ulong)((value == 0) ? 0 : 1);
 
-        static ulong INumber<ulong>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
-
-        static ulong INumber<ulong>.Sign(ulong value)
-            => (ulong)((value == 0) ? 0 : 1);
-
+        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool INumber<ulong>.TryCreate<TOther>(TOther value, out ulong result)
+        public static bool TryCreate<TOther>(TOther value, out ulong result)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -797,73 +814,63 @@ namespace System
             }
         }
 
-        static bool INumber<ulong>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out ulong result)
-            => TryParse(s, style, provider, out result);
-
-        static bool INumber<ulong>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out ulong result)
-            => TryParse(s, style, provider, out result);
-
         //
         // IParseable
         //
 
-        static ulong IParseable<ulong>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider);
-
-        static bool IParseable<ulong>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out ulong result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out ulong result) => TryParse(s, NumberStyles.Integer, provider, out result);
 
         //
         // IShiftOperators
         //
 
-        static ulong IShiftOperators<ulong, ulong>.operator <<(ulong value, int shiftAmount)
-            => value << (int)shiftAmount;
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_LeftShift(TSelf, int)" />
+        static ulong IShiftOperators<ulong, ulong>.operator <<(ulong value, int shiftAmount) => value << (int)shiftAmount;
 
-        static ulong IShiftOperators<ulong, ulong>.operator >>(ulong value, int shiftAmount)
-            => value >> (int)shiftAmount;
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_RightShift(TSelf, int)" />
+        static ulong IShiftOperators<ulong, ulong>.operator >>(ulong value, int shiftAmount) => value >> (int)shiftAmount;
 
-        // static ulong IShiftOperators<ulong, ulong>.operator >>>(ulong value, int shiftAmount)
-        //     => value >> (int)shiftAmount;
+        // /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_UnsignedRightShift(TSelf, int)" />
+        // static ulong IShiftOperators<ulong, ulong>.operator >>>(ulong value, int shiftAmount) => value >> (int)shiftAmount;
 
         //
         // ISpanParseable
         //
 
-        static ulong ISpanParseable<ulong>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, NumberStyles.Integer, provider);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.Parse(ReadOnlySpan{char}, IFormatProvider?)" />
+        public static ulong Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, NumberStyles.Integer, provider);
 
-        static bool ISpanParseable<ulong>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out ulong result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
+        /// <inheritdoc cref="ISpanParseable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out ulong result) => TryParse(s, NumberStyles.Integer, provider, out result);
 
         //
         // ISubtractionOperators
         //
 
-        static ulong ISubtractionOperators<ulong, ulong, ulong>.operator -(ulong left, ulong right)
-            => left - right;
+        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_Subtraction(TSelf, TOther)" />
+        static ulong ISubtractionOperators<ulong, ulong, ulong>.operator -(ulong left, ulong right) => left - right;
 
-        // static checked ulong ISubtractionOperators<ulong, ulong, ulong>.operator -(ulong left, ulong right)
-        //     => checked(left - right);
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static ulong ISubtractionOperators<ulong, ulong, ulong>.operator checked -(ulong left, ulong right) => checked(left - right);
 
         //
         // IUnaryNegationOperators
         //
 
-        static ulong IUnaryNegationOperators<ulong, ulong>.operator -(ulong value)
-            => 0UL - value;
+        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_UnaryNegation(TSelf)" />
+        static ulong IUnaryNegationOperators<ulong, ulong>.operator -(ulong value) => 0UL - value;
 
-        // static checked ulong IUnaryNegationOperators<ulong, ulong>.operator -(ulong value)
-        //     => checked(0UL - value);
+        // /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
+        // static ulong IUnaryNegationOperators<ulong, ulong>.operator checked -(ulong value) => checked(0UL - value);
 
         //
         // IUnaryPlusOperators
         //
 
-        static ulong IUnaryPlusOperators<ulong, ulong>.operator +(ulong value)
-            => +value;
+        /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_UnaryPlus(TSelf)" />
+        static ulong IUnaryPlusOperators<ulong, ulong>.operator +(ulong value) => +value;
 
-        // static checked ulong IUnaryPlusOperators<ulong, ulong>.operator +(ulong value)
-        //     => checked(+value);
+        // /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_CheckedUnaryPlus(TSelf)" />
+        // static ulong IUnaryPlusOperators<ulong, ulong>.operator checked +(ulong value) => checked(+value);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
@@ -23,7 +23,7 @@ namespace System
     [Serializable]
     [CLSCompliant(false)]
     [StructLayout(LayoutKind.Sequential)]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct UIntPtr
         : IEquatable<nuint>,
           IComparable,
@@ -169,12 +169,14 @@ namespace System
         [NonVersionable]
         public unsafe void* ToPointer() => _value;
 
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
         public static UIntPtr MaxValue
         {
             [NonVersionable]
             get => (UIntPtr)nuint_t.MaxValue;
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
         public static UIntPtr MinValue
         {
             [NonVersionable]
@@ -214,12 +216,19 @@ namespace System
         public static UIntPtr Parse(string s, NumberStyles style) => (UIntPtr)nuint_t.Parse(s, style);
         public static UIntPtr Parse(string s, IFormatProvider? provider) => (UIntPtr)nuint_t.Parse(s, provider);
         public static UIntPtr Parse(string s, NumberStyles style, IFormatProvider? provider) => (UIntPtr)nuint_t.Parse(s, style, provider);
+        public static UIntPtr Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => (UIntPtr)nuint_t.Parse(s, provider);
         public static UIntPtr Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null) => (UIntPtr)nuint_t.Parse(s, style, provider);
 
         public static bool TryParse([NotNullWhen(true)] string? s, out UIntPtr result)
         {
             Unsafe.SkipInit(out result);
             return nuint_t.TryParse(s, out Unsafe.As<UIntPtr, nuint_t>(ref result));
+        }
+
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out UIntPtr result)
+        {
+            Unsafe.SkipInit(out result);
+            return nuint_t.TryParse(s, provider, out Unsafe.As<UIntPtr, nuint_t>(ref result));
         }
 
         public static bool TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out UIntPtr result)
@@ -234,6 +243,12 @@ namespace System
             return nuint_t.TryParse(s, out Unsafe.As<UIntPtr, nuint_t>(ref result));
         }
 
+        public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out UIntPtr result)
+        {
+            Unsafe.SkipInit(out result);
+            return nuint_t.TryParse(s, provider, out Unsafe.As<UIntPtr, nuint_t>(ref result));
+        }
+
         public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out UIntPtr result)
         {
             Unsafe.SkipInit(out result);
@@ -244,22 +259,24 @@ namespace System
         // IAdditionOperators
         //
 
-        static nuint IAdditionOperators<nuint, nuint, nuint>.operator +(nuint left, nuint right)
-            => (nuint)(left + right);
+        /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        static nuint IAdditionOperators<nuint, nuint, nuint>.operator +(nuint left, nuint right) => (nuint)(left + right);
 
-        // static checked nuint IAdditionOperators<nuint, nuint, nuint>.operator +(nuint left, nuint right)
-        //     => checked((nuint)(left + right));
+        // /// <inheritdoc cref="IAdditionOperators{TSelf, TOther, TResult}.op_Addition(TSelf, TOther)" />
+        // static nuint IAdditionOperators<nuint, nuint, nuint>.operator checked +(nuint left, nuint right) => checked((nuint)(left + right));
 
         //
         // IAdditiveIdentity
         //
 
+        /// <inheritdoc cref="IAdditiveIdentity{TSelf, TResult}.AdditiveIdentity" />
         static nuint IAdditiveIdentity<nuint, nuint>.AdditiveIdentity => 0;
 
         //
         // IBinaryInteger
         //
 
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.LeadingZeroCount(TSelf)" />
         static nuint IBinaryInteger<nuint>.LeadingZeroCount(nuint value)
         {
             if (Environment.Is64BitProcess)
@@ -272,6 +289,7 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.PopCount(TSelf)" />
         static nuint IBinaryInteger<nuint>.PopCount(nuint value)
         {
             if (Environment.Is64BitProcess)
@@ -284,6 +302,7 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateLeft(TSelf, int)" />
         static nuint IBinaryInteger<nuint>.RotateLeft(nuint value, int rotateAmount)
         {
             if (Environment.Is64BitProcess)
@@ -296,6 +315,7 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateRight(TSelf, int)" />
         static nuint IBinaryInteger<nuint>.RotateRight(nuint value, int rotateAmount)
         {
             if (Environment.Is64BitProcess)
@@ -308,6 +328,7 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="IBinaryInteger{TSelf}.TrailingZeroCount(TSelf)" />
         static nuint IBinaryInteger<nuint>.TrailingZeroCount(nuint value)
         {
             if (Environment.Is64BitProcess)
@@ -324,6 +345,7 @@ namespace System
         // IBinaryNumber
         //
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
         static bool IBinaryNumber<nuint>.IsPow2(nuint value)
         {
             if (Environment.Is64BitProcess)
@@ -336,6 +358,7 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />
         static nuint IBinaryNumber<nuint>.Log2(nuint value)
         {
             if (Environment.Is64BitProcess)
@@ -352,122 +375,115 @@ namespace System
         // IBitwiseOperators
         //
 
-        static nuint IBitwiseOperators<nuint, nuint, nuint>.operator &(nuint left, nuint right)
-            => left & right;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseAnd(TSelf, TOther)" />
+        static nuint IBitwiseOperators<nuint, nuint, nuint>.operator &(nuint left, nuint right) => left & right;
 
-        static nuint IBitwiseOperators<nuint, nuint, nuint>.operator |(nuint left, nuint right)
-            => left | right;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_BitwiseOr(TSelf, TOther)" />
+        static nuint IBitwiseOperators<nuint, nuint, nuint>.operator |(nuint left, nuint right) => left | right;
 
-        static nuint IBitwiseOperators<nuint, nuint, nuint>.operator ^(nuint left, nuint right)
-            => left ^ right;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_ExclusiveOr(TSelf, TOther)" />
+        static nuint IBitwiseOperators<nuint, nuint, nuint>.operator ^(nuint left, nuint right) => left ^ right;
 
-        static nuint IBitwiseOperators<nuint, nuint, nuint>.operator ~(nuint value)
-            => ~value;
+        /// <inheritdoc cref="IBitwiseOperators{TSelf, TOther, TResult}.op_OnesComplement(TSelf)" />
+        static nuint IBitwiseOperators<nuint, nuint, nuint>.operator ~(nuint value) => ~value;
 
         //
         // IComparisonOperators
         //
 
-        static bool IComparisonOperators<nuint, nuint>.operator <(nuint left, nuint right)
-            => left < right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThan(TSelf, TOther)" />
+        static bool IComparisonOperators<nuint, nuint>.operator <(nuint left, nuint right) => left < right;
 
-        static bool IComparisonOperators<nuint, nuint>.operator <=(nuint left, nuint right)
-            => left <= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_LessThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<nuint, nuint>.operator <=(nuint left, nuint right) => left <= right;
 
-        static bool IComparisonOperators<nuint, nuint>.operator >(nuint left, nuint right)
-            => left > right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThan(TSelf, TOther)" />
+        static bool IComparisonOperators<nuint, nuint>.operator >(nuint left, nuint right) => left > right;
 
-        static bool IComparisonOperators<nuint, nuint>.operator >=(nuint left, nuint right)
-            => left >= right;
+        /// <inheritdoc cref="IComparisonOperators{TSelf, TOther}.op_GreaterThanOrEqual(TSelf, TOther)" />
+        static bool IComparisonOperators<nuint, nuint>.operator >=(nuint left, nuint right) => left >= right;
 
         //
         // IDecrementOperators
         //
 
-        static nuint IDecrementOperators<nuint>.operator --(nuint value)
-            => --value;
+        /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        static nuint IDecrementOperators<nuint>.operator --(nuint value) => --value;
 
-        // static checked nuint IDecrementOperators<nuint>.operator --(nuint value)
-        //     => checked(--value);
+        // /// <inheritdoc cref="IDecrementOperators{TSelf}.op_Decrement(TSelf)" />
+        // static nuint IDecrementOperators<nuint>.operator checked --(nuint value) => checked(--value);
 
         //
         // IDivisionOperators
         //
 
-        static nuint IDivisionOperators<nuint, nuint, nuint>.operator /(nuint left, nuint right)
-            => left / right;
+        /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_Division(TSelf, TOther)" />
+        static nuint IDivisionOperators<nuint, nuint, nuint>.operator /(nuint left, nuint right) => left / right;
 
-        // static checked nuint IDivisionOperators<nuint, nuint, nuint>.operator /(nuint left, nuint right)
-        //     => checked(left / right);
-
-        //
-        // IEqualityOperators
-        //
-
-        static bool IEqualityOperators<nuint, nuint>.operator ==(nuint left, nuint right)
-            => left == right;
-
-        static bool IEqualityOperators<nuint, nuint>.operator !=(nuint left, nuint right)
-            => left != right;
+        // /// <inheritdoc cref="IDivisionOperators{TSelf, TOther, TResult}.op_CheckedDivision(TSelf, TOther)" />
+        // static nuint IDivisionOperators<nuint, nuint, nuint>.operator checked /(nuint left, nuint right) => checked(left / right);
 
         //
         // IIncrementOperators
         //
 
-        static nuint IIncrementOperators<nuint>.operator ++(nuint value)
-            => ++value;
+        /// <inheritdoc cref="IIncrementOperators{TSelf}.op_Increment(TSelf)" />
+        static nuint IIncrementOperators<nuint>.operator ++(nuint value) => ++value;
 
-        // static checked nuint IIncrementOperators<nuint>.operator ++(nuint value)
-        //     => checked(++value);
+        // /// <inheritdoc cref="IIncrementOperators{TSelf}.op_CheckedIncrement(TSelf)" />
+        // static nuint IIncrementOperators<nuint>.operator checked ++(nuint value) => checked(++value);
 
         //
         // IMinMaxValue
         //
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MinValue" />
         static nuint IMinMaxValue<nuint>.MinValue => MinValue;
 
+        /// <inheritdoc cref="IMinMaxValue{TSelf}.MaxValue" />
         static nuint IMinMaxValue<nuint>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        static nuint IModulusOperators<nuint, nuint, nuint>.operator %(nuint left, nuint right)
-            => left % right;
-
-        // static checked nuint IModulusOperators<nuint, nuint, nuint>.operator %(nuint left, nuint right)
-        //     => checked(left % right);
+        /// <inheritdoc cref="IModulusOperators{TSelf, TOther, TResult}.op_Modulus(TSelf, TOther)" />
+        static nuint IModulusOperators<nuint, nuint, nuint>.operator %(nuint left, nuint right) => left % right;
 
         //
         // IMultiplicativeIdentity
         //
 
+        /// <inheritdoc cref="IMultiplicativeIdentity{TSelf, TResult}.MultiplicativeIdentity" />
         static nuint IMultiplicativeIdentity<nuint, nuint>.MultiplicativeIdentity => 1;
 
         //
         // IMultiplyOperators
         //
 
-        static nuint IMultiplyOperators<nuint, nuint, nuint>.operator *(nuint left, nuint right)
-            => left * right;
+        /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_Multiply(TSelf, TOther)" />
+        static nuint IMultiplyOperators<nuint, nuint, nuint>.operator *(nuint left, nuint right) => left * right;
 
-        // static checked nuint IMultiplyOperators<nuint, nuint, nuint>.operator *(nuint left, nuint right)
-        //     => checked(left * right);
+        // /// <inheritdoc cref="IMultiplyOperators{TSelf, TOther, TResult}.op_CheckedMultiply(TSelf, TOther)" />
+        // static nuint IMultiplyOperators<nuint, nuint, nuint>.operator checked *(nuint left, nuint right) => checked(left * right);
 
         //
         // INumber
         //
 
+        /// <inheritdoc cref="INumber{TSelf}.One" />
         static nuint INumber<nuint>.One => 1;
 
+        /// <inheritdoc cref="INumber{TSelf}.Zero" />
         static nuint INumber<nuint>.Zero => 0;
 
-        static nuint INumber<nuint>.Abs(nuint value)
-            => value;
+        /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
+        static nuint INumber<nuint>.Abs(nuint value) => value;
 
-        static nuint INumber<nuint>.Clamp(nuint value, nuint min, nuint max)
-            => Math.Clamp(value, min, max);
+        /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
+        static nuint INumber<nuint>.Clamp(nuint value, nuint min, nuint max) => Math.Clamp(value, min, max);
 
+        /// <inheritdoc cref="INumber{TSelf}.Create{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static nuint INumber<nuint>.Create<TOther>(TOther value)
         {
@@ -534,6 +550,7 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static nuint INumber<nuint>.CreateSaturating<TOther>(TOther value)
         {
@@ -614,6 +631,7 @@ namespace System
             }
         }
 
+        /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static nuint INumber<nuint>.CreateTruncating<TOther>(TOther value)
         {
@@ -680,24 +698,19 @@ namespace System
             }
         }
 
-        static (nuint Quotient, nuint Remainder) INumber<nuint>.DivRem(nuint left, nuint right)
-            => Math.DivRem(left, right);
+        /// <inheritdoc cref="INumber{TSelf}.DivRem(TSelf, TSelf)" />
+        static (nuint Quotient, nuint Remainder) INumber<nuint>.DivRem(nuint left, nuint right) => Math.DivRem(left, right);
 
-        static nuint INumber<nuint>.Max(nuint x, nuint y)
-            => Math.Max(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
+        static nuint INumber<nuint>.Max(nuint x, nuint y) => Math.Max(x, y);
 
-        static nuint INumber<nuint>.Min(nuint x, nuint y)
-            => Math.Min(x, y);
+        /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
+        static nuint INumber<nuint>.Min(nuint x, nuint y) => Math.Min(x, y);
 
-        static nuint INumber<nuint>.Parse(string s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
+        /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
+        static nuint INumber<nuint>.Sign(nuint value) => (nuint)((value == 0) ? 0 : 1);
 
-        static nuint INumber<nuint>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
-            => Parse(s, style, provider);
-
-        static nuint INumber<nuint>.Sign(nuint value)
-            => (nuint)((value == 0) ? 0 : 1);
-
+        /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool INumber<nuint>.TryCreate<TOther>(TOther value, out nuint result)
         {
@@ -851,73 +864,47 @@ namespace System
             }
         }
 
-        static bool INumber<nuint>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out nuint result)
-            => TryParse(s, style, provider, out result);
-
-        static bool INumber<nuint>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out nuint result)
-            => TryParse(s, style, provider, out result);
-
-        //
-        // IParseable
-        //
-
-        static nuint IParseable<nuint>.Parse(string s, IFormatProvider? provider)
-            => Parse(s, provider);
-
-        static bool IParseable<nuint>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out nuint result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
-
         //
         // IShiftOperators
         //
 
-        static nuint IShiftOperators<nuint, nuint>.operator <<(nuint value, int shiftAmount)
-            => value << (int)shiftAmount;
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_LeftShift(TSelf, int)" />
+        static nuint IShiftOperators<nuint, nuint>.operator <<(nuint value, int shiftAmount) => value << (int)shiftAmount;
 
-        static nuint IShiftOperators<nuint, nuint>.operator >>(nuint value, int shiftAmount)
-            => value >> (int)shiftAmount;
+        /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_RightShift(TSelf, int)" />
+        static nuint IShiftOperators<nuint, nuint>.operator >>(nuint value, int shiftAmount) => value >> (int)shiftAmount;
 
-        // static nuint IShiftOperators<nuint, nuint>.operator >>>(nuint value, int shiftAmount)
-        //     => value >> (int)shiftAmount;
-
-        //
-        // ISpanParseable
-        //
-
-        static nuint ISpanParseable<nuint>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
-            => Parse(s, NumberStyles.Integer, provider);
-
-        static bool ISpanParseable<nuint>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out nuint result)
-            => TryParse(s, NumberStyles.Integer, provider, out result);
+        // /// <inheritdoc cref="IShiftOperators{TSelf, TResult}.op_UnsignedRightShift(TSelf, int)" />
+        // static nuint IShiftOperators<nuint, nuint>.operator >>>(nuint value, int shiftAmount) => value >> (int)shiftAmount;
 
         //
         // ISubtractionOperators
         //
 
-        static nuint ISubtractionOperators<nuint, nuint, nuint>.operator -(nuint left, nuint right)
-            => left - right;
+        /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_Subtraction(TSelf, TOther)" />
+        static nuint ISubtractionOperators<nuint, nuint, nuint>.operator -(nuint left, nuint right) => left - right;
 
-        // static checked nuint ISubtractionOperators<nuint, nuint, nuint>.operator -(nuint left, nuint right)
-        //     => checked(left - right);
+        // /// <inheritdoc cref="ISubtractionOperators{TSelf, TOther, TResult}.op_CheckedSubtraction(TSelf, TOther)" />
+        // static nuint ISubtractionOperators<nuint, nuint, nuint>.operator checked -(nuint left, nuint right) => checked(left - right);
 
         //
         // IUnaryNegationOperators
         //
 
-        static nuint IUnaryNegationOperators<nuint, nuint>.operator -(nuint value)
-            => (nuint)0 - value;
+        /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_UnaryNegation(TSelf)" />
+        static nuint IUnaryNegationOperators<nuint, nuint>.operator -(nuint value) => (nuint)0 - value;
 
-        // static checked nuint IUnaryNegationOperators<nuint, nuint>.operator -(nuint value)
-        //     => checked((nuint)0 - value);
+        // /// <inheritdoc cref="IUnaryNegationOperators{TSelf, TResult}.op_CheckedUnaryNegation(TSelf)" />
+        // static nuint IUnaryNegationOperators<nuint, nuint>.operator checked -(nuint value) => checked((nuint)0 - value);
 
         //
         // IUnaryPlusOperators
         //
 
-        static nuint IUnaryPlusOperators<nuint, nuint>.operator +(nuint value)
-            => +value;
+        /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_UnaryPlus(TSelf)" />
+        static nuint IUnaryPlusOperators<nuint, nuint>.operator +(nuint value) => +value;
 
-        // static checked nuint IUnaryPlusOperators<nuint, nuint>.operator +(nuint value)
-        //     => checked(+value);
+        // /// <inheritdoc cref="IUnaryPlusOperators{TSelf, TResult}.op_CheckedUnaryPlus(TSelf)" />
+        // static nuint IUnaryPlusOperators<nuint, nuint>.operator checked +(nuint value) => checked(+value);
     }
 }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -713,22 +713,57 @@ namespace System
         public unsafe static void MemoryCopy(void* source, void* destination, ulong destinationSizeInBytes, ulong sourceBytesToCopy) { }
         public static void SetByte(System.Array array, int index, byte value) { }
     }
-    public readonly partial struct Byte : System.IComparable, System.IComparable<byte>, System.IConvertible, System.IEquatable<byte>, System.ISpanFormattable, System.IBinaryInteger<byte>, System.IMinMaxValue<byte>, System.IUnsignedNumber<byte>
+    public readonly partial struct Byte : System.IAdditionOperators<byte, byte, byte>, System.IAdditiveIdentity<byte, byte>, System.IBinaryInteger<byte>, System.IBinaryNumber<byte>, System.IBitwiseOperators<byte, byte, byte>, System.IComparable, System.IComparable<byte>, System.IComparisonOperators<byte, byte>, System.IConvertible, System.IDecrementOperators<byte>, System.IDivisionOperators<byte, byte, byte>, System.IEqualityOperators<byte, byte>, System.IEquatable<byte>, System.IFormattable, System.IIncrementOperators<byte>, System.IMinMaxValue<byte>, System.IModulusOperators<byte, byte, byte>, System.IMultiplicativeIdentity<byte, byte>, System.IMultiplyOperators<byte, byte, byte>, System.INumber<byte>, System.IParseable<byte>, System.IShiftOperators<byte, byte>, System.ISpanFormattable, System.ISpanParseable<byte>, System.ISubtractionOperators<byte, byte, byte>, System.IUnaryNegationOperators<byte, byte>, System.IUnaryPlusOperators<byte, byte>, System.IUnsignedNumber<byte>
     {
         private readonly byte _dummyPrimitive;
+        public const byte AdditiveIdentity = (byte)0;
         public const byte MaxValue = (byte)255;
         public const byte MinValue = (byte)0;
+        public const byte MultiplicativeIdentity = (byte)1;
+        public const byte One = (byte)1;
+        public const byte Zero = (byte)0;
+        static byte System.IAdditiveIdentity<System.Byte,System.Byte>.AdditiveIdentity { get { throw null; } }
+        static byte System.IMinMaxValue<System.Byte>.MaxValue { get { throw null; } }
+        static byte System.IMinMaxValue<System.Byte>.MinValue { get { throw null; } }
+        static byte System.IMultiplicativeIdentity<System.Byte,System.Byte>.MultiplicativeIdentity { get { throw null; } }
+        static byte System.INumber<System.Byte>.One { get { throw null; } }
+        static byte System.INumber<System.Byte>.Zero { get { throw null; } }
+        public static System.Byte Abs(System.Byte value) { throw null; }
+        public static System.Byte Clamp(System.Byte value, System.Byte min, System.Byte max) { throw null; }
         public int CompareTo(System.Byte value) { throw null; }
         public int CompareTo(object? value) { throw null; }
+        public static System.Byte CreateSaturating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.Byte CreateTruncating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.Byte Create<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static (byte Quotient, byte Remainder) DivRem(System.Byte left, System.Byte right) { throw null; }
         public bool Equals(System.Byte obj) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsPow2(System.Byte value) { throw null; }
+        public static System.Byte LeadingZeroCount(System.Byte value) { throw null; }
+        public static System.Byte Log2(System.Byte value) { throw null; }
+        public static System.Byte Max(System.Byte x, System.Byte y) { throw null; }
+        public static System.Byte Min(System.Byte x, System.Byte y) { throw null; }
         public static System.Byte Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider? provider = null) { throw null; }
+        public static System.Byte Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
         public static System.Byte Parse(string s) { throw null; }
         public static System.Byte Parse(string s, System.Globalization.NumberStyles style) { throw null; }
         public static System.Byte Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
         public static System.Byte Parse(string s, System.IFormatProvider? provider) { throw null; }
+        public static System.Byte PopCount(System.Byte value) { throw null; }
+        public static System.Byte RotateLeft(System.Byte value, int rotateAmount) { throw null; }
+        public static System.Byte RotateRight(System.Byte value, int rotateAmount) { throw null; }
+        public static System.Byte Sign(System.Byte value) { throw null; }
+        static System.Byte System.IAdditionOperators<System.Byte,System.Byte,System.Byte>.operator +(System.Byte left, System.Byte right) { throw null; }
+        static System.Byte System.IBitwiseOperators<System.Byte,System.Byte,System.Byte>.operator &(System.Byte left, System.Byte right) { throw null; }
+        static System.Byte System.IBitwiseOperators<System.Byte,System.Byte,System.Byte>.operator |(System.Byte left, System.Byte right) { throw null; }
+        static System.Byte System.IBitwiseOperators<System.Byte,System.Byte,System.Byte>.operator ^(System.Byte left, System.Byte right) { throw null; }
+        static System.Byte System.IBitwiseOperators<System.Byte,System.Byte,System.Byte>.operator ~(System.Byte value) { throw null; }
+        static bool System.IComparisonOperators<System.Byte,System.Byte>.operator >(System.Byte left, System.Byte right) { throw null; }
+        static bool System.IComparisonOperators<System.Byte,System.Byte>.operator >=(System.Byte left, System.Byte right) { throw null; }
+        static bool System.IComparisonOperators<System.Byte,System.Byte>.operator <(System.Byte left, System.Byte right) { throw null; }
+        static bool System.IComparisonOperators<System.Byte,System.Byte>.operator <=(System.Byte left, System.Byte right) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider? provider) { throw null; }
         System.Byte System.IConvertible.ToByte(System.IFormatProvider? provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider? provider) { throw null; }
@@ -744,89 +779,31 @@ namespace System
         ushort System.IConvertible.ToUInt16(System.IFormatProvider? provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider? provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider? provider) { throw null; }
+        static System.Byte System.IDecrementOperators<System.Byte>.operator --(System.Byte value) { throw null; }
+        static System.Byte System.IDivisionOperators<System.Byte,System.Byte,System.Byte>.operator /(System.Byte left, System.Byte right) { throw null; }
+        static bool System.IEqualityOperators<System.Byte,System.Byte>.operator ==(System.Byte left, System.Byte right) { throw null; }
+        static bool System.IEqualityOperators<System.Byte,System.Byte>.operator !=(System.Byte left, System.Byte right) { throw null; }
+        static System.Byte System.IIncrementOperators<System.Byte>.operator ++(System.Byte value) { throw null; }
+        static System.Byte System.IModulusOperators<System.Byte,System.Byte,System.Byte>.operator %(System.Byte left, System.Byte right) { throw null; }
+        static System.Byte System.IMultiplyOperators<System.Byte,System.Byte,System.Byte>.operator *(System.Byte left, System.Byte right) { throw null; }
+        static System.Byte System.IShiftOperators<System.Byte,System.Byte>.operator <<(System.Byte value, int shiftAmount) { throw null; }
+        static System.Byte System.IShiftOperators<System.Byte,System.Byte>.operator >>(System.Byte value, int shiftAmount) { throw null; }
+        static System.Byte System.ISubtractionOperators<System.Byte,System.Byte,System.Byte>.operator -(System.Byte left, System.Byte right) { throw null; }
+        static System.Byte System.IUnaryNegationOperators<System.Byte,System.Byte>.operator -(System.Byte value) { throw null; }
+        static System.Byte System.IUnaryPlusOperators<System.Byte,System.Byte>.operator +(System.Byte value) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString(string? format) { throw null; }
         public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
+        public static System.Byte TrailingZeroCount(System.Byte value) { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.Byte result) where TOther : INumber<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out System.Byte result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Byte result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Byte result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Byte result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Byte result) { throw null; }
-
-        static byte IAdditiveIdentity<byte, byte>.AdditiveIdentity { get { throw null; } }
-
-        static byte IMinMaxValue<byte>.MinValue { get { throw null; } }
-        static byte IMinMaxValue<byte>.MaxValue { get { throw null; } }
-
-        static byte IMultiplicativeIdentity<byte, byte>.MultiplicativeIdentity { get { throw null; } }
-
-        static byte INumber<byte>.One { get { throw null; } }
-        static byte INumber<byte>.Zero { get { throw null; } }
-
-        static byte IAdditionOperators<byte, byte, byte>.operator +(byte left, byte right) { throw null; }
-
-        static byte IBinaryInteger<byte>.LeadingZeroCount(byte value) { throw null; }
-        static byte IBinaryInteger<byte>.PopCount(byte value) { throw null; }
-        static byte IBinaryInteger<byte>.RotateLeft(byte value, int rotateAmount) { throw null; }
-        static byte IBinaryInteger<byte>.RotateRight(byte value, int rotateAmount) { throw null; }
-        static byte IBinaryInteger<byte>.TrailingZeroCount(byte value) { throw null; }
-
-        static bool IBinaryNumber<byte>.IsPow2(byte value) { throw null; }
-        static byte IBinaryNumber<byte>.Log2(byte value) { throw null; }
-
-        static byte IBitwiseOperators<byte, byte, byte>.operator &(byte left, byte right) { throw null; }
-        static byte IBitwiseOperators<byte, byte, byte>.operator |(byte left, byte right) { throw null; }
-        static byte IBitwiseOperators<byte, byte, byte>.operator ^(byte left, byte right) { throw null; }
-        static byte IBitwiseOperators<byte, byte, byte>.operator ~(byte value) { throw null; }
-
-        static bool IComparisonOperators<byte, byte>.operator <(byte left, byte right) { throw null; }
-        static bool IComparisonOperators<byte, byte>.operator <=(byte left, byte right) { throw null; }
-        static bool IComparisonOperators<byte, byte>.operator >(byte left, byte right) { throw null; }
-        static bool IComparisonOperators<byte, byte>.operator >=(byte left, byte right) { throw null; }
-
-        static byte IDecrementOperators<byte>.operator --(byte value) { throw null; }
-
-        static byte IDivisionOperators<byte, byte, byte>.operator /(byte left, byte right) { throw null; }
-
-        static bool IEqualityOperators<byte, byte>.operator ==(byte left, byte right) { throw null; }
-        static bool IEqualityOperators<byte, byte>.operator !=(byte left, byte right) { throw null; }
-
-        static byte IIncrementOperators<byte>.operator ++(byte value) { throw null; }
-
-        static byte IModulusOperators<byte, byte, byte>.operator %(byte left, byte right) { throw null; }
-
-        static byte IMultiplyOperators<byte, byte, byte>.operator *(byte left, byte right) { throw null; }
-
-        static byte INumber<byte>.Abs(byte value) { throw null; }
-        static byte INumber<byte>.Clamp(byte value, byte min, byte max) { throw null; }
-        static byte INumber<byte>.Create<TOther>(TOther value) { throw null; }
-        static byte INumber<byte>.CreateSaturating<TOther>(TOther value) { throw null; }
-        static byte INumber<byte>.CreateTruncating<TOther>(TOther value) { throw null; }
-        static (byte Quotient, byte Remainder) INumber<byte>.DivRem(byte left, byte right) { throw null; }
-        static byte INumber<byte>.Max(byte x, byte y) { throw null; }
-        static byte INumber<byte>.Min(byte x, byte y) { throw null; }
-        static byte INumber<byte>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static byte INumber<byte>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static byte INumber<byte>.Sign(byte value) { throw null; }
-        static bool INumber<byte>.TryCreate<TOther>(TOther value, out byte result) { throw null; }
-        static bool INumber<byte>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out byte result) { throw null; }
-        static bool INumber<byte>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out byte result) { throw null; }
-
-        static byte IParseable<byte>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<byte>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out byte result) { throw null; }
-
-        static byte IShiftOperators<byte, byte>.operator <<(byte value, int shiftAmount) { throw null; }
-        static byte IShiftOperators<byte, byte>.operator >>(byte value, int shiftAmount) { throw null; }
-
-        static byte ISpanParseable<byte>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<byte>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out byte result) { throw null; }
-
-        static byte ISubtractionOperators<byte, byte, byte>.operator -(byte left, byte right) { throw null; }
-
-        static byte IUnaryNegationOperators<byte, byte>.operator -(byte value) { throw null; }
-
-        static byte IUnaryPlusOperators<byte, byte>.operator +(byte value) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.Byte result) { throw null; }
     }
     public partial class CannotUnloadAppDomainException : System.SystemException
     {
@@ -835,16 +812,28 @@ namespace System
         public CannotUnloadAppDomainException(string? message) { }
         public CannotUnloadAppDomainException(string? message, System.Exception? innerException) { }
     }
-    public readonly partial struct Char : System.IComparable, System.IComparable<char>, System.IConvertible, System.IEquatable<char>, System.ISpanFormattable, System.IBinaryInteger<char>, System.IMinMaxValue<char>, System.IUnsignedNumber<char>
+    public readonly partial struct Char : System.IAdditionOperators<char, char, char>, System.IAdditiveIdentity<char, char>, System.IBinaryInteger<char>, System.IBinaryNumber<char>, System.IBitwiseOperators<char, char, char>, System.IComparable, System.IComparable<char>, System.IComparisonOperators<char, char>, System.IConvertible, System.IDecrementOperators<char>, System.IDivisionOperators<char, char, char>, System.IEqualityOperators<char, char>, System.IEquatable<char>, System.IFormattable, System.IIncrementOperators<char>, System.IMinMaxValue<char>, System.IModulusOperators<char, char, char>, System.IMultiplicativeIdentity<char, char>, System.IMultiplyOperators<char, char, char>, System.INumber<char>, System.IParseable<char>, System.IShiftOperators<char, char>, System.ISpanFormattable, System.ISpanParseable<char>, System.ISubtractionOperators<char, char, char>, System.IUnaryNegationOperators<char, char>, System.IUnaryPlusOperators<char, char>, System.IUnsignedNumber<char>
     {
         private readonly char _dummyPrimitive;
         public const char MaxValue = '\uFFFF';
         public const char MinValue = '\0';
+        static char System.IAdditiveIdentity<System.Char,System.Char>.AdditiveIdentity { get { throw null; } }
+        static char System.IMinMaxValue<System.Char>.MaxValue { get { throw null; } }
+        static char System.IMinMaxValue<System.Char>.MinValue { get { throw null; } }
+        static char System.IMultiplicativeIdentity<System.Char,System.Char>.MultiplicativeIdentity { get { throw null; } }
+        static char System.INumber<System.Char>.One { get { throw null; } }
+        static char System.INumber<System.Char>.Zero { get { throw null; } }
+        public static System.Char Abs(System.Char value) { throw null; }
+        public static System.Char Clamp(System.Char value, System.Char min, System.Char max) { throw null; }
         public int CompareTo(System.Char value) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public static string ConvertFromUtf32(int utf32) { throw null; }
         public static int ConvertToUtf32(System.Char highSurrogate, System.Char lowSurrogate) { throw null; }
         public static int ConvertToUtf32(string s, int index) { throw null; }
+        public static System.Char CreateSaturating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.Char CreateTruncating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.Char Create<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static (char Quotient, char Remainder) DivRem(System.Char left, System.Char right) { throw null; }
         public bool Equals(System.Char obj) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
@@ -870,6 +859,7 @@ namespace System
         public static bool IsLowSurrogate(string s, int index) { throw null; }
         public static bool IsNumber(System.Char c) { throw null; }
         public static bool IsNumber(string s, int index) { throw null; }
+        public static bool IsPow2(System.Char value) { throw null; }
         public static bool IsPunctuation(System.Char c) { throw null; }
         public static bool IsPunctuation(string s, int index) { throw null; }
         public static bool IsSeparator(System.Char c) { throw null; }
@@ -884,7 +874,24 @@ namespace System
         public static bool IsUpper(string s, int index) { throw null; }
         public static bool IsWhiteSpace(System.Char c) { throw null; }
         public static bool IsWhiteSpace(string s, int index) { throw null; }
+        public static System.Char LeadingZeroCount(System.Char value) { throw null; }
+        public static System.Char Log2(System.Char value) { throw null; }
+        public static System.Char Max(System.Char x, System.Char y) { throw null; }
+        public static System.Char Min(System.Char x, System.Char y) { throw null; }
         public static System.Char Parse(string s) { throw null; }
+        public static System.Char PopCount(System.Char value) { throw null; }
+        public static System.Char RotateLeft(System.Char value, int rotateAmount) { throw null; }
+        public static System.Char RotateRight(System.Char value, int rotateAmount) { throw null; }
+        public static System.Char Sign(System.Char value) { throw null; }
+        static System.Char System.IAdditionOperators<System.Char,System.Char,System.Char>.operator +(System.Char left, System.Char right) { throw null; }
+        static System.Char System.IBitwiseOperators<System.Char,System.Char,System.Char>.operator &(System.Char left, System.Char right) { throw null; }
+        static System.Char System.IBitwiseOperators<System.Char,System.Char,System.Char>.operator |(System.Char left, System.Char right) { throw null; }
+        static System.Char System.IBitwiseOperators<System.Char,System.Char,System.Char>.operator ^(System.Char left, System.Char right) { throw null; }
+        static System.Char System.IBitwiseOperators<System.Char,System.Char,System.Char>.operator ~(System.Char value) { throw null; }
+        static bool System.IComparisonOperators<System.Char,System.Char>.operator >(System.Char left, System.Char right) { throw null; }
+        static bool System.IComparisonOperators<System.Char,System.Char>.operator >=(System.Char left, System.Char right) { throw null; }
+        static bool System.IComparisonOperators<System.Char,System.Char>.operator <(System.Char left, System.Char right) { throw null; }
+        static bool System.IComparisonOperators<System.Char,System.Char>.operator <=(System.Char left, System.Char right) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider? provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider? provider) { throw null; }
         System.Char System.IConvertible.ToChar(System.IFormatProvider? provider) { throw null; }
@@ -900,6 +907,28 @@ namespace System
         ushort System.IConvertible.ToUInt16(System.IFormatProvider? provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider? provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider? provider) { throw null; }
+        static System.Char System.IDecrementOperators<System.Char>.operator --(System.Char value) { throw null; }
+        static System.Char System.IDivisionOperators<System.Char,System.Char,System.Char>.operator /(System.Char left, System.Char right) { throw null; }
+        static bool System.IEqualityOperators<System.Char,System.Char>.operator ==(System.Char left, System.Char right) { throw null; }
+        static bool System.IEqualityOperators<System.Char,System.Char>.operator !=(System.Char left, System.Char right) { throw null; }
+        string System.IFormattable.ToString(string? format, System.IFormatProvider? formatProvider) { throw null; }
+        static System.Char System.IIncrementOperators<System.Char>.operator ++(System.Char value) { throw null; }
+        static System.Char System.IModulusOperators<System.Char,System.Char,System.Char>.operator %(System.Char left, System.Char right) { throw null; }
+        static System.Char System.IMultiplyOperators<System.Char,System.Char,System.Char>.operator *(System.Char left, System.Char right) { throw null; }
+        static System.Char System.INumber<System.Char>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
+        static System.Char System.INumber<System.Char>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
+        static bool System.INumber<System.Char>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Char result) { throw null; }
+        static bool System.INumber<System.Char>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Char result) { throw null; }
+        static System.Char System.IParseable<System.Char>.Parse(string s, System.IFormatProvider? provider) { throw null; }
+        static bool System.IParseable<System.Char>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.Char result) { throw null; }
+        static System.Char System.IShiftOperators<System.Char,System.Char>.operator <<(System.Char value, int shiftAmount) { throw null; }
+        static System.Char System.IShiftOperators<System.Char,System.Char>.operator >>(System.Char value, int shiftAmount) { throw null; }
+        bool System.ISpanFormattable.TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) { throw null; }
+        static System.Char System.ISpanParseable<System.Char>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
+        static bool System.ISpanParseable<System.Char>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Char result) { throw null; }
+        static System.Char System.ISubtractionOperators<System.Char,System.Char,System.Char>.operator -(System.Char left, System.Char right) { throw null; }
+        static System.Char System.IUnaryNegationOperators<System.Char,System.Char>.operator -(System.Char value) { throw null; }
+        static System.Char System.IUnaryPlusOperators<System.Char,System.Char>.operator +(System.Char value) { throw null; }
         public static System.Char ToLower(System.Char c) { throw null; }
         public static System.Char ToLower(System.Char c, System.Globalization.CultureInfo culture) { throw null; }
         public static System.Char ToLowerInvariant(System.Char c) { throw null; }
@@ -909,83 +938,9 @@ namespace System
         public static System.Char ToUpper(System.Char c) { throw null; }
         public static System.Char ToUpper(System.Char c, System.Globalization.CultureInfo culture) { throw null; }
         public static System.Char ToUpperInvariant(System.Char c) { throw null; }
+        public static System.Char TrailingZeroCount(System.Char value) { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.Char result) where TOther : INumber<TOther> { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Char result) { throw null; }
-        bool System.ISpanFormattable.TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) { throw null; }
-        string System.IFormattable.ToString(string? format, IFormatProvider? formatProvider) { throw null; }
-
-        static char IAdditiveIdentity<char, char>.AdditiveIdentity { get { throw null; } }
-
-        static char IMinMaxValue<char>.MinValue { get { throw null; } }
-        static char IMinMaxValue<char>.MaxValue { get { throw null; } }
-
-        static char IMultiplicativeIdentity<char, char>.MultiplicativeIdentity { get { throw null; } }
-
-        static char INumber<char>.One { get { throw null; } }
-        static char INumber<char>.Zero { get { throw null; } }
-
-        static char IAdditionOperators<char, char, char>.operator +(char left, char right) { throw null; }
-
-        static char IBinaryInteger<char>.LeadingZeroCount(char value) { throw null; }
-        static char IBinaryInteger<char>.PopCount(char value) { throw null; }
-        static char IBinaryInteger<char>.RotateLeft(char value, int rotateAmount) { throw null; }
-        static char IBinaryInteger<char>.RotateRight(char value, int rotateAmount) { throw null; }
-        static char IBinaryInteger<char>.TrailingZeroCount(char value) { throw null; }
-
-        static bool IBinaryNumber<char>.IsPow2(char value) { throw null; }
-        static char IBinaryNumber<char>.Log2(char value) { throw null; }
-
-        static char IBitwiseOperators<char, char, char>.operator &(char left, char right) { throw null; }
-        static char IBitwiseOperators<char, char, char>.operator |(char left, char right) { throw null; }
-        static char IBitwiseOperators<char, char, char>.operator ^(char left, char right) { throw null; }
-        static char IBitwiseOperators<char, char, char>.operator ~(char value) { throw null; }
-
-        static bool IComparisonOperators<char, char>.operator <(char left, char right) { throw null; }
-        static bool IComparisonOperators<char, char>.operator <=(char left, char right) { throw null; }
-        static bool IComparisonOperators<char, char>.operator >(char left, char right) { throw null; }
-        static bool IComparisonOperators<char, char>.operator >=(char left, char right) { throw null; }
-
-        static char IDecrementOperators<char>.operator --(char value) { throw null; }
-
-        static char IDivisionOperators<char, char, char>.operator /(char left, char right) { throw null; }
-
-        static bool IEqualityOperators<char, char>.operator ==(char left, char right) { throw null; }
-        static bool IEqualityOperators<char, char>.operator !=(char left, char right) { throw null; }
-
-        static char IIncrementOperators<char>.operator ++(char value) { throw null; }
-
-        static char IModulusOperators<char, char, char>.operator %(char left, char right) { throw null; }
-
-        static char IMultiplyOperators<char, char, char>.operator *(char left, char right) { throw null; }
-
-        static char INumber<char>.Abs(char value) { throw null; }
-        static char INumber<char>.Clamp(char value, char min, char max) { throw null; }
-        static char INumber<char>.Create<TOther>(TOther value) { throw null; }
-        static char INumber<char>.CreateSaturating<TOther>(TOther value) { throw null; }
-        static char INumber<char>.CreateTruncating<TOther>(TOther value) { throw null; }
-        static (char Quotient, char Remainder) INumber<char>.DivRem(char left, char right) { throw null; }
-        static char INumber<char>.Max(char x, char y) { throw null; }
-        static char INumber<char>.Min(char x, char y) { throw null; }
-        static char INumber<char>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static char INumber<char>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static char INumber<char>.Sign(char value) { throw null; }
-        static bool INumber<char>.TryCreate<TOther>(TOther value, out char result) { throw null; }
-        static bool INumber<char>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out char result) { throw null; }
-        static bool INumber<char>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out char result) { throw null; }
-
-        static char IParseable<char>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<char>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out char result) { throw null; }
-
-        static char IShiftOperators<char, char>.operator <<(char value, int shiftAmount) { throw null; }
-        static char IShiftOperators<char, char>.operator >>(char value, int shiftAmount) { throw null; }
-
-        static char ISpanParseable<char>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<char>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out char result) { throw null; }
-
-        static char ISubtractionOperators<char, char, char>.operator -(char left, char right) { throw null; }
-
-        static char IUnaryNegationOperators<char, char>.operator -(char value) { throw null; }
-
-        static char IUnaryPlusOperators<char, char>.operator +(char value) { throw null; }
     }
     public sealed partial class CharEnumerator : System.Collections.Generic.IEnumerator<char>, System.Collections.IEnumerator, System.ICloneable, System.IDisposable
     {
@@ -1474,84 +1429,72 @@ namespace System
         public static bool TryToBase64Chars(System.ReadOnlySpan<byte> bytes, System.Span<char> chars, out int charsWritten, System.Base64FormattingOptions options = System.Base64FormattingOptions.None) { throw null; }
     }
     public delegate TOutput Converter<in TInput, out TOutput>(TInput input);
-    public readonly partial struct DateOnly : System.IComparable, System.IComparable<System.DateOnly>, System.IEquatable<System.DateOnly>, System.ISpanFormattable, System.IComparisonOperators<DateOnly, DateOnly>, System.IMinMaxValue<DateOnly>, System.ISpanParseable<DateOnly>
+    public readonly partial struct DateOnly : System.IComparable, System.IComparable<System.DateOnly>, System.IComparisonOperators<System.DateOnly, System.DateOnly>, System.IEqualityOperators<System.DateOnly, System.DateOnly>, System.IEquatable<System.DateOnly>, System.IFormattable, System.IMinMaxValue<System.DateOnly>, System.IParseable<System.DateOnly>, System.ISpanFormattable, System.ISpanParseable<System.DateOnly>
     {
-        public static DateOnly MinValue { get { throw null; } }
-        public static DateOnly MaxValue { get { throw null; } }
+        private readonly int _dummyPrimitive;
         public DateOnly(int year, int month, int day) { throw null; }
         public DateOnly(int year, int month, int day, System.Globalization.Calendar calendar) { throw null; }
-        public static DateOnly FromDayNumber(int dayNumber) { throw null; }
-        public int Year { get { throw null; } }
-        public int Month { get { throw null; } }
         public int Day { get { throw null; } }
+        public int DayNumber { get { throw null; } }
         public System.DayOfWeek DayOfWeek { get { throw null; } }
         public int DayOfYear { get { throw null; } }
-        public int DayNumber { get { throw null; } }
-        public System.DateOnly AddDays(int value)  { throw null; }
+        public static System.DateOnly MaxValue { get { throw null; } }
+        public static System.DateOnly MinValue { get { throw null; } }
+        public int Month { get { throw null; } }
+        public int Year { get { throw null; } }
+        public System.DateOnly AddDays(int value) { throw null; }
         public System.DateOnly AddMonths(int value) { throw null; }
         public System.DateOnly AddYears(int value) { throw null; }
+        public int CompareTo(System.DateOnly value) { throw null; }
+        public int CompareTo(object? value) { throw null; }
+        public bool Equals(System.DateOnly value) { throw null; }
+        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? value) { throw null; }
+        public static System.DateOnly FromDateTime(System.DateTime dateTime) { throw null; }
+        public static System.DateOnly FromDayNumber(int dayNumber) { throw null; }
+        public override int GetHashCode() { throw null; }
         public static bool operator ==(System.DateOnly left, System.DateOnly right) { throw null; }
         public static bool operator >(System.DateOnly left, System.DateOnly right) { throw null; }
         public static bool operator >=(System.DateOnly left, System.DateOnly right) { throw null; }
         public static bool operator !=(System.DateOnly left, System.DateOnly right) { throw null; }
         public static bool operator <(System.DateOnly left, System.DateOnly right) { throw null; }
         public static bool operator <=(System.DateOnly left, System.DateOnly right) { throw null; }
-        public System.DateTime ToDateTime(System.TimeOnly time) { throw null; }
-        public System.DateTime ToDateTime(System.TimeOnly time, System.DateTimeKind kind) { throw null; }
-        public static System.DateOnly FromDateTime(System.DateTime dateTime) { throw null; }
-        public int CompareTo(System.DateOnly value) { throw null; }
-        public int CompareTo(object? value)  { throw null; }
-        public bool Equals(System.DateOnly value) { throw null; }
-        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? value) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public static System.DateOnly Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider = default, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
-        public static System.DateOnly ParseExact(System.ReadOnlySpan<char> s, System.ReadOnlySpan<char> format, System.IFormatProvider? provider = default, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
+        public static System.DateOnly Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
+        public static System.DateOnly Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider = null, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
+        public static System.DateOnly Parse(string s) { throw null; }
+        public static System.DateOnly Parse(string s, System.IFormatProvider? provider) { throw null; }
+        public static System.DateOnly Parse(string s, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
+        public static System.DateOnly ParseExact(System.ReadOnlySpan<char> s, System.ReadOnlySpan<char> format, System.IFormatProvider? provider = null, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
         public static System.DateOnly ParseExact(System.ReadOnlySpan<char> s, string[] formats) { throw null; }
         public static System.DateOnly ParseExact(System.ReadOnlySpan<char> s, string[] formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
-        public static System.DateOnly Parse(string s) { throw null; }
-        public static System.DateOnly Parse(string s, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
         public static System.DateOnly ParseExact(string s, string format) { throw null; }
         public static System.DateOnly ParseExact(string s, string format, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
         public static System.DateOnly ParseExact(string s, string[] formats) { throw null; }
         public static System.DateOnly ParseExact(string s, string[] formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
+        public System.DateTime ToDateTime(System.TimeOnly time) { throw null; }
+        public System.DateTime ToDateTime(System.TimeOnly time, System.DateTimeKind kind) { throw null; }
+        public string ToLongDateString() { throw null; }
+        public string ToShortDateString() { throw null; }
+        public override string ToString() { throw null; }
+        public string ToString(System.IFormatProvider? provider) { throw null; }
+        public string ToString(string? format) { throw null; }
+        public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out System.DateOnly result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.DateOnly result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.DateOnly result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.DateOnly result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.DateOnly result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.DateOnly result) { throw null; }
         public static bool TryParseExact(System.ReadOnlySpan<char> s, System.ReadOnlySpan<char> format, out System.DateOnly result) { throw null; }
         public static bool TryParseExact(System.ReadOnlySpan<char> s, System.ReadOnlySpan<char> format, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.DateOnly result) { throw null; }
         public static bool TryParseExact(System.ReadOnlySpan<char> s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string?[]? formats, out System.DateOnly result) { throw null; }
         public static bool TryParseExact(System.ReadOnlySpan<char> s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string?[]? formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.DateOnly result) { throw null; }
-        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.DateOnly result) { throw null; }
-        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.DateOnly result) { throw null; }
         public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? format, out System.DateOnly result) { throw null; }
         public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? format, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.DateOnly result) { throw null; }
         public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string?[]? formats, out System.DateOnly result) { throw null; }
         public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string?[]? formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.DateOnly result) { throw null; }
-        public string ToLongDateString() { throw null; }
-        public string ToShortDateString() { throw null; }
-        public override string ToString() { throw null; }
-        public string ToString(string? format) { throw null; }
-        public string ToString(System.IFormatProvider? provider) { throw null; }
-        public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
-
-        static System.DateOnly IMinMaxValue<System.DateOnly>.MinValue { get { throw null; } }
-        static System.DateOnly IMinMaxValue<System.DateOnly>.MaxValue { get { throw null; } }
-
-        static bool IComparisonOperators<System.DateOnly, System.DateOnly>.operator <(System.DateOnly left, System.DateOnly right) { throw null; }
-        static bool IComparisonOperators<System.DateOnly, System.DateOnly>.operator <=(System.DateOnly left, System.DateOnly right) { throw null; }
-        static bool IComparisonOperators<System.DateOnly, System.DateOnly>.operator >(System.DateOnly left, System.DateOnly right) { throw null; }
-        static bool IComparisonOperators<System.DateOnly, System.DateOnly>.operator >=(System.DateOnly left, System.DateOnly right) { throw null; }
-
-        static bool IEqualityOperators<System.DateOnly, System.DateOnly>.operator ==(System.DateOnly left, System.DateOnly right) { throw null; }
-        static bool IEqualityOperators<System.DateOnly, System.DateOnly>.operator !=(System.DateOnly left, System.DateOnly right) { throw null; }
-
-        static System.DateOnly IParseable<System.DateOnly>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<System.DateOnly>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.DateOnly result) { throw null; }
-
-        static System.DateOnly ISpanParseable<System.DateOnly>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<System.DateOnly>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.DateOnly result) { throw null; }
     }
-    public readonly partial struct DateTime : System.IComparable, System.IComparable<System.DateTime>, System.IConvertible, System.IEquatable<System.DateTime>, System.ISpanFormattable, System.Runtime.Serialization.ISerializable, System.IAdditionOperators<System.DateTime, System.TimeSpan, System.DateTime>, System.IAdditiveIdentity<System.DateTime, System.TimeSpan>, System.IComparisonOperators<System.DateTime, System.DateTime>, System.IMinMaxValue<System.DateTime>, System.ISpanParseable<System.DateTime>, System.ISubtractionOperators<System.DateTime, System.TimeSpan, System.DateTime>, System.ISubtractionOperators<System.DateTime, System.DateTime, System.TimeSpan>
+    public readonly partial struct DateTime : System.IAdditionOperators<System.DateTime, System.TimeSpan, System.DateTime>, System.IAdditiveIdentity<System.DateTime, System.TimeSpan>, System.IComparable, System.IComparable<System.DateTime>, System.IComparisonOperators<System.DateTime, System.DateTime>, System.IConvertible, System.IEqualityOperators<System.DateTime, System.DateTime>, System.IEquatable<System.DateTime>, System.IFormattable, System.IMinMaxValue<System.DateTime>, System.IParseable<System.DateTime>, System.ISpanFormattable, System.ISpanParseable<System.DateTime>, System.ISubtractionOperators<System.DateTime, System.DateTime, System.TimeSpan>, System.ISubtractionOperators<System.DateTime, System.TimeSpan, System.DateTime>, System.Runtime.Serialization.ISerializable
     {
         private readonly int _dummyPrimitive;
         public static readonly System.DateTime MaxValue;
@@ -1568,6 +1511,7 @@ namespace System
         public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, System.Globalization.Calendar calendar, System.DateTimeKind kind) { throw null; }
         public DateTime(long ticks) { throw null; }
         public DateTime(long ticks, System.DateTimeKind kind) { throw null; }
+        public static System.TimeSpan AdditiveIdentity { get { throw null; } }
         public System.DateTime Date { get { throw null; } }
         public int Day { get { throw null; } }
         public System.DayOfWeek DayOfWeek { get { throw null; } }
@@ -1579,6 +1523,8 @@ namespace System
         public int Month { get { throw null; } }
         public static System.DateTime Now { get { throw null; } }
         public int Second { get { throw null; } }
+        static System.DateTime System.IMinMaxValue<System.DateTime>.MaxValue { get { throw null; } }
+        static System.DateTime System.IMinMaxValue<System.DateTime>.MinValue { get { throw null; } }
         public long Ticks { get { throw null; } }
         public System.TimeSpan TimeOfDay { get { throw null; } }
         public static System.DateTime Today { get { throw null; } }
@@ -1621,15 +1567,16 @@ namespace System
         public static bool operator <=(System.DateTime t1, System.DateTime t2) { throw null; }
         public static System.TimeSpan operator -(System.DateTime d1, System.DateTime d2) { throw null; }
         public static System.DateTime operator -(System.DateTime d, System.TimeSpan t) { throw null; }
+        public static System.DateTime Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
         public static System.DateTime Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider = null, System.Globalization.DateTimeStyles styles = System.Globalization.DateTimeStyles.None) { throw null; }
         public static System.DateTime Parse(string s) { throw null; }
         public static System.DateTime Parse(string s, System.IFormatProvider? provider) { throw null; }
         public static System.DateTime Parse(string s, System.IFormatProvider? provider, System.Globalization.DateTimeStyles styles) { throw null; }
-        public static System.DateTime ParseExact(System.ReadOnlySpan<char> s, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] System.ReadOnlySpan<char> format, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
-        public static System.DateTime ParseExact(System.ReadOnlySpan<char> s, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] string[] formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
-        public static System.DateTime ParseExact(string s, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] string format, System.IFormatProvider? provider) { throw null; }
-        public static System.DateTime ParseExact(string s, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] string format, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style) { throw null; }
-        public static System.DateTime ParseExact(string s, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] string[] formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style) { throw null; }
+        public static System.DateTime ParseExact(System.ReadOnlySpan<char> s, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] System.ReadOnlySpan<char> format, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
+        public static System.DateTime ParseExact(System.ReadOnlySpan<char> s, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] string[] formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
+        public static System.DateTime ParseExact(string s, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] string format, System.IFormatProvider? provider) { throw null; }
+        public static System.DateTime ParseExact(string s, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] string format, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style) { throw null; }
+        public static System.DateTime ParseExact(string s, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] string[] formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style) { throw null; }
         public static System.DateTime SpecifyKind(System.DateTime value, System.DateTimeKind kind) { throw null; }
         public System.TimeSpan Subtract(System.DateTime value) { throw null; }
         public System.DateTime Subtract(System.TimeSpan value) { throw null; }
@@ -1660,42 +1607,20 @@ namespace System
         public string ToShortTimeString() { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
-        public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] string? format) { throw null; }
-        public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] string? format, System.IFormatProvider? provider) { throw null; }
+        public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] string? format) { throw null; }
+        public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public System.DateTime ToUniversalTime() { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out System.DateTime result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.DateTime result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, System.Globalization.DateTimeStyles styles, out System.DateTime result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.DateTime result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.DateTime result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, System.Globalization.DateTimeStyles styles, out System.DateTime result) { throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> s, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] System.ReadOnlySpan<char> format, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true), System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] string?[]? formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
-        public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true), System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] string? format, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
-        public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true), System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] string?[]? formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
-
-        static System.TimeSpan IAdditiveIdentity<System.DateTime, System.TimeSpan>.AdditiveIdentity { get { throw null; } }
-
-        static System.DateTime IMinMaxValue<System.DateTime>.MinValue { get { throw null; } }
-        static System.DateTime IMinMaxValue<System.DateTime>.MaxValue { get { throw null; } }
-
-        static System.DateTime IAdditionOperators<System.DateTime, System.TimeSpan, System.DateTime>.operator +(System.DateTime left, System.TimeSpan right) { throw null; }
-
-        static bool IComparisonOperators<System.DateTime, System.DateTime>.operator <(System.DateTime left, System.DateTime right) { throw null; }
-        static bool IComparisonOperators<System.DateTime, System.DateTime>.operator <=(System.DateTime left, System.DateTime right) { throw null; }
-        static bool IComparisonOperators<System.DateTime, System.DateTime>.operator >(System.DateTime left, System.DateTime right) { throw null; }
-        static bool IComparisonOperators<System.DateTime, System.DateTime>.operator >=(System.DateTime left, System.DateTime right) { throw null; }
-
-        static bool IEqualityOperators<System.DateTime, System.DateTime>.operator ==(System.DateTime left, System.DateTime right) { throw null; }
-        static bool IEqualityOperators<System.DateTime, System.DateTime>.operator !=(System.DateTime left, System.DateTime right) { throw null; }
-
-        static System.DateTime IParseable<System.DateTime>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<System.DateTime>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.DateTime result) { throw null; }
-
-        static System.DateTime ISpanParseable<System.DateTime>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<System.DateTime>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.DateTime result) { throw null; }
-
-        static System.DateTime ISubtractionOperators<System.DateTime, System.TimeSpan, System.DateTime>.operator -(System.DateTime left, System.TimeSpan right) { throw null; }
-        static System.TimeSpan ISubtractionOperators<System.DateTime, System.DateTime, System.TimeSpan>.operator -(System.DateTime left, System.DateTime right) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> s, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] System.ReadOnlySpan<char> format, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true), System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] string?[]? formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
+        public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true), System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] string? format, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
+        public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true), System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] string?[]? formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
     }
     public enum DateTimeKind
     {
@@ -1703,7 +1628,7 @@ namespace System
         Utc = 1,
         Local = 2,
     }
-    public readonly partial struct DateTimeOffset : System.IComparable, System.IComparable<System.DateTimeOffset>, System.IEquatable<System.DateTimeOffset>, System.ISpanFormattable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable, System.IAdditionOperators<System.DateTimeOffset, System.TimeSpan, System.DateTimeOffset>, System.IAdditiveIdentity<System.DateTimeOffset, System.TimeSpan>, System.IComparisonOperators<System.DateTimeOffset, System.DateTimeOffset>, System.IMinMaxValue<System.DateTimeOffset>, System.ISpanParseable<System.DateTimeOffset>, System.ISubtractionOperators<System.DateTimeOffset, System.TimeSpan, System.DateTimeOffset>, System.ISubtractionOperators<System.DateTimeOffset, System.DateTimeOffset, System.TimeSpan>
+    public readonly partial struct DateTimeOffset : System.IAdditionOperators<System.DateTimeOffset, System.TimeSpan, System.DateTimeOffset>, System.IAdditiveIdentity<System.DateTimeOffset, System.TimeSpan>, System.IComparable, System.IComparable<System.DateTimeOffset>, System.IComparisonOperators<System.DateTimeOffset, System.DateTimeOffset>, System.IEqualityOperators<System.DateTimeOffset, System.DateTimeOffset>, System.IEquatable<System.DateTimeOffset>, System.IFormattable, System.IMinMaxValue<System.DateTimeOffset>, System.IParseable<System.DateTimeOffset>, System.ISpanFormattable, System.ISpanParseable<System.DateTimeOffset>, System.ISubtractionOperators<System.DateTimeOffset, System.DateTimeOffset, System.TimeSpan>, System.ISubtractionOperators<System.DateTimeOffset, System.TimeSpan, System.DateTimeOffset>, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         private readonly int _dummyPrimitive;
         public static readonly System.DateTimeOffset MaxValue;
@@ -1715,6 +1640,7 @@ namespace System
         public DateTimeOffset(int year, int month, int day, int hour, int minute, int second, int millisecond, System.TimeSpan offset) { throw null; }
         public DateTimeOffset(int year, int month, int day, int hour, int minute, int second, System.TimeSpan offset) { throw null; }
         public DateTimeOffset(long ticks, System.TimeSpan offset) { throw null; }
+        public static System.TimeSpan AdditiveIdentity { get { throw null; } }
         public System.DateTime Date { get { throw null; } }
         public System.DateTime DateTime { get { throw null; } }
         public int Day { get { throw null; } }
@@ -1728,6 +1654,8 @@ namespace System
         public static System.DateTimeOffset Now { get { throw null; } }
         public System.TimeSpan Offset { get { throw null; } }
         public int Second { get { throw null; } }
+        static System.DateTimeOffset System.IMinMaxValue<System.DateTimeOffset>.MaxValue { get { throw null; } }
+        static System.DateTimeOffset System.IMinMaxValue<System.DateTimeOffset>.MinValue { get { throw null; } }
         public long Ticks { get { throw null; } }
         public System.TimeSpan TimeOfDay { get { throw null; } }
         public System.DateTime UtcDateTime { get { throw null; } }
@@ -1763,15 +1691,16 @@ namespace System
         public static bool operator <=(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
         public static System.TimeSpan operator -(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
         public static System.DateTimeOffset operator -(System.DateTimeOffset dateTimeOffset, System.TimeSpan timeSpan) { throw null; }
+        public static System.DateTimeOffset Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
         public static System.DateTimeOffset Parse(System.ReadOnlySpan<char> input, System.IFormatProvider? formatProvider = null, System.Globalization.DateTimeStyles styles = System.Globalization.DateTimeStyles.None) { throw null; }
         public static System.DateTimeOffset Parse(string input) { throw null; }
         public static System.DateTimeOffset Parse(string input, System.IFormatProvider? formatProvider) { throw null; }
         public static System.DateTimeOffset Parse(string input, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles) { throw null; }
-        public static System.DateTimeOffset ParseExact(System.ReadOnlySpan<char> input, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] System.ReadOnlySpan<char> format, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles = System.Globalization.DateTimeStyles.None) { throw null; }
-        public static System.DateTimeOffset ParseExact(System.ReadOnlySpan<char> input, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] string[] formats, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles = System.Globalization.DateTimeStyles.None) { throw null; }
-        public static System.DateTimeOffset ParseExact(string input, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] string format, System.IFormatProvider? formatProvider) { throw null; }
-        public static System.DateTimeOffset ParseExact(string input, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] string format, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles) { throw null; }
-        public static System.DateTimeOffset ParseExact(string input, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] string[] formats, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles) { throw null; }
+        public static System.DateTimeOffset ParseExact(System.ReadOnlySpan<char> input, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] System.ReadOnlySpan<char> format, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles = System.Globalization.DateTimeStyles.None) { throw null; }
+        public static System.DateTimeOffset ParseExact(System.ReadOnlySpan<char> input, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] string[] formats, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles = System.Globalization.DateTimeStyles.None) { throw null; }
+        public static System.DateTimeOffset ParseExact(string input, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] string format, System.IFormatProvider? formatProvider) { throw null; }
+        public static System.DateTimeOffset ParseExact(string input, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] string format, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles) { throw null; }
+        public static System.DateTimeOffset ParseExact(string input, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] string[] formats, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles) { throw null; }
         public System.TimeSpan Subtract(System.DateTimeOffset value) { throw null; }
         public System.DateTimeOffset Subtract(System.TimeSpan value) { throw null; }
         int System.IComparable.CompareTo(object? obj) { throw null; }
@@ -1782,44 +1711,22 @@ namespace System
         public System.DateTimeOffset ToOffset(System.TimeSpan offset) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? formatProvider) { throw null; }
-        public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] string? format) { throw null; }
-        public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] string? format, System.IFormatProvider? formatProvider) { throw null; }
+        public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] string? format) { throw null; }
+        public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] string? format, System.IFormatProvider? formatProvider) { throw null; }
         public System.DateTimeOffset ToUniversalTime() { throw null; }
         public long ToUnixTimeMilliseconds() { throw null; }
         public long ToUnixTimeSeconds() { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? formatProvider = null) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? formatProvider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> input, out System.DateTimeOffset result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.DateTimeOffset result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> input, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, out System.DateTimeOffset result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.DateTimeOffset result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> input, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] System.ReadOnlySpan<char> format, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true), System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] string?[]? formats, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
-        public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true), System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] string? format, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
-        public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true), System.Diagnostics.CodeAnalysis.StringSyntaxAttribute(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.DateTimeFormat)] string?[]? formats, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
-
-        static System.TimeSpan IAdditiveIdentity<System.DateTimeOffset, System.TimeSpan>.AdditiveIdentity { get { throw null; } }
-
-        static System.DateTimeOffset IMinMaxValue<System.DateTimeOffset>.MinValue { get { throw null; } }
-        static System.DateTimeOffset IMinMaxValue<System.DateTimeOffset>.MaxValue { get { throw null; } }
-
-        static System.DateTimeOffset IAdditionOperators<System.DateTimeOffset, System.TimeSpan, System.DateTimeOffset>.operator +(System.DateTimeOffset left, System.TimeSpan right) { throw null; }
-
-        static bool IComparisonOperators<System.DateTimeOffset, System.DateTimeOffset>.operator <(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
-        static bool IComparisonOperators<System.DateTimeOffset, System.DateTimeOffset>.operator <=(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
-        static bool IComparisonOperators<System.DateTimeOffset, System.DateTimeOffset>.operator >(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
-        static bool IComparisonOperators<System.DateTimeOffset, System.DateTimeOffset>.operator >=(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
-
-        static bool IEqualityOperators<System.DateTimeOffset, System.DateTimeOffset>.operator ==(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
-        static bool IEqualityOperators<System.DateTimeOffset, System.DateTimeOffset>.operator !=(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
-
-        static System.DateTimeOffset IParseable<System.DateTimeOffset>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<System.DateTimeOffset>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.DateTimeOffset result) { throw null; }
-
-        static System.DateTimeOffset ISpanParseable<System.DateTimeOffset>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<System.DateTimeOffset>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.DateTimeOffset result) { throw null; }
-
-        static System.DateTimeOffset ISubtractionOperators<System.DateTimeOffset, System.TimeSpan, System.DateTimeOffset>.operator -(System.DateTimeOffset left, System.TimeSpan right) { throw null; }
-        static System.TimeSpan ISubtractionOperators<System.DateTimeOffset, System.DateTimeOffset, System.TimeSpan>.operator -(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> input, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] System.ReadOnlySpan<char> format, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true), System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] string?[]? formats, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
+        public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true), System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] string? format, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
+        public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true), System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("DateTimeFormat")] string?[]? formats, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
     }
     public enum DayOfWeek
     {
@@ -1855,15 +1762,21 @@ namespace System
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
     }
-    public readonly partial struct Decimal : System.IComparable, System.IComparable<decimal>, System.IConvertible, System.IEquatable<decimal>, System.ISpanFormattable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable, System.IMinMaxValue<decimal>, System.ISignedNumber<decimal>
+    public readonly partial struct Decimal : System.IAdditionOperators<decimal, decimal, decimal>, System.IAdditiveIdentity<decimal, decimal>, System.IComparable, System.IComparable<decimal>, System.IComparisonOperators<decimal, decimal>, System.IConvertible, System.IDecrementOperators<decimal>, System.IDivisionOperators<decimal, decimal, decimal>, System.IEqualityOperators<decimal, decimal>, System.IEquatable<decimal>, System.IFormattable, System.IIncrementOperators<decimal>, System.IMinMaxValue<decimal>, System.IModulusOperators<decimal, decimal, decimal>, System.IMultiplicativeIdentity<decimal, decimal>, System.IMultiplyOperators<decimal, decimal, decimal>, System.INumber<decimal>, System.IParseable<decimal>, System.ISignedNumber<decimal>, System.ISpanFormattable, System.ISpanParseable<decimal>, System.ISubtractionOperators<decimal, decimal, decimal>, System.IUnaryNegationOperators<decimal, decimal>, System.IUnaryPlusOperators<decimal, decimal>, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
         private readonly int _dummyPrimitive;
+        [System.Runtime.CompilerServices.DecimalConstantAttribute((byte)0, (byte)0, (uint)0, (uint)0, (uint)0)]
+        public static readonly decimal AdditiveIdentity;
         [System.Runtime.CompilerServices.DecimalConstantAttribute((byte)0, (byte)0, (uint)4294967295, (uint)4294967295, (uint)4294967295)]
         public static readonly decimal MaxValue;
         [System.Runtime.CompilerServices.DecimalConstantAttribute((byte)0, (byte)128, (uint)0, (uint)0, (uint)1)]
         public static readonly decimal MinusOne;
         [System.Runtime.CompilerServices.DecimalConstantAttribute((byte)0, (byte)128, (uint)4294967295, (uint)4294967295, (uint)4294967295)]
         public static readonly decimal MinValue;
+        [System.Runtime.CompilerServices.DecimalConstantAttribute((byte)0, (byte)0, (uint)0, (uint)0, (uint)1)]
+        public static readonly decimal MultiplicativeIdentity;
+        [System.Runtime.CompilerServices.DecimalConstantAttribute((byte)0, (byte)128, (uint)0, (uint)0, (uint)1)]
+        public static readonly decimal NegativeOne;
         [System.Runtime.CompilerServices.DecimalConstantAttribute((byte)0, (byte)0, (uint)0, (uint)0, (uint)1)]
         public static readonly decimal One;
         [System.Runtime.CompilerServices.DecimalConstantAttribute((byte)0, (byte)0, (uint)0, (uint)0, (uint)0)]
@@ -1880,12 +1793,25 @@ namespace System
         [System.CLSCompliantAttribute(false)]
         public Decimal(ulong value) { throw null; }
         public byte Scale { get { throw null; } }
+        static decimal System.IAdditiveIdentity<System.Decimal,System.Decimal>.AdditiveIdentity { get { throw null; } }
+        static decimal System.IMinMaxValue<System.Decimal>.MaxValue { get { throw null; } }
+        static decimal System.IMinMaxValue<System.Decimal>.MinValue { get { throw null; } }
+        static decimal System.IMultiplicativeIdentity<System.Decimal,System.Decimal>.MultiplicativeIdentity { get { throw null; } }
+        static decimal System.INumber<System.Decimal>.One { get { throw null; } }
+        static decimal System.INumber<System.Decimal>.Zero { get { throw null; } }
+        static decimal System.ISignedNumber<System.Decimal>.NegativeOne { get { throw null; } }
+        public static System.Decimal Abs(System.Decimal value) { throw null; }
         public static System.Decimal Add(System.Decimal d1, System.Decimal d2) { throw null; }
         public static System.Decimal Ceiling(System.Decimal d) { throw null; }
+        public static System.Decimal Clamp(System.Decimal value, System.Decimal min, System.Decimal max) { throw null; }
         public static int Compare(System.Decimal d1, System.Decimal d2) { throw null; }
         public int CompareTo(System.Decimal value) { throw null; }
         public int CompareTo(object? value) { throw null; }
+        public static System.Decimal CreateSaturating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.Decimal CreateTruncating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.Decimal Create<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
         public static System.Decimal Divide(System.Decimal d1, System.Decimal d2) { throw null; }
+        public static (decimal Quotient, decimal Remainder) DivRem(System.Decimal left, System.Decimal right) { throw null; }
         public bool Equals(System.Decimal value) { throw null; }
         public static bool Equals(System.Decimal d1, System.Decimal d2) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? value) { throw null; }
@@ -1895,6 +1821,8 @@ namespace System
         public static int GetBits(System.Decimal d, System.Span<int> destination) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static System.Decimal Max(System.Decimal x, System.Decimal y) { throw null; }
+        public static System.Decimal Min(System.Decimal x, System.Decimal y) { throw null; }
         public static System.Decimal Multiply(System.Decimal d1, System.Decimal d2) { throw null; }
         public static System.Decimal Negate(System.Decimal d) { throw null; }
         public static System.Decimal operator +(System.Decimal d1, System.Decimal d2) { throw null; }
@@ -1943,6 +1871,7 @@ namespace System
         public static System.Decimal operator -(System.Decimal d) { throw null; }
         public static System.Decimal operator +(System.Decimal d) { throw null; }
         public static System.Decimal Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Number, System.IFormatProvider? provider = null) { throw null; }
+        public static System.Decimal Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
         public static System.Decimal Parse(string s) { throw null; }
         public static System.Decimal Parse(string s, System.Globalization.NumberStyles style) { throw null; }
         public static System.Decimal Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
@@ -1968,6 +1897,7 @@ namespace System
         ushort System.IConvertible.ToUInt16(System.IFormatProvider? provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider? provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider? provider) { throw null; }
+        static System.Decimal System.INumber<System.Decimal>.Sign(System.Decimal value) { throw null; }
         void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object? sender) { }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public static byte ToByte(System.Decimal value) { throw null; }
@@ -1990,71 +1920,15 @@ namespace System
         [System.CLSCompliantAttribute(false)]
         public static ulong ToUInt64(System.Decimal d) { throw null; }
         public static System.Decimal Truncate(System.Decimal d) { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.Decimal result) where TOther : INumber<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryGetBits(System.Decimal d, System.Span<int> destination, out int valuesWritten) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out System.Decimal result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Decimal result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Decimal result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Decimal result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Decimal result) { throw null; }
-
-        static decimal IAdditiveIdentity<decimal, decimal>.AdditiveIdentity { get { throw null; } }
-
-        static decimal IMinMaxValue<decimal>.MinValue { get { throw null; } }
-        static decimal IMinMaxValue<decimal>.MaxValue { get { throw null; } }
-
-        static decimal IMultiplicativeIdentity<decimal, decimal>.MultiplicativeIdentity { get { throw null; } }
-
-        static decimal INumber<decimal>.One { get { throw null; } }
-        static decimal INumber<decimal>.Zero { get { throw null; } }
-
-        static decimal IAdditionOperators<decimal, decimal, decimal>.operator +(decimal left, decimal right) { throw null; }
-
-        static bool IComparisonOperators<decimal, decimal>.operator <(decimal left, decimal right) { throw null; }
-        static bool IComparisonOperators<decimal, decimal>.operator <=(decimal left, decimal right) { throw null; }
-        static bool IComparisonOperators<decimal, decimal>.operator >(decimal left, decimal right) { throw null; }
-        static bool IComparisonOperators<decimal, decimal>.operator >=(decimal left, decimal right) { throw null; }
-
-        static decimal IDecrementOperators<decimal>.operator --(decimal value) { throw null; }
-
-        static decimal IDivisionOperators<decimal, decimal, decimal>.operator /(decimal left, decimal right) { throw null; }
-
-        static bool IEqualityOperators<decimal, decimal>.operator ==(decimal left, decimal right) { throw null; }
-        static bool IEqualityOperators<decimal, decimal>.operator !=(decimal left, decimal right) { throw null; }
-
-        static decimal IIncrementOperators<decimal>.operator ++(decimal value) { throw null; }
-
-        static decimal IModulusOperators<decimal, decimal, decimal>.operator %(decimal left, decimal right) { throw null; }
-
-        static decimal IMultiplyOperators<decimal, decimal, decimal>.operator *(decimal left, decimal right) { throw null; }
-
-        static decimal INumber<decimal>.Abs(decimal value) { throw null; }
-        static decimal INumber<decimal>.Clamp(decimal value, decimal min, decimal max) { throw null; }
-        static decimal INumber<decimal>.Create<TOther>(TOther value) { throw null; }
-        static decimal INumber<decimal>.CreateSaturating<TOther>(TOther value) { throw null; }
-        static decimal INumber<decimal>.CreateTruncating<TOther>(TOther value) { throw null; }
-        static (decimal Quotient, decimal Remainder) INumber<decimal>.DivRem(decimal left, decimal right) { throw null; }
-        static decimal INumber<decimal>.Max(decimal x, decimal y) { throw null; }
-        static decimal INumber<decimal>.Min(decimal x, decimal y) { throw null; }
-        static decimal INumber<decimal>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static decimal INumber<decimal>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static decimal INumber<decimal>.Sign(decimal value) { throw null; }
-        static bool INumber<decimal>.TryCreate<TOther>(TOther value, out decimal result) { throw null; }
-        static bool INumber<decimal>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out decimal result) { throw null; }
-        static bool INumber<decimal>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out decimal result) { throw null; }
-
-        static decimal IParseable<decimal>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<decimal>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out decimal result) { throw null; }
-
-        static decimal ISignedNumber<decimal>.NegativeOne { get; }
-
-        static decimal ISpanParseable<decimal>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<decimal>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out decimal result) { throw null; }
-
-        static decimal ISubtractionOperators<decimal, decimal, decimal>.operator -(decimal left, decimal right) { throw null; }
-
-        static decimal IUnaryNegationOperators<decimal, decimal>.operator -(decimal value) { throw null; }
-
-        static decimal IUnaryPlusOperators<decimal, decimal>.operator +(decimal value) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.Decimal result) { throw null; }
     }
     public abstract partial class Delegate : System.ICloneable, System.Runtime.Serialization.ISerializable
     {
@@ -2102,21 +1976,70 @@ namespace System
         public DivideByZeroException(string? message) { }
         public DivideByZeroException(string? message, System.Exception? innerException) { }
     }
-    public readonly partial struct Double : System.IComparable, System.IComparable<double>, System.IConvertible, System.IEquatable<double>, System.ISpanFormattable, System.IBinaryFloatingPoint<double>, System.IMinMaxValue<double>
+    public readonly partial struct Double : System.IAdditionOperators<double, double, double>, System.IAdditiveIdentity<double, double>, System.IBinaryFloatingPoint<double>, System.IBinaryNumber<double>, System.IBitwiseOperators<double, double, double>, System.IComparable, System.IComparable<double>, System.IComparisonOperators<double, double>, System.IConvertible, System.IDecrementOperators<double>, System.IDivisionOperators<double, double, double>, System.IEqualityOperators<double, double>, System.IEquatable<double>, System.IFloatingPoint<double>, System.IFormattable, System.IIncrementOperators<double>, System.IMinMaxValue<double>, System.IModulusOperators<double, double, double>, System.IMultiplicativeIdentity<double, double>, System.IMultiplyOperators<double, double, double>, System.INumber<double>, System.IParseable<double>, System.ISignedNumber<double>, System.ISpanFormattable, System.ISpanParseable<double>, System.ISubtractionOperators<double, double, double>, System.IUnaryNegationOperators<double, double>, System.IUnaryPlusOperators<double, double>
     {
         private readonly double _dummyPrimitive;
+        public const double AdditiveIdentity = 0;
+        public const double E = 2.718281828459045;
         public const double Epsilon = 5E-324;
         public const double MaxValue = 1.7976931348623157E+308;
         public const double MinValue = -1.7976931348623157E+308;
+        public const double MultiplicativeIdentity = 1;
         public const double NaN = 0.0 / 0.0;
         public const double NegativeInfinity = -1.0 / 0.0;
+        public const double NegativeOne = -1;
+        public const double NegativeZero = -0;
+        public const double One = 1;
+        public const double Pi = 3.141592653589793;
         public const double PositiveInfinity = 1.0 / 0.0;
+        public const double Tau = 6.283185307179586;
+        public const double Zero = 0;
+        static double System.IAdditiveIdentity<System.Double,System.Double>.AdditiveIdentity { get { throw null; } }
+        static double System.IFloatingPoint<System.Double>.E { get { throw null; } }
+        static double System.IFloatingPoint<System.Double>.Epsilon { get { throw null; } }
+        static double System.IFloatingPoint<System.Double>.NaN { get { throw null; } }
+        static double System.IFloatingPoint<System.Double>.NegativeInfinity { get { throw null; } }
+        static double System.IFloatingPoint<System.Double>.NegativeZero { get { throw null; } }
+        static double System.IFloatingPoint<System.Double>.Pi { get { throw null; } }
+        static double System.IFloatingPoint<System.Double>.PositiveInfinity { get { throw null; } }
+        static double System.IFloatingPoint<System.Double>.Tau { get { throw null; } }
+        static double System.IMinMaxValue<System.Double>.MaxValue { get { throw null; } }
+        static double System.IMinMaxValue<System.Double>.MinValue { get { throw null; } }
+        static double System.IMultiplicativeIdentity<System.Double,System.Double>.MultiplicativeIdentity { get { throw null; } }
+        static double System.INumber<System.Double>.One { get { throw null; } }
+        static double System.INumber<System.Double>.Zero { get { throw null; } }
+        static double System.ISignedNumber<System.Double>.NegativeOne { get { throw null; } }
+        public static System.Double Abs(System.Double value) { throw null; }
+        public static System.Double Acos(System.Double x) { throw null; }
+        public static System.Double Acosh(System.Double x) { throw null; }
+        public static System.Double Asin(System.Double x) { throw null; }
+        public static System.Double Asinh(System.Double x) { throw null; }
+        public static System.Double Atan(System.Double x) { throw null; }
+        public static System.Double Atan2(System.Double y, System.Double x) { throw null; }
+        public static System.Double Atanh(System.Double x) { throw null; }
+        public static System.Double BitDecrement(System.Double x) { throw null; }
+        public static System.Double BitIncrement(System.Double x) { throw null; }
+        public static System.Double Cbrt(System.Double x) { throw null; }
+        public static System.Double Ceiling(System.Double x) { throw null; }
+        public static System.Double Clamp(System.Double value, System.Double min, System.Double max) { throw null; }
         public int CompareTo(System.Double value) { throw null; }
         public int CompareTo(object? value) { throw null; }
+        public static System.Double CopySign(System.Double x, System.Double y) { throw null; }
+        public static System.Double Cos(System.Double x) { throw null; }
+        public static System.Double Cosh(System.Double x) { throw null; }
+        public static System.Double CreateSaturating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.Double CreateTruncating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.Double Create<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static (double Quotient, double Remainder) DivRem(System.Double left, System.Double right) { throw null; }
         public bool Equals(System.Double obj) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public static System.Double Exp(System.Double x) { throw null; }
+        public static System.Double Floor(System.Double x) { throw null; }
+        public static System.Double FusedMultiplyAdd(System.Double left, System.Double right, System.Double addend) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static System.Double IEEERemainder(System.Double left, System.Double right) { throw null; }
+        public static TInteger ILogB<TInteger>(System.Double x) where TInteger : IBinaryInteger<TInteger> { throw null; }
         public static bool IsFinite(System.Double d) { throw null; }
         public static bool IsInfinity(System.Double d) { throw null; }
         public static bool IsNaN(System.Double d) { throw null; }
@@ -2124,7 +2047,16 @@ namespace System
         public static bool IsNegativeInfinity(System.Double d) { throw null; }
         public static bool IsNormal(System.Double d) { throw null; }
         public static bool IsPositiveInfinity(System.Double d) { throw null; }
+        public static bool IsPow2(System.Double value) { throw null; }
         public static bool IsSubnormal(System.Double d) { throw null; }
+        public static System.Double Log(System.Double x) { throw null; }
+        public static System.Double Log(System.Double x, System.Double newBase) { throw null; }
+        public static System.Double Log10(System.Double x) { throw null; }
+        public static System.Double Log2(System.Double value) { throw null; }
+        public static System.Double Max(System.Double x, System.Double y) { throw null; }
+        public static System.Double MaxMagnitude(System.Double x, System.Double y) { throw null; }
+        public static System.Double Min(System.Double x, System.Double y) { throw null; }
+        public static System.Double MinMagnitude(System.Double x, System.Double y) { throw null; }
         public static bool operator ==(System.Double left, System.Double right) { throw null; }
         public static bool operator >(System.Double left, System.Double right) { throw null; }
         public static bool operator >=(System.Double left, System.Double right) { throw null; }
@@ -2132,10 +2064,26 @@ namespace System
         public static bool operator <(System.Double left, System.Double right) { throw null; }
         public static bool operator <=(System.Double left, System.Double right) { throw null; }
         public static System.Double Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.AllowDecimalPoint | System.Globalization.NumberStyles.AllowExponent | System.Globalization.NumberStyles.AllowLeadingSign | System.Globalization.NumberStyles.AllowLeadingWhite | System.Globalization.NumberStyles.AllowThousands | System.Globalization.NumberStyles.AllowTrailingWhite, System.IFormatProvider? provider = null) { throw null; }
+        public static System.Double Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
         public static System.Double Parse(string s) { throw null; }
         public static System.Double Parse(string s, System.Globalization.NumberStyles style) { throw null; }
         public static System.Double Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
         public static System.Double Parse(string s, System.IFormatProvider? provider) { throw null; }
+        public static System.Double Pow(System.Double x, System.Double y) { throw null; }
+        public static System.Double Round(System.Double x) { throw null; }
+        public static System.Double Round(System.Double x, System.MidpointRounding mode) { throw null; }
+        public static System.Double Round<TInteger>(System.Double x, TInteger digits) where TInteger : IBinaryInteger<TInteger> { throw null; }
+        public static System.Double Round<TInteger>(System.Double x, TInteger digits, System.MidpointRounding mode) where TInteger : IBinaryInteger<TInteger> { throw null; }
+        public static System.Double ScaleB<TInteger>(System.Double x, TInteger n) where TInteger : IBinaryInteger<TInteger> { throw null; }
+        public static System.Double Sign(System.Double value) { throw null; }
+        public static System.Double Sin(System.Double x) { throw null; }
+        public static System.Double Sinh(System.Double x) { throw null; }
+        public static System.Double Sqrt(System.Double x) { throw null; }
+        static System.Double System.IAdditionOperators<System.Double,System.Double,System.Double>.operator +(System.Double left, System.Double right) { throw null; }
+        static System.Double System.IBitwiseOperators<System.Double,System.Double,System.Double>.operator &(System.Double left, System.Double right) { throw null; }
+        static System.Double System.IBitwiseOperators<System.Double,System.Double,System.Double>.operator |(System.Double left, System.Double right) { throw null; }
+        static System.Double System.IBitwiseOperators<System.Double,System.Double,System.Double>.operator ^(System.Double left, System.Double right) { throw null; }
+        static System.Double System.IBitwiseOperators<System.Double,System.Double,System.Double>.operator ~(System.Double value) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider? provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider? provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider? provider) { throw null; }
@@ -2151,138 +2099,29 @@ namespace System
         ushort System.IConvertible.ToUInt16(System.IFormatProvider? provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider? provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider? provider) { throw null; }
+        static System.Double System.IDecrementOperators<System.Double>.operator --(System.Double value) { throw null; }
+        static System.Double System.IDivisionOperators<System.Double,System.Double,System.Double>.operator /(System.Double left, System.Double right) { throw null; }
+        static System.Double System.IIncrementOperators<System.Double>.operator ++(System.Double value) { throw null; }
+        static System.Double System.IModulusOperators<System.Double,System.Double,System.Double>.operator %(System.Double left, System.Double right) { throw null; }
+        static System.Double System.IMultiplyOperators<System.Double,System.Double,System.Double>.operator *(System.Double left, System.Double right) { throw null; }
+        static System.Double System.ISubtractionOperators<System.Double,System.Double,System.Double>.operator -(System.Double left, System.Double right) { throw null; }
+        static System.Double System.IUnaryNegationOperators<System.Double,System.Double>.operator -(System.Double value) { throw null; }
+        static System.Double System.IUnaryPlusOperators<System.Double,System.Double>.operator +(System.Double value) { throw null; }
+        public static System.Double Tan(System.Double x) { throw null; }
+        public static System.Double Tanh(System.Double x) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString(string? format) { throw null; }
         public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
+        public static System.Double Truncate(System.Double x) { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.Double result) where TOther : INumber<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out System.Double result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Double result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Double result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Double result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Double result) { throw null; }
-
-        static double IAdditiveIdentity<double, double>.AdditiveIdentity { get { throw null; } }
-
-        static double IFloatingPoint<double>.E { get { throw null; } }
-        static double IFloatingPoint<double>.Epsilon { get { throw null; } }
-        static double IFloatingPoint<double>.NaN { get { throw null; } }
-        static double IFloatingPoint<double>.NegativeInfinity { get { throw null; } }
-        static double IFloatingPoint<double>.NegativeZero { get { throw null; } }
-        static double IFloatingPoint<double>.Pi { get { throw null; } }
-        static double IFloatingPoint<double>.PositiveInfinity { get { throw null; } }
-        static double IFloatingPoint<double>.Tau { get { throw null; } }
-
-        static double IMinMaxValue<double>.MinValue { get { throw null; } }
-        static double IMinMaxValue<double>.MaxValue { get { throw null; } }
-
-        static double INumber<double>.One { get { throw null; } }
-        static double INumber<double>.Zero { get { throw null; } }
-
-        static double IMultiplicativeIdentity<double, double>.MultiplicativeIdentity { get { throw null; } }
-
-        static double IAdditionOperators<double, double, double>.operator +(double left, double right) { throw null; }
-
-        static bool IBinaryNumber<double>.IsPow2(double value) { throw null; }
-        static double IBinaryNumber<double>.Log2(double value) { throw null; }
-
-        static double IBitwiseOperators<double, double, double>.operator &(double left, double right) { throw null; }
-        static double IBitwiseOperators<double, double, double>.operator |(double left, double right) { throw null; }
-        static double IBitwiseOperators<double, double, double>.operator ^(double left, double right) { throw null; }
-        static double IBitwiseOperators<double, double, double>.operator ~(double value) { throw null; }
-
-        static bool IComparisonOperators<double, double>.operator <(double left, double right) { throw null; }
-        static bool IComparisonOperators<double, double>.operator <=(double left, double right) { throw null; }
-        static bool IComparisonOperators<double, double>.operator >(double left, double right) { throw null; }
-        static bool IComparisonOperators<double, double>.operator >=(double left, double right) { throw null; }
-
-        static double IDecrementOperators<double>.operator --(double value) { throw null; }
-
-        static double IDivisionOperators<double, double, double>.operator /(double left, double right) { throw null; }
-
-        static bool IEqualityOperators<double, double>.operator ==(double left, double right) { throw null; }
-        static bool IEqualityOperators<double, double>.operator !=(double left, double right) { throw null; }
-
-        static double IFloatingPoint<double>.Acos(double x) { throw null; }
-        static double IFloatingPoint<double>.Acosh(double x) { throw null; }
-        static double IFloatingPoint<double>.Asin(double x) { throw null; }
-        static double IFloatingPoint<double>.Asinh(double x) { throw null; }
-        static double IFloatingPoint<double>.Atan(double x) { throw null; }
-        static double IFloatingPoint<double>.Atan2(double y, double x) { throw null; }
-        static double IFloatingPoint<double>.Atanh(double x) { throw null; }
-        static double IFloatingPoint<double>.BitIncrement(double x) { throw null; }
-        static double IFloatingPoint<double>.BitDecrement(double x) { throw null; }
-        static double IFloatingPoint<double>.Cbrt(double x) { throw null; }
-        static double IFloatingPoint<double>.Ceiling(double x) { throw null; }
-        static double IFloatingPoint<double>.CopySign(double x, double y) { throw null; }
-        static double IFloatingPoint<double>.Cos(double x) { throw null; }
-        static double IFloatingPoint<double>.Cosh(double x) { throw null; }
-        static double IFloatingPoint<double>.Exp(double x) { throw null; }
-        static double IFloatingPoint<double>.Floor(double x) { throw null; }
-        static double IFloatingPoint<double>.FusedMultiplyAdd(double left, double right, double addend) { throw null; }
-        static double IFloatingPoint<double>.IEEERemainder(double left, double right) { throw null; }
-        static TInteger IFloatingPoint<double>.ILogB<TInteger>(double x) { throw null; }
-        static double IFloatingPoint<double>.Log(double x) { throw null; }
-        static double IFloatingPoint<double>.Log(double x, double newBase) { throw null; }
-        static double IFloatingPoint<double>.Log2(double x) { throw null; }
-        static double IFloatingPoint<double>.Log10(double x) { throw null; }
-        static double IFloatingPoint<double>.MaxMagnitude(double x, double y) { throw null; }
-        static double IFloatingPoint<double>.MinMagnitude(double x, double y) { throw null; }
-        static double IFloatingPoint<double>.Pow(double x, double y) { throw null; }
-        static double IFloatingPoint<double>.Round(double x) { throw null; }
-        static double IFloatingPoint<double>.Round<TInteger>(double x, TInteger digits) { throw null; }
-        static double IFloatingPoint<double>.Round(double x, System.MidpointRounding mode) { throw null; }
-        static double IFloatingPoint<double>.Round<TInteger>(double x, TInteger digits, System.MidpointRounding mode) { throw null; }
-        static double IFloatingPoint<double>.ScaleB<TInteger>(double x, TInteger n) { throw null; }
-        static double IFloatingPoint<double>.Sin(double x) { throw null; }
-        static double IFloatingPoint<double>.Sinh(double x) { throw null; }
-        static double IFloatingPoint<double>.Sqrt(double x) { throw null; }
-        static double IFloatingPoint<double>.Tan(double x) { throw null; }
-        static double IFloatingPoint<double>.Tanh(double x) { throw null; }
-        static double IFloatingPoint<double>.Truncate(double x) { throw null; }
-
-        static bool IFloatingPoint<double>.IsFinite(double d) { throw null; }
-        static bool IFloatingPoint<double>.IsInfinity(double d) { throw null; }
-        static bool IFloatingPoint<double>.IsNaN(double d) { throw null; }
-        static bool IFloatingPoint<double>.IsNegative(double d) { throw null; }
-        static bool IFloatingPoint<double>.IsNegativeInfinity(double d) { throw null; }
-        static bool IFloatingPoint<double>.IsNormal(double d) { throw null; }
-        static bool IFloatingPoint<double>.IsPositiveInfinity(double d) { throw null; }
-        static bool IFloatingPoint<double>.IsSubnormal(double d) { throw null; }
-
-        static double IIncrementOperators<double>.operator ++(double value) { throw null; }
-
-        static double IModulusOperators<double, double, double>.operator %(double left, double right) { throw null; }
-
-        static double IMultiplyOperators<double, double, double>.operator *(double left, double right) { throw null; }
-
-        static double INumber<double>.Abs(double value) { throw null; }
-        static double INumber<double>.Clamp(double value, double min, double max) { throw null; }
-        static double INumber<double>.Create<TOther>(TOther value) { throw null; }
-        static double INumber<double>.CreateSaturating<TOther>(TOther value) { throw null; }
-        static double INumber<double>.CreateTruncating<TOther>(TOther value) { throw null; }
-        static (double Quotient, double Remainder) INumber<double>.DivRem(double left, double right) { throw null; }
-        static double INumber<double>.Max(double x, double y) { throw null; }
-        static double INumber<double>.Min(double x, double y) { throw null; }
-        static double INumber<double>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static double INumber<double>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static double INumber<double>.Sign(double value) { throw null; }
-        static bool INumber<double>.TryCreate<TOther>(TOther value, out double result) { throw null; }
-        static bool INumber<double>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out double result) { throw null; }
-        static bool INumber<double>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out double result) { throw null; }
-
-        static double IParseable<double>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<double>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out double result) { throw null; }
-
-        static double ISignedNumber<double>.NegativeOne { get; }
-
-        static double ISpanParseable<double>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<double>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out double result) { throw null; }
-
-        static double ISubtractionOperators<double, double, double>.operator -(double left, double right) { throw null; }
-
-        static double IUnaryNegationOperators<double, double>.operator -(double value) { throw null; }
-
-        static double IUnaryPlusOperators<double, double>.operator +(double value) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.Double result) { throw null; }
     }
     public partial class DuplicateWaitObjectException : System.ArgumentException
     {
@@ -2676,7 +2515,7 @@ namespace System
     {
         public GopherStyleUriParser() { }
     }
-    public readonly partial struct Guid : System.IComparable, System.IComparable<System.Guid>, System.IEquatable<System.Guid>, System.ISpanFormattable, System.IComparisonOperators<System.Guid, System.Guid>, System.ISpanParseable<System.Guid>
+    public readonly partial struct Guid : System.IComparable, System.IComparable<System.Guid>, System.IComparisonOperators<System.Guid, System.Guid>, System.IEqualityOperators<System.Guid, System.Guid>, System.IEquatable<System.Guid>, System.IFormattable, System.IParseable<System.Guid>, System.ISpanFormattable, System.ISpanParseable<System.Guid>
     {
         private readonly int _dummyPrimitive;
         public static readonly System.Guid Empty;
@@ -2694,51 +2533,79 @@ namespace System
         public override int GetHashCode() { throw null; }
         public static System.Guid NewGuid() { throw null; }
         public static bool operator ==(System.Guid a, System.Guid b) { throw null; }
+        public static bool operator >(System.Guid left, System.Guid right) { throw null; }
+        public static bool operator >=(System.Guid left, System.Guid right) { throw null; }
         public static bool operator !=(System.Guid a, System.Guid b) { throw null; }
+        public static bool operator <(System.Guid left, System.Guid right) { throw null; }
+        public static bool operator <=(System.Guid left, System.Guid right) { throw null; }
         public static System.Guid Parse(System.ReadOnlySpan<char> input) { throw null; }
+        public static System.Guid Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
         public static System.Guid Parse(string input) { throw null; }
+        public static System.Guid Parse(string s, System.IFormatProvider? provider) { throw null; }
         public static System.Guid ParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format) { throw null; }
         public static System.Guid ParseExact(string input, string format) { throw null; }
+        bool System.ISpanFormattable.TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) { throw null; }
         public byte[] ToByteArray() { throw null; }
         public override string ToString() { throw null; }
         public string ToString(string? format) { throw null; }
         public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>)) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> input, out System.Guid result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Guid result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, out System.Guid result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.Guid result) { throw null; }
         public static bool TryParseExact(System.ReadOnlySpan<char> input, System.ReadOnlySpan<char> format, out System.Guid result) { throw null; }
         public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? format, out System.Guid result) { throw null; }
         public bool TryWriteBytes(System.Span<byte> destination) { throw null; }
-        bool System.ISpanFormattable.TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) { throw null; }
-
-        static bool IComparisonOperators<System.Guid, System.Guid>.operator <(System.Guid left, System.Guid right) { throw null; }
-        static bool IComparisonOperators<System.Guid, System.Guid>.operator <=(System.Guid left, System.Guid right) { throw null; }
-        static bool IComparisonOperators<System.Guid, System.Guid>.operator >(System.Guid left, System.Guid right) { throw null; }
-        static bool IComparisonOperators<System.Guid, System.Guid>.operator >=(System.Guid left, System.Guid right) { throw null; }
-
-        static bool IEqualityOperators<System.Guid, System.Guid>.operator ==(System.Guid left, System.Guid right) { throw null; }
-        static bool IEqualityOperators<System.Guid, System.Guid>.operator !=(System.Guid left, System.Guid right) { throw null; }
-
-        static System.Guid IParseable<System.Guid>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<System.Guid>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.Guid result) { throw null; }
-
-        static System.Guid ISpanParseable<System.Guid>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<System.Guid>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Guid result) { throw null; }
     }
-    public readonly partial struct Half : System.IComparable, System.IComparable<System.Half>, System.IEquatable<System.Half>, System.ISpanFormattable, System.IBinaryFloatingPoint<System.Half>, System.IMinMaxValue<System.Half>
+    public readonly partial struct Half : System.IAdditionOperators<System.Half, System.Half, System.Half>, System.IAdditiveIdentity<System.Half, System.Half>, System.IBinaryFloatingPoint<System.Half>, System.IBinaryNumber<System.Half>, System.IBitwiseOperators<System.Half, System.Half, System.Half>, System.IComparable, System.IComparable<System.Half>, System.IComparisonOperators<System.Half, System.Half>, System.IDecrementOperators<System.Half>, System.IDivisionOperators<System.Half, System.Half, System.Half>, System.IEqualityOperators<System.Half, System.Half>, System.IEquatable<System.Half>, System.IFloatingPoint<System.Half>, System.IFormattable, System.IIncrementOperators<System.Half>, System.IMinMaxValue<System.Half>, System.IModulusOperators<System.Half, System.Half, System.Half>, System.IMultiplicativeIdentity<System.Half, System.Half>, System.IMultiplyOperators<System.Half, System.Half, System.Half>, System.INumber<System.Half>, System.IParseable<System.Half>, System.ISignedNumber<System.Half>, System.ISpanFormattable, System.ISpanParseable<System.Half>, System.ISubtractionOperators<System.Half, System.Half, System.Half>, System.IUnaryNegationOperators<System.Half, System.Half>, System.IUnaryPlusOperators<System.Half, System.Half>
     {
         private readonly int _dummyPrimitive;
+        public static System.Half AdditiveIdentity { get { throw null; } }
+        public static System.Half E { get { throw null; } }
         public static System.Half Epsilon { get { throw null; } }
         public static System.Half MaxValue { get { throw null; } }
         public static System.Half MinValue { get { throw null; } }
+        public static System.Half MultiplicativeIdentity { get { throw null; } }
         public static System.Half NaN { get { throw null; } }
         public static System.Half NegativeInfinity { get { throw null; } }
+        public static System.Half NegativeOne { get { throw null; } }
+        public static System.Half NegativeZero { get { throw null; } }
+        public static System.Half One { get { throw null; } }
+        public static System.Half Pi { get { throw null; } }
         public static System.Half PositiveInfinity { get { throw null; } }
+        public static System.Half Tau { get { throw null; } }
+        public static System.Half Zero { get { throw null; } }
+        public static System.Half Abs(System.Half value) { throw null; }
+        public static System.Half Acos(System.Half x) { throw null; }
+        public static System.Half Acosh(System.Half x) { throw null; }
+        public static System.Half Asin(System.Half x) { throw null; }
+        public static System.Half Asinh(System.Half x) { throw null; }
+        public static System.Half Atan(System.Half x) { throw null; }
+        public static System.Half Atan2(System.Half y, System.Half x) { throw null; }
+        public static System.Half Atanh(System.Half x) { throw null; }
+        public static System.Half BitDecrement(System.Half x) { throw null; }
+        public static System.Half BitIncrement(System.Half x) { throw null; }
+        public static System.Half Cbrt(System.Half x) { throw null; }
+        public static System.Half Ceiling(System.Half x) { throw null; }
+        public static System.Half Clamp(System.Half value, System.Half min, System.Half max) { throw null; }
         public int CompareTo(System.Half other) { throw null; }
         public int CompareTo(object? obj) { throw null; }
+        public static System.Half CopySign(System.Half x, System.Half y) { throw null; }
+        public static System.Half Cos(System.Half x) { throw null; }
+        public static System.Half Cosh(System.Half x) { throw null; }
+        public static System.Half CreateSaturating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.Half CreateTruncating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.Half Create<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static (System.Half Quotient, System.Half Remainder) DivRem(System.Half left, System.Half right) { throw null; }
         public bool Equals(System.Half other) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public static System.Half Exp(System.Half x) { throw null; }
+        public static System.Half Floor(System.Half x) { throw null; }
+        public static System.Half FusedMultiplyAdd(System.Half left, System.Half right, System.Half addend) { throw null; }
         public override int GetHashCode() { throw null; }
+        public static System.Half IEEERemainder(System.Half left, System.Half right) { throw null; }
+        public static TInteger ILogB<TInteger>(System.Half x) where TInteger : IBinaryInteger<TInteger> { throw null; }
         public static bool IsFinite(System.Half value) { throw null; }
         public static bool IsInfinity(System.Half value) { throw null; }
         public static bool IsNaN(System.Half value) { throw null; }
@@ -2746,7 +2613,19 @@ namespace System
         public static bool IsNegativeInfinity(System.Half value) { throw null; }
         public static bool IsNormal(System.Half value) { throw null; }
         public static bool IsPositiveInfinity(System.Half value) { throw null; }
+        public static bool IsPow2(System.Half value) { throw null; }
         public static bool IsSubnormal(System.Half value) { throw null; }
+        public static System.Half Log(System.Half x) { throw null; }
+        public static System.Half Log(System.Half x, System.Half newBase) { throw null; }
+        public static System.Half Log10(System.Half x) { throw null; }
+        public static System.Half Log2(System.Half value) { throw null; }
+        public static System.Half Max(System.Half x, System.Half y) { throw null; }
+        public static System.Half MaxMagnitude(System.Half x, System.Half y) { throw null; }
+        public static System.Half Min(System.Half x, System.Half y) { throw null; }
+        public static System.Half MinMagnitude(System.Half x, System.Half y) { throw null; }
+        public static System.Half operator +(System.Half left, System.Half right) { throw null; }
+        public static System.Half operator --(System.Half value) { throw null; }
+        public static System.Half operator /(System.Half left, System.Half right) { throw null; }
         public static bool operator ==(System.Half left, System.Half right) { throw null; }
         public static explicit operator System.Half (double value) { throw null; }
         public static explicit operator double (System.Half value) { throw null; }
@@ -2754,146 +2633,50 @@ namespace System
         public static explicit operator System.Half (float value) { throw null; }
         public static bool operator >(System.Half left, System.Half right) { throw null; }
         public static bool operator >=(System.Half left, System.Half right) { throw null; }
+        public static System.Half operator ++(System.Half value) { throw null; }
         public static bool operator !=(System.Half left, System.Half right) { throw null; }
         public static bool operator <(System.Half left, System.Half right) { throw null; }
         public static bool operator <=(System.Half left, System.Half right) { throw null; }
+        public static System.Half operator %(System.Half left, System.Half right) { throw null; }
+        public static System.Half operator *(System.Half left, System.Half right) { throw null; }
+        public static System.Half operator -(System.Half left, System.Half right) { throw null; }
+        public static System.Half operator -(System.Half value) { throw null; }
+        public static System.Half operator +(System.Half value) { throw null; }
         public static System.Half Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.AllowDecimalPoint | System.Globalization.NumberStyles.AllowExponent | System.Globalization.NumberStyles.AllowLeadingSign | System.Globalization.NumberStyles.AllowLeadingWhite | System.Globalization.NumberStyles.AllowThousands | System.Globalization.NumberStyles.AllowTrailingWhite, System.IFormatProvider? provider = null) { throw null; }
+        public static System.Half Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
         public static System.Half Parse(string s) { throw null; }
         public static System.Half Parse(string s, System.Globalization.NumberStyles style) { throw null; }
         public static System.Half Parse(string s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.AllowDecimalPoint | System.Globalization.NumberStyles.AllowExponent | System.Globalization.NumberStyles.AllowLeadingSign | System.Globalization.NumberStyles.AllowLeadingWhite | System.Globalization.NumberStyles.AllowThousands | System.Globalization.NumberStyles.AllowTrailingWhite, System.IFormatProvider? provider = null) { throw null; }
         public static System.Half Parse(string s, System.IFormatProvider? provider) { throw null; }
+        public static System.Half Pow(System.Half x, System.Half y) { throw null; }
+        public static System.Half Round(System.Half x) { throw null; }
+        public static System.Half Round(System.Half x, System.MidpointRounding mode) { throw null; }
+        public static System.Half Round<TInteger>(System.Half x, TInteger digits) where TInteger : IBinaryInteger<TInteger> { throw null; }
+        public static System.Half Round<TInteger>(System.Half x, TInteger digits, System.MidpointRounding mode) where TInteger : IBinaryInteger<TInteger> { throw null; }
+        public static System.Half ScaleB<TInteger>(System.Half x, TInteger n) where TInteger : IBinaryInteger<TInteger> { throw null; }
+        public static System.Half Sign(System.Half value) { throw null; }
+        public static System.Half Sin(System.Half x) { throw null; }
+        public static System.Half Sinh(System.Half x) { throw null; }
+        public static System.Half Sqrt(System.Half x) { throw null; }
+        static System.Half System.IBitwiseOperators<System.Half,System.Half,System.Half>.operator &(System.Half left, System.Half right) { throw null; }
+        static System.Half System.IBitwiseOperators<System.Half,System.Half,System.Half>.operator |(System.Half left, System.Half right) { throw null; }
+        static System.Half System.IBitwiseOperators<System.Half,System.Half,System.Half>.operator ^(System.Half left, System.Half right) { throw null; }
+        static System.Half System.IBitwiseOperators<System.Half,System.Half,System.Half>.operator ~(System.Half value) { throw null; }
+        public static System.Half Tan(System.Half x) { throw null; }
+        public static System.Half Tanh(System.Half x) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString(string? format) { throw null; }
         public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
+        public static System.Half Truncate(System.Half x) { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.Half result) where TOther : INumber<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Half result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out System.Half result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Half result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Half result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Half result) { throw null; }
-
-        static System.Half IAdditiveIdentity<System.Half, System.Half>.AdditiveIdentity { get { throw null; } }
-
-        static System.Half IFloatingPoint<System.Half>.E { get { throw null; } }
-        static System.Half IFloatingPoint<System.Half>.Epsilon { get { throw null; } }
-        static System.Half IFloatingPoint<System.Half>.NaN { get { throw null; } }
-        static System.Half IFloatingPoint<System.Half>.NegativeInfinity { get { throw null; } }
-        static System.Half IFloatingPoint<System.Half>.NegativeZero { get { throw null; } }
-        static System.Half IFloatingPoint<System.Half>.Pi { get { throw null; } }
-        static System.Half IFloatingPoint<System.Half>.PositiveInfinity { get { throw null; } }
-        static System.Half IFloatingPoint<System.Half>.Tau { get { throw null; } }
-
-        static System.Half IMinMaxValue<System.Half>.MinValue { get { throw null; } }
-        static System.Half IMinMaxValue<System.Half>.MaxValue { get { throw null; } }
-
-        static System.Half INumber<System.Half>.One { get { throw null; } }
-        static System.Half INumber<System.Half>.Zero { get { throw null; } }
-
-        static System.Half IMultiplicativeIdentity<System.Half, System.Half>.MultiplicativeIdentity { get { throw null; } }
-
-        static System.Half IAdditionOperators<System.Half, System.Half, System.Half>.operator +(System.Half left, System.Half right) { throw null; }
-
-        static bool IBinaryNumber<System.Half>.IsPow2(System.Half value) { throw null; }
-        static System.Half IBinaryNumber<System.Half>.Log2(System.Half value) { throw null; }
-
-        static System.Half IBitwiseOperators<System.Half, System.Half, System.Half>.operator &(System.Half left, System.Half right) { throw null; }
-        static System.Half IBitwiseOperators<System.Half, System.Half, System.Half>.operator |(System.Half left, System.Half right) { throw null; }
-        static System.Half IBitwiseOperators<System.Half, System.Half, System.Half>.operator ^(System.Half left, System.Half right) { throw null; }
-        static System.Half IBitwiseOperators<System.Half, System.Half, System.Half>.operator ~(System.Half value) { throw null; }
-
-        static bool IComparisonOperators<System.Half, System.Half>.operator <(System.Half left, System.Half right) { throw null; }
-        static bool IComparisonOperators<System.Half, System.Half>.operator <=(System.Half left, System.Half right) { throw null; }
-        static bool IComparisonOperators<System.Half, System.Half>.operator >(System.Half left, System.Half right) { throw null; }
-        static bool IComparisonOperators<System.Half, System.Half>.operator >=(System.Half left, System.Half right) { throw null; }
-
-        static System.Half IDecrementOperators<System.Half>.operator --(System.Half value) { throw null; }
-
-        static System.Half IDivisionOperators<System.Half, System.Half, System.Half>.operator /(System.Half left, System.Half right) { throw null; }
-
-        static bool IEqualityOperators<System.Half, System.Half>.operator ==(System.Half left, System.Half right) { throw null; }
-        static bool IEqualityOperators<System.Half, System.Half>.operator !=(System.Half left, System.Half right) { throw null; }
-
-        static System.Half IFloatingPoint<System.Half>.Acos(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Acosh(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Asin(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Asinh(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Atan(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Atan2(System.Half y, System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Atanh(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.BitIncrement(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.BitDecrement(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Cbrt(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Ceiling(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.CopySign(System.Half x, System.Half y) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Cos(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Cosh(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Exp(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Floor(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.FusedMultiplyAdd(System.Half left, System.Half right, System.Half addend) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.IEEERemainder(System.Half left, System.Half right) { throw null; }
-        static TInteger IFloatingPoint<System.Half>.ILogB<TInteger>(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Log(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Log(System.Half x, System.Half newBase) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Log2(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Log10(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.MaxMagnitude(System.Half x, System.Half y) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.MinMagnitude(System.Half x, System.Half y) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Pow(System.Half x, System.Half y) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Round(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Round<TInteger>(System.Half x, TInteger digits) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Round(System.Half x, System.MidpointRounding mode) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Round<TInteger>(System.Half x, TInteger digits, System.MidpointRounding mode) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.ScaleB<TInteger>(System.Half x, TInteger n) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Sin(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Sinh(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Sqrt(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Tan(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Tanh(System.Half x) { throw null; }
-        static System.Half IFloatingPoint<System.Half>.Truncate(System.Half x) { throw null; }
-
-        static bool IFloatingPoint<System.Half>.IsFinite(System.Half x) { throw null; }
-        static bool IFloatingPoint<System.Half>.IsInfinity(System.Half x) { throw null; }
-        static bool IFloatingPoint<System.Half>.IsNaN(System.Half x) { throw null; }
-        static bool IFloatingPoint<System.Half>.IsNegative(System.Half x) { throw null; }
-        static bool IFloatingPoint<System.Half>.IsNegativeInfinity(System.Half x) { throw null; }
-        static bool IFloatingPoint<System.Half>.IsNormal(System.Half x) { throw null; }
-        static bool IFloatingPoint<System.Half>.IsPositiveInfinity(System.Half x) { throw null; }
-        static bool IFloatingPoint<System.Half>.IsSubnormal(System.Half x) { throw null; }
-
-        static System.Half IIncrementOperators<System.Half>.operator ++(System.Half value) { throw null; }
-
-        static System.Half IModulusOperators<System.Half, System.Half, System.Half>.operator %(System.Half left, System.Half right) { throw null; }
-
-        static System.Half IMultiplyOperators<System.Half, System.Half, System.Half>.operator *(System.Half left, System.Half right) { throw null; }
-
-        static System.Half INumber<System.Half>.Abs(System.Half value) { throw null; }
-        static System.Half INumber<System.Half>.Clamp(System.Half value, System.Half min, System.Half max) { throw null; }
-        static System.Half INumber<System.Half>.Create<TOther>(TOther value) { throw null; }
-        static System.Half INumber<System.Half>.CreateSaturating<TOther>(TOther value) { throw null; }
-        static System.Half INumber<System.Half>.CreateTruncating<TOther>(TOther value) { throw null; }
-        static (System.Half Quotient, System.Half Remainder) INumber<System.Half>.DivRem(System.Half left, System.Half right) { throw null; }
-        static System.Half INumber<System.Half>.Max(System.Half x, System.Half y) { throw null; }
-        static System.Half INumber<System.Half>.Min(System.Half x, System.Half y) { throw null; }
-        static System.Half INumber<System.Half>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static System.Half INumber<System.Half>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static System.Half INumber<System.Half>.Sign(System.Half value) { throw null; }
-        static bool INumber<System.Half>.TryCreate<TOther>(TOther value, out System.Half result) { throw null; }
-        static bool INumber<System.Half>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Half result) { throw null; }
-        static bool INumber<System.Half>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Half result) { throw null; }
-
-        static System.Half IParseable<System.Half>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<System.Half>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.Half result) { throw null; }
-
-        static System.Half ISignedNumber<System.Half>.NegativeOne { get; }
-
-        static System.Half ISpanParseable<System.Half>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<System.Half>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Half result) { throw null; }
-
-        static System.Half ISubtractionOperators<System.Half, System.Half, System.Half>.operator -(System.Half left, System.Half right) { throw null; }
-
-        static System.Half IUnaryNegationOperators<System.Half, System.Half>.operator -(System.Half value) { throw null; }
-
-        static System.Half IUnaryPlusOperators<System.Half, System.Half>.operator +(System.Half value) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.Half result) { throw null; }
     }
     public partial struct HashCode
     {
@@ -3226,22 +3009,59 @@ namespace System
         public InsufficientMemoryException(string? message) { }
         public InsufficientMemoryException(string? message, System.Exception? innerException) { }
     }
-    public readonly partial struct Int16 : System.IComparable, System.IComparable<short>, System.IConvertible, System.IEquatable<short>, System.ISpanFormattable, System.IBinaryInteger<short>, System.IMinMaxValue<short>, System.ISignedNumber<short>
+    public readonly partial struct Int16 : System.IAdditionOperators<short, short, short>, System.IAdditiveIdentity<short, short>, System.IBinaryInteger<short>, System.IBinaryNumber<short>, System.IBitwiseOperators<short, short, short>, System.IComparable, System.IComparable<short>, System.IComparisonOperators<short, short>, System.IConvertible, System.IDecrementOperators<short>, System.IDivisionOperators<short, short, short>, System.IEqualityOperators<short, short>, System.IEquatable<short>, System.IFormattable, System.IIncrementOperators<short>, System.IMinMaxValue<short>, System.IModulusOperators<short, short, short>, System.IMultiplicativeIdentity<short, short>, System.IMultiplyOperators<short, short, short>, System.INumber<short>, System.IParseable<short>, System.IShiftOperators<short, short>, System.ISignedNumber<short>, System.ISpanFormattable, System.ISpanParseable<short>, System.ISubtractionOperators<short, short, short>, System.IUnaryNegationOperators<short, short>, System.IUnaryPlusOperators<short, short>
     {
         private readonly short _dummyPrimitive;
+        public const short AdditiveIdentity = (short)0;
         public const short MaxValue = (short)32767;
         public const short MinValue = (short)-32768;
+        public const short MultiplicativeIdentity = (short)1;
+        public const short NegativeOne = (short)-1;
+        public const short One = (short)1;
+        public const short Zero = (short)0;
+        static short System.IAdditiveIdentity<System.Int16,System.Int16>.AdditiveIdentity { get { throw null; } }
+        static short System.IMinMaxValue<System.Int16>.MaxValue { get { throw null; } }
+        static short System.IMinMaxValue<System.Int16>.MinValue { get { throw null; } }
+        static short System.IMultiplicativeIdentity<System.Int16,System.Int16>.MultiplicativeIdentity { get { throw null; } }
+        static short System.INumber<System.Int16>.One { get { throw null; } }
+        static short System.INumber<System.Int16>.Zero { get { throw null; } }
+        static short System.ISignedNumber<System.Int16>.NegativeOne { get { throw null; } }
+        public static System.Int16 Abs(System.Int16 value) { throw null; }
+        public static System.Int16 Clamp(System.Int16 value, System.Int16 min, System.Int16 max) { throw null; }
         public int CompareTo(System.Int16 value) { throw null; }
         public int CompareTo(object? value) { throw null; }
+        public static System.Int16 CreateSaturating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.Int16 CreateTruncating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.Int16 Create<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static (short Quotient, short Remainder) DivRem(System.Int16 left, System.Int16 right) { throw null; }
         public bool Equals(System.Int16 obj) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsPow2(System.Int16 value) { throw null; }
+        public static System.Int16 LeadingZeroCount(System.Int16 value) { throw null; }
+        public static System.Int16 Log2(System.Int16 value) { throw null; }
+        public static System.Int16 Max(System.Int16 x, System.Int16 y) { throw null; }
+        public static System.Int16 Min(System.Int16 x, System.Int16 y) { throw null; }
         public static System.Int16 Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider? provider = null) { throw null; }
+        public static System.Int16 Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
         public static System.Int16 Parse(string s) { throw null; }
         public static System.Int16 Parse(string s, System.Globalization.NumberStyles style) { throw null; }
         public static System.Int16 Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
         public static System.Int16 Parse(string s, System.IFormatProvider? provider) { throw null; }
+        public static System.Int16 PopCount(System.Int16 value) { throw null; }
+        public static System.Int16 RotateLeft(System.Int16 value, int rotateAmount) { throw null; }
+        public static System.Int16 RotateRight(System.Int16 value, int rotateAmount) { throw null; }
+        public static System.Int16 Sign(System.Int16 value) { throw null; }
+        static System.Int16 System.IAdditionOperators<System.Int16,System.Int16,System.Int16>.operator +(System.Int16 left, System.Int16 right) { throw null; }
+        static System.Int16 System.IBitwiseOperators<System.Int16,System.Int16,System.Int16>.operator &(System.Int16 left, System.Int16 right) { throw null; }
+        static System.Int16 System.IBitwiseOperators<System.Int16,System.Int16,System.Int16>.operator |(System.Int16 left, System.Int16 right) { throw null; }
+        static System.Int16 System.IBitwiseOperators<System.Int16,System.Int16,System.Int16>.operator ^(System.Int16 left, System.Int16 right) { throw null; }
+        static System.Int16 System.IBitwiseOperators<System.Int16,System.Int16,System.Int16>.operator ~(System.Int16 value) { throw null; }
+        static bool System.IComparisonOperators<System.Int16,System.Int16>.operator >(System.Int16 left, System.Int16 right) { throw null; }
+        static bool System.IComparisonOperators<System.Int16,System.Int16>.operator >=(System.Int16 left, System.Int16 right) { throw null; }
+        static bool System.IComparisonOperators<System.Int16,System.Int16>.operator <(System.Int16 left, System.Int16 right) { throw null; }
+        static bool System.IComparisonOperators<System.Int16,System.Int16>.operator <=(System.Int16 left, System.Int16 right) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider? provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider? provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider? provider) { throw null; }
@@ -3257,108 +3077,85 @@ namespace System
         ushort System.IConvertible.ToUInt16(System.IFormatProvider? provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider? provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider? provider) { throw null; }
+        static System.Int16 System.IDecrementOperators<System.Int16>.operator --(System.Int16 value) { throw null; }
+        static System.Int16 System.IDivisionOperators<System.Int16,System.Int16,System.Int16>.operator /(System.Int16 left, System.Int16 right) { throw null; }
+        static bool System.IEqualityOperators<System.Int16,System.Int16>.operator ==(System.Int16 left, System.Int16 right) { throw null; }
+        static bool System.IEqualityOperators<System.Int16,System.Int16>.operator !=(System.Int16 left, System.Int16 right) { throw null; }
+        static System.Int16 System.IIncrementOperators<System.Int16>.operator ++(System.Int16 value) { throw null; }
+        static System.Int16 System.IModulusOperators<System.Int16,System.Int16,System.Int16>.operator %(System.Int16 left, System.Int16 right) { throw null; }
+        static System.Int16 System.IMultiplyOperators<System.Int16,System.Int16,System.Int16>.operator *(System.Int16 left, System.Int16 right) { throw null; }
+        static System.Int16 System.IShiftOperators<System.Int16,System.Int16>.operator <<(System.Int16 value, int shiftAmount) { throw null; }
+        static System.Int16 System.IShiftOperators<System.Int16,System.Int16>.operator >>(System.Int16 value, int shiftAmount) { throw null; }
+        static System.Int16 System.ISubtractionOperators<System.Int16,System.Int16,System.Int16>.operator -(System.Int16 left, System.Int16 right) { throw null; }
+        static System.Int16 System.IUnaryNegationOperators<System.Int16,System.Int16>.operator -(System.Int16 value) { throw null; }
+        static System.Int16 System.IUnaryPlusOperators<System.Int16,System.Int16>.operator +(System.Int16 value) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString(string? format) { throw null; }
         public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
+        public static System.Int16 TrailingZeroCount(System.Int16 value) { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.Int16 result) where TOther : INumber<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int16 result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Int16 result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out System.Int16 result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int16 result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.Int16 result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Int16 result) { throw null; }
-
-        static short IAdditiveIdentity<short, short>.AdditiveIdentity { get { throw null; } }
-
-        static short IMinMaxValue<short>.MinValue { get { throw null; } }
-        static short IMinMaxValue<short>.MaxValue { get { throw null; } }
-
-        static short IMultiplicativeIdentity<short, short>.MultiplicativeIdentity { get { throw null; } }
-
-        static short INumber<short>.One { get { throw null; } }
-        static short INumber<short>.Zero { get { throw null; } }
-
-        static short IAdditionOperators<short, short, short>.operator +(short left, short right) { throw null; }
-
-        static short IBinaryInteger<short>.LeadingZeroCount(short value) { throw null; }
-        static short IBinaryInteger<short>.PopCount(short value) { throw null; }
-        static short IBinaryInteger<short>.RotateLeft(short value, int rotateAmount) { throw null; }
-        static short IBinaryInteger<short>.RotateRight(short value, int rotateAmount) { throw null; }
-        static short IBinaryInteger<short>.TrailingZeroCount(short value) { throw null; }
-
-        static bool IBinaryNumber<short>.IsPow2(short value) { throw null; }
-        static short IBinaryNumber<short>.Log2(short value) { throw null; }
-
-        static short IBitwiseOperators<short, short, short>.operator &(short left, short right) { throw null; }
-        static short IBitwiseOperators<short, short, short>.operator |(short left, short right) { throw null; }
-        static short IBitwiseOperators<short, short, short>.operator ^(short left, short right) { throw null; }
-        static short IBitwiseOperators<short, short, short>.operator ~(short value) { throw null; }
-
-        static bool IComparisonOperators<short, short>.operator <(short left, short right) { throw null; }
-        static bool IComparisonOperators<short, short>.operator <=(short left, short right) { throw null; }
-        static bool IComparisonOperators<short, short>.operator >(short left, short right) { throw null; }
-        static bool IComparisonOperators<short, short>.operator >=(short left, short right) { throw null; }
-
-        static short IDecrementOperators<short>.operator --(short value) { throw null; }
-
-        static short IDivisionOperators<short, short, short>.operator /(short left, short right) { throw null; }
-
-        static bool IEqualityOperators<short, short>.operator ==(short left, short right) { throw null; }
-        static bool IEqualityOperators<short, short>.operator !=(short left, short right) { throw null; }
-
-        static short IIncrementOperators<short>.operator ++(short value) { throw null; }
-
-        static short IModulusOperators<short, short, short>.operator %(short left, short right) { throw null; }
-
-        static short IMultiplyOperators<short, short, short>.operator *(short left, short right) { throw null; }
-
-        static short INumber<short>.Abs(short value) { throw null; }
-        static short INumber<short>.Clamp(short value, short min, short max) { throw null; }
-        static short INumber<short>.Create<TOther>(TOther value) { throw null; }
-        static short INumber<short>.CreateSaturating<TOther>(TOther value) { throw null; }
-        static short INumber<short>.CreateTruncating<TOther>(TOther value) { throw null; }
-        static (short Quotient, short Remainder) INumber<short>.DivRem(short left, short right) { throw null; }
-        static short INumber<short>.Max(short x, short y) { throw null; }
-        static short INumber<short>.Min(short x, short y) { throw null; }
-        static short INumber<short>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static short INumber<short>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static short INumber<short>.Sign(short value) { throw null; }
-        static bool INumber<short>.TryCreate<TOther>(TOther value, out short result) { throw null; }
-        static bool INumber<short>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out short result) { throw null; }
-        static bool INumber<short>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out short result) { throw null; }
-
-        static short IParseable<short>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<short>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out short result) { throw null; }
-
-        static short IShiftOperators<short, short>.operator <<(short value, int shiftAmount) { throw null; }
-        static short IShiftOperators<short, short>.operator >>(short value, int shiftAmount) { throw null; }
-
-        static short ISignedNumber<short>.NegativeOne { get; }
-
-        static short ISpanParseable<short>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<short>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out short result) { throw null; }
-
-        static short ISubtractionOperators<short, short, short>.operator -(short left, short right) { throw null; }
-
-        static short IUnaryNegationOperators<short, short>.operator -(short value) { throw null; }
-
-        static short IUnaryPlusOperators<short, short>.operator +(short value) { throw null; }
     }
-    public readonly partial struct Int32 : System.IComparable, System.IComparable<int>, System.IConvertible, System.IEquatable<int>, System.ISpanFormattable, System.IBinaryInteger<int>, System.IMinMaxValue<int>, System.ISignedNumber<int>
+    public readonly partial struct Int32 : System.IAdditionOperators<int, int, int>, System.IAdditiveIdentity<int, int>, System.IBinaryInteger<int>, System.IBinaryNumber<int>, System.IBitwiseOperators<int, int, int>, System.IComparable, System.IComparable<int>, System.IComparisonOperators<int, int>, System.IConvertible, System.IDecrementOperators<int>, System.IDivisionOperators<int, int, int>, System.IEqualityOperators<int, int>, System.IEquatable<int>, System.IFormattable, System.IIncrementOperators<int>, System.IMinMaxValue<int>, System.IModulusOperators<int, int, int>, System.IMultiplicativeIdentity<int, int>, System.IMultiplyOperators<int, int, int>, System.INumber<int>, System.IParseable<int>, System.IShiftOperators<int, int>, System.ISignedNumber<int>, System.ISpanFormattable, System.ISpanParseable<int>, System.ISubtractionOperators<int, int, int>, System.IUnaryNegationOperators<int, int>, System.IUnaryPlusOperators<int, int>
     {
         private readonly int _dummyPrimitive;
+        public const int AdditiveIdentity = 0;
         public const int MaxValue = 2147483647;
         public const int MinValue = -2147483648;
+        public const int MultiplicativeIdentity = 1;
+        public const int NegativeOne = -1;
+        public const int One = 1;
+        public const int Zero = 0;
+        static int System.IAdditiveIdentity<System.Int32,System.Int32>.AdditiveIdentity { get { throw null; } }
+        static int System.IMinMaxValue<System.Int32>.MaxValue { get { throw null; } }
+        static int System.IMinMaxValue<System.Int32>.MinValue { get { throw null; } }
+        static int System.IMultiplicativeIdentity<System.Int32,System.Int32>.MultiplicativeIdentity { get { throw null; } }
+        static int System.INumber<System.Int32>.One { get { throw null; } }
+        static int System.INumber<System.Int32>.Zero { get { throw null; } }
+        static int System.ISignedNumber<System.Int32>.NegativeOne { get { throw null; } }
+        public static System.Int32 Abs(System.Int32 value) { throw null; }
+        public static System.Int32 Clamp(System.Int32 value, System.Int32 min, System.Int32 max) { throw null; }
         public System.Int32 CompareTo(System.Int32 value) { throw null; }
         public System.Int32 CompareTo(object? value) { throw null; }
+        public static System.Int32 CreateSaturating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.Int32 CreateTruncating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.Int32 Create<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static (int Quotient, int Remainder) DivRem(System.Int32 left, System.Int32 right) { throw null; }
         public bool Equals(System.Int32 obj) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public override System.Int32 GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsPow2(System.Int32 value) { throw null; }
+        public static System.Int32 LeadingZeroCount(System.Int32 value) { throw null; }
+        public static System.Int32 Log2(System.Int32 value) { throw null; }
+        public static System.Int32 Max(System.Int32 x, System.Int32 y) { throw null; }
+        public static System.Int32 Min(System.Int32 x, System.Int32 y) { throw null; }
         public static System.Int32 Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider? provider = null) { throw null; }
+        public static System.Int32 Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
         public static System.Int32 Parse(string s) { throw null; }
         public static System.Int32 Parse(string s, System.Globalization.NumberStyles style) { throw null; }
         public static System.Int32 Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
         public static System.Int32 Parse(string s, System.IFormatProvider? provider) { throw null; }
+        public static System.Int32 PopCount(System.Int32 value) { throw null; }
+        public static System.Int32 RotateLeft(System.Int32 value, System.Int32 rotateAmount) { throw null; }
+        public static System.Int32 RotateRight(System.Int32 value, System.Int32 rotateAmount) { throw null; }
+        public static System.Int32 Sign(System.Int32 value) { throw null; }
+        static System.Int32 System.IAdditionOperators<System.Int32,System.Int32,System.Int32>.operator +(System.Int32 left, System.Int32 right) { throw null; }
+        static System.Int32 System.IBitwiseOperators<System.Int32,System.Int32,System.Int32>.operator &(System.Int32 left, System.Int32 right) { throw null; }
+        static System.Int32 System.IBitwiseOperators<System.Int32,System.Int32,System.Int32>.operator |(System.Int32 left, System.Int32 right) { throw null; }
+        static System.Int32 System.IBitwiseOperators<System.Int32,System.Int32,System.Int32>.operator ^(System.Int32 left, System.Int32 right) { throw null; }
+        static System.Int32 System.IBitwiseOperators<System.Int32,System.Int32,System.Int32>.operator ~(System.Int32 value) { throw null; }
+        static bool System.IComparisonOperators<System.Int32,System.Int32>.operator >(System.Int32 left, System.Int32 right) { throw null; }
+        static bool System.IComparisonOperators<System.Int32,System.Int32>.operator >=(System.Int32 left, System.Int32 right) { throw null; }
+        static bool System.IComparisonOperators<System.Int32,System.Int32>.operator <(System.Int32 left, System.Int32 right) { throw null; }
+        static bool System.IComparisonOperators<System.Int32,System.Int32>.operator <=(System.Int32 left, System.Int32 right) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider? provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider? provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider? provider) { throw null; }
@@ -3374,108 +3171,85 @@ namespace System
         ushort System.IConvertible.ToUInt16(System.IFormatProvider? provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider? provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider? provider) { throw null; }
+        static System.Int32 System.IDecrementOperators<System.Int32>.operator --(System.Int32 value) { throw null; }
+        static System.Int32 System.IDivisionOperators<System.Int32,System.Int32,System.Int32>.operator /(System.Int32 left, System.Int32 right) { throw null; }
+        static bool System.IEqualityOperators<System.Int32,System.Int32>.operator ==(System.Int32 left, System.Int32 right) { throw null; }
+        static bool System.IEqualityOperators<System.Int32,System.Int32>.operator !=(System.Int32 left, System.Int32 right) { throw null; }
+        static System.Int32 System.IIncrementOperators<System.Int32>.operator ++(System.Int32 value) { throw null; }
+        static System.Int32 System.IModulusOperators<System.Int32,System.Int32,System.Int32>.operator %(System.Int32 left, System.Int32 right) { throw null; }
+        static System.Int32 System.IMultiplyOperators<System.Int32,System.Int32,System.Int32>.operator *(System.Int32 left, System.Int32 right) { throw null; }
+        static System.Int32 System.IShiftOperators<System.Int32,System.Int32>.operator <<(System.Int32 value, System.Int32 shiftAmount) { throw null; }
+        static System.Int32 System.IShiftOperators<System.Int32,System.Int32>.operator >>(System.Int32 value, System.Int32 shiftAmount) { throw null; }
+        static System.Int32 System.ISubtractionOperators<System.Int32,System.Int32,System.Int32>.operator -(System.Int32 left, System.Int32 right) { throw null; }
+        static System.Int32 System.IUnaryNegationOperators<System.Int32,System.Int32>.operator -(System.Int32 value) { throw null; }
+        static System.Int32 System.IUnaryPlusOperators<System.Int32,System.Int32>.operator +(System.Int32 value) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString(string? format) { throw null; }
         public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
+        public static System.Int32 TrailingZeroCount(System.Int32 value) { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.Int32 result) where TOther : INumber<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out System.Int32 charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int32 result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Int32 result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out System.Int32 result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int32 result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.Int32 result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Int32 result) { throw null; }
-
-        static int IAdditiveIdentity<int, int>.AdditiveIdentity { get { throw null; } }
-
-        static int IMinMaxValue<int>.MinValue { get { throw null; } }
-        static int IMinMaxValue<int>.MaxValue { get { throw null; } }
-
-        static int IMultiplicativeIdentity<int, int>.MultiplicativeIdentity { get { throw null; } }
-
-        static int INumber<int>.One { get { throw null; } }
-        static int INumber<int>.Zero { get { throw null; } }
-
-        static int IAdditionOperators<int, int, int>.operator +(int left, int right) { throw null; }
-
-        static int IBinaryInteger<int>.LeadingZeroCount(int value) { throw null; }
-        static int IBinaryInteger<int>.PopCount(int value) { throw null; }
-        static int IBinaryInteger<int>.RotateLeft(int value, int rotateAmount) { throw null; }
-        static int IBinaryInteger<int>.RotateRight(int value, int rotateAmount) { throw null; }
-        static int IBinaryInteger<int>.TrailingZeroCount(int value) { throw null; }
-
-        static bool IBinaryNumber<int>.IsPow2(int value) { throw null; }
-        static int IBinaryNumber<int>.Log2(int value) { throw null; }
-
-        static int IBitwiseOperators<int, int, int>.operator &(int left, int right) { throw null; }
-        static int IBitwiseOperators<int, int, int>.operator |(int left, int right) { throw null; }
-        static int IBitwiseOperators<int, int, int>.operator ^(int left, int right) { throw null; }
-        static int IBitwiseOperators<int, int, int>.operator ~(int value) { throw null; }
-
-        static bool IComparisonOperators<int, int>.operator <(int left, int right) { throw null; }
-        static bool IComparisonOperators<int, int>.operator <=(int left, int right) { throw null; }
-        static bool IComparisonOperators<int, int>.operator >(int left, int right) { throw null; }
-        static bool IComparisonOperators<int, int>.operator >=(int left, int right) { throw null; }
-
-        static int IDecrementOperators<int>.operator --(int value) { throw null; }
-
-        static int IDivisionOperators<int, int, int>.operator /(int left, int right) { throw null; }
-
-        static bool IEqualityOperators<int, int>.operator ==(int left, int right) { throw null; }
-        static bool IEqualityOperators<int, int>.operator !=(int left, int right) { throw null; }
-
-        static int IIncrementOperators<int>.operator ++(int value) { throw null; }
-
-        static int IModulusOperators<int, int, int>.operator %(int left, int right) { throw null; }
-
-        static int IMultiplyOperators<int, int, int>.operator *(int left, int right) { throw null; }
-
-        static int INumber<int>.Abs(int value) { throw null; }
-        static int INumber<int>.Clamp(int value, int min, int max) { throw null; }
-        static int INumber<int>.Create<TOther>(TOther value) { throw null; }
-        static int INumber<int>.CreateSaturating<TOther>(TOther value) { throw null; }
-        static int INumber<int>.CreateTruncating<TOther>(TOther value) { throw null; }
-        static (int Quotient, int Remainder) INumber<int>.DivRem(int left, int right) { throw null; }
-        static int INumber<int>.Max(int x, int y) { throw null; }
-        static int INumber<int>.Min(int x, int y) { throw null; }
-        static int INumber<int>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static int INumber<int>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static int INumber<int>.Sign(int value) { throw null; }
-        static bool INumber<int>.TryCreate<TOther>(TOther value, out int result) { throw null; }
-        static bool INumber<int>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out int result) { throw null; }
-        static bool INumber<int>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out int result) { throw null; }
-
-        static int IParseable<int>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<int>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out int result) { throw null; }
-
-        static int IShiftOperators<int, int>.operator <<(int value, int shiftAmount) { throw null; }
-        static int IShiftOperators<int, int>.operator >>(int value, int shiftAmount) { throw null; }
-
-        static int ISignedNumber<int>.NegativeOne { get; }
-
-        static int ISpanParseable<int>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<int>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out int result) { throw null; }
-
-        static int ISubtractionOperators<int, int, int>.operator -(int left, int right) { throw null; }
-
-        static int IUnaryNegationOperators<int, int>.operator -(int value) { throw null; }
-
-        static int IUnaryPlusOperators<int, int>.operator +(int value) { throw null; }
     }
-    public readonly partial struct Int64 : System.IComparable, System.IComparable<long>, System.IConvertible, System.IEquatable<long>, System.ISpanFormattable, System.IBinaryInteger<long>, System.IMinMaxValue<long>, System.ISignedNumber<long>
+    public readonly partial struct Int64 : System.IAdditionOperators<long, long, long>, System.IAdditiveIdentity<long, long>, System.IBinaryInteger<long>, System.IBinaryNumber<long>, System.IBitwiseOperators<long, long, long>, System.IComparable, System.IComparable<long>, System.IComparisonOperators<long, long>, System.IConvertible, System.IDecrementOperators<long>, System.IDivisionOperators<long, long, long>, System.IEqualityOperators<long, long>, System.IEquatable<long>, System.IFormattable, System.IIncrementOperators<long>, System.IMinMaxValue<long>, System.IModulusOperators<long, long, long>, System.IMultiplicativeIdentity<long, long>, System.IMultiplyOperators<long, long, long>, System.INumber<long>, System.IParseable<long>, System.IShiftOperators<long, long>, System.ISignedNumber<long>, System.ISpanFormattable, System.ISpanParseable<long>, System.ISubtractionOperators<long, long, long>, System.IUnaryNegationOperators<long, long>, System.IUnaryPlusOperators<long, long>
     {
         private readonly long _dummyPrimitive;
+        public const long AdditiveIdentity = (long)0;
         public const long MaxValue = (long)9223372036854775807;
         public const long MinValue = (long)-9223372036854775808;
+        public const long MultiplicativeIdentity = (long)1;
+        public const long NegativeOne = (long)-1;
+        public const long One = (long)1;
+        public const long Zero = (long)0;
+        static long System.IAdditiveIdentity<System.Int64,System.Int64>.AdditiveIdentity { get { throw null; } }
+        static long System.IMinMaxValue<System.Int64>.MaxValue { get { throw null; } }
+        static long System.IMinMaxValue<System.Int64>.MinValue { get { throw null; } }
+        static long System.IMultiplicativeIdentity<System.Int64,System.Int64>.MultiplicativeIdentity { get { throw null; } }
+        static long System.INumber<System.Int64>.One { get { throw null; } }
+        static long System.INumber<System.Int64>.Zero { get { throw null; } }
+        static long System.ISignedNumber<System.Int64>.NegativeOne { get { throw null; } }
+        public static System.Int64 Abs(System.Int64 value) { throw null; }
+        public static System.Int64 Clamp(System.Int64 value, System.Int64 min, System.Int64 max) { throw null; }
         public int CompareTo(System.Int64 value) { throw null; }
         public int CompareTo(object? value) { throw null; }
+        public static System.Int64 CreateSaturating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.Int64 CreateTruncating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.Int64 Create<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static (long Quotient, long Remainder) DivRem(System.Int64 left, System.Int64 right) { throw null; }
         public bool Equals(System.Int64 obj) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsPow2(System.Int64 value) { throw null; }
+        public static System.Int64 LeadingZeroCount(System.Int64 value) { throw null; }
+        public static System.Int64 Log2(System.Int64 value) { throw null; }
+        public static System.Int64 Max(System.Int64 x, System.Int64 y) { throw null; }
+        public static System.Int64 Min(System.Int64 x, System.Int64 y) { throw null; }
         public static System.Int64 Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider? provider = null) { throw null; }
+        public static System.Int64 Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
         public static System.Int64 Parse(string s) { throw null; }
         public static System.Int64 Parse(string s, System.Globalization.NumberStyles style) { throw null; }
         public static System.Int64 Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
         public static System.Int64 Parse(string s, System.IFormatProvider? provider) { throw null; }
+        public static System.Int64 PopCount(System.Int64 value) { throw null; }
+        public static System.Int64 RotateLeft(System.Int64 value, int rotateAmount) { throw null; }
+        public static System.Int64 RotateRight(System.Int64 value, int rotateAmount) { throw null; }
+        public static System.Int64 Sign(System.Int64 value) { throw null; }
+        static System.Int64 System.IAdditionOperators<System.Int64,System.Int64,System.Int64>.operator +(System.Int64 left, System.Int64 right) { throw null; }
+        static System.Int64 System.IBitwiseOperators<System.Int64,System.Int64,System.Int64>.operator &(System.Int64 left, System.Int64 right) { throw null; }
+        static System.Int64 System.IBitwiseOperators<System.Int64,System.Int64,System.Int64>.operator |(System.Int64 left, System.Int64 right) { throw null; }
+        static System.Int64 System.IBitwiseOperators<System.Int64,System.Int64,System.Int64>.operator ^(System.Int64 left, System.Int64 right) { throw null; }
+        static System.Int64 System.IBitwiseOperators<System.Int64,System.Int64,System.Int64>.operator ~(System.Int64 value) { throw null; }
+        static bool System.IComparisonOperators<System.Int64,System.Int64>.operator >(System.Int64 left, System.Int64 right) { throw null; }
+        static bool System.IComparisonOperators<System.Int64,System.Int64>.operator >=(System.Int64 left, System.Int64 right) { throw null; }
+        static bool System.IComparisonOperators<System.Int64,System.Int64>.operator <(System.Int64 left, System.Int64 right) { throw null; }
+        static bool System.IComparisonOperators<System.Int64,System.Int64>.operator <=(System.Int64 left, System.Int64 right) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider? provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider? provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider? provider) { throw null; }
@@ -3491,93 +3265,33 @@ namespace System
         ushort System.IConvertible.ToUInt16(System.IFormatProvider? provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider? provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider? provider) { throw null; }
+        static System.Int64 System.IDecrementOperators<System.Int64>.operator --(System.Int64 value) { throw null; }
+        static System.Int64 System.IDivisionOperators<System.Int64,System.Int64,System.Int64>.operator /(System.Int64 left, System.Int64 right) { throw null; }
+        static bool System.IEqualityOperators<System.Int64,System.Int64>.operator ==(System.Int64 left, System.Int64 right) { throw null; }
+        static bool System.IEqualityOperators<System.Int64,System.Int64>.operator !=(System.Int64 left, System.Int64 right) { throw null; }
+        static System.Int64 System.IIncrementOperators<System.Int64>.operator ++(System.Int64 value) { throw null; }
+        static System.Int64 System.IModulusOperators<System.Int64,System.Int64,System.Int64>.operator %(System.Int64 left, System.Int64 right) { throw null; }
+        static System.Int64 System.IMultiplyOperators<System.Int64,System.Int64,System.Int64>.operator *(System.Int64 left, System.Int64 right) { throw null; }
+        static System.Int64 System.IShiftOperators<System.Int64,System.Int64>.operator <<(System.Int64 value, int shiftAmount) { throw null; }
+        static System.Int64 System.IShiftOperators<System.Int64,System.Int64>.operator >>(System.Int64 value, int shiftAmount) { throw null; }
+        static System.Int64 System.ISubtractionOperators<System.Int64,System.Int64,System.Int64>.operator -(System.Int64 left, System.Int64 right) { throw null; }
+        static System.Int64 System.IUnaryNegationOperators<System.Int64,System.Int64>.operator -(System.Int64 value) { throw null; }
+        static System.Int64 System.IUnaryPlusOperators<System.Int64,System.Int64>.operator +(System.Int64 value) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString(string? format) { throw null; }
         public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
+        public static System.Int64 TrailingZeroCount(System.Int64 value) { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.Int64 result) where TOther : INumber<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int64 result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Int64 result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out System.Int64 result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Int64 result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.Int64 result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Int64 result) { throw null; }
-
-        static long IAdditiveIdentity<long, long>.AdditiveIdentity { get { throw null; } }
-
-        static long IMinMaxValue<long>.MinValue { get { throw null; } }
-        static long IMinMaxValue<long>.MaxValue { get { throw null; } }
-
-        static long IMultiplicativeIdentity<long, long>.MultiplicativeIdentity { get { throw null; } }
-
-        static long INumber<long>.One { get { throw null; } }
-        static long INumber<long>.Zero { get { throw null; } }
-
-        static long IAdditionOperators<long, long, long>.operator +(long left, long right) { throw null; }
-
-        static long IBinaryInteger<long>.LeadingZeroCount(long value) { throw null; }
-        static long IBinaryInteger<long>.PopCount(long value) { throw null; }
-        static long IBinaryInteger<long>.RotateLeft(long value, int rotateAmount) { throw null; }
-        static long IBinaryInteger<long>.RotateRight(long value, int rotateAmount) { throw null; }
-        static long IBinaryInteger<long>.TrailingZeroCount(long value) { throw null; }
-
-        static bool IBinaryNumber<long>.IsPow2(long value) { throw null; }
-        static long IBinaryNumber<long>.Log2(long value) { throw null; }
-
-        static long IBitwiseOperators<long, long, long>.operator &(long left, long right) { throw null; }
-        static long IBitwiseOperators<long, long, long>.operator |(long left, long right) { throw null; }
-        static long IBitwiseOperators<long, long, long>.operator ^(long left, long right) { throw null; }
-        static long IBitwiseOperators<long, long, long>.operator ~(long value) { throw null; }
-
-        static bool IComparisonOperators<long, long>.operator <(long left, long right) { throw null; }
-        static bool IComparisonOperators<long, long>.operator <=(long left, long right) { throw null; }
-        static bool IComparisonOperators<long, long>.operator >(long left, long right) { throw null; }
-        static bool IComparisonOperators<long, long>.operator >=(long left, long right) { throw null; }
-
-        static long IDecrementOperators<long>.operator --(long value) { throw null; }
-
-        static long IDivisionOperators<long, long, long>.operator /(long left, long right) { throw null; }
-
-        static bool IEqualityOperators<long, long>.operator ==(long left, long right) { throw null; }
-        static bool IEqualityOperators<long, long>.operator !=(long left, long right) { throw null; }
-
-        static long IIncrementOperators<long>.operator ++(long value) { throw null; }
-
-        static long IModulusOperators<long, long, long>.operator %(long left, long right) { throw null; }
-
-        static long IMultiplyOperators<long, long, long>.operator *(long left, long right) { throw null; }
-
-        static long INumber<long>.Abs(long value) { throw null; }
-        static long INumber<long>.Clamp(long value, long min, long max) { throw null; }
-        static long INumber<long>.Create<TOther>(TOther value) { throw null; }
-        static long INumber<long>.CreateSaturating<TOther>(TOther value) { throw null; }
-        static long INumber<long>.CreateTruncating<TOther>(TOther value) { throw null; }
-        static (long Quotient, long Remainder) INumber<long>.DivRem(long left, long right) { throw null; }
-        static long INumber<long>.Max(long x, long y) { throw null; }
-        static long INumber<long>.Min(long x, long y) { throw null; }
-        static long INumber<long>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static long INumber<long>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static long INumber<long>.Sign(long value) { throw null; }
-        static bool INumber<long>.TryCreate<TOther>(TOther value, out long result) { throw null; }
-        static bool INumber<long>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out long result) { throw null; }
-        static bool INumber<long>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out long result) { throw null; }
-
-        static long IParseable<long>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<long>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out long result) { throw null; }
-
-        static long IShiftOperators<long, long>.operator <<(long value, int shiftAmount) { throw null; }
-        static long IShiftOperators<long, long>.operator >>(long value, int shiftAmount) { throw null; }
-
-        static long ISignedNumber<long>.NegativeOne { get; }
-
-        static long ISpanParseable<long>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<long>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out long result) { throw null; }
-
-        static long ISubtractionOperators<long, long, long>.operator -(long left, long right) { throw null; }
-
-        static long IUnaryNegationOperators<long, long>.operator -(long value) { throw null; }
-
-        static long IUnaryPlusOperators<long, long>.operator +(long value) { throw null; }
     }
-    public readonly partial struct IntPtr : System.IComparable, System.IComparable<nint>, System.IEquatable<nint>, System.ISpanFormattable, System.Runtime.Serialization.ISerializable, System.IBinaryInteger<nint>, System.IMinMaxValue<nint>, System.ISignedNumber<nint>
+    public readonly partial struct IntPtr : System.IAdditionOperators<nint, nint, nint>, System.IAdditiveIdentity<nint, nint>, System.IBinaryInteger<nint>, System.IBinaryNumber<nint>, System.IBitwiseOperators<nint, nint, nint>, System.IComparable, System.IComparable<nint>, System.IComparisonOperators<nint, nint>, System.IDecrementOperators<nint>, System.IDivisionOperators<nint, nint, nint>, System.IEqualityOperators<nint, nint>, System.IEquatable<nint>, System.IFormattable, System.IIncrementOperators<nint>, System.IMinMaxValue<nint>, System.IModulusOperators<nint, nint, nint>, System.IMultiplicativeIdentity<nint, nint>, System.IMultiplyOperators<nint, nint, nint>, System.INumber<nint>, System.IParseable<nint>, System.IShiftOperators<nint, nint>, System.ISignedNumber<nint>, System.ISpanFormattable, System.ISpanParseable<nint>, System.ISubtractionOperators<nint, nint, nint>, System.IUnaryNegationOperators<nint, nint>, System.IUnaryPlusOperators<nint, nint>, System.Runtime.Serialization.ISerializable
     {
         private readonly int _dummyPrimitive;
         public static readonly System.IntPtr Zero;
@@ -3588,6 +3302,13 @@ namespace System
         public static System.IntPtr MaxValue { get { throw null; } }
         public static System.IntPtr MinValue { get { throw null; } }
         public static int Size { get { throw null; } }
+        static nint System.IAdditiveIdentity<nint,nint>.AdditiveIdentity { get { throw null; } }
+        static nint System.IMinMaxValue<nint>.MaxValue { get { throw null; } }
+        static nint System.IMinMaxValue<nint>.MinValue { get { throw null; } }
+        static nint System.IMultiplicativeIdentity<nint,nint>.MultiplicativeIdentity { get { throw null; } }
+        static nint System.INumber<nint>.One { get { throw null; } }
+        static nint System.INumber<nint>.Zero { get { throw null; } }
+        static nint System.ISignedNumber<nint>.NegativeOne { get { throw null; } }
         public static System.IntPtr Add(System.IntPtr pointer, int offset) { throw null; }
         public int CompareTo(System.IntPtr value) { throw null; }
         public int CompareTo(object? value) { throw null; }
@@ -3606,13 +3327,49 @@ namespace System
         public unsafe static explicit operator System.IntPtr (void* value) { throw null; }
         public static bool operator !=(System.IntPtr value1, System.IntPtr value2) { throw null; }
         public static System.IntPtr operator -(System.IntPtr pointer, int offset) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
+        public static System.IntPtr Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider? provider = null) { throw null; }
+        public static System.IntPtr Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
         public static System.IntPtr Parse(string s) { throw null; }
         public static System.IntPtr Parse(string s, System.Globalization.NumberStyles style) { throw null; }
         public static System.IntPtr Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
         public static System.IntPtr Parse(string s, System.IFormatProvider? provider) { throw null; }
-        public static System.IntPtr Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider? provider = null) { throw null; }
         public static System.IntPtr Subtract(System.IntPtr pointer, int offset) { throw null; }
+        static nint System.IAdditionOperators<nint,nint,nint>.operator +(nint left, nint right) { throw null; }
+        static nint System.IBinaryInteger<nint>.LeadingZeroCount(nint value) { throw null; }
+        static nint System.IBinaryInteger<nint>.PopCount(nint value) { throw null; }
+        static nint System.IBinaryInteger<nint>.RotateLeft(nint value, int rotateAmount) { throw null; }
+        static nint System.IBinaryInteger<nint>.RotateRight(nint value, int rotateAmount) { throw null; }
+        static nint System.IBinaryInteger<nint>.TrailingZeroCount(nint value) { throw null; }
+        static bool System.IBinaryNumber<nint>.IsPow2(nint value) { throw null; }
+        static nint System.IBinaryNumber<nint>.Log2(nint value) { throw null; }
+        static nint System.IBitwiseOperators<nint,nint,nint>.operator &(nint left, nint right) { throw null; }
+        static nint System.IBitwiseOperators<nint,nint,nint>.operator |(nint left, nint right) { throw null; }
+        static nint System.IBitwiseOperators<nint,nint,nint>.operator ^(nint left, nint right) { throw null; }
+        static nint System.IBitwiseOperators<nint,nint,nint>.operator ~(nint value) { throw null; }
+        static bool System.IComparisonOperators<nint,nint>.operator >(nint left, nint right) { throw null; }
+        static bool System.IComparisonOperators<nint,nint>.operator >=(nint left, nint right) { throw null; }
+        static bool System.IComparisonOperators<nint,nint>.operator <(nint left, nint right) { throw null; }
+        static bool System.IComparisonOperators<nint,nint>.operator <=(nint left, nint right) { throw null; }
+        static nint System.IDecrementOperators<nint>.operator --(nint value) { throw null; }
+        static nint System.IDivisionOperators<nint,nint,nint>.operator /(nint left, nint right) { throw null; }
+        static nint System.IIncrementOperators<nint>.operator ++(nint value) { throw null; }
+        static nint System.IModulusOperators<nint,nint,nint>.operator %(nint left, nint right) { throw null; }
+        static nint System.IMultiplyOperators<nint,nint,nint>.operator *(nint left, nint right) { throw null; }
+        static nint System.INumber<nint>.Abs(nint value) { throw null; }
+        static nint System.INumber<nint>.Clamp(nint value, nint min, nint max) { throw null; }
+        static nint System.INumber<nint>.CreateSaturating<TOther>(TOther value) { throw null; }
+        static nint System.INumber<nint>.CreateTruncating<TOther>(TOther value) { throw null; }
+        static nint System.INumber<nint>.Create<TOther>(TOther value) { throw null; }
+        static (nint Quotient, nint Remainder) System.INumber<nint>.DivRem(nint left, nint right) { throw null; }
+        static nint System.INumber<nint>.Max(nint x, nint y) { throw null; }
+        static nint System.INumber<nint>.Min(nint x, nint y) { throw null; }
+        static nint System.INumber<nint>.Sign(nint value) { throw null; }
+        static bool System.INumber<nint>.TryCreate<TOther>(TOther value, out nint result) { throw null; }
+        static nint System.IShiftOperators<nint,nint>.operator <<(nint value, int shiftAmount) { throw null; }
+        static nint System.IShiftOperators<nint,nint>.operator >>(nint value, int shiftAmount) { throw null; }
+        static nint System.ISubtractionOperators<nint,nint,nint>.operator -(nint left, nint right) { throw null; }
+        static nint System.IUnaryNegationOperators<nint,nint>.operator -(nint value) { throw null; }
+        static nint System.IUnaryPlusOperators<nint,nint>.operator +(nint value) { throw null; }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public int ToInt32() { throw null; }
         public long ToInt64() { throw null; }
@@ -3622,86 +3379,13 @@ namespace System
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString(string? format) { throw null; }
         public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
-        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.IntPtr result) { throw null; }
-        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.IntPtr result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.IntPtr result) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.IntPtr result) { throw null; }
-
-        static nint IAdditiveIdentity<nint, nint>.AdditiveIdentity { get { throw null; } }
-
-        static nint IMinMaxValue<nint>.MinValue { get { throw null; } }
-        static nint IMinMaxValue<nint>.MaxValue { get { throw null; } }
-
-        static nint IMultiplicativeIdentity<nint, nint>.MultiplicativeIdentity { get { throw null; } }
-
-        static nint INumber<nint>.One { get { throw null; } }
-        static nint INumber<nint>.Zero { get { throw null; } }
-
-        static nint IAdditionOperators<nint, nint, nint>.operator +(nint left, nint right) { throw null; }
-
-        static nint IBinaryInteger<nint>.LeadingZeroCount(nint value) { throw null; }
-        static nint IBinaryInteger<nint>.PopCount(nint value) { throw null; }
-        static nint IBinaryInteger<nint>.RotateLeft(nint value, int rotateAmount) { throw null; }
-        static nint IBinaryInteger<nint>.RotateRight(nint value, int rotateAmount) { throw null; }
-        static nint IBinaryInteger<nint>.TrailingZeroCount(nint value) { throw null; }
-
-        static bool IBinaryNumber<nint>.IsPow2(nint value) { throw null; }
-        static nint IBinaryNumber<nint>.Log2(nint value) { throw null; }
-
-        static nint IBitwiseOperators<nint, nint, nint>.operator &(nint left, nint right) { throw null; }
-        static nint IBitwiseOperators<nint, nint, nint>.operator |(nint left, nint right) { throw null; }
-        static nint IBitwiseOperators<nint, nint, nint>.operator ^(nint left, nint right) { throw null; }
-        static nint IBitwiseOperators<nint, nint, nint>.operator ~(nint value) { throw null; }
-
-        static bool IComparisonOperators<nint, nint>.operator <(nint left, nint right) { throw null; }
-        static bool IComparisonOperators<nint, nint>.operator <=(nint left, nint right) { throw null; }
-        static bool IComparisonOperators<nint, nint>.operator >(nint left, nint right) { throw null; }
-        static bool IComparisonOperators<nint, nint>.operator >=(nint left, nint right) { throw null; }
-
-        static nint IDecrementOperators<nint>.operator --(nint value) { throw null; }
-
-        static nint IDivisionOperators<nint, nint, nint>.operator /(nint left, nint right) { throw null; }
-
-        static bool IEqualityOperators<nint, nint>.operator ==(nint left, nint right) { throw null; }
-        static bool IEqualityOperators<nint, nint>.operator !=(nint left, nint right) { throw null; }
-
-        static nint IIncrementOperators<nint>.operator ++(nint value) { throw null; }
-
-        static nint IModulusOperators<nint, nint, nint>.operator %(nint left, nint right) { throw null; }
-
-        static nint IMultiplyOperators<nint, nint, nint>.operator *(nint left, nint right) { throw null; }
-
-        static nint INumber<nint>.Abs(nint value) { throw null; }
-        static nint INumber<nint>.Clamp(nint value, nint min, nint max) { throw null; }
-        static nint INumber<nint>.Create<TOther>(TOther value) { throw null; }
-        static nint INumber<nint>.CreateSaturating<TOther>(TOther value) { throw null; }
-        static nint INumber<nint>.CreateTruncating<TOther>(TOther value) { throw null; }
-        static (nint Quotient, nint Remainder) INumber<nint>.DivRem(nint left, nint right) { throw null; }
-        static nint INumber<nint>.Max(nint x, nint y) { throw null; }
-        static nint INumber<nint>.Min(nint x, nint y) { throw null; }
-        static nint INumber<nint>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static nint INumber<nint>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static nint INumber<nint>.Sign(nint value) { throw null; }
-        static bool INumber<nint>.TryCreate<TOther>(TOther value, out nint result) { throw null; }
-        static bool INumber<nint>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out nint result) { throw null; }
-        static bool INumber<nint>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out nint result) { throw null; }
-
-        static nint IParseable<nint>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<nint>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out nint result) { throw null; }
-
-        static nint IShiftOperators<nint, nint>.operator <<(nint value, int shiftAmount) { throw null; }
-        static nint IShiftOperators<nint, nint>.operator >>(nint value, int shiftAmount) { throw null; }
-
-        static nint ISignedNumber<nint>.NegativeOne { get; }
-
-        static nint ISpanParseable<nint>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<nint>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out nint result) { throw null; }
-
-        static nint ISubtractionOperators<nint, nint, nint>.operator -(nint left, nint right) { throw null; }
-
-        static nint IUnaryNegationOperators<nint, nint>.operator -(nint value) { throw null; }
-
-        static nint IUnaryPlusOperators<nint, nint>.operator +(nint value) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.IntPtr result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.IntPtr result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.IntPtr result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.IntPtr result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.IntPtr result) { throw null; }
     }
     public partial class InvalidCastException : System.SystemException
     {
@@ -4492,22 +4176,59 @@ namespace System
         public static bool operator !=(System.RuntimeTypeHandle left, object? right) { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
-    public readonly partial struct SByte : System.IComparable, System.IComparable<sbyte>, System.IConvertible, System.IEquatable<sbyte>, System.ISpanFormattable, System.IBinaryInteger<sbyte>, System.IMinMaxValue<sbyte>, System.ISignedNumber<sbyte>
+    public readonly partial struct SByte : System.IAdditionOperators<sbyte, sbyte, sbyte>, System.IAdditiveIdentity<sbyte, sbyte>, System.IBinaryInteger<sbyte>, System.IBinaryNumber<sbyte>, System.IBitwiseOperators<sbyte, sbyte, sbyte>, System.IComparable, System.IComparable<sbyte>, System.IComparisonOperators<sbyte, sbyte>, System.IConvertible, System.IDecrementOperators<sbyte>, System.IDivisionOperators<sbyte, sbyte, sbyte>, System.IEqualityOperators<sbyte, sbyte>, System.IEquatable<sbyte>, System.IFormattable, System.IIncrementOperators<sbyte>, System.IMinMaxValue<sbyte>, System.IModulusOperators<sbyte, sbyte, sbyte>, System.IMultiplicativeIdentity<sbyte, sbyte>, System.IMultiplyOperators<sbyte, sbyte, sbyte>, System.INumber<sbyte>, System.IParseable<sbyte>, System.IShiftOperators<sbyte, sbyte>, System.ISignedNumber<sbyte>, System.ISpanFormattable, System.ISpanParseable<sbyte>, System.ISubtractionOperators<sbyte, sbyte, sbyte>, System.IUnaryNegationOperators<sbyte, sbyte>, System.IUnaryPlusOperators<sbyte, sbyte>
     {
         private readonly sbyte _dummyPrimitive;
+        public const sbyte AdditiveIdentity = (sbyte)0;
         public const sbyte MaxValue = (sbyte)127;
         public const sbyte MinValue = (sbyte)-128;
+        public const sbyte MultiplicativeIdentity = (sbyte)1;
+        public const sbyte NegativeOne = (sbyte)-1;
+        public const sbyte One = (sbyte)1;
+        public const sbyte Zero = (sbyte)0;
+        static sbyte System.IAdditiveIdentity<System.SByte,System.SByte>.AdditiveIdentity { get { throw null; } }
+        static sbyte System.IMinMaxValue<System.SByte>.MaxValue { get { throw null; } }
+        static sbyte System.IMinMaxValue<System.SByte>.MinValue { get { throw null; } }
+        static sbyte System.IMultiplicativeIdentity<System.SByte,System.SByte>.MultiplicativeIdentity { get { throw null; } }
+        static sbyte System.INumber<System.SByte>.One { get { throw null; } }
+        static sbyte System.INumber<System.SByte>.Zero { get { throw null; } }
+        static sbyte System.ISignedNumber<System.SByte>.NegativeOne { get { throw null; } }
+        public static System.SByte Abs(System.SByte value) { throw null; }
+        public static System.SByte Clamp(System.SByte value, System.SByte min, System.SByte max) { throw null; }
         public int CompareTo(object? obj) { throw null; }
         public int CompareTo(System.SByte value) { throw null; }
+        public static System.SByte CreateSaturating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.SByte CreateTruncating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.SByte Create<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static (sbyte Quotient, sbyte Remainder) DivRem(System.SByte left, System.SByte right) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public bool Equals(System.SByte obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsPow2(System.SByte value) { throw null; }
+        public static System.SByte LeadingZeroCount(System.SByte value) { throw null; }
+        public static System.SByte Log2(System.SByte value) { throw null; }
+        public static System.SByte Max(System.SByte x, System.SByte y) { throw null; }
+        public static System.SByte Min(System.SByte x, System.SByte y) { throw null; }
         public static System.SByte Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider? provider = null) { throw null; }
+        public static System.SByte Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
         public static System.SByte Parse(string s) { throw null; }
         public static System.SByte Parse(string s, System.Globalization.NumberStyles style) { throw null; }
         public static System.SByte Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
         public static System.SByte Parse(string s, System.IFormatProvider? provider) { throw null; }
+        public static System.SByte PopCount(System.SByte value) { throw null; }
+        public static System.SByte RotateLeft(System.SByte value, int rotateAmount) { throw null; }
+        public static System.SByte RotateRight(System.SByte value, int rotateAmount) { throw null; }
+        public static System.SByte Sign(System.SByte value) { throw null; }
+        static System.SByte System.IAdditionOperators<System.SByte,System.SByte,System.SByte>.operator +(System.SByte left, System.SByte right) { throw null; }
+        static System.SByte System.IBitwiseOperators<System.SByte,System.SByte,System.SByte>.operator &(System.SByte left, System.SByte right) { throw null; }
+        static System.SByte System.IBitwiseOperators<System.SByte,System.SByte,System.SByte>.operator |(System.SByte left, System.SByte right) { throw null; }
+        static System.SByte System.IBitwiseOperators<System.SByte,System.SByte,System.SByte>.operator ^(System.SByte left, System.SByte right) { throw null; }
+        static System.SByte System.IBitwiseOperators<System.SByte,System.SByte,System.SByte>.operator ~(System.SByte value) { throw null; }
+        static bool System.IComparisonOperators<System.SByte,System.SByte>.operator >(System.SByte left, System.SByte right) { throw null; }
+        static bool System.IComparisonOperators<System.SByte,System.SByte>.operator >=(System.SByte left, System.SByte right) { throw null; }
+        static bool System.IComparisonOperators<System.SByte,System.SByte>.operator <(System.SByte left, System.SByte right) { throw null; }
+        static bool System.IComparisonOperators<System.SByte,System.SByte>.operator <=(System.SByte left, System.SByte right) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider? provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider? provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider? provider) { throw null; }
@@ -4523,112 +4244,101 @@ namespace System
         ushort System.IConvertible.ToUInt16(System.IFormatProvider? provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider? provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider? provider) { throw null; }
+        static System.SByte System.IDecrementOperators<System.SByte>.operator --(System.SByte value) { throw null; }
+        static System.SByte System.IDivisionOperators<System.SByte,System.SByte,System.SByte>.operator /(System.SByte left, System.SByte right) { throw null; }
+        static bool System.IEqualityOperators<System.SByte,System.SByte>.operator ==(System.SByte left, System.SByte right) { throw null; }
+        static bool System.IEqualityOperators<System.SByte,System.SByte>.operator !=(System.SByte left, System.SByte right) { throw null; }
+        static System.SByte System.IIncrementOperators<System.SByte>.operator ++(System.SByte value) { throw null; }
+        static System.SByte System.IModulusOperators<System.SByte,System.SByte,System.SByte>.operator %(System.SByte left, System.SByte right) { throw null; }
+        static System.SByte System.IMultiplyOperators<System.SByte,System.SByte,System.SByte>.operator *(System.SByte left, System.SByte right) { throw null; }
+        static System.SByte System.IShiftOperators<System.SByte,System.SByte>.operator <<(System.SByte value, int shiftAmount) { throw null; }
+        static System.SByte System.IShiftOperators<System.SByte,System.SByte>.operator >>(System.SByte value, int shiftAmount) { throw null; }
+        static System.SByte System.ISubtractionOperators<System.SByte,System.SByte,System.SByte>.operator -(System.SByte left, System.SByte right) { throw null; }
+        static System.SByte System.IUnaryNegationOperators<System.SByte,System.SByte>.operator -(System.SByte value) { throw null; }
+        static System.SByte System.IUnaryPlusOperators<System.SByte,System.SByte>.operator +(System.SByte value) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString(string? format) { throw null; }
         public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
+        public static System.SByte TrailingZeroCount(System.SByte value) { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.SByte result) where TOther : INumber<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.SByte result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.SByte result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out System.SByte result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.SByte result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.SByte result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.SByte result) { throw null; }
-
-        static sbyte IAdditiveIdentity<sbyte, sbyte>.AdditiveIdentity { get { throw null; } }
-
-        static sbyte IMinMaxValue<sbyte>.MinValue { get { throw null; } }
-        static sbyte IMinMaxValue<sbyte>.MaxValue { get { throw null; } }
-
-        static sbyte IMultiplicativeIdentity<sbyte, sbyte>.MultiplicativeIdentity { get { throw null; } }
-
-        static sbyte INumber<sbyte>.One { get { throw null; } }
-        static sbyte INumber<sbyte>.Zero { get { throw null; } }
-
-        static sbyte IAdditionOperators<sbyte, sbyte, sbyte>.operator +(sbyte left, sbyte right) { throw null; }
-
-        static sbyte IBinaryInteger<sbyte>.LeadingZeroCount(sbyte value) { throw null; }
-        static sbyte IBinaryInteger<sbyte>.PopCount(sbyte value) { throw null; }
-        static sbyte IBinaryInteger<sbyte>.RotateLeft(sbyte value, int rotateAmount) { throw null; }
-        static sbyte IBinaryInteger<sbyte>.RotateRight(sbyte value, int rotateAmount) { throw null; }
-        static sbyte IBinaryInteger<sbyte>.TrailingZeroCount(sbyte value) { throw null; }
-
-        static bool IBinaryNumber<sbyte>.IsPow2(sbyte value) { throw null; }
-        static sbyte IBinaryNumber<sbyte>.Log2(sbyte value) { throw null; }
-
-        static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator &(sbyte left, sbyte right) { throw null; }
-        static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator |(sbyte left, sbyte right) { throw null; }
-        static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator ^(sbyte left, sbyte right) { throw null; }
-        static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator ~(sbyte value) { throw null; }
-
-        static bool IComparisonOperators<sbyte, sbyte>.operator <(sbyte left, sbyte right) { throw null; }
-        static bool IComparisonOperators<sbyte, sbyte>.operator <=(sbyte left, sbyte right) { throw null; }
-        static bool IComparisonOperators<sbyte, sbyte>.operator >(sbyte left, sbyte right) { throw null; }
-        static bool IComparisonOperators<sbyte, sbyte>.operator >=(sbyte left, sbyte right) { throw null; }
-
-        static sbyte IDecrementOperators<sbyte>.operator --(sbyte value) { throw null; }
-
-        static sbyte IDivisionOperators<sbyte, sbyte, sbyte>.operator /(sbyte left, sbyte right) { throw null; }
-
-        static bool IEqualityOperators<sbyte, sbyte>.operator ==(sbyte left, sbyte right) { throw null; }
-        static bool IEqualityOperators<sbyte, sbyte>.operator !=(sbyte left, sbyte right) { throw null; }
-
-        static sbyte IIncrementOperators<sbyte>.operator ++(sbyte value) { throw null; }
-
-        static sbyte IModulusOperators<sbyte, sbyte, sbyte>.operator %(sbyte left, sbyte right) { throw null; }
-
-        static sbyte IMultiplyOperators<sbyte, sbyte, sbyte>.operator *(sbyte left, sbyte right) { throw null; }
-
-        static sbyte INumber<sbyte>.Abs(sbyte value) { throw null; }
-        static sbyte INumber<sbyte>.Clamp(sbyte value, sbyte min, sbyte max) { throw null; }
-        static sbyte INumber<sbyte>.Create<TOther>(TOther value) { throw null; }
-        static sbyte INumber<sbyte>.CreateSaturating<TOther>(TOther value) { throw null; }
-        static sbyte INumber<sbyte>.CreateTruncating<TOther>(TOther value) { throw null; }
-        static (sbyte Quotient, sbyte Remainder) INumber<sbyte>.DivRem(sbyte left, sbyte right) { throw null; }
-        static sbyte INumber<sbyte>.Max(sbyte x, sbyte y) { throw null; }
-        static sbyte INumber<sbyte>.Min(sbyte x, sbyte y) { throw null; }
-        static sbyte INumber<sbyte>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static sbyte INumber<sbyte>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static sbyte INumber<sbyte>.Sign(sbyte value) { throw null; }
-        static bool INumber<sbyte>.TryCreate<TOther>(TOther value, out sbyte result) { throw null; }
-        static bool INumber<sbyte>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out sbyte result) { throw null; }
-        static bool INumber<sbyte>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out sbyte result) { throw null; }
-
-        static sbyte IParseable<sbyte>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<sbyte>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out sbyte result) { throw null; }
-
-        static sbyte IShiftOperators<sbyte, sbyte>.operator <<(sbyte value, int shiftAmount) { throw null; }
-        static sbyte IShiftOperators<sbyte, sbyte>.operator >>(sbyte value, int shiftAmount) { throw null; }
-
-        static sbyte ISignedNumber<sbyte>.NegativeOne { get; }
-
-        static sbyte ISpanParseable<sbyte>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<sbyte>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out sbyte result) { throw null; }
-
-        static sbyte ISubtractionOperators<sbyte, sbyte, sbyte>.operator -(sbyte left, sbyte right) { throw null; }
-
-        static sbyte IUnaryNegationOperators<sbyte, sbyte>.operator -(sbyte value) { throw null; }
-
-        static sbyte IUnaryPlusOperators<sbyte, sbyte>.operator +(sbyte value) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Delegate | System.AttributeTargets.Enum | System.AttributeTargets.Struct, Inherited=false)]
     public sealed partial class SerializableAttribute : System.Attribute
     {
         public SerializableAttribute() { }
     }
-    public readonly partial struct Single : System.IComparable, System.IComparable<float>, System.IConvertible, System.IEquatable<float>, System.ISpanFormattable, System.IBinaryFloatingPoint<float>, System.IMinMaxValue<float>
+    public readonly partial struct Single : System.IAdditionOperators<float, float, float>, System.IAdditiveIdentity<float, float>, System.IBinaryFloatingPoint<float>, System.IBinaryNumber<float>, System.IBitwiseOperators<float, float, float>, System.IComparable, System.IComparable<float>, System.IComparisonOperators<float, float>, System.IConvertible, System.IDecrementOperators<float>, System.IDivisionOperators<float, float, float>, System.IEqualityOperators<float, float>, System.IEquatable<float>, System.IFloatingPoint<float>, System.IFormattable, System.IIncrementOperators<float>, System.IMinMaxValue<float>, System.IModulusOperators<float, float, float>, System.IMultiplicativeIdentity<float, float>, System.IMultiplyOperators<float, float, float>, System.INumber<float>, System.IParseable<float>, System.ISignedNumber<float>, System.ISpanFormattable, System.ISpanParseable<float>, System.ISubtractionOperators<float, float, float>, System.IUnaryNegationOperators<float, float>, System.IUnaryPlusOperators<float, float>
     {
         private readonly float _dummyPrimitive;
+        public const float AdditiveIdentity = 0f;
+        public const float E = 2.7182817f;
         public const float Epsilon = 1E-45f;
         public const float MaxValue = 3.4028235E+38f;
         public const float MinValue = -3.4028235E+38f;
+        public const float MultiplicativeIdentity = 1f;
         public const float NaN = 0.0f / 0.0f;
         public const float NegativeInfinity = -1.0f / 0.0f;
+        public const float NegativeOne = -1f;
+        public const float NegativeZero = -0f;
+        public const float One = 1f;
+        public const float Pi = 3.1415927f;
         public const float PositiveInfinity = 1.0f / 0.0f;
+        public const float Tau = 6.2831855f;
+        public const float Zero = 0f;
+        static float System.IAdditiveIdentity<System.Single,System.Single>.AdditiveIdentity { get { throw null; } }
+        static float System.IFloatingPoint<System.Single>.E { get { throw null; } }
+        static float System.IFloatingPoint<System.Single>.Epsilon { get { throw null; } }
+        static float System.IFloatingPoint<System.Single>.NaN { get { throw null; } }
+        static float System.IFloatingPoint<System.Single>.NegativeInfinity { get { throw null; } }
+        static float System.IFloatingPoint<System.Single>.NegativeZero { get { throw null; } }
+        static float System.IFloatingPoint<System.Single>.Pi { get { throw null; } }
+        static float System.IFloatingPoint<System.Single>.PositiveInfinity { get { throw null; } }
+        static float System.IFloatingPoint<System.Single>.Tau { get { throw null; } }
+        static float System.IMinMaxValue<System.Single>.MaxValue { get { throw null; } }
+        static float System.IMinMaxValue<System.Single>.MinValue { get { throw null; } }
+        static float System.IMultiplicativeIdentity<System.Single,System.Single>.MultiplicativeIdentity { get { throw null; } }
+        static float System.INumber<System.Single>.One { get { throw null; } }
+        static float System.INumber<System.Single>.Zero { get { throw null; } }
+        static float System.ISignedNumber<System.Single>.NegativeOne { get { throw null; } }
+        public static System.Single Abs(System.Single value) { throw null; }
+        public static System.Single Acos(System.Single x) { throw null; }
+        public static System.Single Acosh(System.Single x) { throw null; }
+        public static System.Single Asin(System.Single x) { throw null; }
+        public static System.Single Asinh(System.Single x) { throw null; }
+        public static System.Single Atan(System.Single x) { throw null; }
+        public static System.Single Atan2(System.Single y, System.Single x) { throw null; }
+        public static System.Single Atanh(System.Single x) { throw null; }
+        public static System.Single BitDecrement(System.Single x) { throw null; }
+        public static System.Single BitIncrement(System.Single x) { throw null; }
+        public static System.Single Cbrt(System.Single x) { throw null; }
+        public static System.Single Ceiling(System.Single x) { throw null; }
+        public static System.Single Clamp(System.Single value, System.Single min, System.Single max) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public int CompareTo(System.Single value) { throw null; }
+        public static System.Single CopySign(System.Single x, System.Single y) { throw null; }
+        public static System.Single Cos(System.Single x) { throw null; }
+        public static System.Single Cosh(System.Single x) { throw null; }
+        public static System.Single CreateSaturating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.Single CreateTruncating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.Single Create<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static (float Quotient, float Remainder) DivRem(System.Single left, System.Single right) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public bool Equals(System.Single obj) { throw null; }
+        public static System.Single Exp(System.Single x) { throw null; }
+        public static System.Single Floor(System.Single x) { throw null; }
+        public static System.Single FusedMultiplyAdd(System.Single left, System.Single right, System.Single addend) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static System.Single IEEERemainder(System.Single left, System.Single right) { throw null; }
+        public static TInteger ILogB<TInteger>(System.Single x) where TInteger : IBinaryInteger<TInteger> { throw null; }
         public static bool IsFinite(System.Single f) { throw null; }
         public static bool IsInfinity(System.Single f) { throw null; }
         public static bool IsNaN(System.Single f) { throw null; }
@@ -4636,7 +4346,16 @@ namespace System
         public static bool IsNegativeInfinity(System.Single f) { throw null; }
         public static bool IsNormal(System.Single f) { throw null; }
         public static bool IsPositiveInfinity(System.Single f) { throw null; }
+        public static bool IsPow2(System.Single value) { throw null; }
         public static bool IsSubnormal(System.Single f) { throw null; }
+        public static System.Single Log(System.Single x) { throw null; }
+        public static System.Single Log(System.Single x, System.Single newBase) { throw null; }
+        public static System.Single Log10(System.Single x) { throw null; }
+        public static System.Single Log2(System.Single value) { throw null; }
+        public static System.Single Max(System.Single x, System.Single y) { throw null; }
+        public static System.Single MaxMagnitude(System.Single x, System.Single y) { throw null; }
+        public static System.Single Min(System.Single x, System.Single y) { throw null; }
+        public static System.Single MinMagnitude(System.Single x, System.Single y) { throw null; }
         public static bool operator ==(System.Single left, System.Single right) { throw null; }
         public static bool operator >(System.Single left, System.Single right) { throw null; }
         public static bool operator >=(System.Single left, System.Single right) { throw null; }
@@ -4644,10 +4363,26 @@ namespace System
         public static bool operator <(System.Single left, System.Single right) { throw null; }
         public static bool operator <=(System.Single left, System.Single right) { throw null; }
         public static System.Single Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.AllowDecimalPoint | System.Globalization.NumberStyles.AllowExponent | System.Globalization.NumberStyles.AllowLeadingSign | System.Globalization.NumberStyles.AllowLeadingWhite | System.Globalization.NumberStyles.AllowThousands | System.Globalization.NumberStyles.AllowTrailingWhite, System.IFormatProvider? provider = null) { throw null; }
+        public static System.Single Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
         public static System.Single Parse(string s) { throw null; }
         public static System.Single Parse(string s, System.Globalization.NumberStyles style) { throw null; }
         public static System.Single Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
         public static System.Single Parse(string s, System.IFormatProvider? provider) { throw null; }
+        public static System.Single Pow(System.Single x, System.Single y) { throw null; }
+        public static System.Single Round(System.Single x) { throw null; }
+        public static System.Single Round(System.Single x, System.MidpointRounding mode) { throw null; }
+        public static System.Single Round<TInteger>(System.Single x, TInteger digits) where TInteger : IBinaryInteger<TInteger>  { throw null; }
+        public static System.Single Round<TInteger>(System.Single x, TInteger digits, System.MidpointRounding mode) where TInteger : IBinaryInteger<TInteger>  { throw null; }
+        public static System.Single ScaleB<TInteger>(System.Single x, TInteger n) where TInteger : IBinaryInteger<TInteger>  { throw null; }
+        public static System.Single Sign(System.Single value) { throw null; }
+        public static System.Single Sin(System.Single x) { throw null; }
+        public static System.Single Sinh(System.Single x) { throw null; }
+        public static System.Single Sqrt(System.Single x) { throw null; }
+        static System.Single System.IAdditionOperators<System.Single,System.Single,System.Single>.operator +(System.Single left, System.Single right) { throw null; }
+        static System.Single System.IBitwiseOperators<System.Single,System.Single,System.Single>.operator &(System.Single left, System.Single right) { throw null; }
+        static System.Single System.IBitwiseOperators<System.Single,System.Single,System.Single>.operator |(System.Single left, System.Single right) { throw null; }
+        static System.Single System.IBitwiseOperators<System.Single,System.Single,System.Single>.operator ^(System.Single left, System.Single right) { throw null; }
+        static System.Single System.IBitwiseOperators<System.Single,System.Single,System.Single>.operator ~(System.Single value) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider? provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider? provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider? provider) { throw null; }
@@ -4663,138 +4398,29 @@ namespace System
         ushort System.IConvertible.ToUInt16(System.IFormatProvider? provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider? provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider? provider) { throw null; }
+        static System.Single System.IDecrementOperators<System.Single>.operator --(System.Single value) { throw null; }
+        static System.Single System.IDivisionOperators<System.Single,System.Single,System.Single>.operator /(System.Single left, System.Single right) { throw null; }
+        static System.Single System.IIncrementOperators<System.Single>.operator ++(System.Single value) { throw null; }
+        static System.Single System.IModulusOperators<System.Single,System.Single,System.Single>.operator %(System.Single left, System.Single right) { throw null; }
+        static System.Single System.IMultiplyOperators<System.Single,System.Single,System.Single>.operator *(System.Single left, System.Single right) { throw null; }
+        static System.Single System.ISubtractionOperators<System.Single,System.Single,System.Single>.operator -(System.Single left, System.Single right) { throw null; }
+        static System.Single System.IUnaryNegationOperators<System.Single,System.Single>.operator -(System.Single value) { throw null; }
+        static System.Single System.IUnaryPlusOperators<System.Single,System.Single>.operator +(System.Single value) { throw null; }
+        public static System.Single Tan(System.Single x) { throw null; }
+        public static System.Single Tanh(System.Single x) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString(string? format) { throw null; }
         public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
+        public static System.Single Truncate(System.Single x) { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.Single result) where TOther : INumber<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Single result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Single result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out System.Single result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Single result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.Single result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Single result) { throw null; }
-
-        static float IAdditiveIdentity<float, float>.AdditiveIdentity { get { throw null; } }
-
-        static float IFloatingPoint<float>.E { get { throw null; } }
-        static float IFloatingPoint<float>.Epsilon { get { throw null; } }
-        static float IFloatingPoint<float>.NaN { get { throw null; } }
-        static float IFloatingPoint<float>.NegativeInfinity { get { throw null; } }
-        static float IFloatingPoint<float>.NegativeZero { get { throw null; } }
-        static float IFloatingPoint<float>.Pi { get { throw null; } }
-        static float IFloatingPoint<float>.PositiveInfinity { get { throw null; } }
-        static float IFloatingPoint<float>.Tau { get { throw null; } }
-
-        static float IMinMaxValue<float>.MinValue { get { throw null; } }
-        static float IMinMaxValue<float>.MaxValue { get { throw null; } }
-
-        static float INumber<float>.One { get { throw null; } }
-        static float INumber<float>.Zero { get { throw null; } }
-
-        static float IMultiplicativeIdentity<float, float>.MultiplicativeIdentity { get { throw null; } }
-
-        static float IAdditionOperators<float, float, float>.operator +(float left, float right) { throw null; }
-
-        static bool IBinaryNumber<float>.IsPow2(float value) { throw null; }
-        static float IBinaryNumber<float>.Log2(float value) { throw null; }
-
-        static float IBitwiseOperators<float, float, float>.operator &(float left, float right) { throw null; }
-        static float IBitwiseOperators<float, float, float>.operator |(float left, float right) { throw null; }
-        static float IBitwiseOperators<float, float, float>.operator ^(float left, float right) { throw null; }
-        static float IBitwiseOperators<float, float, float>.operator ~(float value) { throw null; }
-
-        static bool IComparisonOperators<float, float>.operator <(float left, float right) { throw null; }
-        static bool IComparisonOperators<float, float>.operator <=(float left, float right) { throw null; }
-        static bool IComparisonOperators<float, float>.operator >(float left, float right) { throw null; }
-        static bool IComparisonOperators<float, float>.operator >=(float left, float right) { throw null; }
-
-        static float IDecrementOperators<float>.operator --(float value) { throw null; }
-
-        static float IDivisionOperators<float, float, float>.operator /(float left, float right) { throw null; }
-
-        static bool IEqualityOperators<float, float>.operator ==(float left, float right) { throw null; }
-        static bool IEqualityOperators<float, float>.operator !=(float left, float right) { throw null; }
-
-        static float IFloatingPoint<float>.Acos(float x) { throw null; }
-        static float IFloatingPoint<float>.Acosh(float x) { throw null; }
-        static float IFloatingPoint<float>.Asin(float x) { throw null; }
-        static float IFloatingPoint<float>.Asinh(float x) { throw null; }
-        static float IFloatingPoint<float>.Atan(float x) { throw null; }
-        static float IFloatingPoint<float>.Atan2(float y, float x) { throw null; }
-        static float IFloatingPoint<float>.Atanh(float x) { throw null; }
-        static float IFloatingPoint<float>.BitIncrement(float x) { throw null; }
-        static float IFloatingPoint<float>.BitDecrement(float x) { throw null; }
-        static float IFloatingPoint<float>.Cbrt(float x) { throw null; }
-        static float IFloatingPoint<float>.Ceiling(float x) { throw null; }
-        static float IFloatingPoint<float>.CopySign(float x, float y) { throw null; }
-        static float IFloatingPoint<float>.Cos(float x) { throw null; }
-        static float IFloatingPoint<float>.Cosh(float x) { throw null; }
-        static float IFloatingPoint<float>.Exp(float x) { throw null; }
-        static float IFloatingPoint<float>.Floor(float x) { throw null; }
-        static float IFloatingPoint<float>.FusedMultiplyAdd(float left, float right, float addend) { throw null; }
-        static float IFloatingPoint<float>.IEEERemainder(float left, float right) { throw null; }
-        static TInteger IFloatingPoint<float>.ILogB<TInteger>(float x) { throw null; }
-        static float IFloatingPoint<float>.Log(float x) { throw null; }
-        static float IFloatingPoint<float>.Log(float x, float newBase) { throw null; }
-        static float IFloatingPoint<float>.Log2(float x) { throw null; }
-        static float IFloatingPoint<float>.Log10(float x) { throw null; }
-        static float IFloatingPoint<float>.MaxMagnitude(float x, float y) { throw null; }
-        static float IFloatingPoint<float>.MinMagnitude(float x, float y) { throw null; }
-        static float IFloatingPoint<float>.Pow(float x, float y) { throw null; }
-        static float IFloatingPoint<float>.Round(float x) { throw null; }
-        static float IFloatingPoint<float>.Round<TInteger>(float x, TInteger digits) { throw null; }
-        static float IFloatingPoint<float>.Round(float x, System.MidpointRounding mode) { throw null; }
-        static float IFloatingPoint<float>.Round<TInteger>(float x, TInteger digits, System.MidpointRounding mode) { throw null; }
-        static float IFloatingPoint<float>.ScaleB<TInteger>(float x, TInteger n) { throw null; }
-        static float IFloatingPoint<float>.Sin(float x) { throw null; }
-        static float IFloatingPoint<float>.Sinh(float x) { throw null; }
-        static float IFloatingPoint<float>.Sqrt(float x) { throw null; }
-        static float IFloatingPoint<float>.Tan(float x) { throw null; }
-        static float IFloatingPoint<float>.Tanh(float x) { throw null; }
-        static float IFloatingPoint<float>.Truncate(float x) { throw null; }
-
-        static bool IFloatingPoint<float>.IsFinite(float x) { throw null; }
-        static bool IFloatingPoint<float>.IsInfinity(float x) { throw null; }
-        static bool IFloatingPoint<float>.IsNaN(float x) { throw null; }
-        static bool IFloatingPoint<float>.IsNegative(float x) { throw null; }
-        static bool IFloatingPoint<float>.IsNegativeInfinity(float x) { throw null; }
-        static bool IFloatingPoint<float>.IsNormal(float x) { throw null; }
-        static bool IFloatingPoint<float>.IsPositiveInfinity(float x) { throw null; }
-        static bool IFloatingPoint<float>.IsSubnormal(float x) { throw null; }
-
-        static float IIncrementOperators<float>.operator ++(float value) { throw null; }
-
-        static float IModulusOperators<float, float, float>.operator %(float left, float right) { throw null; }
-
-        static float IMultiplyOperators<float, float, float>.operator *(float left, float right) { throw null; }
-
-        static float INumber<float>.Abs(float value) { throw null; }
-        static float INumber<float>.Clamp(float value, float min, float max) { throw null; }
-        static float INumber<float>.Create<TOther>(TOther value) { throw null; }
-        static float INumber<float>.CreateSaturating<TOther>(TOther value) { throw null; }
-        static float INumber<float>.CreateTruncating<TOther>(TOther value) { throw null; }
-        static (float Quotient, float Remainder) INumber<float>.DivRem(float left, float right) { throw null; }
-        static float INumber<float>.Max(float x, float y) { throw null; }
-        static float INumber<float>.Min(float x, float y) { throw null; }
-        static float INumber<float>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static float INumber<float>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static float INumber<float>.Sign(float value) { throw null; }
-        static bool INumber<float>.TryCreate<TOther>(TOther value, out float result) { throw null; }
-        static bool INumber<float>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out float result) { throw null; }
-        static bool INumber<float>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out float result) { throw null; }
-
-        static float IParseable<float>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<float>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out float result) { throw null; }
-
-        static float ISignedNumber<float>.NegativeOne { get; }
-
-        static float ISpanParseable<float>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<float>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out float result) { throw null; }
-
-        static float ISubtractionOperators<float, float, float>.operator -(float left, float right) { throw null; }
-
-        static float IUnaryNegationOperators<float, float>.operator -(float value) { throw null; }
-
-        static float IUnaryPlusOperators<float, float>.operator +(float value) { throw null; }
     }
     public readonly ref partial struct Span<T>
     {
@@ -5103,18 +4729,21 @@ namespace System
     {
         public ThreadStaticAttribute() { }
     }
-    public readonly partial struct TimeOnly : System.IComparable, System.IComparable<System.TimeOnly>, System.IEquatable<System.TimeOnly>, System.ISpanFormattable, System.IComparisonOperators<System.TimeOnly, System.TimeOnly>, System.IMinMaxValue<System.TimeOnly>, System.ISpanParseable<System.TimeOnly>, System.ISubtractionOperators<System.TimeOnly, System.TimeOnly, System.TimeSpan>
+    public readonly partial struct TimeOnly : System.IComparable, System.IComparable<System.TimeOnly>, System.IComparisonOperators<System.TimeOnly, System.TimeOnly>, System.IEqualityOperators<System.TimeOnly, System.TimeOnly>, System.IEquatable<System.TimeOnly>, System.IFormattable, System.IMinMaxValue<System.TimeOnly>, System.IParseable<System.TimeOnly>, System.ISpanFormattable, System.ISpanParseable<System.TimeOnly>, System.ISubtractionOperators<System.TimeOnly, System.TimeOnly, System.TimeSpan>
     {
-        public static System.TimeOnly MinValue { get { throw null; } }
-        public static System.TimeOnly MaxValue { get { throw null; } }
+        private readonly int _dummyPrimitive;
         public TimeOnly(int hour, int minute) { throw null; }
         public TimeOnly(int hour, int minute, int second) { throw null; }
         public TimeOnly(int hour, int minute, int second, int millisecond) { throw null; }
         public TimeOnly(long ticks) { throw null; }
         public int Hour { get { throw null; } }
-        public int Minute { get { throw null; } }
-        public int Second { get { throw null; } }
+        public static System.TimeOnly MaxValue { get { throw null; } }
         public int Millisecond { get { throw null; } }
+        public int Minute { get { throw null; } }
+        public static System.TimeOnly MinValue { get { throw null; } }
+        public int Second { get { throw null; } }
+        static System.TimeOnly System.IMinMaxValue<System.TimeOnly>.MaxValue { get { throw null; } }
+        static System.TimeOnly System.IMinMaxValue<System.TimeOnly>.MinValue { get { throw null; } }
         public long Ticks { get { throw null; } }
         public System.TimeOnly Add(System.TimeSpan value) { throw null; }
         public System.TimeOnly Add(System.TimeSpan value, out int wrappedDays) { throw null; }
@@ -5122,6 +4751,13 @@ namespace System
         public System.TimeOnly AddHours(double value, out int wrappedDays) { throw null; }
         public System.TimeOnly AddMinutes(double value) { throw null; }
         public System.TimeOnly AddMinutes(double value, out int wrappedDays) { throw null; }
+        public int CompareTo(object? value) { throw null; }
+        public int CompareTo(System.TimeOnly value) { throw null; }
+        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? value) { throw null; }
+        public bool Equals(System.TimeOnly value) { throw null; }
+        public static System.TimeOnly FromDateTime(System.DateTime dateTime) { throw null; }
+        public static System.TimeOnly FromTimeSpan(System.TimeSpan timeSpan) { throw null; }
+        public override int GetHashCode() { throw null; }
         public bool IsBetween(System.TimeOnly start, System.TimeOnly end) { throw null; }
         public static bool operator ==(System.TimeOnly left, System.TimeOnly right) { throw null; }
         public static bool operator >(System.TimeOnly left, System.TimeOnly right) { throw null; }
@@ -5130,62 +4766,40 @@ namespace System
         public static bool operator <(System.TimeOnly left, System.TimeOnly right) { throw null; }
         public static bool operator <=(System.TimeOnly left, System.TimeOnly right) { throw null; }
         public static System.TimeSpan operator -(System.TimeOnly t1, System.TimeOnly t2) { throw null; }
-        public static System.TimeOnly FromTimeSpan(System.TimeSpan timeSpan) { throw null; }
-        public static System.TimeOnly FromDateTime(System.DateTime dateTime) { throw null; }
-        public System.TimeSpan ToTimeSpan() { throw null; }
-        public int CompareTo(System.TimeOnly value) { throw null; }
-        public int CompareTo(object? value) { throw null; }
-        public bool Equals(System.TimeOnly value) { throw null; }
-        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? value) { throw null; }
-        public override int GetHashCode() { throw null; }
-        public static System.TimeOnly Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider = default, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
-        public static System.TimeOnly ParseExact(System.ReadOnlySpan<char> s, System.ReadOnlySpan<char> format, System.IFormatProvider? provider = default, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
+        public static System.TimeOnly Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
+        public static System.TimeOnly Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider = null, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
+        public static System.TimeOnly Parse(string s) { throw null; }
+        public static System.TimeOnly Parse(string s, System.IFormatProvider? provider) { throw null; }
+        public static System.TimeOnly Parse(string s, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
+        public static System.TimeOnly ParseExact(System.ReadOnlySpan<char> s, System.ReadOnlySpan<char> format, System.IFormatProvider? provider = null, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
         public static System.TimeOnly ParseExact(System.ReadOnlySpan<char> s, string[] formats) { throw null; }
         public static System.TimeOnly ParseExact(System.ReadOnlySpan<char> s, string[] formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
-        public static System.TimeOnly Parse(string s) { throw null; }
-        public static System.TimeOnly Parse(string s, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
         public static System.TimeOnly ParseExact(string s, string format) { throw null; }
         public static System.TimeOnly ParseExact(string s, string format, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
         public static System.TimeOnly ParseExact(string s, string[] formats) { throw null; }
         public static System.TimeOnly ParseExact(string s, string[] formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style = System.Globalization.DateTimeStyles.None) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.TimeOnly result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.TimeOnly result) { throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> s, System.ReadOnlySpan<char> format, out System.TimeOnly result) { throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> s, System.ReadOnlySpan<char> format, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.TimeOnly result) { throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string?[]? formats, out System.TimeOnly result) { throw null; }
-        public static bool TryParseExact(System.ReadOnlySpan<char> s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string?[]? formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.TimeOnly result) { throw null; }
-        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.TimeOnly result) { throw null; }
-        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.TimeOnly result) { throw null; }
-        public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? format, out System.TimeOnly result) { throw null; }
-        public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? format, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.TimeOnly result) { throw null; }
-        public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string?[]? formats, out System.TimeOnly result) { throw null; }
-        public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string?[]? formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.TimeOnly result) { throw null; }
         public string ToLongTimeString() { throw null; }
         public string ToShortTimeString() { throw null; }
         public override string ToString() { throw null; }
-        public string ToString(string? format) { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
+        public string ToString(string? format) { throw null; }
         public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
+        public System.TimeSpan ToTimeSpan() { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
-
-        static bool IComparisonOperators<System.TimeOnly, System.TimeOnly>.operator <(System.TimeOnly left, System.TimeOnly right) { throw null; }
-        static bool IComparisonOperators<System.TimeOnly, System.TimeOnly>.operator <=(System.TimeOnly left, System.TimeOnly right) { throw null; }
-        static bool IComparisonOperators<System.TimeOnly, System.TimeOnly>.operator >(System.TimeOnly left, System.TimeOnly right) { throw null; }
-        static bool IComparisonOperators<System.TimeOnly, System.TimeOnly>.operator >=(System.TimeOnly left, System.TimeOnly right) { throw null; }
-
-        static bool IEqualityOperators<System.TimeOnly, System.TimeOnly>.operator ==(System.TimeOnly left, System.TimeOnly right) { throw null; }
-        static bool IEqualityOperators<System.TimeOnly, System.TimeOnly>.operator !=(System.TimeOnly left, System.TimeOnly right) { throw null; }
-
-        static System.TimeOnly IParseable<System.TimeOnly>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<System.TimeOnly>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.TimeOnly result) { throw null; }
-
-        static System.TimeOnly ISpanParseable<System.TimeOnly>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<System.TimeOnly>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.TimeOnly result) { throw null; }
-
-        static System.TimeSpan ISubtractionOperators<System.TimeOnly, System.TimeOnly, System.TimeSpan>.operator -(System.TimeOnly left, System.TimeOnly right) { throw null; }
-
-        static System.TimeOnly IMinMaxValue<System.TimeOnly>.MinValue { get { throw null; } }
-        static System.TimeOnly IMinMaxValue<System.TimeOnly>.MaxValue { get { throw null; } }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.TimeOnly result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.TimeOnly result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.TimeOnly result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.TimeOnly result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.TimeOnly result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.TimeOnly result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> s, System.ReadOnlySpan<char> format, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.TimeOnly result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> s, System.ReadOnlySpan<char> format, out System.TimeOnly result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string?[]? formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.TimeOnly result) { throw null; }
+        public static bool TryParseExact(System.ReadOnlySpan<char> s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string?[]? formats, out System.TimeOnly result) { throw null; }
+        public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? format, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.TimeOnly result) { throw null; }
+        public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? format, out System.TimeOnly result) { throw null; }
+        public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string?[]? formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.TimeOnly result) { throw null; }
+        public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string?[]? formats, out System.TimeOnly result) { throw null; }
     }
     public partial class TimeoutException : System.SystemException
     {
@@ -5194,7 +4808,7 @@ namespace System
         public TimeoutException(string? message) { }
         public TimeoutException(string? message, System.Exception? innerException) { }
     }
-    public readonly partial struct TimeSpan : System.IComparable, System.IComparable<System.TimeSpan>, System.IEquatable<System.TimeSpan>, System.ISpanFormattable, System.IAdditionOperators<System.TimeSpan, System.TimeSpan, System.TimeSpan>, System.IAdditiveIdentity<System.TimeSpan, System.TimeSpan>, System.IComparisonOperators<System.TimeSpan, System.TimeSpan>, System.IDivisionOperators<System.TimeSpan, double, System.TimeSpan>, System.IDivisionOperators<System.TimeSpan, System.TimeSpan, double>, System.IMinMaxValue<System.TimeSpan>, System.IMultiplyOperators<System.TimeSpan, double, System.TimeSpan>, System.IMultiplicativeIdentity<System.TimeSpan, double>, System.ISpanParseable<System.TimeSpan>, System.ISubtractionOperators<System.TimeSpan, System.TimeSpan, System.TimeSpan>, System.IUnaryNegationOperators<System.TimeSpan, System.TimeSpan>, System.IUnaryPlusOperators<System.TimeSpan, System.TimeSpan>
+    public readonly partial struct TimeSpan : System.IAdditionOperators<System.TimeSpan, System.TimeSpan, System.TimeSpan>, System.IAdditiveIdentity<System.TimeSpan, System.TimeSpan>, System.IComparable, System.IComparable<System.TimeSpan>, System.IComparisonOperators<System.TimeSpan, System.TimeSpan>, System.IDivisionOperators<System.TimeSpan, double, System.TimeSpan>, System.IDivisionOperators<System.TimeSpan, System.TimeSpan, double>, System.IEqualityOperators<System.TimeSpan, System.TimeSpan>, System.IEquatable<System.TimeSpan>, System.IFormattable, System.IMinMaxValue<System.TimeSpan>, System.IMultiplicativeIdentity<System.TimeSpan, double>, System.IMultiplyOperators<System.TimeSpan, double, System.TimeSpan>, System.IParseable<System.TimeSpan>, System.ISpanFormattable, System.ISpanParseable<System.TimeSpan>, System.ISubtractionOperators<System.TimeSpan, System.TimeSpan, System.TimeSpan>, System.IUnaryNegationOperators<System.TimeSpan, System.TimeSpan>, System.IUnaryPlusOperators<System.TimeSpan, System.TimeSpan>
     {
         private readonly int _dummyPrimitive;
         public static readonly System.TimeSpan MaxValue;
@@ -5209,11 +4823,15 @@ namespace System
         public TimeSpan(int days, int hours, int minutes, int seconds) { throw null; }
         public TimeSpan(int days, int hours, int minutes, int seconds, int milliseconds) { throw null; }
         public TimeSpan(long ticks) { throw null; }
+        public static System.TimeSpan AdditiveIdentity { get { throw null; } }
         public int Days { get { throw null; } }
         public int Hours { get { throw null; } }
         public int Milliseconds { get { throw null; } }
         public int Minutes { get { throw null; } }
+        public static double MultiplicativeIdentity { get { throw null; } }
         public int Seconds { get { throw null; } }
+        static System.TimeSpan System.IMinMaxValue<System.TimeSpan>.MaxValue { get { throw null; } }
+        static System.TimeSpan System.IMinMaxValue<System.TimeSpan>.MinValue { get { throw null; } }
         public long Ticks { get { throw null; } }
         public double TotalDays { get { throw null; } }
         public double TotalHours { get { throw null; } }
@@ -5279,40 +4897,6 @@ namespace System
         public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? format, System.IFormatProvider? formatProvider, out System.TimeSpan result) { throw null; }
         public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string?[]? formats, System.IFormatProvider? formatProvider, System.Globalization.TimeSpanStyles styles, out System.TimeSpan result) { throw null; }
         public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string?[]? formats, System.IFormatProvider? formatProvider, out System.TimeSpan result) { throw null; }
-
-        static System.TimeSpan IAdditiveIdentity<System.TimeSpan, System.TimeSpan>.AdditiveIdentity { get { throw null; } }
-
-        static System.TimeSpan IMinMaxValue<System.TimeSpan>.MinValue { get { throw null; } }
-        static System.TimeSpan IMinMaxValue<System.TimeSpan>.MaxValue { get { throw null; } }
-
-        static double IMultiplicativeIdentity<System.TimeSpan, double>.MultiplicativeIdentity { get { throw null; } }
-
-        static System.TimeSpan IAdditionOperators<System.TimeSpan, System.TimeSpan, System.TimeSpan>.operator +(System.TimeSpan left, System.TimeSpan right) { throw null; }
-
-        static bool IComparisonOperators<System.TimeSpan, System.TimeSpan>.operator <(System.TimeSpan left, System.TimeSpan right) { throw null; }
-        static bool IComparisonOperators<System.TimeSpan, System.TimeSpan>.operator <=(System.TimeSpan left, System.TimeSpan right) { throw null; }
-        static bool IComparisonOperators<System.TimeSpan, System.TimeSpan>.operator >(System.TimeSpan left, System.TimeSpan right) { throw null; }
-        static bool IComparisonOperators<System.TimeSpan, System.TimeSpan>.operator >=(System.TimeSpan left, System.TimeSpan right) { throw null; }
-
-        static System.TimeSpan IDivisionOperators<System.TimeSpan, double, System.TimeSpan>.operator /(System.TimeSpan left, double right) { throw null; }
-        static double IDivisionOperators<System.TimeSpan, System.TimeSpan, double>.operator /(System.TimeSpan left, System.TimeSpan right) { throw null; }
-
-        static bool IEqualityOperators<System.TimeSpan, System.TimeSpan>.operator ==(System.TimeSpan left, System.TimeSpan right) { throw null; }
-        static bool IEqualityOperators<System.TimeSpan, System.TimeSpan>.operator !=(System.TimeSpan left, System.TimeSpan right) { throw null; }
-
-        static System.TimeSpan IMultiplyOperators<System.TimeSpan, double, System.TimeSpan>.operator *(System.TimeSpan left, double right) { throw null; }
-
-        static System.TimeSpan IParseable<System.TimeSpan>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<System.TimeSpan>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.TimeSpan result) { throw null; }
-
-        static System.TimeSpan ISpanParseable<System.TimeSpan>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<System.TimeSpan>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.TimeSpan result) { throw null; }
-
-        static System.TimeSpan ISubtractionOperators<System.TimeSpan, System.TimeSpan, System.TimeSpan>.operator -(System.TimeSpan left, System.TimeSpan right) { throw null; }
-
-        static System.TimeSpan IUnaryNegationOperators<System.TimeSpan, System.TimeSpan>.operator -(System.TimeSpan value) { throw null; }
-
-        static System.TimeSpan IUnaryPlusOperators<System.TimeSpan, System.TimeSpan>.operator +(System.TimeSpan value) { throw null; }
     }
     [System.ObsoleteAttribute("System.TimeZone has been deprecated. Investigate the use of System.TimeZoneInfo instead.")]
     public abstract partial class TimeZone
@@ -6001,22 +5585,57 @@ namespace System
         public TypeUnloadedException(string? message, System.Exception? innerException) { }
     }
     [System.CLSCompliantAttribute(false)]
-    public readonly partial struct UInt16 : System.IComparable, System.IComparable<ushort>, System.IConvertible, System.IEquatable<ushort>, System.ISpanFormattable, System.IBinaryInteger<ushort>, System.IMinMaxValue<ushort>, System.IUnsignedNumber<ushort>
+    public readonly partial struct UInt16 : System.IAdditionOperators<ushort, ushort, ushort>, System.IAdditiveIdentity<ushort, ushort>, System.IBinaryInteger<ushort>, System.IBinaryNumber<ushort>, System.IBitwiseOperators<ushort, ushort, ushort>, System.IComparable, System.IComparable<ushort>, System.IComparisonOperators<ushort, ushort>, System.IConvertible, System.IDecrementOperators<ushort>, System.IDivisionOperators<ushort, ushort, ushort>, System.IEqualityOperators<ushort, ushort>, System.IEquatable<ushort>, System.IFormattable, System.IIncrementOperators<ushort>, System.IMinMaxValue<ushort>, System.IModulusOperators<ushort, ushort, ushort>, System.IMultiplicativeIdentity<ushort, ushort>, System.IMultiplyOperators<ushort, ushort, ushort>, System.INumber<ushort>, System.IParseable<ushort>, System.IShiftOperators<ushort, ushort>, System.ISpanFormattable, System.ISpanParseable<ushort>, System.ISubtractionOperators<ushort, ushort, ushort>, System.IUnaryNegationOperators<ushort, ushort>, System.IUnaryPlusOperators<ushort, ushort>, System.IUnsignedNumber<ushort>
     {
         private readonly ushort _dummyPrimitive;
+        public const ushort AdditiveIdentity = (ushort)0;
         public const ushort MaxValue = (ushort)65535;
         public const ushort MinValue = (ushort)0;
+        public const ushort MultiplicativeIdentity = (ushort)1;
+        public const ushort One = (ushort)1;
+        public const ushort Zero = (ushort)0;
+        static ushort System.IAdditiveIdentity<System.UInt16,System.UInt16>.AdditiveIdentity { get { throw null; } }
+        static ushort System.IMinMaxValue<System.UInt16>.MaxValue { get { throw null; } }
+        static ushort System.IMinMaxValue<System.UInt16>.MinValue { get { throw null; } }
+        static ushort System.IMultiplicativeIdentity<System.UInt16,System.UInt16>.MultiplicativeIdentity { get { throw null; } }
+        static ushort System.INumber<System.UInt16>.One { get { throw null; } }
+        static ushort System.INumber<System.UInt16>.Zero { get { throw null; } }
+        public static System.UInt16 Abs(System.UInt16 value) { throw null; }
+        public static System.UInt16 Clamp(System.UInt16 value, System.UInt16 min, System.UInt16 max) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public int CompareTo(System.UInt16 value) { throw null; }
+        public static System.UInt16 CreateSaturating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.UInt16 CreateTruncating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.UInt16 Create<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static (ushort Quotient, ushort Remainder) DivRem(System.UInt16 left, System.UInt16 right) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public bool Equals(System.UInt16 obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsPow2(System.UInt16 value) { throw null; }
+        public static System.UInt16 LeadingZeroCount(System.UInt16 value) { throw null; }
+        public static System.UInt16 Log2(System.UInt16 value) { throw null; }
+        public static System.UInt16 Max(System.UInt16 x, System.UInt16 y) { throw null; }
+        public static System.UInt16 Min(System.UInt16 x, System.UInt16 y) { throw null; }
         public static System.UInt16 Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider? provider = null) { throw null; }
+        public static System.UInt16 Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
         public static System.UInt16 Parse(string s) { throw null; }
         public static System.UInt16 Parse(string s, System.Globalization.NumberStyles style) { throw null; }
         public static System.UInt16 Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
         public static System.UInt16 Parse(string s, System.IFormatProvider? provider) { throw null; }
+        public static System.UInt16 PopCount(System.UInt16 value) { throw null; }
+        public static System.UInt16 RotateLeft(System.UInt16 value, int rotateAmount) { throw null; }
+        public static System.UInt16 RotateRight(System.UInt16 value, int rotateAmount) { throw null; }
+        public static System.UInt16 Sign(System.UInt16 value) { throw null; }
+        static System.UInt16 System.IAdditionOperators<System.UInt16,System.UInt16,System.UInt16>.operator +(System.UInt16 left, System.UInt16 right) { throw null; }
+        static System.UInt16 System.IBitwiseOperators<System.UInt16,System.UInt16,System.UInt16>.operator &(System.UInt16 left, System.UInt16 right) { throw null; }
+        static System.UInt16 System.IBitwiseOperators<System.UInt16,System.UInt16,System.UInt16>.operator |(System.UInt16 left, System.UInt16 right) { throw null; }
+        static System.UInt16 System.IBitwiseOperators<System.UInt16,System.UInt16,System.UInt16>.operator ^(System.UInt16 left, System.UInt16 right) { throw null; }
+        static System.UInt16 System.IBitwiseOperators<System.UInt16,System.UInt16,System.UInt16>.operator ~(System.UInt16 value) { throw null; }
+        static bool System.IComparisonOperators<System.UInt16,System.UInt16>.operator >(System.UInt16 left, System.UInt16 right) { throw null; }
+        static bool System.IComparisonOperators<System.UInt16,System.UInt16>.operator >=(System.UInt16 left, System.UInt16 right) { throw null; }
+        static bool System.IComparisonOperators<System.UInt16,System.UInt16>.operator <(System.UInt16 left, System.UInt16 right) { throw null; }
+        static bool System.IComparisonOperators<System.UInt16,System.UInt16>.operator <=(System.UInt16 left, System.UInt16 right) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider? provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider? provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider? provider) { throw null; }
@@ -6032,107 +5651,84 @@ namespace System
         System.UInt16 System.IConvertible.ToUInt16(System.IFormatProvider? provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider? provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider? provider) { throw null; }
+        static System.UInt16 System.IDecrementOperators<System.UInt16>.operator --(System.UInt16 value) { throw null; }
+        static System.UInt16 System.IDivisionOperators<System.UInt16,System.UInt16,System.UInt16>.operator /(System.UInt16 left, System.UInt16 right) { throw null; }
+        static bool System.IEqualityOperators<System.UInt16,System.UInt16>.operator ==(System.UInt16 left, System.UInt16 right) { throw null; }
+        static bool System.IEqualityOperators<System.UInt16,System.UInt16>.operator !=(System.UInt16 left, System.UInt16 right) { throw null; }
+        static System.UInt16 System.IIncrementOperators<System.UInt16>.operator ++(System.UInt16 value) { throw null; }
+        static System.UInt16 System.IModulusOperators<System.UInt16,System.UInt16,System.UInt16>.operator %(System.UInt16 left, System.UInt16 right) { throw null; }
+        static System.UInt16 System.IMultiplyOperators<System.UInt16,System.UInt16,System.UInt16>.operator *(System.UInt16 left, System.UInt16 right) { throw null; }
+        static System.UInt16 System.IShiftOperators<System.UInt16,System.UInt16>.operator <<(System.UInt16 value, int shiftAmount) { throw null; }
+        static System.UInt16 System.IShiftOperators<System.UInt16,System.UInt16>.operator >>(System.UInt16 value, int shiftAmount) { throw null; }
+        static System.UInt16 System.ISubtractionOperators<System.UInt16,System.UInt16,System.UInt16>.operator -(System.UInt16 left, System.UInt16 right) { throw null; }
+        static System.UInt16 System.IUnaryNegationOperators<System.UInt16,System.UInt16>.operator -(System.UInt16 value) { throw null; }
+        static System.UInt16 System.IUnaryPlusOperators<System.UInt16,System.UInt16>.operator +(System.UInt16 value) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString(string? format) { throw null; }
         public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
+        public static System.UInt16 TrailingZeroCount(System.UInt16 value) { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.UInt16 result) where TOther : INumber<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UInt16 result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.UInt16 result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out System.UInt16 result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UInt16 result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.UInt16 result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.UInt16 result) { throw null; }
-
-        static ushort IAdditiveIdentity<ushort, ushort>.AdditiveIdentity { get { throw null; } }
-
-        static ushort IMinMaxValue<ushort>.MinValue { get { throw null; } }
-        static ushort IMinMaxValue<ushort>.MaxValue { get { throw null; } }
-
-        static ushort IMultiplicativeIdentity<ushort, ushort>.MultiplicativeIdentity { get { throw null; } }
-
-        static ushort INumber<ushort>.One { get { throw null; } }
-        static ushort INumber<ushort>.Zero { get { throw null; } }
-
-        static ushort IAdditionOperators<ushort, ushort, ushort>.operator +(ushort left, ushort right) { throw null; }
-
-        static ushort IBinaryInteger<ushort>.LeadingZeroCount(ushort value) { throw null; }
-        static ushort IBinaryInteger<ushort>.PopCount(ushort value) { throw null; }
-        static ushort IBinaryInteger<ushort>.RotateLeft(ushort value, int rotateAmount) { throw null; }
-        static ushort IBinaryInteger<ushort>.RotateRight(ushort value, int rotateAmount) { throw null; }
-        static ushort IBinaryInteger<ushort>.TrailingZeroCount(ushort value) { throw null; }
-
-        static bool IBinaryNumber<ushort>.IsPow2(ushort value) { throw null; }
-        static ushort IBinaryNumber<ushort>.Log2(ushort value) { throw null; }
-
-        static ushort IBitwiseOperators<ushort, ushort, ushort>.operator &(ushort left, ushort right) { throw null; }
-        static ushort IBitwiseOperators<ushort, ushort, ushort>.operator |(ushort left, ushort right) { throw null; }
-        static ushort IBitwiseOperators<ushort, ushort, ushort>.operator ^(ushort left, ushort right) { throw null; }
-        static ushort IBitwiseOperators<ushort, ushort, ushort>.operator ~(ushort value) { throw null; }
-
-        static bool IComparisonOperators<ushort, ushort>.operator <(ushort left, ushort right) { throw null; }
-        static bool IComparisonOperators<ushort, ushort>.operator <=(ushort left, ushort right) { throw null; }
-        static bool IComparisonOperators<ushort, ushort>.operator >(ushort left, ushort right) { throw null; }
-        static bool IComparisonOperators<ushort, ushort>.operator >=(ushort left, ushort right) { throw null; }
-
-        static ushort IDecrementOperators<ushort>.operator --(ushort value) { throw null; }
-
-        static ushort IDivisionOperators<ushort, ushort, ushort>.operator /(ushort left, ushort right) { throw null; }
-
-        static bool IEqualityOperators<ushort, ushort>.operator ==(ushort left, ushort right) { throw null; }
-        static bool IEqualityOperators<ushort, ushort>.operator !=(ushort left, ushort right) { throw null; }
-
-        static ushort IIncrementOperators<ushort>.operator ++(ushort value) { throw null; }
-
-        static ushort IModulusOperators<ushort, ushort, ushort>.operator %(ushort left, ushort right) { throw null; }
-
-        static ushort IMultiplyOperators<ushort, ushort, ushort>.operator *(ushort left, ushort right) { throw null; }
-
-        static ushort INumber<ushort>.Abs(ushort value) { throw null; }
-        static ushort INumber<ushort>.Clamp(ushort value, ushort min, ushort max) { throw null; }
-        static ushort INumber<ushort>.Create<TOther>(TOther value) { throw null; }
-        static ushort INumber<ushort>.CreateSaturating<TOther>(TOther value) { throw null; }
-        static ushort INumber<ushort>.CreateTruncating<TOther>(TOther value) { throw null; }
-        static (ushort Quotient, ushort Remainder) INumber<ushort>.DivRem(ushort left, ushort right) { throw null; }
-        static ushort INumber<ushort>.Max(ushort x, ushort y) { throw null; }
-        static ushort INumber<ushort>.Min(ushort x, ushort y) { throw null; }
-        static ushort INumber<ushort>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static ushort INumber<ushort>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static ushort INumber<ushort>.Sign(ushort value) { throw null; }
-        static bool INumber<ushort>.TryCreate<TOther>(TOther value, out ushort result) { throw null; }
-        static bool INumber<ushort>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out ushort result) { throw null; }
-        static bool INumber<ushort>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out ushort result) { throw null; }
-
-        static ushort IParseable<ushort>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<ushort>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out ushort result) { throw null; }
-
-        static ushort IShiftOperators<ushort, ushort>.operator <<(ushort value, int shiftAmount) { throw null; }
-        static ushort IShiftOperators<ushort, ushort>.operator >>(ushort value, int shiftAmount) { throw null; }
-
-        static ushort ISpanParseable<ushort>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<ushort>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out ushort result) { throw null; }
-
-        static ushort ISubtractionOperators<ushort, ushort, ushort>.operator -(ushort left, ushort right) { throw null; }
-
-        static ushort IUnaryNegationOperators<ushort, ushort>.operator -(ushort value) { throw null; }
-
-        static ushort IUnaryPlusOperators<ushort, ushort>.operator +(ushort value) { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
-    public readonly partial struct UInt32 : System.IComparable, System.IComparable<uint>, System.IConvertible, System.IEquatable<uint>, System.ISpanFormattable, System.IBinaryInteger<uint>, System.IMinMaxValue<uint>, System.IUnsignedNumber<uint>
+    public readonly partial struct UInt32 : System.IAdditionOperators<uint, uint, uint>, System.IAdditiveIdentity<uint, uint>, System.IBinaryInteger<uint>, System.IBinaryNumber<uint>, System.IBitwiseOperators<uint, uint, uint>, System.IComparable, System.IComparable<uint>, System.IComparisonOperators<uint, uint>, System.IConvertible, System.IDecrementOperators<uint>, System.IDivisionOperators<uint, uint, uint>, System.IEqualityOperators<uint, uint>, System.IEquatable<uint>, System.IFormattable, System.IIncrementOperators<uint>, System.IMinMaxValue<uint>, System.IModulusOperators<uint, uint, uint>, System.IMultiplicativeIdentity<uint, uint>, System.IMultiplyOperators<uint, uint, uint>, System.INumber<uint>, System.IParseable<uint>, System.IShiftOperators<uint, uint>, System.ISpanFormattable, System.ISpanParseable<uint>, System.ISubtractionOperators<uint, uint, uint>, System.IUnaryNegationOperators<uint, uint>, System.IUnaryPlusOperators<uint, uint>, System.IUnsignedNumber<uint>
     {
         private readonly uint _dummyPrimitive;
+        public const uint AdditiveIdentity = (uint)0;
         public const uint MaxValue = (uint)4294967295;
         public const uint MinValue = (uint)0;
+        public const uint MultiplicativeIdentity = (uint)1;
+        public const uint One = (uint)1;
+        public const uint Zero = (uint)0;
+        static uint System.IAdditiveIdentity<System.UInt32,System.UInt32>.AdditiveIdentity { get { throw null; } }
+        static uint System.IMinMaxValue<System.UInt32>.MaxValue { get { throw null; } }
+        static uint System.IMinMaxValue<System.UInt32>.MinValue { get { throw null; } }
+        static uint System.IMultiplicativeIdentity<System.UInt32,System.UInt32>.MultiplicativeIdentity { get { throw null; } }
+        static uint System.INumber<System.UInt32>.One { get { throw null; } }
+        static uint System.INumber<System.UInt32>.Zero { get { throw null; } }
+        public static System.UInt32 Abs(System.UInt32 value) { throw null; }
+        public static System.UInt32 Clamp(System.UInt32 value, System.UInt32 min, System.UInt32 max) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public int CompareTo(System.UInt32 value) { throw null; }
+        public static System.UInt32 CreateSaturating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.UInt32 CreateTruncating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.UInt32 Create<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static (uint Quotient, uint Remainder) DivRem(System.UInt32 left, System.UInt32 right) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public bool Equals(System.UInt32 obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsPow2(System.UInt32 value) { throw null; }
+        public static System.UInt32 LeadingZeroCount(System.UInt32 value) { throw null; }
+        public static System.UInt32 Log2(System.UInt32 value) { throw null; }
+        public static System.UInt32 Max(System.UInt32 x, System.UInt32 y) { throw null; }
+        public static System.UInt32 Min(System.UInt32 x, System.UInt32 y) { throw null; }
         public static System.UInt32 Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider? provider = null) { throw null; }
+        public static System.UInt32 Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
         public static System.UInt32 Parse(string s) { throw null; }
         public static System.UInt32 Parse(string s, System.Globalization.NumberStyles style) { throw null; }
         public static System.UInt32 Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
         public static System.UInt32 Parse(string s, System.IFormatProvider? provider) { throw null; }
+        public static System.UInt32 PopCount(System.UInt32 value) { throw null; }
+        public static System.UInt32 RotateLeft(System.UInt32 value, int rotateAmount) { throw null; }
+        public static System.UInt32 RotateRight(System.UInt32 value, int rotateAmount) { throw null; }
+        public static System.UInt32 Sign(System.UInt32 value) { throw null; }
+        static System.UInt32 System.IAdditionOperators<System.UInt32,System.UInt32,System.UInt32>.operator +(System.UInt32 left, System.UInt32 right) { throw null; }
+        static System.UInt32 System.IBitwiseOperators<System.UInt32,System.UInt32,System.UInt32>.operator &(System.UInt32 left, System.UInt32 right) { throw null; }
+        static System.UInt32 System.IBitwiseOperators<System.UInt32,System.UInt32,System.UInt32>.operator |(System.UInt32 left, System.UInt32 right) { throw null; }
+        static System.UInt32 System.IBitwiseOperators<System.UInt32,System.UInt32,System.UInt32>.operator ^(System.UInt32 left, System.UInt32 right) { throw null; }
+        static System.UInt32 System.IBitwiseOperators<System.UInt32,System.UInt32,System.UInt32>.operator ~(System.UInt32 value) { throw null; }
+        static bool System.IComparisonOperators<System.UInt32,System.UInt32>.operator >(System.UInt32 left, System.UInt32 right) { throw null; }
+        static bool System.IComparisonOperators<System.UInt32,System.UInt32>.operator >=(System.UInt32 left, System.UInt32 right) { throw null; }
+        static bool System.IComparisonOperators<System.UInt32,System.UInt32>.operator <(System.UInt32 left, System.UInt32 right) { throw null; }
+        static bool System.IComparisonOperators<System.UInt32,System.UInt32>.operator <=(System.UInt32 left, System.UInt32 right) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider? provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider? provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider? provider) { throw null; }
@@ -6148,107 +5744,84 @@ namespace System
         ushort System.IConvertible.ToUInt16(System.IFormatProvider? provider) { throw null; }
         System.UInt32 System.IConvertible.ToUInt32(System.IFormatProvider? provider) { throw null; }
         ulong System.IConvertible.ToUInt64(System.IFormatProvider? provider) { throw null; }
+        static System.UInt32 System.IDecrementOperators<System.UInt32>.operator --(System.UInt32 value) { throw null; }
+        static System.UInt32 System.IDivisionOperators<System.UInt32,System.UInt32,System.UInt32>.operator /(System.UInt32 left, System.UInt32 right) { throw null; }
+        static bool System.IEqualityOperators<System.UInt32,System.UInt32>.operator ==(System.UInt32 left, System.UInt32 right) { throw null; }
+        static bool System.IEqualityOperators<System.UInt32,System.UInt32>.operator !=(System.UInt32 left, System.UInt32 right) { throw null; }
+        static System.UInt32 System.IIncrementOperators<System.UInt32>.operator ++(System.UInt32 value) { throw null; }
+        static System.UInt32 System.IModulusOperators<System.UInt32,System.UInt32,System.UInt32>.operator %(System.UInt32 left, System.UInt32 right) { throw null; }
+        static System.UInt32 System.IMultiplyOperators<System.UInt32,System.UInt32,System.UInt32>.operator *(System.UInt32 left, System.UInt32 right) { throw null; }
+        static System.UInt32 System.IShiftOperators<System.UInt32,System.UInt32>.operator <<(System.UInt32 value, int shiftAmount) { throw null; }
+        static System.UInt32 System.IShiftOperators<System.UInt32,System.UInt32>.operator >>(System.UInt32 value, int shiftAmount) { throw null; }
+        static System.UInt32 System.ISubtractionOperators<System.UInt32,System.UInt32,System.UInt32>.operator -(System.UInt32 left, System.UInt32 right) { throw null; }
+        static System.UInt32 System.IUnaryNegationOperators<System.UInt32,System.UInt32>.operator -(System.UInt32 value) { throw null; }
+        static System.UInt32 System.IUnaryPlusOperators<System.UInt32,System.UInt32>.operator +(System.UInt32 value) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString(string? format) { throw null; }
         public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
+        public static System.UInt32 TrailingZeroCount(System.UInt32 value) { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.UInt32 result) where TOther : INumber<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UInt32 result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.UInt32 result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out System.UInt32 result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UInt32 result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.UInt32 result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.UInt32 result) { throw null; }
-
-        static uint IAdditiveIdentity<uint, uint>.AdditiveIdentity { get { throw null; } }
-
-        static uint IMinMaxValue<uint>.MinValue { get { throw null; } }
-        static uint IMinMaxValue<uint>.MaxValue { get { throw null; } }
-
-        static uint IMultiplicativeIdentity<uint, uint>.MultiplicativeIdentity { get { throw null; } }
-
-        static uint INumber<uint>.One { get { throw null; } }
-        static uint INumber<uint>.Zero { get { throw null; } }
-
-        static uint IAdditionOperators<uint, uint, uint>.operator +(uint left, uint right) { throw null; }
-
-        static uint IBinaryInteger<uint>.LeadingZeroCount(uint value) { throw null; }
-        static uint IBinaryInteger<uint>.PopCount(uint value) { throw null; }
-        static uint IBinaryInteger<uint>.RotateLeft(uint value, int rotateAmount) { throw null; }
-        static uint IBinaryInteger<uint>.RotateRight(uint value, int rotateAmount) { throw null; }
-        static uint IBinaryInteger<uint>.TrailingZeroCount(uint value) { throw null; }
-
-        static bool IBinaryNumber<uint>.IsPow2(uint value) { throw null; }
-        static uint IBinaryNumber<uint>.Log2(uint value) { throw null; }
-
-        static uint IBitwiseOperators<uint, uint, uint>.operator &(uint left, uint right) { throw null; }
-        static uint IBitwiseOperators<uint, uint, uint>.operator |(uint left, uint right) { throw null; }
-        static uint IBitwiseOperators<uint, uint, uint>.operator ^(uint left, uint right) { throw null; }
-        static uint IBitwiseOperators<uint, uint, uint>.operator ~(uint value) { throw null; }
-
-        static bool IComparisonOperators<uint, uint>.operator <(uint left, uint right) { throw null; }
-        static bool IComparisonOperators<uint, uint>.operator <=(uint left, uint right) { throw null; }
-        static bool IComparisonOperators<uint, uint>.operator >(uint left, uint right) { throw null; }
-        static bool IComparisonOperators<uint, uint>.operator >=(uint left, uint right) { throw null; }
-
-        static uint IDecrementOperators<uint>.operator --(uint value) { throw null; }
-
-        static uint IDivisionOperators<uint, uint, uint>.operator /(uint left, uint right) { throw null; }
-
-        static bool IEqualityOperators<uint, uint>.operator ==(uint left, uint right) { throw null; }
-        static bool IEqualityOperators<uint, uint>.operator !=(uint left, uint right) { throw null; }
-
-        static uint IIncrementOperators<uint>.operator ++(uint value) { throw null; }
-
-        static uint IModulusOperators<uint, uint, uint>.operator %(uint left, uint right) { throw null; }
-
-        static uint IMultiplyOperators<uint, uint, uint>.operator *(uint left, uint right) { throw null; }
-
-        static uint INumber<uint>.Abs(uint value) { throw null; }
-        static uint INumber<uint>.Clamp(uint value, uint min, uint max) { throw null; }
-        static uint INumber<uint>.Create<TOther>(TOther value) { throw null; }
-        static uint INumber<uint>.CreateSaturating<TOther>(TOther value) { throw null; }
-        static uint INumber<uint>.CreateTruncating<TOther>(TOther value) { throw null; }
-        static (uint Quotient, uint Remainder) INumber<uint>.DivRem(uint left, uint right) { throw null; }
-        static uint INumber<uint>.Max(uint x, uint y) { throw null; }
-        static uint INumber<uint>.Min(uint x, uint y) { throw null; }
-        static uint INumber<uint>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static uint INumber<uint>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static uint INumber<uint>.Sign(uint value) { throw null; }
-        static bool INumber<uint>.TryCreate<TOther>(TOther value, out uint result) { throw null; }
-        static bool INumber<uint>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out uint result) { throw null; }
-        static bool INumber<uint>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out uint result) { throw null; }
-
-        static uint IParseable<uint>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<uint>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out uint result) { throw null; }
-
-        static uint IShiftOperators<uint, uint>.operator <<(uint value, int shiftAmount) { throw null; }
-        static uint IShiftOperators<uint, uint>.operator >>(uint value, int shiftAmount) { throw null; }
-
-        static uint ISpanParseable<uint>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<uint>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out uint result) { throw null; }
-
-        static uint ISubtractionOperators<uint, uint, uint>.operator -(uint left, uint right) { throw null; }
-
-        static uint IUnaryNegationOperators<uint, uint>.operator -(uint value) { throw null; }
-
-        static uint IUnaryPlusOperators<uint, uint>.operator +(uint value) { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
-    public readonly partial struct UInt64 : System.IComparable, System.IComparable<ulong>, System.IConvertible, System.IEquatable<ulong>, System.ISpanFormattable, System.IBinaryInteger<ulong>, System.IMinMaxValue<ulong>, System.IUnsignedNumber<ulong>
+    public readonly partial struct UInt64 : System.IAdditionOperators<ulong, ulong, ulong>, System.IAdditiveIdentity<ulong, ulong>, System.IBinaryInteger<ulong>, System.IBinaryNumber<ulong>, System.IBitwiseOperators<ulong, ulong, ulong>, System.IComparable, System.IComparable<ulong>, System.IComparisonOperators<ulong, ulong>, System.IConvertible, System.IDecrementOperators<ulong>, System.IDivisionOperators<ulong, ulong, ulong>, System.IEqualityOperators<ulong, ulong>, System.IEquatable<ulong>, System.IFormattable, System.IIncrementOperators<ulong>, System.IMinMaxValue<ulong>, System.IModulusOperators<ulong, ulong, ulong>, System.IMultiplicativeIdentity<ulong, ulong>, System.IMultiplyOperators<ulong, ulong, ulong>, System.INumber<ulong>, System.IParseable<ulong>, System.IShiftOperators<ulong, ulong>, System.ISpanFormattable, System.ISpanParseable<ulong>, System.ISubtractionOperators<ulong, ulong, ulong>, System.IUnaryNegationOperators<ulong, ulong>, System.IUnaryPlusOperators<ulong, ulong>, System.IUnsignedNumber<ulong>
     {
         private readonly ulong _dummyPrimitive;
+        public const ulong AdditiveIdentity = (ulong)0;
         public const ulong MaxValue = (ulong)18446744073709551615;
         public const ulong MinValue = (ulong)0;
+        public const ulong MultiplicativeIdentity = (ulong)1;
+        public const ulong One = (ulong)1;
+        public const ulong Zero = (ulong)0;
+        static ulong System.IAdditiveIdentity<System.UInt64,System.UInt64>.AdditiveIdentity { get { throw null; } }
+        static ulong System.IMinMaxValue<System.UInt64>.MaxValue { get { throw null; } }
+        static ulong System.IMinMaxValue<System.UInt64>.MinValue { get { throw null; } }
+        static ulong System.IMultiplicativeIdentity<System.UInt64,System.UInt64>.MultiplicativeIdentity { get { throw null; } }
+        static ulong System.INumber<System.UInt64>.One { get { throw null; } }
+        static ulong System.INumber<System.UInt64>.Zero { get { throw null; } }
+        public static System.UInt64 Abs(System.UInt64 value) { throw null; }
+        public static System.UInt64 Clamp(System.UInt64 value, System.UInt64 min, System.UInt64 max) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public int CompareTo(System.UInt64 value) { throw null; }
+        public static System.UInt64 CreateSaturating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.UInt64 CreateTruncating<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static System.UInt64 Create<TOther>(TOther value) where TOther : INumber<TOther> { throw null; }
+        public static (ulong Quotient, ulong Remainder) DivRem(System.UInt64 left, System.UInt64 right) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public bool Equals(System.UInt64 obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.TypeCode GetTypeCode() { throw null; }
+        public static bool IsPow2(System.UInt64 value) { throw null; }
+        public static System.UInt64 LeadingZeroCount(System.UInt64 value) { throw null; }
+        public static System.UInt64 Log2(System.UInt64 value) { throw null; }
+        public static System.UInt64 Max(System.UInt64 x, System.UInt64 y) { throw null; }
+        public static System.UInt64 Min(System.UInt64 x, System.UInt64 y) { throw null; }
         public static System.UInt64 Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider? provider = null) { throw null; }
+        public static System.UInt64 Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
         public static System.UInt64 Parse(string s) { throw null; }
         public static System.UInt64 Parse(string s, System.Globalization.NumberStyles style) { throw null; }
         public static System.UInt64 Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
         public static System.UInt64 Parse(string s, System.IFormatProvider? provider) { throw null; }
+        public static System.UInt64 PopCount(System.UInt64 value) { throw null; }
+        public static System.UInt64 RotateLeft(System.UInt64 value, int rotateAmount) { throw null; }
+        public static System.UInt64 RotateRight(System.UInt64 value, int rotateAmount) { throw null; }
+        public static System.UInt64 Sign(System.UInt64 value) { throw null; }
+        static System.UInt64 System.IAdditionOperators<System.UInt64,System.UInt64,System.UInt64>.operator +(System.UInt64 left, System.UInt64 right) { throw null; }
+        static System.UInt64 System.IBitwiseOperators<System.UInt64,System.UInt64,System.UInt64>.operator &(System.UInt64 left, System.UInt64 right) { throw null; }
+        static System.UInt64 System.IBitwiseOperators<System.UInt64,System.UInt64,System.UInt64>.operator |(System.UInt64 left, System.UInt64 right) { throw null; }
+        static System.UInt64 System.IBitwiseOperators<System.UInt64,System.UInt64,System.UInt64>.operator ^(System.UInt64 left, System.UInt64 right) { throw null; }
+        static System.UInt64 System.IBitwiseOperators<System.UInt64,System.UInt64,System.UInt64>.operator ~(System.UInt64 value) { throw null; }
+        static bool System.IComparisonOperators<System.UInt64,System.UInt64>.operator >(System.UInt64 left, System.UInt64 right) { throw null; }
+        static bool System.IComparisonOperators<System.UInt64,System.UInt64>.operator >=(System.UInt64 left, System.UInt64 right) { throw null; }
+        static bool System.IComparisonOperators<System.UInt64,System.UInt64>.operator <(System.UInt64 left, System.UInt64 right) { throw null; }
+        static bool System.IComparisonOperators<System.UInt64,System.UInt64>.operator <=(System.UInt64 left, System.UInt64 right) { throw null; }
         bool System.IConvertible.ToBoolean(System.IFormatProvider? provider) { throw null; }
         byte System.IConvertible.ToByte(System.IFormatProvider? provider) { throw null; }
         char System.IConvertible.ToChar(System.IFormatProvider? provider) { throw null; }
@@ -6264,92 +5837,34 @@ namespace System
         ushort System.IConvertible.ToUInt16(System.IFormatProvider? provider) { throw null; }
         uint System.IConvertible.ToUInt32(System.IFormatProvider? provider) { throw null; }
         System.UInt64 System.IConvertible.ToUInt64(System.IFormatProvider? provider) { throw null; }
+        static System.UInt64 System.IDecrementOperators<System.UInt64>.operator --(System.UInt64 value) { throw null; }
+        static System.UInt64 System.IDivisionOperators<System.UInt64,System.UInt64,System.UInt64>.operator /(System.UInt64 left, System.UInt64 right) { throw null; }
+        static bool System.IEqualityOperators<System.UInt64,System.UInt64>.operator ==(System.UInt64 left, System.UInt64 right) { throw null; }
+        static bool System.IEqualityOperators<System.UInt64,System.UInt64>.operator !=(System.UInt64 left, System.UInt64 right) { throw null; }
+        static System.UInt64 System.IIncrementOperators<System.UInt64>.operator ++(System.UInt64 value) { throw null; }
+        static System.UInt64 System.IModulusOperators<System.UInt64,System.UInt64,System.UInt64>.operator %(System.UInt64 left, System.UInt64 right) { throw null; }
+        static System.UInt64 System.IMultiplyOperators<System.UInt64,System.UInt64,System.UInt64>.operator *(System.UInt64 left, System.UInt64 right) { throw null; }
+        static System.UInt64 System.IShiftOperators<System.UInt64,System.UInt64>.operator <<(System.UInt64 value, int shiftAmount) { throw null; }
+        static System.UInt64 System.IShiftOperators<System.UInt64,System.UInt64>.operator >>(System.UInt64 value, int shiftAmount) { throw null; }
+        static System.UInt64 System.ISubtractionOperators<System.UInt64,System.UInt64,System.UInt64>.operator -(System.UInt64 left, System.UInt64 right) { throw null; }
+        static System.UInt64 System.IUnaryNegationOperators<System.UInt64,System.UInt64>.operator -(System.UInt64 value) { throw null; }
+        static System.UInt64 System.IUnaryPlusOperators<System.UInt64,System.UInt64>.operator +(System.UInt64 value) { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString(string? format) { throw null; }
         public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
+        public static System.UInt64 TrailingZeroCount(System.UInt64 value) { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out System.UInt64 result) where TOther : INumber<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UInt64 result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.UInt64 result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, out System.UInt64 result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UInt64 result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.UInt64 result) { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.UInt64 result) { throw null; }
-
-        static ulong IAdditiveIdentity<ulong, ulong>.AdditiveIdentity { get { throw null; } }
-
-        static ulong IMinMaxValue<ulong>.MinValue { get { throw null; } }
-        static ulong IMinMaxValue<ulong>.MaxValue { get { throw null; } }
-
-        static ulong IMultiplicativeIdentity<ulong, ulong>.MultiplicativeIdentity { get { throw null; } }
-
-        static ulong INumber<ulong>.One { get { throw null; } }
-        static ulong INumber<ulong>.Zero { get { throw null; } }
-
-        static ulong IAdditionOperators<ulong, ulong, ulong>.operator +(ulong left, ulong right) { throw null; }
-
-        static ulong IBinaryInteger<ulong>.LeadingZeroCount(ulong value) { throw null; }
-        static ulong IBinaryInteger<ulong>.PopCount(ulong value) { throw null; }
-        static ulong IBinaryInteger<ulong>.RotateLeft(ulong value, int rotateAmount) { throw null; }
-        static ulong IBinaryInteger<ulong>.RotateRight(ulong value, int rotateAmount) { throw null; }
-        static ulong IBinaryInteger<ulong>.TrailingZeroCount(ulong value) { throw null; }
-
-        static bool IBinaryNumber<ulong>.IsPow2(ulong value) { throw null; }
-        static ulong IBinaryNumber<ulong>.Log2(ulong value) { throw null; }
-
-        static ulong IBitwiseOperators<ulong, ulong, ulong>.operator &(ulong left, ulong right) { throw null; }
-        static ulong IBitwiseOperators<ulong, ulong, ulong>.operator |(ulong left, ulong right) { throw null; }
-        static ulong IBitwiseOperators<ulong, ulong, ulong>.operator ^(ulong left, ulong right) { throw null; }
-        static ulong IBitwiseOperators<ulong, ulong, ulong>.operator ~(ulong value) { throw null; }
-
-        static bool IComparisonOperators<ulong, ulong>.operator <(ulong left, ulong right) { throw null; }
-        static bool IComparisonOperators<ulong, ulong>.operator <=(ulong left, ulong right) { throw null; }
-        static bool IComparisonOperators<ulong, ulong>.operator >(ulong left, ulong right) { throw null; }
-        static bool IComparisonOperators<ulong, ulong>.operator >=(ulong left, ulong right) { throw null; }
-
-        static ulong IDecrementOperators<ulong>.operator --(ulong value) { throw null; }
-
-        static ulong IDivisionOperators<ulong, ulong, ulong>.operator /(ulong left, ulong right) { throw null; }
-
-        static bool IEqualityOperators<ulong, ulong>.operator ==(ulong left, ulong right) { throw null; }
-        static bool IEqualityOperators<ulong, ulong>.operator !=(ulong left, ulong right) { throw null; }
-
-        static ulong IIncrementOperators<ulong>.operator ++(ulong value) { throw null; }
-
-        static ulong IModulusOperators<ulong, ulong, ulong>.operator %(ulong left, ulong right) { throw null; }
-
-        static ulong IMultiplyOperators<ulong, ulong, ulong>.operator *(ulong left, ulong right) { throw null; }
-
-        static ulong INumber<ulong>.Abs(ulong value) { throw null; }
-        static ulong INumber<ulong>.Clamp(ulong value, ulong min, ulong max) { throw null; }
-        static ulong INumber<ulong>.Create<TOther>(TOther value) { throw null; }
-        static ulong INumber<ulong>.CreateSaturating<TOther>(TOther value) { throw null; }
-        static ulong INumber<ulong>.CreateTruncating<TOther>(TOther value) { throw null; }
-        static (ulong Quotient, ulong Remainder) INumber<ulong>.DivRem(ulong left, ulong right) { throw null; }
-        static ulong INumber<ulong>.Max(ulong x, ulong y) { throw null; }
-        static ulong INumber<ulong>.Min(ulong x, ulong y) { throw null; }
-        static ulong INumber<ulong>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static ulong INumber<ulong>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static ulong INumber<ulong>.Sign(ulong value) { throw null; }
-        static bool INumber<ulong>.TryCreate<TOther>(TOther value, out ulong result) { throw null; }
-        static bool INumber<ulong>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out ulong result) { throw null; }
-        static bool INumber<ulong>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out ulong result) { throw null; }
-
-        static ulong IParseable<ulong>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<ulong>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out ulong result) { throw null; }
-
-        static ulong IShiftOperators<ulong, ulong>.operator <<(ulong value, int shiftAmount) { throw null; }
-        static ulong IShiftOperators<ulong, ulong>.operator >>(ulong value, int shiftAmount) { throw null; }
-
-        static ulong ISpanParseable<ulong>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<ulong>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out ulong result) { throw null; }
-
-        static ulong ISubtractionOperators<ulong, ulong, ulong>.operator -(ulong left, ulong right) { throw null; }
-
-        static ulong IUnaryNegationOperators<ulong, ulong>.operator -(ulong value) { throw null; }
-
-        static ulong IUnaryPlusOperators<ulong, ulong>.operator +(ulong value) { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
-    public readonly partial struct UIntPtr : System.IComparable, System.IComparable<nuint>, System.IEquatable<nuint>, System.ISpanFormattable, System.Runtime.Serialization.ISerializable, System.IBinaryInteger<nuint>, System.IMinMaxValue<nuint>, System.IUnsignedNumber<nuint>
+    public readonly partial struct UIntPtr : System.IAdditionOperators<nuint, nuint, nuint>, System.IAdditiveIdentity<nuint, nuint>, System.IBinaryInteger<nuint>, System.IBinaryNumber<nuint>, System.IBitwiseOperators<nuint, nuint, nuint>, System.IComparable, System.IComparable<nuint>, System.IComparisonOperators<nuint, nuint>, System.IDecrementOperators<nuint>, System.IDivisionOperators<nuint, nuint, nuint>, System.IEqualityOperators<nuint, nuint>, System.IEquatable<nuint>, System.IFormattable, System.IIncrementOperators<nuint>, System.IMinMaxValue<nuint>, System.IModulusOperators<nuint, nuint, nuint>, System.IMultiplicativeIdentity<nuint, nuint>, System.IMultiplyOperators<nuint, nuint, nuint>, System.INumber<nuint>, System.IParseable<nuint>, System.IShiftOperators<nuint, nuint>, System.ISpanFormattable, System.ISpanParseable<nuint>, System.ISubtractionOperators<nuint, nuint, nuint>, System.IUnaryNegationOperators<nuint, nuint>, System.IUnaryPlusOperators<nuint, nuint>, System.IUnsignedNumber<nuint>, System.Runtime.Serialization.ISerializable
     {
         private readonly int _dummyPrimitive;
         public static readonly System.UIntPtr Zero;
@@ -6359,6 +5874,12 @@ namespace System
         public static System.UIntPtr MaxValue { get { throw null; } }
         public static System.UIntPtr MinValue { get { throw null; } }
         public static int Size { get { throw null; } }
+        static nuint System.IAdditiveIdentity<nuint,nuint>.AdditiveIdentity { get { throw null; } }
+        static nuint System.IMinMaxValue<nuint>.MaxValue { get { throw null; } }
+        static nuint System.IMinMaxValue<nuint>.MinValue { get { throw null; } }
+        static nuint System.IMultiplicativeIdentity<nuint,nuint>.MultiplicativeIdentity { get { throw null; } }
+        static nuint System.INumber<nuint>.One { get { throw null; } }
+        static nuint System.INumber<nuint>.Zero { get { throw null; } }
         public static System.UIntPtr Add(System.UIntPtr pointer, int offset) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public int CompareTo(System.UIntPtr value) { throw null; }
@@ -6375,13 +5896,49 @@ namespace System
         public unsafe static explicit operator System.UIntPtr (void* value) { throw null; }
         public static bool operator !=(System.UIntPtr value1, System.UIntPtr value2) { throw null; }
         public static System.UIntPtr operator -(System.UIntPtr pointer, int offset) { throw null; }
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
+        public static System.UIntPtr Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider? provider = null) { throw null; }
+        public static System.UIntPtr Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
         public static System.UIntPtr Parse(string s) { throw null; }
         public static System.UIntPtr Parse(string s, System.Globalization.NumberStyles style) { throw null; }
         public static System.UIntPtr Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
         public static System.UIntPtr Parse(string s, System.IFormatProvider? provider) { throw null; }
-        public static System.UIntPtr Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider? provider = null) { throw null; }
         public static System.UIntPtr Subtract(System.UIntPtr pointer, int offset) { throw null; }
+        static nuint System.IAdditionOperators<nuint,nuint,nuint>.operator +(nuint left, nuint right) { throw null; }
+        static nuint System.IBinaryInteger<nuint>.LeadingZeroCount(nuint value) { throw null; }
+        static nuint System.IBinaryInteger<nuint>.PopCount(nuint value) { throw null; }
+        static nuint System.IBinaryInteger<nuint>.RotateLeft(nuint value, int rotateAmount) { throw null; }
+        static nuint System.IBinaryInteger<nuint>.RotateRight(nuint value, int rotateAmount) { throw null; }
+        static nuint System.IBinaryInteger<nuint>.TrailingZeroCount(nuint value) { throw null; }
+        static bool System.IBinaryNumber<nuint>.IsPow2(nuint value) { throw null; }
+        static nuint System.IBinaryNumber<nuint>.Log2(nuint value) { throw null; }
+        static nuint System.IBitwiseOperators<nuint,nuint,nuint>.operator &(nuint left, nuint right) { throw null; }
+        static nuint System.IBitwiseOperators<nuint,nuint,nuint>.operator |(nuint left, nuint right) { throw null; }
+        static nuint System.IBitwiseOperators<nuint,nuint,nuint>.operator ^(nuint left, nuint right) { throw null; }
+        static nuint System.IBitwiseOperators<nuint,nuint,nuint>.operator ~(nuint value) { throw null; }
+        static bool System.IComparisonOperators<nuint,nuint>.operator >(nuint left, nuint right) { throw null; }
+        static bool System.IComparisonOperators<nuint,nuint>.operator >=(nuint left, nuint right) { throw null; }
+        static bool System.IComparisonOperators<nuint,nuint>.operator <(nuint left, nuint right) { throw null; }
+        static bool System.IComparisonOperators<nuint,nuint>.operator <=(nuint left, nuint right) { throw null; }
+        static nuint System.IDecrementOperators<nuint>.operator --(nuint value) { throw null; }
+        static nuint System.IDivisionOperators<nuint,nuint,nuint>.operator /(nuint left, nuint right) { throw null; }
+        static nuint System.IIncrementOperators<nuint>.operator ++(nuint value) { throw null; }
+        static nuint System.IModulusOperators<nuint,nuint,nuint>.operator %(nuint left, nuint right) { throw null; }
+        static nuint System.IMultiplyOperators<nuint,nuint,nuint>.operator *(nuint left, nuint right) { throw null; }
+        static nuint System.INumber<nuint>.Abs(nuint value) { throw null; }
+        static nuint System.INumber<nuint>.Clamp(nuint value, nuint min, nuint max) { throw null; }
+        static nuint System.INumber<nuint>.CreateSaturating<TOther>(TOther value) { throw null; }
+        static nuint System.INumber<nuint>.CreateTruncating<TOther>(TOther value) { throw null; }
+        static nuint System.INumber<nuint>.Create<TOther>(TOther value) { throw null; }
+        static (nuint Quotient, nuint Remainder) System.INumber<nuint>.DivRem(nuint left, nuint right) { throw null; }
+        static nuint System.INumber<nuint>.Max(nuint x, nuint y) { throw null; }
+        static nuint System.INumber<nuint>.Min(nuint x, nuint y) { throw null; }
+        static nuint System.INumber<nuint>.Sign(nuint value) { throw null; }
+        static bool System.INumber<nuint>.TryCreate<TOther>(TOther value, out nuint result) { throw null; }
+        static nuint System.IShiftOperators<nuint,nuint>.operator <<(nuint value, int shiftAmount) { throw null; }
+        static nuint System.IShiftOperators<nuint,nuint>.operator >>(nuint value, int shiftAmount) { throw null; }
+        static nuint System.ISubtractionOperators<nuint,nuint,nuint>.operator -(nuint left, nuint right) { throw null; }
+        static nuint System.IUnaryNegationOperators<nuint,nuint>.operator -(nuint value) { throw null; }
+        static nuint System.IUnaryPlusOperators<nuint,nuint>.operator +(nuint value) { throw null; }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public unsafe void* ToPointer() { throw null; }
         public override string ToString() { throw null; }
@@ -6390,84 +5947,13 @@ namespace System
         public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
         public uint ToUInt32() { throw null; }
         public ulong ToUInt64() { throw null; }
-        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UIntPtr result) { throw null; }
-        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.UIntPtr result) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.UIntPtr result) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UIntPtr result) { throw null; }
-
-        static nuint IAdditiveIdentity<nuint, nuint>.AdditiveIdentity { get { throw null; } }
-
-        static nuint IMinMaxValue<nuint>.MinValue { get { throw null; } }
-        static nuint IMinMaxValue<nuint>.MaxValue { get { throw null; } }
-
-        static nuint IMultiplicativeIdentity<nuint, nuint>.MultiplicativeIdentity { get { throw null; } }
-
-        static nuint INumber<nuint>.One { get { throw null; } }
-        static nuint INumber<nuint>.Zero { get { throw null; } }
-
-        static nuint IAdditionOperators<nuint, nuint, nuint>.operator +(nuint left, nuint right) { throw null; }
-
-        static nuint IBinaryInteger<nuint>.LeadingZeroCount(nuint value) { throw null; }
-        static nuint IBinaryInteger<nuint>.PopCount(nuint value) { throw null; }
-        static nuint IBinaryInteger<nuint>.RotateLeft(nuint value, int rotateAmount) { throw null; }
-        static nuint IBinaryInteger<nuint>.RotateRight(nuint value, int rotateAmount) { throw null; }
-        static nuint IBinaryInteger<nuint>.TrailingZeroCount(nuint value) { throw null; }
-
-        static bool IBinaryNumber<nuint>.IsPow2(nuint value) { throw null; }
-        static nuint IBinaryNumber<nuint>.Log2(nuint value) { throw null; }
-
-        static nuint IBitwiseOperators<nuint, nuint, nuint>.operator &(nuint left, nuint right) { throw null; }
-        static nuint IBitwiseOperators<nuint, nuint, nuint>.operator |(nuint left, nuint right) { throw null; }
-        static nuint IBitwiseOperators<nuint, nuint, nuint>.operator ^(nuint left, nuint right) { throw null; }
-        static nuint IBitwiseOperators<nuint, nuint, nuint>.operator ~(nuint value) { throw null; }
-
-        static bool IComparisonOperators<nuint, nuint>.operator <(nuint left, nuint right) { throw null; }
-        static bool IComparisonOperators<nuint, nuint>.operator <=(nuint left, nuint right) { throw null; }
-        static bool IComparisonOperators<nuint, nuint>.operator >(nuint left, nuint right) { throw null; }
-        static bool IComparisonOperators<nuint, nuint>.operator >=(nuint left, nuint right) { throw null; }
-
-        static nuint IDecrementOperators<nuint>.operator --(nuint value) { throw null; }
-
-        static nuint IDivisionOperators<nuint, nuint, nuint>.operator /(nuint left, nuint right) { throw null; }
-
-        static bool IEqualityOperators<nuint, nuint>.operator ==(nuint left, nuint right) { throw null; }
-        static bool IEqualityOperators<nuint, nuint>.operator !=(nuint left, nuint right) { throw null; }
-
-        static nuint IIncrementOperators<nuint>.operator ++(nuint value) { throw null; }
-
-        static nuint IModulusOperators<nuint, nuint, nuint>.operator %(nuint left, nuint right) { throw null; }
-
-        static nuint IMultiplyOperators<nuint, nuint, nuint>.operator *(nuint left, nuint right) { throw null; }
-
-        static nuint INumber<nuint>.Abs(nuint value) { throw null; }
-        static nuint INumber<nuint>.Clamp(nuint value, nuint min, nuint max) { throw null; }
-        static nuint INumber<nuint>.Create<TOther>(TOther value) { throw null; }
-        static nuint INumber<nuint>.CreateSaturating<TOther>(TOther value) { throw null; }
-        static nuint INumber<nuint>.CreateTruncating<TOther>(TOther value) { throw null; }
-        static (nuint Quotient, nuint Remainder) INumber<nuint>.DivRem(nuint left, nuint right) { throw null; }
-        static nuint INumber<nuint>.Max(nuint x, nuint y) { throw null; }
-        static nuint INumber<nuint>.Min(nuint x, nuint y) { throw null; }
-        static nuint INumber<nuint>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static nuint INumber<nuint>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        static nuint INumber<nuint>.Sign(nuint value) { throw null; }
-        static bool INumber<nuint>.TryCreate<TOther>(TOther value, out nuint result) { throw null; }
-        static bool INumber<nuint>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out nuint result) { throw null; }
-        static bool INumber<nuint>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out nuint result) { throw null; }
-
-        static nuint IParseable<nuint>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        static bool IParseable<nuint>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out nuint result) { throw null; }
-
-        static nuint IShiftOperators<nuint, nuint>.operator <<(nuint value, int shiftAmount) { throw null; }
-        static nuint IShiftOperators<nuint, nuint>.operator >>(nuint value, int shiftAmount) { throw null; }
-
-        static nuint ISpanParseable<nuint>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        static bool ISpanParseable<nuint>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out nuint result) { throw null; }
-
-        static nuint ISubtractionOperators<nuint, nuint, nuint>.operator -(nuint left, nuint right) { throw null; }
-
-        static nuint IUnaryNegationOperators<nuint, nuint>.operator -(nuint value) { throw null; }
-
-        static nuint IUnaryPlusOperators<nuint, nuint>.operator +(nuint value) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.UIntPtr result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, out System.UIntPtr result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UIntPtr result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.UIntPtr result) { throw null; }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.UIntPtr result) { throw null; }
     }
     public partial class UnauthorizedAccessException : System.SystemException
     {


### PR DESCRIPTION
Notably this deviates from API review slightly. In API review, it was determined that interfaces should be implicitly implemented. However, most types cannot implement the operators implicitly. This comes down to causing issues with `System.Linq.Expressions` for a couple types and it being a technically problematic scenario from the perspective of the C# Language Spec (but not the current Roslyn implementation). Likewise, `IntPtr` and `UIntPtr` have a pending design discussion with relevant folks from the C# Language Design Team to determine what the penultimate behavior is going to be.

The meeting around IntPtr/UIntPtr is going to happen before the next API review and the deviation here is going to be raised in the next API review. It shouldn't be considered a blocker, however.