### PR TITLE
Improve exception thrown when constructing SslCertificateTrust

### DIFF
--- a/src/libraries/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/libraries/System.Net.Security/ref/System.Net.Security.cs
@@ -139,7 +139,6 @@ namespace System.Net.Security
         public static SslCertificateTrust CreateForX509Store(
                                                 System.Security.Cryptography.X509Certificates.X509Store store,
                                                 bool sendTrustInHandshake = false) { throw null;  }
-        [System.Runtime.Versioning.UnsupportedOSPlatform("windows")]
         public static SslCertificateTrust CreateForX509Collection(
                                                 System.Security.Cryptography.X509Certificates.X509Certificate2Collection trustList,
                                                 bool sendTrustInHandshake = false) { throw null; }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslCertificateTrust.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslCertificateTrust.cs
@@ -39,7 +39,6 @@ namespace System.Net.Security
             return trust;
         }
 
-        [UnsupportedOSPlatform("windows")]
         public static SslCertificateTrust CreateForX509Collection(X509Certificate2Collection trustList, bool sendTrustInHandshake = false)
         {
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslCertificateTrust.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslCertificateTrust.cs
@@ -20,7 +20,7 @@ namespace System.Net.Security
             {
                 throw new PlatformNotSupportedException(SR.net_ssl_trust_store);
             }
-#else
+#endif
             if (sendTrustInHandshake && !System.OperatingSystem.IsLinux() && !System.OperatingSystem.IsMacOS() &&
                 // Necessary functions are available only on win 8 onwards
                 !OperatingSystem.IsWindowsVersionAtLeast(6, 2))
@@ -28,7 +28,6 @@ namespace System.Net.Security
                 // to be removed when implemented.
                 throw new PlatformNotSupportedException(SR.net_ssl_trust_handshake);
             }
-#endif
             if (!store.IsOpen)
             {
                 store.Open(OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly);
@@ -43,10 +42,18 @@ namespace System.Net.Security
         [UnsupportedOSPlatform("windows")]
         public static SslCertificateTrust CreateForX509Collection(X509Certificate2Collection trustList, bool sendTrustInHandshake = false)
         {
+
+#if TARGET_WINDOWS
+            if (sendTrustInHandshake)
+            {
+                throw new PlatformNotSupportedException(SR.net_ssl_trust_collection);
+            }
+#else
             if (sendTrustInHandshake && !System.OperatingSystem.IsLinux() && !System.OperatingSystem.IsMacOS())
             {
                 throw new PlatformNotSupportedException(SR.net_ssl_trust_handshake);
             }
+#endif
 
             var trust = new SslCertificateTrust();
             trust._trustList = trustList;

--- a/src/libraries/apicompat/ApiCompatBaseline.NetCoreAppLatestStable.txt
+++ b/src/libraries/apicompat/ApiCompatBaseline.NetCoreAppLatestStable.txt
@@ -89,6 +89,8 @@ CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatfo
 Compat issues with assembly System.Diagnostics.Process:
 CannotChangeAttribute : Attribute 'System.Runtime.Versioning.SupportedOSPlatformAttribute' on 'System.Diagnostics.Process.MaxWorkingSet.set(System.IntPtr)' changed from '[SupportedOSPlatformAttribute("freebsd")]' in the contract to '[SupportedOSPlatformAttribute("freebsd")]' in the implementation.
 CannotChangeAttribute : Attribute 'System.Runtime.Versioning.SupportedOSPlatformAttribute' on 'System.Diagnostics.Process.MinWorkingSet.set(System.IntPtr)' changed from '[SupportedOSPlatformAttribute("freebsd")]' in the contract to '[SupportedOSPlatformAttribute("freebsd")]' in the implementation.
+Compat issues with assembly System.Net.Security:
+CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Net.Security.SslCertificateTrust.CreateForX509Collection(System.Security.Cryptography.X509Certificates.X509Certificate2Collection, System.Boolean)' in the contract but not the implementation.
 Compat issues with assembly System.Numerics.Vectors:
 CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.IsReadOnlyAttribute' exists on 'System.Numerics.Vector<T>.CopyTo(System.Span<System.Byte>)' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.IsReadOnlyAttribute' exists on 'System.Numerics.Vector<T>.CopyTo(System.Span<T>)' in the contract but not the implementation.
@@ -142,4 +144,4 @@ CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatfo
 CannotRemoveAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' exists on 'System.Security.Cryptography.TripleDES' in the contract but not the implementation.
 Compat issues with assembly System.Security.Cryptography.X509Certificates:
 CannotChangeAttribute : Attribute 'System.Runtime.Versioning.UnsupportedOSPlatformAttribute' on 'System.Security.Cryptography.X509Certificates.PublicKey.GetDSAPublicKey()' changed from '[UnsupportedOSPlatformAttribute("ios")]' in the contract to '[UnsupportedOSPlatformAttribute("browser")]' in the implementation.
-Total Issues: 135
+Total Issues: 136


### PR DESCRIPTION
This PR improves message when `SslCertificateTrust.CreateForX509Collection(..., true)` is called on Windows (the message explicitly says that sending collection-based trust this is not supported on Windows.

`SslCertificateTrust.CreateForX509Store(..., true)` now also really throws for older versions of Windows (the branch was hidden under preprocessor directive`