### PR TITLE
Give end-marker symbols their own addresses to work around a linker bug

### DIFF
--- a/src/coreclr/pal/inc/unixasmmacrosamd64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosamd64.inc
@@ -51,9 +51,9 @@ C_FUNC(\Name):
 .macro LEAF_END_MARKED Name, Section
 C_FUNC(\Name\()_End):
         .global C_FUNC(\Name\()_End)
+        LEAF_END \Name, \Section
         // make sure this symbol gets its own address
         nop
-        LEAF_END \Name, \Section
 .endm
 
 .macro NOP_6_BYTE

--- a/src/coreclr/pal/inc/unixasmmacrosamd64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosamd64.inc
@@ -51,6 +51,8 @@ C_FUNC(\Name):
 .macro LEAF_END_MARKED Name, Section
 C_FUNC(\Name\()_End):
         .global C_FUNC(\Name\()_End)
+        ; make sure this symbol gets its own address
+        nop
         LEAF_END \Name, \Section
 .endm
 

--- a/src/coreclr/pal/inc/unixasmmacrosamd64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosamd64.inc
@@ -51,7 +51,7 @@ C_FUNC(\Name):
 .macro LEAF_END_MARKED Name, Section
 C_FUNC(\Name\()_End):
         .global C_FUNC(\Name\()_End)
-        ; make sure this symbol gets its own address
+        // make sure this symbol gets its own address
         nop
         LEAF_END \Name, \Section
 .endm

--- a/src/coreclr/pal/inc/unixasmmacrosarm.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosarm.inc
@@ -39,6 +39,8 @@ C_FUNC(\Name):
         .thumb_func
         .global C_FUNC(\Name\()_End)
 C_FUNC(\Name\()_End):
+        ; make sure this symbol gets its own address
+        nop
         LEAF_END \Name, \Section
 .endm
 

--- a/src/coreclr/pal/inc/unixasmmacrosarm.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosarm.inc
@@ -39,7 +39,7 @@ C_FUNC(\Name):
         .thumb_func
         .global C_FUNC(\Name\()_End)
 C_FUNC(\Name\()_End):
-        ; make sure this symbol gets its own address
+        // make sure this symbol gets its own address
         nop
         LEAF_END \Name, \Section
 .endm

--- a/src/coreclr/pal/inc/unixasmmacrosarm.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosarm.inc
@@ -39,9 +39,9 @@ C_FUNC(\Name):
         .thumb_func
         .global C_FUNC(\Name\()_End)
 C_FUNC(\Name\()_End):
+        LEAF_END \Name, \Section
         // make sure this symbol gets its own address
         nop
-        LEAF_END \Name, \Section
 .endm
 
 .macro PREPARE_EXTERNAL_VAR Name, HelperReg

--- a/src/coreclr/pal/inc/unixasmmacrosarm64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosarm64.inc
@@ -43,6 +43,8 @@ C_FUNC(\Name):
 .macro LEAF_END_MARKED Name, Section
 C_FUNC(\Name\()_End):
         .global C_FUNC(\Name\()_End)
+        ; make sure this symbol gets its own address
+        nop
         LEAF_END \Name, \Section
 .endm
 

--- a/src/coreclr/pal/inc/unixasmmacrosarm64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosarm64.inc
@@ -43,7 +43,7 @@ C_FUNC(\Name):
 .macro LEAF_END_MARKED Name, Section
 C_FUNC(\Name\()_End):
         .global C_FUNC(\Name\()_End)
-        ; make sure this symbol gets its own address
+        // make sure this symbol gets its own address
         nop
         LEAF_END \Name, \Section
 .endm

--- a/src/coreclr/pal/inc/unixasmmacrosarm64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosarm64.inc
@@ -43,9 +43,9 @@ C_FUNC(\Name):
 .macro LEAF_END_MARKED Name, Section
 C_FUNC(\Name\()_End):
         .global C_FUNC(\Name\()_End)
+        LEAF_END \Name, \Section
         // make sure this symbol gets its own address
         nop
-        LEAF_END \Name, \Section
 .endm
 
 .macro PREPARE_EXTERNAL_VAR Name, HelperReg

--- a/src/coreclr/pal/inc/unixasmmacrosx86.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosx86.inc
@@ -32,7 +32,7 @@ C_FUNC(\Name):
 .macro LEAF_END_MARKED Name, Section
 C_FUNC(\Name\()_End):
         .global C_FUNC(\Name\()_End)
-        ; make sure this symbol gets its own address
+        // make sure this symbol gets its own address
         nop
         LEAF_END \Name, \Section
 .endm

--- a/src/coreclr/pal/inc/unixasmmacrosx86.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosx86.inc
@@ -32,9 +32,9 @@ C_FUNC(\Name):
 .macro LEAF_END_MARKED Name, Section
 C_FUNC(\Name\()_End):
         .global C_FUNC(\Name\()_End)
+        LEAF_END \Name, \Section
         // make sure this symbol gets its own address
         nop
-        LEAF_END \Name, \Section
 .endm
 
 .macro PROLOG_BEG

--- a/src/coreclr/pal/inc/unixasmmacrosx86.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosx86.inc
@@ -32,6 +32,8 @@ C_FUNC(\Name):
 .macro LEAF_END_MARKED Name, Section
 C_FUNC(\Name\()_End):
         .global C_FUNC(\Name\()_End)
+        ; make sure this symbol gets its own address
+        nop
         LEAF_END \Name, \Section
 .endm
 

--- a/src/coreclr/vm/amd64/AsmMacros.inc
+++ b/src/coreclr/vm/amd64/AsmMacros.inc
@@ -133,11 +133,12 @@ Section ends
 LEAF_END_MARKED macro Name, section
         public Name&_End
 Name&_End label qword
+
+Name    endp
+
         ; this nop is important to keep the label in
         ; the right place in the face of BBT
         nop
-
-Name    endp
 
 Section ends
 

--- a/src/coreclr/vm/arm/asmmacros.h
+++ b/src/coreclr/vm/arm/asmmacros.h
@@ -29,6 +29,9 @@ $__EndLabelName
 
     LEAF_END $FuncName
 
+    ; Make sure this symbol gets its own address
+    nop
+
     MEND
 
 ;-----------------------------------------------------------------------------

--- a/src/coreclr/vm/arm64/asmmacros.h
+++ b/src/coreclr/vm/arm64/asmmacros.h
@@ -147,6 +147,9 @@ $__EndLabelName
 
     LEAF_END $FuncName
 
+    ; make sure this symbol gets its own address
+    nop
+
     MEND
 ;-----------------------------------------------------------------------------
 ; Macro use for enabling C++ to know where to patch code at runtime.

--- a/src/coreclr/vm/i386/AsmMacros.inc
+++ b/src/coreclr/vm/i386/AsmMacros.inc
@@ -37,9 +37,9 @@ LEAF_END_MARKED macro functionName
     endMarkerName TEXTEQU @CatStr(%bareFunctionName, <_End@0>)
     %endMarkerName:
     PUBLIC endMarkerName
+    functionName ENDP
     ; make sure this symbol gets its own address
     nop
-    functionName ENDP
 endm
 
 PATCH_LABEL macro labelName

--- a/src/coreclr/vm/i386/AsmMacros.inc
+++ b/src/coreclr/vm/i386/AsmMacros.inc
@@ -37,6 +37,8 @@ LEAF_END_MARKED macro functionName
     endMarkerName TEXTEQU @CatStr(%bareFunctionName, <_End@0>)
     %endMarkerName:
     PUBLIC endMarkerName
+    ; make sure this symbol gets its own address
+    nop
     functionName ENDP
 endm
 


### PR DESCRIPTION
It seems there is a linker bug related to control-flow guard that is
causing #66969. In eb8460f a thunktemplates.asm file was added that has
a LEAF_END_MARKED at the end of the file. This creates two symbols for
the same upcoming address. Normally that should be fine, but in this
case it causes the linker to place the same address twice in a CFG table
in the PE file. This causes the kernel to fail while loading the image.

A simple workaround would be to add a nop at the end of
thunktemplates.asm, but @janvorli suggested giving these symbols their
own address in all cases for goodness when debugging. We already do so
for Windows x64 it looks like.

Fix #66969