### PR TITLE
[release/6.0] Add a --aot-lazy-assembly-load command line option to load assemblies

### DIFF
--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -62,6 +62,7 @@
 #include <mono/utils/mono-threads-coop.h>
 #include <mono/utils/bsearch.h>
 #include <mono/utils/mono-tls-inline.h>
+#include <mono/utils/options.h>
 
 #include "mini.h"
 #include "seq-points.h"
@@ -1895,7 +1896,6 @@ load_aot_module (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer 
 	gpointer *globals = NULL;
 	MonoAotFileInfo *info = NULL;
 	int i, version;
-	gboolean do_load_image = TRUE;
 	int align_double, align_int64;
 	guint8 *aot_data = NULL;
 
@@ -2289,7 +2289,7 @@ load_aot_module (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer 
 	 * non-lazily, since we can't handle out-of-date errors later.
 	 * The cached class info also depends on the exact assemblies.
 	 */
-	if (do_load_image) {
+	if (!mono_opt_aot_lazy_assembly_load) {
 		for (i = 0; i < amodule->image_table_len; ++i) {
 			ERROR_DECL (error);
 			load_image (amodule, i, error);

--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -1787,10 +1787,22 @@ parse_qualified_method_name (char *method_name)
 void
 mono_jit_parse_options (int argc, char * argv[])
 {
+	ERROR_DECL (error);
 	int i;
 	char *trace_options = NULL;
 	int mini_verbose_level = 0;
 	guint32 opt;
+
+	/* Make a copy since mono_options_parse_options () modifies argv */
+	char **copy_argv = g_new0 (char*, argc);
+	memcpy (copy_argv, argv, sizeof (char*) * argc);
+	argv = copy_argv;
+
+	mono_options_parse_options ((const char**)argv, argc, &argc, error);
+	if (!is_ok (error)) {
+		g_printerr ("%s", mono_error_get_message (error));
+		mono_error_cleanup (error);
+	}
 
 	/* 
 	 * Some options have no effect here, since they influence the behavior of 
@@ -1880,6 +1892,9 @@ mono_jit_parse_options (int argc, char * argv[])
 
 	if (mini_verbose_level)
 		mono_set_verbose_level (mini_verbose_level);
+
+	/* Free the copy */
+	g_free (argv);
 }
 
 static void

--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -60,6 +60,7 @@ DEFINE_BOOL_READONLY(readonly_flag, "readonly-flag", FALSE, "Example")
 #endif
 */
 
+DEFINE_BOOL(aot_lazy_assembly_load, "aot-lazy-assembly-load", FALSE, "Load assemblies referenced by AOT images lazily")
 /* Cleanup */
 #undef DEFINE_OPTION_FULL
 #undef DEFINE_OPTION_READONLY

--- a/src/mono/mono/utils/options.c
+++ b/src/mono/mono/utils/options.c
@@ -86,7 +86,7 @@ mono_options_print_usage (void)
 }
 
 /*
- * mono_optiond_parse_options:
+ * mono_options_parse_options:
  *
  *   Set options based on the command line arguments in ARGV/ARGC.
  * Remove processed arguments from ARGV and set *OUT_ARGC to the


### PR DESCRIPTION
Backport of  #67024, related to #66361 

---

# Customer Impact

This PR aims to improve startup performance for MAUI apps using profiled AOT on Android and iOS.
It adds a new option to the Mono runtime to load assemblies referenced by AOT image lazily when they are first needed rather than eagerly when the AOT image is first loaded. 

# Testing

Manual testing

# Risk

Low.  The new option is not on by default (although the .NET MAUI team may choose to turn it on by default in certain scenarios).  With the option off, we use the old AOT loading algorithm that loads all referenced assemblies eagerly.
