### PR TITLE
Add Arm64 PGO Builds 

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -91,7 +91,7 @@ jobs:
       platform: Linux_arm64
       container:
         ${{ if eq(parameters.container, '') }}:
-          image: ubuntu-18.04-cross-arm64-20220426130400-6e40d49
+          image: ubuntu-18.04-cross-arm64-20220427171722-6e40d49
         ${{ if ne(parameters.container, '') }}:
           image: ${{ parameters.container }}
         registry: mcr

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -41,7 +41,7 @@ jobs:
       - ${{ if or(eq(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
         - (Ubuntu.2110.Arm64.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-21.10-helix-arm64v8-20211116135000-0f8d97e
       - ${{ if or(ne(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
-        - (Ubuntu.1804.ArmArch.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-20220427171722-6e40d49
+        - (Ubuntu.1804.ArmArch.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-20220427172132-97d8652
 
     # Linux musl x64
     - ${{ if eq(parameters.platform, 'Linux_musl_x64') }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -41,7 +41,7 @@ jobs:
       - ${{ if or(eq(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
         - (Ubuntu.2110.Arm64.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-21.10-helix-arm64v8-20211116135000-0f8d97e
       - ${{ if or(ne(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
-        - (Ubuntu.1804.ArmArch.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-20220426125905-97d8652
+        - (Ubuntu.1804.ArmArch.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-20220427171722-6e40d49
 
     # Linux musl x64
     - ${{ if eq(parameters.platform, 'Linux_musl_x64') }}:

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -378,6 +378,8 @@ stages:
       - windows_x64
       - windows_x86
       - Linux_x64
+      - windows_arm64
+      - Linux_arm64
       jobParameters:
         isOfficialBuild: ${{ variables.isOfficialBuild }}
         signBinaries: false
@@ -399,6 +401,8 @@ stages:
       - windows_x64
       - windows_x86
       - Linux_x64
+      - windows_arm64
+      - Linux_arm64
 
   #
   # Build Workloads

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -155,6 +155,35 @@ jobs:
       testGroup: innerloop
 
 #
+# Build PGO CoreCLR release
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+    buildConfig: release
+    platforms:
+    - windows_arm64
+    - Linux_arm64
+    jobParameters:
+      testGroup: innerloop
+      pgoType: 'PGO'
+
+  #
+  # PGO Build
+  #
+  - template: /eng/pipelines/installer/installer-matrix.yml
+    parameters:
+      buildConfig: Release
+      jobParameters:
+        liveRuntimeBuildConfig: release
+        liveLibrariesBuildConfig: Release
+        pgoType: 'PGO'
+      platforms:
+      - windows_arm64
+      - Linux_arm64
+
+
+#
 # Build CoreCLR Formatting Job
 # Only when CoreCLR is changed, and only in the 'main' branch (no release branches;
 # both Rolling and PR builds).

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -749,6 +749,7 @@ jobs:
     buildConfig: Release
     platforms:
     - Linux_arm
+    - Linux_arm64
     - Linux_musl_arm
     - Linux_musl_arm64
     - windows_arm

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -155,35 +155,6 @@ jobs:
       testGroup: innerloop
 
 #
-# Build PGO CoreCLR release
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-    buildConfig: release
-    platforms:
-    - windows_arm64
-    - Linux_arm64
-    jobParameters:
-      testGroup: innerloop
-      pgoType: 'PGO'
-
-  #
-  # PGO Build
-  #
-- template: /eng/pipelines/installer/installer-matrix.yml
-  parameters:
-    buildConfig: Release
-    jobParameters:
-      liveRuntimeBuildConfig: release
-      liveLibrariesBuildConfig: Release
-      pgoType: 'PGO'
-    platforms:
-    - windows_arm64
-    - Linux_arm64
-
-
-#
 # Build CoreCLR Formatting Job
 # Only when CoreCLR is changed, and only in the 'main' branch (no release branches;
 # both Rolling and PR builds).
@@ -749,7 +720,6 @@ jobs:
     buildConfig: Release
     platforms:
     - Linux_arm
-    - Linux_arm64
     - Linux_musl_arm
     - Linux_musl_arm64
     - windows_arm

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -171,16 +171,16 @@ jobs:
   #
   # PGO Build
   #
-  - template: /eng/pipelines/installer/installer-matrix.yml
-    parameters:
-      buildConfig: Release
-      jobParameters:
-        liveRuntimeBuildConfig: release
-        liveLibrariesBuildConfig: Release
-        pgoType: 'PGO'
-      platforms:
-      - windows_arm64
-      - Linux_arm64
+- template: /eng/pipelines/installer/installer-matrix.yml
+  parameters:
+    buildConfig: Release
+    jobParameters:
+      liveRuntimeBuildConfig: release
+      liveLibrariesBuildConfig: Release
+      pgoType: 'PGO'
+    platforms:
+    - windows_arm64
+    - Linux_arm64
 
 
 #


### PR DESCRIPTION
- Add PGO for arm64
- Switch to using compiler container images which support PGO compilation on Arm64