### PR TITLE
Fix some alloc-dealloc mismatches found by ASAN

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -34032,7 +34032,7 @@ void gc_heap::background_grow_c_mark_list()
         assert (new_c_mark_list);
         memcpy (new_c_mark_list, c_mark_list, c_mark_list_length*sizeof(uint8_t*));
         c_mark_list_length = c_mark_list_length*2;
-        delete c_mark_list;
+        delete[] c_mark_list;
         c_mark_list = new_c_mark_list;
     }
 }

--- a/src/coreclr/vm/virtualcallstub.cpp
+++ b/src/coreclr/vm/virtualcallstub.cpp
@@ -3346,7 +3346,7 @@ void BucketTable::Reclaim()
     while (list)
     {
         size_t next = list->contents[CALL_STUB_DEAD_LINK];
-        delete [] (size_t*)list;
+        delete list;
         list = (FastTable*) next;
     }
 }

--- a/src/coreclr/vm/virtualcallstub.cpp
+++ b/src/coreclr/vm/virtualcallstub.cpp
@@ -103,6 +103,8 @@ UINT32 STUB_COLLIDE_WRITE_PCT = 100;
 UINT32 STUB_COLLIDE_MONO_PCT  =   0;
 #endif // STUB_LOGGING
 
+FastTable::NumCallStubs_t FastTable::NumCallStubs;
+
 FastTable* BucketTable::dead = NULL;    //linked list of the abandoned buckets
 
 DispatchCache *g_resolveCache = NULL;    //cache of dispatch stubs for in line lookup by resolve stubs.

--- a/src/coreclr/vm/virtualcallstub.h
+++ b/src/coreclr/vm/virtualcallstub.h
@@ -1567,8 +1567,7 @@ private:
         while (size < numberOfEntries) {size = size<<1;}
 //        if (size == CALL_STUB_MIN_ENTRIES)
 //            size += 3;
-        size_t* bucket = new size_t[(sizeof(FastTable)/sizeof(size_t))+size+CALL_STUB_FIRST_INDEX];
-        FastTable* table = new (bucket) FastTable();
+        FastTable* table = new (NumCallStubs, size) FastTable();
         table->InitializeContents(size);
         return table;
     }
@@ -1592,6 +1591,15 @@ private:
     //we have an unused cell to use as a temp at bucket[CALL_STUB_DEAD_LINK==2],
     //and the table starts at bucket[CALL_STUB_FIRST_INDEX==3],
     size_t contents[0];
+
+    void* operator new(size_t) = delete;
+
+    static struct NumCallStubs_t {} NumCallStubs;
+
+    void* operator new(size_t baseSize, NumCallStubs_t, size_t numCallStubs)
+    {
+        return ::operator new(baseSize + (numCallStubs + CALL_STUB_FIRST_INDEX) * sizeof(size_t));
+    }
 };
 #ifdef _MSC_VER
 #pragma warning(pop)


### PR DESCRIPTION
I finally got around to doing another round of testing with ASAN and I found a few more alloc-dealloc mismatches. This PR fixes an alloc-dealloc mismatch in the GC and one with the virtual stub hash table.