### PR TITLE
Improve nullable annotations for `ILogger.BeginScope`

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.cs
@@ -100,13 +100,13 @@ namespace Microsoft.Extensions.Logging
     {
         public static System.Action<Microsoft.Extensions.Logging.ILogger, System.Exception?> Define(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, string formatString) { throw null; }
         public static System.Action<Microsoft.Extensions.Logging.ILogger, System.Exception?> Define(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, string formatString, Microsoft.Extensions.Logging.LogDefineOptions? options) { throw null; }
-        public static System.Func<Microsoft.Extensions.Logging.ILogger, System.IDisposable> DefineScope(string formatString) { throw null; }
-        public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, System.IDisposable> DefineScope<T1>(string formatString) { throw null; }
-        public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, System.IDisposable> DefineScope<T1, T2>(string formatString) { throw null; }
-        public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, System.IDisposable> DefineScope<T1, T2, T3>(string formatString) { throw null; }
-        public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, System.IDisposable> DefineScope<T1, T2, T3, T4>(string formatString) { throw null; }
-        public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, T5, System.IDisposable> DefineScope<T1, T2, T3, T4, T5>(string formatString) { throw null; }
-        public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, T5, T6, System.IDisposable> DefineScope<T1, T2, T3, T4, T5, T6>(string formatString) { throw null; }
+        public static System.Func<Microsoft.Extensions.Logging.ILogger, System.IDisposable?> DefineScope(string formatString) { throw null; }
+        public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, System.IDisposable?> DefineScope<T1>(string formatString) { throw null; }
+        public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, System.IDisposable?> DefineScope<T1, T2>(string formatString) { throw null; }
+        public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, System.IDisposable?> DefineScope<T1, T2, T3>(string formatString) { throw null; }
+        public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, System.IDisposable?> DefineScope<T1, T2, T3, T4>(string formatString) { throw null; }
+        public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, T5, System.IDisposable?> DefineScope<T1, T2, T3, T4, T5>(string formatString) { throw null; }
+        public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, T5, T6, System.IDisposable?> DefineScope<T1, T2, T3, T4, T5, T6>(string formatString) { throw null; }
         public static System.Action<Microsoft.Extensions.Logging.ILogger, T1, System.Exception?> Define<T1>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, string formatString) { throw null; }
         public static System.Action<Microsoft.Extensions.Logging.ILogger, T1, System.Exception?> Define<T1>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, string formatString, Microsoft.Extensions.Logging.LogDefineOptions? options) { throw null; }
         public static System.Action<Microsoft.Extensions.Logging.ILogger, T1, T2, System.Exception?> Define<T1, T2>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, string formatString) { throw null; }
@@ -168,7 +168,7 @@ namespace Microsoft.Extensions.Logging.Abstractions
     {
         internal NullLogger() { }
         public static Microsoft.Extensions.Logging.Abstractions.NullLogger Instance { get { throw null; } }
-        public System.IDisposable? BeginScope<TState>(TState state) where TState : notnull { throw null; }
+        public System.IDisposable BeginScope<TState>(TState state) where TState : notnull { throw null; }
         public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) { throw null; }
         public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter) { }
     }
@@ -191,7 +191,7 @@ namespace Microsoft.Extensions.Logging.Abstractions
     {
         public static readonly Microsoft.Extensions.Logging.Abstractions.NullLogger<T> Instance;
         public NullLogger() { }
-        public System.IDisposable? BeginScope<TState>(TState state) where TState : notnull { throw null; }
+        public System.IDisposable BeginScope<TState>(TState state) where TState : notnull { throw null; }
         public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) { throw null; }
         public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter) { }
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Extensions.Logging
     }
     public partial interface ILogger
     {
-        System.IDisposable BeginScope<TState>(TState state);
+        System.IDisposable? BeginScope<TState>(TState state) where TState : notnull;
         bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel);
         void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter);
     }
@@ -55,7 +55,7 @@ namespace Microsoft.Extensions.Logging
     }
     public static partial class LoggerExtensions
     {
-        public static System.IDisposable BeginScope(this Microsoft.Extensions.Logging.ILogger logger, string messageFormat, params object?[] args) { throw null; }
+        public static System.IDisposable? BeginScope(this Microsoft.Extensions.Logging.ILogger logger, string messageFormat, params object?[] args) { throw null; }
         public static void Log(this Microsoft.Extensions.Logging.ILogger logger, Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, System.Exception? exception, string? message, params object?[] args) { }
         public static void Log(this Microsoft.Extensions.Logging.ILogger logger, Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, string? message, params object?[] args) { }
         public static void Log(this Microsoft.Extensions.Logging.ILogger logger, Microsoft.Extensions.Logging.LogLevel logLevel, System.Exception? exception, string? message, params object?[] args) { }
@@ -134,7 +134,7 @@ namespace Microsoft.Extensions.Logging
     public partial class Logger<T> : Microsoft.Extensions.Logging.ILogger, Microsoft.Extensions.Logging.ILogger<T>
     {
         public Logger(Microsoft.Extensions.Logging.ILoggerFactory factory) { }
-        System.IDisposable Microsoft.Extensions.Logging.ILogger.BeginScope<TState>(TState state) { throw null; }
+        System.IDisposable? Microsoft.Extensions.Logging.ILogger.BeginScope<TState>(TState state) { throw null; }
         bool Microsoft.Extensions.Logging.ILogger.IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) { throw null; }
         void Microsoft.Extensions.Logging.ILogger.Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter) { }
     }
@@ -168,7 +168,7 @@ namespace Microsoft.Extensions.Logging.Abstractions
     {
         internal NullLogger() { }
         public static Microsoft.Extensions.Logging.Abstractions.NullLogger Instance { get { throw null; } }
-        public System.IDisposable BeginScope<TState>(TState state) { throw null; }
+        public System.IDisposable? BeginScope<TState>(TState state) where TState : notnull { throw null; }
         public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) { throw null; }
         public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter) { }
     }
@@ -191,7 +191,7 @@ namespace Microsoft.Extensions.Logging.Abstractions
     {
         public static readonly Microsoft.Extensions.Logging.Abstractions.NullLogger<T> Instance;
         public NullLogger() { }
-        public System.IDisposable BeginScope<TState>(TState state) { throw null; }
+        public System.IDisposable? BeginScope<TState>(TState state) where TState : notnull { throw null; }
         public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) { throw null; }
         public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter) { }
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/ILogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/ILogger.cs
@@ -35,6 +35,6 @@ namespace Microsoft.Extensions.Logging
         /// <param name="state">The identifier for the scope.</param>
         /// <typeparam name="TState">The type of the state to begin scope for.</typeparam>
         /// <returns>An <see cref="IDisposable"/> that ends the logical operation scope on dispose.</returns>
-        IDisposable BeginScope<TState>(TState state);
+        IDisposable? BeginScope<TState>(TState state) where TState : notnull;
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerExtensions.cs
@@ -402,7 +402,7 @@ namespace Microsoft.Extensions.Logging
         /// {
         /// }
         /// </example>
-        public static IDisposable BeginScope(
+        public static IDisposable? BeginScope(
             this ILogger logger!!,
             string messageFormat,
             params object?[] args)

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessage.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessage.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="formatString">The named format string</param>
         /// <returns>A delegate which when invoked creates a log scope.</returns>
-        public static Func<ILogger, IDisposable> DefineScope(string formatString)
+        public static Func<ILogger, IDisposable?> DefineScope(string formatString)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 0);
 
@@ -33,7 +33,7 @@ namespace Microsoft.Extensions.Logging
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
         /// <param name="formatString">The named format string</param>
         /// <returns>A delegate which when invoked creates a log scope.</returns>
-        public static Func<ILogger, T1, IDisposable> DefineScope<T1>(string formatString)
+        public static Func<ILogger, T1, IDisposable?> DefineScope<T1>(string formatString)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 1);
 
@@ -47,7 +47,7 @@ namespace Microsoft.Extensions.Logging
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
         /// <param name="formatString">The named format string</param>
         /// <returns>A delegate which when invoked creates a log scope.</returns>
-        public static Func<ILogger, T1, T2, IDisposable> DefineScope<T1, T2>(string formatString)
+        public static Func<ILogger, T1, T2, IDisposable?> DefineScope<T1, T2>(string formatString)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 2);
 
@@ -62,7 +62,7 @@ namespace Microsoft.Extensions.Logging
         /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
         /// <param name="formatString">The named format string</param>
         /// <returns>A delegate which when invoked creates a log scope.</returns>
-        public static Func<ILogger, T1, T2, T3, IDisposable> DefineScope<T1, T2, T3>(string formatString)
+        public static Func<ILogger, T1, T2, T3, IDisposable?> DefineScope<T1, T2, T3>(string formatString)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 3);
 
@@ -78,7 +78,7 @@ namespace Microsoft.Extensions.Logging
         /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
         /// <param name="formatString">The named format string</param>
         /// <returns>A delegate which when invoked creates a log scope.</returns>
-        public static Func<ILogger, T1, T2, T3, T4, IDisposable> DefineScope<T1, T2, T3, T4>(string formatString)
+        public static Func<ILogger, T1, T2, T3, T4, IDisposable?> DefineScope<T1, T2, T3, T4>(string formatString)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 4);
 
@@ -95,7 +95,7 @@ namespace Microsoft.Extensions.Logging
         /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
         /// <param name="formatString">The named format string</param>
         /// <returns>A delegate which when invoked creates a log scope.</returns>
-        public static Func<ILogger, T1, T2, T3, T4, T5, IDisposable> DefineScope<T1, T2, T3, T4, T5>(string formatString)
+        public static Func<ILogger, T1, T2, T3, T4, T5, IDisposable?> DefineScope<T1, T2, T3, T4, T5>(string formatString)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 5);
 
@@ -113,7 +113,7 @@ namespace Microsoft.Extensions.Logging
         /// <typeparam name="T6">The type of the sixth parameter passed to the named format string.</typeparam>
         /// <param name="formatString">The named format string</param>
         /// <returns>A delegate which when invoked creates a log scope.</returns>
-        public static Func<ILogger, T1, T2, T3, T4, T5, T6, IDisposable> DefineScope<T1, T2, T3, T4, T5, T6>(string formatString)
+        public static Func<ILogger, T1, T2, T3, T4, T5, T6, IDisposable?> DefineScope<T1, T2, T3, T4, T5, T6>(string formatString)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 6);
 

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerT.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerT.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <inheritdoc />
-        IDisposable ILogger.BeginScope<TState>(TState state)
+        IDisposable? ILogger.BeginScope<TState>(TState state)
         {
             return _logger.BeginScope(state);
         }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/NullLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/NullLogger.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.Logging.Abstractions
         }
 
         /// <inheritdoc />
-        public IDisposable BeginScope<TState>(TState state)
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
         {
             return NullScope.Instance;
         }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/NullLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/NullLogger.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.Logging.Abstractions
         }
 
         /// <inheritdoc />
-        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull
         {
             return NullScope.Instance;
         }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/NullLoggerT.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/NullLoggerT.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.Logging.Abstractions
         public static readonly NullLogger<T> Instance = new NullLogger<T>();
 
         /// <inheritdoc />
-        public IDisposable BeginScope<TState>(TState state)
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull
         {
             return NullScope.Instance;
         }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/MockLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/MockLogger.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.Logging.Generators.Tests
             Reset();
         }
 
-        public IDisposable BeginScope<TState>(TState state)
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull
         {
             return new Disposable();
         }

--- a/src/libraries/Microsoft.Extensions.Logging/src/Logger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/Logger.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Extensions.Logging
             }
         }
 
-        public IDisposable BeginScope<TState>(TState state)
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
         {
             ScopeLogger[]? loggers = ScopeLoggers;
 

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerInformation.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerInformation.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Extensions.Logging
 
         public IExternalScopeProvider? ExternalScopeProvider { get; }
 
-        public IDisposable CreateScope<TState>(TState state)
+        public IDisposable? CreateScope<TState>(TState state) where TState : notnull
         {
             if (ExternalScopeProvider != null)
             {


### PR DESCRIPTION
Based on this discussion: https://github.com/dotnet/runtime/pull/66892#issuecomment-1074263709