### PR TITLE
Remove char[] allocations from RegistryKey

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegQueryValueEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegQueryValueEx.cs
@@ -22,30 +22,12 @@ internal static partial class Interop
             ref int lpcbData);
 
         [LibraryImport(Libraries.Advapi32, EntryPoint = "RegQueryValueExW", StringMarshalling = StringMarshalling.Utf16)]
-        internal static partial int RegQueryValueEx(
+        internal static unsafe partial int RegQueryValueEx(
             SafeRegistryHandle hKey,
             string? lpValueName,
-            int[]? lpReserved,
-            ref int lpType,
-            ref int lpData,
-            ref int lpcbData);
-
-        [LibraryImport(Libraries.Advapi32, EntryPoint = "RegQueryValueExW", StringMarshalling = StringMarshalling.Utf16)]
-        internal static partial int RegQueryValueEx(
-            SafeRegistryHandle hKey,
-            string? lpValueName,
-            int[]? lpReserved,
-            ref int lpType,
-            ref long lpData,
-            ref int lpcbData);
-
-        [LibraryImport(Libraries.Advapi32, EntryPoint = "RegQueryValueExW", StringMarshalling = StringMarshalling.Utf16)]
-        internal static partial int RegQueryValueEx(
-            SafeRegistryHandle hKey,
-            string? lpValueName,
-            int[]? lpReserved,
-            ref int lpType,
-            [Out] char[]? lpData,
-            ref int lpcbData);
+            int* lpReserved,
+            int* lpType,
+            byte* lpData,
+            uint* lpcbData);
     }
 }

--- a/src/libraries/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.Windows.cs
+++ b/src/libraries/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.Windows.cs
@@ -6,8 +6,11 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security;
+using System.Text;
 
 /*
   Note on transaction support:
@@ -528,263 +531,220 @@ namespace Microsoft.Win32
             return names.ToArray();
         }
 
-        private object? InternalGetValueCore(string? name, object? defaultValue, bool doNotExpand)
+        private unsafe object? InternalGetValueCore(string? name, object? defaultValue, bool doNotExpand)
         {
-            object? data = defaultValue;
-            int type = 0;
-            int datasize = 0;
-
-            int ret = Interop.Advapi32.RegQueryValueEx(_hkey, name, null, ref type, (byte[]?)null, ref datasize);
-
-            if (ret != 0)
+            // Create an initial stack buffer large enough to satisfy many reg keys.  We need to call RegQueryValueEx
+            // in order to determine the type of the value, and we can avoid further retries if all of the data can be
+            // retrieved in that single call with this buffer.  If we do need to grow, we grow into a pooled array. The
+            // caller is always handed back a copy of this data, either in an array, a string, or a boxed integer.
+            Span<byte> span = stackalloc byte[512];
+            byte[]? pooledArray = null;
+            if (IsPerfDataKey())
             {
-                if (IsPerfDataKey())
-                {
-                    int size = 65000;
-                    int sizeInput = size;
-
-                    int r;
-                    byte[] blob = new byte[size];
-                    while (Interop.Errors.ERROR_MORE_DATA == (r = Interop.Advapi32.RegQueryValueEx(_hkey, name, null, ref type, blob, ref sizeInput)))
-                    {
-                        if (size == int.MaxValue)
-                        {
-                            // ERROR_MORE_DATA was returned however we cannot increase the buffer size beyond Int32.MaxValue
-                            Win32Error(r, name);
-                        }
-                        else if (size > (int.MaxValue / 2))
-                        {
-                            // at this point in the loop "size * 2" would cause an overflow
-                            size = int.MaxValue;
-                        }
-                        else
-                        {
-                            size *= 2;
-                        }
-                        sizeInput = size;
-                        blob = new byte[size];
-                    }
-                    if (r != 0)
-                    {
-                        Win32Error(r, name);
-                    }
-                    return blob;
-                }
-                else
-                {
-                    // For stuff like ERROR_FILE_NOT_FOUND, we want to return null (data).
-                    // Some OS's returned ERROR_MORE_DATA even in success cases, so we
-                    // want to continue on through the function.
-                    if (ret != Interop.Errors.ERROR_MORE_DATA)
-                    {
-                        return data;
-                    }
-                }
+                // If this is a performance key (rare usage), we're not actually retrieving data stored in the registry:
+                // calling RegQueryValueEx causes the system to collect the data from the appropriate provider. The value
+                // is expected to be much larger than for other keys, such that our stack-allocated space is less likely
+                // to be sufficient, so we immediately grow into the ArrayPool, using the same buffer size chosen
+                // in .NET Framework (until such time as a better estimate is selected).  Additionally, the returned
+                // length when dealing with perf data keys can't be trusted, so the buffer needs to be zero'd.
+                span = pooledArray = ArrayPool<byte>.Shared.Rent(65_000);
+                span.Clear();
             }
 
-            if (datasize < 0)
+            try
             {
-                // unexpected code path
-                Debug.Fail("[InternalGetValue] RegQueryValue returned ERROR_SUCCESS but gave a negative datasize");
-                datasize = 0;
-            }
+                // Loop in case we need to try again with a larger buffer size.
+                while (true)
+                {
+                    int type = 0;
+                    int result;
+                    int dataLength = span.Length;
 
-            switch (type)
-            {
-                case Interop.Advapi32.RegistryValues.REG_NONE:
-                case Interop.Advapi32.RegistryValues.REG_DWORD_BIG_ENDIAN:
-                case Interop.Advapi32.RegistryValues.REG_BINARY:
+                    fixed (byte* lpData = &MemoryMarshal.GetReference(span))
                     {
-                        byte[] blob = new byte[datasize];
-                        Interop.Advapi32.RegQueryValueEx(_hkey, name, null, ref type, blob, ref datasize);
-                        data = blob;
-                    }
-                    break;
-                case Interop.Advapi32.RegistryValues.REG_QWORD:
-                    {    // also REG_QWORD_LITTLE_ENDIAN
-                        if (datasize > 8)
+                        result = Interop.Advapi32.RegQueryValueEx(_hkey, name, null, &type, lpData, (uint*)&dataLength);
+                        if (dataLength < 0)
                         {
-                            // prevent an AV in the edge case that datasize is larger than sizeof(long)
-                            goto case Interop.Advapi32.RegistryValues.REG_BINARY;
+                            // Greater than 2GB values aren't supported.
+                            throw new IOException(SR.Arg_RegValueTooLarge);
                         }
-                        long blob = 0;
-                        Debug.Assert(datasize == 8, "datasize==8");
-                        // Here, datasize must be 8 when calling this
-                        Interop.Advapi32.RegQueryValueEx(_hkey, name, null, ref type, ref blob, ref datasize);
-
-                        data = blob;
                     }
-                    break;
-                case Interop.Advapi32.RegistryValues.REG_DWORD:
-                    {    // also REG_DWORD_LITTLE_ENDIAN
-                        if (datasize > 4)
-                        {
-                            // prevent an AV in the edge case that datasize is larger than sizeof(int)
-                            goto case Interop.Advapi32.RegistryValues.REG_QWORD;
-                        }
-                        int blob = 0;
-                        Debug.Assert(datasize == 4, "datasize==4");
-                        // Here, datasize must be four when calling this
-                        Interop.Advapi32.RegQueryValueEx(_hkey, name, null, ref type, ref blob, ref datasize);
 
-                        data = blob;
-                    }
-                    break;
-
-                case Interop.Advapi32.RegistryValues.REG_SZ:
+                    // If RegQueryValueEx told us we need a larger buffer, get one and then loop around to try again.
+                    if (result == Interop.Errors.ERROR_MORE_DATA)
                     {
-                        if (datasize % 2 == 1)
+                        if (IsPerfDataKey())
                         {
-                            // handle the case where the registry contains an odd-byte length (corrupt data?)
-                            try
-                            {
-                                datasize = checked(datasize + 1);
-                            }
-                            catch (OverflowException e)
-                            {
-                                throw new IOException(SR.Arg_RegGetOverflowBug, e);
-                            }
+                            // In the case of a performance key, dataLength is not reliable, but we know the existing
+                            // size was insufficient, so double the buffer size.
+                            dataLength = span.Length * 2;
                         }
-                        char[] blob = new char[datasize / 2];
 
-                        Interop.Advapi32.RegQueryValueEx(_hkey, name, null, ref type, blob, ref datasize);
-                        if (blob.Length > 0 && blob[blob.Length - 1] == (char)0)
+                        if (pooledArray is not null)
                         {
-                            data = new string(blob, 0, blob.Length - 1);
+                            // This should only happen if the registry key was changed concurrently, such that
+                            // we called RegQueryValueEx with our initial buffer size that was too small, we then
+                            // rented a buffer of the reportedly right size and called RegQueryValueEx again, but
+                            // it still came back with ERROR_MORE_DATA again.
+                            byte[] toReturn = pooledArray;
+                            pooledArray = null;
+                            ArrayPool<byte>.Shared.Return(toReturn);
                         }
-                        else
+
+                        // Greater than 2GB values aren't supported.
+                        if (dataLength < 0)
                         {
-                            // in the very unlikely case the data is missing null termination,
-                            // pass in the whole char[] to prevent truncating a character
-                            data = new string(blob);
+                            throw new IOException(SR.Arg_RegValueTooLarge);
                         }
+
+                        span = pooledArray = ArrayPool<byte>.Shared.Rent(dataLength);
+                        if (IsPerfDataKey())
+                        {
+                            span.Clear();
+                        }
+
+                        continue;
                     }
-                    break;
 
-                case Interop.Advapi32.RegistryValues.REG_EXPAND_SZ:
+                    // For any other error, return the default value.  This might be ERROR_FILE_NOT_FOUND if the reg key
+                    // wasn't found, or any other system error value for unspecified reasons. For compat, an exception
+                    // is thrown for perf keys rather than returning the default value.
+                    if (result != Interop.Errors.ERROR_SUCCESS)
                     {
-                        if (datasize % 2 == 1)
+                        if (IsPerfDataKey())
                         {
-                            // handle the case where the registry contains an odd-byte length (corrupt data?)
-                            try
-                            {
-                                datasize = checked(datasize + 1);
-                            }
-                            catch (OverflowException e)
-                            {
-                                throw new IOException(SR.Arg_RegGetOverflowBug, e);
-                            }
+                            Win32Error(result, name);
                         }
-                        char[] blob = new char[datasize / 2];
-
-                        Interop.Advapi32.RegQueryValueEx(_hkey, name, null, ref type, blob, ref datasize);
-
-                        if (blob.Length > 0 && blob[blob.Length - 1] == (char)0)
-                        {
-                            data = new string(blob, 0, blob.Length - 1);
-                        }
-                        else
-                        {
-                            // in the very unlikely case the data is missing null termination,
-                            // pass in the whole char[] to prevent truncating a character
-                            data = new string(blob);
-                        }
-
-                        if (!doNotExpand)
-                        {
-                            data = Environment.ExpandEnvironmentVariables((string)data);
-                        }
+                        return defaultValue;
                     }
-                    break;
-                case Interop.Advapi32.RegistryValues.REG_MULTI_SZ:
+
+                    // We only get here for a successful query of the data. Process and return the results.
+                    Debug.Assert((uint)dataLength <= span.Length, $"Expected {dataLength} <= {span.Length}");
+                    switch (type)
                     {
-                        if (datasize % 2 == 1)
-                        {
-                            // handle the case where the registry contains an odd-byte length (corrupt data?)
-                            try
+                        case Interop.Advapi32.RegistryValues.REG_NONE:
+                        case Interop.Advapi32.RegistryValues.REG_BINARY:
+                        case Interop.Advapi32.RegistryValues.REG_DWORD_BIG_ENDIAN:
+                            return span.Slice(0, dataLength).ToArray();
+
+                        case Interop.Advapi32.RegistryValues.REG_DWORD:
+                        case Interop.Advapi32.RegistryValues.REG_QWORD:
+                            return dataLength switch
                             {
-                                datasize = checked(datasize + 1);
-                            }
-                            catch (OverflowException e)
+                                4 => MemoryMarshal.Read<int>(span),
+                                8 => MemoryMarshal.Read<long>(span),
+                                _ => span.Slice(0, dataLength).ToArray(), // This shouldn't happen, but the previous implementation included it defensively.
+                            };
+
+                        case Interop.Advapi32.RegistryValues.REG_SZ:
+                        case Interop.Advapi32.RegistryValues.REG_EXPAND_SZ:
+                        case Interop.Advapi32.RegistryValues.REG_MULTI_SZ:
                             {
-                                throw new IOException(SR.Arg_RegGetOverflowBug, e);
-                            }
-                        }
-                        char[] blob = new char[datasize / 2];
-
-                        ret = Interop.Advapi32.RegQueryValueEx(_hkey, name, null, ref type, blob, ref datasize);
-
-                        // make sure the string is null terminated before processing the data
-                        if (blob.Length > 0 && blob[blob.Length - 1] != (char)0)
-                        {
-                            Array.Resize(ref blob, blob.Length + 1);
-                        }
-
-                        string[] strings = Array.Empty<string>();
-                        int stringsCount = 0;
-
-                        int cur = 0;
-                        int len = blob.Length;
-
-                        while (ret == 0 && cur < len)
-                        {
-                            int nextNull = cur;
-                            while (nextNull < len && blob[nextNull] != (char)0)
-                            {
-                                nextNull++;
-                            }
-
-                            string? toAdd = null;
-                            if (nextNull < len)
-                            {
-                                Debug.Assert(blob[nextNull] == (char)0, "blob[nextNull] should be 0");
-                                if (nextNull - cur > 0)
+                                // Handle the case where the registry contains an odd-byte length (corrupt data?)
+                                // by increasing the data by a single zero byte.
+                                if (dataLength % 2 == 1)
                                 {
-                                    toAdd = new string(blob, cur, nextNull - cur);
+                                    if (dataLength == int.MaxValue)
+                                    {
+                                        throw new IOException(SR.Arg_RegValueTooLarge);
+                                    }
+
+                                    if (dataLength >= span.Length)
+                                    {
+                                        byte[] newPooled = ArrayPool<byte>.Shared.Rent(dataLength + 1);
+                                        span.CopyTo(newPooled);
+                                        if (pooledArray is not null)
+                                        {
+                                            byte[] toReturn = pooledArray;
+                                            pooledArray = null;
+                                            ArrayPool<byte>.Shared.Return(toReturn);
+                                        }
+                                        span = pooledArray = newPooled;
+                                    }
+
+                                    span[dataLength++] = 0;
+                                }
+
+                                // From here on, we interpret the read bytes as chars; span and dataLength should no longer be used.
+                                ReadOnlySpan<char> chars = MemoryMarshal.Cast<byte, char>(span.Slice(0, dataLength));
+
+                                if (type == Interop.Advapi32.RegistryValues.REG_MULTI_SZ)
+                                {
+                                    string[] strings = Array.Empty<string>();
+                                    int count = 0;
+
+                                    while (chars.Length > 1 || (chars.Length == 1 && chars[0] != '\0'))
+                                    {
+                                        int nullPos = chars.IndexOf('\0');
+                                        string toAdd;
+                                        if (nullPos < 0)
+                                        {
+                                            toAdd = chars.ToString();
+                                            chars = default;
+                                        }
+                                        else
+                                        {
+                                            toAdd = chars.Slice(0, nullPos).ToString();
+                                            chars = chars.Slice(nullPos + 1);
+                                        }
+
+                                        if (count == strings.Length)
+                                        {
+                                            Array.Resize(ref strings, count == 0 ? 4 : count * 2);
+                                        }
+                                        strings[count++] = toAdd;
+                                    }
+
+                                    if (count != 0)
+                                    {
+                                        Array.Resize(ref strings, count);
+                                    }
+
+                                    return strings;
                                 }
                                 else
                                 {
-                                    // we found an empty string.  But if we're at the end of the data,
-                                    // it's just the extra null terminator.
-                                    if (nextNull != len - 1)
+                                    if (chars.Length == 0)
                                     {
-                                        toAdd = string.Empty;
+                                        return string.Empty;
                                     }
+
+                                    // Remove null termination if it exists.
+                                    if (chars[^1] == 0)
+                                    {
+                                        chars = chars[0..^1];
+                                    }
+
+                                    // Get the resulting string from the bytes.
+                                    string str = chars.ToString();
+                                    if (type == Interop.Advapi32.RegistryValues.REG_EXPAND_SZ && !doNotExpand)
+                                    {
+                                        str = Environment.ExpandEnvironmentVariables(str);
+                                    }
+
+                                    return str;
                                 }
                             }
-                            else
-                            {
-                                toAdd = new string(blob, cur, len - cur);
-                            }
-                            cur = nextNull + 1;
 
-                            if (toAdd != null)
-                            {
-                                if (strings.Length == stringsCount)
-                                {
-                                    Array.Resize(ref strings, stringsCount > 0 ? stringsCount * 2 : 4);
-                                }
-                                strings[stringsCount++] = toAdd;
-                            }
-                        }
-
-                        Array.Resize(ref strings, stringsCount);
-                        data = strings;
+                        default:
+                            return defaultValue;
                     }
-                    break;
-                case Interop.Advapi32.RegistryValues.REG_LINK:
-                default:
-                    break;
+                }
             }
-
-            return data;
+            finally
+            {
+                if (pooledArray is not null)
+                {
+                    ArrayPool<byte>.Shared.Return(pooledArray);
+                }
+            }
         }
 
-        private RegistryValueKind GetValueKindCore(string? name)
+        private unsafe RegistryValueKind GetValueKindCore(string? name)
         {
             int type = 0;
             int datasize = 0;
-            int ret = Interop.Advapi32.RegQueryValueEx(_hkey, name, null, ref type, (byte[]?)null, ref datasize);
+            int ret = Interop.Advapi32.RegQueryValueEx(_hkey, name, null, &type, (byte*)null, (uint*)&datasize);
             if (ret != 0)
             {
                 Win32Error(ret, null);

--- a/src/libraries/Microsoft.Win32.Registry/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Win32.Registry/src/Resources/Strings.resx
@@ -1,4 +1,5 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -84,8 +85,8 @@
   <data name="Arg_RegBadKeyKind" xml:space="preserve">
     <value>The specified RegistryValueKind is an invalid value.</value>
   </data>
-  <data name="Arg_RegGetOverflowBug" xml:space="preserve">
-    <value>RegistryKey.GetValue does not allow a String that has a length greater than Int32.MaxValue.</value>
+  <data name="Arg_RegValueTooLarge" xml:space="preserve">
+    <value>RegistryKey.GetValue does not support values with more than Int32.MaxValue bytes.</value>
   </data>
   <data name="Arg_RegSetMismatchedKind" xml:space="preserve">
     <value>The type of the value object did not match the specified RegistryValueKind or the object could not be properly converted.</value>

--- a/src/libraries/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_GetValue_CorruptData.cs
+++ b/src/libraries/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_GetValue_CorruptData.cs
@@ -44,10 +44,13 @@ namespace Microsoft.Win32.RegistryTests
         }
 
         [Theory]
-        [InlineData(RegistryValueKind.String, new byte[] { 6, 5, 6 })]
-        [InlineData(RegistryValueKind.ExpandString, new byte[] { 6, 5, 6 })]
-        [InlineData(RegistryValueKind.MultiString, new byte[] { 6, 5, 6, 0, 0 })]
-        public void RegSzOddByteLength(RegistryValueKind kind, byte[] contents)
+        [InlineData(RegistryValueKind.String, new byte[] { 6, 5, 6 }, "\u0506")]
+        [InlineData(RegistryValueKind.ExpandString, new byte[] { 6, 5, 6 }, "\u0506")]
+        [InlineData(RegistryValueKind.MultiString, new byte[] { 6, 5, 6 }, "\u0506")]
+        [InlineData(RegistryValueKind.String, new byte[] { 6, 5, 6, 0, 0 }, "\u0506\u0006")]
+        [InlineData(RegistryValueKind.ExpandString, new byte[] { 6, 5, 6, 0, 0 }, "\u0506\u0006")]
+        [InlineData(RegistryValueKind.MultiString, new byte[] { 6, 5, 6, 0, 0 }, "\u0506\u0006")]
+        public void RegSzOddByteLength(RegistryValueKind kind, byte[] contents, string expected)
         {
             const string TestValueName = "CorruptData2";
 
@@ -73,9 +76,7 @@ namespace Microsoft.Win32.RegistryTests
                     s = (string)o;
                 }
 
-                Assert.Equal(2, s.Length);
-                Assert.Equal(0x506, s[0]);
-                Assert.Equal(0x6, s[1]);
+                Assert.Equal(expected, s);
             }
             finally
             {

--- a/src/libraries/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_GetValue_str.cs
+++ b/src/libraries/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_GetValue_str.cs
@@ -86,5 +86,12 @@ namespace Microsoft.Win32.RegistryTests
             Assert.Equal(expected, (string[])TestRegistryKey.GetValue(valueName));
             TestRegistryKey.DeleteValue(valueName);
         }
+
+        [Fact]
+        public void GetPerformanceKeyValue()
+        {
+            string[] counterNames = (string[])Registry.PerformanceData.GetValue("Counter");
+            Assert.NotEmpty(counterNames);
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/Internal/Win32/RegistryKey.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Win32/RegistryKey.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security;
 
 using Internal.Win32.SafeHandles;
@@ -219,217 +220,187 @@ namespace Internal.Win32
         }
 
         [return: NotNullIfNotNull("defaultValue")]
-        public object? GetValue(string name, object? defaultValue)
+        public unsafe object? GetValue(string name, object? defaultValue)
         {
-            object? data = defaultValue;
-            int type = 0;
-            int datasize = 0;
+            // Create an initial stack buffer large enough to satisfy many reg keys.  We need to call RegQueryValueEx
+            // in order to determine the type of the value, and we can avoid further retries if all of the data can be
+            // retrieved in that single call with this buffer.  If we do need to grow, we grow into a pooled array. The
+            // caller is always handed back a copy of this data, either in an array, a string, or a boxed integer.
+            Span<byte> span = stackalloc byte[512];
+            byte[]? pooledArray = null;
 
-            int ret = Interop.Advapi32.RegQueryValueEx(_hkey, name, null, ref type, (byte[]?)null, ref datasize);
-
-            if (ret != 0)
+            try
             {
-                // For stuff like ERROR_FILE_NOT_FOUND, we want to return null (data).
-                // Some OS's returned ERROR_MORE_DATA even in success cases, so we
-                // want to continue on through the function.
-                if (ret != Interop.Errors.ERROR_MORE_DATA)
-                    return data;
-            }
+                // Loop in case we need to try again with a larger buffer size.
+                while (true)
+                {
+                    int type = 0;
+                    int result;
+                    int dataLength = span.Length;
 
-            if (datasize < 0)
-            {
-                // unexpected code path
-                Debug.Fail("[InternalGetValue] RegQueryValue returned ERROR_SUCCESS but gave a negative datasize");
-                datasize = 0;
-            }
-
-
-            switch (type)
-            {
-                case Interop.Advapi32.RegistryValues.REG_NONE:
-                case Interop.Advapi32.RegistryValues.REG_DWORD_BIG_ENDIAN:
-                case Interop.Advapi32.RegistryValues.REG_BINARY:
+                    fixed (byte* lpData = &MemoryMarshal.GetReference(span))
                     {
-                        byte[] blob = new byte[datasize];
-                        Interop.Advapi32.RegQueryValueEx(_hkey, name, null, ref type, blob, ref datasize);
-                        data = blob;
-                    }
-                    break;
-                case Interop.Advapi32.RegistryValues.REG_QWORD:
-                    {    // also REG_QWORD_LITTLE_ENDIAN
-                        if (datasize > 8)
+                        result = Interop.Advapi32.RegQueryValueEx(_hkey, name, null, &type, lpData, (uint*)&dataLength);
+                        if (dataLength < 0)
                         {
-                            // prevent an AV in the edge case that datasize is larger than sizeof(long)
-                            goto case Interop.Advapi32.RegistryValues.REG_BINARY;
+                            // Greater than 2GB values aren't supported.
+                            throw new IOException(SR.Arg_RegValueTooLarge);
                         }
-                        long blob = 0;
-                        Debug.Assert(datasize == 8, "datasize==8");
-                        // Here, datasize must be 8 when calling this
-                        Interop.Advapi32.RegQueryValueEx(_hkey, name, null, ref type, ref blob, ref datasize);
-
-                        data = blob;
                     }
-                    break;
-                case Interop.Advapi32.RegistryValues.REG_DWORD:
-                    {    // also REG_DWORD_LITTLE_ENDIAN
-                        if (datasize > 4)
-                        {
-                            // prevent an AV in the edge case that datasize is larger than sizeof(int)
-                            goto case Interop.Advapi32.RegistryValues.REG_QWORD;
-                        }
-                        int blob = 0;
-                        Debug.Assert(datasize == 4, "datasize==4");
-                        // Here, datasize must be four when calling this
-                        Interop.Advapi32.RegQueryValueEx(_hkey, name, null, ref type, ref blob, ref datasize);
 
-                        data = blob;
-                    }
-                    break;
-
-                case Interop.Advapi32.RegistryValues.REG_SZ:
+                    // If RegQueryValueEx told us we need a larger buffer, get one and then loop around to try again.
+                    if (result == Interop.Errors.ERROR_MORE_DATA)
                     {
-                        if (datasize % 2 == 1)
+                        if (pooledArray is not null)
                         {
-                            // handle the case where the registry contains an odd-byte length (corrupt data?)
-                            try
-                            {
-                                datasize = checked(datasize + 1);
-                            }
-                            catch (OverflowException e)
-                            {
-                                throw new IOException(SR.Arg_RegGetOverflowBug, e);
-                            }
+                            // This should only happen if the registry key was changed concurrently, such that
+                            // we called RegQueryValueEx with our initial buffer size that was too small, we then
+                            // rented a buffer of the reportedly right size and called RegQueryValueEx again, but
+                            // it still came back with ERROR_MORE_DATA again.
+                            byte[] toReturn = pooledArray;
+                            pooledArray = null;
+                            ArrayPool<byte>.Shared.Return(toReturn);
                         }
-                        char[] blob = new char[datasize / 2];
 
-                        Interop.Advapi32.RegQueryValueEx(_hkey, name, null, ref type, blob, ref datasize);
-                        if (blob.Length > 0 && blob[^1] == (char)0)
+                        // Greater than 2GB values aren't supported.
+                        if (dataLength < 0)
                         {
-                            data = new string(blob, 0, blob.Length - 1);
+                            throw new IOException(SR.Arg_RegValueTooLarge);
                         }
-                        else
-                        {
-                            // in the very unlikely case the data is missing null termination,
-                            // pass in the whole char[] to prevent truncating a character
-                            data = new string(blob);
-                        }
+
+                        span = pooledArray = ArrayPool<byte>.Shared.Rent(dataLength);
+
+                        continue;
                     }
-                    break;
 
-                case Interop.Advapi32.RegistryValues.REG_EXPAND_SZ:
+                    // For any other error, return the default value.  This might be ERROR_FILE_NOT_FOUND if the reg key
+                    // wasn't found, or any other system error value for unspecified reasons. For compat, an exception
+                    // is thrown for perf keys rather than returning the default value.
+                    if (result != Interop.Errors.ERROR_SUCCESS)
                     {
-                        if (datasize % 2 == 1)
-                        {
-                            // handle the case where the registry contains an odd-byte length (corrupt data?)
-                            try
-                            {
-                                datasize = checked(datasize + 1);
-                            }
-                            catch (OverflowException e)
-                            {
-                                throw new IOException(SR.Arg_RegGetOverflowBug, e);
-                            }
-                        }
-                        char[] blob = new char[datasize / 2];
-
-                        Interop.Advapi32.RegQueryValueEx(_hkey, name, null, ref type, blob, ref datasize);
-
-                        if (blob.Length > 0 && blob[^1] == (char)0)
-                        {
-                            data = new string(blob, 0, blob.Length - 1);
-                        }
-                        else
-                        {
-                            // in the very unlikely case the data is missing null termination,
-                            // pass in the whole char[] to prevent truncating a character
-                            data = new string(blob);
-                        }
-
-                        data = Environment.ExpandEnvironmentVariables((string)data);
+                        return defaultValue;
                     }
-                    break;
-                case Interop.Advapi32.RegistryValues.REG_MULTI_SZ:
+
+                    // We only get here for a successful query of the data. Process and return the results.
+                    Debug.Assert((uint)dataLength <= span.Length, $"Expected {dataLength} <= {span.Length}");
+                    switch (type)
                     {
-                        if (datasize % 2 == 1)
-                        {
-                            // handle the case where the registry contains an odd-byte length (corrupt data?)
-                            try
+                        case Interop.Advapi32.RegistryValues.REG_NONE:
+                        case Interop.Advapi32.RegistryValues.REG_BINARY:
+                        case Interop.Advapi32.RegistryValues.REG_DWORD_BIG_ENDIAN:
+                            return span.Slice(0, dataLength).ToArray();
+
+                        case Interop.Advapi32.RegistryValues.REG_DWORD:
+                        case Interop.Advapi32.RegistryValues.REG_QWORD:
+                            return dataLength switch
                             {
-                                datasize = checked(datasize + 1);
-                            }
-                            catch (OverflowException e)
+                                4 => MemoryMarshal.Read<int>(span),
+                                8 => MemoryMarshal.Read<long>(span),
+                                _ => span.Slice(0, dataLength).ToArray(), // This shouldn't happen, but the previous implementation included it defensively.
+                            };
+
+                        case Interop.Advapi32.RegistryValues.REG_SZ:
+                        case Interop.Advapi32.RegistryValues.REG_EXPAND_SZ:
+                        case Interop.Advapi32.RegistryValues.REG_MULTI_SZ:
                             {
-                                throw new IOException(SR.Arg_RegGetOverflowBug, e);
-                            }
-                        }
-                        char[] blob = new char[datasize / 2];
-
-                        ret = Interop.Advapi32.RegQueryValueEx(_hkey, name, null, ref type, blob, ref datasize);
-
-                        // make sure the string is null terminated before processing the data
-                        if (blob.Length > 0 && blob[^1] != (char)0)
-                        {
-                            Array.Resize(ref blob, blob.Length + 1);
-                        }
-
-                        string[] strings = Array.Empty<string>();
-                        int stringsCount = 0;
-
-                        int cur = 0;
-                        int len = blob.Length;
-
-                        while (ret == 0 && cur < len)
-                        {
-                            int nextNull = cur;
-                            while (nextNull < len && blob[nextNull] != (char)0)
-                            {
-                                nextNull++;
-                            }
-
-                            string? toAdd = null;
-                            if (nextNull < len)
-                            {
-                                Debug.Assert(blob[nextNull] == (char)0, "blob[nextNull] should be 0");
-                                if (nextNull - cur > 0)
+                                // Handle the case where the registry contains an odd-byte length (corrupt data?)
+                                // by increasing the data by a single zero byte.
+                                if (dataLength % 2 == 1)
                                 {
-                                    toAdd = new string(blob, cur, nextNull - cur);
+                                    if (dataLength == int.MaxValue)
+                                    {
+                                        throw new IOException(SR.Arg_RegValueTooLarge);
+                                    }
+
+                                    if (dataLength >= span.Length)
+                                    {
+                                        byte[] newPooled = ArrayPool<byte>.Shared.Rent(dataLength + 1);
+                                        span.CopyTo(newPooled);
+                                        if (pooledArray is not null)
+                                        {
+                                            byte[] toReturn = pooledArray;
+                                            pooledArray = null;
+                                            ArrayPool<byte>.Shared.Return(toReturn);
+                                        }
+                                        span = pooledArray = newPooled;
+                                    }
+
+                                    span[dataLength++] = 0;
+                                }
+
+                                // From here on, we interpret the read bytes as chars; span and dataLength should no longer be used.
+                                ReadOnlySpan<char> chars = MemoryMarshal.Cast<byte, char>(span.Slice(0, dataLength));
+
+                                if (type == Interop.Advapi32.RegistryValues.REG_MULTI_SZ)
+                                {
+                                    string[] strings = Array.Empty<string>();
+                                    int count = 0;
+
+                                    while (chars.Length > 1 || (chars.Length == 1 && chars[0] != '\0'))
+                                    {
+                                        int nullPos = chars.IndexOf('\0');
+                                        string toAdd;
+                                        if (nullPos < 0)
+                                        {
+                                            toAdd = chars.ToString();
+                                            chars = default;
+                                        }
+                                        else
+                                        {
+                                            toAdd = chars.Slice(0, nullPos).ToString();
+                                            chars = chars.Slice(nullPos + 1);
+                                        }
+
+                                        if (count == strings.Length)
+                                        {
+                                            Array.Resize(ref strings, count == 0 ? 4 : count * 2);
+                                        }
+                                        strings[count++] = toAdd;
+                                    }
+
+                                    if (count != 0)
+                                    {
+                                        Array.Resize(ref strings, count);
+                                    }
+
+                                    return strings;
                                 }
                                 else
                                 {
-                                    // we found an empty string.  But if we're at the end of the data,
-                                    // it's just the extra null terminator.
-                                    if (nextNull != len - 1)
+                                    if (chars.Length == 0)
                                     {
-                                        toAdd = string.Empty;
+                                        return string.Empty;
                                     }
+
+                                    // Remove null termination if it exists.
+                                    if (chars[^1] == 0)
+                                    {
+                                        chars = chars[0..^1];
+                                    }
+
+                                    // Get the resulting string from the bytes.
+                                    string str = chars.ToString();
+                                    if (type == Interop.Advapi32.RegistryValues.REG_EXPAND_SZ)
+                                    {
+                                        str = Environment.ExpandEnvironmentVariables(str);
+                                    }
+
+                                    return str;
                                 }
                             }
-                            else
-                            {
-                                toAdd = new string(blob, cur, len - cur);
-                            }
-                            cur = nextNull + 1;
 
-                            if (toAdd != null)
-                            {
-                                if (strings.Length == stringsCount)
-                                {
-                                    Array.Resize(ref strings, stringsCount > 0 ? stringsCount * 2 : 4);
-                                }
-                                strings[stringsCount++] = toAdd;
-                            }
-                        }
-
-                        Array.Resize(ref strings, stringsCount);
-                        data = strings;
+                        default:
+                            return defaultValue;
                     }
-                    break;
-                case Interop.Advapi32.RegistryValues.REG_LINK:
-                default:
-                    break;
+                }
             }
-
-            return data;
+            finally
+            {
+                if (pooledArray is not null)
+                {
+                    ArrayPool<byte>.Shared.Return(pooledArray);
+                }
+            }
         }
 
         // The actual api is SetValue(string name, object value) but we only need to set Strings

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -699,8 +699,8 @@
   <data name="Arg_RanksAndBounds" xml:space="preserve">
     <value>Number of lengths and lowerBounds must match.</value>
   </data>
-  <data name="Arg_RegGetOverflowBug" xml:space="preserve">
-    <value>RegistryKey.GetValue does not allow a String that has a length greater than Int32.MaxValue.</value>
+  <data name="Arg_RegValueTooLarge" xml:space="preserve">
+    <value>RegistryKey.GetValue does not support values with more than Int32.MaxValue bytes.</value>
   </data>
   <data name="Arg_RegKeyNotFound" xml:space="preserve">
     <value>The specified registry key does not exist.</value>


### PR DESCRIPTION
Replace char[] allocations with stackalloc'd memory, or ArrayPool as a fallback if the size is too large.

I also noticed that the handler for REG_EXPAND_SZ was identical to the handler for REG_SZ save for one block, so I just collapsed the two and added an additional condition to that one block.