### PR TITLE
Fix r4 r8 format numbers

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -1152,8 +1152,12 @@ namespace DebuggerTests
         internal static JObject TNumber(uint value) =>
             JObject.FromObject(new { type = "number", value = @value.ToString(), description = value.ToString() });
 
-        internal static JObject TNumber(string value) =>
-            JObject.FromObject(new { type = "number", value = @value.ToString(), description = value });
+        // If is decimal, skip description due to culture-specific separators.
+        // They depend on user's settings and we are not able to detect them here
+        internal static JObject TNumber(string value, bool isDecimal = false) =>
+            isDecimal ?
+            JObject.FromObject(new { type = "number", value = @value.ToString() }) :
+            JObject.FromObject(new { type = "number", value = @value.ToString(), description = double.Parse(value, System.Globalization.CultureInfo.InvariantCulture).ToString() });
 
         internal static JObject TValueType(string className, string description = null, object members = null) =>
             JObject.FromObject(new { type = "object", isValueType = true, className = className, description = description ?? className });


### PR DESCRIPTION
AssignmentTests.InspectVariableBeforeAndAfterAssignment for MONO_TYPE_R4 and MONO_TYPE_R8 failed on some cultures where decimal separator is a comma, not a dot. This change fixes it. Separated from PR: https://github.com/dotnet/runtime/pull/66821#discussion_r831416997 and should be merged **only** after that PR.

Reason: we are passing double/float without type change into JSON, so it preserves dot in every culture. We are passing description as a string, converting double/float to string before passing to JSON. This makes description vary from culture to culture.
Then, in tests we have this method overriding:
```
internal static JObject TNumber(string value)
```
where we pass string as a description, without editing it according to culture.

Failed tests:
```
DebuggerTests.AssignmentTests.InspectVariableBeforeAndAfterAssignment(clazz: "MONO_TYPE_R4", checkDefault: [[[...]], [[...]], [[...]]], checkValue: [[[...]], [[...]], [[...]]]) [FAIL]
DebuggerTests.AssignmentTests.InspectVariableBeforeAndAfterAssignment(clazz: "MONO_TYPE_R8", checkDefault: [[[...]], [[...]], [[...]]], checkValue: [[[...]], [[...]], [[...]]]) [FAIL]
```

Failure description:
```
Expected: 3.1415
Actual:   3,1415 
Expected: {
  "type": "number",
  "value": "3.1415",
  "description": "3.1415"
} 
Actual: {
  "type": "number",
  "value": 3.1415,
  "description": "3,1415"
}
  Failed DebuggerTests.AssignmentTests.InspectVariableBeforeAndAfterAssignment(clazz: "MONO_TYPE_R4", checkDefault: [[[...]], [[...]], [[...]]], checkValue: [[[...]], [[...]], [[...]]]) [142 ms]
  Error Message:
   [[r] Value for json property named description didn't match.]

Expected: 3.1415
Actual:   3,1415
```

Fix:
Leave the method with string as param but assume all strings passed there will be in InvariantCulture double format. Then, first cast the string to double and afterwards, using current culture - back to string. It will eliminate inconsistency between Debugger and Tests while preserving description consistent with machine's culture.
