### PR TITLE
Use guint64 in UCONTEXT_REG_SET_PC (arm64)

### DIFF
--- a/src/mono/mono/utils/mono-sigcontext.h
+++ b/src/mono/mono/utils/mono-sigcontext.h
@@ -449,7 +449,7 @@
 
 #ifndef UCONTEXT_REG_SET_PC
 #define UCONTEXT_REG_SET_PC(ctx, val) do { \
-	UCONTEXT_REG_PC (ctx) = (__uint64_t)(val); \
+	UCONTEXT_REG_PC (ctx) = (guint64)(val); \
 	 } while (0)
 #endif
 #ifndef UCONTEXT_REG_SET_SP


### PR DESCRIPTION
In this scope, `__uint64_t` is not available on musl based systems. Switched to `guint64`, which nearby code is using.

cc @lambdageek