### PR TITLE
Ensure that fgMorphFieldToSimdGetElement doesn't call gtNewSimdGetElementNode if the ISA is unsupported

### DIFF
--- a/src/coreclr/jit/importer_vectorization.cpp
+++ b/src/coreclr/jit/importer_vectorization.cpp
@@ -142,9 +142,9 @@ GenTree* Compiler::impExpandHalfConstEqualsSIMD(
     constexpr int maxPossibleLength = 32;
     assert(len >= 8 && len <= maxPossibleLength);
 
-    if (!compOpportunisticallyDependsOn(InstructionSet_Vector128))
+    if (!IsBaselineSimdIsaSupported())
     {
-        // We need SSE2 or ADVSIMD at least
+        // We need baseline SIMD support at least
         return nullptr;
     }
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -10867,7 +10867,12 @@ GenTree* Compiler::fgMorphFieldToSimdGetElement(GenTree* tree)
                 unreached();
             }
         }
-#endif // TARGET_XARCH
+#elif defined(TARGET_ARM64)
+        if (!compOpportunisticallyDependsOn(InstructionSet_AdvSimd))
+        {
+            return tree;
+        }
+#endif // !TARGET_XARCH && !TARGET_ARM64
 
         tree = gtNewSimdGetElementNode(simdBaseType, simdStructNode, op2, simdBaseJitType, simdSize,
                                        /* isSimdAsHWIntrinsic */ true);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -10833,6 +10833,42 @@ GenTree* Compiler::fgMorphFieldToSimdGetElement(GenTree* tree)
         assert(simdSize <= 16);
         assert(simdSize >= ((index + 1) * genTypeSize(simdBaseType)));
 
+#if defined(TARGET_XARCH)
+        switch (simdBaseType)
+        {
+            case TYP_BYTE:
+            case TYP_UBYTE:
+            case TYP_INT:
+            case TYP_UINT:
+            case TYP_LONG:
+            case TYP_ULONG:
+            {
+                if (!compOpportunisticallyDependsOn(InstructionSet_SSE41))
+                {
+                    return tree;
+                }
+                break;
+            }
+
+            case TYP_DOUBLE:
+            case TYP_FLOAT:
+            case TYP_SHORT:
+            case TYP_USHORT:
+            {
+                if (!compOpportunisticallyDependsOn(InstructionSet_SSE2))
+                {
+                    return tree;
+                }
+                break;
+            }
+
+            default:
+            {
+                unreached();
+            }
+        }
+#endif // TARGET_XARCH
+
         tree = gtNewSimdGetElementNode(simdBaseType, simdStructNode, op2, simdBaseJitType, simdSize,
                                        /* isSimdAsHWIntrinsic */ true);
     }


### PR DESCRIPTION
This resolves #66205 

Noting that this is the "simple" fix. The change I discussed in the issue is more complex/involved and will require a few other changes/refactorings to be possible, so I opted to do the simple thing first to unblock CI. I'll log an issue tracking the more complex change.