### PR TITLE
Add tests for RegexGenerator on interface and virtual members

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
@@ -131,6 +131,7 @@ namespace System.Text.RegularExpressions.Generator
             }
 
             if (!regexMethodSymbol.IsPartialDefinition ||
+                regexMethodSymbol.IsAbstract ||
                 regexMethodSymbol.Parameters.Length != 0 ||
                 regexMethodSymbol.Arity != 0 ||
                 !regexMethodSymbol.ReturnType.Equals(regexSymbol))

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/Strings.resx
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/Strings.resx
@@ -132,7 +132,7 @@
     <value>The specified regex is invalid. '{0}'</value>
   </data>
   <data name="RegexMethodMustHaveValidSignatureMessage" xml:space="preserve">
-    <value>Regex method must be partial, parameterless, non-generic, and return Regex</value>
+    <value>RegexGenerator method must be partial, parameterless, non-generic, non-abstract, and return Regex</value>
   </data>
   <data name="InvalidLangVersionMessage" xml:space="preserve">
     <value>C# LangVersion of 11 or greater is required</value>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.cs.xlf
@@ -228,8 +228,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegexMethodMustHaveValidSignatureMessage">
-        <source>Regex method must be partial, parameterless, non-generic, and return Regex</source>
-        <target state="translated">Metoda regulárního výrazu musí být částečná, bez parametrů, negenerická a musí vracet regulární výraz.</target>
+        <source>RegexGenerator method must be partial, parameterless, non-generic, non-abstract, and return Regex</source>
+        <target state="needs-review-translation">Metoda regulárního výrazu musí být částečná, bez parametrů, negenerická a musí vracet regulární výraz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReplacementError">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.de.xlf
@@ -228,8 +228,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegexMethodMustHaveValidSignatureMessage">
-        <source>Regex method must be partial, parameterless, non-generic, and return Regex</source>
-        <target state="translated">Die Regex-Methode muss partiell, parameterlos, nicht generisch sein und Regex zurückgeben.</target>
+        <source>RegexGenerator method must be partial, parameterless, non-generic, non-abstract, and return Regex</source>
+        <target state="needs-review-translation">Die Regex-Methode muss partiell, parameterlos, nicht generisch sein und Regex zurückgeben.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReplacementError">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.es.xlf
@@ -228,8 +228,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegexMethodMustHaveValidSignatureMessage">
-        <source>Regex method must be partial, parameterless, non-generic, and return Regex</source>
-        <target state="translated">El método regex debe ser parcial, sin parámetros, no genérico y devolver Regex</target>
+        <source>RegexGenerator method must be partial, parameterless, non-generic, non-abstract, and return Regex</source>
+        <target state="needs-review-translation">El método regex debe ser parcial, sin parámetros, no genérico y devolver Regex</target>
         <note />
       </trans-unit>
       <trans-unit id="ReplacementError">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.fr.xlf
@@ -228,8 +228,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegexMethodMustHaveValidSignatureMessage">
-        <source>Regex method must be partial, parameterless, non-generic, and return Regex</source>
-        <target state="translated">La méthode Regex doit être partielle, sans paramètre, non générique, et renvoyer une expression régulière</target>
+        <source>RegexGenerator method must be partial, parameterless, non-generic, non-abstract, and return Regex</source>
+        <target state="needs-review-translation">La méthode Regex doit être partielle, sans paramètre, non générique, et renvoyer une expression régulière</target>
         <note />
       </trans-unit>
       <trans-unit id="ReplacementError">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.it.xlf
@@ -228,8 +228,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegexMethodMustHaveValidSignatureMessage">
-        <source>Regex method must be partial, parameterless, non-generic, and return Regex</source>
-        <target state="translated">Il metodo Regex deve essere parziale, senza parametri, non generico e restituire Regex</target>
+        <source>RegexGenerator method must be partial, parameterless, non-generic, non-abstract, and return Regex</source>
+        <target state="needs-review-translation">Il metodo Regex deve essere parziale, senza parametri, non generico e restituire Regex</target>
         <note />
       </trans-unit>
       <trans-unit id="ReplacementError">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ja.xlf
@@ -228,8 +228,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegexMethodMustHaveValidSignatureMessage">
-        <source>Regex method must be partial, parameterless, non-generic, and return Regex</source>
-        <target state="translated">正規表現メソッドは、部分的、パラメーターなし、非ジェネリックであり、正規表現を返す必要があります</target>
+        <source>RegexGenerator method must be partial, parameterless, non-generic, non-abstract, and return Regex</source>
+        <target state="needs-review-translation">正規表現メソッドは、部分的、パラメーターなし、非ジェネリックであり、正規表現を返す必要があります</target>
         <note />
       </trans-unit>
       <trans-unit id="ReplacementError">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ko.xlf
@@ -228,8 +228,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegexMethodMustHaveValidSignatureMessage">
-        <source>Regex method must be partial, parameterless, non-generic, and return Regex</source>
-        <target state="translated">Regex 메서드는 부분적이고 매개 변수가 없고 제네릭이 아니어야 하며 Regex를 반환해야 합니다.</target>
+        <source>RegexGenerator method must be partial, parameterless, non-generic, non-abstract, and return Regex</source>
+        <target state="needs-review-translation">Regex 메서드는 부분적이고 매개 변수가 없고 제네릭이 아니어야 하며 Regex를 반환해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReplacementError">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pl.xlf
@@ -228,8 +228,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegexMethodMustHaveValidSignatureMessage">
-        <source>Regex method must be partial, parameterless, non-generic, and return Regex</source>
-        <target state="translated">Metoda wyrażenia regularnego musi być częściowa, bez parametrów, niegeneryczna i zwracać wyrażenie regularne</target>
+        <source>RegexGenerator method must be partial, parameterless, non-generic, non-abstract, and return Regex</source>
+        <target state="needs-review-translation">Metoda wyrażenia regularnego musi być częściowa, bez parametrów, niegeneryczna i zwracać wyrażenie regularne</target>
         <note />
       </trans-unit>
       <trans-unit id="ReplacementError">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -228,8 +228,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegexMethodMustHaveValidSignatureMessage">
-        <source>Regex method must be partial, parameterless, non-generic, and return Regex</source>
-        <target state="translated">O método Regex deve ser parcial, sem parâmetros, não genérico e retornar Regex</target>
+        <source>RegexGenerator method must be partial, parameterless, non-generic, non-abstract, and return Regex</source>
+        <target state="needs-review-translation">O método Regex deve ser parcial, sem parâmetros, não genérico e retornar Regex</target>
         <note />
       </trans-unit>
       <trans-unit id="ReplacementError">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ru.xlf
@@ -228,8 +228,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegexMethodMustHaveValidSignatureMessage">
-        <source>Regex method must be partial, parameterless, non-generic, and return Regex</source>
-        <target state="translated">Метод Regex должен быть частичным, без параметров, неуниверсальным и возвращать регулярное выражение</target>
+        <source>RegexGenerator method must be partial, parameterless, non-generic, non-abstract, and return Regex</source>
+        <target state="needs-review-translation">Метод Regex должен быть частичным, без параметров, неуниверсальным и возвращать регулярное выражение</target>
         <note />
       </trans-unit>
       <trans-unit id="ReplacementError">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.tr.xlf
@@ -228,8 +228,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegexMethodMustHaveValidSignatureMessage">
-        <source>Regex method must be partial, parameterless, non-generic, and return Regex</source>
-        <target state="translated">Regex yöntemi kısmi, parametresiz, genel olmayan olmalıdır ve Regex döndürmelidir</target>
+        <source>RegexGenerator method must be partial, parameterless, non-generic, non-abstract, and return Regex</source>
+        <target state="needs-review-translation">Regex yöntemi kısmi, parametresiz, genel olmayan olmalıdır ve Regex döndürmelidir</target>
         <note />
       </trans-unit>
       <trans-unit id="ReplacementError">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -228,8 +228,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegexMethodMustHaveValidSignatureMessage">
-        <source>Regex method must be partial, parameterless, non-generic, and return Regex</source>
-        <target state="translated">Regex 方法必须是分部、无参数、非泛型，并返回 Regex</target>
+        <source>RegexGenerator method must be partial, parameterless, non-generic, non-abstract, and return Regex</source>
+        <target state="needs-review-translation">Regex 方法必须是分部、无参数、非泛型，并返回 Regex</target>
         <note />
       </trans-unit>
       <trans-unit id="ReplacementError">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -228,8 +228,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegexMethodMustHaveValidSignatureMessage">
-        <source>Regex method must be partial, parameterless, non-generic, and return Regex</source>
-        <target state="translated">Regex 方法必須是部分、無參數、非泛型，並且傳回 Regex</target>
+        <source>RegexGenerator method must be partial, parameterless, non-generic, non-abstract, and return Regex</source>
+        <target state="needs-review-translation">Regex 方法必須是部分、無參數、非泛型，並且傳回 Regex</target>
         <note />
       </trans-unit>
       <trans-unit id="ReplacementError">

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorParserTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorParserTests.cs
@@ -180,6 +180,29 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Equal("SYSLIB1043", Assert.Single(diagnostics).Id);
         }
 
+        [Fact]
+        public async Task Diagnostic_MethodMustBeNonAbstract()
+        {
+            IReadOnlyList<Diagnostic> diagnostics = await RegexGeneratorHelper.RunGenerator(@"
+                using System.Text.RegularExpressions;
+
+                partial class C
+                {
+                    [RegexGenerator(""ab"")]
+                    public abstract partial Regex MethodMustBeNonAbstract();
+                }
+
+                partial interface I
+                {
+                    [RegexGenerator(""ab"")]
+                    public static abstract partial Regex MethodMustBeNonAbstract();
+                }
+            ");
+
+            Assert.Equal(2, diagnostics.Count);
+            Assert.All(diagnostics, d => Assert.Equal("SYSLIB1043", d.Id));
+        }
+
         [Theory]
         [InlineData(LanguageVersion.CSharp9)]
         [InlineData(LanguageVersion.CSharp10)]
@@ -514,6 +537,52 @@ namespace System.Text.RegularExpressions.Tests
                 namespace D
                 {
                     internal interface IBlah { }
+                }
+            ", compile: true));
+        }
+
+        [Fact]
+        public async Task Valid_InterfaceStatics()
+        {
+            Assert.Empty(await RegexGeneratorHelper.RunGenerator(@"
+                using System.Text.RegularExpressions;
+
+                partial interface INonGeneric
+                {
+                    [RegexGenerator("".+?"")]
+                    public static partial Regex Test();
+                }
+
+                partial interface IGeneric<T>
+                {
+                    [RegexGenerator("".+?"")]
+                    public static partial Regex Test();
+                }
+
+                partial interface ICovariantGeneric<out T>
+                {
+                    [RegexGenerator("".+?"")]
+                    public static partial Regex Test();
+                }
+
+                partial interface IContravariantGeneric<in T>
+                {
+                    [RegexGenerator("".+?"")]
+                    public static partial Regex Test();
+                }
+            ", compile: true));
+        }
+
+        [Fact]
+        public async Task Valid_VirtualBaseImplementations()
+        {
+            Assert.Empty(await RegexGeneratorHelper.RunGenerator(@"
+                using System.Text.RegularExpressions;
+
+                partial class C
+                {
+                    [RegexGenerator(""ab"")]
+                    public virtual partial Regex Valid();
                 }
             ", compile: true));
         }


### PR DESCRIPTION
Add tests to validate https://github.com/dotnet/runtime/issues/66842, which was already addressed by https://github.com/dotnet/runtime/pull/66432.  I also added tests for virtual and abstract members, and in doing so realized that we were missing a check for abstract; adding one just serves to provide a better error message, since we can't generate a body for an abstract member.

Closes https://github.com/dotnet/runtime/issues/66842