### PR TITLE
Bump IntelliSense package to .NET 7.0 Preview1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -167,7 +167,7 @@
     <SdkVersionForWorkloadTesting>7.0.100-preview.3.22151.18</SdkVersionForWorkloadTesting>
     <CompilerPlatformTestingVersion>1.1.2-beta1.22122.4</CompilerPlatformTestingVersion>
     <!-- Docs -->
-    <MicrosoftPrivateIntellisenseVersion>6.0.0-preview-20220104.1</MicrosoftPrivateIntellisenseVersion>
+    <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20220316.2</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->
     <MicrosoftNETILLinkTasksVersion>7.0.100-1.22160.1</MicrosoftNETILLinkTasksVersion>
     <MicrosoftNETILLinkAnalyzerPackageVersion>$(MicrosoftNETILLinkTasksVersion)</MicrosoftNETILLinkAnalyzerPackageVersion>


### PR DESCRIPTION
We already have the `dotnet7-transport` in NuGet.config: https://github.com/dotnet/runtime/blob/main/NuGet.config#L20

Here is the pipeline job that generated it: https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=282902&view=results