### PR TITLE
Add validation target to avoid losing test coverage with merged test wrappers

### DIFF
--- a/src/tests/Common/mergedrunner.targets
+++ b/src/tests/Common/mergedrunner.targets
@@ -9,7 +9,7 @@
       Produce an error if any project references were removed due to conflict resolution.
       If a ProjectReference is removed due to conflict resolution, then we're likely losing test coverage as it's probably a test that has the same assembly name and version as another test.
     -->
-    <Error Text="@(_ProjectReferencesRemovedDueToConflictResolution->'This project has an assembly name identital to another project: %(FullPath)', '&#010;')" Condition="'@(_ProjectReferencesRemovedDueToConflictResolution)' != ''"  />
+    <Error Text="@(_ProjectReferencesRemovedDueToConflictResolution->'This project has an assembly name identical to another project: %(FullPath)', '&#010;')" Condition="'@(_ProjectReferencesRemovedDueToConflictResolution)' != ''"  />
   </Target>
   
   <Import Project="$(RepoRoot)/src/tests/Common/mergedrunnermobile.targets" Condition="'$(TargetsMobile)' == 'true'" />

--- a/src/tests/Common/mergedrunner.targets
+++ b/src/tests/Common/mergedrunner.targets
@@ -1,0 +1,15 @@
+<Project>
+  <Target Name="_ValidateNoTestProjectsDroppedByConflictResolution" AfterTargets="ResolveReferences">
+    <ItemGroup>
+      <_ProjectReferencesUsedByReferencePaths Include="@(ReferencePath->Metadata('ProjectReferenceOriginalItemSpec'))" />
+      <_ProjectReferencesRemovedDueToConflictResolution Include="@(ProjectReference)" Exclude="@(_ProjectReferencesUsedByReferencePaths)" />
+    </ItemGroup>
+    <!--
+      Produce an error if any project references were removed due to conflict resolution.
+      If a ProjectReference is removed due to conflict resolution, then we're likely losing test coverage as it's probably a test that has the same assembly name and version as another test.
+    -->
+    <Error Text="@(_ProjectReferencesRemovedDueToConflictResolution->'This project has an assembly name identital to another project: %(FullPath)')" Condition="'@(_ProjectReferencesRemovedDueToConflictResolution)' != ''"  />
+  </Target>
+  
+  <Import Project="$(RepoRoot)/src/tests/Common/mergedrunnermobile.targets" Condition="'$(TargetsMobile)' == 'true'" />
+</Project>

--- a/src/tests/Common/mergedrunner.targets
+++ b/src/tests/Common/mergedrunner.targets
@@ -2,13 +2,14 @@
   <Target Name="_ValidateNoTestProjectsDroppedByConflictResolution" AfterTargets="ResolveReferences">
     <ItemGroup>
       <_ProjectReferencesUsedByReferencePaths Include="@(ReferencePath->Metadata('ProjectReferenceOriginalItemSpec'))" />
-      <_ProjectReferencesRemovedDueToConflictResolution Include="@(ProjectReference)" Exclude="@(_ProjectReferencesUsedByReferencePaths)" />
+      <_ProjectAssemblyReferences Include="@(ProjectReference)" Condition="'%(ProjectReference.OutputItemType)' == ''" />
+      <_ProjectReferencesRemovedDueToConflictResolution Include="@(_ProjectAssemblyReferences)" Exclude="@(_ProjectReferencesUsedByReferencePaths)" />
     </ItemGroup>
     <!--
       Produce an error if any project references were removed due to conflict resolution.
       If a ProjectReference is removed due to conflict resolution, then we're likely losing test coverage as it's probably a test that has the same assembly name and version as another test.
     -->
-    <Error Text="@(_ProjectReferencesRemovedDueToConflictResolution->'This project has an assembly name identital to another project: %(FullPath)')" Condition="'@(_ProjectReferencesRemovedDueToConflictResolution)' != ''"  />
+    <Error Text="@(_ProjectReferencesRemovedDueToConflictResolution->'This project has an assembly name identital to another project: %(FullPath)', '&#010;')" Condition="'@(_ProjectReferencesRemovedDueToConflictResolution)' != ''"  />
   </Target>
   
   <Import Project="$(RepoRoot)/src/tests/Common/mergedrunnermobile.targets" Condition="'$(TargetsMobile)' == 'true'" />

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -462,7 +462,7 @@
   <Import Project="$(RepoRoot)/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.props" />
   <Import Project="$(RepoRoot)eng/liveBuilds.targets" />
   <Import Project="$(MSBuildProjectFullPath).targets" Condition="Exists('$(MSBuildProjectFullPath).targets')"/>
-  <Import Project="$(RepoRoot)/src/tests/Common/mergedrunnermobile.targets" Condition="'$(IsMergedTestRunnerAssembly)' == 'true' and '$(TargetsMobile)' == 'true'" />
+  <Import Project="$(RepoRoot)/src/tests/Common/mergedrunner.targets" Condition="'$(IsMergedTestRunnerAssembly)' == 'true'" />
 
   <Target Name="GetBinPlaceTargetFramework" />
 


### PR DESCRIPTION
Add a simple validation target to identify when a project has the same assembly name as another project and produce a build-time error.

Contributes to concerns mentioned in #64841