### PR TITLE
[release/6.0] Fix unaligned UTF16 string read in collect tracing EventPipe command.

### DIFF
--- a/src/native/eventpipe/ds-eventpipe-protocol.c
+++ b/src/native/eventpipe/ds-eventpipe-protocol.c
@@ -140,7 +140,7 @@ eventpipe_collect_tracing_command_try_parse_rundown_requested (
 	EP_ASSERT (buffer_len != NULL);
 	EP_ASSERT (rundown_requested != NULL);
 
-	return ds_ipc_message_try_parse_value (buffer, buffer_len, (uint8_t *)rundown_requested, (uint32_t)sizeof (bool));
+	return ds_ipc_message_try_parse_value (buffer, buffer_len, (uint8_t *)rundown_requested, 1);
 }
 
 static
@@ -160,6 +160,9 @@ eventpipe_collect_tracing_command_try_parse_config (
 	const uint32_t max_count_configs = 1000;
 	uint32_t count_configs = 0;
 
+	uint8_t *provider_name_byte_array = NULL;
+	uint8_t *filter_data_byte_array = NULL;
+
 	ep_char8_t *provider_name_utf8 = NULL;
 	ep_char8_t *filter_data_utf8 = NULL;
 
@@ -176,20 +179,27 @@ eventpipe_collect_tracing_command_try_parse_config (
 		ep_raise_error_if_nok (ds_ipc_message_try_parse_uint32_t (buffer, buffer_len, &log_level));
 		ep_raise_error_if_nok (log_level <= EP_EVENT_LEVEL_VERBOSE);
 
-		const ep_char16_t *provider_name = NULL;
-		ep_raise_error_if_nok (ds_ipc_message_try_parse_string_utf16_t (buffer, buffer_len, &provider_name));
+		uint32_t provider_name_byte_array_len = 0;
+		ep_raise_error_if_nok (ds_ipc_message_try_parse_string_utf16_t_byte_array_alloc (buffer, buffer_len, &provider_name_byte_array, &provider_name_byte_array_len));
 
-		provider_name_utf8 = ep_rt_utf16_to_utf8_string (provider_name, -1);
+		provider_name_utf8 = ep_rt_utf16_to_utf8_string ((const ep_char16_t *)provider_name_byte_array, -1);
 		ep_raise_error_if_nok (provider_name_utf8 != NULL);
 
 		ep_raise_error_if_nok (!ep_rt_utf8_string_is_null_or_empty (provider_name_utf8));
 
-		const ep_char16_t *filter_data = NULL; // This parameter is optional.
-		ds_ipc_message_try_parse_string_utf16_t (buffer, buffer_len, &filter_data);
+		ep_rt_byte_array_free (provider_name_byte_array);
+		provider_name_byte_array = NULL;
 
-		if (filter_data) {
-			filter_data_utf8 = ep_rt_utf16_to_utf8_string (filter_data, -1);
+		uint32_t filter_data_byte_array_len = 0;
+		ep_raise_error_if_nok (ds_ipc_message_try_parse_string_utf16_t_byte_array_alloc (buffer, buffer_len, &filter_data_byte_array, &filter_data_byte_array_len));
+
+		// This parameter is optional.
+		if (filter_data_byte_array) {
+			filter_data_utf8 = ep_rt_utf16_to_utf8_string ((const ep_char16_t *)filter_data_byte_array, -1);
 			ep_raise_error_if_nok (filter_data_utf8 != NULL);
+
+			ep_rt_byte_array_free (filter_data_byte_array);
+			filter_data_byte_array = NULL;
 		}
 
 		EventPipeProviderConfiguration provider_config;
@@ -209,7 +219,9 @@ ep_on_exit:
 
 ep_on_error:
 	count_configs = 0;
+	ep_rt_byte_array_free (provider_name_byte_array);
 	ep_rt_utf8_string_free (provider_name_utf8);
+	ep_rt_byte_array_free (filter_data_byte_array);
 	ep_rt_utf8_string_free (filter_data_utf8);
 	ep_exit_error_handler ();
 }

--- a/src/native/eventpipe/ds-protocol.c
+++ b/src/native/eventpipe/ds-protocol.c
@@ -59,6 +59,14 @@ ipc_message_flatten (
 	uint16_t payload_len,
 	ds_ipc_flatten_payload_func flatten_payload);
 
+static
+bool
+ipc_message_try_parse_string_utf16_t_byte_array (
+	uint8_t **buffer,
+	uint32_t *buffer_len,
+	const uint8_t **string_byte_array,
+	uint32_t *string_byte_array_len);
+
 /*
 * DiagnosticsIpc
 */
@@ -306,6 +314,50 @@ ep_on_error:
 	ep_exit_error_handler ();
 }
 
+static
+bool
+ipc_message_try_parse_string_utf16_t_byte_array (
+	uint8_t **buffer,
+	uint32_t *buffer_len,
+	const uint8_t **string_byte_array,
+	uint32_t *string_byte_array_len)
+{
+	EP_ASSERT (buffer != NULL);
+	EP_ASSERT (buffer_len != NULL);
+	EP_ASSERT (string_byte_array != NULL);
+	EP_ASSERT (string_byte_array_len != NULL);
+
+	bool result = false;
+
+	ep_raise_error_if_nok (ds_ipc_message_try_parse_uint32_t (buffer, buffer_len, string_byte_array_len));
+	*string_byte_array_len *= sizeof (ep_char16_t);
+
+	if (*string_byte_array_len != 0) {
+		if (*string_byte_array_len > *buffer_len)
+			ep_raise_error ();
+
+		if (((const ep_char16_t *)*buffer) [(*string_byte_array_len / sizeof (ep_char16_t)) - 1] != 0)
+			ep_raise_error ();
+
+		*string_byte_array = *buffer;
+
+	} else {
+		*string_byte_array = NULL;
+	}
+
+	*buffer = *buffer + *string_byte_array_len;
+	*buffer_len = *buffer_len - *string_byte_array_len;
+
+	result = true;
+
+ep_on_exit:
+	return result;
+
+ep_on_error:
+	EP_ASSERT (!result);
+	ep_exit_error_handler ();
+}
+
 DiagnosticsIpcMessage *
 ds_ipc_message_init (DiagnosticsIpcMessage *message)
 {
@@ -383,7 +435,45 @@ ds_ipc_message_try_parse_uint32_t (
 	return result;
 }
 
-// TODO: Strings are in little endian format in buffer.
+bool
+ds_ipc_message_try_parse_string_utf16_t_byte_array_alloc (
+	uint8_t **buffer,
+	uint32_t *buffer_len,
+	uint8_t **string_byte_array,
+	uint32_t *string_byte_array_len)
+{
+	EP_ASSERT (buffer != NULL);
+	EP_ASSERT (buffer_len != NULL);
+	EP_ASSERT (string_byte_array != NULL);
+	EP_ASSERT (string_byte_array_len != NULL);
+
+	bool result = false;
+
+	const uint8_t *temp_buffer = NULL;
+	uint32_t temp_buffer_len = 0;
+
+	ep_raise_error_if_nok (ipc_message_try_parse_string_utf16_t_byte_array (buffer, buffer_len, (const uint8_t **)&temp_buffer, &temp_buffer_len));
+
+	if (temp_buffer_len != 0) {
+		*string_byte_array = ep_rt_byte_array_alloc (temp_buffer_len);
+		ep_raise_error_if_nok (*string_byte_array != NULL);
+
+		memcpy (*string_byte_array, temp_buffer, temp_buffer_len);
+	} else {
+		*string_byte_array = NULL;
+	}
+
+	*string_byte_array_len = temp_buffer_len;
+	result = true;
+
+ep_on_exit:
+	return result;
+
+ep_on_error:
+	EP_ASSERT (!result);
+	ep_exit_error_handler ();
+}
+
 bool
 ds_ipc_message_try_parse_string_utf16_t (
 	uint8_t **buffer,
@@ -393,36 +483,10 @@ ds_ipc_message_try_parse_string_utf16_t (
 	EP_ASSERT (buffer != NULL);
 	EP_ASSERT (buffer_len != NULL);
 	EP_ASSERT (value != NULL);
+	EP_ASSERT (!(((size_t)*buffer) & 0x1));
 
-	bool result = false;
-
-	uint32_t string_len = 0;
-	ep_raise_error_if_nok (ds_ipc_message_try_parse_uint32_t (buffer, buffer_len, &string_len));
-
-	if (string_len != 0) {
-		if (string_len > (*buffer_len / sizeof (ep_char16_t)))
-			ep_raise_error ();
-
-		if (((const ep_char16_t *)*buffer) [string_len - 1] != 0)
-			ep_raise_error ();
-
-		*value = (ep_char16_t *)*buffer;
-
-	} else {
-		*value = NULL;
-	}
-
-	*buffer = *buffer + (string_len * sizeof (ep_char16_t));
-	*buffer_len = *buffer_len - (string_len * sizeof (ep_char16_t));
-
-	result = true;
-
-ep_on_exit:
-	return result;
-
-ep_on_error:
-	EP_ASSERT (!result);
-	ep_exit_error_handler ();
+	uint32_t string_byte_array_len = 0;
+	return ipc_message_try_parse_string_utf16_t_byte_array (buffer, buffer_len, (const uint8_t **)value, &string_byte_array_len);
 }
 
 bool

--- a/src/native/eventpipe/ds-protocol.h
+++ b/src/native/eventpipe/ds-protocol.h
@@ -146,6 +146,13 @@ ds_ipc_message_try_parse_int32_t (
 }
 
 bool
+ds_ipc_message_try_parse_string_utf16_t_byte_array_alloc (
+	uint8_t **buffer,
+	uint32_t *buffer_len,
+	uint8_t **string_byte_array,
+	uint32_t *string_byte_array_len);
+
+bool
 ds_ipc_message_try_parse_string_utf16_t (
 	uint8_t **buffer,
 	uint32_t *buffer_len,


### PR DESCRIPTION
Collect tracing 2 EventPipe command triggers an unaligned UTF16 string read that could cause a SIGBUS on platforms not supporting unaligned reads of UTF16 strings.

On CoreCLR this could even cause a unaligned int read due to optimizations used in UTF8Encoding::GetByteCount.

## Customer Impact
Trying to use dotnet-trace command towards a CoreCLR runtime running on 32-bit ARM will trigger SIGBUS and runtime crash making it impossible to trace an application using dotnet-trace diagnostic tooling.

https://github.com/dotnet/runtime/issues/66772

## Testing
Manual validation for .net6. This change is currently in the main branch and has a test running in CI/PR validation. All tests are passing in main. Enabling these same tests in the .net6 branch is possible, but will require larger code changes (~5k LOC from https://github.com/dotnet/runtime/pull/64358).

## Risk
Low