### PR TITLE
Replace AsArgument/AsParameter with less P/Invoke-centric concepts

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/PInvokeStubCodeGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/PInvokeStubCodeGenerator.cs
@@ -512,10 +512,8 @@ namespace Microsoft.Interop
                 ParameterList(
                     SeparatedList(
                         _paramMarshallers.Select(marshaler => marshaler.Generator.AsParameter(marshaler.TypeInfo)))),
-                _retMarshaller.Generator.AsNativeType(_retMarshaller.TypeInfo),
-                _retMarshaller.Generator is IAttributedReturnTypeMarshallingGenerator attributedReturn
-                ? attributedReturn.GenerateAttributesForReturnType(_retMarshaller.TypeInfo)
-                : null
+                _retMarshaller.Generator.AsReturnType(_retMarshaller.TypeInfo),
+                _retMarshaller.Generator.GenerateAttributesForReturnType(_retMarshaller.TypeInfo)
             );
         }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ArrayMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ArrayMarshaller.cs
@@ -27,14 +27,13 @@ namespace Microsoft.Interop
             return target is TargetFramework.Net && version.Major >= 7;
         }
 
-        public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
+        public ValueBoundaryBehavior GetValueBoundaryBehavior(TypePositionInfo info, StubCodeContext context)
         {
             if (IsPinningPathSupported(info, context))
             {
-                string identifier = context.GetIdentifiers(info).native;
-                return Argument(CastExpression(AsNativeType(info), IdentifierName(identifier)));
+                return ValueBoundaryBehavior.NativeIdentifier;
             }
-            return _manualMarshallingGenerator.AsArgument(info, context);
+            return _manualMarshallingGenerator.GetValueBoundaryBehavior(info, context);
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
@@ -42,9 +41,9 @@ namespace Microsoft.Interop
             return _manualMarshallingGenerator.AsNativeType(info);
         }
 
-        public ParameterSyntax AsParameter(TypePositionInfo info)
+        public SignatureBehavior GetNativeSignatureBehavior(TypePositionInfo info)
         {
-            return _manualMarshallingGenerator.AsParameter(info);
+            return _manualMarshallingGenerator.GetNativeSignatureBehavior(info);
         }
 
         public IEnumerable<StatementSyntax> Generate(TypePositionInfo info, StubCodeContext context)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/BlittableMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/BlittableMarshaller.cs
@@ -20,29 +20,22 @@ namespace Microsoft.Interop
             return info.ManagedType.Syntax;
         }
 
-        public ParameterSyntax AsParameter(TypePositionInfo info)
+        public SignatureBehavior GetNativeSignatureBehavior(TypePositionInfo info)
         {
-            TypeSyntax type = info.IsByRef
-                ? PointerType(AsNativeType(info))
-                : AsNativeType(info);
-            return Parameter(Identifier(info.InstanceIdentifier))
-                .WithType(type);
+            return info.IsByRef ? SignatureBehavior.PointerToNativeType : SignatureBehavior.NativeType;
         }
 
-        public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
+        public ValueBoundaryBehavior GetValueBoundaryBehavior(TypePositionInfo info, StubCodeContext context)
         {
             if (!info.IsByRef)
             {
-                return Argument(IdentifierName(info.InstanceIdentifier));
+                return ValueBoundaryBehavior.ManagedIdentifier;
             }
             else if (context.SingleFrameSpansNativeContext && !info.IsManagedReturnPosition)
             {
-                return Argument(IdentifierName(context.GetIdentifiers(info).native));
+                return ValueBoundaryBehavior.NativeIdentifier;
             }
-            return Argument(
-                    PrefixUnaryExpression(
-                        SyntaxKind.AddressOfExpression,
-                        IdentifierName(context.GetIdentifiers(info).native)));
+            return ValueBoundaryBehavior.AddressOfNativeIdentifier;
         }
 
         public IEnumerable<StatementSyntax> Generate(TypePositionInfo info, StubCodeContext context)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/BoolMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/BoolMarshaller.cs
@@ -35,27 +35,19 @@ namespace Microsoft.Interop
             return _nativeType;
         }
 
-        public ParameterSyntax AsParameter(TypePositionInfo info)
+        public SignatureBehavior GetNativeSignatureBehavior(TypePositionInfo info)
         {
-            TypeSyntax type = info.IsByRef
-                ? PointerType(AsNativeType(info))
-                : AsNativeType(info);
-            return Parameter(Identifier(info.InstanceIdentifier))
-                .WithType(type);
+            return info.IsByRef ? SignatureBehavior.PointerToNativeType : SignatureBehavior.NativeType;
         }
 
-        public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
+        public ValueBoundaryBehavior GetValueBoundaryBehavior(TypePositionInfo info, StubCodeContext context)
         {
-            string identifier = context.GetIdentifiers(info).native;
             if (info.IsByRef)
             {
-                return Argument(
-                    PrefixUnaryExpression(
-                        SyntaxKind.AddressOfExpression,
-                        IdentifierName(identifier)));
+                return ValueBoundaryBehavior.AddressOfNativeIdentifier;
             }
 
-            return Argument(IdentifierName(identifier));
+            return ValueBoundaryBehavior.NativeIdentifier;
         }
 
         public IEnumerable<StatementSyntax> Generate(TypePositionInfo info, StubCodeContext context)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshaller.cs
@@ -22,31 +22,18 @@ namespace Microsoft.Interop
 
         public bool IsSupported(TargetFramework target, Version version) => true;
 
-        public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
+        public ValueBoundaryBehavior GetValueBoundaryBehavior(TypePositionInfo info, StubCodeContext context)
         {
-            (string managedIdentifier, string nativeIdentifier) = context.GetIdentifiers(info);
             if (!info.IsByRef)
             {
-                // (ushort)<managedIdentifier>
-                return Argument(
-                    CastExpression(
-                        AsNativeType(info),
-                        IdentifierName(managedIdentifier)));
+                return ValueBoundaryBehavior.ManagedIdentifier;
             }
             else if (IsPinningPathSupported(info, context))
             {
-                // (ushort*)<pinned>
-                return Argument(
-                    CastExpression(
-                        PointerType(AsNativeType(info)),
-                        IdentifierName(PinnedIdentifier(info.InstanceIdentifier))));
+                return ValueBoundaryBehavior.NativeIdentifier;
             }
 
-            // &<nativeIdentifier>
-            return Argument(
-                PrefixUnaryExpression(
-                    SyntaxKind.AddressOfExpression,
-                    IdentifierName(nativeIdentifier)));
+            return ValueBoundaryBehavior.AddressOfNativeIdentifier;
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
@@ -55,13 +42,9 @@ namespace Microsoft.Interop
             return s_nativeType;
         }
 
-        public ParameterSyntax AsParameter(TypePositionInfo info)
+        public SignatureBehavior GetNativeSignatureBehavior(TypePositionInfo info)
         {
-            TypeSyntax type = info.IsByRef
-                ? PointerType(AsNativeType(info))
-                : AsNativeType(info);
-            return Parameter(Identifier(info.InstanceIdentifier))
-                .WithType(type);
+            return info.IsByRef ? SignatureBehavior.PointerToNativeType : SignatureBehavior.NativeType;
         }
 
         public IEnumerable<StatementSyntax> Generate(TypePositionInfo info, StubCodeContext context)
@@ -85,7 +68,15 @@ namespace Microsoft.Interop
                                     ))
                             )
                         ),
-                        EmptyStatement()
+                        // ushort* <native> = (ushort*)<pinned>;
+                        LocalDeclarationStatement(
+                            VariableDeclaration(PointerType(AsNativeType(info)),
+                                SingletonSeparatedList(
+                                    VariableDeclarator(nativeIdentifier)
+                                        .WithInitializer(EqualsValueClause(
+                                            CastExpression(
+                                                PointerType(AsNativeType(info)),
+                                                IdentifierName(PinnedIdentifier(info.InstanceIdentifier))))))))
                     );
                 }
                 yield break;

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ConditionalStackallocMarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ConditionalStackallocMarshallingGenerator.cs
@@ -238,10 +238,10 @@ namespace Microsoft.Interop
         public abstract TypeSyntax AsNativeType(TypePositionInfo info);
 
         /// <inheritdoc/>
-        public abstract ParameterSyntax AsParameter(TypePositionInfo info);
+        public abstract SignatureBehavior GetNativeSignatureBehavior(TypePositionInfo info);
 
         /// <inheritdoc/>
-        public abstract ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context);
+        public abstract ValueBoundaryBehavior GetValueBoundaryBehavior(TypePositionInfo info, StubCodeContext context);
 
         /// <inheritdoc/>
         public abstract IEnumerable<StatementSyntax> Generate(TypePositionInfo info, StubCodeContext context);

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CustomNativeTypeMarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CustomNativeTypeMarshallingGenerator.cs
@@ -28,9 +28,9 @@ namespace Microsoft.Interop
             return target is TargetFramework.Net && version.Major >= 6;
         }
 
-        public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
+        public ValueBoundaryBehavior GetValueBoundaryBehavior(TypePositionInfo info, StubCodeContext context)
         {
-            return _nativeTypeMarshaller.AsArgument(info, context);
+            return info.IsByRef ? ValueBoundaryBehavior.AddressOfNativeIdentifier : ValueBoundaryBehavior.NativeIdentifier;
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
@@ -38,13 +38,9 @@ namespace Microsoft.Interop
             return _nativeTypeMarshaller.AsNativeType(info);
         }
 
-        public ParameterSyntax AsParameter(TypePositionInfo info)
+        public SignatureBehavior GetNativeSignatureBehavior(TypePositionInfo info)
         {
-            TypeSyntax type = info.IsByRef
-                ? PointerType(AsNativeType(info))
-                : AsNativeType(info);
-            return Parameter(Identifier(info.InstanceIdentifier))
-                .WithType(type);
+            return info.IsByRef ? SignatureBehavior.PointerToNativeType : SignatureBehavior.NativeType;
         }
 
         public IEnumerable<StatementSyntax> Generate(TypePositionInfo info, StubCodeContext context)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/DelegateMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/DelegateMarshaller.cs
@@ -19,27 +19,14 @@ namespace Microsoft.Interop
             return MarshallerHelpers.SystemIntPtrType;
         }
 
-        public ParameterSyntax AsParameter(TypePositionInfo info)
+        public SignatureBehavior GetNativeSignatureBehavior(TypePositionInfo info)
         {
-            TypeSyntax type = info.IsByRef
-                ? PointerType(AsNativeType(info))
-                : AsNativeType(info);
-            return Parameter(Identifier(info.InstanceIdentifier))
-                .WithType(type);
+            return info.IsByRef ? SignatureBehavior.PointerToNativeType : SignatureBehavior.NativeType;
         }
 
-        public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
+        public ValueBoundaryBehavior GetValueBoundaryBehavior(TypePositionInfo info, StubCodeContext context)
         {
-            string identifier = context.GetIdentifiers(info).native;
-            if (info.IsByRef)
-            {
-                return Argument(
-                    PrefixUnaryExpression(
-                        SyntaxKind.AddressOfExpression,
-                        IdentifierName(identifier)));
-            }
-
-            return Argument(IdentifierName(identifier));
+            return info.IsByRef ? ValueBoundaryBehavior.AddressOfNativeIdentifier : ValueBoundaryBehavior.NativeIdentifier;
         }
 
         public IEnumerable<StatementSyntax> Generate(TypePositionInfo info, StubCodeContext context)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/Forwarder.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/Forwarder.cs
@@ -11,7 +11,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Interop
 {
-    public sealed class Forwarder : IMarshallingGenerator, IAttributedReturnTypeMarshallingGenerator
+    public sealed class Forwarder : IMarshallingGenerator
     {
         public bool IsSupported(TargetFramework target, Version version) => true;
 
@@ -20,129 +20,14 @@ namespace Microsoft.Interop
             return info.ManagedType.Syntax;
         }
 
-        private bool TryRehydrateMarshalAsAttribute(TypePositionInfo info, out AttributeSyntax marshalAsAttribute)
+        public SignatureBehavior GetNativeSignatureBehavior(TypePositionInfo info)
         {
-            marshalAsAttribute = null!;
-            // If the parameter has [MarshalAs] marshalling, we resurface that
-            // in the forwarding target since the built-in system understands it.
-            // ICustomMarshaller marshalling requires additional information that we throw away earlier since it's unsupported,
-            // so explicitly do not resurface a [MarshalAs(UnmanagdType.CustomMarshaler)] attribute.
-            if (info.MarshallingAttributeInfo is MarshalAsInfo { UnmanagedType: not UnmanagedType.CustomMarshaler } marshalAs)
-            {
-                marshalAsAttribute = Attribute(ParseName(TypeNames.System_Runtime_InteropServices_MarshalAsAttribute))
-                        .WithArgumentList(AttributeArgumentList(SingletonSeparatedList(AttributeArgument(
-                        CastExpression(ParseTypeName(TypeNames.System_Runtime_InteropServices_UnmanagedType),
-                        LiteralExpression(SyntaxKind.NumericLiteralExpression,
-                            Literal((int)marshalAs.UnmanagedType)))))));
-                return true;
-            }
-
-            if (info.ManagedType is SzArrayType)
-            {
-                CountInfo countInfo;
-                MarshallingInfo elementMarshallingInfo;
-                if (info.MarshallingAttributeInfo is NativeContiguousCollectionMarshallingInfo collectionMarshalling
-                    && collectionMarshalling.UseDefaultMarshalling
-                    && collectionMarshalling.ElementCountInfo is NoCountInfo or SizeAndParamIndexInfo
-                    && collectionMarshalling.ElementMarshallingInfo is NoMarshallingInfo or MarshalAsInfo { UnmanagedType: not UnmanagedType.CustomMarshaler }
-                    )
-                {
-                    countInfo = collectionMarshalling.ElementCountInfo;
-                    elementMarshallingInfo = collectionMarshalling.ElementMarshallingInfo;
-                }
-                else if (info.MarshallingAttributeInfo is MissingSupportCollectionMarshallingInfo missingSupport)
-                {
-                    countInfo = missingSupport.CountInfo;
-                    elementMarshallingInfo = missingSupport.ElementMarshallingInfo;
-                }
-                else
-                {
-                    // This condition can be hit in two ways:
-                    // 1. User uses the MarshalUsing attribute to provide count info or element marshalling information.
-                    // Since the MarshalUsing attribute doesn't exist on downlevel platforms where we don't support arrays,
-                    // this case is unlikely to come in supported scenarios, but could come up with a custom CoreLib implementation
-                    // 2. User provides a MarsalAs attribute with the ArraySubType field set to UnmanagedType.CustomMarshaler
-                    // As mentioned above, we don't support ICustomMarshaler in the generator so we fail to forward the attribute instead of partially fowarding it.
-                    return false;
-                }
-
-                List<AttributeArgumentSyntax> marshalAsArguments = new List<AttributeArgumentSyntax>
-                {
-                    AttributeArgument(
-                        CastExpression(ParseTypeName(TypeNames.System_Runtime_InteropServices_UnmanagedType),
-                        LiteralExpression(SyntaxKind.NumericLiteralExpression,
-                            Literal((int)UnmanagedType.LPArray))))
-                };
-
-                if (countInfo is SizeAndParamIndexInfo sizeParamIndex)
-                {
-                    if (sizeParamIndex.ConstSize != SizeAndParamIndexInfo.UnspecifiedConstSize)
-                    {
-                        marshalAsArguments.Add(
-                            AttributeArgument(NameEquals("SizeConst"), null,
-                                LiteralExpression(SyntaxKind.NumericLiteralExpression,
-                                    Literal(sizeParamIndex.ConstSize)))
-                        );
-                    }
-                    if (sizeParamIndex.ParamAtIndex is { ManagedIndex: int paramIndex })
-                    {
-                        marshalAsArguments.Add(
-                            AttributeArgument(NameEquals("SizeParamIndex"), null,
-                                LiteralExpression(SyntaxKind.NumericLiteralExpression,
-                                    Literal(paramIndex)))
-                        );
-                    }
-                }
-
-                if (elementMarshallingInfo is MarshalAsInfo elementMarshalAs)
-                {
-                    marshalAsArguments.Add(
-                        AttributeArgument(NameEquals("ArraySubType"), null,
-                            CastExpression(ParseTypeName(TypeNames.System_Runtime_InteropServices_UnmanagedType),
-                            LiteralExpression(SyntaxKind.NumericLiteralExpression,
-                                Literal((int)elementMarshalAs.UnmanagedType))))
-                        );
-                }
-                marshalAsAttribute = Attribute(ParseName(TypeNames.System_Runtime_InteropServices_MarshalAsAttribute))
-                        .WithArgumentList(AttributeArgumentList(SeparatedList(marshalAsArguments)));
-                return true;
-            }
-
-            return false;
+            return SignatureBehavior.ManagedTypeAndAttributes;
         }
 
-        public ParameterSyntax AsParameter(TypePositionInfo info)
+        public ValueBoundaryBehavior GetValueBoundaryBehavior(TypePositionInfo info, StubCodeContext context)
         {
-            ParameterSyntax param = Parameter(Identifier(info.InstanceIdentifier))
-                .WithModifiers(TokenList(Token(info.RefKindSyntax)))
-                .WithType(info.ManagedType.Syntax);
-
-            List<AttributeSyntax> rehydratedAttributes = new();
-            if (TryRehydrateMarshalAsAttribute(info, out AttributeSyntax marshalAsAttribute))
-            {
-                rehydratedAttributes.Add(marshalAsAttribute);
-            }
-            if (info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.In))
-            {
-                rehydratedAttributes.Add(Attribute(IdentifierName(TypeNames.System_Runtime_InteropServices_InAttribute)));
-            }
-            if (info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.Out))
-            {
-                rehydratedAttributes.Add(Attribute(IdentifierName(TypeNames.System_Runtime_InteropServices_OutAttribute)));
-            }
-
-            if (rehydratedAttributes.Count > 0)
-            {
-                param = param.AddAttributeLists(AttributeList(SeparatedList(rehydratedAttributes)));
-            }
-
-            return param;
-        }
-
-        public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
-        {
-            return Argument(IdentifierName(info.InstanceIdentifier))
-                .WithRefKindKeyword(Token(info.RefKindSyntax));
+            return ValueBoundaryBehavior.ManagedIdentifier;
         }
 
         public IEnumerable<StatementSyntax> Generate(TypePositionInfo info, StubCodeContext context)
@@ -153,14 +38,5 @@ namespace Microsoft.Interop
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => false;
 
         public bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context) => true;
-
-        public AttributeListSyntax? GenerateAttributesForReturnType(TypePositionInfo info)
-        {
-            if (!TryRehydrateMarshalAsAttribute(info, out AttributeSyntax marshalAsAttribute))
-            {
-                return null;
-            }
-            return AttributeList(SingletonSeparatedList(marshalAsAttribute));
-        }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
@@ -18,8 +18,6 @@ namespace Microsoft.Interop
     {
         TypeSyntax AsNativeType(TypePositionInfo info);
 
-        ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context);
-
         IEnumerable<ArgumentSyntax> GetNativeTypeConstructorArguments(TypePositionInfo info, StubCodeContext context);
 
         IEnumerable<StatementSyntax> GenerateMarshalStatements(TypePositionInfo info, StubCodeContext context, IEnumerable<ArgumentSyntax> nativeTypeConstructorArguments);
@@ -45,20 +43,6 @@ namespace Microsoft.Interop
         public SimpleCustomNativeTypeMarshalling(TypeSyntax nativeTypeSyntax)
         {
             _nativeTypeSyntax = nativeTypeSyntax;
-        }
-
-        public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
-        {
-            string identifier = context.GetIdentifiers(info).native;
-            if (info.IsByRef)
-            {
-                return Argument(
-                    PrefixUnaryExpression(
-                        SyntaxKind.AddressOfExpression,
-                        IdentifierName(identifier)));
-            }
-
-            return Argument(IdentifierName(identifier));
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
@@ -157,20 +141,6 @@ namespace Microsoft.Interop
         {
             _innerMarshaller = innerMarshaller;
             _valuePropertyType = valuePropertyType;
-        }
-
-        public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
-        {
-            string identifier = context.GetIdentifiers(info).native;
-            if (info.IsByRef)
-            {
-                return Argument(
-                    PrefixUnaryExpression(
-                        SyntaxKind.AddressOfExpression,
-                        IdentifierName(identifier)));
-            }
-
-            return Argument(IdentifierName(identifier));
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
@@ -287,11 +257,6 @@ namespace Microsoft.Interop
             _innerMarshaller = innerMarshaller;
         }
 
-        public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
-        {
-            return _innerMarshaller.AsArgument(info, context);
-        }
-
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
             return _innerMarshaller.AsNativeType(info);
@@ -396,11 +361,6 @@ namespace Microsoft.Interop
             _innerMarshaller = innerMarshaller;
         }
 
-        public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
-        {
-            return _innerMarshaller.AsArgument(info, context);
-        }
-
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
             return _innerMarshaller.AsNativeType(info);
@@ -469,11 +429,6 @@ namespace Microsoft.Interop
         private bool CanPinMarshaller(TypePositionInfo info, StubCodeContext context)
         {
             return context.SingleFrameSpansNativeContext && !info.IsManagedReturnPosition && !info.IsByRef || info.RefKind == RefKind.In;
-        }
-
-        public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
-        {
-            return _innerMarshaller.AsArgument(info, context);
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
@@ -608,11 +563,6 @@ namespace Microsoft.Interop
             _sizeOfElementExpression = sizeOfElementExpression;
         }
 
-        public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
-        {
-            return _innerMarshaller.AsArgument(info, context);
-        }
-
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
             return _innerMarshaller.AsNativeType(info);
@@ -719,11 +669,6 @@ namespace Microsoft.Interop
         {
             _innerMarshaller = innerMarshaller;
             _elementType = elementType;
-        }
-
-        public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
-        {
-            return _innerMarshaller.AsArgument(info, context);
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
@@ -944,11 +889,6 @@ namespace Microsoft.Interop
                                     .WithStatement(marshallingStatement));
             }
             return EmptyStatement();
-        }
-
-        public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
-        {
-            return _innerMarshaller.AsArgument(info, context);
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshalAsMarshallingGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshalAsMarshallingGeneratorFactory.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Interop
         private static readonly VariantBoolMarshaller s_variantBool = new();
 
         private static readonly Utf16CharMarshaller s_utf16Char = new();
-        private static readonly Utf16StringMarshaller s_utf16String = new();
+        private static readonly IMarshallingGenerator s_utf16String = new PinnableManagedValueMarshaller(new Utf16StringMarshaller());
         private static readonly Utf8StringMarshaller s_utf8String = new();
         private static readonly AnsiStringMarshaller s_ansiString = new AnsiStringMarshaller(s_utf8String);
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGenerator.cs
@@ -21,6 +21,44 @@ namespace Microsoft.Interop
     }
 
     /// <summary>
+    /// An enumeration describing how a <see cref="TypePositionInfo"/> should be represented in its corresponding native signature element (parameter, field, or return value).
+    /// </summary>
+    public enum SignatureBehavior
+    {
+        /// <summary>
+        /// The native type should match the managed type, including rehydrating marshalling attributes and by-ref syntax (pure forwarding).
+        /// </summary>
+        ManagedTypeAndAttributes,
+        /// <summary>
+        /// The native signature should be the type returned by <see cref="IMarshallingGenerator.AsNativeType(TypePositionInfo)"/> passed by value.
+        /// </summary>
+        NativeType,
+        /// <summary>
+        /// The native signature should be a pointer to the type returned by <see cref="IMarshallingGenerator.AsNativeType(TypePositionInfo)"/> passed by value.
+        /// </summary>
+        PointerToNativeType
+    }
+
+    /// <summary>
+    /// An enumeration describing how a <see cref="TypePositionInfo"/> should be represented in its corresponding native signature element (parameter, field, or return value).
+    /// </summary>
+    public enum ValueBoundaryBehavior
+    {
+        /// <summary>
+        /// The managed value should be passed as-is, including any managed by-ref syntax used in the managed declaration.
+        /// </summary>
+        ManagedIdentifier,
+        /// <summary>
+        /// The native identifier provided by <see cref="StubCodeContext.GetIdentifiers(TypePositionInfo)"/> should be passed by value.
+        /// </summary>
+        NativeIdentifier,
+        /// <summary>
+        /// The address of the native identifier provided by <see cref="StubCodeContext.GetIdentifiers(TypePositionInfo)"/> should be passed by value.
+        /// </summary>
+        AddressOfNativeIdentifier
+    }
+
+    /// <summary>
     /// Interface for generation of marshalling code for P/Invoke stubs
     /// </summary>
     public interface IMarshallingGenerator
@@ -41,19 +79,19 @@ namespace Microsoft.Interop
         TypeSyntax AsNativeType(TypePositionInfo info);
 
         /// <summary>
-        /// Get the <paramref name="info"/> as a parameter of the P/Invoke declaration
+        /// Get shape that represents the provided <paramref name="info"/> in the native signature
         /// </summary>
         /// <param name="info">Object to marshal</param>
         /// <returns>Parameter syntax for <paramref name="info"/></returns>
-        ParameterSyntax AsParameter(TypePositionInfo info);
+        SignatureBehavior GetNativeSignatureBehavior(TypePositionInfo info);
 
         /// <summary>
-        /// Get the <paramref name="info"/> as an argument to be passed to the P/Invoke
+        /// Get shape of how the value represented by <paramref name="info"/> should be passed at the managed/native boundary in the provided <paramref name="context"/>
         /// </summary>
         /// <param name="info">Object to marshal</param>
         /// <param name="context">Code generation context</param>
         /// <returns>Argument syntax for <paramref name="info"/></returns>
-        ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context);
+        ValueBoundaryBehavior GetValueBoundaryBehavior(TypePositionInfo info, StubCodeContext context);
 
         /// <summary>
         /// Generate code for marshalling
@@ -89,19 +127,6 @@ namespace Microsoft.Interop
         /// <param name="context">The marshalling context.</param>
         /// <returns></returns>
         bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context);
-    }
-
-    /// <summary>
-    /// Interface for generating attributes for native return types.
-    /// </summary>
-    public interface IAttributedReturnTypeMarshallingGenerator : IMarshallingGenerator
-    {
-        /// <summary>
-        /// Gets any attributes that should be applied to the return type for this <paramref name="info"/>.
-        /// </summary>
-        /// <param name="info">Object to marshal</param>
-        /// <returns>Attributes for the return type for this <paramref name="info"/>, or <c>null</c> if no attributes should be added.</returns>
-        AttributeListSyntax? GenerateAttributesForReturnType(TypePositionInfo info);
     }
 
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGeneratorExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGeneratorExtensions.cs
@@ -12,6 +12,11 @@ namespace Microsoft.Interop
 {
     public static class MarshallingGeneratorExtensions
     {
+        /// <summary>
+        /// Gets the return type for the unmanaged signature that represents the provided <paramref name="info"/>.
+        /// </summary>
+        /// <param name="generator">The marshalling generator for this <paramref name="info"/></param>
+        /// <param name="info">Object to marshal</param>
         public static TypeSyntax AsReturnType(this IMarshallingGenerator generator, TypePositionInfo info)
         {
             return generator.GetNativeSignatureBehavior(info) switch
@@ -42,6 +47,11 @@ namespace Microsoft.Interop
             return AttributeList(SingletonSeparatedList(marshalAsAttribute));
         }
 
+        /// <summary>
+        /// Gets a parameter for the unmanaged signature that represents the provided <paramref name="info"/>.
+        /// </summary>
+        /// <param name="generator">The marshalling generator for this <paramref name="info"/></param>
+        /// <param name="info">Object to marshal</param>
         public static ParameterSyntax AsParameter(this IMarshallingGenerator generator, TypePositionInfo info)
         {
             SignatureBehavior behavior = generator.GetNativeSignatureBehavior(info);
@@ -178,6 +188,12 @@ namespace Microsoft.Interop
             return false;
         }
 
+        /// <summary>
+        /// Gets an argument expression for the unmanaged signature that can be used to pass a value of the provided <paramref name="info" /> in the specified <paramref name="context" />.
+        /// </summary>
+        /// <param name="generator">The marshalling generator for this <paramref name="info"/></param>
+        /// <param name="info">Object to marshal</param>
+        /// <param name="context">Marshalling context</param>
         public static ArgumentSyntax AsArgument(this IMarshallingGenerator generator, TypePositionInfo info, StubCodeContext context)
         {
             (string managedIdentifier, string nativeIdentifier) = context.GetIdentifiers(info);

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGeneratorExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGeneratorExtensions.cs
@@ -1,0 +1,194 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.Interop
+{
+    public static class MarshallingGeneratorExtensions
+    {
+        public static TypeSyntax AsReturnType(this IMarshallingGenerator generator, TypePositionInfo info)
+        {
+            return generator.GetNativeSignatureBehavior(info) switch
+            {
+                SignatureBehavior.ManagedTypeAndAttributes => info.ManagedType.Syntax,
+                SignatureBehavior.NativeType => generator.AsNativeType(info),
+                SignatureBehavior.PointerToNativeType => PointerType(generator.AsNativeType(info)),
+                _ => throw new InvalidOperationException()
+            };
+        }
+        /// <summary>
+        /// Gets any attributes that should be applied to the return type for this <paramref name="info"/>.
+        /// </summary>
+        /// <param name="generator">The marshalling generator for this <paramref name="info"/></param>
+        /// <param name="info">Object to marshal</param>
+        /// <returns>Attributes for the return type for this <paramref name="info"/>, or <c>null</c> if no attributes should be added.</returns>
+        public static AttributeListSyntax? GenerateAttributesForReturnType(this IMarshallingGenerator generator, TypePositionInfo info)
+        {
+            if (generator.GetNativeSignatureBehavior(info) != SignatureBehavior.ManagedTypeAndAttributes)
+            {
+                return null;
+            }
+
+            if (!TryRehydrateMarshalAsAttribute(info, out AttributeSyntax marshalAsAttribute))
+            {
+                return null;
+            }
+            return AttributeList(SingletonSeparatedList(marshalAsAttribute));
+        }
+
+        public static ParameterSyntax AsParameter(this IMarshallingGenerator generator, TypePositionInfo info)
+        {
+            SignatureBehavior behavior = generator.GetNativeSignatureBehavior(info);
+            if (behavior == SignatureBehavior.ManagedTypeAndAttributes)
+            {
+                return GenerateForwardingParameter(info);
+            }
+            return Parameter(Identifier(info.InstanceIdentifier))
+                .WithType(behavior switch
+                {
+                    SignatureBehavior.NativeType => generator.AsNativeType(info),
+                    SignatureBehavior.PointerToNativeType => PointerType(generator.AsNativeType(info)),
+                    _ => throw new InvalidOperationException()
+                });
+        }
+
+        private static ParameterSyntax GenerateForwardingParameter(TypePositionInfo info)
+        {
+            ParameterSyntax param = Parameter(Identifier(info.InstanceIdentifier))
+                .WithModifiers(TokenList(Token(info.RefKindSyntax)))
+                .WithType(info.ManagedType.Syntax);
+
+            List<AttributeSyntax> rehydratedAttributes = new();
+            if (TryRehydrateMarshalAsAttribute(info, out AttributeSyntax marshalAsAttribute))
+            {
+                rehydratedAttributes.Add(marshalAsAttribute);
+            }
+            if (info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.In))
+            {
+                rehydratedAttributes.Add(Attribute(IdentifierName(TypeNames.System_Runtime_InteropServices_InAttribute)));
+            }
+            if (info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.Out))
+            {
+                rehydratedAttributes.Add(Attribute(IdentifierName(TypeNames.System_Runtime_InteropServices_OutAttribute)));
+            }
+
+            if (rehydratedAttributes.Count > 0)
+            {
+                param = param.AddAttributeLists(AttributeList(SeparatedList(rehydratedAttributes)));
+            }
+
+            return param;
+        }
+
+
+        private static bool TryRehydrateMarshalAsAttribute(TypePositionInfo info, out AttributeSyntax marshalAsAttribute)
+        {
+            marshalAsAttribute = null!;
+            // If the parameter has [MarshalAs] marshalling, we resurface that
+            // in the forwarding target since the built-in system understands it.
+            // ICustomMarshaller marshalling requires additional information that we throw away earlier since it's unsupported,
+            // so explicitly do not resurface a [MarshalAs(UnmanagdType.CustomMarshaler)] attribute.
+            if (info.MarshallingAttributeInfo is MarshalAsInfo { UnmanagedType: not UnmanagedType.CustomMarshaler } marshalAs)
+            {
+                marshalAsAttribute = Attribute(ParseName(TypeNames.System_Runtime_InteropServices_MarshalAsAttribute))
+                        .WithArgumentList(AttributeArgumentList(SingletonSeparatedList(AttributeArgument(
+                        CastExpression(ParseTypeName(TypeNames.System_Runtime_InteropServices_UnmanagedType),
+                        LiteralExpression(SyntaxKind.NumericLiteralExpression,
+                            Literal((int)marshalAs.UnmanagedType)))))));
+                return true;
+            }
+
+            if (info.ManagedType is SzArrayType)
+            {
+                CountInfo countInfo;
+                MarshallingInfo elementMarshallingInfo;
+                if (info.MarshallingAttributeInfo is NativeContiguousCollectionMarshallingInfo collectionMarshalling
+                    && collectionMarshalling.UseDefaultMarshalling
+                    && collectionMarshalling.ElementCountInfo is NoCountInfo or SizeAndParamIndexInfo
+                    && collectionMarshalling.ElementMarshallingInfo is NoMarshallingInfo or MarshalAsInfo { UnmanagedType: not UnmanagedType.CustomMarshaler }
+                    )
+                {
+                    countInfo = collectionMarshalling.ElementCountInfo;
+                    elementMarshallingInfo = collectionMarshalling.ElementMarshallingInfo;
+                }
+                else if (info.MarshallingAttributeInfo is MissingSupportCollectionMarshallingInfo missingSupport)
+                {
+                    countInfo = missingSupport.CountInfo;
+                    elementMarshallingInfo = missingSupport.ElementMarshallingInfo;
+                }
+                else
+                {
+                    // This condition can be hit in two ways:
+                    // 1. User uses the MarshalUsing attribute to provide count info or element marshalling information.
+                    // Since the MarshalUsing attribute doesn't exist on downlevel platforms where we don't support arrays,
+                    // this case is unlikely to come in supported scenarios, but could come up with a custom CoreLib implementation
+                    // 2. User provides a MarsalAs attribute with the ArraySubType field set to UnmanagedType.CustomMarshaler
+                    // As mentioned above, we don't support ICustomMarshaler in the generator so we fail to forward the attribute instead of partially fowarding it.
+                    return false;
+                }
+
+                List<AttributeArgumentSyntax> marshalAsArguments = new List<AttributeArgumentSyntax>
+                {
+                    AttributeArgument(
+                        CastExpression(ParseTypeName(TypeNames.System_Runtime_InteropServices_UnmanagedType),
+                        LiteralExpression(SyntaxKind.NumericLiteralExpression,
+                            Literal((int)UnmanagedType.LPArray))))
+                };
+
+                if (countInfo is SizeAndParamIndexInfo sizeParamIndex)
+                {
+                    if (sizeParamIndex.ConstSize != SizeAndParamIndexInfo.UnspecifiedConstSize)
+                    {
+                        marshalAsArguments.Add(
+                            AttributeArgument(NameEquals("SizeConst"), null,
+                                LiteralExpression(SyntaxKind.NumericLiteralExpression,
+                                    Literal(sizeParamIndex.ConstSize)))
+                        );
+                    }
+                    if (sizeParamIndex.ParamAtIndex is { ManagedIndex: int paramIndex })
+                    {
+                        marshalAsArguments.Add(
+                            AttributeArgument(NameEquals("SizeParamIndex"), null,
+                                LiteralExpression(SyntaxKind.NumericLiteralExpression,
+                                    Literal(paramIndex)))
+                        );
+                    }
+                }
+
+                if (elementMarshallingInfo is MarshalAsInfo elementMarshalAs)
+                {
+                    marshalAsArguments.Add(
+                        AttributeArgument(NameEquals("ArraySubType"), null,
+                            CastExpression(ParseTypeName(TypeNames.System_Runtime_InteropServices_UnmanagedType),
+                            LiteralExpression(SyntaxKind.NumericLiteralExpression,
+                                Literal((int)elementMarshalAs.UnmanagedType))))
+                        );
+                }
+                marshalAsAttribute = Attribute(ParseName(TypeNames.System_Runtime_InteropServices_MarshalAsAttribute))
+                        .WithArgumentList(AttributeArgumentList(SeparatedList(marshalAsArguments)));
+                return true;
+            }
+
+            return false;
+        }
+
+        public static ArgumentSyntax AsArgument(this IMarshallingGenerator generator, TypePositionInfo info, StubCodeContext context)
+        {
+            (string managedIdentifier, string nativeIdentifier) = context.GetIdentifiers(info);
+            return generator.GetValueBoundaryBehavior(info, context) switch
+            {
+                ValueBoundaryBehavior.ManagedIdentifier when !info.IsByRef => Argument(IdentifierName(managedIdentifier)),
+                ValueBoundaryBehavior.ManagedIdentifier when info.IsByRef => Argument(IdentifierName(managedIdentifier)).WithRefKindKeyword(Token(info.RefKindSyntax)),
+                ValueBoundaryBehavior.NativeIdentifier => Argument(IdentifierName(nativeIdentifier)),
+                ValueBoundaryBehavior.AddressOfNativeIdentifier => Argument(PrefixUnaryExpression(SyntaxKind.AddressOfExpression, IdentifierName(nativeIdentifier))),
+                _ => throw new InvalidOperationException()
+            };
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/SafeHandleMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/SafeHandleMarshaller.cs
@@ -23,27 +23,14 @@ namespace Microsoft.Interop
             return MarshallerHelpers.SystemIntPtrType;
         }
 
-        public ParameterSyntax AsParameter(TypePositionInfo info)
+        public SignatureBehavior GetNativeSignatureBehavior(TypePositionInfo info)
         {
-            TypeSyntax type = info.IsByRef
-                ? PointerType(AsNativeType(info))
-                : AsNativeType(info);
-            return Parameter(Identifier(info.InstanceIdentifier))
-                .WithType(type);
+            return info.IsByRef ? SignatureBehavior.PointerToNativeType : SignatureBehavior.NativeType;
         }
 
-        public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
+        public ValueBoundaryBehavior GetValueBoundaryBehavior(TypePositionInfo info, StubCodeContext context)
         {
-            string identifier = context.GetIdentifiers(info).native;
-            if (info.IsByRef)
-            {
-                return Argument(
-                    PrefixUnaryExpression(
-                        SyntaxKind.AddressOfExpression,
-                        IdentifierName(identifier)));
-            }
-
-            return Argument(IdentifierName(identifier));
+            return info.IsByRef ? ValueBoundaryBehavior.AddressOfNativeIdentifier : ValueBoundaryBehavior.NativeIdentifier;
         }
 
         public IEnumerable<StatementSyntax> Generate(TypePositionInfo info, StubCodeContext context)


### PR DESCRIPTION
Replace AsArgument/AsParameter with enum-based options to help simplify future work with non-forward-P/Invoke support (in particular unmanaged->managed support).

This change will enable us to add behavior in one place to support getting a native value from an argument value so we don't need to manually add identical (or nearly identical) behavior to every one of our marshalling generators.

It also allows us to remove some special casing for the `Forwarder` generator.