### PR TITLE
Update the latest node for markdownlint

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 16.x
     - name: Run Markdownlint
       run: |
         echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"


### PR DESCRIPTION
Node.js 12 is going [out-of-support in about a month](https://nodejs.org/en/about/releases/). This updates the action to use Node.js 16 LTS. 