### PR TITLE
Use the stapled OCSP response from TLS, when available.

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OCSP.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OCSP.cs
@@ -53,6 +53,22 @@ internal static partial class Interop
             return response;
         }
 
+        [LibraryImport(Libraries.CryptoNative)]
+        private static partial int CryptoNative_X509ChainHasStapledOcsp(SafeX509StoreCtxHandle storeCtx);
+
+        internal static bool X509ChainHasStapledOcsp(SafeX509StoreCtxHandle storeCtx)
+        {
+            int resp = CryptoNative_X509ChainHasStapledOcsp(storeCtx);
+
+            if (resp == 1)
+            {
+                return true;
+            }
+
+            Debug.Assert(resp == 0, $"Unexpected response from X509ChainHasStapledOcsp: {resp}");
+            return false;
+        }
+
         [LibraryImport(Libraries.CryptoNative, StringMarshalling = StringMarshalling.Utf8)]
         private static partial int CryptoNative_X509ChainVerifyOcsp(
             SafeX509StoreCtxHandle ctx,

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainEventSource.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainEventSource.cs
@@ -59,6 +59,7 @@ namespace System.Security.Cryptography.X509Certificates
         private const int EventId_RevocationCheckStart = 45;
         private const int EventId_RevocationCheckStop = 46;
         private const int EventId_CrlIdentifiersDetermined = 47;
+        private const int EventId_StapledOcspPresent = 48;
 
         private static string GetCertificateSubject(SafeX509Handle certHandle)
         {
@@ -744,6 +745,18 @@ namespace System.Security.Cryptography.X509Certificates
         private void CrlIdentifiersDetermined(string subjectName, string crlDistributionPoint, string cacheFileName)
         {
             WriteEvent(EventId_CrlIdentifiersDetermined, subjectName, crlDistributionPoint, cacheFileName);
+        }
+
+        [Event(
+            EventId_StapledOcspPresent,
+            Level = EventLevel.Verbose,
+            Message = "The target certificate has a stapled OCSP request, skipping the CRL check.")]
+        internal void StapledOcspPresent()
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(EventId_StapledOcspPresent);
+            }
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainProcessor.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainProcessor.cs
@@ -388,15 +388,25 @@ namespace System.Security.Cryptography.X509Certificates
                 {
                     for (int i = 0; i < revocationSize; i++)
                     {
-                        using (SafeX509Handle cert =
-                            Interop.Crypto.X509UpRef(Interop.Crypto.GetX509StackField(chainStack, i)))
+                        if (i == 0 && Interop.Crypto.X509ChainHasStapledOcsp(_storeCtx))
                         {
-                            OpenSslCrlCache.AddCrlForCertificate(
-                                cert,
-                                _store,
-                                revocationMode,
-                                _verificationTime,
-                                _downloadTimeout);
+                            if (OpenSslX509ChainEventSource.Log.IsEnabled())
+                            {
+                                OpenSslX509ChainEventSource.Log.StapledOcspPresent();
+                            }
+                        }
+                        else
+                        {
+                            using (SafeX509Handle cert =
+                                Interop.Crypto.X509UpRef(Interop.Crypto.GetX509StackField(chainStack, i)))
+                            {
+                                OpenSslCrlCache.AddCrlForCertificate(
+                                    cert,
+                                    _store,
+                                    revocationMode,
+                                    _verificationTime,
+                                    _downloadTimeout);
+                            }
                         }
                     }
                 }

--- a/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
+++ b/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
@@ -236,6 +236,7 @@ static const Entry s_cryptoNative[] =
     DllImportEntry(CryptoNative_UpRefEvpPkey)
     DllImportEntry(CryptoNative_X509ChainBuildOcspRequest)
     DllImportEntry(CryptoNative_X509ChainGetCachedOcspStatus)
+    DllImportEntry(CryptoNative_X509ChainHasStapledOcsp)
     DllImportEntry(CryptoNative_X509ChainNew)
     DllImportEntry(CryptoNative_X509ChainVerifyOcsp)
     DllImportEntry(CryptoNative_X509CheckPurpose)

--- a/src/native/libs/System.Security.Cryptography.Native/openssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/openssl.c
@@ -1488,7 +1488,11 @@ static int32_t EnsureOpenSslInitializedCore()
     ret = EnsureOpenSsl11Initialized();
 #endif
 
-    assert(g_x509_ocsp_index != 0);
+    if (ret == 0)
+    {
+        assert(g_x509_ocsp_index != 0);
+    }
+
     return ret;
 }
 

--- a/src/native/libs/System.Security.Cryptography.Native/openssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/openssl.c
@@ -1462,7 +1462,7 @@ int32_t CryptoNative_OpenSslAvailable()
 }
 
 static int32_t g_initStatus = 1;
-int g_x509_ocsp_index;
+int g_x509_ocsp_index = -1;
 
 static int32_t EnsureOpenSslInitializedCore()
 {
@@ -1490,7 +1490,9 @@ static int32_t EnsureOpenSslInitializedCore()
 
     if (ret == 0)
     {
-        assert(g_x509_ocsp_index != 0);
+        // On OpenSSL 1.0.2 our expected index is 0.
+        // On OpenSSL 1.1.0+ 0 is a reserved value and we expect 1.
+        assert(g_x509_ocsp_index != -1);
     }
 
     return ret;

--- a/src/native/libs/System.Security.Cryptography.Native/openssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/openssl.c
@@ -1202,10 +1202,20 @@ static void ExDataFree(
     }
 }
 
+// In the OpenSSL 1.0.2 headers, the `from` argument is not const (became const in 1.1.0)
+// In the OpenSSL 3 headers, `from_d` changed from (void*) to (void**).
 static int ExDataDup(
     CRYPTO_EX_DATA* to,
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_1_1_0_RTM
     const CRYPTO_EX_DATA* from,
+#else
+    CRYPTO_EX_DATA* from,
+#endif
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_3_0_RTM
+    void** from_d,
+#else
     void* from_d,
+#endif
     int idx,
     long argl,
     void* argp)

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
@@ -195,6 +195,7 @@ const EVP_CIPHER* EVP_chacha20_poly1305(void);
     REQUIRED_FUNCTION(BN_num_bits) \
     REQUIRED_FUNCTION(BN_set_word) \
     LEGACY_FUNCTION(CRYPTO_add_lock) \
+    REQUIRED_FUNCTION(CRYPTO_get_ex_new_index) \
     LEGACY_FUNCTION(CRYPTO_num_locks) \
     LEGACY_FUNCTION(CRYPTO_set_locking_callback) \
     REQUIRED_FUNCTION(d2i_ASN1_BIT_STRING) \
@@ -539,6 +540,7 @@ const EVP_CIPHER* EVP_chacha20_poly1305(void);
     REQUIRED_FUNCTION(X509_get_default_cert_dir_env) \
     REQUIRED_FUNCTION(X509_get_default_cert_file) \
     REQUIRED_FUNCTION(X509_get_default_cert_file_env) \
+    REQUIRED_FUNCTION(X509_get_ex_data) \
     REQUIRED_FUNCTION(X509_get_ext) \
     REQUIRED_FUNCTION(X509_get_ext_by_NID) \
     REQUIRED_FUNCTION(X509_get_ext_count) \
@@ -566,6 +568,7 @@ const EVP_CIPHER* EVP_chacha20_poly1305(void);
     REQUIRED_FUNCTION(X509_new) \
     REQUIRED_FUNCTION(X509_PUBKEY_get) \
     FALLBACK_FUNCTION(X509_PUBKEY_get0_param) \
+    REQUIRED_FUNCTION(X509_set_ex_data) \
     REQUIRED_FUNCTION(X509_set_pubkey) \
     REQUIRED_FUNCTION(X509_sign) \
     REQUIRED_FUNCTION(X509_subject_name_hash) \
@@ -657,6 +660,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define BN_num_bits BN_num_bits_ptr
 #define BN_set_word BN_set_word_ptr
 #define CRYPTO_add_lock CRYPTO_add_lock_ptr
+#define CRYPTO_get_ex_new_index CRYPTO_get_ex_new_index_ptr
 #define CRYPTO_num_locks CRYPTO_num_locks_ptr
 #define CRYPTO_set_locking_callback CRYPTO_set_locking_callback_ptr
 #define d2i_ASN1_BIT_STRING d2i_ASN1_BIT_STRING_ptr
@@ -1010,6 +1014,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_get_default_cert_dir_env X509_get_default_cert_dir_env_ptr
 #define X509_get_default_cert_file X509_get_default_cert_file_ptr
 #define X509_get_default_cert_file_env X509_get_default_cert_file_env_ptr
+#define X509_get_ex_data X509_get_ex_data_ptr
 #define X509_get_ext X509_get_ext_ptr
 #define X509_get_ext_by_NID X509_get_ext_by_NID_ptr
 #define X509_get_ext_count X509_get_ext_count_ptr
@@ -1031,6 +1036,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_new X509_new_ptr
 #define X509_PUBKEY_get0_param X509_PUBKEY_get0_param_ptr
 #define X509_PUBKEY_get X509_PUBKEY_get_ptr
+#define X509_set_ex_data X509_set_ex_data_ptr
 #define X509_set_pubkey X509_set_pubkey_ptr
 #define X509_subject_name_hash X509_subject_name_hash_ptr
 #define X509_sign X509_sign_ptr

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
@@ -190,7 +190,11 @@ SSL_CTX* CryptoNative_SslCtxCreate(const SSL_METHOD* method)
             }
         }
 
-        SSL_CTX_set_tlsext_status_type(ctx, TLSEXT_STATUSTYPE_ocsp);
+        // Opportunistically request the server present a stapled OCSP response.
+        if (SSL_CTX_ctrl(ctx, SSL_CTRL_SET_TLSEXT_STATUS_REQ_TYPE, TLSEXT_STATUSTYPE_ocsp, NULL) != 1)
+        {
+            ERR_clear_error();
+        }
     }
 
     return ctx;

--- a/src/native/libs/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_x509.h
@@ -5,6 +5,8 @@
 #include "pal_compiler.h"
 #include "pal_crypto_types.h"
 
+extern int g_x509_ocsp_index;
+
 /*
 These values should be kept in sync with System.Security.Cryptography.X509Certificates.X509RevocationFlag.
 */
@@ -380,6 +382,11 @@ Build an OCSP request appropriate for the end-entity certificate using the issue
 determined by the chain in storeCtx.
 */
 PALEXPORT OCSP_REQUEST* CryptoNative_X509ChainBuildOcspRequest(X509_STORE_CTX* storeCtx, int chainDepth);
+
+/*
+Checks if the target certificate has an appropriate stapled OCSP response.
+*/
+PALEXPORT int32_t CryptoNative_X509ChainHasStapledOcsp(X509_STORE_CTX* storeCtx);
 
 /*
 Determine if the OCSP response is acceptable, and if acceptable report the status and


### PR DESCRIPTION
Based on (non-exhaustive) testing, chain builds from a Let's Encrypt issued certificate have
the following characteristics:

* Live OCSP request required (uncached/unstapled): 577ms
* OCSP response retrieved from cache (unstapled): 183ms
* OCSP response utilized from TLS stapling (bypasses cache): 182ms

In both cached and stapled the revocation portion was about 39ms.
(The revocation mode was ExcludeRoot, the CRL pertaining to the intermediate was cached for all three measurements.)

The pattern of carrying the stapled response as extra (behind-the-scenes) data on the certificate is inspired by the Win32 behavior ([CERT_OCSP_RESPONSE_PROP_ID](https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certgetcertificatecontextproperty#cert_ocsp_response_prop_id)).

Contributes to #33377.