### PR TITLE
Add support for creating delegates to static virtual methods

### DIFF
--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -2441,6 +2441,7 @@ public:
 
     virtual void getReadyToRunDelegateCtorHelper(
             CORINFO_RESOLVED_TOKEN * pTargetMethod,
+            mdToken                  targetConstraint,
             CORINFO_CLASS_HANDLE     delegateType,
             CORINFO_LOOKUP *   pLookup
             ) = 0;

--- a/src/coreclr/inc/icorjitinfoimpl_generated.h
+++ b/src/coreclr/inc/icorjitinfoimpl_generated.h
@@ -283,6 +283,7 @@ bool getReadyToRunHelper(
 
 void getReadyToRunDelegateCtorHelper(
           CORINFO_RESOLVED_TOKEN* pTargetMethod,
+          mdToken targetConstraint,
           CORINFO_CLASS_HANDLE delegateType,
           CORINFO_LOOKUP* pLookup) override;
 

--- a/src/coreclr/inc/jiteeversionguid.h
+++ b/src/coreclr/inc/jiteeversionguid.h
@@ -43,11 +43,11 @@ typedef const GUID *LPCGUID;
 #define GUID_DEFINED
 #endif // !GUID_DEFINED
 
-constexpr GUID JITEEVersionIdentifier = { /* bcc99ca6-5291-4cc0-a5d9-2758456053f3 */
-    0xbcc99ca6,
-    0x5291,
-    0x4cc0,
-    { 0xa5, 0xd9, 0x27, 0x58, 0x45, 0x60, 0x53, 0xf3 }
+constexpr GUID JITEEVersionIdentifier = { /* 398270b8-d474-428f-8113-3834281853cf */
+    0x398270b8,
+    0xd474,
+    0x428f,
+    {0x81, 0x13, 0x38, 0x34, 0x28, 0x18, 0x53, 0xcf}
   };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/coreclr/jit/ICorJitInfo_API_wrapper.hpp
+++ b/src/coreclr/jit/ICorJitInfo_API_wrapper.hpp
@@ -656,11 +656,12 @@ bool WrapICorJitInfo::getReadyToRunHelper(
 
 void WrapICorJitInfo::getReadyToRunDelegateCtorHelper(
           CORINFO_RESOLVED_TOKEN* pTargetMethod,
+          mdToken targetConstraint,
           CORINFO_CLASS_HANDLE delegateType,
           CORINFO_LOOKUP* pLookup)
 {
     API_ENTER(getReadyToRunDelegateCtorHelper);
-    wrapHnd->getReadyToRunDelegateCtorHelper(pTargetMethod, delegateType, pLookup);
+    wrapHnd->getReadyToRunDelegateCtorHelper(pTargetMethod, targetConstraint, delegateType, pLookup);
     API_LEAVE(getReadyToRunDelegateCtorHelper);
 }
 

--- a/src/coreclr/jit/_typeinfo.h
+++ b/src/coreclr/jit/_typeinfo.h
@@ -148,7 +148,7 @@ inline ti_types JITtype2tiType(CorInfoType type)
 * m_token is the CORINFO_RESOLVED_TOKEN from the IL, potentially with a more
 *         precise method handle from getCallInfo
 * m_tokenConstraint is the constraint if this was a constrained ldftn.
-* 
+*
 */
 class methodPointerInfo
 {
@@ -377,7 +377,7 @@ public:
         assert(methodPointerInfo != nullptr);
         assert(methodPointerInfo->m_token.hMethod != nullptr);
         assert(!isInvalidHandle(methodPointerInfo->m_token.hMethod));
-        m_flags = TI_METHOD;
+        m_flags             = TI_METHOD;
         m_methodPointerInfo = methodPointerInfo;
     }
 

--- a/src/coreclr/jit/_typeinfo.h
+++ b/src/coreclr/jit/_typeinfo.h
@@ -143,6 +143,21 @@ inline ti_types JITtype2tiType(CorInfoType type)
 };
 
 /*****************************************************************************
+* Captures information about a method pointer
+*
+* m_token is the CORINFO_RESOLVED_TOKEN from the IL, potentially with a more
+*         precise method handle from getCallInfo
+* m_tokenConstraint is the constraint if this was a constrained ldftn.
+* 
+*/
+class methodPointerInfo
+{
+public:
+    CORINFO_RESOLVED_TOKEN m_token;
+    mdToken                m_tokenConstraint;
+};
+
+/*****************************************************************************
  * Declares the typeInfo class, which represents the type of an entity on the
  * stack, in a local variable or an argument.
  *
@@ -221,9 +236,6 @@ inline ti_types JITtype2tiType(CorInfoType type)
 // since conversions between them are not verifiable.
 #define TI_FLAG_NATIVE_INT 0x00000200
 
-// This item contains resolved token. It is used for ctor delegate optimization.
-#define TI_FLAG_TOKEN 0x00000400
-
 // This item contains the 'this' pointer (used for tracking)
 
 #define TI_FLAG_THIS_PTR 0x00001000
@@ -270,7 +282,7 @@ inline ti_types JITtype2tiType(CorInfoType type)
  * - A type (ref, array, value type) (m_cls describes the type)
  * - An array (m_cls describes the array type)
  * - A byref (byref flag set, otherwise the same as the above),
- * - A Function Pointer (m_method)
+ * - A Function Pointer (m_methodPointerInfo)
  * - A byref local variable (byref and byref local flags set), can be
  *   uninitialized
  *
@@ -291,7 +303,7 @@ private:
             unsigned byref : 1;            // used
             unsigned byref_readonly : 1;   // used
             unsigned nativeInt : 1;        // used
-            unsigned token : 1;            // used
+            unsigned : 1;                  // unused
             unsigned : 1;                  // unused
             unsigned thisPtr : 1;          // used
             unsigned thisPermHome : 1;     // used
@@ -303,10 +315,8 @@ private:
 
     union {
         CORINFO_CLASS_HANDLE m_cls;
-        // Valid only for type TI_METHOD without IsToken
-        CORINFO_METHOD_HANDLE m_method;
-        // Valid only for TI_TOKEN with IsToken
-        CORINFO_RESOLVED_TOKEN* m_token;
+        // Valid only for type TI_METHOD
+        methodPointerInfo* m_methodPointerInfo;
     };
 
     template <typename T>
@@ -362,21 +372,13 @@ public:
         m_cls = cls;
     }
 
-    typeInfo(CORINFO_METHOD_HANDLE method)
+    typeInfo(methodPointerInfo* methodPointerInfo)
     {
-        assert(method != nullptr && !isInvalidHandle(method));
-        m_flags  = TI_METHOD;
-        m_method = method;
-    }
-
-    typeInfo(CORINFO_RESOLVED_TOKEN* token)
-    {
-        assert(token != nullptr);
-        assert(token->hMethod != nullptr);
-        assert(!isInvalidHandle(token->hMethod));
+        assert(methodPointerInfo != nullptr);
+        assert(methodPointerInfo->m_token.hMethod != nullptr);
+        assert(!isInvalidHandle(methodPointerInfo->m_token.hMethod));
         m_flags = TI_METHOD;
-        SetIsToken();
-        m_token = token;
+        m_methodPointerInfo = methodPointerInfo;
     }
 
 #ifdef DEBUG
@@ -457,12 +459,6 @@ public:
     /////////////////////////////////////////////////////////////////////////
     // Operations
     /////////////////////////////////////////////////////////////////////////
-
-    void SetIsToken()
-    {
-        m_flags |= TI_FLAG_TOKEN;
-        assert(m_bits.token);
-    }
 
     void SetIsThisPtr()
     {
@@ -573,17 +569,13 @@ public:
     CORINFO_METHOD_HANDLE GetMethod() const
     {
         assert(GetType() == TI_METHOD);
-        if (IsToken())
-        {
-            return m_token->hMethod;
-        }
-        return m_method;
+        return m_methodPointerInfo->m_token.hMethod;
     }
 
-    CORINFO_RESOLVED_TOKEN* GetToken() const
+    methodPointerInfo* GetMethodPointerInfo() const
     {
-        assert(IsToken());
-        return m_token;
+        assert(GetType() == TI_METHOD);
+        return m_methodPointerInfo;
     }
 
     // Get this item's type
@@ -748,11 +740,6 @@ public:
     bool IsUninitialisedObjRef() const
     {
         return (m_flags & TI_FLAG_UNINIT_OBJREF);
-    }
-
-    bool IsToken() const
-    {
-        return IsMethod() && ((m_flags & TI_FLAG_TOKEN) != 0);
     }
 
 private:

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4987,7 +4987,7 @@ private:
     bool impIsClassExact(CORINFO_CLASS_HANDLE classHnd);
     bool impCanSkipCovariantStoreCheck(GenTree* value, GenTree* array);
 
-    CORINFO_RESOLVED_TOKEN* impAllocateToken(const CORINFO_RESOLVED_TOKEN& token);
+    methodPointerInfo* impAllocateMethodPointerInfo(const CORINFO_RESOLVED_TOKEN& token, mdToken tokenConstrained);
 
     /*
     XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -6486,7 +6486,7 @@ private:
 #endif
     GenTree* fgOptimizeDelegateConstructor(GenTreeCall*            call,
                                            CORINFO_CONTEXT_HANDLE* ExactContextHnd,
-                                           CORINFO_RESOLVED_TOKEN* ldftnToken);
+                                           methodPointerInfo*      ldftnToken);
     GenTree* fgMorphLeaf(GenTree* tree);
     void fgAssignSetVarDef(GenTree* tree);
     GenTree* fgMorphOneAsgBlockOp(GenTree* tree);

--- a/src/coreclr/tools/Common/JitInterface/CorInfoBase.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoBase.cs
@@ -989,12 +989,12 @@ namespace Internal.JitInterface
         }
 
         [UnmanagedCallersOnly]
-        static void _getReadyToRunDelegateCtorHelper(IntPtr thisHandle, IntPtr* ppException, CORINFO_RESOLVED_TOKEN* pTargetMethod, CORINFO_CLASS_STRUCT_* delegateType, CORINFO_LOOKUP* pLookup)
+        static void _getReadyToRunDelegateCtorHelper(IntPtr thisHandle, IntPtr* ppException, CORINFO_RESOLVED_TOKEN* pTargetMethod, mdToken targetConstraint, CORINFO_CLASS_STRUCT_* delegateType, CORINFO_LOOKUP* pLookup)
         {
             var _this = GetThis(thisHandle);
             try
             {
-                _this.getReadyToRunDelegateCtorHelper(ref *pTargetMethod, delegateType, ref *pLookup);
+                _this.getReadyToRunDelegateCtorHelper(ref *pTargetMethod, targetConstraint, delegateType, ref *pLookup);
             }
             catch (Exception ex)
             {
@@ -2635,7 +2635,7 @@ namespace Internal.JitInterface
             callbacks[63] = (delegate* unmanaged<IntPtr, IntPtr*, CORINFO_CLASS_STRUCT_*, CorInfoHelpFunc>)&_getBoxHelper;
             callbacks[64] = (delegate* unmanaged<IntPtr, IntPtr*, CORINFO_CLASS_STRUCT_*, CorInfoHelpFunc>)&_getUnBoxHelper;
             callbacks[65] = (delegate* unmanaged<IntPtr, IntPtr*, CORINFO_RESOLVED_TOKEN*, CORINFO_LOOKUP_KIND*, CorInfoHelpFunc, CORINFO_CONST_LOOKUP*, byte>)&_getReadyToRunHelper;
-            callbacks[66] = (delegate* unmanaged<IntPtr, IntPtr*, CORINFO_RESOLVED_TOKEN*, CORINFO_CLASS_STRUCT_*, CORINFO_LOOKUP*, void>)&_getReadyToRunDelegateCtorHelper;
+            callbacks[66] = (delegate* unmanaged<IntPtr, IntPtr*, CORINFO_RESOLVED_TOKEN*, mdToken, CORINFO_CLASS_STRUCT_*, CORINFO_LOOKUP*, void>)&_getReadyToRunDelegateCtorHelper;
             callbacks[67] = (delegate* unmanaged<IntPtr, IntPtr*, CorInfoHelpFunc, byte*>)&_getHelperName;
             callbacks[68] = (delegate* unmanaged<IntPtr, IntPtr*, CORINFO_FIELD_STRUCT_*, CORINFO_METHOD_STRUCT_*, CORINFO_CONTEXT_STRUCT*, CorInfoInitClassResult>)&_initClass;
             callbacks[69] = (delegate* unmanaged<IntPtr, IntPtr*, CORINFO_CLASS_STRUCT_*, void>)&_classMustBeLoadedBeforeCodeIsRun;

--- a/src/coreclr/tools/Common/JitInterface/ThunkGenerator/ThunkInput.txt
+++ b/src/coreclr/tools/Common/JitInterface/ThunkGenerator/ThunkInput.txt
@@ -219,7 +219,7 @@ FUNCTIONS
     CorInfoHelpFunc getBoxHelper(CORINFO_CLASS_HANDLE cls)
     CorInfoHelpFunc getUnBoxHelper(CORINFO_CLASS_HANDLE cls)
     bool getReadyToRunHelper(CORINFO_RESOLVED_TOKEN * pResolvedToken, CORINFO_LOOKUP_KIND * pGenericLookupKind, CorInfoHelpFunc id, CORINFO_CONST_LOOKUP *pLookup)
-    void getReadyToRunDelegateCtorHelper(CORINFO_RESOLVED_TOKEN * pTargetMethod, CORINFO_CLASS_HANDLE delegateType, CORINFO_LOOKUP *pLookup)
+    void getReadyToRunDelegateCtorHelper(CORINFO_RESOLVED_TOKEN * pTargetMethod, mdToken targetConstraint, CORINFO_CLASS_HANDLE delegateType, CORINFO_LOOKUP *pLookup)
     const char* getHelperName(CorInfoHelpFunc helpFunc)
     CorInfoInitClassResult initClass(CORINFO_FIELD_HANDLE field, CORINFO_METHOD_HANDLE method, CORINFO_CONTEXT_HANDLE context)
     void classMustBeLoadedBeforeCodeIsRun(CORINFO_CLASS_HANDLE cls)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -112,7 +112,7 @@ namespace ILCompiler
             return _devirtualizationManager.CanConstructType(type);
         }
 
-        public DelegateCreationInfo GetDelegateCtor(TypeDesc delegateType, MethodDesc target, bool followVirtualDispatch)
+        public DelegateCreationInfo GetDelegateCtor(TypeDesc delegateType, MethodDesc target, TypeDesc constrainedType, bool followVirtualDispatch)
         {
             // If we're creating a delegate to a virtual method that cannot be overriden, devirtualize.
             // This is not just an optimization - it's required for correctness in the presence of sealed
@@ -123,7 +123,7 @@ namespace ILCompiler
             if (followVirtualDispatch)
                 target = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(target);
 
-            return DelegateCreationInfo.Create(delegateType, target, NodeFactory, followVirtualDispatch);
+            return DelegateCreationInfo.Create(delegateType, target, constrainedType, NodeFactory, followVirtualDispatch);
         }
 
         /// <summary>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DelegateCreationInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DelegateCreationInfo.cs
@@ -25,9 +25,13 @@ namespace ILCompiler
             InterfaceDispatch,
             VTableLookup,
             MethodHandle,
+            ConstrainedMethod,
         }
 
         private TargetKind _targetKind;
+
+        private TypeDesc _constrainedType;
+        private MethodDesc _targetMethod;
 
         /// <summary>
         /// Gets the node corresponding to the method that initializes the delegate.
@@ -39,7 +43,11 @@ namespace ILCompiler
 
         public MethodDesc TargetMethod
         {
-            get;
+            get
+            {
+                Debug.Assert(_constrainedType == null);
+                return _targetMethod;
+            }
         }
 
         private bool TargetMethodIsUnboxingThunk
@@ -75,6 +83,10 @@ namespace ILCompiler
                     case TargetKind.MethodHandle:
                         return TargetMethod.IsRuntimeDeterminedExactMethod;
 
+                    case TargetKind.ConstrainedMethod:
+                        Debug.Assert(_targetMethod.IsRuntimeDeterminedExactMethod || _constrainedType.IsRuntimeDeterminedSubtype);
+                        return true;
+
                     default:
                         Debug.Assert(false);
                         return false;
@@ -99,6 +111,9 @@ namespace ILCompiler
 
                 case TargetKind.MethodHandle:
                     return factory.GenericLookup.MethodHandle(TargetMethod);
+
+                case TargetKind.ConstrainedMethod:
+                    return factory.GenericLookup.ConstrainedMethodUse(_targetMethod, _constrainedType, directCall: !_targetMethod.HasInstantiation);
 
                 default:
                     Debug.Assert(false);
@@ -145,12 +160,13 @@ namespace ILCompiler
             get;
         }
 
-        private DelegateCreationInfo(IMethodNode constructor, MethodDesc targetMethod, TargetKind targetKind, IMethodNode thunk = null)
+        private DelegateCreationInfo(IMethodNode constructor, MethodDesc targetMethod, TypeDesc constrainedType, TargetKind targetKind, IMethodNode thunk = null)
         {
             Debug.Assert(targetKind != TargetKind.VTableLookup
                 || MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(targetMethod) == targetMethod);
             Constructor = constructor;
-            TargetMethod = targetMethod;
+            _targetMethod = targetMethod;
+            _constrainedType = constrainedType;
             _targetKind = targetKind;
             Thunk = thunk;
         }
@@ -159,7 +175,7 @@ namespace ILCompiler
         /// Constructs a new instance of <see cref="DelegateCreationInfo"/> set up to construct a delegate of type
         /// '<paramref name="delegateType"/>' pointing to '<paramref name="targetMethod"/>'.
         /// </summary>
-        public static DelegateCreationInfo Create(TypeDesc delegateType, MethodDesc targetMethod, NodeFactory factory, bool followVirtualDispatch)
+        public static DelegateCreationInfo Create(TypeDesc delegateType, MethodDesc targetMethod, TypeDesc constrainedType, NodeFactory factory, bool followVirtualDispatch)
         {
             CompilerTypeSystemContext context = factory.TypeSystemContext;
             DefType systemDelegate = context.GetWellKnownType(WellKnownType.MulticastDelegate).BaseType;
@@ -206,7 +222,8 @@ namespace ILCompiler
                 return new DelegateCreationInfo(
                     factory.MethodEntrypoint(initMethod),
                     targetMethod,
-                    TargetKind.ExactCallableAddress,
+                    constrainedType,
+                    constrainedType == null ? TargetKind.ExactCallableAddress : TargetKind.ConstrainedMethod,
                     factory.MethodEntrypoint(invokeThunk));
             }
             else
@@ -260,9 +277,11 @@ namespace ILCompiler
                     }
                 }
 
+                Debug.Assert(constrainedType == null);
                 return new DelegateCreationInfo(
                     factory.MethodEntrypoint(systemDelegate.GetKnownMethod(initializeMethodName, null)),
                     targetMethod,
+                    constrainedType,
                     kind);
             }
         }
@@ -274,7 +293,12 @@ namespace ILCompiler
                 sb.Append("FromVtbl_");
             Constructor.AppendMangledName(nameMangler, sb);
             sb.Append("__");
-            sb.Append(nameMangler.GetMangledMethodName(TargetMethod));
+            sb.Append(nameMangler.GetMangledMethodName(_targetMethod));
+            if (_constrainedType != null)
+            {
+                sb.Append("__");
+                nameMangler.GetMangledTypeName(_constrainedType);
+            }
             if (Thunk != null)
             {
                 sb.Append("__");
@@ -287,14 +311,15 @@ namespace ILCompiler
             var other = obj as DelegateCreationInfo;
             return other != null
                 && Constructor == other.Constructor
-                && TargetMethod == other.TargetMethod
+                && _targetMethod == other._targetMethod
+                && _constrainedType == other._constrainedType
                 && _targetKind == other._targetKind
                 && Thunk == other.Thunk;
         }
 
         public override int GetHashCode()
         {
-            return Constructor.GetHashCode() ^ TargetMethod.GetHashCode();
+            return Constructor.GetHashCode() ^ _targetMethod.GetHashCode();
         }
 
 #if !SUPPORT_JIT
@@ -311,6 +336,20 @@ namespace ILCompiler
             compare = comparer.Compare(Constructor.Method, other.Constructor.Method);
             if (compare != 0)
                 return compare;
+
+            if (_constrainedType != null && other._constrainedType != null)
+            {
+                compare = comparer.Compare(_constrainedType, other._constrainedType);
+                if (compare != 0)
+                    return compare;
+            }
+            else
+            {
+                if (_constrainedType != null)
+                    return 1;
+                if (other._constrainedType != null)
+                    return -1;
+            }
 
             if (Thunk == other.Thunk)
                 return 0;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -1388,6 +1388,10 @@ namespace ILCompiler
                         }
                         break;
 
+                    case ILOpcode.constrained:
+                        // Fallthrough. If this is ever implemented, make sure delegates to static virtual methods
+                        // are also handled. We currently assume the frozen delegate will not be to a static
+                        // virtual interface method.
                     default:
                         return Status.Fail(methodIL.OwningMethod, opcode);
                 }
@@ -1991,7 +1995,12 @@ namespace ILCompiler
             {
                 Debug.Assert(_methodPointed.Signature.IsStatic == (_firstParameter == null));
 
-                var creationInfo = DelegateCreationInfo.Create(Type.ConvertToCanonForm(CanonicalFormKind.Specific), _methodPointed, factory, followVirtualDispatch: false);
+                var creationInfo = DelegateCreationInfo.Create(
+                    Type.ConvertToCanonForm(CanonicalFormKind.Specific),
+                    _methodPointed,
+                    constrainedType: null,
+                    factory,
+                    followVirtualDispatch: false);
 
                 Debug.Assert(!creationInfo.TargetNeedsVTableLookup);
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -590,7 +590,7 @@ namespace Internal.JitInterface
             return true;
         }
 
-        private void getReadyToRunDelegateCtorHelper(ref CORINFO_RESOLVED_TOKEN pTargetMethod, CORINFO_CLASS_STRUCT_* delegateType, ref CORINFO_LOOKUP pLookup)
+        private void getReadyToRunDelegateCtorHelper(ref CORINFO_RESOLVED_TOKEN pTargetMethod, mdToken targetConstraint, CORINFO_CLASS_STRUCT_* delegateType, ref CORINFO_LOOKUP pLookup)
         {
 #if DEBUG
             // In debug, write some bogus data to the struct to ensure we have filled everything

--- a/src/coreclr/tools/aot/jitinterface/jitinterface.h
+++ b/src/coreclr/tools/aot/jitinterface/jitinterface.h
@@ -77,7 +77,7 @@ struct JitInterfaceCallbacks
     CorInfoHelpFunc (* getBoxHelper)(void * thisHandle, CorInfoExceptionClass** ppException, CORINFO_CLASS_HANDLE cls);
     CorInfoHelpFunc (* getUnBoxHelper)(void * thisHandle, CorInfoExceptionClass** ppException, CORINFO_CLASS_HANDLE cls);
     bool (* getReadyToRunHelper)(void * thisHandle, CorInfoExceptionClass** ppException, CORINFO_RESOLVED_TOKEN* pResolvedToken, CORINFO_LOOKUP_KIND* pGenericLookupKind, CorInfoHelpFunc id, CORINFO_CONST_LOOKUP* pLookup);
-    void (* getReadyToRunDelegateCtorHelper)(void * thisHandle, CorInfoExceptionClass** ppException, CORINFO_RESOLVED_TOKEN* pTargetMethod, CORINFO_CLASS_HANDLE delegateType, CORINFO_LOOKUP* pLookup);
+    void (* getReadyToRunDelegateCtorHelper)(void * thisHandle, CorInfoExceptionClass** ppException, CORINFO_RESOLVED_TOKEN* pTargetMethod, unsigned int targetConstraint, CORINFO_CLASS_HANDLE delegateType, CORINFO_LOOKUP* pLookup);
     const char* (* getHelperName)(void * thisHandle, CorInfoExceptionClass** ppException, CorInfoHelpFunc helpFunc);
     CorInfoInitClassResult (* initClass)(void * thisHandle, CorInfoExceptionClass** ppException, CORINFO_FIELD_HANDLE field, CORINFO_METHOD_HANDLE method, CORINFO_CONTEXT_HANDLE context);
     void (* classMustBeLoadedBeforeCodeIsRun)(void * thisHandle, CorInfoExceptionClass** ppException, CORINFO_CLASS_HANDLE cls);
@@ -843,11 +843,12 @@ public:
 
     virtual void getReadyToRunDelegateCtorHelper(
           CORINFO_RESOLVED_TOKEN* pTargetMethod,
+          unsigned int targetConstraint,
           CORINFO_CLASS_HANDLE delegateType,
           CORINFO_LOOKUP* pLookup)
 {
     CorInfoExceptionClass* pException = nullptr;
-    _callbacks->getReadyToRunDelegateCtorHelper(_thisHandle, &pException, pTargetMethod, delegateType, pLookup);
+    _callbacks->getReadyToRunDelegateCtorHelper(_thisHandle, &pException, pTargetMethod, targetConstraint, delegateType, pLookup);
     if (pException != nullptr) throw pException;
 }
 

--- a/src/coreclr/tools/superpmi/superpmi-shared/agnostic.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/agnostic.h
@@ -637,6 +637,7 @@ struct GetReadyToRunHelper_TOKENout
 struct GetReadyToRunDelegateCtorHelper_TOKENIn
 {
     Agnostic_CORINFO_RESOLVED_TOKEN TargetMethod;
+    mdToken                         targetConstraint;
     DWORDLONG                       delegateType;
 };
 

--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
@@ -2233,6 +2233,7 @@ bool MethodContext::repGetReadyToRunHelper(CORINFO_RESOLVED_TOKEN* pResolvedToke
 }
 
 void MethodContext::recGetReadyToRunDelegateCtorHelper(CORINFO_RESOLVED_TOKEN* pTargetMethod,
+                                                       mdToken                 targetConstraint,
                                                        CORINFO_CLASS_HANDLE    delegateType,
                                                        CORINFO_LOOKUP*         pLookup)
 {
@@ -2244,6 +2245,7 @@ void MethodContext::recGetReadyToRunDelegateCtorHelper(CORINFO_RESOLVED_TOKEN* p
     ZeroMemory(&key, sizeof(key)); // Zero key including any struct padding
     key.TargetMethod =
         SpmiRecordsHelper::StoreAgnostic_CORINFO_RESOLVED_TOKEN(pTargetMethod, GetReadyToRunDelegateCtorHelper);
+    key.targetConstraint          = targetConstraint;
     key.delegateType              = CastHandle(delegateType);
     Agnostic_CORINFO_LOOKUP value = SpmiRecordsHelper::StoreAgnostic_CORINFO_LOOKUP(pLookup);
     GetReadyToRunDelegateCtorHelper->Add(key, value);
@@ -2253,12 +2255,13 @@ void MethodContext::recGetReadyToRunDelegateCtorHelper(CORINFO_RESOLVED_TOKEN* p
 void MethodContext::dmpGetReadyToRunDelegateCtorHelper(GetReadyToRunDelegateCtorHelper_TOKENIn key,
                                                        Agnostic_CORINFO_LOOKUP                 value)
 {
-    printf("GetReadyToRunDelegateCtorHelper key: method tk{%s} type-%016llX",
-           SpmiDumpHelper::DumpAgnostic_CORINFO_RESOLVED_TOKEN(key.TargetMethod).c_str(), key.delegateType);
+    printf("GetReadyToRunDelegateCtorHelper key: method tk{%s} type-%016llX constraint-%08X",
+           SpmiDumpHelper::DumpAgnostic_CORINFO_RESOLVED_TOKEN(key.TargetMethod).c_str(), key.delegateType, key.targetConstraint);
     printf(", value: %s", SpmiDumpHelper::DumpAgnostic_CORINFO_LOOKUP(value).c_str());
 }
 
 void MethodContext::repGetReadyToRunDelegateCtorHelper(CORINFO_RESOLVED_TOKEN* pTargetMethod,
+                                                       mdToken                 targetConstraint,
                                                        CORINFO_CLASS_HANDLE    delegateType,
                                                        CORINFO_LOOKUP*         pLookup)
 {
@@ -2268,7 +2271,8 @@ void MethodContext::repGetReadyToRunDelegateCtorHelper(CORINFO_RESOLVED_TOKEN* p
     ZeroMemory(&key, sizeof(key)); // Zero key including any struct padding
     key.TargetMethod =
         SpmiRecordsHelper::RestoreAgnostic_CORINFO_RESOLVED_TOKEN(pTargetMethod, GetReadyToRunDelegateCtorHelper);
-    key.delegateType = CastHandle(delegateType);
+    key.targetConstraint = targetConstraint;
+    key.delegateType     = CastHandle(delegateType);
 
     AssertKeyExistsNoMessage(GetReadyToRunDelegateCtorHelper, key);
 

--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.h
@@ -315,11 +315,13 @@ public:
                                 CORINFO_CONST_LOOKUP*   pLookup);
 
     void recGetReadyToRunDelegateCtorHelper(CORINFO_RESOLVED_TOKEN* pTargetMethod,
+                                            mdToken                 targetConstraint,
                                             CORINFO_CLASS_HANDLE    delegateType,
                                             CORINFO_LOOKUP*         pLookup);
     void dmpGetReadyToRunDelegateCtorHelper(GetReadyToRunDelegateCtorHelper_TOKENIn key,
                                             Agnostic_CORINFO_LOOKUP                 pLookup);
     void repGetReadyToRunDelegateCtorHelper(CORINFO_RESOLVED_TOKEN* pTargetMethod,
+                                            mdToken                 targetConstraint,
                                             CORINFO_CLASS_HANDLE    delegateType,
                                             CORINFO_LOOKUP*         pLookup);
 

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/icorjitinfo.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/icorjitinfo.cpp
@@ -760,12 +760,13 @@ bool interceptor_ICJI::getReadyToRunHelper(CORINFO_RESOLVED_TOKEN* pResolvedToke
 }
 
 void interceptor_ICJI::getReadyToRunDelegateCtorHelper(CORINFO_RESOLVED_TOKEN* pTargetMethod,
+                                                       mdToken                 targetConstraint,
                                                        CORINFO_CLASS_HANDLE    delegateType,
                                                        CORINFO_LOOKUP*         pLookup)
 {
     mc->cr->AddCall("getReadyToRunDelegateCtorHelper");
-    original_ICorJitInfo->getReadyToRunDelegateCtorHelper(pTargetMethod, delegateType, pLookup);
-    mc->recGetReadyToRunDelegateCtorHelper(pTargetMethod, delegateType, pLookup);
+    original_ICorJitInfo->getReadyToRunDelegateCtorHelper(pTargetMethod, targetConstraint, delegateType, pLookup);
+    mc->recGetReadyToRunDelegateCtorHelper(pTargetMethod, targetConstraint, delegateType, pLookup);
 }
 
 const char* interceptor_ICJI::getHelperName(CorInfoHelpFunc funcNum)

--- a/src/coreclr/tools/superpmi/superpmi-shim-counter/icorjitinfo.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-counter/icorjitinfo.cpp
@@ -538,11 +538,12 @@ bool interceptor_ICJI::getReadyToRunHelper(
 
 void interceptor_ICJI::getReadyToRunDelegateCtorHelper(
           CORINFO_RESOLVED_TOKEN* pTargetMethod,
+          mdToken targetConstraint,
           CORINFO_CLASS_HANDLE delegateType,
           CORINFO_LOOKUP* pLookup)
 {
     mcs->AddCall("getReadyToRunDelegateCtorHelper");
-    original_ICorJitInfo->getReadyToRunDelegateCtorHelper(pTargetMethod, delegateType, pLookup);
+    original_ICorJitInfo->getReadyToRunDelegateCtorHelper(pTargetMethod, targetConstraint, delegateType, pLookup);
 }
 
 const char* interceptor_ICJI::getHelperName(

--- a/src/coreclr/tools/superpmi/superpmi-shim-simple/icorjitinfo.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-simple/icorjitinfo.cpp
@@ -472,10 +472,11 @@ bool interceptor_ICJI::getReadyToRunHelper(
 
 void interceptor_ICJI::getReadyToRunDelegateCtorHelper(
           CORINFO_RESOLVED_TOKEN* pTargetMethod,
+          mdToken targetConstraint,
           CORINFO_CLASS_HANDLE delegateType,
           CORINFO_LOOKUP* pLookup)
 {
-    original_ICorJitInfo->getReadyToRunDelegateCtorHelper(pTargetMethod, delegateType, pLookup);
+    original_ICorJitInfo->getReadyToRunDelegateCtorHelper(pTargetMethod, targetConstraint, delegateType, pLookup);
 }
 
 const char* interceptor_ICJI::getHelperName(

--- a/src/coreclr/tools/superpmi/superpmi/icorjitinfo.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/icorjitinfo.cpp
@@ -657,11 +657,12 @@ bool MyICJI::getReadyToRunHelper(CORINFO_RESOLVED_TOKEN* pResolvedToken,
 }
 
 void MyICJI::getReadyToRunDelegateCtorHelper(CORINFO_RESOLVED_TOKEN* pTargetMethod,
+                                             mdToken                 targetConstraint,
                                              CORINFO_CLASS_HANDLE    delegateType,
                                              CORINFO_LOOKUP*         pLookup)
 {
     jitInstance->mc->cr->AddCall("getReadyToRunDelegateCtorHelper");
-    jitInstance->mc->repGetReadyToRunDelegateCtorHelper(pTargetMethod, delegateType, pLookup);
+    jitInstance->mc->repGetReadyToRunDelegateCtorHelper(pTargetMethod, targetConstraint, delegateType, pLookup);
 }
 
 const char* MyICJI::getHelperName(CorInfoHelpFunc funcNum)

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -5983,6 +5983,7 @@ bool CEEInfo::getReadyToRunHelper(
 /***********************************************************************/
 void CEEInfo::getReadyToRunDelegateCtorHelper(
         CORINFO_RESOLVED_TOKEN * pTargetMethod,
+        mdToken                  targetConstraint,
         CORINFO_CLASS_HANDLE     delegateType,
         CORINFO_LOOKUP *   pLookup
         )

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
@@ -930,6 +930,16 @@ public class Interfaces
             {
                 throw new Exception($"{actual} != {expected}");
             }
+
+            // Uncomment after we pick up fix for https://github.com/dotnet/roslyn/issues/60069
+#if false
+            Func<string> del = T.GetCookie;
+            actual = del();
+            if (actual != expected)
+            {
+                throw new Exception($"{actual} != {expected}");
+            }
+#endif
         }
 
         static void TestSimpleInterfaceWithGenericMethod<T, U>(string expected) where T : ISimple
@@ -939,11 +949,25 @@ public class Interfaces
             {
                 throw new Exception($"{actual} != {expected}");
             }
+
+            Func<string> del = T.GetCookieGeneric<U>;
+            actual = del();
+            if (actual != expected)
+            {
+                throw new Exception($"{actual} != {expected}");
+            }
         }
 
         static void TestVariantInterface<T, U>(string expected) where T : IVariant<U>
         {
             string actual = T.WhichMethod(default);
+            if (actual != expected)
+            {
+                throw new Exception($"{actual} != {expected}");
+            }
+
+            Func<U, string> del = T.WhichMethod;
+            actual = del(default);
             if (actual != expected)
             {
                 throw new Exception($"{actual} != {expected}");


### PR DESCRIPTION
Requires a JitInterface change because we need to be able to pass information about constraints to `getReadyToRunDelegateCtorHelper`