### PR TITLE
Try to fix a time-sensitive thread pool test

### DIFF
--- a/src/libraries/System.Threading.ThreadPool/tests/System.Threading.ThreadPool.Tests.csproj
+++ b/src/libraries/System.Threading.ThreadPool/tests/System.Threading.ThreadPool.Tests.csproj
@@ -11,5 +11,7 @@
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\Threading\ThreadTestHelpers.cs"
              Link="CommonTest\System\Threading\ThreadTestHelpers.cs" />
+    <Compile Include="$(CommonTestPath)TestUtilities\System\DisableParallelization.cs"
+             Link="CommonTest\TestUtilities\System\DisableParallelization.cs" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -912,7 +912,7 @@ namespace System.Threading.ThreadPools.Tests
     [Collection(nameof(DisableParallelization))] // these tests may be sensitive to timing
     public class ThreadPoolTests_NonParallel
     {
-        [ConditionalFact(nameof(ThreadPoolTests.IsThreadingAndRemoteExecutorSupported))]
+        [ConditionalFact(typeof(ThreadPoolTests), nameof(ThreadPoolTests.IsThreadingAndRemoteExecutorSupported))]
         public static void CooperativeBlockingCanCreateThreadsFaster()
         {
             // Run in a separate process to test in a clean thread pool environment such that work items queued by the test
@@ -975,7 +975,7 @@ namespace System.Threading.ThreadPools.Tests
             }).Dispose();
         }
 
-        [ConditionalFact(nameof(ThreadPoolTests.IsThreadingAndRemoteExecutorSupported))]
+        [ConditionalFact(typeof(ThreadPoolTests), nameof(ThreadPoolTests.IsThreadingAndRemoteExecutorSupported))]
         public static void CooperativeBlockingWithProcessingThreadsAndGoalThreadsAndAddWorkerRaceTest()
         {
             // Avoid contaminating the main process' environment

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -907,7 +907,7 @@ namespace System.Threading.ThreadPools.Tests
         }
 
         [ConditionalFact(nameof(IsThreadingAndRemoteExecutorSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/66852", TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/66854", TestRuntimes.Mono)]
         public static void CooperativeBlockingCanCreateThreadsFaster()
         {
             // Run in a separate process to test in a clean thread pool environment such that work items queued by the test

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -905,8 +905,14 @@ namespace System.Threading.ThreadPools.Tests
             }).Dispose();
         }
 
-        [ConditionalFact(nameof(IsThreadingAndRemoteExecutorSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/66852", TestPlatforms.OSX)]
+        public static bool IsThreadingAndRemoteExecutorSupported =>
+            PlatformDetection.IsThreadingSupported && RemoteExecutor.IsSupported;
+    }
+
+    [Collection(nameof(DisableParallelization))] // these tests may be sensitive to timing
+    public class ThreadPoolTests_NonParallel
+    {
+        [ConditionalFact(nameof(ThreadPoolTests.IsThreadingAndRemoteExecutorSupported))]
         public static void CooperativeBlockingCanCreateThreadsFaster()
         {
             // Run in a separate process to test in a clean thread pool environment such that work items queued by the test
@@ -969,7 +975,7 @@ namespace System.Threading.ThreadPools.Tests
             }).Dispose();
         }
 
-        [ConditionalFact(nameof(IsThreadingAndRemoteExecutorSupported))]
+        [ConditionalFact(nameof(ThreadPoolTests.IsThreadingAndRemoteExecutorSupported))]
         public static void CooperativeBlockingWithProcessingThreadsAndGoalThreadsAndAddWorkerRaceTest()
         {
             // Avoid contaminating the main process' environment
@@ -1019,8 +1025,5 @@ namespace System.Threading.ThreadPools.Tests
                 }).Dispose();
             }).Dispose();
         }
-
-        public static bool IsThreadingAndRemoteExecutorSupported =>
-            PlatformDetection.IsThreadingSupported && RemoteExecutor.IsSupported;
     }
 }

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -907,7 +906,7 @@ namespace System.Threading.ThreadPools.Tests
         }
 
         [ConditionalFact(nameof(IsThreadingAndRemoteExecutorSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/66854", TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/66852", TestPlatforms.OSX)]
         public static void CooperativeBlockingCanCreateThreadsFaster()
         {
             // Run in a separate process to test in a clean thread pool environment such that work items queued by the test
@@ -925,19 +924,6 @@ namespace System.Threading.ThreadPools.Tests
                 int workItemCount = processorCount + 120;
                 SetBlockingConfigValue("ThreadsToAddWithoutDelay_ProcCountFactor", 1);
                 SetBlockingConfigValue("MaxDelayMs", 1);
-
-                // Since this is a time-sensitive test that needs to create many threads before it completes, if it is run in
-                // parallel with other tests busily using the CPU, it may end up timing out due to lack of resources. Subscribe
-                // to thread adjustment events to extend the timeout if progress is being made.
-                bool gotCooperativeBlockingEvent = false;
-                using var threadAdjustmentListener = new ThreadPoolAdjustmentEventListener();
-                threadAdjustmentListener.ThreadAdjustment += (_, reason) =>
-                {
-                    if (reason == ThreadAdjustmentReason.CooperativeBlocking)
-                    {
-                        gotCooperativeBlockingEvent = true;
-                    }
-                };
 
                 var allWorkItemsUnblocked = new AutoResetEvent(false);
 
@@ -965,17 +951,7 @@ namespace System.Threading.ThreadPools.Tests
 
                     Action<int> unblockingWorkItem = _ => tcs.SetResult(0);
                     ThreadPool.UnsafeQueueUserWorkItem(unblockingWorkItem, 0, preferLocal: false);
-
-                    while (true)
-                    {
-                        gotCooperativeBlockingEvent = false;
-                        if (allWorkItemsUnblocked.WaitOne(30_000))
-                        {
-                            break;
-                        }
-
-                        Assert.True(gotCooperativeBlockingEvent);
-                    }
+                    Assert.True(allWorkItemsUnblocked.WaitOne(30_000));
                 }
 
                 void SetBlockingConfigValue(string name, int value) =>
@@ -1046,51 +1022,5 @@ namespace System.Threading.ThreadPools.Tests
 
         public static bool IsThreadingAndRemoteExecutorSupported =>
             PlatformDetection.IsThreadingSupported && RemoteExecutor.IsSupported;
-
-        private sealed class ThreadPoolAdjustmentEventListener : EventListener
-        {
-            private const string ClrProviderName = "Microsoft-Windows-DotNETRuntime";
-            private const EventKeywords ThreadingKeyword = (EventKeywords)0x10000;
-            private const int ThreadPoolWorkerThreadAdjustmentAdjustmentEventId = 55;
-            private const int ReasonPayloadIndex = 2;
-
-            public event EventHandler<ThreadAdjustmentReason> ThreadAdjustment;
-
-            protected override void OnEventSourceCreated(EventSource eventSource)
-            {
-                if (eventSource.Name == ClrProviderName)
-                {
-                    EnableEvents(eventSource, EventLevel.Informational, ThreadingKeyword);
-                }
-
-                base.OnEventSourceCreated(eventSource);
-            }
-
-            protected override void OnEventWritten(EventWrittenEventArgs eventData)
-            {
-                if (eventData.EventId == ThreadPoolWorkerThreadAdjustmentAdjustmentEventId &&
-                    eventData.Payload != null &&
-                    ReasonPayloadIndex < eventData.Payload.Count &&
-                    eventData.Payload[ReasonPayloadIndex] is uint reasonValue)
-                {
-                    ThreadAdjustment?.Invoke(this, (ThreadAdjustmentReason)reasonValue);
-                }
-
-                base.OnEventWritten(eventData);
-            }
-        }
-
-        public enum ThreadAdjustmentReason : uint
-        {
-            Warmup,
-            Initializing,
-            RandomMove,
-            ClimbingMove,
-            ChangePoint,
-            Stabilizing,
-            Starvation,
-            ThreadTimedOut,
-            CooperativeBlocking,
-        }
     }
 }


### PR DESCRIPTION
I guess the test may occasionally time out if it's running in parallel with other tests, depending on what those other tests are doing. Subscribed to thread adjustment events to see if progress is being made to extend the timeout.

Hopefully fixes https://github.com/dotnet/runtime/issues/66852