### PR TITLE
Fix reporting GC refs as byrefs for crossgen2 promoted structs

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1860,7 +1860,7 @@ bool Compiler::StructPromotionHelper::CanConstructAndPromoteField(lvaStructPromo
     fldInfo.fldOffset  = 0;
     fldInfo.fldOrdinal = 0;
     fldInfo.fldSize    = TARGET_POINTER_SIZE;
-    fldInfo.fldType    = TYP_BYREF;
+    fldInfo.fldType    = TYP_REF;
 
     structPromotionInfo->canPromote = true;
     return true;


### PR DESCRIPTION
cc @dotnet/jit-contrib @Maoni0 @mangod9 @PeterSolMS @sandreenko 
