### PR TITLE
Issue at most one connection attempt per request

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -2054,7 +2054,7 @@ namespace System.Net.Http
                 _idleSinceTickCount = Environment.TickCount64;
 
                 // Put connection back in the pool.
-                _pool.ReturnHttp11Connection(this);
+                _pool.ReturnHttp11Connection(this, isNewConnection: false);
             }
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -491,7 +491,8 @@ namespace System.Net.Http
             // Determine if we can and should add a new connection to the pool.
             if (_availableHttp11Connections.Count == 0 &&                           // No available connections
                 _http11RequestQueue.Count > _pendingHttp11ConnectionCount &&        // More requests queued than pending connections
-                _associatedHttp11ConnectionCount < _maxHttp11Connections)           // Under the connection limit
+                _associatedHttp11ConnectionCount < _maxHttp11Connections &&         // Under the connection limit
+                _http11RequestQueue.RequestsWithoutAConnectionAttempt != 0)         // There are requests we haven't issued a connection attempt for
             {
                 _associatedHttp11ConnectionCount++;
                 _pendingHttp11ConnectionCount++;
@@ -712,7 +713,8 @@ namespace System.Net.Http
             if ((_availableHttp2Connections?.Count ?? 0) == 0 &&                            // No available connections
                 !_pendingHttp2Connection &&                                                 // Only allow one pending HTTP2 connection at a time
                 _http2RequestQueue.Count > 0 &&                                             // There are requests left on the queue
-                (_associatedHttp2ConnectionCount == 0 || EnableMultipleHttp2Connections))   // We allow multiple connections, or don't have a connection currently
+                (_associatedHttp2ConnectionCount == 0 || EnableMultipleHttp2Connections) && // We allow multiple connections, or don't have a connection currently
+                _http2RequestQueue.RequestsWithoutAConnectionAttempt != 0)                  // There are requests we haven't issued a connection attempt for
             {
                 _associatedHttp2ConnectionCount++;
                 _pendingHttp2Connection = true;


### PR DESCRIPTION
This PR changes how we associate connection attempts to requests:

Instead of always associating with the first request in the queue, each request in the queue will be associated with at most one connection attempt.

If the connection ends up establishing, it will always process the associated request first, before looking at the rest of the queue.
If it fails, it will fail only the associated request, as long as it wasn't already processed by a different connection.

This means that we may now have completed requests amongst the canceled and pending ones in the queue.
We are relying on other connections to prune the head of the queue, similar to #66992.
This is something we could improve in the future (immediately remove such entries to reduce memory usage).

To track which requests already have an associated connection attempt, the `RequestQueue` keeps an extra head pointer (`_attemptedConnectionsOffset`). This pointer tracks the first request without an associated connection attempt.