### PR TITLE
Reduce string allocations in XmlWriterTraceListener

### DIFF
--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/src/System.Diagnostics.TextWriterTraceListener.csproj
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/src/System.Diagnostics.TextWriterTraceListener.csproj
@@ -16,6 +16,7 @@
     <Reference Include="System.Collections.Specialized" />
     <Reference Include="System.Diagnostics.Process" />
     <Reference Include="System.Diagnostics.TraceSource" />
+    <Reference Include="System.Memory" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />

--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/TextWriterTraceListener.cs
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/TextWriterTraceListener.cs
@@ -206,6 +206,11 @@ namespace System.Diagnostics
         {
             if (_writer == null)
             {
+                InitializeWriter();
+            }
+
+            void InitializeWriter()
+            {
                 bool success = false;
 
                 if (_fileName == null)
@@ -217,8 +222,7 @@ namespace System.Diagnostics
                 // encoding to substitute illegal chars. For ex, In case of high surrogate character
                 // D800-DBFF without a following low surrogate character DC00-DFFF
                 // NOTE: We also need to use an encoding that does't emit BOM which is StreamWriter's default
-                Encoding noBOMwithFallback = GetEncodingWithFallback(new System.Text.UTF8Encoding(false));
-
+                Encoding noBOMwithFallback = GetEncodingWithFallback(new UTF8Encoding(false));
 
                 // To support multiple appdomains/instances tracing to the same file,
                 // we will try to open the given file for append but if we encounter
@@ -264,10 +268,6 @@ namespace System.Diagnostics
             }
         }
 
-        internal bool IsEnabled(TraceOptions opts)
-        {
-            return (opts & TraceOutputOptions) != 0;
-        }
-
+        internal bool IsEnabled(TraceOptions opts) => (opts & TraceOutputOptions) != 0;
     }
 }


### PR DESCRIPTION
Rather than ToString'ing everything, most of the header data can be formatted into a span and then written out to the writer.

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Diagnostics;
using System.IO;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    private XmlWriterTraceListener _listener = new XmlWriterTraceListener(Stream.Null);
    private TraceEventCache _cache = new TraceEventCache();

    [Benchmark]
    public void Trace()
    {
        _listener.TraceEvent(_cache, "something", TraceEventType.Information, 42);
    }
}
```

| Method |         Toolchain |     Mean |   Error | Ratio | Allocated |
|------- |------------------ |---------:|--------:|------:|----------:|
|  Trace | \main\corerun.exe | 585.9 ns | 9.29 ns |  1.00 |     272 B |
|  Trace |   \pr\corerun.exe | 481.7 ns | 3.88 ns |  0.82 |      24 B |
