### PR TITLE
Delete System.Runtime.Experimental leftovers

### DIFF
--- a/src/libraries/System.Runtime/src/System.Runtime.csproj
+++ b/src/libraries/System.Runtime/src/System.Runtime.csproj
@@ -18,8 +18,4 @@
     <ProjectReference Include="$(CoreLibProject)" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Private.Uri\src\System.Private.Uri.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <!-- Set the ReferenceAssembly metadata to the inbox version of System.Runtime and not to System.Runtime.Experimental. -->
-    <ProjectReference Include="..\ref\System.Runtime.csproj" ReferenceOutputAssembly="false" OutputItemType="ResolvedMatchingContractOverride" />
-  </ItemGroup>
 </Project>

--- a/src/libraries/testPackages/packageSettings/System.Runtime.Experimental/settings.targets
+++ b/src/libraries/testPackages/packageSettings/System.Runtime.Experimental/settings.targets
@@ -1,5 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <SkipVerifyRuntime>true</SkipVerifyRuntime>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
e34e8dd85e7ffaaad8c884de0967cb8d845af5c6 merged the API surface of System.Runtime.Experimental inbox and deleted the project and the package. Hence we should delete leftovers that reference it.