### PR TITLE
[mono] Fix typo in detecting sys/auxv.h

### DIFF
--- a/src/mono/cmake/config.h.in
+++ b/src/mono/cmake/config.h.in
@@ -506,7 +506,7 @@
 #cmakedefine HAVE_PTHREAD_JIT_WRITE_PROTECT_NP 1
 
 /* Have getauxval */
-#cmakedefine HAVE_GETAUXVAL 1
+#cmakedefine01 HAVE_GETAUXVAL
 
 /* Define to 1 if you have the declaration of `pthread_mutexattr_setprotocol',
    and to 0 if you don't. */

--- a/src/mono/cmake/config.h.in
+++ b/src/mono/cmake/config.h.in
@@ -351,9 +351,6 @@
 /* Define to 1 if you have the <execinfo.h> header file. */
 #cmakedefine HAVE_EXECINFO_H 1
 
-/* Define to 1 if you have the <sys/auxv.h> header file. */
-#cmakedefine HAVE_SYS_AUXV_H 1
-
 /* Define to 1 if you have the <sys/resource.h> header file. */
 #cmakedefine HAVE_SYS_RESOURCE_H 1
 

--- a/src/mono/cmake/config.h.in
+++ b/src/mono/cmake/config.h.in
@@ -505,7 +505,8 @@
 /* Define to 1 if you have the `pthread_jit_write_protect_np' function. */
 #cmakedefine HAVE_PTHREAD_JIT_WRITE_PROTECT_NP 1
 
-#cmakedefine01 HAVE_GETAUXVAL
+/* Have getauxval */
+#cmakedefine HAVE_GETAUXVAL 1
 
 /* Define to 1 if you have the declaration of `pthread_mutexattr_setprotocol',
    and to 0 if you don't. */

--- a/src/mono/cmake/configure.cmake
+++ b/src/mono/cmake/configure.cmake
@@ -66,7 +66,7 @@ endfunction()
 
 ac_check_headers (
   sys/types.h sys/stat.h sys/filio.h sys/sockio.h sys/utime.h sys/un.h sys/syscall.h sys/uio.h sys/param.h
-  sys/prctl.h sys/socket.h sys/utsname.h sys/select.h sys/poll.h sys/wait.h sts/auxv.h sys/resource.h
+  sys/prctl.h sys/socket.h sys/utsname.h sys/select.h sys/poll.h sys/wait.h sys/resource.h
   sys/ioctl.h sys/errno.h sys/sendfile.h sys/statvfs.h sys/statfs.h sys/mman.h sys/mount.h sys/time.h sys/random.h
   strings.h stdint.h unistd.h signal.h setjmp.h syslog.h netdb.h utime.h semaphore.h alloca.h ucontext.h pwd.h elf.h
   gnu/lib-names.h netinet/tcp.h netinet/in.h link.h arpa/inet.h unwind.h poll.h wchar.h linux/magic.h

--- a/src/mono/mono/utils/mono-hwcap-arm.c
+++ b/src/mono/mono/utils/mono-hwcap-arm.c
@@ -22,7 +22,7 @@
 
 #include "mono/utils/mono-hwcap.h"
 
-#if defined(HAVE_SYS_AUXV_H) && !defined(HOST_ANDROID)
+#if defined(HAVE_GETAUXVAL) && !defined(HOST_ANDROID)
 #include <sys/auxv.h>
 #elif defined(__APPLE__)
 #include <mach/machine.h>
@@ -38,7 +38,7 @@
 void
 mono_hwcap_arch_init (void)
 {
-#if defined(HAVE_SYS_AUXV_H) && !defined(HOST_ANDROID)
+#if defined(HAVE_GETAUXVAL) && !defined(HOST_ANDROID)
 	unsigned long hwcap;
 	unsigned long platform;
 

--- a/src/mono/mono/utils/mono-hwcap-arm.c
+++ b/src/mono/mono/utils/mono-hwcap-arm.c
@@ -22,7 +22,7 @@
 
 #include "mono/utils/mono-hwcap.h"
 
-#if defined(HAVE_GETAUXVAL) && !defined(HOST_ANDROID)
+#if HAVE_GETAUXVAL && !defined(HOST_ANDROID)
 #include <sys/auxv.h>
 #elif defined(__APPLE__)
 #include <mach/machine.h>
@@ -38,7 +38,7 @@
 void
 mono_hwcap_arch_init (void)
 {
-#if defined(HAVE_GETAUXVAL) && !defined(HOST_ANDROID)
+#if HAVE_GETAUXVAL && !defined(HOST_ANDROID)
 	unsigned long hwcap;
 	unsigned long platform;
 

--- a/src/mono/mono/utils/mono-hwcap-ppc.c
+++ b/src/mono/mono/utils/mono-hwcap-ppc.c
@@ -22,7 +22,7 @@
 
 #include "mono/utils/mono-hwcap.h"
 
-#if defined(__linux__) && defined(HAVE_GETAUXVAL)
+#if defined(__linux__) && HAVE_GETAUXVAL
 #include <string.h>
 #include <sys/auxv.h>
 #elif defined(_AIX)
@@ -46,7 +46,7 @@
 void
 mono_hwcap_arch_init (void)
 {
-#if defined(__linux__) && defined(HAVE_GETAUXVAL)
+#if defined(__linux__) && HAVE_GETAUXVAL
 	unsigned long hwcap;
 	unsigned long platform;
 

--- a/src/mono/mono/utils/mono-hwcap-ppc.c
+++ b/src/mono/mono/utils/mono-hwcap-ppc.c
@@ -22,7 +22,7 @@
 
 #include "mono/utils/mono-hwcap.h"
 
-#if defined(__linux__) && defined(HAVE_SYS_AUXV_H)
+#if defined(__linux__) && defined(HAVE_GETAUXVAL)
 #include <string.h>
 #include <sys/auxv.h>
 #elif defined(_AIX)
@@ -46,7 +46,7 @@
 void
 mono_hwcap_arch_init (void)
 {
-#if defined(__linux__) && defined(HAVE_SYS_AUXV_H)
+#if defined(__linux__) && defined(HAVE_GETAUXVAL)
 	unsigned long hwcap;
 	unsigned long platform;
 


### PR DESCRIPTION
We were checking `sts/auxv.h` instead of `sys/auxv.h` so we were never defining `HAVE_SYS_AUXV_H`.

Instead of fixing the typo let's switch to checking for `HAVE_GETAUXVAL` which is what coreclr/libs.native are using.