### PR TITLE
Reject mismatched symbol files

### DIFF
--- a/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
@@ -315,39 +315,39 @@ namespace ILCompiler
 
         private PdbSymbolReader OpenAssociatedSymbolFile(string peFilePath, PEReader peReader)
         {
-            // Assume that the .pdb file is next to the binary
-            var pdbFilename = Path.ChangeExtension(peFilePath, ".pdb");
-            string searchPath = "";
+            string pdbFileName = null;
+            BlobContentId pdbContentId = default;
 
-            if (!File.Exists(pdbFilename))
+            foreach (DebugDirectoryEntry debugEntry in peReader.ReadDebugDirectory())
             {
-                pdbFilename = null;
+                if (debugEntry.Type != DebugDirectoryEntryType.CodeView)
+                    continue;
 
-                // If the file doesn't exist, try the path specified in the CodeView section of the image
-                foreach (DebugDirectoryEntry debugEntry in peReader.ReadDebugDirectory())
+                CodeViewDebugDirectoryData debugDirectoryData = peReader.ReadCodeViewDebugDirectoryData(debugEntry);
+
+                string candidatePath  = debugDirectoryData.Path;
+                if (!Path.IsPathRooted(candidatePath) || !File.Exists(candidatePath))
                 {
-                    if (debugEntry.Type != DebugDirectoryEntryType.CodeView)
+                    // Also check next to the PE file
+                    candidatePath = Path.Combine(Path.GetDirectoryName(peFilePath), Path.GetFileName(candidatePath));
+                    if (!File.Exists(candidatePath))
                         continue;
-
-                    string candidateFileName = peReader.ReadCodeViewDebugDirectoryData(debugEntry).Path;
-                    if (Path.IsPathRooted(candidateFileName) && File.Exists(candidateFileName))
-                    {
-                        pdbFilename = candidateFileName;
-                        searchPath = Path.GetDirectoryName(pdbFilename);
-                        break;
-                    }
                 }
-
-                if (pdbFilename == null)
-                    return null;
+                
+                pdbFileName = candidatePath;
+                pdbContentId = new BlobContentId(debugDirectoryData.Guid, debugEntry.Stamp);
+                break;
             }
 
+            if (pdbFileName == null)
+                return null;
+
             // Try to open the symbol file as portable pdb first
-            PdbSymbolReader reader = PortablePdbSymbolReader.TryOpen(pdbFilename, GetMetadataStringDecoder());
+            PdbSymbolReader reader = PortablePdbSymbolReader.TryOpen(pdbFileName, GetMetadataStringDecoder(), pdbContentId);
             if (reader == null)
             {
                 // Fallback to the diasymreader for non-portable pdbs
-                reader = UnmanagedPdbSymbolReader.TryOpenSymbolReaderForMetadataFile(peFilePath, searchPath);
+                reader = UnmanagedPdbSymbolReader.TryOpenSymbolReaderForMetadataFile(peFilePath, Path.GetDirectoryName(pdbFileName));
             }
 
             return reader;

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/SymbolReader/PortablePdbSymbolReader.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/SymbolReader/PortablePdbSymbolReader.cs
@@ -62,12 +62,19 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public static PdbSymbolReader TryOpen(string pdbFilename, MetadataStringDecoder stringDecoder)
+        public static PdbSymbolReader TryOpen(string pdbFilename, MetadataStringDecoder stringDecoder, BlobContentId expectedContentId)
         {
             MemoryMappedViewAccessor mappedViewAccessor;
             MetadataReader reader = TryOpenMetadataFile(pdbFilename, stringDecoder, out mappedViewAccessor);
             if (reader == null)
                 return null;
+
+            var foundContentId = new BlobContentId(reader.DebugMetadataHeader.Id);
+            if (foundContentId != expectedContentId)
+            {
+                mappedViewAccessor.Dispose();
+                return null;
+            }
 
             return new PortablePdbSymbolReader(reader, mappedViewAccessor);
         }


### PR DESCRIPTION
`UnmanagedPdbSymbolReader` will already perform a GUID check that rejects mismatched symbol files. Do the same for the portable symbol reader.

Fixes #63779.