### PR TITLE
[mono] Make the --llvmonly mode the same as --llvmonly-interp.

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -8499,6 +8499,7 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 			opts->mode = MONO_AOT_MODE_FULL;
 			opts->llvm = TRUE;
 			opts->llvm_only = TRUE;
+			opts->interp = TRUE;
 		} else if (str_begins_with (arg, "data-outfile=")) {
 			opts->data_outfile = g_strdup (arg + strlen ("data-outfile="));
 		} else if (str_begins_with (arg, "profile=")) {

--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -464,7 +464,7 @@ method_should_be_regression_tested (MonoMethod *method, gboolean interp)
 			return FALSE;
 		}
 
-		if ((mono_aot_mode == MONO_AOT_MODE_INTERP_LLVMONLY || mono_aot_mode == MONO_AOT_MODE_LLVMONLY) && !strcmp (utf8_str, "!BITCODE")) {
+		if ((mono_aot_mode == MONO_AOT_MODE_INTERP_LLVMONLY || mono_aot_mode == MONO_AOT_MODE_LLVMONLY_INTERP) && !strcmp (utf8_str, "!BITCODE")) {
 			g_print ("skip %s...\n", method->name);
 			return FALSE;
 		}
@@ -681,7 +681,7 @@ mini_regression (MonoImage *image, int verbose, int *total_run)
 					continue;
 
 			//we running in AOT only, it makes no sense to try multiple flags
-			if ((mono_aot_mode == MONO_AOT_MODE_FULL || mono_aot_mode == MONO_AOT_MODE_LLVMONLY) && opt_sets [opt] != DEFAULT_OPTIMIZATIONS) {
+			if ((mono_aot_mode == MONO_AOT_MODE_FULL || mono_aot_mode == MONO_AOT_MODE_LLVMONLY_INTERP) && opt_sets [opt] != DEFAULT_OPTIMIZATIONS) {
 				continue;
 			}
 
@@ -2246,12 +2246,13 @@ mono_main (int argc, char* argv[])
 			g_warning ("--verify-all is obsolete, ignoring");
 		} else if (strcmp (argv [i], "--full-aot") == 0) {
 			mono_jit_set_aot_mode (MONO_AOT_MODE_FULL);
-		} else if (strcmp (argv [i], "--llvmonly") == 0) {
-			mono_jit_set_aot_mode (MONO_AOT_MODE_LLVMONLY);
 		} else if (strcmp (argv [i], "--hybrid-aot") == 0) {
 			mono_jit_set_aot_mode (MONO_AOT_MODE_HYBRID);
 		} else if (strcmp (argv [i], "--full-aot-interp") == 0) {
 			mono_jit_set_aot_mode (MONO_AOT_MODE_INTERP);
+		} else if (strcmp (argv [i], "--llvmonly") == 0) {
+			/* Same as llvmonly-interp */
+			mono_jit_set_aot_mode (MONO_AOT_MODE_LLVMONLY_INTERP);
 		} else if (strcmp (argv [i], "--llvmonly-interp") == 0) {
 			mono_jit_set_aot_mode (MONO_AOT_MODE_LLVMONLY_INTERP);
 		} else if (strcmp (argv [i], "--print-vtable") == 0) {
@@ -2871,13 +2872,6 @@ mono_runtime_set_execution_mode_full (int mode, gboolean override)
 	memset (&mono_ee_features, 0, sizeof (mono_ee_features));
 
 	switch (mode) {
-	case MONO_AOT_MODE_LLVMONLY:
-		mono_aot_only = TRUE;
-		mono_llvm_only = TRUE;
-
-		mono_ee_features.use_aot_trampolines = TRUE;
-		break;
-
 	case MONO_AOT_MODE_FULL:
 		mono_aot_only = TRUE;
 
@@ -2904,6 +2898,7 @@ mono_runtime_set_execution_mode_full (int mode, gboolean override)
 		mono_ee_features.force_use_interpreter = TRUE;
 		break;
 
+	case MONO_AOT_MODE_LLVMONLY:
 	case MONO_AOT_MODE_LLVMONLY_INTERP:
 		mono_aot_only = TRUE;
 		mono_use_interpreter = TRUE;


### PR DESCRIPTION
The --llvmonly mode is not used in production, it also doesn't
have correct EH semantics.