### PR TITLE
[mono] Hot Reload: support for reloadable types

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddNestedClass/AddNestedClass.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddNestedClass/AddNestedClass.cs
@@ -7,6 +7,10 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
 {
     public class AddNestedClass
     {
+        public static Action<string> X; // make the linker happy
+        public static Delegate Y;
+        public event Action<string> Evt;
+        public void R () { Evt ("123"); }
         public AddNestedClass()
         {
         }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddNestedClass/AddNestedClass_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddNestedClass/AddNestedClass_v1.cs
@@ -7,6 +7,10 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
 {
     public class AddNestedClass
     {
+        public static Action<string> X; // make the linker happy
+        public static Delegate Y;
+        public event Action<string> Evt;
+        public void R () { Evt ("123"); }
         public AddNestedClass()
         {
         }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddNestedClass/AddNestedClass_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddNestedClass/AddNestedClass_v1.cs
@@ -13,16 +13,18 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
 
         public string TestMethod()
         {
-            var n = new Nested();
+            var n = new Nested<string, int>();
             n.f = "123";
+	    n.g = 456;
             return n.M();
         }
 
-        private class Nested {
+        private class Nested<T, U> {
             public Nested() { }
-            internal string f;
+            internal T f;
+	    internal U g;
             public string M () {
-                return f + "456";
+                return f.ToString() + g.ToString();
             }
         }
     }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddNestedClass/AddNestedClass_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddNestedClass/AddNestedClass_v1.cs
@@ -16,7 +16,9 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
             var n = new Nested<string, int>();
             n.Eff = "123";
 	    n.g = 456;
-            return n.M();
+	    n.Evt += new Action<string> (n.DefaultHandler);
+	    n.RaiseEvt();
+            return n.M() + n.buf;
         }
 
         private class Nested<T, U> {
@@ -30,6 +32,18 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
             public string M () {
                 return Eff.ToString() + g.ToString();
             }
+
+	    public event Action<string> Evt;
+
+	    public void RaiseEvt () {
+		Evt ("789");
+	    }
+
+	    public string buf;
+
+	    public void DefaultHandler (string s) {
+		this.buf = s;
+	    }
         }
     }
 }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddNestedClass/AddNestedClass_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddNestedClass/AddNestedClass_v1.cs
@@ -15,35 +15,35 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
         {
             var n = new Nested<string, int>();
             n.Eff = "123";
-	    n.g = 456;
-	    n.Evt += new Action<string> (n.DefaultHandler);
-	    n.RaiseEvt();
+            n.g = 456;
+            n.Evt += new Action<string> (n.DefaultHandler);
+            n.RaiseEvt();
             return n.M() + n.buf;
         }
 
         private class Nested<T, U> {
             public Nested() { }
             internal T f;
-	    internal U g;
-	    public T Eff {
-		get => f;
-		set { f = value; }
-	    }
+            internal U g;
+            public T Eff {
+                get => f;
+                set { f = value; }
+            }
             public string M () {
                 return Eff.ToString() + g.ToString();
             }
 
-	    public event Action<string> Evt;
+            public event Action<string> Evt;
 
-	    public void RaiseEvt () {
-		Evt ("789");
-	    }
+            public void RaiseEvt () {
+                Evt ("789");
+            }
 
-	    public string buf;
+            public string buf;
 
-	    public void DefaultHandler (string s) {
-		this.buf = s;
-	    }
+            public void DefaultHandler (string s) {
+                this.buf = s;
+            }
         }
     }
 }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddNestedClass/AddNestedClass_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddNestedClass/AddNestedClass_v1.cs
@@ -14,7 +14,7 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
         public string TestMethod()
         {
             var n = new Nested<string, int>();
-            n.f = "123";
+            n.Eff = "123";
 	    n.g = 456;
             return n.M();
         }
@@ -23,8 +23,12 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
             public Nested() { }
             internal T f;
 	    internal U g;
+	    public T Eff {
+		get => f;
+		set { f = value; }
+	    }
             public string M () {
-                return f.ToString() + g.ToString();
+                return Eff.ToString() + g.ToString();
             }
         }
     }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType.cs
@@ -11,4 +11,5 @@ public interface IExistingInterface {
 
 public class ZExistingClass
 {
+    public class PreviousNestedClass { }
 }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+
+
+namespace System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType;
+
+public interface IExistingInterface {
+    public string ItfMethod(int i);
+}
+
+public class ZExistingClass
+{
+}

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType.cs
@@ -13,3 +13,10 @@ public class ZExistingClass
 {
     public class PreviousNestedClass { }
 }
+
+[AttributeUsage(AttributeTargets.All, AllowMultiple=true, Inherited=false)]
+public class CustomNoteAttribute : Attribute {
+    public CustomNoteAttribute(string note) {Note = note;}
+
+    public string Note;
+}

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType.cs
@@ -9,9 +9,22 @@ public interface IExistingInterface {
     public string ItfMethod(int i);
 }
 
+public struct QExistingStruct
+{
+}
+
+public enum FExistingEnum {
+    One, Two
+}
+
 public class ZExistingClass
 {
-    public class PreviousNestedClass { }
+    public class PreviousNestedClass {
+        public static DateTime Now; // make the linker happy
+        public static ICloneable C;
+        public event EventHandler<string> E;
+        public void R() { E(this,"123"); }
+    }
 }
 
 [AttributeUsage(AttributeTargets.All, AllowMultiple=true, Inherited=false)]

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
@@ -17,11 +17,14 @@ public class ZExistingClass
 
     public string NewMethod (string s, int i) => s + i.ToString();
 
+    // Mono doesn't support instance fields yet
+#if false
     public int NewField;
+#endif
 
     public static DateTime NewStaticField;
 
-    public double NewProp { get; set; }
+    public static double NewProp { get; set; }
 }
 
 [AttributeUsage(AttributeTargets.All, AllowMultiple=true, Inherited=false)]

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
@@ -19,6 +19,8 @@ public class ZExistingClass
 
     public int NewField;
 
+    public static DateTime NewStaticField;
+
     public double NewProp { get; set; }
 }
 

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
@@ -13,6 +13,13 @@ public class ZExistingClass
 {
     public class PreviousNestedClass { }
     public class NewNestedClass {};
+
+
+    public string NewMethod (string s, int i) => s + i.ToString();
+
+    public int NewField;
+
+    public double NewProp { get; set; }
 }
 
 public class NewToplevelClass : IExistingInterface, ICloneable {

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
@@ -11,6 +11,7 @@ public interface IExistingInterface {
 
 public class ZExistingClass
 {
+    public class PreviousNestedClass { }
     public class NewNestedClass {};
 }
 
@@ -19,8 +20,16 @@ public class NewToplevelClass : IExistingInterface, ICloneable {
         return i.ToString();
     }
 
-    public object Clone() {
+    public virtual object Clone() {
         return new NewToplevelClass();
+    }
+
+    public class AlsoNested { }
+}
+
+public class NewGenericClass<T> : NewToplevelClass {
+    public override object Clone() {
+	return new NewGenericClass<T>();
     }
 }
 
@@ -29,4 +38,8 @@ public struct NewToplevelStruct  {
 
 public interface INewInterface : IExistingInterface {
     public int AddedItfMethod (string s);
+}
+
+public enum NewEnum {
+    Red, Yellow, Green
 }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
@@ -9,9 +9,22 @@ public interface IExistingInterface {
     public string ItfMethod(int i);
 }
 
+public struct QExistingStruct
+{
+}
+
+public enum FExistingEnum {
+    One, Two
+}
+
 public class ZExistingClass
 {
-    public class PreviousNestedClass { }
+    public class PreviousNestedClass {
+        public static DateTime Now; // make the linker happy
+        public static ICloneable C;
+        public event EventHandler<string> E;
+        public void R() { E(this,"123"); }
+    }
     public class NewNestedClass {};
 
 

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
@@ -24,10 +24,21 @@ public class ZExistingClass
     public double NewProp { get; set; }
 }
 
+[AttributeUsage(AttributeTargets.All, AllowMultiple=true, Inherited=false)]
+public class CustomNoteAttribute : Attribute {
+    public CustomNoteAttribute(string note) {Note = note;}
+
+    public string Note;
+}
+
+[CustomNote("123")]
 public class NewToplevelClass : IExistingInterface, ICloneable {
     public string ItfMethod(int i) {
         return i.ToString();
     }
+
+    [CustomNote("abcd")]
+    public void SomeMethod(int x) {}
 
     public virtual object Clone() {
         return new NewToplevelClass();
@@ -35,6 +46,7 @@ public class NewToplevelClass : IExistingInterface, ICloneable {
 
     public class AlsoNested { }
 
+    [CustomNote("hijkl")]
     public float NewProp {get; set;}
 
     public byte[] OtherNewProp {get; set;}

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
@@ -57,7 +57,7 @@ public class NewToplevelClass : IExistingInterface, ICloneable {
 
 public class NewGenericClass<T> : NewToplevelClass {
     public override object Clone() {
-	return new NewGenericClass<T>();
+        return new NewGenericClass<T>();
     }
 }
 

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+
+
+namespace System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType;
+
+public interface IExistingInterface {
+    public string ItfMethod(int i);
+}
+
+public class ZExistingClass
+{
+    public class NewNestedClass {};
+}
+
+public class NewToplevelClass : IExistingInterface, ICloneable {
+    public string ItfMethod(int i) {
+        return i.ToString();
+    }
+
+    public object Clone() {
+        return new NewToplevelClass();
+    }
+}
+
+public struct NewToplevelStruct  {
+}
+
+public interface INewInterface : IExistingInterface {
+    public int AddedItfMethod (string s);
+}

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
@@ -34,6 +34,11 @@ public class NewToplevelClass : IExistingInterface, ICloneable {
     }
 
     public class AlsoNested { }
+
+    public float NewProp {get; set;}
+
+    public byte[] OtherNewProp {get; set;}
+
 }
 
 public class NewGenericClass<T> : NewToplevelClass {

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
@@ -39,6 +39,8 @@ public class NewToplevelClass : IExistingInterface, ICloneable {
 
     public byte[] OtherNewProp {get; set;}
 
+    public event EventHandler<string> NewEvent;
+    public event EventHandler<byte> OtherNewEvent;
 }
 
 public class NewGenericClass<T> : NewToplevelClass {

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>System.Runtime.Loader.Tests</RootNamespace>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TestRuntime>true</TestRuntime>
+    <DeltaScript>deltascript.json</DeltaScript>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ReflectionAddNewType.cs" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/deltascript.json
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/deltascript.json
@@ -1,0 +1,6 @@
+{
+    "changes": [
+        {"document": "ReflectionAddNewType.cs", "update": "ReflectionAddNewType_v1.cs"},
+    ]
+}
+

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -501,6 +501,28 @@ namespace System.Reflection.Metadata
 		    Assert.Equal(newField, ty.GetField("NewField"));
 		    Assert.Equal(newStaticField, ty.GetField("NewStaticField", BindingFlags.Static | BindingFlags.Public));
 
+		    // FIXME: finish this
+#if false
+		    var allProperties = ty.GetProperties();
+
+		    PropertyInfo newProp = null;
+		    foreach (var prop in allProperties)
+		    {
+			if (prop.Name == "NewProp")
+			    newProp = prop;
+		    }
+		    Assert.NotNull(newProp);
+
+		    Assert.Equal(newProp, ty.GetProperty("NewProp"));
+
+		    MethodInfo newPropGet = newProp.GetGetMethod();
+		    Assert.NotNull(newPropGet);
+		    MethodInfo newPropSet = newProp.GetSetMethod();
+		    Assert.NotNull(newPropSet);
+
+		    Assert.Equal("get_NewProp", newPropGet.Name);
+#endif
+
 		});
 		CheckReflectedType(assm, allTypes, ns, "ZExistingClass+PreviousNestedClass");
 		CheckReflectedType(assm, allTypes, ns, "IExistingInterface");
@@ -535,7 +557,17 @@ namespace System.Reflection.Metadata
 		CheckReflectedType(assm, allTypes, ns, "NewGenericClass`1");
 		CheckReflectedType(assm, allTypes, ns, "NewToplevelStruct");
 		CheckReflectedType(assm, allTypes, ns, "INewInterface");
-		CheckReflectedType(assm, allTypes, ns, "NewEnum");
+		CheckReflectedType(assm, allTypes, ns, "NewEnum", static (ty) => {
+#if false
+		    var names = Enum.GetNames (ty);
+		    Assert.Equal(3, names.Length);
+		    var vals = Enum.GetValues (ty);
+		    Assert.Equal(3, vals.Length);
+
+		    Assert.NotNull(Enum.Parse (ty, "Red"));
+		    Assert.NotNull(Enum.Parse (ty, "Yellow"));
+#endif
+		});
 
 		// make some instances using reflection and use them through known interfaces
 		var o = Activator.CreateInstance(newTy);

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -324,7 +324,7 @@ namespace System.Reflection.Metadata
 
                 r = x.TestMethod();
 
-                Assert.Equal("123456", r);
+                Assert.Equal("123456789", r);
             });
         }
 

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -513,19 +513,26 @@ namespace System.Reflection.Metadata
 
                     var allFields = ty.GetFields(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public);
 
+                    // Mono doesn't do instance fields yet
+#if false
                     FieldInfo newField = null;
+#endif
                     FieldInfo newStaticField = null;
                     foreach (var fld in allFields)
                     {
+#if false
                         if (fld.Name == "NewField")
                             newField = fld;
+#endif
                         if (fld.Name == "NewStaticField")
                             newStaticField = fld;
                     }
+#if false
                     Assert.NotNull(newField);
-                    Assert.NotNull(newStaticField);
-
                     Assert.Equal(newField, ty.GetField("NewField"));
+#endif
+
+                    Assert.NotNull(newStaticField);
                     Assert.Equal(newStaticField, ty.GetField("NewStaticField", BindingFlags.Static | BindingFlags.Public));
 
                 });

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -476,7 +476,7 @@ namespace System.Reflection.Metadata
 
 		CheckReflectedType(assm, allTypes, ns, "ZExistingClass+NewNestedClass");
 
-		CheckReflectedType(assm, allTypes, ns, "NewToplevelClass", static (ty) => {
+		var newTy = CheckReflectedType(assm, allTypes, ns, "NewToplevelClass", static (ty) => {
 		    var nested = ty.GetNestedType("AlsoNested");
 		    var allNested = ty.GetNestedTypes();
 
@@ -485,13 +485,32 @@ namespace System.Reflection.Metadata
 
 		    Assert.Equal(1, allNested.Length);
 		    Assert.Same(nested, allNested[0]);
+
+		    var allInterfaces = ty.GetInterfaces();
+
+		    Assert.Equal (2, allInterfaces.Length);
+		    bool hasICloneable = false, hasINewInterface = false;
+		    for (int i = 0; i < allInterfaces.Length; ++i) {
+			var itf = allInterfaces[i];
+			if (itf.Name == "ICloneable")
+			    hasICloneable = true;
+			if (itf.Name == "IExistingInterface")
+			    hasINewInterface = true;
+		    }
+		    Assert.True (hasICloneable);
+		    Assert.True (hasINewInterface);
 		});
 		CheckReflectedType(assm, allTypes, ns, "NewGenericClass`1");
 		CheckReflectedType(assm, allTypes, ns, "NewToplevelStruct");
 		CheckReflectedType(assm, allTypes, ns, "INewInterface");
 		CheckReflectedType(assm, allTypes, ns, "NewEnum");
 
+		// make some instances using reflection and use them through known interfaces
+		var o = Activator.CreateInstance (newTy);
 
+		var i = (System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType.IExistingInterface)o;
+
+		Assert.Equal ("123", i.ItfMethod (123));
 	    });
 	}
     }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -553,6 +553,24 @@ namespace System.Reflection.Metadata
 		    }
 		    Assert.True(hasICloneable);
 		    Assert.True(hasINewInterface);
+
+		    var allProperties = ty.GetProperties();
+
+		    PropertyInfo newProp = null;
+		    foreach (var prop in allProperties)
+		    {
+			if (prop.Name == "NewProp")
+			    newProp = prop;
+		    }
+		    Assert.NotNull(newProp);
+
+		    Assert.Equal(newProp, ty.GetProperty("NewProp"));
+		    MethodInfo newPropGet = newProp.GetGetMethod();
+		    Assert.NotNull(newPropGet);
+		    MethodInfo newPropSet = newProp.GetSetMethod();
+		    Assert.NotNull(newPropSet);
+
+		    Assert.Equal("get_NewProp", newPropGet.Name);
 		});
 		CheckReflectedType(assm, allTypes, ns, "NewGenericClass`1");
 		CheckReflectedType(assm, allTypes, ns, "NewToplevelStruct");

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -528,28 +528,6 @@ namespace System.Reflection.Metadata
                     Assert.Equal(newField, ty.GetField("NewField"));
                     Assert.Equal(newStaticField, ty.GetField("NewStaticField", BindingFlags.Static | BindingFlags.Public));
 
-                    // FIXME: finish this
-#if false
-                    var allProperties = ty.GetProperties();
-
-                    PropertyInfo newProp = null;
-                    foreach (var prop in allProperties)
-                    {
-                        if (prop.Name == "NewProp")
-                            newProp = prop;
-                    }
-                    Assert.NotNull(newProp);
-
-                    Assert.Equal(newProp, ty.GetProperty("NewProp"));
-
-                    MethodInfo newPropGet = newProp.GetGetMethod();
-                    Assert.NotNull(newPropGet);
-                    MethodInfo newPropSet = newProp.GetSetMethod();
-                    Assert.NotNull(newPropSet);
-
-                    Assert.Equal("get_NewProp", newPropGet.Name);
-#endif
-
                 });
                 CheckReflectedType(assm, allTypes, ns, "ZExistingClass+PreviousNestedClass");
                 CheckReflectedType(assm, allTypes, ns, "IExistingInterface");

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -306,7 +306,6 @@ namespace System.Reflection.Metadata
             });
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/63643", TestRuntimes.Mono)]
         [ConditionalFact(typeof(ApplyUpdateUtil), nameof(ApplyUpdateUtil.IsSupported))]
         public static void TestAddNestedClass()
         {

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -470,13 +470,40 @@ namespace System.Reflection.Metadata
 
 		allTypes = assm.GetTypes();
 
-		CheckReflectedType(assm, allTypes, ns, "ZExistingClass");
+		CheckReflectedType(assm, allTypes, ns, "ZExistingClass", static (ty) =>
+		{
+		    var allMethods = ty.GetMethods();
+
+		    MethodInfo newMethod = null;
+		    foreach (var meth in allMethods)
+		    {
+			if (meth.Name == "NewMethod")
+			    newMethod = meth;
+		    }
+		    Assert.NotNull (newMethod);
+
+		    Assert.Equal (newMethod, ty.GetMethod ("NewMethod"));
+
+		    var allFields = ty.GetFields();
+
+		    FieldInfo newField = null;
+		    foreach (var fld in allFields)
+		    {
+			if (fld.Name == "NewField")
+			    newField = fld;
+		    }
+		    Assert.NotNull(newField);
+
+		    Assert.Equal(newField, ty.GetField("NewField"));
+
+		});
 		CheckReflectedType(assm, allTypes, ns, "ZExistingClass+PreviousNestedClass");
 		CheckReflectedType(assm, allTypes, ns, "IExistingInterface");
 
 		CheckReflectedType(assm, allTypes, ns, "ZExistingClass+NewNestedClass");
 
-		var newTy = CheckReflectedType(assm, allTypes, ns, "NewToplevelClass", static (ty) => {
+		var newTy = CheckReflectedType(assm, allTypes, ns, "NewToplevelClass", static (ty) =>
+		{
 		    var nested = ty.GetNestedType("AlsoNested");
 		    var allNested = ty.GetNestedTypes();
 
@@ -497,8 +524,8 @@ namespace System.Reflection.Metadata
 			if (itf.Name == "IExistingInterface")
 			    hasINewInterface = true;
 		    }
-		    Assert.True (hasICloneable);
-		    Assert.True (hasINewInterface);
+		    Assert.True(hasICloneable);
+		    Assert.True(hasINewInterface);
 		});
 		CheckReflectedType(assm, allTypes, ns, "NewGenericClass`1");
 		CheckReflectedType(assm, allTypes, ns, "NewToplevelStruct");
@@ -506,11 +533,11 @@ namespace System.Reflection.Metadata
 		CheckReflectedType(assm, allTypes, ns, "NewEnum");
 
 		// make some instances using reflection and use them through known interfaces
-		var o = Activator.CreateInstance (newTy);
+		var o = Activator.CreateInstance(newTy);
 
 		var i = (System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType.IExistingInterface)o;
 
-		Assert.Equal ("123", i.ItfMethod (123));
+		Assert.Equal("123", i.ItfMethod(123));
 	    });
 	}
     }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -428,219 +428,219 @@ namespace System.Reflection.Metadata
             });
         }
 
-	private static bool ContainsTypeWithName(Type[] types, string fullName)
-	{
-	    foreach (var ty in types) {
-		if (ty.FullName == fullName)
-		    return true;
-	    }
-	    return false;
-	}
+        private static bool ContainsTypeWithName(Type[] types, string fullName)
+        {
+            foreach (var ty in types) {
+                if (ty.FullName == fullName)
+                    return true;
+            }
+            return false;
+        }
 
-	internal static Type CheckReflectedType(Assembly assm, Type[] allTypes, string nameSpace, string typeName, Action<Type> moreChecks = null, [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
-	{
-	    var fullName = $"{nameSpace}.{typeName}";
-	    var ty = assm.GetType(fullName);
-	    Assert.True(ty != null, $"{callerFilePath}:{callerLineNumber}: expected Assembly.GetType for '{typeName}' to return non-null in {callerMemberName}");
-	    int nestedIdx = typeName.LastIndexOf('+');
-	    string comparisonName = typeName;
-	    if (nestedIdx != -1)
-		comparisonName = typeName.Substring(nestedIdx+1);
-	    Assert.True(comparisonName == ty.Name, $"{callerFilePath}:{callerLineNumber}: returned type has unexpected name '{ty.Name}' (expected: '{comparisonName}') in {callerMemberName}");
-	    Assert.True(ContainsTypeWithName (allTypes, fullName), $"{callerFilePath}:{callerLineNumber}: expected Assembly.GetTypes to contain '{fullName}', but it didn't in {callerMemberName}");
-	    if (moreChecks != null)
-		moreChecks(ty);
-	    return ty;
-	}
+        internal static Type CheckReflectedType(Assembly assm, Type[] allTypes, string nameSpace, string typeName, Action<Type> moreChecks = null, [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            var fullName = $"{nameSpace}.{typeName}";
+            var ty = assm.GetType(fullName);
+            Assert.True(ty != null, $"{callerFilePath}:{callerLineNumber}: expected Assembly.GetType for '{typeName}' to return non-null in {callerMemberName}");
+            int nestedIdx = typeName.LastIndexOf('+');
+            string comparisonName = typeName;
+            if (nestedIdx != -1)
+                comparisonName = typeName.Substring(nestedIdx+1);
+            Assert.True(comparisonName == ty.Name, $"{callerFilePath}:{callerLineNumber}: returned type has unexpected name '{ty.Name}' (expected: '{comparisonName}') in {callerMemberName}");
+            Assert.True(ContainsTypeWithName (allTypes, fullName), $"{callerFilePath}:{callerLineNumber}: expected Assembly.GetTypes to contain '{fullName}', but it didn't in {callerMemberName}");
+            if (moreChecks != null)
+                moreChecks(ty);
+            return ty;
+        }
 
 
-	internal static void CheckCustomNoteAttribute(MemberInfo subject, string expectedAttributeValue, [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
-	{
-	    var attrData = subject.GetCustomAttributesData();
-	    CustomAttributeData noteData = null;
-	    foreach (var cad in attrData)
-	    {
-		if (cad.AttributeType.FullName.Contains("CustomNoteAttribute"))
-		    noteData = cad;
-	    }
-	    Assert.True(noteData != null, $"{callerFilePath}:{callerLineNumber}: expected a CustomNoteAttribute attributes on '{subject.Name}', but got null, in {callerMemberName}");
-	    Assert.True(1 == noteData.ConstructorArguments.Count, $"{callerFilePath}:{callerLineNumber}: expected exactly 1 constructor argument on CustomNoteAttribute, got {noteData.ConstructorArguments.Count}, in {callerMemberName}");
-	    object argVal = noteData.ConstructorArguments[0].Value;
-	    Assert.True(expectedAttributeValue.Equals(argVal), $"{callerFilePath}:{callerLineNumber}: expected '{expectedAttributeValue}' as CustomNoteAttribute argument, got '{argVal}', in {callerMemberName}");
+        internal static void CheckCustomNoteAttribute(MemberInfo subject, string expectedAttributeValue, [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+        {
+            var attrData = subject.GetCustomAttributesData();
+            CustomAttributeData noteData = null;
+            foreach (var cad in attrData)
+            {
+                if (cad.AttributeType.FullName.Contains("CustomNoteAttribute"))
+                    noteData = cad;
+            }
+            Assert.True(noteData != null, $"{callerFilePath}:{callerLineNumber}: expected a CustomNoteAttribute attributes on '{subject.Name}', but got null, in {callerMemberName}");
+            Assert.True(1 == noteData.ConstructorArguments.Count, $"{callerFilePath}:{callerLineNumber}: expected exactly 1 constructor argument on CustomNoteAttribute, got {noteData.ConstructorArguments.Count}, in {callerMemberName}");
+            object argVal = noteData.ConstructorArguments[0].Value;
+            Assert.True(expectedAttributeValue.Equals(argVal), $"{callerFilePath}:{callerLineNumber}: expected '{expectedAttributeValue}' as CustomNoteAttribute argument, got '{argVal}', in {callerMemberName}");
 
-	    var attrs = subject.GetCustomAttributes(false);
-	    object note = null;
-	    foreach (var attr in attrs)
-	    {
-		if (attr.GetType().FullName.Contains("CustomNoteAttribute"))
-		    note = attr;
-	    }
-	    Assert.True(note != null, $"{callerFilePath}:{callerLineNumber}: expected a CustomNoteAttribute object on '{subject.Name}', but got null, in {callerMemberName}");
-	    object v = note.GetType().GetField("Note").GetValue(note);
-	    Assert.True(expectedAttributeValue.Equals(v), $"{callerFilePath}:{callerLineNumber}: expected '{expectedAttributeValue}' in CustomNoteAttribute Note field, but got '{v}', in {callerMemberName}");
-	}
+            var attrs = subject.GetCustomAttributes(false);
+            object note = null;
+            foreach (var attr in attrs)
+            {
+                if (attr.GetType().FullName.Contains("CustomNoteAttribute"))
+                    note = attr;
+            }
+            Assert.True(note != null, $"{callerFilePath}:{callerLineNumber}: expected a CustomNoteAttribute object on '{subject.Name}', but got null, in {callerMemberName}");
+            object v = note.GetType().GetField("Note").GetValue(note);
+            Assert.True(expectedAttributeValue.Equals(v), $"{callerFilePath}:{callerLineNumber}: expected '{expectedAttributeValue}' in CustomNoteAttribute Note field, but got '{v}', in {callerMemberName}");
+        }
 
-	[ConditionalFact(typeof(ApplyUpdateUtil), nameof(ApplyUpdateUtil.IsSupported))]
-	public static void TestReflectionAddNewType()
-	{
-	    ApplyUpdateUtil.TestCase(static () =>
-	    {
-		const string ns = "System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType";
-		var assm = typeof(System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType.ZExistingClass).Assembly;
+        [ConditionalFact(typeof(ApplyUpdateUtil), nameof(ApplyUpdateUtil.IsSupported))]
+        public static void TestReflectionAddNewType()
+        {
+            ApplyUpdateUtil.TestCase(static () =>
+            {
+                const string ns = "System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType";
+                var assm = typeof(System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType.ZExistingClass).Assembly;
 
-		var allTypes = assm.GetTypes();
+                var allTypes = assm.GetTypes();
 
-		CheckReflectedType(assm, allTypes, ns, "ZExistingClass");
-		CheckReflectedType(assm, allTypes, ns, "ZExistingClass+PreviousNestedClass");
+                CheckReflectedType(assm, allTypes, ns, "ZExistingClass");
+                CheckReflectedType(assm, allTypes, ns, "ZExistingClass+PreviousNestedClass");
 
-		ApplyUpdateUtil.ApplyUpdate(assm);
+                ApplyUpdateUtil.ApplyUpdate(assm);
 
-		allTypes = assm.GetTypes();
+                allTypes = assm.GetTypes();
 
-		CheckReflectedType(assm, allTypes, ns, "ZExistingClass", static (ty) =>
-		{
-		    var allMethods = ty.GetMethods();
+                CheckReflectedType(assm, allTypes, ns, "ZExistingClass", static (ty) =>
+                {
+                    var allMethods = ty.GetMethods();
 
-		    MethodInfo newMethod = null;
-		    foreach (var meth in allMethods)
-		    {
-			if (meth.Name == "NewMethod")
-			    newMethod = meth;
-		    }
-		    Assert.NotNull (newMethod);
+                    MethodInfo newMethod = null;
+                    foreach (var meth in allMethods)
+                    {
+                        if (meth.Name == "NewMethod")
+                            newMethod = meth;
+                    }
+                    Assert.NotNull (newMethod);
 
-		    Assert.Equal (newMethod, ty.GetMethod ("NewMethod"));
+                    Assert.Equal (newMethod, ty.GetMethod ("NewMethod"));
 
-		    var allFields = ty.GetFields(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public);
+                    var allFields = ty.GetFields(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public);
 
-		    FieldInfo newField = null;
-		    FieldInfo newStaticField = null;
-		    foreach (var fld in allFields)
-		    {
-			if (fld.Name == "NewField")
-			    newField = fld;
-			if (fld.Name == "NewStaticField")
-			    newStaticField = fld;
-		    }
-		    Assert.NotNull(newField);
-		    Assert.NotNull(newStaticField);
+                    FieldInfo newField = null;
+                    FieldInfo newStaticField = null;
+                    foreach (var fld in allFields)
+                    {
+                        if (fld.Name == "NewField")
+                            newField = fld;
+                        if (fld.Name == "NewStaticField")
+                            newStaticField = fld;
+                    }
+                    Assert.NotNull(newField);
+                    Assert.NotNull(newStaticField);
 
-		    Assert.Equal(newField, ty.GetField("NewField"));
-		    Assert.Equal(newStaticField, ty.GetField("NewStaticField", BindingFlags.Static | BindingFlags.Public));
+                    Assert.Equal(newField, ty.GetField("NewField"));
+                    Assert.Equal(newStaticField, ty.GetField("NewStaticField", BindingFlags.Static | BindingFlags.Public));
 
-		    // FIXME: finish this
+                    // FIXME: finish this
 #if false
-		    var allProperties = ty.GetProperties();
+                    var allProperties = ty.GetProperties();
 
-		    PropertyInfo newProp = null;
-		    foreach (var prop in allProperties)
-		    {
-			if (prop.Name == "NewProp")
-			    newProp = prop;
-		    }
-		    Assert.NotNull(newProp);
+                    PropertyInfo newProp = null;
+                    foreach (var prop in allProperties)
+                    {
+                        if (prop.Name == "NewProp")
+                            newProp = prop;
+                    }
+                    Assert.NotNull(newProp);
 
-		    Assert.Equal(newProp, ty.GetProperty("NewProp"));
+                    Assert.Equal(newProp, ty.GetProperty("NewProp"));
 
-		    MethodInfo newPropGet = newProp.GetGetMethod();
-		    Assert.NotNull(newPropGet);
-		    MethodInfo newPropSet = newProp.GetSetMethod();
-		    Assert.NotNull(newPropSet);
+                    MethodInfo newPropGet = newProp.GetGetMethod();
+                    Assert.NotNull(newPropGet);
+                    MethodInfo newPropSet = newProp.GetSetMethod();
+                    Assert.NotNull(newPropSet);
 
-		    Assert.Equal("get_NewProp", newPropGet.Name);
+                    Assert.Equal("get_NewProp", newPropGet.Name);
 #endif
 
-		});
-		CheckReflectedType(assm, allTypes, ns, "ZExistingClass+PreviousNestedClass");
-		CheckReflectedType(assm, allTypes, ns, "IExistingInterface");
+                });
+                CheckReflectedType(assm, allTypes, ns, "ZExistingClass+PreviousNestedClass");
+                CheckReflectedType(assm, allTypes, ns, "IExistingInterface");
 
-		CheckReflectedType(assm, allTypes, ns, "ZExistingClass+NewNestedClass");
+                CheckReflectedType(assm, allTypes, ns, "ZExistingClass+NewNestedClass");
 
-		var newTy = CheckReflectedType(assm, allTypes, ns, "NewToplevelClass", static (ty) =>
-		{
-		    CheckCustomNoteAttribute(ty, "123");
+                var newTy = CheckReflectedType(assm, allTypes, ns, "NewToplevelClass", static (ty) =>
+                {
+                    CheckCustomNoteAttribute(ty, "123");
 
-		    var nested = ty.GetNestedType("AlsoNested");
-		    var allNested = ty.GetNestedTypes();
+                    var nested = ty.GetNestedType("AlsoNested");
+                    var allNested = ty.GetNestedTypes();
 
-		    Assert.Equal("AlsoNested", nested.Name);
-		    Assert.Same(ty, nested.DeclaringType);
+                    Assert.Equal("AlsoNested", nested.Name);
+                    Assert.Same(ty, nested.DeclaringType);
 
-		    Assert.Equal(1, allNested.Length);
-		    Assert.Same(nested, allNested[0]);
+                    Assert.Equal(1, allNested.Length);
+                    Assert.Same(nested, allNested[0]);
 
-		    var allInterfaces = ty.GetInterfaces();
+                    var allInterfaces = ty.GetInterfaces();
 
-		    Assert.Equal (2, allInterfaces.Length);
-		    bool hasICloneable = false, hasINewInterface = false;
-		    for (int i = 0; i < allInterfaces.Length; ++i) {
-			var itf = allInterfaces[i];
-			if (itf.Name == "ICloneable")
-			    hasICloneable = true;
-			if (itf.Name == "IExistingInterface")
-			    hasINewInterface = true;
-		    }
-		    Assert.True(hasICloneable);
-		    Assert.True(hasINewInterface);
+                    Assert.Equal (2, allInterfaces.Length);
+                    bool hasICloneable = false, hasINewInterface = false;
+                    for (int i = 0; i < allInterfaces.Length; ++i) {
+                        var itf = allInterfaces[i];
+                        if (itf.Name == "ICloneable")
+                            hasICloneable = true;
+                        if (itf.Name == "IExistingInterface")
+                            hasINewInterface = true;
+                    }
+                    Assert.True(hasICloneable);
+                    Assert.True(hasINewInterface);
 
-		    var allProperties = ty.GetProperties();
+                    var allProperties = ty.GetProperties();
 
-		    PropertyInfo newProp = null;
-		    foreach (var prop in allProperties)
-		    {
-			if (prop.Name == "NewProp")
-			    newProp = prop;
-		    }
-		    Assert.NotNull(newProp);
+                    PropertyInfo newProp = null;
+                    foreach (var prop in allProperties)
+                    {
+                        if (prop.Name == "NewProp")
+                            newProp = prop;
+                    }
+                    Assert.NotNull(newProp);
 
-		    Assert.Equal(newProp, ty.GetProperty("NewProp"));
-		    MethodInfo newPropGet = newProp.GetGetMethod();
-		    Assert.NotNull(newPropGet);
-		    MethodInfo newPropSet = newProp.GetSetMethod();
-		    Assert.NotNull(newPropSet);
+                    Assert.Equal(newProp, ty.GetProperty("NewProp"));
+                    MethodInfo newPropGet = newProp.GetGetMethod();
+                    Assert.NotNull(newPropGet);
+                    MethodInfo newPropSet = newProp.GetSetMethod();
+                    Assert.NotNull(newPropSet);
 
-		    Assert.Equal("get_NewProp", newPropGet.Name);
+                    Assert.Equal("get_NewProp", newPropGet.Name);
 
-		    CheckCustomNoteAttribute (newProp, "hijkl");
+                    CheckCustomNoteAttribute (newProp, "hijkl");
 
-		    var allEvents = ty.GetEvents();
+                    var allEvents = ty.GetEvents();
 
-		    EventInfo newEvt = null;
-		    foreach (var evt in allEvents)
-		    {
-			if (evt.Name == "NewEvent")
-			    newEvt = evt;
-		    }
-		    Assert.NotNull(newEvt);
+                    EventInfo newEvt = null;
+                    foreach (var evt in allEvents)
+                    {
+                        if (evt.Name == "NewEvent")
+                            newEvt = evt;
+                    }
+                    Assert.NotNull(newEvt);
 
-		    Assert.Equal(newEvt, ty.GetEvent("NewEvent"));
-		    MethodInfo newEvtAdd = newEvt.GetAddMethod();
-		    Assert.NotNull(newEvtAdd);
-		    MethodInfo newEvtRemove = newEvt.GetRemoveMethod();
-		    Assert.NotNull(newEvtRemove);
+                    Assert.Equal(newEvt, ty.GetEvent("NewEvent"));
+                    MethodInfo newEvtAdd = newEvt.GetAddMethod();
+                    Assert.NotNull(newEvtAdd);
+                    MethodInfo newEvtRemove = newEvt.GetRemoveMethod();
+                    Assert.NotNull(newEvtRemove);
 
-		    Assert.Equal("add_NewEvent", newEvtAdd.Name);
-		});
-		CheckReflectedType(assm, allTypes, ns, "NewGenericClass`1");
-		CheckReflectedType(assm, allTypes, ns, "NewToplevelStruct");
-		CheckReflectedType(assm, allTypes, ns, "INewInterface");
-		CheckReflectedType(assm, allTypes, ns, "NewEnum", static (ty) => {
-		    var names = Enum.GetNames (ty);
-		    Assert.Equal(3, names.Length);
-		    var vals = Enum.GetValues (ty);
-		    Assert.Equal(3, vals.Length);
+                    Assert.Equal("add_NewEvent", newEvtAdd.Name);
+                });
+                CheckReflectedType(assm, allTypes, ns, "NewGenericClass`1");
+                CheckReflectedType(assm, allTypes, ns, "NewToplevelStruct");
+                CheckReflectedType(assm, allTypes, ns, "INewInterface");
+                CheckReflectedType(assm, allTypes, ns, "NewEnum", static (ty) => {
+                    var names = Enum.GetNames (ty);
+                    Assert.Equal(3, names.Length);
+                    var vals = Enum.GetValues (ty);
+                    Assert.Equal(3, vals.Length);
 
-		    Assert.NotNull(Enum.Parse (ty, "Red"));
-		    Assert.NotNull(Enum.Parse (ty, "Yellow"));
-		});
+                    Assert.NotNull(Enum.Parse (ty, "Red"));
+                    Assert.NotNull(Enum.Parse (ty, "Yellow"));
+                });
 
-		// make some instances using reflection and use them through known interfaces
-		var o = Activator.CreateInstance(newTy);
+                // make some instances using reflection and use them through known interfaces
+                var o = Activator.CreateInstance(newTy);
 
-		var i = (System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType.IExistingInterface)o;
+                var i = (System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType.IExistingInterface)o;
 
-		Assert.Equal("123", i.ItfMethod(123));
-	    });
-	}
+                Assert.Equal("123", i.ItfMethod(123));
+            });
+        }
     }
 }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -558,7 +558,6 @@ namespace System.Reflection.Metadata
 		CheckReflectedType(assm, allTypes, ns, "NewToplevelStruct");
 		CheckReflectedType(assm, allTypes, ns, "INewInterface");
 		CheckReflectedType(assm, allTypes, ns, "NewEnum", static (ty) => {
-#if false
 		    var names = Enum.GetNames (ty);
 		    Assert.Equal(3, names.Length);
 		    var vals = Enum.GetValues (ty);
@@ -566,7 +565,6 @@ namespace System.Reflection.Metadata
 
 		    Assert.NotNull(Enum.Parse (ty, "Red"));
 		    Assert.NotNull(Enum.Parse (ty, "Yellow"));
-#endif
 		});
 
 		// make some instances using reflection and use them through known interfaces

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -484,17 +484,22 @@ namespace System.Reflection.Metadata
 
 		    Assert.Equal (newMethod, ty.GetMethod ("NewMethod"));
 
-		    var allFields = ty.GetFields();
+		    var allFields = ty.GetFields(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public);
 
 		    FieldInfo newField = null;
+		    FieldInfo newStaticField = null;
 		    foreach (var fld in allFields)
 		    {
 			if (fld.Name == "NewField")
 			    newField = fld;
+			if (fld.Name == "NewStaticField")
+			    newStaticField = fld;
 		    }
 		    Assert.NotNull(newField);
+		    Assert.NotNull(newStaticField);
 
 		    Assert.Equal(newField, ty.GetField("NewField"));
+		    Assert.Equal(newStaticField, ty.GetField("NewStaticField", BindingFlags.Static | BindingFlags.Public));
 
 		});
 		CheckReflectedType(assm, allTypes, ns, "ZExistingClass+PreviousNestedClass");

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -571,6 +571,24 @@ namespace System.Reflection.Metadata
 		    Assert.NotNull(newPropSet);
 
 		    Assert.Equal("get_NewProp", newPropGet.Name);
+
+		    var allEvents = ty.GetEvents();
+
+		    EventInfo newEvt = null;
+		    foreach (var evt in allEvents)
+		    {
+			if (evt.Name == "NewEvent")
+			    newEvt = evt;
+		    }
+		    Assert.NotNull(newEvt);
+
+		    Assert.Equal(newEvt, ty.GetEvent("NewEvent"));
+		    MethodInfo newEvtAdd = newEvt.GetAddMethod();
+		    Assert.NotNull(newEvtAdd);
+		    MethodInfo newEvtRemove = newEvt.GetRemoveMethod();
+		    Assert.NotNull(newEvtRemove);
+
+		    Assert.Equal("add_NewEvent", newEvtAdd.Name);
 		});
 		CheckReflectedType(assm, allTypes, ns, "NewGenericClass`1");
 		CheckReflectedType(assm, allTypes, ns, "NewToplevelStruct");

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -61,6 +61,7 @@
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.AddNestedClass\System.Reflection.Metadata.ApplyUpdate.Test.AddNestedClass.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.AddStaticLambda\System.Reflection.Metadata.ApplyUpdate.Test.AddStaticLambda.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.StaticLambdaRegression\System.Reflection.Metadata.ApplyUpdate.Test.StaticLambdaRegression.csproj" />
+    <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType\System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
     <WasmFilesToIncludeFromPublishDir Include="$(AssemblyName).dll" />

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -8012,7 +8012,7 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 			buffer_add_string (buf, p->name);
 			buffer_add_methodid (buf, domain, p->get);
 			buffer_add_methodid (buf, domain, p->set);
-			buffer_add_int (buf, p->attrs);
+			buffer_add_int (buf, p->attrs & ~MONO_PROPERTY_META_FLAG_MASK);
 			i ++;
 		}
 		g_assert (i == nprops);

--- a/src/mono/mono/component/hot_reload-internals.h
+++ b/src/mono/mono/component/hot_reload-internals.h
@@ -27,7 +27,9 @@ struct _MonoClassMetadataUpdateInfo {
 	 * to the BaselineInfo for the image and cleanup from there. */
 	GSList *added_members; /* a set of Method or Field table tokens of any methods or fields added to this class, allocated from the MonoClass mempool */
 
-	GPtrArray *added_fields; /* a set of MonoClassMetadataUpdateField* values for every added field. */
+	GSList *added_fields; /* a set of MonoClassMetadataUpdateField* values for every added field. */
+	GSList *added_props; /* a set of MonoClassMetadataUpdateProperty* values */
+	GSList *added_events; /* a set of MonoClassMetadataUpdateEvent* values */
 
 	MonoClassRuntimeMetadataUpdateInfo runtime;
 };
@@ -67,10 +69,18 @@ typedef struct _MonoClassMetadataUpdateField {
 	uint32_t generation; /* when this field was added */
 	uint32_t token; /* the Field table token where this field was defined. (this won't make
 			 * sense for generic instances, once EnC is supported there) */
-	/* if non-zero the EnC update came before the parent class was initialized.  The field is
-	 * stored in the instance at this offset.  MonoClassField:offset is -1.  Not used for static
-	 * fields. */
-	int before_init_instance_offset;
 } MonoClassMetadataUpdateField;
+
+typedef struct _MonoClassMetadataUpdateProperty {
+	MonoProperty prop;
+	uint32_t generation; /* when this prop was added */
+	uint32_t token; /* the Property table token where this prop was defined. */
+} MonoClassMetadataUpdateProperty;
+
+typedef struct _MonoClassMetadataUpdateEvent {
+	MonoEvent evt;
+	uint32_t generatino; /* when this event was added */
+	uint32_t token; /* the Event table token where this event was defined. */
+} MonoClassMetadataUpdateEvent;
 
 #endif/*_MONO_COMPONENT_HOT_RELOAD_INTERNALS_H*/

--- a/src/mono/mono/component/hot_reload-internals.h
+++ b/src/mono/mono/component/hot_reload-internals.h
@@ -54,7 +54,10 @@ typedef struct _MonoAddedDefSkeleton {
 	uint32_t first_method_idx, first_field_idx;
 	uint32_t method_count;
 	uint32_t field_count;
-	/* TODO: metadata-update: property and event adds. */
+	uint32_t first_prop_idx;
+	uint32_t prop_count;
+	uint32_t first_event_idx;
+	uint32_t event_count;
 } MonoAddedDefSkeleton;
 
 

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -89,6 +89,8 @@ hot_reload_stub_find_method_by_name (MonoClass *klass, const char *name, int par
 static gboolean
 hot_reload_stub_get_typedef_skeleton (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_method_idx, uint32_t *method_count,  uint32_t *first_field_idx, uint32_t *field_count);
 
+static MonoMethod *
+hot_reload_stub_added_methods_iter (MonoClass *klass, gpointer *iter);
 
 static MonoComponentHotReload fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &hot_reload_stub_available },
@@ -116,6 +118,7 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_stub_get_static_field_addr,
 	&hot_reload_stub_find_method_by_name,
 	&hot_reload_stub_get_typedef_skeleton,
+	&hot_reload_stub_added_methods_iter,
 };
 
 static bool
@@ -272,6 +275,12 @@ static gboolean
 hot_reload_stub_get_typedef_skeleton (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_method_idx, uint32_t *method_count,  uint32_t *first_field_idx, uint32_t *field_count)
 {
 	return FALSE;
+}
+
+static MonoMethod *
+hot_reload_stub_added_methods_iter (MonoClass *klass, gpointer *iter)
+{
+	return NULL;
 }
 
 

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -92,6 +92,9 @@ hot_reload_stub_get_typedef_skeleton (MonoImage *base_image, uint32_t typedef_to
 static gboolean
 hot_reload_stub_get_typedef_skeleton_properties (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_prop_idx, uint32_t *prop_count);
 
+static gboolean
+hot_reload_stub_get_typedef_skeleton_events (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_event_idx, uint32_t *event_count);
+
 static MonoMethod *
 hot_reload_stub_added_methods_iter (MonoClass *klass, gpointer *iter);
 
@@ -125,6 +128,7 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_stub_find_method_by_name,
 	&hot_reload_stub_get_typedef_skeleton,
 	&hot_reload_stub_get_typedef_skeleton_properties,
+	&hot_reload_stub_get_typedef_skeleton_events,
 	&hot_reload_stub_added_methods_iter,
 	&hot_reload_stub_added_fields_iter,
 };
@@ -287,6 +291,12 @@ hot_reload_stub_get_typedef_skeleton (MonoImage *base_image, uint32_t typedef_to
 
 static gboolean
 hot_reload_stub_get_typedef_skeleton_properties (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_prop_idx, uint32_t *prop_count)
+{
+	return FALSE;
+}
+
+static gboolean
+hot_reload_stub_get_typedef_skeleton_events (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_event_idx, uint32_t *event_count)
 {
 	return FALSE;
 }

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -92,6 +92,9 @@ hot_reload_stub_get_typedef_skeleton (MonoImage *base_image, uint32_t typedef_to
 static MonoMethod *
 hot_reload_stub_added_methods_iter (MonoClass *klass, gpointer *iter);
 
+static MonoClassField *
+hot_reload_stub_added_fields_iter (MonoClass *klass, gboolean lazy, gpointer *iter);
+
 static MonoComponentHotReload fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &hot_reload_stub_available },
 	&hot_reload_stub_set_fastpath_data,
@@ -119,6 +122,7 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_stub_find_method_by_name,
 	&hot_reload_stub_get_typedef_skeleton,
 	&hot_reload_stub_added_methods_iter,
+	&hot_reload_stub_added_fields_iter,
 };
 
 static bool
@@ -279,6 +283,12 @@ hot_reload_stub_get_typedef_skeleton (MonoImage *base_image, uint32_t typedef_to
 
 static MonoMethod *
 hot_reload_stub_added_methods_iter (MonoClass *klass, gpointer *iter)
+{
+	return NULL;
+}
+
+static MonoClassField *
+hot_reload_stub_added_fields_iter (MonoClass *klass, gboolean lazy, gpointer *iter)
 {
 	return NULL;
 }

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -89,6 +89,9 @@ hot_reload_stub_find_method_by_name (MonoClass *klass, const char *name, int par
 static gboolean
 hot_reload_stub_get_typedef_skeleton (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_method_idx, uint32_t *method_count,  uint32_t *first_field_idx, uint32_t *field_count);
 
+static gboolean
+hot_reload_stub_get_typedef_skeleton_properties (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_prop_idx, uint32_t *prop_count);
+
 static MonoMethod *
 hot_reload_stub_added_methods_iter (MonoClass *klass, gpointer *iter);
 
@@ -121,6 +124,7 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_stub_get_static_field_addr,
 	&hot_reload_stub_find_method_by_name,
 	&hot_reload_stub_get_typedef_skeleton,
+	&hot_reload_stub_get_typedef_skeleton_properties,
 	&hot_reload_stub_added_methods_iter,
 	&hot_reload_stub_added_fields_iter,
 };
@@ -277,6 +281,12 @@ hot_reload_stub_find_method_by_name (MonoClass *klass, const char *name, int par
 
 static gboolean
 hot_reload_stub_get_typedef_skeleton (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_method_idx, uint32_t *method_count,  uint32_t *first_field_idx, uint32_t *field_count)
+{
+	return FALSE;
+}
+
+static gboolean
+hot_reload_stub_get_typedef_skeleton_properties (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_prop_idx, uint32_t *prop_count)
 {
 	return FALSE;
 }

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -86,6 +86,10 @@ hot_reload_stub_get_static_field_addr (MonoClassField *field);
 static MonoMethod *
 hot_reload_stub_find_method_by_name (MonoClass *klass, const char *name, int param_count, int flags, MonoError *error);
 
+static gboolean
+hot_reload_stub_get_typedef_skeleton (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_method_idx, uint32_t *method_count,  uint32_t *first_field_idx, uint32_t *field_count);
+
+
 static MonoComponentHotReload fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &hot_reload_stub_available },
 	&hot_reload_stub_set_fastpath_data,
@@ -111,6 +115,7 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_stub_get_field,
 	&hot_reload_stub_get_static_field_addr,
 	&hot_reload_stub_find_method_by_name,
+	&hot_reload_stub_get_typedef_skeleton,
 };
 
 static bool
@@ -261,6 +266,12 @@ static MonoMethod *
 hot_reload_stub_find_method_by_name (MonoClass *klass, const char *name, int param_count, int flags, MonoError *error)
 {
 	return NULL;
+}
+
+static gboolean
+hot_reload_stub_get_typedef_skeleton (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_method_idx, uint32_t *method_count,  uint32_t *first_field_idx, uint32_t *field_count)
+{
+	return FALSE;
 }
 
 

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -1784,14 +1784,12 @@ static gboolean
 hot_reload_get_typedef_skeleton (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_method_idx, uint32_t *method_count,  uint32_t *first_field_idx, uint32_t *field_count)
 {
 	BaselineInfo *info = baseline_info_lookup (base_image);
-	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "skeleton lookup begin - wanted 0x%08x", typedef_token);
 	if (!info || !info->skeletons)
 		return FALSE;
 	gboolean found = FALSE;
 	mono_image_lock (base_image);
 	for (int i = 0; i < info->skeletons->len; ++i) {
 		MonoAddedDefSkeleton *sk = &((MonoAddedDefSkeleton*)info->skeletons->data)[i];
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "skeleton lookup[%d] - wanted 0x%08x got 0x%08x", i, typedef_token, sk->typedef_token);
 		if (sk->typedef_token == typedef_token) {
 			found = TRUE;
 			g_assert (first_method_idx);

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -2433,7 +2433,7 @@ hot_reload_table_num_rows_slow (MonoImage *base, int table_index)
 {
 	BaselineInfo *base_info = baseline_info_lookup (base);
 	if (!base_info)
-		return FALSE;
+		return 0;
 
 	uint32_t current_gen = hot_reload_get_thread_generation ();
 

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -2177,7 +2177,6 @@ apply_enclog_pass2 (Pass2Context *ctx, MonoImage *image_base, BaselineInfo *base
 				switch (func_code) {
 				case ENC_FUNC_DEFAULT: {
 					/* ok, added a new class */
-					/* TODO: do things here */
 					pass2_context_add_skeleton (ctx, log_token);
 					add_typedef_to_image_metadata (image_base, log_token);
 					break;
@@ -2231,7 +2230,6 @@ apply_enclog_pass2 (Pass2Context *ctx, MonoImage *image_base, BaselineInfo *base
 				/* FIXME: use DeltaInfo:prev_gen_rows instead of image_base */
 				g_assert (token_index <= table_info_get_rows (&image_base->tables [token_table]));
 			else {
-				/* TODO: adding a property. */
 				g_assert (add_property_propertymap != 0);
 
 				uint32_t parent_type_token = mono_metadata_decode_row_col (&image_base->tables [MONO_TABLE_PROPERTYMAP], mono_metadata_token_index (add_property_propertymap) - 1, MONO_PROPERTY_MAP_PARENT);
@@ -2285,7 +2283,6 @@ apply_enclog_pass2 (Pass2Context *ctx, MonoImage *image_base, BaselineInfo *base
 				/* FIXME: use DeltaInfo:prev_gen_rows instead of image_base */
 				g_assert (token_index <= table_info_get_rows (&image_base->tables [token_table]));
 			else {
-				/* TODO: adding a event. */
 				g_assert (add_event_eventmap != 0);
 
 				uint32_t parent_type_token = mono_metadata_decode_row_col (&image_base->tables [MONO_TABLE_EVENTMAP], mono_metadata_token_index (add_event_eventmap) - 1, MONO_EVENT_MAP_PARENT);

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -33,7 +33,7 @@
 
 #include <mono/utils/mono-compiler.h>
 
-#define ALLOW_INSTANCE_FIELD_ADD
+#undef ALLOW_INSTANCE_FIELD_ADD
 
 typedef struct _BaselineInfo BaselineInfo;
 typedef struct _DeltaInfo DeltaInfo;

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -1777,12 +1777,14 @@ static gboolean
 hot_reload_get_typedef_skeleton (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_method_idx, uint32_t *method_count,  uint32_t *first_field_idx, uint32_t *field_count)
 {
 	BaselineInfo *info = baseline_info_lookup (base_image);
+	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "skeleton lookup begin - wanted 0x%08x", typedef_token);
 	if (!info || !info->skeletons)
 		return FALSE;
 	gboolean found = FALSE;
 	mono_image_lock (base_image);
 	for (int i = 0; i < info->skeletons->len; ++i) {
 		MonoAddedDefSkeleton *sk = &((MonoAddedDefSkeleton*)info->skeletons->data)[i];
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "skeleton lookup[%d] - wanted 0x%08x got 0x%08x", i, typedef_token, sk->typedef_token);
 		if (sk->typedef_token == typedef_token) {
 			found = TRUE;
 			g_assert (first_method_idx);

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -1470,11 +1470,16 @@ apply_enclog_pass1 (MonoImage *image_base, MonoImage *image_dmeta, DeltaInfo *de
 				 * (its parent is set to 0).  Once we support custom attribute
 				 * changes, we will support this kind of deletion for real.
 				 */
+				/* FIXME: https://github.com/dotnet/roslyn/issues/60125
+				 * Roslyn seems to emit CA rows out of order which puts rows with unexpected Parent values in the wrong place.
+				 */
+#ifdef DISALLOW_BROKEN_PARENT
 				if (ca_base_cols [MONO_CUSTOM_ATTR_PARENT] != ca_upd_cols [MONO_CUSTOM_ATTR_PARENT] && ca_upd_cols [MONO_CUSTOM_ATTR_PARENT] != 0) {
 					mono_error_set_type_load_name (error, NULL, image_base->name, "EnC: we do not support patching of existing CA table cols with a different Parent. token=0x%08x", log_token);
 					unsupported_edits = TRUE;
 					continue;
 				}
+#endif
 				break;
 			} else  {
 				/* Added a row. ok */

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -2262,6 +2262,11 @@ apply_enclog_pass2 (Pass2Context *ctx, MonoImage *image_base, BaselineInfo *base
 			 */
 			break;
 		}
+		case MONO_TABLE_INTERFACEIMPL: {
+			g_assert (is_addition);
+			/* added rows ok (for added classes). will be processed when the MonoClass is created. */
+			break;
+		}
 		default: {
 			g_assert (token_index > table_info_get_rows (&image_base->tables [token_table]));
 			if (mono_trace_is_traced (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE))

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -125,6 +125,9 @@ hot_reload_get_typedef_skeleton (MonoImage *base_image, uint32_t typedef_token, 
 static gboolean
 hot_reload_get_typedef_skeleton_properties (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_prop_idx, uint32_t *prop_count);
 
+static gboolean
+hot_reload_get_typedef_skeleton_events (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_event_idx, uint32_t *event_count);
+
 static MonoMethod *
 hot_reload_added_methods_iter (MonoClass *klass, gpointer *iter);
 
@@ -161,6 +164,7 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_find_method_by_name,
 	&hot_reload_get_typedef_skeleton,
 	&hot_reload_get_typedef_skeleton_properties,
+	&hot_reload_get_typedef_skeleton_events,
 	&hot_reload_added_methods_iter,
 	&hot_reload_added_fields_iter,
 };
@@ -1833,6 +1837,29 @@ hot_reload_get_typedef_skeleton_properties (MonoImage *base_image, uint32_t type
 	return found;
 }
 
+static gboolean
+hot_reload_get_typedef_skeleton_events (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_event_idx, uint32_t *event_count)
+{
+	BaselineInfo *info = baseline_info_lookup (base_image);
+	if (!info || !info->skeletons)
+		return FALSE;
+	gboolean found = FALSE;
+	mono_image_lock (base_image);
+	for (int i = 0; i < info->skeletons->len; ++i) {
+		MonoAddedDefSkeleton *sk = &((MonoAddedDefSkeleton*)info->skeletons->data)[i];
+		if (sk->typedef_token == typedef_token) {
+			found = TRUE;
+			g_assert (first_event_idx);
+			*first_event_idx = sk->first_event_idx;
+			g_assert (event_count);
+			*event_count = sk->event_count;
+			break;
+		}
+	}
+	mono_image_unlock (base_image);
+	return found;
+}
+
 /**
  * Adds the given newly-added class to the image, updating various data structures (e.g. name cache).
  */
@@ -2268,7 +2295,8 @@ apply_enclog_pass2 (Pass2Context *ctx, MonoImage *image_base, BaselineInfo *base
 
 				if (pass2_context_is_skeleton (ctx, parent_type_token)) {
 					mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "Adding new event 0x%08x to new class 0x%08x", log_token, parent_type_token);
-					/* nothing to do, actually.  the metadata lookup machinery will find it by doing a linear scan of the table. */
+					pass2_context_add_skeleton_member (ctx, parent_type_token, log_token);
+					add_member_parent (base_info, parent_type_token, log_token);
 					break;
 				} else {
 					MonoClass *add_event_klass = mono_class_get_checked (image_base, parent_type_token, error);

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -41,6 +41,7 @@ typedef struct _MonoComponentHotReload {
 	gpointer (*get_static_field_addr) (MonoClassField *field);
 	MonoMethod* (*find_method_by_name) (MonoClass *klass, const char *name, int param_count, int flags, MonoError *error);
 	gboolean (*get_typedef_skeleton) (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_method_idx, uint32_t *method_count,  uint32_t *first_field_idx, uint32_t *field_count);
+	MonoMethod* (*added_methods_iter) (MonoClass *klass, gpointer *iter);
 } MonoComponentHotReload;
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -40,6 +40,7 @@ typedef struct _MonoComponentHotReload {
 	MonoClassField* (*get_field) (MonoClass *klass, uint32_t fielddef_token);
 	gpointer (*get_static_field_addr) (MonoClassField *field);
 	MonoMethod* (*find_method_by_name) (MonoClass *klass, const char *name, int param_count, int flags, MonoError *error);
+	gboolean (*get_typedef_skeleton) (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_method_idx, uint32_t *method_count,  uint32_t *first_field_idx, uint32_t *field_count);
 } MonoComponentHotReload;
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -42,6 +42,7 @@ typedef struct _MonoComponentHotReload {
 	MonoMethod* (*find_method_by_name) (MonoClass *klass, const char *name, int param_count, int flags, MonoError *error);
 	gboolean (*get_typedef_skeleton) (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_method_idx, uint32_t *method_count,  uint32_t *first_field_idx, uint32_t *field_count);
 	MonoMethod* (*added_methods_iter) (MonoClass *klass, gpointer *iter);
+	MonoClassField* (*added_fields_iter) (MonoClass *klass, gboolean lazy, gpointer *iter);
 } MonoComponentHotReload;
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -42,6 +42,7 @@ typedef struct _MonoComponentHotReload {
 	MonoMethod* (*find_method_by_name) (MonoClass *klass, const char *name, int param_count, int flags, MonoError *error);
 	gboolean (*get_typedef_skeleton) (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_method_idx, uint32_t *method_count,  uint32_t *first_field_idx, uint32_t *field_count);
 	gboolean (*get_typedef_skeleton_properties) (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_prop_idx, uint32_t *prop_count);
+	gboolean (*get_typedef_skeleton_events) (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_event_idx, uint32_t *event_count);
 	MonoMethod* (*added_methods_iter) (MonoClass *klass, gpointer *iter);
 	MonoClassField* (*added_fields_iter) (MonoClass *klass, gboolean lazy, gpointer *iter);
 } MonoComponentHotReload;

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -41,6 +41,7 @@ typedef struct _MonoComponentHotReload {
 	gpointer (*get_static_field_addr) (MonoClassField *field);
 	MonoMethod* (*find_method_by_name) (MonoClass *klass, const char *name, int param_count, int flags, MonoError *error);
 	gboolean (*get_typedef_skeleton) (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_method_idx, uint32_t *method_count,  uint32_t *first_field_idx, uint32_t *field_count);
+	gboolean (*get_typedef_skeleton_properties) (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_prop_idx, uint32_t *prop_count);
 	MonoMethod* (*added_methods_iter) (MonoClass *klass, gpointer *iter);
 	MonoClassField* (*added_fields_iter) (MonoClass *klass, gboolean lazy, gpointer *iter);
 } MonoComponentHotReload;

--- a/src/mono/mono/metadata/class-accessors.c
+++ b/src/mono/mono/metadata/class-accessors.c
@@ -602,6 +602,7 @@ mono_class_get_metadata_update_info (MonoClass *klass)
 		return (MonoClassMetadataUpdateInfo *)get_pointer_property (klass, PROP_METADATA_UPDATE_INFO);
 	case MONO_CLASS_GINST:
 	case MONO_CLASS_GPARAM:
+	case MONO_CLASS_ARRAY:
 	case MONO_CLASS_POINTER:
 	case MONO_CLASS_GC_FILLER:
 		return NULL;

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -21,6 +21,7 @@
 #include <mono/metadata/abi-details.h>
 #include <mono/metadata/tokentype.h>
 #include <mono/metadata/marshal.h>
+#include <mono/metadata/metadata-update.h>
 #include <mono/utils/checked-build.h>
 #include <mono/utils/mono-counters.h>
 #include <mono/utils/mono-error-internals.h>
@@ -652,6 +653,15 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 			mono_class_set_field_count (klass, field_last - first_field_idx);
 		if (cols [MONO_TYPEDEF_METHOD_LIST] <= table_info_get_rows (&image->tables [MONO_TABLE_METHOD]))
 			mono_class_set_method_count (klass, method_last - first_method_idx);
+	} else if (G_UNLIKELY (cols [MONO_TYPEDEF_FIELD_LIST] == 0 && cols [MONO_TYPEDEF_METHOD_LIST] == 0 && image->has_updates)) {
+		uint32_t first_field_idx, first_method_idx, field_count, method_count;
+		if (mono_metadata_update_get_typedef_skeleton (image, type_token, &first_method_idx, &method_count, &first_field_idx, &field_count)) {
+			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_METADATA_UPDATE, "Creating class '%s.%s' from skeleton (first_method_idx = 0x%08x, count = 0x%08x, first_field_idx = 0x%08x, count=0x%08x)", nspace, name, first_method_idx, method_count, first_field_idx, field_count);
+			mono_class_set_first_field_idx (klass, first_field_idx);
+			mono_class_set_first_method_idx (klass, first_method_idx);
+			mono_class_set_field_count (klass, field_count);
+			mono_class_set_method_count (klass, method_count);
+		}
 	}
 
 	/* reserve space to store vector pointer in arrays */

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -657,8 +657,8 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 		uint32_t first_field_idx, first_method_idx, field_count, method_count;
 		if (mono_metadata_update_get_typedef_skeleton (image, type_token, &first_method_idx, &method_count, &first_field_idx, &field_count)) {
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_METADATA_UPDATE, "Creating class '%s.%s' from skeleton (first_method_idx = 0x%08x, count = 0x%08x, first_field_idx = 0x%08x, count=0x%08x)", nspace, name, first_method_idx, method_count, first_field_idx, field_count);
-			mono_class_set_first_field_idx (klass, first_field_idx);
-			mono_class_set_first_method_idx (klass, first_method_idx);
+			mono_class_set_first_field_idx (klass, first_field_idx - 1);
+			mono_class_set_first_method_idx (klass, first_method_idx - 1);
 			mono_class_set_field_count (klass, field_count);
 			mono_class_set_method_count (klass, method_count);
 		}

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -1371,12 +1371,14 @@ mono_class_get_first_field_idx (MonoClass *klass);
 void
 mono_class_set_first_field_idx (MonoClass *klass, guint32 idx);
 
+MONO_COMPONENT_API
 guint32
 mono_class_get_method_count (MonoClass *klass);
 
 void
 mono_class_set_method_count (MonoClass *klass, guint32 count);
 
+MONO_COMPONENT_API
 guint32
 mono_class_get_field_count (MonoClass *klass);
 

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -193,6 +193,9 @@ struct _MonoProperty {
 	MonoMethod *get;
 	MonoMethod *set;
 	guint32 attrs;
+	/* added by metadata-update after class was created;
+	 * not in MonoClassPropertyInfo array - don't do ptr arithmetic */
+	guint32 from_update : 1;
 };
 
 struct _MonoEvent {
@@ -205,6 +208,9 @@ struct _MonoEvent {
 	MonoMethod **other;
 #endif
 	guint32 attrs;
+	/* added by metadata-update after class was created;
+	 * not in MonoClassEventInfo array - don't do ptr arithmetic */
+	guint32 from_update : 1;
 };
 
 /* type of exception being "on hold" for later processing (see exception_type) */
@@ -1602,6 +1608,18 @@ static inline gboolean
 m_field_is_from_update (MonoClassField *field)
 {
 	return (m_field_get_meta_flags (field) & MONO_CLASS_FIELD_META_FLAG_FROM_UPDATE) != 0;
+}
+
+static inline gboolean
+m_property_is_from_update (MonoProperty *prop)
+{
+	return prop->from_update != 0;
+}
+
+static inline gboolean
+m_event_is_from_update (MonoEvent *evt)
+{
+	return evt->from_update != 0;
 }
 
 /*

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -192,11 +192,17 @@ struct _MonoProperty {
 	const char *name;
 	MonoMethod *get;
 	MonoMethod *set;
-	guint32 attrs;
+	guint32 attrs; /* upper bits store non-ECMA flags */
+};
+
+/* non-ECMA flags for the MonoProperty attrs field */
+enum {
 	/* added by metadata-update after class was created;
 	 * not in MonoClassPropertyInfo array - don't do ptr arithmetic */
-	guint32 from_update : 1;
+	MONO_PROPERTY_META_FLAG_FROM_UPDATE = 0x00010000,
+	MONO_PROPERTY_META_FLAG_MASK = 0x00010000,
 };
+
 
 struct _MonoEvent {
 	MonoClass *parent;
@@ -207,11 +213,18 @@ struct _MonoEvent {
 #ifndef MONO_SMALL_CONFIG
 	MonoMethod **other;
 #endif
-	guint32 attrs;
+	guint32 attrs;  /* upper bits store non-ECMA flags */
+};
+
+/* non-ECMA flags for the MonoEvent attrs field */
+enum {
 	/* added by metadata-update after class was created;
 	 * not in MonoClassEventInfo array - don't do ptr arithmetic */
-	guint32 from_update : 1;
+	MONO_EVENT_META_FLAG_FROM_UPDATE = 0x00010000,
+	
+	MONO_EVENT_META_FLAG_MASK = 0x00010000,
 };
+
 
 /* type of exception being "on hold" for later processing (see exception_type) */
 typedef enum {
@@ -1613,13 +1626,13 @@ m_field_is_from_update (MonoClassField *field)
 static inline gboolean
 m_property_is_from_update (MonoProperty *prop)
 {
-	return prop->from_update != 0;
+	return (prop->attrs & MONO_PROPERTY_META_FLAG_FROM_UPDATE) != 0;
 }
 
 static inline gboolean
 m_event_is_from_update (MonoEvent *evt)
 {
-	return evt->from_update != 0;
+	return (evt->attrs & MONO_EVENT_META_FLAG_FROM_UPDATE) != 0;
 }
 
 /*

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -1401,9 +1401,11 @@ mono_class_get_exception_data (MonoClass *klass);
 void
 mono_class_set_exception_data (MonoClass *klass, MonoErrorBoxed *value);
 
+MONO_COMPONENT_API
 GList*
 mono_class_get_nested_classes_property (MonoClass *klass);
 
+MONO_COMPONENT_API
 void
 mono_class_set_nested_classes_property (MonoClass *klass, GList *value);
 

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -2541,10 +2541,9 @@ mono_class_get_field_token (MonoClassField *field)
 static int
 mono_field_get_index (MonoClassField *field)
 {
+	g_assert (!m_field_is_from_update (field));
 	int index = field - m_class_get_fields (m_field_get_parent (field));
 	g_assert (index >= 0 && index < mono_class_get_field_count (m_field_get_parent (field)));
-	/* TODO: metadata-update: check if the field was added */
-	g_assert (!m_class_get_image (m_field_get_parent (field))->has_updates);
 
 	return index;
 }

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -3088,7 +3088,7 @@ mono_image_init_name_cache (MonoImage *image)
 	mono_image_unlock (image);
 }
 
-/*FIXME Only dynamic assemblies should allow this operation.*/
+/*FIXME Only dynamic assemblies or metadata-update should allow this operation.*/
 /**
  * mono_image_add_to_name_cache:
  */

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -2653,6 +2653,8 @@ mono_class_get_event_token (MonoEvent *event)
 		MonoClassEventInfo *info = mono_class_get_event_info (klass);
 		if (info) {
 			for (i = 0; i < info->count; ++i) {
+				/* TODO: metadata-update: get tokens for added props, too */
+				g_assert (!m_event_is_from_update (&info->events[i]));
 				if (&info->events [i] == event)
 					return mono_metadata_make_token (MONO_TABLE_EVENT, info->first + i + 1);
 			}
@@ -2696,6 +2698,8 @@ mono_class_get_property_token (MonoProperty *prop)
 		gpointer iter = NULL;
 		MonoClassPropertyInfo *info = mono_class_get_property_info (klass);
 		while ((p = mono_class_get_properties (klass, &iter))) {
+			/* TODO: metadata-update: get tokens for added props, too */
+			g_assert (!m_property_is_from_update (p));
 			if (&info->properties [i] == prop)
 				return mono_metadata_make_token (MONO_TABLE_PROPERTY, info->first + i + 1);
 

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -5624,7 +5624,7 @@ mono_property_get_parent (MonoProperty *prop)
 guint32
 mono_property_get_flags (MonoProperty *prop)
 {
-	return prop->attrs;
+	return prop->attrs & ~MONO_PROPERTY_META_FLAG_MASK;
 }
 
 /**
@@ -5694,7 +5694,7 @@ mono_event_get_parent (MonoEvent *event)
 guint32
 mono_event_get_flags (MonoEvent *event)
 {
-	return event->attrs;
+	return event->attrs & ~MONO_EVENT_META_FLAG_MASK;
 }
 
 /**

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -2349,7 +2349,7 @@ ves_icall_RuntimePropertyInfo_get_property_info (MonoReflectionPropertyHandle pr
 	}
 
 	if ((req_info & PInfo_Attributes) != 0)
-		info->attrs = pproperty->attrs;
+		info->attrs = (pproperty->attrs & ~MONO_PROPERTY_META_FLAG_MASK);
 
 	if ((req_info & PInfo_GetMethod) != 0) {
 		MonoClass *property_klass = MONO_HANDLE_GETVAL (property, klass);
@@ -2414,7 +2414,7 @@ ves_icall_RuntimeEventInfo_get_event_info (MonoReflectionMonoEventHandle ref_eve
 	return_if_nok (error);
 	MONO_STRUCT_SETREF_INTERNAL (info, name, MONO_HANDLE_RAW (ev_name));
 
-	info->attrs = event->attrs;
+	info->attrs = event->attrs & ~MONO_EVENT_META_FLAG_MASK;
 
 	MonoReflectionMethodHandle rm;
 	if (event->add) {

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -5048,9 +5048,8 @@ image_get_type (MonoImage *image, MonoTableInfo *tdef, int table_idx, int count,
 static MonoArrayHandle
 mono_module_get_types (MonoImage *image, MonoArrayHandleOut exceptions, MonoBoolean exportedOnly, MonoError *error)
 {
-	/* FIXME: metadata-update */
 	MonoTableInfo *tdef = &image->tables [MONO_TABLE_TYPEDEF];
-	int rows = table_info_get_rows (tdef);
+	int rows = mono_metadata_table_num_rows (image, MONO_TABLE_TYPEDEF);
 	int i, count;
 
 	/* we start the count from 1 because we skip the special type <Module> */

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -723,6 +723,7 @@ mono_image_strdup_vprintf (MonoImage *image, const char *format, va_list args);
 char*
 mono_image_strdup_printf (MonoImage *image, const char *format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
 
+MONO_COMPONENT_API
 GList*
 mono_g_list_prepend_image (MonoImage *image, GList *list, gpointer data);
 

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -195,6 +195,12 @@ metadata_update_get_typedef_skeleton_properties (MonoImage *base_image, uint32_t
 	return mono_component_hot_reload()->get_typedef_skeleton_properties (base_image, typedef_token, first_prop_idx, prop_count);
 }
 
+gboolean
+metadata_update_get_typedef_skeleton_events (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_event_idx, uint32_t *event_count)
+{
+	return mono_component_hot_reload()->get_typedef_skeleton_events (base_image, typedef_token, first_event_idx, event_count);
+}
+
 MonoMethod *
 mono_metadata_update_added_methods_iter (MonoClass *klass, gpointer *iter)
 {

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -182,3 +182,9 @@ mono_metadata_update_find_method_by_name (MonoClass *klass, const char *name, in
 {
 	return mono_component_hot_reload()->find_method_by_name (klass, name, param_count, flags, error);
 }
+
+gboolean
+mono_metadata_update_get_typedef_skeleton (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_method_idx, uint32_t *method_count,  uint32_t *first_field_idx, uint32_t *field_count)
+{
+	return mono_component_hot_reload()->get_typedef_skeleton (base_image, typedef_token, first_method_idx, method_count, first_field_idx, field_count);
+}

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -189,6 +189,12 @@ mono_metadata_update_get_typedef_skeleton (MonoImage *base_image, uint32_t typed
 	return mono_component_hot_reload()->get_typedef_skeleton (base_image, typedef_token, first_method_idx, method_count, first_field_idx, field_count);
 }
 
+gboolean
+metadata_update_get_typedef_skeleton_properties (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_prop_idx, uint32_t *prop_count)
+{
+	return mono_component_hot_reload()->get_typedef_skeleton_properties (base_image, typedef_token, first_prop_idx, prop_count);
+}
+
 MonoMethod *
 mono_metadata_update_added_methods_iter (MonoClass *klass, gpointer *iter)
 {

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -194,3 +194,9 @@ mono_metadata_update_added_methods_iter (MonoClass *klass, gpointer *iter)
 {
 	return mono_component_hot_reload()->added_methods_iter (klass, iter);
 }
+
+MonoClassField *
+mono_metadata_update_added_fields_iter (MonoClass *klass, gboolean lazy, gpointer *iter)
+{
+	return mono_component_hot_reload()->added_fields_iter (klass, lazy, iter);
+}

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -188,3 +188,9 @@ mono_metadata_update_get_typedef_skeleton (MonoImage *base_image, uint32_t typed
 {
 	return mono_component_hot_reload()->get_typedef_skeleton (base_image, typedef_token, first_method_idx, method_count, first_field_idx, field_count);
 }
+
+MonoMethod *
+mono_metadata_update_added_methods_iter (MonoClass *klass, gpointer *iter)
+{
+	return mono_component_hot_reload()->added_methods_iter (klass, iter);
+}

--- a/src/mono/mono/metadata/metadata-update.h
+++ b/src/mono/mono/metadata/metadata-update.h
@@ -79,4 +79,7 @@ mono_metadata_update_get_static_field_addr (MonoClassField *field);
 MonoMethod *
 mono_metadata_update_added_methods_iter (MonoClass *klass, gpointer *iter);
 
+MonoClassField *
+mono_metadata_update_added_fields_iter (MonoClass *klass, gboolean lazy, gpointer *iter);
+
 #endif /*__MONO_METADATA_UPDATE_H__*/

--- a/src/mono/mono/metadata/metadata-update.h
+++ b/src/mono/mono/metadata/metadata-update.h
@@ -76,4 +76,7 @@ mono_metadata_update_get_typedef_skeleton (MonoImage *base_image, uint32_t typed
 gpointer
 mono_metadata_update_get_static_field_addr (MonoClassField *field);
 
+MonoMethod *
+mono_metadata_update_added_methods_iter (MonoClass *klass, gpointer *iter);
+
 #endif /*__MONO_METADATA_UPDATE_H__*/

--- a/src/mono/mono/metadata/metadata-update.h
+++ b/src/mono/mono/metadata/metadata-update.h
@@ -70,6 +70,9 @@ mono_metadata_update_get_field_idx (MonoClassField *field);
 MonoClassField *
 mono_metadata_update_get_field (MonoClass *klass, uint32_t fielddef_token);
 
+gboolean
+mono_metadata_update_get_typedef_skeleton (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_method_idx, uint32_t *method_count,  uint32_t *first_field_idx, uint32_t *field_count);
+
 gpointer
 mono_metadata_update_get_static_field_addr (MonoClassField *field);
 

--- a/src/mono/mono/metadata/metadata-update.h
+++ b/src/mono/mono/metadata/metadata-update.h
@@ -73,6 +73,9 @@ mono_metadata_update_get_field (MonoClass *klass, uint32_t fielddef_token);
 gboolean
 mono_metadata_update_get_typedef_skeleton (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_method_idx, uint32_t *method_count,  uint32_t *first_field_idx, uint32_t *field_count);
 
+gboolean
+metadata_update_get_typedef_skeleton_properties (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_prop_idx, uint32_t *prop_count);
+
 gpointer
 mono_metadata_update_get_static_field_addr (MonoClassField *field);
 

--- a/src/mono/mono/metadata/metadata-update.h
+++ b/src/mono/mono/metadata/metadata-update.h
@@ -76,6 +76,9 @@ mono_metadata_update_get_typedef_skeleton (MonoImage *base_image, uint32_t typed
 gboolean
 metadata_update_get_typedef_skeleton_properties (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_prop_idx, uint32_t *prop_count);
 
+gboolean
+metadata_update_get_typedef_skeleton_events (MonoImage *base_image, uint32_t typedef_token, uint32_t *first_event_idx, uint32_t *event_count);
+
 gpointer
 mono_metadata_update_get_static_field_addr (MonoClassField *field);
 

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -6266,8 +6266,6 @@ mono_metadata_get_constant_index (MonoImage *meta, guint32 token, guint32 hint)
 	loc.col_idx = MONO_CONSTANT_PARENT;
 	loc.t = tdef;
 
-	/* FIXME: metadata-update */
-
 	/* FIXME: Index translation */
 
 	if ((hint > 0) && (hint < table_info_get_rows (tdef)) && (mono_metadata_decode_row_col (tdef, hint - 1, MONO_CONSTANT_PARENT) == index))
@@ -6275,6 +6273,11 @@ mono_metadata_get_constant_index (MonoImage *meta, guint32 token, guint32 hint)
 
 	if (tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator)) {
 		return loc.result + 1;
+	}
+
+	if (G_UNLIKELY (meta->has_updates)) {
+		if (mono_metadata_update_metadata_linear_search (meta, tdef, &loc, table_locator))
+			return loc.result + 1;
 	}
 	return 0;
 }

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -6299,17 +6299,28 @@ mono_metadata_events_from_typedef (MonoImage *meta, guint32 index, guint *end_id
 
 	*end_idx = 0;
 
-	if (!tdef->base)
+	if (!tdef->base && !meta->has_updates)
 		return 0;
 
 	loc.t = tdef;
 	loc.col_idx = MONO_EVENT_MAP_PARENT;
 	loc.idx = index + 1;
 
-	/* FIXME: metadata-update */
-
-	if (!mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator))
+	gboolean found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator) != NULL;
+	if (!found && !meta->has_updates)
 		return 0;
+
+	if (G_UNLIKELY (meta->has_updates)) {
+		if (!found) {
+			uint32_t count;
+			if (metadata_update_get_typedef_skeleton_events (meta, mono_metadata_make_token (MONO_TABLE_TYPEDEF, index + 1), &start, &count)) {
+				*end_idx = start + count - 1;
+				return start - 1;
+			} else {
+				return 0;
+			}
+		}
+	}
 
 	start = mono_metadata_decode_row_col (tdef, loc.result, MONO_EVENT_MAP_EVENTLIST);
 	if (loc.result + 1 < table_info_get_rows (tdef)) {
@@ -6339,7 +6350,7 @@ mono_metadata_methods_from_event   (MonoImage *meta, guint32 index, guint *end_i
 	MonoTableInfo *msemt = &meta->tables [MONO_TABLE_METHODSEMANTICS];
 
 	*end_idx = 0;
-	if (!msemt->base)
+	if (!msemt->base && !meta->has_updates)
 		return 0;
 
 	if (meta->uncompressed_metadata)
@@ -6349,10 +6360,15 @@ mono_metadata_methods_from_event   (MonoImage *meta, guint32 index, guint *end_i
 	loc.col_idx = MONO_METHOD_SEMA_ASSOCIATION;
 	loc.idx = ((index + 1) << MONO_HAS_SEMANTICS_BITS) | MONO_HAS_SEMANTICS_EVENT; /* Method association coded index */
 
-	/* FIXME: metadata-update */
+	gboolean found = msemt->base && mono_binary_search (&loc, msemt->base, table_info_get_rows (msemt), msemt->row_size, table_locator) != NULL;
 
-	if (!mono_binary_search (&loc, msemt->base, table_info_get_rows (msemt), msemt->row_size, table_locator))
+	if (!found && !meta->has_updates)
 		return 0;
+
+	if (G_UNLIKELY (meta->has_updates)) {
+		if (!found && !mono_metadata_update_metadata_linear_search (meta, msemt, &loc, table_locator))
+			return 0;
+	}
 
 	start = loc.result;
 	/*
@@ -6365,7 +6381,7 @@ mono_metadata_methods_from_event   (MonoImage *meta, guint32 index, guint *end_i
 			break;
 	}
 	end = start + 1;
-	int rows = table_info_get_rows (msemt);
+	int rows = mono_metadata_table_num_rows (meta, MONO_TABLE_METHODSEMANTICS);
 	while (end < rows) {
 		mono_metadata_decode_row (msemt, end, cols, MONO_METHOD_SEMA_SIZE);
 		if (cols [MONO_METHOD_SEMA_ASSOCIATION] != loc.idx)

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -6405,7 +6405,6 @@ mono_metadata_properties_from_typedef (MonoImage *meta, guint32 index, guint *en
 	if (!found && !meta->has_updates)
 		return 0;
 
-	gboolean found_update = FALSE;
 	if (G_UNLIKELY (meta->has_updates)) {
 		if (!found) {
 			uint32_t count;

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -5022,9 +5022,7 @@ mono_metadata_nesting_typedef (MonoImage *meta, guint32 index, guint32 start_ind
 
 	start = start_index;
 
-	/* FIXME: metadata-udpate */
-
-	int rows = table_info_get_rows (tdef);
+	int rows = mono_metadata_table_num_rows (meta, MONO_TABLE_NESTEDCLASS);
 	while (start <= rows) {
 		if (class_index == mono_metadata_decode_row_col (tdef, start - 1, MONO_NESTED_CLASS_ENCLOSING))
 			break;

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -7164,8 +7164,6 @@ mono_metadata_get_generic_param_row (MonoImage *image, guint32 token, guint32 *o
 	loc.col_idx = MONO_GENERICPARAM_OWNER;
 	loc.t = tdef;
 
-	/* FIXME: metadata-update */
-
 	gboolean found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator) != NULL;
 	if (!found && !image->has_updates)
 		return 0;


### PR DESCRIPTION
Fully implement support for the `NewTypeDefinition` EnC capability: a hot reload edit can add a new type definition (class, struct, interface, enum) that contains new fields, methods, properties, events, and nested classes, and can have generic params.  Also add reflection support for all of the above.

This is sufficient to support hot reload of types tagged with [`CreateNewOnMetadataUpdateAttribute`](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.createnewonmetadataupdateattribute?view=net-6.0).

Contributes to https://github.com/dotnet/runtime/issues/63643 and https://github.com/dotnet/runtime/issues/57365

---

The implementation introduces `MonoAddedDefSkeleton` which is a bookkeeping structure that records the metadata indexes of where to find methods, fields, properties and events for a newly-added class.  The issue is that normally `mono_class_create_from_typedef` expects to find all that stuff in a contiguous block starting at the row pointed by the `MONO_TYPEDEF_FIELD_LIST` or `MONO_TYPEDEF_METHOD_LIST` columns of the new typedef.  But in EnC deltas, those columns are zeroed out, and instead the EnCLog functions like `ENC_FUNC_ADD_METHOD` and `ENC_FUNC_ADD_FIELD` explicitly record when a new row is added that is relevant to a particular type definition.

So during the pass over the EnCLog, we start creating skeletons when we see a new row added to the typedef table.  Then when we see the add functions, we record the row indices of the field, method, etc tables.  As far as I can tell, the rows for a particular type definition are contiguous, so we just record the first index and the count.

At the end of the pass, we save the skeletons on the metadata delta, and when code finally creates the `MonoClass` for a particular freshly-added type definition, we check the skeleton and use the recorded rows to populate the fields and methods.  Event and property data is created on-demand (the demand being reflection) in basically the same way.

One important note: we try very hard not to accidentally materialize a newly-added class as a `MonoClass` during the update itself - we need to at least get through the entire EnCLog - otherwise we might not see every field/method/etc and set up the class incorrectly.

The upshot is that the newly-added `MonoClass` behaves like any other "normal" class - all its fields are laid out normally (they're stored in the object, not in a separate hash table).  It can be generic.  It can have base types, interfaces, etc.

This is different from how added fields, props and events will be implemented on existing classes - we won't modify `MonoClass:fields` or the `MonoClassPropertyInfo:properties` arrays - once they have been allocated, we don't want to mess with them.  Instead additions to existing classes with create `MonoClassMetadataUpdateField` (`MonoClassMetadataUpdateProperty` and `MonoClassMetadataUpdateEvent`) structs that are going to be stored on the `MonoClassMetadataUpdateInfo` that's associated with each `MonoClass`.  The various iterators like `mono_class_get_fields` and `mono_class_get_props` will be modified to return the added fields/props/etc after the existing ones.

This is already implemented for fields.  Props and Events will be part of a separate effort to implement reflection support for them.