### PR TITLE
Track all HttpConnectionPoolManager instances in a global list

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -32,7 +32,7 @@ namespace System.Net.Http
     internal sealed class HttpConnectionPoolManager : IDisposable
     {
         /// <summary>
-        /// WeakReferences to all managers in the process. The value is a dummy with no functional significance.
+        /// WeakReferences to all non-disposed managers in the process. The value is a dummy with no functional significance.
         /// This collection is iterated every second in HeartBeatAndCleanAllPools and collected instances are pruned.
         /// </summary>
         public static readonly ConcurrentDictionary<WeakReference<HttpConnectionPoolManager>, byte> AllManagers = new();
@@ -138,7 +138,8 @@ namespace System.Net.Http
                 else
                 {
                     // These are only non-disposed instances that the GC collected
-                    AllManagers.TryRemove(managerReference, out _);
+                    bool removed = AllManagers.TryRemove(managerReference, out _);
+                    Debug.Assert(removed);
                     managersRemoved++;
                 }
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -424,9 +424,7 @@ namespace System.Net.Http
         /// <summary>Disposes of the pools, disposing of each individual pool.</summary>
         public void Dispose()
         {
-            AllManagers.TryRemove(_weakThisRef, out _);
-
-            if (_pools is not null)
+            if (AllManagers.TryRemove(_weakThisRef, out _) && _pools is not null)
             {
                 foreach ((_, HttpConnectionPool pool) in _pools)
                 {


### PR DESCRIPTION
I was looking at what events & counters may be useful to add to connection pooling (https://github.com/dotnet/runtime/pull/66605#discussion_r828305848).

For some things, it would be useful to have a reference to every `HttpConnectionPoolManager` in the process.
Having such a list would make it possible to improve a few things:
- Reduce per-request overhead of tracking stats like `http11-requests-in-queue`
  - Doing such tracking inline during the request isn't prohibitively expensive though
- Simplify the cleaning & heartbeat timer logic across pools
  - A single timer can be used for the whole process, instead of toggling timers per manager instance
- Simplify the `NetworkChange` notifications
  - A single notification is sufficient for all managers, avoiding the added logic around the callback registration cleanup
- Potentially simplify other per-pool timer mechanisms (not sure if this is viable yet)
  - Recent example of issues that come along with that: #66782
- We avoid tracking some things like `http11-connections-current-total` when telemetry is disabled. As a result, you will see wrong values if you turn telemetry on later on during the process's lifetime.
  - With a global list, we can always know the correct value

This PR adds such a collection `HttpConnectionPoolManager.AllManagers`, uses a global timer for cleanup & heartbeats and a single `NetworkChange` callback.

Cases where this approach may have a higher overhead:
- You have A LOT of `SocketsHttpHandler` instances that are completely idle (without a single pool)
- You have a lot of handler instances, but your cleaning/heartbeat intervals are really high, making the 1 Hz scanning more expensive

Opening as a draft to gather feedback on whether we think such a change is a horrible idea.