### PR TITLE
Perform reachability analysis before codegen 

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4769,8 +4769,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
         // Compute reachability sets and dominators.
         //
-        auto computeReachability = [this]() { fgComputeReachability(); };
-        DoPhase(this, PHASE_COMPUTE_REACHABILITY, computeReachability);
+        DoPhase(this, PHASE_COMPUTE_REACHABILITY, &Compiler::fgComputeReachability);
 
         // Scale block weights and mark run rarely blocks.
         //
@@ -4944,17 +4943,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
             RecomputeLoopInfo();
         }
     }
-
-    ////
-    //// Compute reachability and remove unreachable blocks, if any.
-    ////
-    //auto computeReachability = [this]() {
-
-    //    EnsureBasicBlockEpoch();
-    //    fgComputeReachability(/* computeDoms */ false, /* doRenumbering */ false);
-    //};
-    //DoPhase(this, PHASE_REMOVE_DEAD_BLOCKS, computeReachability);
-
 
     // Remove dead blocks
     DoPhase(this, PHASE_REMOVE_DEAD_BLOCKS, &Compiler::fgRemoveDeadBlocks);

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4945,15 +4945,19 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         }
     }
 
-    //
-    // Compute reachability and remove unreachable blocks, if any.
-    //
-    auto computeReachability = [this]() {
+    ////
+    //// Compute reachability and remove unreachable blocks, if any.
+    ////
+    //auto computeReachability = [this]() {
 
-        EnsureBasicBlockEpoch();
-        fgComputeReachability(/* computeDoms */ false, /* doRenumbering */ false);
-    };
-    DoPhase(this, PHASE_COMPUTE_REACHABILITY, computeReachability);
+    //    EnsureBasicBlockEpoch();
+    //    fgComputeReachability(/* computeDoms */ false, /* doRenumbering */ false);
+    //};
+    //DoPhase(this, PHASE_REMOVE_DEAD_BLOCKS, computeReachability);
+
+
+    // Remove dead blocks
+    DoPhase(this, PHASE_REMOVE_DEAD_BLOCKS, &Compiler::fgRemoveDeadBlocks);
 
     // Insert GC Polls
     DoPhase(this, PHASE_INSERT_GC_POLLS, &Compiler::fgInsertGCPolls);

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4948,7 +4948,11 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     //
     // Compute reachability and remove unreachable blocks, if any.
     //
-    auto computeReachability = [this]() { fgComputeReachability(/* computeDoms */ false, /* doRenumbering */ false); };
+    auto computeReachability = [this]() {
+
+        EnsureBasicBlockEpoch();
+        fgComputeReachability(/* computeDoms */ false, /* doRenumbering */ false);
+    };
     DoPhase(this, PHASE_COMPUTE_REACHABILITY, computeReachability);
 
     // Insert GC Polls

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4769,7 +4769,8 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
         // Compute reachability sets and dominators.
         //
-        DoPhase(this, PHASE_COMPUTE_REACHABILITY, &Compiler::fgComputeReachability);
+        auto computeReachability = [this]() { fgComputeReachability(); };
+        DoPhase(this, PHASE_COMPUTE_REACHABILITY, computeReachability);
 
         // Scale block weights and mark run rarely blocks.
         //
@@ -4943,6 +4944,12 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
             RecomputeLoopInfo();
         }
     }
+
+    //
+    // Compute reachability and remove unreachable blocks, if any.
+    //
+    auto computeReachability = [this]() { fgComputeReachability(/* computeDoms */ false, /* doRenumbering */ false); };
+    DoPhase(this, PHASE_COMPUTE_REACHABILITY, computeReachability);
 
     // Insert GC Polls
     DoPhase(this, PHASE_INSERT_GC_POLLS, &Compiler::fgInsertGCPolls);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5775,10 +5775,17 @@ protected:
     void fgComputeEnterBlocksSet(DEBUG_ARG1(bool renumberingDone = true)); // Compute the set of entry blocks,
                                                                            // 'fgEnterBlks'.
 
-    bool fgRemoveUnreachableBlocks(); // Remove blocks determined to be unreachable by the bbReach sets.
+    template <typename CanRemoveBlockBody>
+    bool fgRemoveUnreachableBlocks(CanRemoveBlockBody canRemoveBlock); // Remove blocks determined to be
+                                                                               // unreachable by
+                                                                        // the bbReach sets.
+
+    //bool fgRemoveUnreachableBlocks(bool (*_action)(BasicBlock* block)); // Remove blocks determined to be unreachable by the bbReach sets.
 
     void fgComputeReachability(bool computeDoms = true, bool doRenumber = true); // Perform flow graph node reachability
                                                                                  // analysis.
+
+    void fgRemoveDeadBlocks();
 
     BasicBlock* fgIntersectDom(BasicBlock* a, BasicBlock* b); // Intersect two immediate dominator sets.
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5196,7 +5196,6 @@ public:
     bool     fgHaveValidEdgeWeights;   // true if we were successful in computing all of the edge weights
     bool     fgSlopUsedInEdgeWeights;  // true if their was some slop used when computing the edge weights
     bool     fgRangeUsedInEdgeWeights; // true if some of the edgeWeight are expressed in Min..Max form
-    bool     fgNeedsUpdateFlowGraph;   // true if we need to run fgUpdateFlowGraph
     weight_t fgCalledCount;            // count of the number of times this method was called
                                        // This is derived from the profile data
                                        // or is BB_UNITY_WEIGHT when we don't have profile data

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5772,20 +5772,15 @@ protected:
 
     void fgComputeReturnBlocks(); // Initialize fgReturnBlocks to a list of BBJ_RETURN blocks.
 
-    void fgComputeEnterBlocksSet(DEBUG_ARG1(bool renumberingDone = true)); // Compute the set of entry blocks,
-                                                                           // 'fgEnterBlks'.
+    void fgComputeEnterBlocksSet(); // Compute the set of entry blocks, 'fgEnterBlks'.
 
+    // Remove blocks determined to be unreachable by the 'canRemoveBlock'.
     template <typename CanRemoveBlockBody>
-    bool fgRemoveUnreachableBlocks(CanRemoveBlockBody canRemoveBlock); // Remove blocks determined to be
-                                                                               // unreachable by
-                                                                        // the bbReach sets.
+    bool fgRemoveUnreachableBlocks(CanRemoveBlockBody canRemoveBlock);
 
-    //bool fgRemoveUnreachableBlocks(bool (*_action)(BasicBlock* block)); // Remove blocks determined to be unreachable by the bbReach sets.
+    void fgComputeReachability(); // Perform flow graph node reachability analysis.
 
-    void fgComputeReachability(bool computeDoms = true, bool doRenumber = true); // Perform flow graph node reachability
-                                                                                 // analysis.
-
-    void fgRemoveDeadBlocks();
+    void fgRemoveDeadBlocks(); // Identify and remove dead blocks.
 
     BasicBlock* fgIntersectDom(BasicBlock* a, BasicBlock* b); // Intersect two immediate dominator sets.
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5772,7 +5772,8 @@ protected:
 
     void fgComputeReturnBlocks(); // Initialize fgReturnBlocks to a list of BBJ_RETURN blocks.
 
-    void fgComputeEnterBlocksSet(); // Compute the set of entry blocks, 'fgEnterBlks'.
+    void fgComputeEnterBlocksSet(DEBUG_ARG1(bool renumberingDone = true)); // Compute the set of entry blocks,
+                                                                           // 'fgEnterBlks'.
 
     bool fgRemoveUnreachableBlocks(); // Remove blocks determined to be unreachable by the bbReach sets.
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5776,7 +5776,8 @@ protected:
 
     bool fgRemoveUnreachableBlocks(); // Remove blocks determined to be unreachable by the bbReach sets.
 
-    void fgComputeReachability(); // Perform flow graph node reachability analysis.
+    void fgComputeReachability(bool computeDoms = true, bool doRenumber = true); // Perform flow graph node reachability
+                                                                                 // analysis.
 
     BasicBlock* fgIntersectDom(BasicBlock* a, BasicBlock* b); // Intersect two immediate dominator sets.
 

--- a/src/coreclr/jit/compphases.h
+++ b/src/coreclr/jit/compphases.h
@@ -84,6 +84,7 @@ CompPhaseNameMacro(PHASE_OPTIMIZE_BRANCHES,      "Redundant branch opts",       
 CompPhaseNameMacro(PHASE_ASSERTION_PROP_MAIN,    "Assertion prop",                 "AST-PROP", false, -1, false)
 CompPhaseNameMacro(PHASE_OPT_UPDATE_FLOW_GRAPH,  "Update flow graph opt pass",     "UPD-FG-O", false, -1, false)
 CompPhaseNameMacro(PHASE_COMPUTE_EDGE_WEIGHTS2,  "Compute edge weights (2, false)","EDG-WGT2", false, -1, false)
+CompPhaseNameMacro(PHASE_REMOVE_DEAD_BLOCKS,     "Remove dead blocks",             "DEAD-BLK", false, -1, false)
 CompPhaseNameMacro(PHASE_INSERT_GC_POLLS,        "Insert GC Polls",                "GC-POLLS", false, -1, true)
 CompPhaseNameMacro(PHASE_DETERMINE_FIRST_COLD_BLOCK, "Determine first cold block", "COLD-BLK", false, -1, true)
 CompPhaseNameMacro(PHASE_RATIONALIZE,            "Rationalize IR",                 "RAT",      false, -1, false)

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6556,7 +6556,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 #ifdef DEBUG
         if (emitComp->opts.disAsm || emitComp->verbose)
         {
-            printf("\t\t\t\t\t\t;;  size=%d   bbWeight=%s PerfScore %.2f", ig->igSize, refCntWtd2str(ig->igWeight),
+            printf("\t\t\t\t\t\t;; size=%d bbWeight=%s PerfScore %.2f", ig->igSize, refCntWtd2str(ig->igWeight),
                    ig->igPerfScore);
         }
         *instrCount += ig->igInsCnt;

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6556,7 +6556,8 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 #ifdef DEBUG
         if (emitComp->opts.disAsm || emitComp->verbose)
         {
-            printf("\t\t\t\t\t\t;; bbWeight=%s PerfScore %.2f", refCntWtd2str(ig->igWeight), ig->igPerfScore);
+            printf("\t\t\t\t\t\t;;  size=%d   bbWeight=%s PerfScore %.2f", ig->igSize, refCntWtd2str(ig->igWeight),
+                   ig->igPerfScore);
         }
         *instrCount += ig->igInsCnt;
 #endif // DEBUG

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -31,7 +31,6 @@ void Compiler::fgInit()
     fgHaveValidEdgeWeights   = false;
     fgSlopUsedInEdgeWeights  = false;
     fgRangeUsedInEdgeWeights = true;
-    fgNeedsUpdateFlowGraph   = false;
     fgCalledCount            = BB_ZERO_WEIGHT;
 
     /* We haven't yet computed the dominator sets */

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -673,7 +673,7 @@ void Compiler::fgRemoveDeadBlocks()
             assert(block->isBBCallAlwaysPair());
 
             // Don't remove the BBJ_ALWAYS block that is only here for the unwinder.
-            worklist.insert(worklist.end(), block->bbNext);
+            worklist.push_back(block->bbNext);
         }
     }
 #endif // defined(FEATURE_EH_FUNCLETS) && defined(TARGET_ARM)

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -351,7 +351,10 @@ void Compiler::fgComputeReturnBlocks()
 // to avoid creating "retless" calls, since we need the BBJ_ALWAYS for the purpose
 // of unwinding, even if the call doesn't return (due to an explicit throw, for example).
 //
-void Compiler::fgComputeEnterBlocksSet()
+// Arguments:
+//    renumberingDone -- `true` if block renumbering was done.
+//
+void Compiler::fgComputeEnterBlocksSet(DEBUG_ARG1(const bool renumberingDone))
 {
 #ifdef DEBUG
     fgEnterBlksSetValid = false;
@@ -365,7 +368,7 @@ void Compiler::fgComputeEnterBlocksSet()
 
     /* Now set the entry basic block */
     BlockSetOps::AddElemD(this, fgEnterBlks, fgFirstBB->bbNum);
-    assert(fgFirstBB->bbNum == 1);
+    assert(fgFirstBB->bbNum == 1 || !renumberingDone);
 
     if (compHndBBtabCount > 0)
     {
@@ -596,7 +599,7 @@ void Compiler::fgComputeReachability(const bool computeDoms, const bool doRenumb
         // Compute fgEnterBlks
         //
 
-        fgComputeEnterBlocksSet();
+        fgComputeEnterBlocksSet(DEBUG_ARG1(doRenumber));
 
         //
         // Compute bbReach

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -543,10 +543,14 @@ bool Compiler::fgRemoveUnreachableBlocks()
 // Also, compute the list of return blocks `fgReturnBlocks` and set of enter blocks `fgEnterBlks`.
 // Delete unreachable blocks.
 //
+//  Arguments:
+//       computeDoms - Whether to compute doms or not.
+//       doRenumber  - Should it do block renumbering or not.
+//
 // Assumptions:
 //    Assumes the predecessor lists are computed and correct.
 //
-void Compiler::fgComputeReachability()
+void Compiler::fgComputeReachability(const bool computeDoms, const bool doRenumber)
 {
 #ifdef DEBUG
     if (verbose)
@@ -580,10 +584,13 @@ void Compiler::fgComputeReachability()
             noway_assert(!"Too many unreachable block removal loops");
         }
 
-        // Walk the flow graph, reassign block numbers to keep them in ascending order.
-        JITDUMP("\nRenumbering the basic blocks for fgComputeReachability pass #%u\n", passNum);
+        if (doRenumber)
+        {
+            // Walk the flow graph, reassign block numbers to keep them in ascending order.
+            JITDUMP("\nRenumbering the basic blocks for fgComputeReachability pass #%u\n", passNum);
+            fgRenumberBlocks();
+        }
         passNum++;
-        fgRenumberBlocks();
 
         //
         // Compute fgEnterBlks
@@ -614,14 +621,17 @@ void Compiler::fgComputeReachability()
     }
 
     fgVerifyHandlerTab();
-    fgDebugCheckBBlist(true);
+    fgDebugCheckBBlist(doRenumber);
 #endif // DEBUG
 
-    //
-    // Now, compute the dominators
-    //
+    if (computeDoms)
+    {
+        //
+        // Now, compute the dominators
+        //
 
-    fgComputeDoms();
+        fgComputeDoms();
+    }
 }
 
 //-------------------------------------------------------------

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -1044,6 +1044,33 @@ int LinearScan::compareBlocksForSequencing(BasicBlock* block1, BasicBlock* block
         }
     }
 
+   /* unsigned block1Reach =
+        BlockSetOps::MayBeUninit(block1->bbReach) ? 0 : BlockSetOps::Count(compiler, block1->bbReach);
+    unsigned block2Reach =
+        BlockSetOps::MayBeUninit(block2->bbReach) ? 0 : BlockSetOps::Count(compiler, block2->bbReach);*/
+
+    //if (block1Reach < block2Reach)
+    //{
+    //    return -1;
+    //}
+    //else if (block1Reach > block2Reach)
+    //{
+    //    return 1;
+    //}
+
+    //if (block1->countOfInEdges() > block2->countOfInEdges())
+    //{
+    //    return 1;
+    //}
+    //else if (block1->countOfInEdges() < block2->countOfInEdges())
+    //{
+    //    return -1;
+    //}
+    /*else
+    {
+        assert(!"failed");
+    }*/
+
     // If weights are the same prefer LOWER bbnum
     if (block1->bbNum < block2->bbNum)
     {

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -1044,33 +1044,6 @@ int LinearScan::compareBlocksForSequencing(BasicBlock* block1, BasicBlock* block
         }
     }
 
-   /* unsigned block1Reach =
-        BlockSetOps::MayBeUninit(block1->bbReach) ? 0 : BlockSetOps::Count(compiler, block1->bbReach);
-    unsigned block2Reach =
-        BlockSetOps::MayBeUninit(block2->bbReach) ? 0 : BlockSetOps::Count(compiler, block2->bbReach);*/
-
-    //if (block1Reach < block2Reach)
-    //{
-    //    return -1;
-    //}
-    //else if (block1Reach > block2Reach)
-    //{
-    //    return 1;
-    //}
-
-    //if (block1->countOfInEdges() > block2->countOfInEdges())
-    //{
-    //    return 1;
-    //}
-    //else if (block1->countOfInEdges() < block2->countOfInEdges())
-    //{
-    //    return -1;
-    //}
-    /*else
-    {
-        assert(!"failed");
-    }*/
-
     // If weights are the same prefer LOWER bbnum
     if (block1->bbNum < block2->bbNum)
     {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_66578/Runtime_66578.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_66578/Runtime_66578.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+// Note: In below test case, would keep around unreachable blocks which would wrongly keep the
+//       variables alive and we end up generating false refpositions. This leads to not marking
+//       an interval as spilled.
+using System;
+using System.Runtime.CompilerServices;
+
+public interface I0
+{
+}
+
+public interface I1
+{
+}
+
+public class C0 : I0, I1
+{
+    public sbyte F0;
+    public bool F1;
+    public uint F2;
+    public ushort F5;
+    public C0(sbyte f0, bool f1, uint f2, ushort f5)
+    {
+        F0 = f0;
+        F1 = f1;
+        F2 = f2;
+        F5 = f5;
+    }
+}
+
+public class Program2
+{
+    public static I1[][] s_18;
+    //= { new I1[] { null }, };
+
+    public static ushort[][] s_43;
+    public static I1 s_64;
+    public static I0 s_88;
+
+    public static int Main()
+    {
+        var vr6 = new C0(0, false, 0, 0);
+        try
+        {
+            M52(vr6);
+        } catch (NullReferenceException ex)
+        {
+            return 100;
+        }
+        return 1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void M52(C0 argThis)
+    {
+        I1 vr9 = s_18[0][0];
+        if (argThis.F1)
+        {
+            return;
+        }
+
+        if (argThis.F1)
+        {
+            try
+            {
+                s_43 = new ushort[][] { new ushort[] { 0 } };
+            }
+            finally
+            {
+                for (int var8 = 0; var8 < 2; var8++)
+                {
+                    s_64 = argThis;
+                }
+
+                C0 vr10 = new C0(0, true, 0, 0);
+                s_88 = new C0(-1, true, 0, 0);
+            }
+
+            I1 vr12 = s_18[0][0];
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_66578/Runtime_66578.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_66578/Runtime_66578.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Perform reachability analysis one last time before doing code gen to eliminate unreachable blocks. 

While investigating, #66578, I noticed that there was lot of dead blocks that were kept around and that keeps variables alive longer and creating unnecessary refpositions. Having extra refpositions is not problematic, but the liveness of variables was not tracked correctly because of unreachable blocks. The liveness of variables decides if an interval should be spilled or not. As seen in my analysis in https://github.com/dotnet/runtime/issues/66578#issuecomment-1069769609, there were 3 refpositions (def, use, use) created for the problematic variable, but because of missing liveness, both the uses were marked as `lastUse` leading to making the interval as inactive instead of spilled.

In this PR, I have added the `computeReachability()` phase after all the optimizations are done so it can remove any unreachable blocks. It performs the block renumbering, but since LSRA is sensitive to block renumbering (see https://github.com/dotnet/runtime/issues/66994), I didn't want to see its impact as part of this change. Hence, I have added an option to skip the block renumbering in the final phase.

PIN numbers on windows/x64 SPMI

| Collection | Base          | Diff          | % diff |
|------------|---------------|---------------|--------|
| libraries  | 1392303237458 | 1393889260100 | 0.11%  |
| benchmarks | 328547820836  | 328920196300  | 0.11%  |


Also emit the block size after every block in order to spot the code size diff at block level.

Fixes: https://github.com/dotnet/runtime/issues/66578