### PR TITLE
Include method instantiation MethodTables in compilation

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -253,13 +253,20 @@ namespace ILCompiler.DependencyAnalysis
         {
             var dependencies = (DependencyList)base.GetStaticDependencies(factory);
 
-            dependencies.Add(factory.GVMDependencies(_method.GetCanonMethodTarget(CanonicalFormKind.Specific)), "Potential generic virtual method call");
+            MethodDesc canonMethod = _method.GetCanonMethodTarget(CanonicalFormKind.Specific);
+
+            dependencies.Add(factory.GVMDependencies(canonMethod), "Potential generic virtual method call");
 
             // Variant generic virtual method calls at runtime might need to build the concrete version of the
             // type we could be dispatching on to find the appropriate GVM entry.
             if (_method.OwningType.HasVariance)
             {
                 GenericTypesTemplateMap.GetTemplateTypeDependencies(ref dependencies, factory, _method.OwningType.ConvertToCanonForm(CanonicalFormKind.Specific));
+            }
+
+            foreach (TypeDesc instArg in canonMethod.Instantiation)
+            {
+                dependencies.Add(factory.MaximallyConstructableType(instArg), "Type we need to look up for GVM dispatch");
             }
 
             return dependencies;

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
@@ -44,6 +44,7 @@ class Generics
         TestGenericRecursionFromNpgsql.Run();
         TestRecursionInGenericVirtualMethods.Run();
         TestRecursionThroughGenericLookups.Run();
+        TestGvmLookupDependency.Run();
 #if !CODEGEN_CPP
         TestNullableCasting.Run();
         TestVariantCasting.Run();
@@ -3145,6 +3146,26 @@ class Generics
             // There is a generic recursion in the above hierarchy. This just tests that we can compile.
             new ArrayHandler<object>().Write(null);
             new RangeHandler<object>().Write(default);
+        }
+    }
+
+    static class TestGvmLookupDependency
+    {
+        struct SmallCat<T> { }
+
+        interface ITechnique
+        {
+            void CatSlaps<T>() { /* Cannot reference T or it stops testing the thing it should */ }
+        }
+
+        struct Technique : ITechnique { }
+
+        static void CatConcepts<T, U>() where T : ITechnique => default(T).CatSlaps<SmallCat<U>>();
+
+        public static void Run()
+        {
+            CatConcepts<Technique, int>();
+            CatConcepts<Technique, object>();
         }
     }
 }


### PR DESCRIPTION
We'll need to load the `MethodTable` so that we can search for it in GVM tables.

Fixes #66659.