### PR TITLE
Leaf level AOT annotation for CoreLib library

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs
@@ -434,6 +434,7 @@ namespace System
                 SR.Format(SR.Format_AttributeUsage, type));
         }
 
+        [RequiresDynamicCode("The code for an array of the specified type might not be available.")]
         private static Attribute[] CreateAttributeArrayHelper(Type elementType, int elementCount) =>
             elementType.ContainsGenericParameters ? new Attribute[elementCount] : (Attribute[])Array.CreateInstance(elementType, elementCount);
         #endregion

--- a/src/coreclr/System.Private.CoreLib/src/System/Collections/Generic/ComparerHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Collections/Generic/ComparerHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using static System.RuntimeTypeHandle;
 
 namespace System.Collections.Generic
@@ -25,6 +26,8 @@ namespace System.Collections.Generic
         /// The logic in this method is replicated in vm/compile.cpp to ensure that NGen saves the right instantiations,
         /// and in vm/jitinterface.cpp so the jit can model the behavior of this method.
         /// </remarks>
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:UnrecognizedReflectionPattern",
+            Justification = "MakeGenericType is safe in this method")]
         internal static object CreateDefaultComparer(Type type)
         {
             Debug.Assert(type != null && type is RuntimeType);
@@ -59,6 +62,8 @@ namespace System.Collections.Generic
         /// Creates the default <see cref="Comparer{T}"/> for a nullable type.
         /// </summary>
         /// <param name="nullableType">The nullable type to create the default comparer for.</param>
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:UnrecognizedReflectionPattern",
+            Justification = "MakeGenericType is safe in this method")]
         private static object? TryCreateNullableComparer(RuntimeType nullableType)
         {
             Debug.Assert(nullableType != null);
@@ -113,6 +118,8 @@ namespace System.Collections.Generic
         /// <remarks>
         /// The logic in this method is replicated in vm/compile.cpp to ensure that NGen saves the right instantiations.
         /// </remarks>
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:UnrecognizedReflectionPattern",
+            Justification = "MakeGenericType is safe in this method")]
         internal static object CreateDefaultEqualityComparer(Type type)
         {
             Debug.Assert(type != null && type is RuntimeType);
@@ -157,6 +164,8 @@ namespace System.Collections.Generic
         /// Creates the default <see cref="EqualityComparer{T}"/> for a nullable type.
         /// </summary>
         /// <param name="nullableType">The nullable type to create the default equality comparer for.</param>
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:UnrecognizedReflectionPattern",
+            Justification = "MakeGenericType is safe in this method")]
         private static object? TryCreateNullableEqualityComparer(RuntimeType nullableType)
         {
             Debug.Assert(nullableType != null);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilderInstantiation.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilderInstantiation.cs
@@ -79,6 +79,7 @@ namespace System.Reflection.Emit
         }
 
         [RequiresUnreferencedCode("If some of the generic arguments are annotated (either with DynamicallyAccessedMembersAttribute, or generic constraints), trimming can't validate that the requirements of those annotations are met.")]
+        [RequiresDynamicCode("The native code for this instantiation might not be available at runtime.")]
         public override MethodInfo MakeGenericMethod(params Type[] arguments)
         {
             throw new InvalidOperationException(SR.Format(SR.Arg_NotGenericMethodDefinition, this));

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/SymbolType.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/SymbolType.cs
@@ -275,11 +275,13 @@ namespace System.Reflection.Emit
             return SymbolType.FormCompoundType(m_format + "&", m_baseType, 0)!;
         }
 
+        [RequiresDynamicCode("The code for an array of the specified type might not be available.")]
         public override Type MakeArrayType()
         {
             return SymbolType.FormCompoundType(m_format + "[]", m_baseType, 0)!;
         }
 
+        [RequiresDynamicCode("The code for an array of the specified type might not be available.")]
         public override Type MakeArrayType(int rank)
         {
             string s = GetRankString(rank);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -55,6 +55,8 @@ namespace System.Reflection.Emit
         #region Public Static Methods
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2055:UnrecognizedReflectionPattern",
             Justification = "MakeGenericType is only called on a TypeBuilder which is not subject to trimming")]
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:UnrecognizedReflectionPattern",
+            Justification = "MakeGenericType is only called on a TypeBuilder which is not subject to trimming")]
         public static MethodInfo GetMethod(Type type, MethodInfo method)
         {
             if (type is not TypeBuilder && type is not TypeBuilderInstantiation)
@@ -89,6 +91,8 @@ namespace System.Reflection.Emit
         }
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2055:UnrecognizedReflectionPattern",
+            Justification = "MakeGenericType is only called on a TypeBuilder which is not subject to trimming")]
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:UnrecognizedReflectionPattern",
             Justification = "MakeGenericType is only called on a TypeBuilder which is not subject to trimming")]
         public static ConstructorInfo GetConstructor(Type type, ConstructorInfo constructor)
         {
@@ -1461,6 +1465,8 @@ namespace System.Reflection.Emit
             Justification = "MakeGenericType is only called on a TypeBuilderInstantiation which is not subject to trimming")]
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
             Justification = "GetConstructor is only called on a TypeBuilderInstantiation which is not subject to trimming")]
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:UnrecognizedReflectionPattern",
+            Justification = "MakeGenericType is only called on a TypeBuilder which is not subject to trimming")]
         private ConstructorBuilder DefineDefaultConstructorNoLock(MethodAttributes attributes)
         {
             ConstructorBuilder constBuilder;

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
@@ -79,10 +79,12 @@ namespace System.Reflection.Emit
         {
             return SymbolType.FormCompoundType("&", this, 0)!;
         }
+        [RequiresDynamicCode("The code for an array of the specified type might not be available.")]
         public override Type MakeArrayType()
         {
             return SymbolType.FormCompoundType("[]", this, 0)!;
         }
+        [RequiresDynamicCode("The code for an array of the specified type might not be available.")]
         public override Type MakeArrayType(int rank)
         {
             if (rank <= 0)
@@ -105,6 +107,11 @@ namespace System.Reflection.Emit
         public override string? Namespace => m_type.Namespace;
         public override string? AssemblyQualifiedName => TypeNameBuilder.ToString(this, TypeNameBuilder.Format.AssemblyQualifiedName);
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2055:UnrecognizedReflectionPattern",
+            Justification = "The entire TypeBuilderInstantiation is serving the MakeGenericType implementation. " +
+                            "Currently this is not supported by linker. Once it is supported the outercall (Type.MakeGenericType)" +
+                            "will validate that the types fullfill the necessary requirements of annotations on type parameters." +
+                            "As such the actual internals of the implementation are not interesting.")]
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:UnrecognizedReflectionPattern",
             Justification = "The entire TypeBuilderInstantiation is serving the MakeGenericType implementation. " +
                             "Currently this is not supported by linker. Once it is supported the outercall (Type.MakeGenericType)" +
                             "will validate that the types fullfill the necessary requirements of annotations on type parameters." +
@@ -251,6 +258,7 @@ namespace System.Reflection.Emit
         public override Type GetGenericTypeDefinition() { return m_type; }
 
         [RequiresUnreferencedCode("If some of the generic arguments are annotated (either with DynamicallyAccessedMembersAttribute, or generic constraints), trimming can't validate that the requirements of those annotations are met.")]
+        [RequiresDynamicCode("The native code for this instantiation might not be available at runtime.")]
         public override Type MakeGenericType(params Type[] inst) { throw new InvalidOperationException(SR.Format(SR.Arg_NotGenericTypeDefinition, this)); }
         public override bool IsAssignableFrom([NotNullWhen(true)] Type? c) { throw new NotSupportedException(); }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/XXXOnTypeBuilderInstantiation.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/XXXOnTypeBuilderInstantiation.cs
@@ -62,6 +62,7 @@ namespace System.Reflection.Emit
         public override bool IsGenericMethodDefinition => m_method.IsGenericMethodDefinition;
         public override bool ContainsGenericParameters => m_method.ContainsGenericParameters;
 
+        [RequiresDynamicCode("The native code for this instantiation might not be available at runtime.")]
         [RequiresUnreferencedCode("If some of the generic arguments are annotated (either with DynamicallyAccessedMembersAttribute, or generic constraints), trimming can't validate that the requirements of those annotations are met.")]
         public override MethodInfo MakeGenericMethod(params Type[] typeArgs)
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
@@ -557,6 +557,7 @@ namespace System.Reflection
         }
         #endregion
 
+        [RequiresDynamicCode("The code for an array of the specified type might not be available.")]
         internal CustomAttributeTypedArgument(RuntimeModule scope, CustomAttributeEncodedArgument encodedArg)
         {
             CustomAttributeEncoding encodedType = encodedArg.CustomAttributeType.EncodedType;
@@ -1433,6 +1434,7 @@ namespace System.Reflection
             return attributeUsageAttribute ?? AttributeUsageAttribute.Default;
         }
 
+        [RequiresDynamicCode("The code for an array of the specified type might not be available.")]
         internal static object[] CreateAttributeArrayHelper(RuntimeType caType, int elementCount)
         {
             bool useAttributeArray = false;

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.CoreCLR.cs
@@ -434,6 +434,7 @@ namespace System.Reflection
 
         #region Generics
         [RequiresUnreferencedCode("If some of the generic arguments are annotated (either with DynamicallyAccessedMembersAttribute, or generic constraints), trimming can't validate that the requirements of those annotations are met.")]
+        [RequiresDynamicCode("The native code for this instantiation might not be available at runtime.")]
         public override MethodInfo MakeGenericMethod(params Type[] methodInstantiation!!)
         {
             RuntimeType[] methodInstantionRuntimeType = new RuntimeType[methodInstantiation.Length];

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -40,6 +40,7 @@ namespace System
         internal static extern bool IsInstanceOfType(RuntimeType type, [NotNullWhen(true)] object? o);
 
         [RequiresUnreferencedCode("MakeGenericType cannot be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.")]
+        [RequiresDynamicCode("The native code for this instantiation might not be available at runtime.")]
         internal static Type GetTypeHelper(Type typeStart, Type[]? genericArgs, IntPtr pModifiers, int cModifiers)
         {
             Type type = typeStart;

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -1015,6 +1015,10 @@ namespace System
                     Justification = "Calls to GetInterfaces technically require all interfaces on ReflectedType" +
                         "But this is not a public API to enumerate reflection items, all the public APIs which do that" +
                         "should be annotated accordingly.")]
+                [UnconditionalSuppressMessage("AotAnalysis", "IL3050:UnrecognizedReflectionPattern",
+                    Justification = "Calls to GetInterfaces technically require all interfaces on ReflectedType" +
+                        "But this is not a public API to enumerate reflection items, all the public APIs which do that" +
+                        "should be annotated accordingly.")]
                 private RuntimeType[] PopulateInterfaces(Filter filter)
                 {
                     ListBuilder<RuntimeType> list = default;
@@ -1601,6 +1605,7 @@ namespace System
                 return m_defaultMemberName;
             }
 
+            [RequiresDynamicCode("The code for an array of the specified type might not be available.")]
             internal object[] GetEmptyArray() => _emptyArray ??= (object[])Array.CreateInstance(m_runtimeType, 0);
             #endregion
 
@@ -3336,6 +3341,7 @@ namespace System
         }
 
         [RequiresUnreferencedCode("If some of the generic arguments are annotated (either with DynamicallyAccessedMembersAttribute, or generic constraints), trimming can't validate that the requirements of those annotations are met.")]
+        [RequiresDynamicCode("The native code for this instantiation might not be available at runtime.")]
         public override Type MakeGenericType(Type[] instantiation!!)
         {
             if (!IsGenericTypeDefinition)
@@ -3438,8 +3444,10 @@ namespace System
 
         public override Type MakeByRefType() => new RuntimeTypeHandle(this).MakeByRef();
 
+        [RequiresDynamicCode("The code for an array of the specified type might not be available.")]
         public override Type MakeArrayType() => new RuntimeTypeHandle(this).MakeSZArray();
 
+        [RequiresDynamicCode("The code for an array of the specified type might not be available.")]
         public override Type MakeArrayType(int rank)
         {
             if (rank <= 0)
@@ -3860,6 +3868,7 @@ namespace System
             return ret;
         }
 
+        [RequiresDynamicCode("The code for an array of the specified type might not be available.")]
         private static void WrapArgsForInvokeCall(object[] aArgs, int[] aArgsWrapperTypes)
         {
             int cArgs = aArgs.Length;

--- a/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.StubHelpers
 {
@@ -1045,6 +1046,7 @@ namespace System.StubHelpers
             }
         }
 
+        [RequiresDynamicCode("Marshalling code for the object might not be available")]
         internal void ClearNative(IntPtr pNativeHome)
         {
             if (pNativeHome != IntPtr.Zero)

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -302,6 +302,7 @@ namespace System
             enumType.GetEnumUnderlyingType();
 
 #if !CORERT
+        [RequiresDynamicCode("It might not be possible to create an array of the enum type at runtime. Use the GetValues<TEnum> overload instead.")]
         public static TEnum[] GetValues<TEnum>() where TEnum : struct, Enum =>
             (TEnum[])GetValues(typeof(TEnum));
 #endif


### PR DESCRIPTION
First round of CoreLib (`coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj`) annotation to get feedback on warning suppression strategy for this level before propagating to all impacted public APIs:

1. Suppressed warnings from `ComparerHelpers` as this internal class seems to be hardened for generic instantiations. The document [sample ](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.equalitycomparer-1?view=net-6.0)code works in `NativeAot` mode.
2. Suppressed warnings from `TypeBuilder` as `Reflection.Emit` is not supported in `NativeAot` mode and will throw a `NotSupportedException`. I want to explore if this option works instead of adding multiple annotations for this class.
3. Suppressed warnings from `MemberInfoCache<T>.PopulateInterfaces` to match the trimmer suppression since this is an internal API.
4. All other leaf level warnings are propagated including `IL3051 `ones.