### PR TITLE
Double the size of the previous segment

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
@@ -15,6 +15,11 @@ namespace System.IO.Pipelines
         private int _end;
 
         /// <summary>
+        /// The amount of avaiable memory in the segment.
+        /// </summary>
+        public int Capacity => AvailableMemory.Length;
+
+        /// <summary>
         /// The End represents the offset into AvailableMemory where the range of "active" bytes ends. At the point when the block is leased
         /// the End is guaranteed to be equal to Start. The value of Start may be assigned anywhere between 0 and
         /// Buffer.Length, and must be equal to or less than End.

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -239,7 +239,7 @@ namespace System.IO.Pipelines
             return newSegment;
         }
 
-        private int GetSegmentSize(int minimumSegmentSize, int sizeHint, int maxBufferSize = int.MaxValue)
+        private static int GetSegmentSize(int minimumSegmentSize, int sizeHint, int maxBufferSize = int.MaxValue)
         {
             // First we need to handle case where hint is smaller than minimum segment size
             sizeHint = Math.Max(minimumSegmentSize, sizeHint);

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs
@@ -44,7 +44,7 @@ namespace System.IO.Pipelines
             // With a default minimum segment size of 4 this maps to 60K
             InitialSegmentPoolSize = 4;
 
-            // With a default minimum segment size of 4K this maps to 1MB. If the pipe has large segments this will be bigger than 1MB...
+            // With a default minimum segment size of 4K this maps to ~250MB.
             MaxSegmentPoolSize = 256;
 
             // By default, we'll throttle the writer at 64K of buffered data

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs
@@ -11,6 +11,9 @@ namespace System.IO.Pipelines
     {
         private const int DefaultMinimumSegmentSize = 4096;
 
+        // Arbitrary 1MB max segment size
+        internal const int MaximumSegmentSize = 1024 * 1024;
+
         /// <summary>Gets the default instance of <see cref="System.IO.Pipelines.PipeOptions" />.</summary>
         /// <value>A <see cref="System.IO.Pipelines.PipeOptions" /> object initialized with default parameters.</value>
         public static PipeOptions Default { get; } = new PipeOptions();
@@ -38,10 +41,10 @@ namespace System.IO.Pipelines
             // to let users specify the maximum buffer size, so we pick a reasonable number based on defaults. They can influence
             // how much gets buffered by increasing the minimum segment size.
 
-            // With a defaukt segment size of 4K this maps to 16K
+            // With a default minimum segment size of 4 this maps to 60K
             InitialSegmentPoolSize = 4;
 
-            // With a defaukt segment size of 4K this maps to 1MB. If the pipe has large segments this will be bigger than 1MB...
+            // With a default minimum segment size of 4K this maps to 1MB. If the pipe has large segments this will be bigger than 1MB...
             MaxSegmentPoolSize = 256;
 
             // By default, we'll throttle the writer at 64K of buffered data

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -167,7 +167,7 @@ namespace System.IO.Pipelines
             return newSegment;
         }
 
-        private int GetSegmentSize(int minimumBufferSize, int sizeHint, int maxBufferSize = int.MaxValue)
+        private static int GetSegmentSize(int minimumBufferSize, int sizeHint, int maxBufferSize = int.MaxValue)
         {
             // First we need to handle case where hint is smaller than minimum segment size
             sizeHint = Math.Max(minimumBufferSize, sizeHint);

--- a/src/libraries/System.IO.Pipelines/tests/PipePoolTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipePoolTests.cs
@@ -101,7 +101,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        public async Task RentsMinimumSegmentSize()
+        public async Task DoublesMinimumSegmentSize()
         {
             var pool = new DisposeTrackingBufferPool();
             var writeSize = 512;
@@ -118,7 +118,7 @@ namespace System.IO.Pipelines.Tests
             pipe.Reader.Complete();
             pipe.Writer.Complete();
 
-            Assert.Equal(2020, ensuredSize);
+            Assert.Equal(4040, ensuredSize);
             Assert.Equal(2020, allocatedSize);
         }
 


### PR DESCRIPTION
- This change comes after long observations around how pipelines doesn't work well for copying large blocks of data mainly due to the segment allocation strategy. Today we allocate each segment > minimum segment size < max pool size. This works well if data is being quickly consumed because we can keep memory allocations to a minimum but doesn't work well when there's large chunks of data are being written. This change doubles the segment size based on the previous segment up to 1MB (arbitrary limit). This should make the default behavior work pretty much the same as today but performance of larger writes/reads should improve.

PS: Running more performance experiments.

Makes https://github.com/dotnet/runtime/issues/49259 more feasible as the number of segments will be less per pipe because of the growth strategy 

Might improve https://github.com/dotnet/runtime/issues/43480 in the default case