### PR TITLE
Add dynamic shim for SSL_CTX_set_options and SSL_set_options

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
@@ -38,6 +38,53 @@ static void EnsureLibSsl10Initialized()
 }
 #endif
 
+#ifdef FEATURE_DISTRO_AGNOSTIC_SSL
+// redirect all SSL_CTX_set_options and SSL_set_options calss via dynamic shims
+// to work around ABI breaking change between 1.1 and 3.0
+
+#undef SSL_CTX_set_options
+#define SSL_CTX_set_options SSL_CTX_set_options_dynamic
+static uint64_t SSL_CTX_set_options_dynamic(SSL_CTX* ctx, uint64_t options)
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-function-type"
+    if (ERR_new) // OpenSSL 3.0 sentinel function
+    {
+        // OpenSSL 3.0 and newer, use uint64_t for options
+        uint64_t (*func)(SSL_CTX* ctx, uint64_t op) = (uint64_t(*)(SSL_CTX*, uint64_t))SSL_CTX_set_options_ptr;
+        return func(ctx, options);
+    }
+    else
+    {
+        // OpenSSL 1.1 and earlier, use uint32_t for options
+        uint32_t (*func)(SSL_CTX* ctx, uint32_t op) = (uint32_t(*)(SSL_CTX*, uint32_t))SSL_CTX_set_options_ptr;
+        return func(ctx, (uint32_t)options);
+    }
+#pragma clang diagnostic pop
+}
+
+#undef SSL_set_options
+#define SSL_set_options SSL_set_options_dynamic
+static uint64_t SSL_set_options_dynamic(SSL* s, uint64_t options)
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-function-type"
+    if (ERR_new) // OpenSSL 3.0 sentinel function
+    {
+        // OpenSSL 3.0 and newer, use uint64_t for options
+        uint64_t (*func)(SSL* s, uint64_t op) = (uint64_t(*)(SSL*, uint64_t))SSL_set_options_ptr;
+        return func(s, options);
+    }
+    else
+    {
+        // OpenSSL 1.1 and earlier, use uint32_t for options
+        uint32_t (*func)(SSL* s, uint32_t op) = (uint32_t(*)(SSL*, uint32_t))SSL_set_options_ptr;
+        return func(s, (uint32_t)options);
+    }
+#pragma clang diagnostic pop
+}
+#endif
+
 static int32_t g_config_specified_ciphersuites = 0;
 static char* g_emptyAlpn = "";
 

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
@@ -48,7 +48,7 @@ static uint64_t SSL_CTX_set_options_dynamic(SSL_CTX* ctx, uint64_t options)
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-function-type"
-    if (ERR_new) // OpenSSL 3.0 sentinel function
+    if (API_EXISTS(ERR_new)) // OpenSSL 3.0 sentinel function
     {
         // OpenSSL 3.0 and newer, use uint64_t for options
         uint64_t (*func)(SSL_CTX* ctx, uint64_t op) = (uint64_t(*)(SSL_CTX*, uint64_t))SSL_CTX_set_options_ptr;

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
@@ -69,7 +69,7 @@ static uint64_t SSL_set_options_dynamic(SSL* s, uint64_t options)
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-function-type"
-    if (ERR_new) // OpenSSL 3.0 sentinel function
+    if (API_EXISTS(ERR_new))
     {
         // OpenSSL 3.0 and newer, use uint64_t for options
         uint64_t (*func)(SSL* s, uint64_t op) = (uint64_t(*)(SSL*, uint64_t))SSL_set_options_ptr;

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
@@ -39,7 +39,7 @@ static void EnsureLibSsl10Initialized()
 #endif
 
 #ifdef FEATURE_DISTRO_AGNOSTIC_SSL
-// redirect all SSL_CTX_set_options and SSL_set_options calss via dynamic shims
+// redirect all SSL_CTX_set_options and SSL_set_options calls via dynamic shims
 // to work around ABI breaking change between 1.1 and 3.0
 
 #undef SSL_CTX_set_options

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
@@ -69,7 +69,7 @@ static uint64_t SSL_set_options_dynamic(SSL* s, uint64_t options)
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-function-type"
-    if (API_EXISTS(ERR_new))
+    if (API_EXISTS(ERR_new)) // OpenSSL 3.0 sentinel function
     {
         // OpenSSL 3.0 and newer, use uint64_t for options
         uint64_t (*func)(SSL* s, uint64_t op) = (uint64_t(*)(SSL*, uint64_t))SSL_set_options_ptr;


### PR DESCRIPTION
This works around ABI breaking change made between OpenSSL 1.1 and 3.0 where argument type and return type was changed from unsigned long to uint64_t, which caused issues on arm32 architectures with OpenSSL 3.0 installed.

I tried to solve it in a way that does not require explicit knowledge of "I can't call `SSL_set_options` directly, I must use *that dynamic shim*", so if we are compiling with `FEATURE_DISTRO_AGNOSTIC_SSL`, `SSL_CTX_set_options` and `SSL_set_options` macros are redefined in `pal_ssl.c` to point to the dynamic shims.

Unfortunately, I didn't find a reasonable way to redefine these macros globally (see [this GodBolt](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:___c,selection:(endColumn:1,endLineNumber:21,positionColumn:1,positionLineNumber:21,selectionStartColumn:1,selectionStartLineNumber:21,startColumn:1,startLineNumber:21),source:'unsigned+long+SSL_CTX_set_options(SSL_CTX+*ctx,+unsigned+long+op)%3B%0A%0A%23ifndef+TYPEOF%0A%23ifdef+__cplusplus%0A%23define+TYPEOF+decltype%0A%23else%0A%23define+TYPEOF+__typeof%0A%23endif+//+__cplusplus%0A%23endif+//+TYPEOF%0A%0A%23define+FOR_ALL_OPENSSL_FUNCTIONS+%5C%0A++++FALLBACK_FUNCTION(SSL_CTX_set_options)%0A%0A%23define+FALLBACK_FUNCTION(fn)+extern+TYPEOF(fn)*+fn%23%23_ptr%3B%0AFOR_ALL_OPENSSL_FUNCTIONS%0A%23undef+FALLBACK_FUNCTION%0A%0A%23define+SSL_CTX_set_options+SSL_CTX_set_options_dynamic+//+point+to+a+shim+to+work+around+ABI+breaking+change+between+1.1+and+3.0,+function+defined+in+pal_ssl.c%0A%0A%23define+FALLBACK_FUNCTION(fn)+TYPEOF(fn)+fn%23%23_ptr%3B%0AFOR_ALL_OPENSSL_FUNCTIONS%0A%23undef+FALLBACK_FUNCTION%0A%0Auint64_t+SSL_CTX_set_options_dynamic(SSL_CTX*+ctx,+uint64_t+options)%0A%7B%0A%23pragma+clang+diagnostic+push%0A%23pragma+clang+diagnostic+ignored+%22-Wcast-function-type%22%0A++++if+(ERR_new)+//+OpenSSL+3.0+sentinel+function%0A++++%7B%0A++++++++//+OpenSSL+3.0+and+newer,+use+uint64_t+for+options%0A++++++++uint64_t+(*func)(SSL_CTX*+ctx,+uint64_t+op)+%3D+(uint64_t(*)(SSL_CTX*,+uint64_t))SSL_CTX_set_options_ptr%3B%0A++++++++return+func(ctx,+options)%3B%0A++++%7D%0A++++else%0A++++%7B%0A++++++++//+OpenSSL+1.1+and+earlier,+use+uint32_t+for+options%0A++++++++uint32_t+(*func)(SSL_CTX*+ctx,+uint32_t+op)+%3D+(uint32_t(*)(SSL_CTX*,+uint32_t))SSL_CTX_set_options_ptr%3B%0A++++++++return+func(ctx,+(uint32_t)options)%3B%0A++++%7D%0A%23pragma+clang+diagnostic+pop%0A%7D'),l:'5',n:'0',o:'C+source+%231',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:cclang1301,filters:(b:'0',binary:'1',commentOnly:'0',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'0',trim:'1'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:___c,libs:!(),options:'-E',selection:(endColumn:29,endLineNumber:12,positionColumn:29,positionLineNumber:12,selectionStartColumn:29,selectionStartLineNumber:12,startColumn:29,startLineNumber:12),source:1,tree:'1'),l:'5',n:'0',o:'x86-64+clang+13.0.1+(C,+Editor+%231,+Compiler+%231)',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4) for my attempt). But I don't expect these functions to be ever called from other files.

Fixes #66310