### PR TITLE
Release `CordbUnmanagedThread` instance from `CordbProcess` member

### DIFF
--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -1312,6 +1312,12 @@ void CordbProcess::NeuterChildren()
     m_steppers.NeuterAndClear(GetProcessLock());
 
 #ifdef FEATURE_INTEROP_DEBUGGING
+    if(m_lastDispatchedIBEvent != NULL)
+    {
+        m_lastDispatchedIBEvent->m_owner->InternalRelease();
+        m_lastDispatchedIBEvent = NULL;
+    }
+
     m_unmanagedThreads.NeuterAndClear(GetProcessLock());
 #endif // FEATURE_INTEROP_DEBUGGING
 

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -1312,7 +1312,7 @@ void CordbProcess::NeuterChildren()
     m_steppers.NeuterAndClear(GetProcessLock());
 
 #ifdef FEATURE_INTEROP_DEBUGGING
-    if(m_lastDispatchedIBEvent != NULL)
+    if (m_lastDispatchedIBEvent != NULL)
     {
         m_lastDispatchedIBEvent->m_owner->InternalRelease();
         m_lastDispatchedIBEvent = NULL;


### PR DESCRIPTION
Fixes #65357

The `m_lastDispatchedIBEvent` was not being cleared during shutdown, which was causing a memory leak assert to fire.

See https://github.com/dotnet/runtime/blob/c3fa7655ea3006f010780d325addcd04aaffa76b/src/coreclr/debug/di/process.cpp#L8130-L8148

I added the clearing in the `NeuterChildren()` method because it seemed like the best place. Suggestions on more appropriate places is welcome.

/cc @dotnet/dotnet-diag 