### PR TITLE
Fix revocation processing on expired chains.

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.OpenSsl.cs
@@ -164,7 +164,12 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 if (OpenSslX509ChainProcessor.IsCompleteChain(status))
                 {
-                    if (status != Interop.Crypto.X509VerifyStatusCode.X509_V_OK)
+                    // Checking the validity period for the certificates in the chain is done after the
+                    // check for a trusted root, so accept expired (or not yet valid) as acceptable for
+                    // processing revocation.
+                    if (status != Interop.Crypto.X509VerifyStatusCode.X509_V_OK &&
+                        status != Interop.Crypto.X509VerifyStatusCodeUniversal.X509_V_ERR_CERT_NOT_YET_VALID &&
+                        status != Interop.Crypto.X509VerifyStatusCodeUniversal.X509_V_ERR_CERT_HAS_EXPIRED)
                     {
                         if (OpenSslX509ChainEventSource.Log.IsEnabled())
                         {


### PR DESCRIPTION
When adding tracing to the Linux X509Chain build, the "when do we process revocation" check got cleaned up to avoid doing wasteful work.  But it got cleaned a bit too aggressively.

With this change, fully-valid and valid-except-for-validity chains will both move into active revocation checks.

Fixes #66803