### PR TITLE
Replace StringBuilder with ValueStringBuilder in AssemblyName.FullName

### DIFF
--- a/src/libraries/Common/src/System/Text/ValueStringBuilder.AppendSpanFormattable.cs
+++ b/src/libraries/Common/src/System/Text/ValueStringBuilder.AppendSpanFormattable.cs
@@ -5,7 +5,7 @@ namespace System.Text
 {
     internal ref partial struct ValueStringBuilder
     {
-        internal void AppendSpanFormattable<T>(T value, string? format, IFormatProvider? provider) where T : ISpanFormattable
+        internal void AppendSpanFormattable<T>(T value, string? format = null, IFormatProvider? provider = null) where T : ISpanFormattable
         {
             if (value.TryFormat(_chars.Slice(_pos), out int charsWritten, format, provider))
             {


### PR DESCRIPTION
```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System;
using System.Globalization;
using System.Linq;
using System.Reflection;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    private AssemblyName[] _names = AppDomain.CurrentDomain.GetAssemblies().Select(a => new AssemblyName(a.FullName)).ToArray();

    [Benchmark]
    public int Names()
    {
        int sum = 0;
        foreach (AssemblyName name in _names)
        {
            sum += name.FullName.Length;
        }
        return sum;
    }
}
```

| Method |         Toolchain |     Mean |     Error |    StdDev | Ratio | Allocated |
|------- |------------------ |---------:|----------:|----------:|------:|----------:|
|  Names | \main\corerun.exe | 3.654 us | 0.0285 us | 0.0238 us |  1.00 |     10 KB |
|  Names |   \pr\corerun.exe | 2.205 us | 0.0202 us | 0.0189 us |  0.60 |      2 KB |