### PR TITLE
[mono] Remove a few set but unused variables

### DIFF
--- a/src/mono/mono/metadata/sgen-new-bridge.c
+++ b/src/mono/mono/metadata/sgen-new-bridge.c
@@ -241,12 +241,10 @@ free_data (void)
 {
 	MonoObject *obj G_GNUC_UNUSED;
 	HashEntry *entry;
-	int total_srcs = 0;
 	int max_srcs = 0;
 
 	SGEN_HASH_TABLE_FOREACH (&hash_table, MonoObject *, obj, HashEntry *, entry) {
 		int entry_size = dyn_array_ptr_size (&entry->srcs);
-		total_srcs += entry_size;
 		if (entry_size > max_srcs)
 			max_srcs = entry_size;
 		dyn_array_ptr_uninit (&entry->srcs);
@@ -255,7 +253,6 @@ free_data (void)
 	sgen_hash_table_clean (&hash_table);
 
 	dyn_array_int_uninit (&merge_array);
-	//g_print ("total srcs %d - max %d\n", total_srcs, max_srcs);
 }
 
 static HashEntry*

--- a/src/mono/mono/metadata/sgen-old-bridge.c
+++ b/src/mono/mono/metadata/sgen-old-bridge.c
@@ -425,12 +425,10 @@ free_data (void)
 {
 	GCObject *obj G_GNUC_UNUSED;
 	HashEntry *entry;
-	int total_srcs = 0;
 	int max_srcs = 0;
 
 	SGEN_HASH_TABLE_FOREACH (&hash_table, GCObject *, obj, HashEntry *, entry) {
 		int entry_size = dyn_array_ptr_size (&entry->srcs);
-		total_srcs += entry_size;
 		if (entry_size > max_srcs)
 			max_srcs = entry_size;
 		dyn_array_ptr_uninit (&entry->srcs);
@@ -439,7 +437,6 @@ free_data (void)
 	sgen_hash_table_clean (&hash_table);
 
 	dyn_array_int_uninit (&merge_array);
-	//g_print ("total srcs %d - max %d\n", total_srcs, max_srcs);
 }
 
 static HashEntry*

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -3352,15 +3352,11 @@ encode_klass_ref_inner (MonoAotCompile *acfg, MonoClass *klass, guint8 *buf, gui
 		} else {
 			MonoClass *gclass = mono_class_get_generic_class (klass)->container_class;
 			MonoGenericInst *inst = mono_class_get_generic_class (klass)->context.class_inst;
-			static int count = 0;
-			guint8 *p1 = p;
 
 			encode_value (MONO_AOT_TYPEREF_GINST, p, &p);
 			encode_klass_ref (acfg, gclass, p, &p);
 			guint32 offset = get_shared_ginst_ref (acfg, inst);
 			encode_value (offset, p, &p);
-
-			count += p - p1;
 		}
 	} else if (m_class_get_type_token (klass)) {
 		int iindex = get_image_index (acfg, m_class_get_image (klass));

--- a/src/mono/mono/mini/image-writer.c
+++ b/src/mono/mono/mini/image-writer.c
@@ -245,6 +245,9 @@ asm_writer_emit_symbol_type (MonoImageWriter *acfg, const char *name, gboolean f
 static void
 asm_writer_emit_symbol_type (MonoImageWriter *acfg, const char *name, gboolean func, gboolean global)
 {
+#if defined(TARGET_ASM_APPLE)
+	asm_writer_emit_unset_mode (acfg);
+#else
 	const char *stype;
 
 	if (func)
@@ -253,13 +256,11 @@ asm_writer_emit_symbol_type (MonoImageWriter *acfg, const char *name, gboolean f
 		stype = "object";
 
 	asm_writer_emit_unset_mode (acfg);
-
-#if defined(TARGET_ASM_APPLE)
-
-#elif defined(TARGET_ARM)
+#if defined(TARGET_ARM)
 	fprintf (acfg->fp, "\t.type %s,#%s\n", name, stype);
 #else
 	fprintf (acfg->fp, "\t.type %s,@%s\n", name, stype);
+#endif
 #endif
 }
 #endif /* TARGET_WIN32 */

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -1538,7 +1538,7 @@ mono_arch_compute_omit_fp (MonoCompile *cfg)
 {
 	MonoMethodSignature *sig;
 	MonoMethodHeader *header;
-	int i, locals_size;
+	int i;
 	CallInfo *cinfo;
 
 	if (cfg->arch.omit_fp_computed)
@@ -1585,14 +1585,6 @@ mono_arch_compute_omit_fp (MonoCompile *cfg)
 			 */
 			cfg->arch.omit_fp = FALSE;
 		}
-	}
-
-	locals_size = 0;
-	for (i = cfg->locals_start; i < cfg->num_varinfo; i++) {
-		MonoInst *ins = cfg->varinfo [i];
-		int ialign;
-
-		locals_size += mono_type_size (ins->inst_vtype, &ialign);
 	}
 }
 

--- a/src/mono/mono/mini/mini-arm.c
+++ b/src/mono/mono/mini/mini-arm.c
@@ -1846,7 +1846,7 @@ mono_arch_compute_omit_fp (MonoCompile *cfg)
 {
 	MonoMethodSignature *sig;
 	MonoMethodHeader *header;
-	int i, locals_size;
+	int i;
 	CallInfo *cinfo;
 
 	if (cfg->arch.omit_fp_computed)
@@ -1894,14 +1894,6 @@ mono_arch_compute_omit_fp (MonoCompile *cfg)
 			 */
 			cfg->arch.omit_fp = FALSE;
 		}
-	}
-
-	locals_size = 0;
-	for (i = cfg->locals_start; i < cfg->num_varinfo; i++) {
-		MonoInst *ins = cfg->varinfo [i];
-		int ialign;
-
-		locals_size += mono_type_size (ins->inst_vtype, &ialign);
 	}
 }
 

--- a/src/mono/mono/mini/mini-mips.c
+++ b/src/mono/mono/mini/mini-mips.c
@@ -1309,7 +1309,7 @@ mono_arch_compute_omit_fp (MonoCompile *cfg)
 {
 	MonoMethodSignature *sig;
 	MonoMethodHeader *header;
-	int i, locals_size;
+	int i;
 	CallInfo *cinfo;
 
 	if (cfg->arch.omit_fp_computed)
@@ -1349,14 +1349,6 @@ mono_arch_compute_omit_fp (MonoCompile *cfg)
 	if (cinfo->stack_usage)
 		cfg->arch.omit_fp = FALSE;
 	*/
-
-	locals_size = 0;
-	for (i = cfg->locals_start; i < cfg->num_varinfo; i++) {
-		MonoInst *ins = cfg->varinfo [i];
-		int ialign;
-
-		locals_size += mono_type_size (ins->inst_vtype, &ialign);
-	}
 
 	//printf ("D: %s %d\n", cfg->method->name, cfg->arch.omit_fp);
 }


### PR DESCRIPTION
These triggered a warning in the new clang included with Xcode 13.3