### PR TITLE
Fix hanging of NamedPipeClientStream when connecting with infinite timeout

### DIFF
--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs
@@ -135,7 +135,7 @@ namespace System.IO.Pipes
                 cancellationToken.ThrowIfCancellationRequested();
 
                 // Determine how long we should wait in this connection attempt
-                int waitTime = timeout - elapsed;
+                int waitTime = timeout == Timeout.Infinite ? CancellationCheckInterval : timeout - elapsed;
                 if (cancellationToken.CanBeCanceled && waitTime > CancellationCheckInterval)
                 {
                     waitTime = CancellationCheckInterval;

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
@@ -678,7 +678,7 @@ namespace System.IO.Pipes.Tests
                 var firstConnectionTasks = new Task[]
                     {
                         firstClient.ConnectAsync(),
-                        Task.Run(() => server.WaitForConnectionAsync())
+                        server.WaitForConnectionAsync()
                     };
 
                 Assert.True(Task.WaitAll(firstConnectionTasks, 1000));

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
@@ -664,6 +664,31 @@ namespace System.IO.Pipes.Tests
             }
         }
 
+        [Fact(Timeout = 1000)]
+        [PlatformSpecific(TestPlatforms.Windows)] // Unix implementation doesn't rely on a timeout and cancellation token when connecting
+        public async Task ClientConnectAsync_Cancel_With_InfiniteTimeout()
+        {
+            string pipeName = PipeStreamConformanceTests.GetUniquePipeName();
+
+            using (var cts = new CancellationTokenSource())
+            using (var server = new NamedPipeServerStream(pipeName))
+            using (var firstClient = new NamedPipeClientStream(pipeName))
+            using (var secondClient = new NamedPipeClientStream(pipeName))
+            {
+                Task[] clientAndServerTasks = new[]
+                    {
+                        firstClient.ConnectAsync(),
+                        Task.Run(() => server.WaitForConnectionAsync())
+                    };
+
+                Task.WaitAll(clientAndServerTasks);
+
+                cts.CancelAfter(50);
+                Task waitingClient = secondClient.ConnectAsync(cts.Token);
+                await Assert.ThrowsAsync<OperationCanceledException>(() => { return waitingClient; });
+            }
+        }
+
         public static IEnumerable<object[]> GetCancellationTokens =>
             new []
             {


### PR DESCRIPTION
# Resolved Problem

**Affected OS:** Only Windows.

The `NamedPipeClientStream` could hang on connection forever while doesn't respond on a cancellation token. This happens when several conditions are met:
1. An underlying file for named pipe is created. It means a pipe server accept connection from a different pipe.
2. The second client tries to connect with infinite timeout to the server.
3. The internal system function `WainNamedPipe` is called by the second client.

After that the second client doesn't exit when passed cancellation token is passed. The situation is
reproduces in the implemented test. One could compare test results before and after the bug fix.

# Explanation of the Error

First, when a timeout parameter is not passed the infinite timeout is used.

```C#
public Task ConnectAsync(CancellationToken cancellationToken)
{
    return ConnectAsync(Timeout.Infinite, cancellationToken);
}
```

After that `private void ConnectInternal(int timeout, CancellationToken cancellationToken, int startTime)` is called.

The `Timeout.Infinite` is resolved to the `-1` integer value. Therefore in the `ConnectInternal()` method `int waitTime` is resolved to `-1` because `elpased` is 0 at first call. And `TryConnect(waitTime, cancellationToken)` is called with `waitTime` as `-1`.

If one inspects implementation of the `TryConnect` method for Windows he could discover two things:
1. The passed cancellation token not used at all.
2. The timeout is passed to the system method `WaitNamedPipe` as integer value:
```C#
if (!Interop.Kernel32.WaitNamedPipe(_normalizedPipePath, timeout))
{
    errorCode = Marshal.GetLastPInvokeError();
    ...
```

But as [MSDN states](https://docs.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-waitnamedpipew) `WaitNamedPipe` has timeout parameter as `DWORD` which is really resolved to `uint`. And there are two special values for the timeout parameters:
1. `NMPWAIT_USE_DEFAULT_WAIT (0x00000000)` to used a timeout specified in the `CreateNamedPipe` function.
2. `NMPWAIT_WAIT_FOREVER (0xffffffff)` to wait infinite until the instance is available.

The passed timeout value to the `TryConnect()` as `-1` of type `int` is marshalled to `0xffffffff` as `DWORD`. And the `TryConnect()` never returns until the pipe will be broken. And therefore passed cancellation token doesn't cancel the operation.

# Implemented Solution
It's not correct to calculate difference between the timeout and the elapsed time when the timeout is infinite. One could do it only if the timeout is finite and grater or equals to zero.

In case of infinite timeout one should use `CancellationCheckInterval` as it was designed at first place.