### PR TITLE
Fix Character Spelling in ContentType

### DIFF
--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ContentType.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ContentType.cs
@@ -402,7 +402,7 @@ namespace System.IO.Packaging
         /// Validating the given token
         /// The following checks are being made -
         /// 1. If all the characters in the token are either ASCII letter or digit.
-        /// 2. If all the characters in the token are either from the remaining allowed cha----ter set.
+        /// 2. If all the characters in the token are either from the remaining allowed character set.
         /// </summary>
         /// <param name="token">string token</param>
         /// <returns>validated string token</returns>
@@ -472,7 +472,7 @@ namespace System.IO.Packaging
 
         /// <summary>
         /// Returns true if the input character is an allowed character
-        /// Returns false if the input cha----ter is not an allowed character
+        /// Returns false if the input character is not an allowed character
         /// </summary>
         /// <param name="character">input character</param>
         /// <returns></returns>


### PR DESCRIPTION
As suggested by @stephentoub in #66764 this PR fixes the two instances of tool-related spelling hiccups.

I did a cursory glance through other files via regex, but couldn't find any obvious other instances of such hiccups