### PR TITLE
Use no-recent-activity in inactive Draft PRs

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1615,7 +1615,7 @@
     "subCapability": "ScheduledSearch",
     "version": "1.1",
     "config": {
-      "taskName": "Add no-recent-activity label to PRs",
+      "taskName": "Add no-recent-activity label to needs-author-action PRs",
       "frequency": [
         {
           "weekDay": 0,
@@ -1701,6 +1701,130 @@
           "name": "hasLabel",
           "parameters": {
             "label": "needs-author-action"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 14
+          }
+        },
+        {
+          "name": "noLabel",
+          "parameters": {
+            "label": "no-recent-activity"
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "no-recent-activity"
+          }
+        },
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "This pull request has been automatically marked `no-recent-activity` because it has not had any activity for 14 days. It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will remove `no-recent-activity`."
+          }
+        }
+      ]
+    },
+    "disabled": false
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "taskName": "Add no-recent-activity label to Draft PRs",
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isPr",
+          "parameters": {}
+        },
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "isDraftPr",
+          "parameters": {
+            "value": "true"
           }
         },
         {
@@ -1857,117 +1981,6 @@
       ],
       "enableForPullRequests": true,
       "replyTemplate": "Tagging subscribers to 'arch-android': ${mentionees}\nSee info in area-owners.md if you want to be subscribed."
-    }
-  },
-  {
-    "taskType": "scheduled",
-    "capabilityId": "ScheduledSearch",
-    "subCapability": "ScheduledSearch",
-    "version": "1.1",
-    "config": {
-      "frequency": [
-        {
-          "weekDay": 0,
-          "hours": [
-            5,
-            11,
-            17,
-            23
-          ],
-          "timezoneOffset": 0
-        },
-        {
-          "weekDay": 1,
-          "hours": [
-            5,
-            11,
-            17,
-            23
-          ],
-          "timezoneOffset": 0
-        },
-        {
-          "weekDay": 2,
-          "hours": [
-            5,
-            11,
-            17,
-            23
-          ],
-          "timezoneOffset": 0
-        },
-        {
-          "weekDay": 3,
-          "hours": [
-            5,
-            11,
-            17,
-            23
-          ],
-          "timezoneOffset": 0
-        },
-        {
-          "weekDay": 4,
-          "hours": [
-            5,
-            11,
-            17,
-            23
-          ],
-          "timezoneOffset": 0
-        },
-        {
-          "weekDay": 5,
-          "hours": [
-            5,
-            11,
-            17,
-            23
-          ],
-          "timezoneOffset": 0
-        },
-        {
-          "weekDay": 6,
-          "hours": [
-            5,
-            11,
-            17,
-            23
-          ],
-          "timezoneOffset": 0
-        }
-      ],
-      "searchTerms": [
-        {
-          "name": "isDraftPr",
-          "parameters": {
-            "value": "true"
-          }
-        },
-        {
-          "name": "isOpen",
-          "parameters": {}
-        },
-        {
-          "name": "noActivitySince",
-          "parameters": {
-            "days": 30
-          }
-        }
-      ],
-      "taskName": "Close inactive Draft PRs",
-      "actions": [
-        {
-          "name": "closeIssue",
-          "parameters": {}
-        },
-        {
-          "name": "addReply",
-          "parameters": {
-            "comment": "Draft Pull Request was automatically closed for inactivity. Please [let us know](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you'd like to reopen it."
-          }
-        }
-      ]
     }
   },
   {


### PR DESCRIPTION
Following feedback from https://github.com/dotnet/runtime/pull/65101#issuecomment-1066200182 this updates Draft PR auto closing automation to use the `no-recent-activity` label workflow. Stale PRs will be issued a warning before being closed automatically 14 days later.