### PR TITLE
Fix nullable annotations in `EventSourceLogger`

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.EventSource/src/EventSourceLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventSource/src/EventSourceLogger.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Extensions.Logging.EventSource
             }
         }
 
-        public IDisposable BeginScope<TState>(TState state)
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull
         {
             if (!IsEnabled(LogLevel.Critical))
             {


### PR DESCRIPTION
Fix issue introduced in #66802 since CI wasn't rerun after #66960 was merged.

@eerhardt could you please merge this asap? From my point of view right now all CI runs for this repo would fail