### PR TITLE
Load R2R images on osx-arm64 according to Apple's guidelines

### DIFF
--- a/src/coreclr/pal/src/map/map.cpp
+++ b/src/coreclr/pal/src/map/map.cpp
@@ -2044,7 +2044,7 @@ MAPmmapAndRecord(
         // Set the requested mapping with forced PROT_WRITE, mmap the file, and copy its contents there.
         // PROT_WRITE can then be removed on Intel, but not on Apple Silicon which requires the use of
         // pthread_jit_write_protect to switch between executable and writable.
-        LPVOID pvMappedFile = mmap(NULL, len + adjust, PROT_READ, MAP_SHARED, fd, offset - adjust);
+        LPVOID pvMappedFile = mmap(NULL, len + adjust, PROT_READ, MAP_PRIVATE, fd, offset - adjust);
         if (pvMappedFile == MAP_FAILED ||
             (mprotect(pvBaseAddress, len + adjust, prot | PROT_WRITE) == -1))
         {

--- a/src/coreclr/pal/src/map/map.cpp
+++ b/src/coreclr/pal/src/map/map.cpp
@@ -2043,7 +2043,7 @@ MAPmmapAndRecord(
 
         // Set the requested mapping with forced PROT_WRITE, mmap the file, and copy its contents there.
         // PROT_WRITE can then be removed on Intel, but not on Apple Silicon which requires the use of
-        // pthread_jit_write_protect to switch between executable and writable.
+        // PAL_JitWriteProtect to switch between executable and writable.
         LPVOID pvMappedFile = mmap(NULL, len + adjust, PROT_READ, MAP_PRIVATE, fd, offset - adjust);
         if (pvMappedFile == MAP_FAILED ||
             (mprotect(pvBaseAddress, len + adjust, prot | PROT_WRITE) == -1))

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -223,7 +223,7 @@ void PEImageLayout::ApplyBaseRelocations(bool relocationMustWriteCopy)
 
         BYTE * pageAddress = (BYTE *)GetBase() + rva;
 
-#if !defined(__APPLE__) && !defined(HOST_ARM64)
+#if !(defined(__APPLE__) && defined(HOST_ARM64))
         // Check whether the page is outside the unprotected region
         if ((SIZE_T)(pageAddress - pWriteableRegion) >= cbWriteableRegion)
         {
@@ -269,7 +269,7 @@ void PEImageLayout::ApplyBaseRelocations(bool relocationMustWriteCopy)
 #endif // TARGET_UNIX
             }
         }
-#endif // !__APPLE__ && !HOST_ARM64
+#endif // !(__APPLE__ && HOST_ARM64)
 
         BYTE* pEndAddressToFlush = NULL;
         for (COUNT_T fixupIndex = 0; fixupIndex < fixupsCount; fixupIndex++)

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -306,8 +306,12 @@ void PEImageLayout::ApplyBaseRelocations(bool relocationMustWriteCopy)
             }
         }
 
+#if defined(__APPLE__) && defined(HOST_ARM64)
+        BOOL bExecRegion = true;
+#else
         BOOL bExecRegion = (dwOldProtection & (PAGE_EXECUTE | PAGE_EXECUTE_READ |
             PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY)) != 0;
+#endif
 
         if (bExecRegion && pEndAddressToFlush != NULL)
         {


### PR DESCRIPTION
Closes #65341.

This PR changes how R2R images are loaded on Apple Silicon by following [Apple's guidelines](https://developer.apple.com/documentation/apple-silicon/porting-just-in-time-compilers-to-apple-silicon#Disable-Write-Protections-Before-You-Generate-Instructions). Without this change, debugging is [broken](https://github.com/dotnet/runtime/issues/65341) on this platform, as the R2R memory cannot be written to.