### PR TITLE
Replace 2 allocations from string.ToCharArray() with ReadOnlySpan in System.Private.Xml library

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/BinHexDecoder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/BinHexDecoder.cs
@@ -116,7 +116,7 @@ namespace System.Xml
         //
         // Static methods
         //
-        public static byte[] Decode(char[] chars!!, bool allowOddChars)
+        public static byte[] Decode(ReadOnlySpan<char> chars, bool allowOddChars)
         {
             int len = chars.Length;
             if (len == 0)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
@@ -975,7 +975,7 @@ namespace System.Xml.Serialization
                 throw new ArgumentException(SR.Format(SR.XmlEmptyArrayType, CurrentTag()), nameof(value));
             }
 
-            char[] chars = value.ToCharArray();
+            ReadOnlySpan<char> chars = value.AsSpan();
             int charsLength = chars.Length;
 
             SoapArrayInfo soapArrayInfo = default;
@@ -1005,7 +1005,7 @@ namespace System.Xml.Serialization
             int len = charsLength - pos - 2;
             if (len > 0)
             {
-                string lengthString = new string(chars, pos + 1, len);
+                string lengthString = new string(chars.Slice(pos + 1, len));
                 try
                 {
                     soapArrayInfo.length = int.Parse(lengthString, CultureInfo.InvariantCulture);
@@ -1043,7 +1043,7 @@ namespace System.Xml.Serialization
             soapArrayInfo.dimensions = 1;
 
             // everything else is qname - validation of qnames?
-            soapArrayInfo.qname = new string(chars, 0, pos + 1);
+            soapArrayInfo.qname = new string(chars.Slice(0, pos + 1));
             return soapArrayInfo;
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
@@ -1005,19 +1005,8 @@ namespace System.Xml.Serialization
             if (len > 0)
             {
                 ReadOnlySpan<char> lengthStringSpan = value.AsSpan(pos + 1, len);
-                try
-                {
-                    if (!int.TryParse(lengthStringSpan, CultureInfo.InvariantCulture, out soapArrayInfo.length))
-                        throw new ArgumentException(SR.Format(SR.XmlInvalidArrayLength, new string(lengthStringSpan)), nameof(value));
-                }
-                catch (Exception e)
-                {
-                    if (e is OutOfMemoryException)
-                    {
-                        throw;
-                    }
+                if (!int.TryParse(lengthStringSpan, CultureInfo.InvariantCulture, out soapArrayInfo.length))
                     throw new ArgumentException(SR.Format(SR.XmlInvalidArrayLength, new string(lengthStringSpan)), nameof(value));
-                }
             }
             else
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlConvert.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlConvert.cs
@@ -314,7 +314,7 @@ namespace System.Xml
 
         internal static byte[] FromBinHexString(string s!!, bool allowOddCount)
         {
-            return BinHexDecoder.Decode(s.ToCharArray(), allowOddCount);
+            return BinHexDecoder.Decode(s.AsSpan(), allowOddCount);
         }
 
         internal static string ToBinHexString(byte[] inArray!!)

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlConvert.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlConvert.cs
@@ -314,6 +314,8 @@ namespace System.Xml
 
         internal static byte[] FromBinHexString(string s!!, bool allowOddCount)
         {
+            if (s == null) throw new ArgumentNullException(nameof(s));
+
             return BinHexDecoder.Decode(s.AsSpan(), allowOddCount);
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlConvert.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlConvert.cs
@@ -314,8 +314,6 @@ namespace System.Xml
 
         internal static byte[] FromBinHexString(string s!!, bool allowOddCount)
         {
-            if (s == null) throw new ArgumentNullException(nameof(s));
-
             return BinHexDecoder.Decode(s.AsSpan(), allowOddCount);
         }
 


### PR DESCRIPTION
Found usage of string.ToCharArray() in BinHexDecoder and XmlSerializationReader and replaced them with Spans.
I have no any benchmark proving that this improves speed, just looks simple and safe change.