### PR TITLE
Make the cross-component build just another invocation of the build-runtime script

### DIFF
--- a/docs/workflow/building/coreclr/cross-building.md
+++ b/docs/workflow/building/coreclr/cross-building.md
@@ -137,6 +137,26 @@ If you wanted to support armv7 CPU with VFPv3-d16, you'd use the following compi
 ./src/coreclr/build-runtime.sh -cross -arm -cmakeargs -DCLR_ARM_FPU_CAPABILITY=0x3 -cmakeargs -DCLR_ARM_FPU_TYPE=vfpv3-d16
 ```
 
+Building the Cross-Targeting Tools
+------------------------------------
+
+Some parts of our build process need some native components that are built for the current machine architecture, even when you are building for a different target architecture. These tools are referred to as cross-targeting tools or "cross tools". There are two categories of these tools today:
+
+- Crossgen2 JIT tools
+- Diagnostic libraries
+
+The Crossgen2 JIT tools are used to run Crossgen2 on libraries built during the current build, such as during the clr.nativecorelib stage. These tools are automatically built when using the `./build.cmd` or `./build.sh` scripts at the root of the repo to build any of the CoreCLR native files, but they are not automatically built when using the `build-runtime.cmd/sh` scripts. To build these tools, you need to pass the `-hostarch` flag with the architecture of the host machine and the `-component crosscomponents` flag to specify that you only want to build the cross-targetting tools. For example:
+
+```
+./src/coreclr/build-runtime.sh -arm -hostarch x64 -component crosscomponents
+```
+
+On Windows, the cross-targeting diagnostic libraries are built with the `linuxdac` and `alpinedac` subsets from the root `build.cmd` script, but they can also be built manually with the `build-runtime.cmd` scripts. These builds also require you to pass the `-os` flag to specify the target OS. For example:
+
+```
+.\src\coreclr\build-runtime.cmd -arm64 -hostarch x64 -os Linux -component crosscomponents
+```
+
 Build System.Private.CoreLib on Ubuntu
 --------------------------------------
 The following instructions assume you are on a Linux machine such as Ubuntu 14.04 x86 64bit.

--- a/docs/workflow/building/coreclr/cross-building.md
+++ b/docs/workflow/building/coreclr/cross-building.md
@@ -148,14 +148,16 @@ Some parts of our build process need some native components that are built for t
 The Crossgen2 JIT tools are used to run Crossgen2 on libraries built during the current build, such as during the clr.nativecorelib stage. These tools are automatically built when using the `./build.cmd` or `./build.sh` scripts at the root of the repo to build any of the CoreCLR native files, but they are not automatically built when using the `build-runtime.cmd/sh` scripts. To build these tools, you need to pass the `-hostarch` flag with the architecture of the host machine and the `-component crosscomponents` flag to specify that you only want to build the cross-targetting tools. For example:
 
 ```
-./src/coreclr/build-runtime.sh -arm -hostarch x64 -component crosscomponents
+./src/coreclr/build-runtime.sh -arm -hostarch x64 -component crosscomponents -cmakeargs  -DCLR_CROSS_COMPONENTS_BUILD=1
 ```
 
 On Windows, the cross-targeting diagnostic libraries are built with the `linuxdac` and `alpinedac` subsets from the root `build.cmd` script, but they can also be built manually with the `build-runtime.cmd` scripts. These builds also require you to pass the `-os` flag to specify the target OS. For example:
 
 ```
-.\src\coreclr\build-runtime.cmd -arm64 -hostarch x64 -os Linux -component crosscomponents
+src\coreclr\build-runtime.cmd -arm64 -hostarch x64 -os Linux -component crosscomponents -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1"
 ```
+
+If you're building the cross-components in powershell, you'll need to wrap `"-DCLR_CROSS_COMPONENTS_BUILD=1"` with single quotes (`'`) to ensure things are escaped correctly for CMD.
 
 Build System.Private.CoreLib on Ubuntu
 --------------------------------------

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -235,7 +235,7 @@
                             ClrCrossComponentsSubset=true;
                             HostArchitecture=$(BuildArchitecture);
                             PgoInstrument=false;
-                            NativeOptimizationDataSupported=false;
+                            NoPgoOptimize=true;
                             CrossBuild=false;
                             CMakeArgs=$(CMakeArgs) -DCLR_CROSS_COMPONENTS_BUILD=1"
       Category="clr" />
@@ -248,7 +248,7 @@
                             ClrCrossComponentsSubset=true;
                             HostArchitecture=x86;
                             PgoInstrument=false;
-                            NativeOptimizationDataSupported=false;
+                            NoPgoOptimize=true;
                             CrossBuild=false;
                             CMakeArgs=$(CMakeArgs) -DCLR_CROSS_COMPONENTS_BUILD=1"
       Category="clr" />
@@ -270,7 +270,7 @@
                             ClrCrossComponentsSubset=true;
                             HostArchitecture=$(CrossDacHostArch);
                             PgoInstrument=false;
-                            NativeOptimizationDataSupported=false;
+                            NoPgoOptimize=true;
                             TargetOS=Linux;
                             CMakeArgs=$(CMakeArgs) -DCLR_CROSS_COMPONENTS_BUILD=1" Category="clr" />
   </ItemGroup>
@@ -282,7 +282,7 @@
                             ClrCrossComponentsSubset=true;
                             HostArchitecture=$(CrossDacHostArch);
                             PgoInstrument=false;
-                            NativeOptimizationDataSupported=false;
+                            NoPgoOptimize=true;
                             TargetOS=alpine;
                             CMakeArgs=$(CMakeArgs) -DCLR_CROSS_COMPONENTS_BUILD=1" Category="clr" />
   </ItemGroup>

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -258,12 +258,19 @@
     <ProjectToBuild Include="$(CoreClrProjectRoot)pal/tests/palsuite/producepaltestlist.proj" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <CrossDacHostArch>x64</CrossDacHostArch>
+    <CrossDacHostArch Condition="'$(TargetArchitecture)' != 'arm'">x86</CrossDacHostArch>
+  </PropertyGroup>
+
   <ItemGroup Condition="$(_subset.Contains('+linuxdac+')) and $([MSBuild]::IsOsPlatform(Windows)) and '$(TargetArchitecture)' != 'x86'">
     <ProjectToBuild
       Include="$(CoreClrProjectRoot)runtime.proj"
       AdditionalProperties="%(AdditionalProperties);
                             ClrCrossComponentsSubset=true;
-                            BuildArchitecture=x64;
+                            HostArchitecture=$(CrossDacHostArch);
+                            PgoInstrument=false;
+                            NativeOptimizationDataSupported=false;
                             TargetOS=Linux;
                             CMakeArgs=$(CMakeArgs) -DCLR_CROSS_COMPONENTS_BUILD=1" Category="clr" />
   </ItemGroup>
@@ -273,7 +280,9 @@
       Include="$(CoreClrProjectRoot)runtime.proj"
       AdditionalProperties="%(AdditionalProperties);
                             ClrCrossComponentsSubset=true;
-                            BuildArchitecture=x64;
+                            HostArchitecture=$(CrossDacHostArch);
+                            PgoInstrument=false;
+                            NativeOptimizationDataSupported=false;
                             TargetOS=alpine;
                             CMakeArgs=$(CMakeArgs) -DCLR_CROSS_COMPONENTS_BUILD=1" Category="clr" />
   </ItemGroup>

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -227,7 +227,8 @@
       Category="clr" />
   </ItemGroup>
 
-  <ItemGroup Condition="('$(ClrRuntimeBuildSubsets)' != '' or $(_subset.Contains('+clr.crossarchtools+'))) and '$(BuildArchitecture)' != '$(TargetArchitecture)'">
+  <!-- Build the CoreCLR cross-arch tools when we're doing a cross-architecture build and either we're building any CoreCLR native tools for platforms CoreCLR fully supports or when someone explicitly requests them -->
+  <ItemGroup Condition="(('$(ClrRuntimeBuildSubsets)' != '' and ('$(PrimaryRuntimeFlavor)' != 'CoreCLR' or '$(TargetsMobile)' != 'true')) or $(_subset.Contains('+clr.crossarchtools+'))) and '$(BuildArchitecture)' != '$(TargetArchitecture)'">
     <ProjectToBuild
       Include="$(CoreClrProjectRoot)runtime.proj"
       AdditionalProperties="%(AdditionalProperties);
@@ -240,7 +241,7 @@
       Category="clr" />
   </ItemGroup>
 
-  <ItemGroup Condition="('$(ClrRuntimeBuildSubsets)' != '' or $(_subset.Contains('+clr.crossarchtools+'))) and $([MSBuild]::IsOsPlatform(Windows)) and '$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' == 'x64'">
+  <ItemGroup Condition="(('$(ClrRuntimeBuildSubsets)' != '' and ('$(PrimaryRuntimeFlavor)' != 'CoreCLR' or '$(TargetsMobile)' != 'true')) or $(_subset.Contains('+clr.crossarchtools+'))) and $([MSBuild]::IsOsPlatform(Windows)) and '$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' == 'x64'">
     <ProjectToBuild
       Include="$(CoreClrProjectRoot)runtime.proj"
       AdditionalProperties="%(AdditionalProperties);

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -58,7 +58,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefaultCoreClrSubsets>clr.native+linuxdac+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs</DefaultCoreClrSubsets>
+    <DefaultCoreClrSubsets>clr.native+linuxdac+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs+clr.crossarchtools</DefaultCoreClrSubsets>
     <!-- Even on platforms that do not support the CoreCLR runtime, we still want to build ilasm/ildasm. -->
     <DefaultCoreClrSubsets Condition="'$(PrimaryRuntimeFlavor)' != 'CoreCLR'">clr.iltools+clr.packages</DefaultCoreClrSubsets>
 
@@ -108,6 +108,7 @@
     <SubsetName Include="Clr.Native" Description="All CoreCLR native non-test components, including the runtime, jits, and other native tools. Includes clr.hosts, clr.runtime, clr.jit, clr.alljits, clr.paltests, clr.iltools, clr.nativeaotruntime, clr.spmi." />
     <SubsetName Include="Clr.NativeAotLibs" Description="The CoreCLR native AOT CoreLib and other low level class libraries." />
     <SubsetName Include="Clr.NativeAotRuntime" Description="The stripped-down CoreCLR native AOT runtime." />
+    <SubsetName Include="Clr.CrossArchTools" Description="The cross-targetted CoreCLR tools." />
     <SubsetName Include="Clr.PalTests" OnDemand="true" Description="The CoreCLR PAL tests." />
     <SubsetName Include="Clr.PalTestList" OnDemand="true" Description="Generate the list of the CoreCLR PAL tests. When using the command line, use Clr.PalTests instead." />
     <SubsetName Include="Clr.Hosts" Description="The CoreCLR corerun test host." />
@@ -226,7 +227,7 @@
       Category="clr" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)'">
+  <ItemGroup Condition="('$(ClrRuntimeBuildSubsets)' != '' or $(_subset.Contains('+clr.crossarchtools+'))) and '$(BuildArchitecture)' != '$(TargetArchitecture)'">
     <ProjectToBuild
       Include="$(CoreClrProjectRoot)runtime.proj"
       AdditionalProperties="%(AdditionalProperties);
@@ -234,11 +235,12 @@
                             HostArchitecture=$(BuildArchitecture);
                             PgoInstrument=false;
                             NativeOptimizationDataSupported=false;
+                            CrossBuild=false;
                             CMakeArgs=$(CMakeArgs) -DCLR_CROSS_COMPONENTS_BUILD=1"
       Category="clr" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' == 'x64'">
+  <ItemGroup Condition="('$(ClrRuntimeBuildSubsets)' != '' or $(_subset.Contains('+clr.crossarchtools+'))) and $([MSBuild]::IsOsPlatform(Windows)) and '$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' == 'x64'">
     <ProjectToBuild
       Include="$(CoreClrProjectRoot)runtime.proj"
       AdditionalProperties="%(AdditionalProperties);
@@ -246,6 +248,7 @@
                             HostArchitecture=x86;
                             PgoInstrument=false;
                             NativeOptimizationDataSupported=false;
+                            CrossBuild=false;
                             CMakeArgs=$(CMakeArgs) -DCLR_CROSS_COMPONENTS_BUILD=1"
       Category="clr" />
   </ItemGroup>

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -260,7 +260,7 @@
 
   <PropertyGroup>
     <CrossDacHostArch>x64</CrossDacHostArch>
-    <CrossDacHostArch Condition="'$(TargetArchitecture)' != 'arm'">x86</CrossDacHostArch>
+    <CrossDacHostArch Condition="'$(TargetArchitecture)' == 'arm'">x86</CrossDacHostArch>
   </PropertyGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+linuxdac+')) and $([MSBuild]::IsOsPlatform(Windows)) and '$(TargetArchitecture)' != 'x86'">

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -228,7 +228,7 @@
   </ItemGroup>
 
   <!-- Build the CoreCLR cross-arch tools when we're doing a cross-architecture build and either we're building any CoreCLR native tools for platforms CoreCLR fully supports or when someone explicitly requests them -->
-  <ItemGroup Condition="(('$(ClrRuntimeBuildSubsets)' != '' and ('$(PrimaryRuntimeFlavor)' != 'CoreCLR' or '$(TargetsMobile)' != 'true')) or $(_subset.Contains('+clr.crossarchtools+'))) and '$(BuildArchitecture)' != '$(TargetArchitecture)'">
+  <ItemGroup Condition="(('$(ClrRuntimeBuildSubsets)' != '' and '$(PrimaryRuntimeFlavor)' == 'CoreCLR' and '$(TargetsMobile)' != 'true') or $(_subset.Contains('+clr.crossarchtools+'))) and '$(BuildArchitecture)' != '$(TargetArchitecture)'">
     <ProjectToBuild
       Include="$(CoreClrProjectRoot)runtime.proj"
       AdditionalProperties="%(AdditionalProperties);
@@ -241,7 +241,7 @@
       Category="clr" />
   </ItemGroup>
 
-  <ItemGroup Condition="(('$(ClrRuntimeBuildSubsets)' != '' and ('$(PrimaryRuntimeFlavor)' != 'CoreCLR' or '$(TargetsMobile)' != 'true')) or $(_subset.Contains('+clr.crossarchtools+'))) and $([MSBuild]::IsOsPlatform(Windows)) and '$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' == 'x64'">
+  <ItemGroup Condition="(('$(ClrRuntimeBuildSubsets)' != '' and '$(PrimaryRuntimeFlavor)' == 'CoreCLR' and '$(TargetsMobile)' != 'true') or $(_subset.Contains('+clr.crossarchtools+'))) and $([MSBuild]::IsOsPlatform(Windows)) and '$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' == 'x64'">
     <ProjectToBuild
       Include="$(CoreClrProjectRoot)runtime.proj"
       AdditionalProperties="%(AdditionalProperties);

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -220,7 +220,34 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(ClrRuntimeBuildSubsets)' != ''">
-    <ProjectToBuild Include="$(CoreClrProjectRoot)runtime.proj" AdditionalProperties="%(AdditionalProperties);$(ClrRuntimeBuildSubsets)" Category="clr" />
+    <ProjectToBuild
+      Include="$(CoreClrProjectRoot)runtime.proj"
+      AdditionalProperties="%(AdditionalProperties);$(ClrRuntimeBuildSubsets)"
+      Category="clr" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)'">
+    <ProjectToBuild
+      Include="$(CoreClrProjectRoot)runtime.proj"
+      AdditionalProperties="%(AdditionalProperties);
+                            ClrCrossComponentsSubset=true;
+                            HostArchitecture=$(BuildArchitecture);
+                            PgoInstrument=false;
+                            NativeOptimizationDataSupported=false;
+                            CMakeArgs=$(CMakeArgs) -DCLR_CROSS_COMPONENTS_BUILD=1"
+      Category="clr" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' == 'x64'">
+    <ProjectToBuild
+      Include="$(CoreClrProjectRoot)runtime.proj"
+      AdditionalProperties="%(AdditionalProperties);
+                            ClrCrossComponentsSubset=true;
+                            HostArchitecture=x86;
+                            PgoInstrument=false;
+                            NativeOptimizationDataSupported=false;
+                            CMakeArgs=$(CMakeArgs) -DCLR_CROSS_COMPONENTS_BUILD=1"
+      Category="clr" />
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+clr.paltestlist+'))">
@@ -228,11 +255,23 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+linuxdac+')) and $([MSBuild]::IsOsPlatform(Windows)) and '$(TargetArchitecture)' != 'x86'">
-    <ProjectToBuild Include="$(CoreClrProjectRoot)runtime.proj" AdditionalProperties="%(AdditionalProperties);$(ClrDefaultRuntimeBuildSubsets);CrossDac=linux" Category="clr" />
+    <ProjectToBuild
+      Include="$(CoreClrProjectRoot)runtime.proj"
+      AdditionalProperties="%(AdditionalProperties);
+                            ClrCrossComponentsSubset=true;
+                            BuildArchitecture=x64;
+                            TargetOS=Linux;
+                            CMakeArgs=$(CMakeArgs) -DCLR_CROSS_COMPONENTS_BUILD=1" Category="clr" />
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+alpinedac+')) and $([MSBuild]::IsOsPlatform(Windows)) and '$(TargetArchitecture)' != 'x86'">
-    <ProjectToBuild Include="$(CoreClrProjectRoot)runtime.proj" AdditionalProperties="%(AdditionalProperties);$(ClrDefaultRuntimeBuildSubsets);CrossDac=alpine" Category="clr" />
+    <ProjectToBuild
+      Include="$(CoreClrProjectRoot)runtime.proj"
+      AdditionalProperties="%(AdditionalProperties);
+                            ClrCrossComponentsSubset=true;
+                            BuildArchitecture=x64;
+                            TargetOS=alpine;
+                            CMakeArgs=$(CMakeArgs) -DCLR_CROSS_COMPONENTS_BUILD=1" Category="clr" />
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+crossdacpack+'))">

--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -424,7 +424,9 @@ while :; do
     shift
 done
 
-__HostArch=$__TargetArch
+if [[ -z "$__HostArch" ]]; then
+    __HostArch=$__TargetArch
+fi
 
 __CommonMSBuildArgs="/p:TargetArchitecture=$__TargetArch /p:Configuration=$__BuildType /p:TargetOS=$__TargetOS /nodeReuse:false $__OfficialBuildIdArg $__SignTypeArg $__SkipRestoreArg"
 

--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -229,7 +229,6 @@ usage()
 source "$__RepoRootDir/eng/native/init-os-and-arch.sh"
 
 __TargetArch=$arch
-__HostArch=$arch
 __TargetOS=$os
 __HostOS=$os
 __BuildOS=$os
@@ -424,6 +423,8 @@ while :; do
 
     shift
 done
+
+__HostArch=$__TargetArch
 
 __CommonMSBuildArgs="/p:TargetArchitecture=$__TargetArch /p:Configuration=$__BuildType /p:TargetOS=$__TargetOS /nodeReuse:false $__OfficialBuildIdArg $__SignTypeArg $__SkipRestoreArg"
 

--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -11,7 +11,7 @@ initTargetDistroRid()
         passedRootfsDir="$ROOTFS_DIR"
     fi
 
-    initDistroRidGlobal "$__TargetOS" "$__BuildArch" "$__PortableBuild" "$passedRootfsDir"
+    initDistroRidGlobal "$__TargetOS" "$__TargetArch" "$__PortableBuild" "$passedRootfsDir"
 }
 
 setup_dirs()
@@ -53,7 +53,7 @@ build_native()
     fi
 
     targetOS="$1"
-    platformArch="$2"
+    hostArch="$2"
     cmakeDir="$3"
     intermediatesDir="$4"
     target="$5"
@@ -61,15 +61,15 @@ build_native()
     message="$7"
 
     # All set to commence the build
-    echo "Commencing build of \"$target\" target in \"$message\" for $__TargetOS.$__BuildArch.$__BuildType in $intermediatesDir"
+    echo "Commencing build of \"$target\" target in \"$message\" for $__TargetOS.$__TargetArch.$__BuildType in $intermediatesDir"
 
     if [[ "$targetOS" == OSX || "$targetOS" == MacCatalyst ]]; then
-        if [[ "$platformArch" == x64 ]]; then
+        if [[ "$hostArch" == x64 ]]; then
             cmakeArgs="-DCMAKE_OSX_ARCHITECTURES=\"x86_64\" $cmakeArgs"
-        elif [[ "$platformArch" == arm64 ]]; then
+        elif [[ "$hostArch" == arm64 ]]; then
             cmakeArgs="-DCMAKE_OSX_ARCHITECTURES=\"arm64\" $cmakeArgs"
         else
-            echo "Error: Unknown OSX architecture $platformArch."
+            echo "Error: Unknown OSX architecture $hostArch."
             exit 1
         fi
     fi
@@ -90,16 +90,16 @@ build_native()
         # Don't try to set CC/CXX in init-compiler.sh - it's handled in android.toolchain.cmake already
         __Compiler="default"
 
-        if [[ "$platformArch" == x64 ]]; then
+        if [[ "$hostArch" == x64 ]]; then
             cmakeArgs="-DANDROID_ABI=x86_64 $cmakeArgs"
-        elif [[ "$platformArch" == x86 ]]; then
+        elif [[ "$hostArch" == x86 ]]; then
             cmakeArgs="-DANDROID_ABI=x86 $cmakeArgs"
-        elif [[ "$platformArch" == arm64 ]]; then
+        elif [[ "$hostArch" == arm64 ]]; then
             cmakeArgs="-DANDROID_ABI=arm64-v8a $cmakeArgs"
-        elif [[ "$platformArch" == arm ]]; then
+        elif [[ "$hostArch" == arm ]]; then
             cmakeArgs="-DANDROID_ABI=armeabi-v7a $cmakeArgs"
         else
-            echo "Error: Unknown Android architecture $platformArch."
+            echo "Error: Unknown Android architecture $hostArch."
             exit 1
         fi
     fi
@@ -117,7 +117,7 @@ build_native()
             scan_build=scan-build
         fi
 
-        nextCommand="\"$__RepoRootDir/eng/native/gen-buildsys.sh\" \"$cmakeDir\" \"$intermediatesDir\" $platformArch $__Compiler $__BuildType \"$generator\" $scan_build $cmakeArgs"
+        nextCommand="\"$__RepoRootDir/eng/native/gen-buildsys.sh\" \"$cmakeDir\" \"$intermediatesDir\" $hostArch $__Compiler $__BuildType \"$generator\" $scan_build $cmakeArgs"
         echo "Invoking $nextCommand"
         eval $nextCommand
 
@@ -228,7 +228,7 @@ usage()
 
 source "$__RepoRootDir/eng/native/init-os-and-arch.sh"
 
-__BuildArch=$arch
+__TargetArch=$arch
 __HostArch=$arch
 __TargetOS=$os
 __HostOS=$os
@@ -267,19 +267,19 @@ while :; do
             ;;
 
         arm|-arm)
-            __BuildArch=arm
+            __TargetArch=arm
             ;;
 
         armv6|-armv6)
-            __BuildArch=armv6
+            __TargetArch=armv6
             ;;
 
         arm64|-arm64)
-            __BuildArch=arm64
+            __TargetArch=arm64
             ;;
 
         armel|-armel)
-            __BuildArch=armel
+            __TargetArch=armel
             ;;
 
         bindir|-bindir)
@@ -374,23 +374,23 @@ while :; do
             ;;
 
         x86|-x86)
-            __BuildArch=x86
+            __TargetArch=x86
             ;;
 
         x64|-x64)
-            __BuildArch=x64
+            __TargetArch=x64
             ;;
 
         loongarch64|-loongarch64)
-            __BuildArch=loongarch64
+            __TargetArch=loongarch64
             ;;
 
         s390x|-s390x)
-            __BuildArch=s390x
+            __TargetArch=s390x
             ;;
 
         wasm|-wasm)
-            __BuildArch=wasm
+            __TargetArch=wasm
             ;;
 
         os|-os)
@@ -399,6 +399,16 @@ while :; do
                 shift
             else
                 echo "ERROR: 'os' requires a non-empty option argument"
+                exit 1
+            fi
+            ;;
+
+        hostarch|-hostarch)
+            if [[ -n "$2" ]]; then
+                __HostArch="$2"
+                shift
+            else
+                echo "ERROR: 'hostarch' requires a non-empty option argument"
                 exit 1
             fi
             ;;
@@ -415,7 +425,7 @@ while :; do
     shift
 done
 
-__CommonMSBuildArgs="/p:TargetArchitecture=$__BuildArch /p:Configuration=$__BuildType /p:TargetOS=$__TargetOS /nodeReuse:false $__OfficialBuildIdArg $__SignTypeArg $__SkipRestoreArg"
+__CommonMSBuildArgs="/p:TargetArchitecture=$__TargetArch /p:Configuration=$__BuildType /p:TargetOS=$__TargetOS /nodeReuse:false $__OfficialBuildIdArg $__SignTypeArg $__SkipRestoreArg"
 
 # Configure environment if we are doing a verbose build
 if [[ "$__VerboseBuild" == 1 ]]; then
@@ -428,7 +438,7 @@ if [[ "$__PortableBuild" == 0 ]]; then
     __CommonMSBuildArgs="$__CommonMSBuildArgs /p:PortableBuild=false"
 fi
 
-if [[ "$__BuildArch" == wasm ]]; then
+if [[ "$__TargetArch" == wasm ]]; then
     # nothing to do here
     true
 elif [[ "$__TargetOS" == iOS || "$__TargetOS" == iOSSimulator ]]; then
@@ -450,7 +460,7 @@ if [[ "$__CrossBuild" == 1 ]]; then
     export CROSSCOMPILE
     # Darwin that doesn't use rootfs
     if [[ -z "$ROOTFS_DIR" && "$platform" != "Darwin" ]]; then
-        ROOTFS_DIR="$__RepoRootDir/.tools/rootfs/$__BuildArch"
+        ROOTFS_DIR="$__RepoRootDir/.tools/rootfs/$__TargetArch"
         export ROOTFS_DIR
     fi
 fi

--- a/eng/native/gen-buildsys.sh
+++ b/eng/native/gen-buildsys.sh
@@ -10,7 +10,7 @@ if [[ "$#" -lt 4 ]]; then
   echo "gen-buildsys.sh <path to top level CMakeLists.txt> <path to intermediate directory> <Architecture> <compiler> [build flavor] [ninja] [scan-build] [cmakeargs]"
   echo "Specify the path to the top level CMake file."
   echo "Specify the path that the build system files are generated in."
-  echo "Specify the target architecture."
+  echo "Specify the host architecture (the architecture the built tools should run on)."
   echo "Specify the name of compiler (clang or gcc)."
   echo "Optionally specify the build configuration (flavor.) Defaults to DEBUG."
   echo "Optionally specify 'scan-build' to enable build with clang static analyzer."
@@ -19,12 +19,12 @@ if [[ "$#" -lt 4 ]]; then
   exit 1
 fi
 
-build_arch="$3"
+host_arch="$3"
 compiler="$4"
 
 if [[ "$compiler" != "default" ]]; then
     nativescriptroot="$( cd -P "$scriptroot/../common/native" && pwd )"
-    source "$nativescriptroot/init-compiler.sh" "$nativescriptroot" "$build_arch" "$compiler"
+    source "$nativescriptroot/init-compiler.sh" "$nativescriptroot" "$host_arch" "$compiler"
 
     CCC_CC="$CC"
     CCC_CXX="$CXX"
@@ -67,7 +67,7 @@ if [[ "$CROSSCOMPILE" == "1" ]]; then
         exit 1
     fi
 
-    TARGET_BUILD_ARCH="$build_arch"
+    TARGET_BUILD_ARCH="$host_arch"
     export TARGET_BUILD_ARCH
 
     cmake_extra_defines="$cmake_extra_defines -C $scriptroot/tryrun.cmake"
@@ -79,7 +79,7 @@ if [[ "$CROSSCOMPILE" == "1" ]]; then
     fi
 fi
 
-if [[ "$build_arch" == "armel" ]]; then
+if [[ "$host_arch" == "armel" ]]; then
     cmake_extra_defines="$cmake_extra_defines -DARM_SOFTFP=1"
 fi
 
@@ -92,7 +92,7 @@ if [[ "$scan_build" == "ON" && -n "$SCAN_BUILD_COMMAND" ]]; then
     cmake_command="$SCAN_BUILD_COMMAND $cmake_command"
 fi
 
-if [[ "$build_arch" == "wasm" ]]; then
+if [[ "$host_arch" == "wasm" ]]; then
     cmake_command="emcmake $cmake_command"
 fi
 

--- a/eng/nativepgo.targets
+++ b/eng/nativepgo.targets
@@ -10,10 +10,15 @@
     <_NativeOptimizationDataPackageTarget Condition="'$(TargetOS)' == 'windows'">windows_nt-$(TargetArchitecture.ToLower())</_NativeOptimizationDataPackageTarget>
 
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="optimization.$(_NativeOptimizationDataPackageTarget).PGO.CoreCLR"
+  <ItemGroup Condition="'$(optimizationPGOCoreCLRVersion)'!='' And '$(NativeOptimizationDataSupported)'=='true'">
+    <PackageReference Include="optimization.windows_nt-x64.PGO.CoreCLR"
       Version="$(optimizationPGOCoreCLRVersion)"
-      Condition="'$(optimizationPGOCoreCLRVersion)'!='' And '$(NativeOptimizationDataSupported)'=='true'"
+      GeneratePathProperty="true" />
+    <PackageReference Include="optimization.windows_nt-x86.PGO.CoreCLR"
+      Version="$(optimizationPGOCoreCLRVersion)"
+      GeneratePathProperty="true" />
+    <PackageReference Include="optimization.linux-x64.PGO.CoreCLR"
+      Version="$(optimizationPGOCoreCLRVersion)"
       GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/eng/nativepgo.targets
+++ b/eng/nativepgo.targets
@@ -3,14 +3,13 @@
     <NativeOptimizationDataSupported Condition="'$(TargetOS)' == 'windows' And ('$(TargetArchitecture)' == 'x64' Or '$(TargetArchitecture)' == 'x86')">true</NativeOptimizationDataSupported>
     <NativeOptimizationDataSupported Condition="'$(TargetOS)' == 'Linux' And '$(TargetArchitecture)' == 'x64'">true</NativeOptimizationDataSupported>
     <NativeOptimizationDataSupported Condition="'$(NoPgoOptimize)' == 'true'">false</NativeOptimizationDataSupported>
-    <NativeOptimizationDataSupported Condition="'$(DotNetBuildFromSource)' == 'true'">false</NativeOptimizationDataSupported>
     <NativeOptimizationDataSupported Condition="'$(Configuration)' != 'Release'">false</NativeOptimizationDataSupported>
 
     <_NativeOptimizationDataPackageTarget>$(TargetOS.ToLower())-$(TargetArchitecture.ToLower())</_NativeOptimizationDataPackageTarget>
     <_NativeOptimizationDataPackageTarget Condition="'$(TargetOS)' == 'windows'">windows_nt-$(TargetArchitecture.ToLower())</_NativeOptimizationDataPackageTarget>
 
   </PropertyGroup>
-  <ItemGroup Condition="'$(optimizationPGOCoreCLRVersion)'!='' And '$(NativeOptimizationDataSupported)'=='true'">
+  <ItemGroup Condition="'$(optimizationPGOCoreCLRVersion)'!='' and '$(DotNetBuildFromSource)' != 'true'">
     <PackageReference Include="optimization.windows_nt-x64.PGO.CoreCLR"
       Version="$(optimizationPGOCoreCLRVersion)"
       GeneratePathProperty="true" />

--- a/eng/pipelines/coreclr/templates/build-jit-job.yml
+++ b/eng/pipelines/coreclr/templates/build-jit-job.yml
@@ -106,7 +106,7 @@ jobs:
       - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) $(crossArg) -ci $(compilerArg) -component alljits -component spmi
         displayName: Build CoreCLR JIT
     - ${{ if eq(parameters.osGroup, 'windows') }}:
-      - script: set __TestIntermediateDir=int&&$(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -ci -component alljits -component spmi
+      - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -ci -component alljits -component spmi
         displayName: Build CoreCLR JIT
 
     - ${{ if eq(parameters.uploadAs, 'azureBlob') }}:

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -293,11 +293,20 @@ jobs:
           displayName: 'product build'
 
     - ${{ if and(in(parameters.osGroup, 'windows', 'Linux'), ne(parameters.archType, 'x86'), ne(parameters.compilerName, 'gcc'), ne(parameters.testGroup, 'clrTools'), eq(parameters.pgoType, '')) }}:
-      - template: /eng/pipelines/coreclr/templates/crossdac-build.yml
-        parameters:
-          archType: ${{ parameters.archType }}
-          osGroup: ${{ parameters.osGroup }}
-          osSubgroup: ${{ parameters.osSubgroup }}
+      - ${{ if ne(parameters.archType, 'arm') }}:
+        - template: /eng/pipelines/coreclr/templates/crossdac-build.yml
+          parameters:
+            archType: ${{ parameters.archType }}
+            osGroup: ${{ parameters.osGroup }}
+            osSubgroup: ${{ parameters.osSubgroup }}
+            hostArchType: x64
+      - ${{ if eq(parameters.archType, 'arm') }}:
+        - template: /eng/pipelines/coreclr/templates/crossdac-build.yml
+          parameters:
+            archType: ${{ parameters.archType }}
+            osGroup: ${{ parameters.osGroup }}
+            osSubgroup: ${{ parameters.osSubgroup }}
+            hostArchType: x86
 
     - ${{ if and(ne(parameters.compilerName, 'gcc'), ne(parameters.testGroup, ''), ne(parameters.testGroup, 'clrTools'), ne(parameters.disableClrTest, true)) }}:
       # Publish test native components for consumption by test execution.

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -197,8 +197,16 @@ jobs:
       - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) $(crossArg) $(osArg) -ci $(compilerArg) $(clrRuntimeComponentsBuildArg) $(pgoInstrumentArg) $(officialBuildIdArg) $(clrInterpreterBuildArg) $(clrRuntimePortableBuildArg) $(CoreClrPgoDataArg)
         displayName: Build CoreCLR Runtime
     - ${{ if eq(parameters.osGroup, 'windows') }}:
-      - script: set __TestIntermediateDir=int&&$(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -ci $(enforcePgoArg) $(pgoInstrumentArg) $(officialBuildIdArg) $(clrInterpreterBuildArg) $(CoreClrPgoDataArg)
+      - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -ci $(enforcePgoArg) $(pgoInstrumentArg) $(officialBuildIdArg) $(clrInterpreterBuildArg) $(CoreClrPgoDataArg)
         displayName: Build CoreCLR Runtime
+
+    - ${{ if ne(parameters.archType, 'x64') }}:
+      - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -hostarch x64 $(osArg) -ci $(compilerArg) -component crosscomponents -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" $(officialBuildIdArg) $(clrRuntimePortableBuildArg)
+        displayName: Build CoreCLR Cross-Arch Tools (Tools that run on x64 targetting x86)
+
+    - ${{ if and(eq(parameters.osGroup, 'windows'), eq(parameters.archType, 'arm')) }}:
+      - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -hostarch x86 $(osArg) -ci $(compilerArg) -component crosscomponents -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" $(officialBuildIdArg) $(clrRuntimePortableBuildArg)
+        displayName: Build CoreCLR Cross-Arch Tools (Tools that run on x86 targetting arm)
 
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:
       - script: |

--- a/eng/pipelines/coreclr/templates/crossdac-build.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-build.yml
@@ -2,14 +2,15 @@ parameters:
   archType: ''
   osGroup: ''
   osSubgroup: ''
+  hostArchType: ''
 
 steps:
   # Always build the crossdac, that way we know in CI/PR if things break to build.
   - ${{ if and(eq(parameters.osGroup, 'windows'), notin(parameters.archType, 'x86')) }}:
-    - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -hostarch x64 -ci -os Linux -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg) -component crosscomponents
+    - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -hostarch $(hostArchType) -ci -os Linux -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg) -component crosscomponents
       displayName: Build Cross OS Linux DAC for Windows
 
-    - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -hostarch x64 -ci -os alpine -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg) -component crosscomponents
+    - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -hostarch $(hostArchType) -ci -os alpine -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg) -component crosscomponents
       displayName: Build Cross OS Linux-musl DAC for Windows
 
     - task: CopyFiles@2

--- a/eng/pipelines/coreclr/templates/crossdac-build.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-build.yml
@@ -6,10 +6,10 @@ parameters:
 steps:
   # Always build the crossdac, that way we know in CI/PR if things break to build.
   - ${{ if and(eq(parameters.osGroup, 'windows'), notin(parameters.archType, 'x86')) }}:
-    - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -ci -os Linux -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg)
+    - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -hostarch x64 -ci -os Linux -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg) -component crosscomponents
       displayName: Build Cross OS Linux DAC for Windows
 
-    - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -ci -os alpine -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg)
+    - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -hostarch x64 -ci -os alpine -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg) -component crosscomponents
       displayName: Build Cross OS Linux-musl DAC for Windows
 
     - task: CopyFiles@2

--- a/eng/pipelines/coreclr/templates/crossdac-build.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-build.yml
@@ -7,10 +7,10 @@ parameters:
 steps:
   # Always build the crossdac, that way we know in CI/PR if things break to build.
   - ${{ if and(eq(parameters.osGroup, 'windows'), notin(parameters.archType, 'x86')) }}:
-    - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -hostarch $(hostArchType) -ci -os Linux -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg) -component crosscomponents
+    - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -hostarch ${{ parameters.hostArchType }} -ci -os Linux -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg) -component crosscomponents
       displayName: Build Cross OS Linux DAC for Windows
 
-    - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -hostarch $(hostArchType) -ci -os alpine -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg) -component crosscomponents
+    - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -hostarch ${{ parameters.hostArchType }} -ci -os alpine -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg) -component crosscomponents
       displayName: Build Cross OS Linux-musl DAC for Windows
 
     - task: CopyFiles@2

--- a/eng/pipelines/coreclr/templates/crossdac-build.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-build.yml
@@ -6,10 +6,10 @@ parameters:
 steps:
   # Always build the crossdac, that way we know in CI/PR if things break to build.
   - ${{ if and(eq(parameters.osGroup, 'windows'), notin(parameters.archType, 'x86')) }}:
-    - script: set __TestIntermediateDir=int&&$(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -ci -linuxdac -ninja $(officialBuildIdArg)
+    - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -ci -os Linux -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg)
       displayName: Build Cross OS Linux DAC for Windows
 
-    - script: set __TestIntermediateDir=int&&$(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -ci -alpinedac -ninja $(officialBuildIdArg)
+    - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -ci -os alpine -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg)
       displayName: Build Cross OS Linux-musl DAC for Windows
 
     - task: CopyFiles@2

--- a/src/coreclr/_build-commons.sh
+++ b/src/coreclr/_build-commons.sh
@@ -1,25 +1,12 @@
 #!/usr/bin/env bash
 
 usage_list+=("-coverage: optional argument to enable code coverage build (currently supported only for Linux and OSX).")
-usage_list+=("-skipmanaged: do not build managed components.")
-usage_list+=("-skipnative: do not build native components.")
 
 handle_arguments() {
 
     case "$1" in
         coverage|-coverage)
             __CodeCoverage=1
-            ;;
-
-        skipmanaged|-skipmanaged)
-            __SkipManaged=1
-            __BuildTestWrappers=0
-            ;;
-
-        skipnative|-skipnative)
-            __SkipNative=1
-            __SkipCoreCLR=1
-            __CopyNativeProjectsAfterCombinedTestBuild=false
             ;;
 
         *)

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -10,20 +10,20 @@ echo %__MsgPrefix%Starting Build at %TIME%
 set __ThisScriptFull="%~f0"
 
 :: Note that the msbuild project files (specifically, dir.proj) will use the following variables, if set:
-::      __BuildArch         -- default: x64
+::      __TargetArch         -- default: x64
 ::      __BuildType         -- default: Debug
 ::      __TargetOS          -- default: windows
 ::      __ProjectDir        -- default: directory of the dir.props file
 ::      __RepoRootDir       -- default: directory two levels above the dir.props file
 ::      __RootBinDir        -- default: %__RepoRootDir%\artifacts\
-::      __BinDir            -- default: %__RootBinDir%\obj\coreclr\%__TargetOS%.%__BuildArch.%__BuildType%\
+::      __BinDir            -- default: %__RootBinDir%\obj\coreclr\%__TargetOS%.%__TargetArch.%__BuildType%\
 ::      __IntermediatesDir
 ::      __PackagesBinDir    -- default: %__BinDir%\.nuget
 ::
 :: Thus, these variables are not simply internal to this script!
 
 :: Set the default arguments for build
-set __BuildArch=x64
+set __TargetArch=x64
 set __BuildType=Debug
 set __TargetOS=windows
 
@@ -38,10 +38,10 @@ set "__RootBinDir=%__RepoRootDir%\artifacts"
 
 set __BuildAll=
 
-set __BuildArchX64=0
-set __BuildArchX86=0
-set __BuildArchArm=0
-set __BuildArchArm64=0
+set __TargetArchX64=0
+set __TargetArchX86=0
+set __TargetArchArm=0
+set __TargetArchArm64=0
 
 set __BuildTypeDebug=0
 set __BuildTypeChecked=0
@@ -50,7 +50,6 @@ set __BuildTypeRelease=0
 set __PgoInstrument=0
 set __PgoOptimize=0
 set __EnforcePgo=0
-set __IbcTuning=
 set __ConsoleLoggingParameters=/clp:ForceNoAlign;Summary
 
 REM __PassThroughArgs is a set of things that will be passed through to nested calls to build.cmd
@@ -62,12 +61,9 @@ set "__remainingArgs=%*"
 set __UnprocessedBuildArgs=
 
 set __BuildNative=1
-set __BuildCrossArchNative=0
-set __SkipCrossArchNative=0
 set __RestoreOptData=1
-set __CrossArch=
-set __CrossArch2=
-set __CrossOS=0
+set __HostArch=
+set __HostArch2=
 set __PgoOptDataPath=
 set __CMakeArgs=
 set __Ninja=1
@@ -86,10 +82,10 @@ if /i "%1" == "-help"  goto Usage
 if /i "%1" == "--help" goto Usage
 
 if /i "%1" == "-all"                 (set __BuildAll=1&shift&goto Arg_Loop)
-if /i "%1" == "-x64"                 (set __BuildArchX64=1&shift&goto Arg_Loop)
-if /i "%1" == "-x86"                 (set __BuildArchX86=1&shift&goto Arg_Loop)
-if /i "%1" == "-arm"                 (set __BuildArchArm=1&shift&goto Arg_Loop)
-if /i "%1" == "-arm64"               (set __BuildArchArm64=1&shift&goto Arg_Loop)
+if /i "%1" == "-x64"                 (set __TargetArchX64=1&shift&goto Arg_Loop)
+if /i "%1" == "-x86"                 (set __TargetArchX86=1&shift&goto Arg_Loop)
+if /i "%1" == "-arm"                 (set __TargetArchArm=1&shift&goto Arg_Loop)
+if /i "%1" == "-arm64"               (set __TargetArchArm64=1&shift&goto Arg_Loop)
 
 if /i "%1" == "-debug"               (set __BuildTypeDebug=1&shift&goto Arg_Loop)
 if /i "%1" == "-checked"             (set __BuildTypeChecked=1&shift&goto Arg_Loop)
@@ -100,10 +96,10 @@ if /i "%1" == "-ci"                  (set __ArcadeScriptArgs="-ci"&set __ErrMsgP
 REM TODO these are deprecated remove them eventually
 REM don't add more, use the - syntax instead
 if /i "%1" == "all"                 (set __BuildAll=1&shift&goto Arg_Loop)
-if /i "%1" == "x64"                 (set __BuildArchX64=1&shift&goto Arg_Loop)
-if /i "%1" == "x86"                 (set __BuildArchX86=1&shift&goto Arg_Loop)
-if /i "%1" == "arm"                 (set __BuildArchArm=1&shift&goto Arg_Loop)
-if /i "%1" == "arm64"               (set __BuildArchArm64=1&shift&goto Arg_Loop)
+if /i "%1" == "x64"                 (set __TargetArchX64=1&shift&goto Arg_Loop)
+if /i "%1" == "x86"                 (set __TargetArchX86=1&shift&goto Arg_Loop)
+if /i "%1" == "arm"                 (set __TargetArchArm=1&shift&goto Arg_Loop)
+if /i "%1" == "arm64"               (set __TargetArchArm64=1&shift&goto Arg_Loop)
 
 if /i "%1" == "debug"               (set __BuildTypeDebug=1&shift&goto Arg_Loop)
 if /i "%1" == "checked"             (set __BuildTypeChecked=1&shift&goto Arg_Loop)
@@ -128,14 +124,13 @@ if [!__PassThroughArgs!]==[] (
     set "__PassThroughArgs=%__PassThroughArgs% %1"
 )
 
-if /i "%1" == "-alpinedac"           (set __BuildNative=0&set __BuildCrossArchNative=1&set __CrossArch=x64&set __CrossOS=1&set __TargetOS=alpine&shift&goto Arg_Loop)
-if /i "%1" == "-linuxdac"            (set __BuildNative=0&set __BuildCrossArchNative=1&set __CrossArch=x64&set __CrossOS=1&set __TargetOS=Linux&shift&goto Arg_Loop)
+if /i "%1" == "-hostarch"            (set __HostArch=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "-os"                  (set __TargetOS=%2&shift&shift&goto Arg_Loop)
 
-if /i "%1" == "-cmakeargs"           (set __CMakeArgs=%2 %__CMakeArgs%&set "__remainingArgs=!__remainingArgs:*%2=!"&shift&shift&goto Arg_Loop)
+if /i "%1" == "-cmakeargs"           (set __CMakeArgs="%2=%3" %__CMakeArgs%&set __remainingArgs="!__remainingArgs:*%2=!"&shift&shift&goto Arg_Loop)
 if /i "%1" == "-configureonly"       (set __ConfigureOnly=1&set __BuildNative=1&shift&goto Arg_Loop)
 if /i "%1" == "-skipconfigure"       (set __SkipConfigure=1&shift&goto Arg_Loop)
 if /i "%1" == "-skipnative"          (set __BuildNative=0&shift&goto Arg_Loop)
-if /i "%1" == "-skipcrossarchnative" (set __SkipCrossArchNative=1&shift&goto Arg_Loop)
 REM -ninja is a no-op option since Ninja is now the default generator on Windows.
 if /i "%1" == "-ninja"               (shift&goto Arg_Loop)
 if /i "%1" == "-msbuild"             (set __Ninja=0&shift&goto Arg_Loop)
@@ -149,7 +144,6 @@ REM don't add more, use the - syntax instead
 if /i "%1" == "configureonly"       (set __ConfigureOnly=1&set __BuildNative=1&shift&goto Arg_Loop)
 if /i "%1" == "skipconfigure"       (set __SkipConfigure=1&shift&goto Arg_Loop)
 if /i "%1" == "skipnative"          (set __BuildNative=0&shift&goto Arg_Loop)
-if /i "%1" == "skipcrossarchnative" (set __SkipCrossArchNative=1&shift&goto Arg_Loop)
 if /i "%1" == "pgoinstrument"       (set __PgoInstrument=1&shift&goto Arg_Loop)
 if /i "%1" == "enforcepgo"          (set __EnforcePgo=1&shift&goto Arg_Loop)
 
@@ -167,8 +161,8 @@ if defined VCINSTALLDIR (
 
 if defined __BuildAll goto BuildAll
 
-set /A __TotalSpecifiedBuildArch=__BuildArchX64 + __BuildArchX86 + __BuildArchArm + __BuildArchArm64
-if %__TotalSpecifiedBuildArch% GTR 1 (
+set /A __TotalSpecifiedTargetArch=__TargetArchX64 + __TargetArchX86 + __TargetArchArm + __TargetArchArm64
+if %__TotalSpecifiedTargetArch% GTR 1 (
     echo Error: more than one build architecture specified, but "all" not specified.
     goto Usage
 )
@@ -176,20 +170,11 @@ if %__TotalSpecifiedBuildArch% GTR 1 (
 set __ProcessorArch=%PROCESSOR_ARCHITEW6432%
 if "%__ProcessorArch%"=="" set __ProcessorArch=%PROCESSOR_ARCHITECTURE%
 
-if %__BuildArchX64%==1      set __BuildArch=x64
-if %__BuildArchX86%==1 (
-    set __BuildArch=x86
-    if /i "%__CrossOS%" NEQ "1" set __CrossArch=x64
-)
-if %__BuildArchArm%==1 (
-    set __BuildArch=arm
-    set __CrossArch=x86
-    if /i "%__CrossOS%" NEQ "1" set __CrossArch2=x64
-)
-if %__BuildArchArm64%==1 (
-    set __BuildArch=arm64
-    if /i not "%__ProcessorArch%"=="ARM64" set __CrossArch=x64
-)
+if %__TargetArchX64%==1   set __TargetArch=x64
+if %__TargetArchX86%==1   set __TargetArch=x86
+if %__TargetArchArm%==1   set __TargetArch=arm
+if %__TargetArchArm64%==1 set __TargetArch=arm64
+if "%__HostArch%" == "" set __HostArch=%__TargetArch%
 
 set /A __TotalSpecifiedBuildType=__BuildTypeDebug + __BuildTypeChecked + __BuildTypeRelease
 if %__TotalSpecifiedBuildType% GTR 1 (
@@ -202,29 +187,13 @@ if %__BuildTypeChecked%==1  set __BuildType=Checked
 if %__BuildTypeRelease%==1  set __BuildType=Release
 
 if %__EnforcePgo%==1 (
-    if %__BuildArchArm%==1 (
+    if %__TargetArchArm%==1 (
         echo NOTICE: enforcepgo does nothing on arm architecture
         set __EnforcePgo=0
     )
-    if %__BuildArchArm64%==1 (
+    if %__TargetArchArm64%==1 (
         echo NOTICE: enforcepgo does nothing on arm64 architecture
         set __EnforcePgo=0
-    )
-)
-
-REM Determine if this is a cross-arch build. Only do cross-arch build if we're also building native.
-
-if %__SkipCrossArchNative% EQU 0 (
-    if %__BuildNative% EQU 1 (
-        if /i "%__BuildArch%"=="arm64" (
-            if defined __CrossArch set __BuildCrossArchNative=1
-        )
-        if /i "%__BuildArch%"=="arm" (
-            set __BuildCrossArchNative=1
-        )
-        if /i "%__BuildArch%"=="x86" (
-            set __BuildCrossArchNative=1
-        )
     )
 )
 
@@ -235,20 +204,17 @@ if NOT "%__BuildType%"=="Release" (
     set __PgoOptimize=0
 )
 
-set "__BinDir=%__RootBinDir%\bin\coreclr\%__TargetOS%.%__BuildArch%.%__BuildType%"
-set "__IntermediatesDir=%__RootBinDir%\obj\coreclr\%__TargetOS%.%__BuildArch%.%__BuildType%"
+set "__BinDir=%__RootBinDir%\bin\coreclr\%__TargetOS%.%__TargetArch%.%__BuildType%"
+set "__IntermediatesDir=%__RootBinDir%\obj\coreclr\%__TargetOS%.%__TargetArch%.%__BuildType%"
 set "__LogsDir=%__RootBinDir%\log\!__BuildType!"
 set "__MsbuildDebugLogsDir=%__LogsDir%\MsbuildDebugLogs"
 set "__ArtifactsIntermediatesDir=%__RepoRootDir%\artifacts\obj\coreclr\"
 if "%__Ninja%"=="0" (set "__IntermediatesDir=%__IntermediatesDir%\ide")
 set "__PackagesBinDir=%__BinDir%\.nuget"
-set "__CrossComponentBinDir=%__BinDir%"
-set "__CrossCompIntermediatesDir=%__IntermediatesDir%\crossgen"
-set "__CrossComp2IntermediatesDir=%__IntermediatesDir%\crossgen_2"
 
 
-if NOT "%__CrossArch%" == "" set __CrossComponentBinDir=%__CrossComponentBinDir%\%__CrossArch%
-if NOT "%__CrossArch2%" == "" set __CrossComponent2BinDir=%__BinDir%\%__CrossArch2%
+if NOT "%__HostArch%" == "%__TargetArch%" set __BinDir=%__BinDir%\%__HostArch%
+if NOT "%__HostArch%" == "%__TargetArch%" set __IntermediatesDir=%__IntermediatesDir%\%__HostArch%
 
 REM Generate path to be set for CMAKE_INSTALL_PREFIX to contain forward slash
 set "__CMakeBinDir=%__BinDir%"
@@ -271,7 +237,7 @@ REM Set the remaining variables based upon the determined build configuration
 
 echo %__MsgPrefix%Checking prerequisites
 
-if %__BuildNative%==0 if %__BuildCrossArchNative%==0 goto SkipLocateCMake
+if %__BuildNative%==0 goto SkipLocateCMake
 
 REM Eval the output from set-cmake-path.ps1
 for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy ByPass "& ""%__RepoRootDir%\eng\native\set-cmake-path.ps1"""') do %%a
@@ -308,7 +274,7 @@ REM ===
 REM =========================================================================================
 
 set __IntermediatesIncDir=%__IntermediatesDir%\src\inc
-set __IntermediatesEventingDir=%__ArtifactsIntermediatesDir%\Eventing\%__BuildArch%\%__BuildType%
+set __IntermediatesEventingDir=%__ArtifactsIntermediatesDir%\Eventing\%__TargetArch%\%__BuildType%
 
 REM Find python and set it to the variable PYTHON
 set _C=-c "import sys; sys.stdout.write(sys.executable)"
@@ -348,172 +314,17 @@ for /f "delims=" %%a in ("-%__RequestedBuildComponents%-") do (
     if not "!string:-spmi-=!"=="!string!" (
         set __CMakeTarget=!__CMakeTarget! spmi
     )
+    if not "!string:-crosscomponents-=!"=="!string!" (
+        set __CMakeTarget=!__CMakeTarget! crosscomponents
+    )
 )
-if [!__CMakeTarget!] == [] (
+if "!__CMakeTarget!" == "" (
     set __CMakeTarget=install
 )
 
 REM =========================================================================================
 REM ===
-REM === Build Cross-Architecture Native Components (if applicable)
-REM ===
-REM =========================================================================================
-
-if %__BuildCrossArchNative% EQU 1 (
-    REM Scope environment changes start {
-    setlocal
-
-    echo %__MsgPrefix%Commencing build of cross architecture native components for %__TargetOS%.%__BuildArch%.%__BuildType%
-
-    REM Set the environment for the cross-arch native build
-    set __VCBuildArch=x86_amd64
-    if /i "%__CrossArch%" == "x86" ( set __VCBuildArch=x86 )
-
-    echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!
-    call                                 "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!
-    @if defined _echo @echo on
-
-    if not exist "%__CrossCompIntermediatesDir%" md "%__CrossCompIntermediatesDir%"
-    if defined __SkipConfigure goto SkipConfigureCrossBuild
-
-    set __CMakeBinDir=%__CrossComponentBinDir%
-    set "__CMakeBinDir=!__CMakeBinDir:\=/!"
-
-    if %__Ninja% EQU 1 (
-        set __ExtraCmakeArgs="-DCMAKE_BUILD_TYPE=!__BuildType!"
-    )
-
-    set __ExtraCmakeArgs=!__ExtraCmakeArgs! "-DCLR_CROSS_COMPONENTS_BUILD=1" "-DCLR_CMAKE_TARGET_ARCH=%__BuildArch%" "-DCLR_CMAKE_TARGET_OS=%__TargetOS%" "-DCLR_CMAKE_PGO_INSTRUMENT=0" "-DCLR_CMAKE_OPTDATA_PATH=%__PgoOptDataPath%" "-DCLR_CMAKE_PGO_OPTIMIZE=0" %__CMakeArgs%
-    call "%__RepoRootDir%\eng\native\gen-buildsys.cmd" "%__ProjectDir%" "%__CrossCompIntermediatesDir%" %__VSVersion% %__CrossArch% !__ExtraCmakeArgs!
-
-    if not !errorlevel! == 0 (
-        echo %__ErrMsgPrefix%%__MsgPrefix%Error: failed to generate cross architecture native component build project %__CrossArch%!
-        goto ExitWithError
-    )
-    @if defined _echo @echo on
-
-:SkipConfigureCrossBuild
-    if not exist "%__CrossCompIntermediatesDir%\CMakeCache.txt" (
-        echo %__ErrMsgPrefix%%__MsgPrefix%Error: unable to find generated cross architecture native component build project %__CrossArch%!
-        goto ExitWithError
-    )
-
-    if defined __ConfigureOnly goto SkipCrossCompBuild
-
-    set __BuildLogRootName=Cross
-    set "__BuildLog="%__LogsDir%\!__BuildLogRootName!_%__TargetOS%__%__BuildArch%__%__BuildType%.log""
-    set "__BuildWrn="%__LogsDir%\!__BuildLogRootName!_%__TargetOS%__%__BuildArch%__%__BuildType%.wrn""
-    set "__BuildErr="%__LogsDir%\!__BuildLogRootName!_%__TargetOS%__%__BuildArch%__%__BuildType%.err""
-    set "__BinLog="%__LogsDir%\!__BuildLogRootName!_%__TargetOS%__%__BuildArch%__%__BuildType%.binlog""
-    set "__MsbuildLog=/flp:Verbosity=normal;LogFile=!__BuildLog!"
-    set "__MsbuildWrn=/flp1:WarningsOnly;LogFile=!__BuildWrn!"
-    set "__MsbuildErr=/flp2:ErrorsOnly;LogFile=!__BuildErr!"
-    set "__MsbuildBinLog=/bl:!__BinLog!"
-    set "__Logging=!__MsbuildLog! !__MsbuildWrn! !__MsbuildErr! !__MsbuildBinLog! !__ConsoleLoggingParameters!"
-
-    set __CmakeBuildToolArgs=
-
-    if %__Ninja% EQU 1 (
-        set __CmakeBuildToolArgs=
-    ) else (
-        REM We pass the /m flag directly to MSBuild so that we can get both MSBuild and CL parallelism, which is fastest for our builds.
-        set __CmakeBuildToolArgs=/nologo /m !__Logging!
-    )
-
-    "%CMakePath%" --build %__CrossCompIntermediatesDir% --target crosscomponents --config %__BuildType% -- !__CmakeBuildToolArgs!
-
-    if not !errorlevel! == 0 (
-        set __exitCode=!errorlevel!
-        echo %__ErrMsgPrefix%%__MsgPrefix%Error: cross-arch components build failed. Refer to the build log files for details.
-        echo     !__BuildLog!
-        echo     !__BuildWrn!
-        echo     !__BuildErr!
-        goto ExitWithCode
-    )
-:SkipCrossCompBuild
-    REM } Scope environment changes end
-    endlocal
-
-    if NOT "%__CrossArch2%" == "" (
-        REM Scope environment changes start {
-        setlocal
-
-        echo %__MsgPrefix%Commencing build of cross architecture native components for %__TargetOS%.%__BuildArch%.%__BuildType% hosted on %__CrossArch2%
-
-        if /i "%__CrossArch2%" == "x86" ( set __VCBuildArch=x86 )
-        if /i "%__CrossArch2%" == "x64" ( set __VCBuildArch=x86_amd64 )
-
-        echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!
-        call                                 "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!
-        @if defined _echo @echo on
-
-        if not exist "%__CrossComp2IntermediatesDir%" md "%__CrossComp2IntermediatesDir%"
-        if defined __SkipConfigure goto SkipConfigureCrossBuild2
-
-        set __CMakeBinDir="%__CrossComponent2BinDir%"
-        set "__CMakeBinDir=!__CMakeBinDir:\=/!"
-
-        if %__Ninja% EQU 1 (
-            set __ExtraCmakeArgs="-DCMAKE_BUILD_TYPE=!__BuildType!"
-        )
-
-        set __ExtraCmakeArgs=!__ExtraCmakeArgs! "-DCLR_CROSS_COMPONENTS_BUILD=1" "-DCLR_CMAKE_TARGET_ARCH=%__BuildArch%" "-DCLR_CMAKE_TARGET_OS=%__TargetOS%" "-DCLR_CMAKE_PGO_INSTRUMENT=0" "-DCLR_CMAKE_OPTDATA_PATH=%__PgoOptDataPath%" "-DCLR_CMAKE_PGO_OPTIMIZE=0" "-DCMAKE_SYSTEM_VERSION=10.0" %__CMakeArgs%
-        call "%__RepoRootDir%\eng\native\gen-buildsys.cmd" "%__ProjectDir%" "%__CrossComp2IntermediatesDir%" %__VSVersion% %__CrossArch2% !__ExtraCmakeArgs!
-
-        if not !errorlevel! == 0 (
-            echo %__ErrMsgPrefix%%__MsgPrefix%Error: failed to generate cross architecture native component build project %__CrossArch2%!
-            goto ExitWithError
-        )
-
-        set __VCBuildArch=x86_amd64
-        if /i "%__CrossArch%" == "x86" ( set __VCBuildArch=x86 )
-        @if defined _echo @echo on
-
-        if not exist "%__CrossComp2IntermediatesDir%\CMakeCache.txt" (
-        echo %__ErrMsgPrefix%%__MsgPrefix%Error: unable to find generated cross architecture native component build project %__CrossArch2%!
-            goto ExitWithError
-        )
-
-:SkipConfigureCrossBuild2
-        set __BuildLogRootName=Cross2
-        set "__BuildLog=%__LogsDir%\!__BuildLogRootName!_%__TargetOS%__%__BuildArch%__%__BuildType%.log"
-        set "__BuildWrn=%__LogsDir%\!__BuildLogRootName!_%__TargetOS%__%__BuildArch%__%__BuildType%.wrn"
-        set "__BuildErr=%__LogsDir%\!__BuildLogRootName!_%__TargetOS%__%__BuildArch%__%__BuildType%.err"
-        set "__BinLog=%__LogsDir%\!__BuildLogRootName!_%__TargetOS%__%__BuildArch%__%__BuildType%.binlog"
-        set "__MsbuildLog=/flp:Verbosity=normal;LogFile=!__BuildLog!"
-        set "__MsbuildWrn=/flp1:WarningsOnly;LogFile=!__BuildWrn!"
-        set "__MsbuildErr=/flp2:ErrorsOnly;LogFile=!__BuildErr!"
-        set "__MsbuildBinLog=/bl:!__BinLog!"
-        set "__Logging=!__MsbuildLog! !__MsbuildWrn! !__MsbuildErr! !__MsbuildBinLog! !__ConsoleLoggingParameters!"
-
-        set __CmakeBuildToolArgs=
-
-        if %__Ninja% EQU 1 (
-            set __CmakeBuildToolArgs=
-        ) else (
-            REM We pass the /m flag directly to MSBuild so that we can get both MSBuild and CL parallelism, which is fastest for our builds.
-            set __CmakeBuildToolArgs=/nologo /m !__Logging!
-        )
-
-        "%CMakePath%" --build %__CrossComp2IntermediatesDir% --target crosscomponents --config %__BuildType% -- !__CmakeBuildToolArgs!
-
-        if not !errorlevel! == 0 (
-            set __exitCode=!errorlevel!
-            echo %__ErrMsgPrefix%%__MsgPrefix%Error: cross-arch components build failed. Refer to the build log files for details.
-            echo     !__BuildLog!
-            echo     !__BuildWrn!
-            echo     !__BuildErr!
-            goto ExitWithCode
-        )
-:SkipCrossCompBuild2
-        REM } Scope environment changes end
-        endlocal
-    )
-)
-
-REM =========================================================================================
-REM ===
-REM === Build the CLR VM
+REM === Build Native assets including CLR runtime
 REM ===
 REM =========================================================================================
 
@@ -521,20 +332,20 @@ if %__BuildNative% EQU 1 (
     REM Scope environment changes start {
     setlocal
 
-    echo %__MsgPrefix%Commencing build of native components for %__TargetOS%.%__BuildArch%.%__BuildType%
+    echo %__MsgPrefix%Commencing build of native components for %__TargetOS%.%__TargetArch%.%__BuildType%
 
     REM Set the environment for the native build
-    set __VCBuildArch=amd64
-    if /i "%__BuildArch%" == "x86" ( set __VCBuildArch=x86 )
-    if /i "%__BuildArch%" == "arm" (
-        set __VCBuildArch=x86_arm
+    set __VCTargetArch=amd64
+    if /i "%__HostArch%" == "x86" ( set __VCTargetArch=x86 )
+    if /i "%__HostArch%" == "arm" (
+        set __VCTargetArch=x86_arm
     )
-    if /i "%__BuildArch%" == "arm64" (
-        set __VCBuildArch=x86_arm64
+    if /i "%__HostArch%" == "arm64" (
+        set __VCTargetArch=x86_arm64
     )
 
-    echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!
-    call                                 "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!
+    echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" !__VCTargetArch!
+    call                                 "%__VCToolsRoot%\vcvarsall.bat" !__VCTargetArch!
     @if defined _echo @echo on
 
     if defined __SkipConfigure goto SkipConfigure
@@ -545,8 +356,8 @@ if %__BuildNative% EQU 1 (
         set __ExtraCmakeArgs="-DCMAKE_BUILD_TYPE=!__BuildType!"
     )
 
-    set __ExtraCmakeArgs=!__ExtraCmakeArgs! "-DCLR_CMAKE_PGO_INSTRUMENT=%__PgoInstrument%" "-DCLR_CMAKE_OPTDATA_PATH=%__PgoOptDataPath%" "-DCLR_CMAKE_PGO_OPTIMIZE=%__PgoOptimize%" %__CMakeArgs%
-    call "%__RepoRootDir%\eng\native\gen-buildsys.cmd" "%__ProjectDir%" "%__IntermediatesDir%" %__VSVersion% %__BuildArch% !__ExtraCmakeArgs!
+    set __ExtraCmakeArgs=!__ExtraCmakeArgs! "-DCLR_CMAKE_TARGET_ARCH=%__TargetArch%" "-DCLR_CMAKE_TARGET_OS=%__TargetOS%" "-DCLR_CMAKE_PGO_INSTRUMENT=%__PgoInstrument%" "-DCLR_CMAKE_OPTDATA_PATH=%__PgoOptDataPath%" "-DCLR_CMAKE_PGO_OPTIMIZE=%__PgoOptimize%" %__CMakeArgs%
+    call "%__RepoRootDir%\eng\native\gen-buildsys.cmd" "%__ProjectDir%" "%__IntermediatesDir%" %__VSVersion% %__HostArch% !__ExtraCmakeArgs!
     if not !errorlevel! == 0 (
         echo %__ErrMsgPrefix%%__MsgPrefix%Error: failed to generate native component build project!
         goto ExitWithError
@@ -563,10 +374,10 @@ if %__BuildNative% EQU 1 (
     if defined __ConfigureOnly goto SkipNativeBuild
 
     set __BuildLogRootName=CoreCLR
-    set "__BuildLog="%__LogsDir%\!__BuildLogRootName!_%__TargetOS%__%__BuildArch%__%__BuildType%.log""
-    set "__BuildWrn="%__LogsDir%\!__BuildLogRootName!_%__TargetOS%__%__BuildArch%__%__BuildType%.wrn""
-    set "__BuildErr="%__LogsDir%\!__BuildLogRootName!_%__TargetOS%__%__BuildArch%__%__BuildType%.err""
-    set "__BinLog="%__LogsDir%\!__BuildLogRootName!_%__TargetOS%__%__BuildArch%__%__BuildType%.binlog""
+    set "__BuildLog="%__LogsDir%\!__BuildLogRootName!_%__TargetOS%__%__TargetArch%__%__BuildType%__%__HostArch%.log""
+    set "__BuildWrn="%__LogsDir%\!__BuildLogRootName!_%__TargetOS%__%__TargetArch%__%__BuildType%__%__HostArch%.wrn""
+    set "__BuildErr="%__LogsDir%\!__BuildLogRootName!_%__TargetOS%__%__TargetArch%__%__BuildType%__%__HostArch%.err""
+    set "__BinLog="%__LogsDir%\!__BuildLogRootName!_%__TargetOS%__%__TargetArch%__%__BuildType%__%__HostArch%.binlog""
     set "__MsbuildLog=/flp:Verbosity=normal;LogFile=!__BuildLog!"
     set "__MsbuildWrn=/flp1:WarningsOnly;LogFile=!__BuildWrn!"
     set "__MsbuildErr=/flp2:ErrorsOnly;LogFile=!__BuildErr!"
@@ -628,20 +439,20 @@ REM ============================================================================
 
 :BuildAll
 
-set __BuildArchList=
+set __TargetArchList=
 
-set /A __TotalSpecifiedBuildArch=__BuildArchX64 + __BuildArchX86 + __BuildArchArm + __BuildArchArm64
-if %__TotalSpecifiedBuildArch% EQU 0 (
+set /A __TotalSpecifiedTargetArch=__TargetArchX64 + __TargetArchX86 + __TargetArchArm + __TargetArchArm64
+if %__TotalSpecifiedTargetArch% EQU 0 (
     REM Nothing specified means we want to build all architectures.
-    set __BuildArchList=x64 x86 arm arm64
+    set __TargetArchList=x64 x86 arm arm64
 )
 
 REM Otherwise, add all the specified architectures to the list.
 
-if %__BuildArchX64%==1      set __BuildArchList=%__BuildArchList% x64
-if %__BuildArchX86%==1      set __BuildArchList=%__BuildArchList% x86
-if %__BuildArchArm%==1      set __BuildArchList=%__BuildArchList% arm
-if %__BuildArchArm64%==1    set __BuildArchList=%__BuildArchList% arm64
+if %__TargetArchX64%==1      set __TargetArchList=%__TargetArchList% x64
+if %__TargetArchX86%==1      set __TargetArchList=%__TargetArchList% x86
+if %__TargetArchArm%==1      set __TargetArchList=%__TargetArchList% arm
+if %__TargetArchArm64%==1    set __TargetArchList=%__TargetArchList% arm64
 
 set __BuildTypeList=
 
@@ -662,7 +473,7 @@ set __AllBuildSuccess=true
 set __BuildResultFile=%TEMP%\build-all-summary-%RANDOM%.txt
 if exist %__BuildResultFile% del /f /q %__BuildResultFile%
 
-for %%i in (%__BuildArchList%) do (
+for %%i in (%__TargetArchList%) do (
     for %%j in (%__BuildTypeList%) do (
         call :BuildOne %%i %%j
     )
@@ -682,13 +493,13 @@ REM This code is unreachable, but leaving it nonetheless, just in case things ch
 exit /b 99
 
 :BuildOne
-set __BuildArch=%1
+set __TargetArch=%1
 set __BuildType=%2
-set __NextCmd=call %__ThisScriptFull% %__BuildArch% %__BuildType% %__PassThroughArgs%
+set __NextCmd=call %__ThisScriptFull% %__TargetArch% %__BuildType% %__PassThroughArgs%
 echo %__MsgPrefix%Invoking: %__NextCmd%
 %__NextCmd%
 if not !errorlevel! == 0 (
-    echo %__MsgPrefix%    %__BuildArch% %__BuildType% %__PassThroughArgs% >> %__BuildResultFile%
+    echo %__MsgPrefix%    %__TargetArch% %__BuildType% %__PassThroughArgs% >> %__BuildResultFile%
     set __AllBuildSuccess=false
 )
 exit /b 0
@@ -734,7 +545,7 @@ echo -cmakeargs: user-settable additional arguments passed to CMake.
 echo -configureonly: skip all builds; only run CMake ^(default: CMake and builds are run^)
 echo -skipconfigure: skip CMake ^(default: CMake is run^)
 echo -skipnative: skip building native components ^(default: native components are built^).
-echo -skipcrossarchnative: skip building cross-architecture native components ^(default: components are built^).
+echo -SkipCrossTargetBuildNative: skip building cross-architecture native components ^(default: components are built^).
 echo.
 echo Examples:
 echo     build-runtime

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -127,7 +127,7 @@ if [!__PassThroughArgs!]==[] (
 if /i "%1" == "-hostarch"            (set __HostArch=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "-os"                  (set __TargetOS=%2&shift&shift&goto Arg_Loop)
 
-if /i "%1" == "-cmakeargs"           (set __CMakeArgs="%2=%3" %__CMakeArgs%&set __remainingArgs="!__remainingArgs:*%2=!"&shift&shift&goto Arg_Loop)
+if /i "%1" == "-cmakeargs"           (set __CMakeArgs=%2 %__CMakeArgs%&set __remainingArgs="!__remainingArgs:*%2=!"&shift&shift&goto Arg_Loop)
 if /i "%1" == "-configureonly"       (set __ConfigureOnly=1&set __BuildNative=1&shift&goto Arg_Loop)
 if /i "%1" == "-skipconfigure"       (set __SkipConfigure=1&shift&goto Arg_Loop)
 if /i "%1" == "-skipnative"          (set __BuildNative=0&shift&goto Arg_Loop)

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -10,7 +10,7 @@ echo %__MsgPrefix%Starting Build at %TIME%
 set __ThisScriptFull="%~f0"
 
 :: Note that the msbuild project files (specifically, dir.proj) will use the following variables, if set:
-::      __TargetArch         -- default: x64
+::      __TargetArch        -- default: x64
 ::      __BuildType         -- default: Debug
 ::      __TargetOS          -- default: windows
 ::      __ProjectDir        -- default: directory of the dir.props file
@@ -546,7 +546,6 @@ echo -cmakeargs: user-settable additional arguments passed to CMake.
 echo -configureonly: skip all builds; only run CMake ^(default: CMake and builds are run^)
 echo -skipconfigure: skip CMake ^(default: CMake is run^)
 echo -skipnative: skip building native components ^(default: native components are built^).
-echo -SkipCrossTargetBuildNative: skip building cross-architecture native components ^(default: components are built^).
 echo.
 echo Examples:
 echo     build-runtime

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -357,6 +357,7 @@ if %__BuildNative% EQU 1 (
     )
 
     set __ExtraCmakeArgs=!__ExtraCmakeArgs! "-DCLR_CMAKE_TARGET_ARCH=%__TargetArch%" "-DCLR_CMAKE_TARGET_OS=%__TargetOS%" "-DCLR_CMAKE_PGO_INSTRUMENT=%__PgoInstrument%" "-DCLR_CMAKE_OPTDATA_PATH=%__PgoOptDataPath%" "-DCLR_CMAKE_PGO_OPTIMIZE=%__PgoOptimize%" %__CMakeArgs%
+    echo Calling "%__RepoRootDir%\eng\native\gen-buildsys.cmd" "%__ProjectDir%" "%__IntermediatesDir%" %__VSVersion% %__HostArch% !__ExtraCmakeArgs!
     call "%__RepoRootDir%\eng\native\gen-buildsys.cmd" "%__ProjectDir%" "%__IntermediatesDir%" %__VSVersion% %__HostArch% !__ExtraCmakeArgs!
     if not !errorlevel! == 0 (
         echo %__ErrMsgPrefix%%__MsgPrefix%Error: failed to generate native component build project!

--- a/src/coreclr/build-runtime.sh
+++ b/src/coreclr/build-runtime.sh
@@ -30,10 +30,6 @@ setup_dirs_local()
 
     mkdir -p "$__LogsDir"
     mkdir -p "$__MsbuildDebugLogsDir"
-
-    if [[ "$__CrossBuild" == 1 ]]; then
-        mkdir -p "$__CrossComponentBinDir"
-    fi
 }
 
 build_cross_architecture_components()
@@ -45,12 +41,12 @@ build_cross_architecture_components()
     mkdir -p "$crossArchBinDir"
 
     __SkipCrossArchBuild=1
-    # check supported cross-architecture components host(__HostArch)/target(__BuildArch) pair
-    if [[ ("$__BuildArch" == "arm" || "$__BuildArch" == "armel") && ("$__CrossArch" == "x86" || "$__CrossArch" == "x64") ]]; then
+    # check supported cross-architecture components host(__HostArch)/target(__TargetArch) pair
+    if [[ ("$__TargetArch" == "arm" || "$__TargetArch" == "armel") && ("$__CrossArch" == "x86" || "$__CrossArch" == "x64") ]]; then
         __SkipCrossArchBuild=0
-    elif [[ "$__BuildArch" == "arm64" && "$__CrossArch" == "x64" ]]; then
+    elif [[ "$__TargetArch" == "arm64" && "$__CrossArch" == "x64" ]]; then
         __SkipCrossArchBuild=0
-    elif [[ "$__BuildArch" == "loongarch64" && "$__CrossArch" == "x64" ]]; then
+    elif [[ "$__TargetArch" == "loongarch64" && "$__CrossArch" == "x64" ]]; then
         __SkipCrossArchBuild=0
     else
         # not supported
@@ -61,7 +57,7 @@ build_cross_architecture_components()
     CROSSCOMPILE=0
     export __CMakeBinDir CROSSCOMPILE
 
-    __CMakeArgs="-DCLR_CMAKE_TARGET_ARCH=$__BuildArch -DCLR_CROSS_COMPONENTS_BUILD=1 $__CMakeArgs"
+    __CMakeArgs="-DCLR_CMAKE_TARGET_ARCH=$__TargetArch -DCLR_CROSS_COMPONENTS_BUILD=1 $__CMakeArgs"
     build_native "$__TargetOS" "$__CrossArch" "$__ProjectRoot" "$intermediatesForBuild" "crosscomponents" "$__CMakeArgs" "cross-architecture components"
 
     CROSSCOMPILE=1
@@ -79,10 +75,6 @@ handle_arguments_local() {
 
         pgoinstrument|-pgoinstrument)
             __PgoInstrument=1
-            ;;
-
-        skipcrossarchnative|-skipcrossarchnative)
-            __SkipCrossArchNative=1
             ;;
 
         staticanalyzer|-staticanalyzer)
@@ -112,7 +104,7 @@ echo "Commencing CoreCLR Repo build"
 __ProjectRoot="$(cd "$(dirname "$0")"; pwd -P)"
 __RepoRootDir="$(cd "$__ProjectRoot"/../..; pwd -P)"
 
-__BuildArch=
+__TargetArch=
 __BuildType=Debug
 __CodeCoverage=0
 
@@ -130,9 +122,6 @@ __ProjectDir="$__ProjectRoot"
 __RootBinDir="$__RepoRootDir/artifacts"
 __SignTypeArg=""
 __SkipConfigure=0
-__SkipNative=0
-__SkipCrossArchNative=0
-__SkipManaged=0
 __SkipRestore=""
 __SourceDir="$__ProjectDir/src"
 __StaticAnalyzer=0
@@ -149,18 +138,17 @@ source "$__ProjectRoot"/_build-commons.sh
 # Set the remaining variables based upon the determined build configuration
 __LogsDir="$__RootBinDir/log/$__BuildType"
 __MsbuildDebugLogsDir="$__LogsDir/MsbuildDebugLogs"
-__ConfigTriplet="$__TargetOS.$__BuildArch.$__BuildType"
+__ConfigTriplet="$__TargetOS.$__TargetArch.$__BuildType"
 __BinDir="$__RootBinDir/bin/coreclr/$__ConfigTriplet"
 __ArtifactsObjDir="$__RepoRootDir/artifacts/obj"
 __ArtifactsIntermediatesDir="$__ArtifactsObjDir/coreclr"
 __IntermediatesDir="$__ArtifactsIntermediatesDir/$__ConfigTriplet"
 
 export __IntermediatesDir __ArtifactsIntermediatesDir
-__CrossComponentBinDir="$__BinDir"
 
 __CrossArch="$__HostArch"
 if [[ "$__CrossBuild" == 1 ]]; then
-    __CrossComponentBinDir="$__CrossComponentBinDir/$__CrossArch"
+    __BinDir="$__BinDir/$__CrossArch"
 fi
 
 # CI_SPECIFIC - On CI machines, $HOME may not be set. In such a case, create a subfolder and set the variable to set.
@@ -205,20 +193,13 @@ if [[ -z "$__CMakeTarget" ]]; then
     __CMakeTarget="install"
 fi
 
-if [[ "$__SkipNative" == 1 ]]; then
-    echo "Skipping CoreCLR component build."
-else
-    eval "$__RepoRootDir/eng/native/version/copy_version_files.sh"
-
-    build_native "$__TargetOS" "$__BuildArch" "$__ProjectRoot" "$__IntermediatesDir" "$__CMakeTarget" "$__CMakeArgs" "CoreCLR component"
-
-    # Build cross-architecture components
-    if [[ "$__SkipCrossArchNative" != 1 ]]; then
-        if [[ "$__CrossBuild" == 1 ]]; then
-            build_cross_architecture_components
-        fi
-    fi
+if [[ "$__TargetArch" != "$__HostArch" ]]; then
+    __CMakeArgs="-DCLR_CMAKE_TARGET_ARCH=$__TargetArch $__CMakeArgs"
 fi
+
+eval "$__RepoRootDir/eng/native/version/copy_version_files.sh"
+
+build_native "$__TargetOS" "$__HostArch" "$__ProjectRoot" "$__IntermediatesDir" "$__CMakeTarget" "$__CMakeArgs" "CoreCLR component"
 
 # Build complete
 

--- a/src/coreclr/build-runtime.sh
+++ b/src/coreclr/build-runtime.sh
@@ -32,38 +32,6 @@ setup_dirs_local()
     mkdir -p "$__MsbuildDebugLogsDir"
 }
 
-build_cross_architecture_components()
-{
-    local intermediatesForBuild="$__IntermediatesDir/Host$__CrossArch/crossgen"
-    local crossArchBinDir="$__BinDir/$__CrossArch"
-
-    mkdir -p "$intermediatesForBuild"
-    mkdir -p "$crossArchBinDir"
-
-    __SkipCrossArchBuild=1
-    # check supported cross-architecture components host(__HostArch)/target(__TargetArch) pair
-    if [[ ("$__TargetArch" == "arm" || "$__TargetArch" == "armel") && ("$__CrossArch" == "x86" || "$__CrossArch" == "x64") ]]; then
-        __SkipCrossArchBuild=0
-    elif [[ "$__TargetArch" == "arm64" && "$__CrossArch" == "x64" ]]; then
-        __SkipCrossArchBuild=0
-    elif [[ "$__TargetArch" == "loongarch64" && "$__CrossArch" == "x64" ]]; then
-        __SkipCrossArchBuild=0
-    else
-        # not supported
-        return
-    fi
-
-    __CMakeBinDir="$crossArchBinDir"
-    CROSSCOMPILE=0
-    export __CMakeBinDir CROSSCOMPILE
-
-    __CMakeArgs="-DCLR_CMAKE_TARGET_ARCH=$__TargetArch -DCLR_CROSS_COMPONENTS_BUILD=1 $__CMakeArgs"
-    build_native "$__TargetOS" "$__CrossArch" "$__ProjectRoot" "$intermediatesForBuild" "crosscomponents" "$__CMakeArgs" "cross-architecture components"
-
-    CROSSCOMPILE=1
-    export CROSSCOMPILE
-}
-
 handle_arguments_local() {
     case "$1" in
 
@@ -146,9 +114,9 @@ __IntermediatesDir="$__ArtifactsIntermediatesDir/$__ConfigTriplet"
 
 export __IntermediatesDir __ArtifactsIntermediatesDir
 
-__CrossArch="$__HostArch"
-if [[ "$__CrossBuild" == 1 ]]; then
-    __BinDir="$__BinDir/$__CrossArch"
+if [[ "$__TargetArch" != "$__HostArch" ]]; then
+    __IntermediatesDir="$__IntermediatesDir/$__HostArch"
+    __BinDir="$__BinDir/$__HostArch"
 fi
 
 # CI_SPECIFIC - On CI machines, $HOME may not be set. In such a case, create a subfolder and set the variable to set.

--- a/src/coreclr/crosscomponents.cmake
+++ b/src/coreclr/crosscomponents.cmake
@@ -1,5 +1,4 @@
 # Add targets to the crosscomponents subcomponent build
-
 if (CLR_CMAKE_HOST_OS STREQUAL CLR_CMAKE_TARGET_OS)
     install_clr (TARGETS
         jitinterface_${ARCH_HOST_NAME}

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -35,7 +35,7 @@
       <_CoreClrBuildArg Condition="'$(Ninja)' == 'true' and !$([MSBuild]::IsOsPlatform(Windows))" Include="-ninja" />
       <_CoreClrBuildArg Condition="'$(Ninja)' == 'false' and $([MSBuild]::IsOsPlatform(Windows))" Include="-msbuild" />
       <_CoreClrBuildArg Condition="'$(PgoInstrument)' == 'true'" Include="-pgoinstrument" />
-      <_CoreClrBuildArg Condition="'$(NativeOptimizationDataSupported)' == 'true' and '$(PgoInstrument)' != 'true'" Include="-pgodatapath &quot;$(PgoPackagePath)&quot;" />
+      <_CoreClrBuildArg Condition="'$(NativeOptimizationDataSupported)' == 'true' and '$(NoPgoOptimize)' != 'true' and '$(PgoInstrument)' != 'true'" Include="-pgodatapath &quot;$(PgoPackagePath)&quot;" />
       <_CoreClrBuildArg Condition="'$(HostArchitecture)' != ''" Include="-hostarch $(HostArchitecture)" />
     </ItemGroup>
 

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -58,7 +58,7 @@
 
     <!-- Use IgnoreStandardErrorWarningFormat because Arcade sets WarnAsError and there's an existing warning in the native build. -->
     <Message Text="Executing &quot;$(MSBuildThisFileDirectory)$(_CoreClrBuildScript)&quot; @(_CoreClrBuildArg->'%(Identity)',' ')" Importance="High" />
-    <!-- <Exec Command="&quot;$(MSBuildThisFileDirectory)$(_CoreClrBuildScript)&quot; @(_CoreClrBuildArg->'%(Identity)',' ')"
-          IgnoreStandardErrorWarningFormat="true" /> -->
+    <Exec Command="&quot;$(MSBuildThisFileDirectory)$(_CoreClrBuildScript)&quot; @(_CoreClrBuildArg->'%(Identity)',' ')"
+          IgnoreStandardErrorWarningFormat="true" />
   </Target>
 </Project>

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -15,8 +15,7 @@
           BeforeTargets="Build">
     <ItemGroup>
       <_CoreClrBuildArg Condition="'$(TargetArchitecture)' != ''" Include="-$(TargetArchitecture)" />
-      <_CoreClrBuildArg Condition="!$([MSBuild]::IsOsPlatform(Windows)) and '$(CMakeArgs)' != ''" Include="$(CMakeArgs)" />
-      <_CoreClrBuildArg Condition="$([MSBuild]::IsOsPlatform(Windows)) and '$(CMakeArgs)' != ''" Include="-cmakeargs &quot;$(CMakeArgs)&quot;" />
+      <_CoreClrBuildArg Condition="'$(CMakeArgs)' != ''" Include="-cmakeargs &quot;$(CMakeArgs)&quot;" />
       <_CoreClrBuildArg Include="-$(Configuration.ToLower())" />
       <_CoreClrBuildArg Include="$(Compiler)" />
       <_CoreClrBuildArg Condition="'$(ConfigureOnly)' == 'true'" Include="-configureonly" />
@@ -59,7 +58,7 @@
 
     <!-- Use IgnoreStandardErrorWarningFormat because Arcade sets WarnAsError and there's an existing warning in the native build. -->
     <Message Text="Executing &quot;$(MSBuildThisFileDirectory)$(_CoreClrBuildScript)&quot; @(_CoreClrBuildArg->'%(Identity)',' ')" Importance="High" />
-    <Exec Command="&quot;$(MSBuildThisFileDirectory)$(_CoreClrBuildScript)&quot; @(_CoreClrBuildArg->'%(Identity)',' ')"
-          IgnoreStandardErrorWarningFormat="true" />
+    <!-- <Exec Command="&quot;$(MSBuildThisFileDirectory)$(_CoreClrBuildScript)&quot; @(_CoreClrBuildArg->'%(Identity)',' ')"
+          IgnoreStandardErrorWarningFormat="true" /> -->
   </Target>
 </Project>

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <NativeBuildPartitionPropertiesToRemove>ClrFullNativeBuild;ClrRuntimeSubset;ClrJitSubset;ClrPalTestsSubset;ClrAllJitsSubset;ClrILToolsSubset</NativeBuildPartitionPropertiesToRemove>
+    <NativeBuildPartitionPropertiesToRemove>ClrFullNativeBuild;ClrRuntimeSubset;ClrJitSubset;ClrPalTestsSubset;ClrAllJitsSubset;ClrILToolsSubset;ClrNativeAotSubset;ClrSpmiSubset;ClrCrossComponentsSubset;HostArchitecture;PgoInstrument;NativeOptimizationDataSupported;CMakeArgs</NativeBuildPartitionPropertiesToRemove>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,7 +24,7 @@
       <_CoreClrBuildArg Condition="'$(CrossBuild)' == 'true'" Include="-cross" />
       <_CoreClrBuildArg Condition="'$(PortableBuild)' != 'true'" Include="-portablebuild=false" />
       <_CoreClrBuildArg Condition="'$(KeepNativeSymbols)' != 'false'" Include="-keepnativesymbols" />
-      <_CoreClrBuildArg Condition="!$([MSBuild]::IsOsPlatform(Windows))" Include="-os $(TargetOS)" />
+      <_CoreClrBuildArg Include="-os $(TargetOS)" />
 
       <_CoreClrBuildArg Condition="$([MSBuild]::IsOsPlatform(Windows)) and
                                    ('$(TargetArchitecture)' == 'x86' or '$(TargetArchitecture)' == 'x64') and
@@ -33,11 +33,11 @@
                                    '$(NativeOptimizationDataSupported)' == 'true' and
                                    '$(PgoInstrument)' != 'true'"
                                    Include="-enforcepgo" />
-      <_CoreClrBuildArg Condition="$([MSBuild]::IsOsPlatform(Windows)) and '$(CrossDac)' != ''" Include="-$(CrossDac)dac" />
       <_CoreClrBuildArg Condition="'$(Ninja)' == 'true' and !$([MSBuild]::IsOsPlatform(Windows))" Include="-ninja" />
       <_CoreClrBuildArg Condition="'$(Ninja)' == 'false' and $([MSBuild]::IsOsPlatform(Windows))" Include="-msbuild" />
       <_CoreClrBuildArg Condition="'$(PgoInstrument)' == 'true'" Include="-pgoinstrument" />
       <_CoreClrBuildArg Condition="'$(NativeOptimizationDataSupported)' == 'true' and '$(PgoInstrument)' != 'true'" Include="-pgodatapath &quot;$(PgoPackagePath)&quot;" />
+      <_CoreClrBuildArg Condition="'$(HostArchitecture)' != ''" Include="-hostarch $(HostArchitecture)" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(ClrFullNativeBuild)' != 'true'">
@@ -49,6 +49,7 @@
       <_CoreClrBuildArg Condition="'$(ClrILToolsSubset)' == 'true'" Include="-component iltools" />
       <_CoreClrBuildArg Condition="'$(ClrNativeAotSubset)' == 'true'" Include="-component nativeaot" />
       <_CoreClrBuildArg Condition="'$(ClrSpmiSubset)' == 'true'" Include="-component spmi" />
+      <_CoreClrBuildArg Condition="'$(ClrCrossComponentsSubset)' == 'true'" Include="-component crosscomponents" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/native/corehost/build.sh
+++ b/src/native/corehost/build.sh
@@ -11,7 +11,7 @@ set -e
 __scriptpath="$(cd "$(dirname "$0")"; pwd -P)"
 __RepoRootDir="$(cd "$__scriptpath"/../../..; pwd -P)"
 
-__BuildArch=x64
+__TargetArch=x64
 __TargetOS=Linux
 __BuildType=Debug
 __CMakeArgs=""
@@ -97,4 +97,4 @@ setup_dirs
 check_prereqs
 
 # Build the installer native components.
-build_native "$__TargetOS" "$__BuildArch" "$__scriptpath" "$__IntermediatesDir" "install" "$__CMakeArgs" "installer component"
+build_native "$__TargetOS" "$__TargetArch" "$__scriptpath" "$__IntermediatesDir" "install" "$__CMakeArgs" "installer component"

--- a/src/native/libs/build-native.sh
+++ b/src/native/libs/build-native.sh
@@ -26,7 +26,7 @@ handle_arguments() {
 }
 
 # Set the various build properties here so that CMake and MSBuild can pick them up
-__BuildArch=x64
+__TargetArch=x64
 __TargetOS=Linux
 __BuildType=Debug
 __CMakeArgs=""
@@ -43,7 +43,7 @@ source "$__RepoRootDir"/eng/native/build-commons.sh
 
 # Set cross build
 
-if [[ "$__BuildArch" == wasm ]]; then
+if [[ "$__TargetArch" == wasm ]]; then
     if [[ -z "$EMSDK_PATH" ]]; then
         echo "Error: You need to set the EMSDK_PATH environment variable pointing to the emscripten SDK root."
         exit 1
@@ -64,9 +64,9 @@ else
     __CMakeArgs="-DFEATURE_DISTRO_AGNOSTIC_SSL=$__PortableBuild $__CMakeArgs"
     __CMakeArgs="-DCMAKE_STATIC_LIB_LINK=$__StaticLibLink $__CMakeArgs"
 
-    if [[ "$__BuildArch" != x86 && "$__BuildArch" != x64 && "$__BuildArch" != "$__HostArch" ]]; then
+    if [[ "$__TargetArch" != x86 && "$__TargetArch" != x64 && "$__TargetArch" != "$__HostArch" ]]; then
         __CrossBuild=1
-        echo "Set CrossBuild for $__BuildArch build"
+        echo "Set CrossBuild for $__TargetArch build"
     fi
 fi
 
@@ -77,54 +77,54 @@ elif [[ "$__TargetOS" == iOSSimulator ]]; then
     # set default iOS simulator deployment target
     # keep in sync with src/mono/Directory.Build.props
     __CMakeArgs="-DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphonesimulator -DCMAKE_OSX_DEPLOYMENT_TARGET=10.0 $__CMakeArgs"
-    if [[ "$__BuildArch" == x64 ]]; then
+    if [[ "$__TargetArch" == x64 ]]; then
         __CMakeArgs="-DCMAKE_OSX_ARCHITECTURES=\"x86_64\" $__CMakeArgs"
-    elif [[ "$__BuildArch" == x86 ]]; then
+    elif [[ "$__TargetArch" == x86 ]]; then
         __CMakeArgs="-DCMAKE_OSX_ARCHITECTURES=\"i386\" $__CMakeArgs"
-    elif [[ "$__BuildArch" == arm64 ]]; then
+    elif [[ "$__TargetArch" == arm64 ]]; then
         __CMakeArgs="-DCMAKE_OSX_ARCHITECTURES=\"arm64\" $__CMakeArgs"
     else
-        echo "Error: Unknown iOSSimulator architecture $__BuildArch."
+        echo "Error: Unknown iOSSimulator architecture $__TargetArch."
         exit 1
     fi
 elif [[ "$__TargetOS" == iOS ]]; then
     # set default iOS device deployment target
     # keep in sync with src/mono/Directory.Build.props
     __CMakeArgs="-DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos -DCMAKE_OSX_DEPLOYMENT_TARGET=10.0 $__CMakeArgs"
-    if [[ "$__BuildArch" == arm64 ]]; then
+    if [[ "$__TargetArch" == arm64 ]]; then
         __CMakeArgs="-DCMAKE_OSX_ARCHITECTURES=\"arm64\" $__CMakeArgs"
-    elif [[ "$__BuildArch" == arm ]]; then
+    elif [[ "$__TargetArch" == arm ]]; then
         __CMakeArgs="-DCMAKE_OSX_ARCHITECTURES=\"armv7;armv7s\" $__CMakeArgs"
     else
-        echo "Error: Unknown iOS architecture $__BuildArch."
+        echo "Error: Unknown iOS architecture $__TargetArch."
         exit 1
     fi
 elif [[ "$__TargetOS" == tvOSSimulator ]]; then
     # set default tvOS simulator deployment target
     # keep in sync with src/mono/Directory.Build.props
     __CMakeArgs="-DCMAKE_SYSTEM_NAME=tvOS -DCMAKE_OSX_SYSROOT=appletvsimulator -DCMAKE_OSX_DEPLOYMENT_TARGET=10.0 $__CMakeArgs"
-    if [[ "$__BuildArch" == x64 ]]; then
+    if [[ "$__TargetArch" == x64 ]]; then
         __CMakeArgs="-DCMAKE_OSX_ARCHITECTURES=\"x86_64\" $__CMakeArgs"
-    elif [[ "$__BuildArch" == arm64 ]]; then
+    elif [[ "$__TargetArch" == arm64 ]]; then
         __CMakeArgs="-DCMAKE_OSX_ARCHITECTURES=\"arm64\" $__CMakeArgs"
     else
-        echo "Error: Unknown tvOSSimulator architecture $__BuildArch."
+        echo "Error: Unknown tvOSSimulator architecture $__TargetArch."
         exit 1
     fi
 elif [[ "$__TargetOS" == tvOS ]]; then
     # set default tvOS device deployment target
     # keep in sync with src/mono/Directory.Build.props
     __CMakeArgs="-DCMAKE_SYSTEM_NAME=tvOS -DCMAKE_OSX_SYSROOT=appletvos -DCMAKE_OSX_DEPLOYMENT_TARGET=10.0 $__CMakeArgs"
-    if [[ "$__BuildArch" == arm64 ]]; then
+    if [[ "$__TargetArch" == arm64 ]]; then
         __CMakeArgs="-DCMAKE_OSX_ARCHITECTURES=\"arm64\" $__CMakeArgs"
     else
-        echo "Error: Unknown tvOS architecture $__BuildArch."
+        echo "Error: Unknown tvOS architecture $__TargetArch."
         exit 1
     fi
 fi
 
 # Set the remaining variables based upon the determined build configuration
-__outConfig="${__outConfig:-"$__TargetOS-$__BuildArch-$__BuildType"}"
+__outConfig="${__outConfig:-"$__TargetOS-$__TargetArch-$__BuildType"}"
 __IntermediatesDir="$__RootBinDir/obj/native/$__outConfig"
 __BinDir="$__RootBinDir/bin/native/$__outConfig"
 
@@ -140,4 +140,4 @@ setup_dirs
 check_prereqs
 
 # Build the corefx native components.
-build_native "$__TargetOS" "$__BuildArch" "$__nativeroot" "$__IntermediatesDir" "install" "$__CMakeArgs" "native libraries component"
+build_native "$__TargetOS" "$__TargetArch" "$__nativeroot" "$__IntermediatesDir" "install" "$__CMakeArgs" "native libraries component"


### PR DESCRIPTION
Simplify the CoreCLR build scripts by making the "cross component" builds be separate invocations of the script instead of having the builds included in the build-runtime script. With this change, each `build-runtime.cmd/sh` runs one build (excluding the `all` command on the Windows script).

This PR also updates our native build scripts to use the same terminology as the CMake scripts for architecture/OS (switch to Build/Host/Target OS/Arch terminology) for an easier understanding of what's going on.

This is a UX change for people who directly use the `build-runtime` script, so it should wait for an infra rollout to be merged.