### PR TITLE
Fix up DiagnosticName of RuntimeDetermined types

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.Diagnostic.cs
+++ b/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.Diagnostic.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 namespace Internal.TypeSystem
 {
     partial class RuntimeDeterminedType
@@ -17,7 +19,7 @@ namespace Internal.TypeSystem
         {
             get
             {
-                return _rawCanonType.DiagnosticNamespace;
+                return String.Concat(_runtimeDeterminedDetailsType.DiagnosticName, "_", _rawCanonType.DiagnosticNamespace); ;
             }
         }
     }


### PR DESCRIPTION
Name/Namespace of these already includes the details type name. Bring this over to DiagnosticName too.

This is so that we can distinguish between `List<__Canon>` and List<T___Canon>`.