### PR TITLE
[perf] Set job name for the performance jobs

### DIFF
--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -50,9 +50,9 @@ jobs:
     javascriptEngine: ${{ parameters.javascriptEngine }}
     iosLlvmBuild: ${{ parameters.iosLlvmBuild }}
 
-    - ${{ if eq(parameters.runtimeType, 'wasm') }}:
+    ${{ if eq(parameters.runtimeType, 'wasm') }}:
       helixTypeSuffix: '/wasm'
-    - ${{ if and(eq(parameters.runtimeType, 'wasm'), eq(parameters.codeGenType, 'aot')) }}:
+    ${{ if and(eq(parameters.runtimeType, 'wasm'), eq(parameters.codeGenType, 'aot')) }}:
       helixTypeSuffix: '/wasm/aot'
 
     # Test job depends on the corresponding build job

--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -70,7 +70,7 @@ jobs:
 
     - ${{ if eq(parameters.runtimeType, 'wasm') }}:
       helixTypeSuffix: '/wasm'
-    - ${{ if and(eq(parameters.runtimeType, 'wasm'), eq(codeGenType, 'aot')) }}:
+    - ${{ if and(eq(parameters.runtimeType, 'wasm'), eq(parameters.codeGenType, 'aot')) }}:
       helixTypeSuffix: '/wasm/aot'
 
     ${{ if and(eq(parameters.osGroup, 'windows'), not(in(parameters.runtimeType, 'AndroidMono', 'iOSMono'))) }}:

--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -50,10 +50,10 @@ jobs:
     javascriptEngine: ${{ parameters.javascriptEngine }}
     iosLlvmBuild: ${{ parameters.iosLlvmBuild }}
 
-    ${{ if eq(parameters.runtimeType, 'wasm') }}:
-      helixTypeSuffix: '/wasm'
     ${{ if and(eq(parameters.runtimeType, 'wasm'), eq(parameters.codeGenType, 'aot')) }}:
       helixTypeSuffix: '/wasm/aot'
+    ${{ if and(eq(parameters.runtimeType, 'wasm'), ne(parameters.codeGenType, 'aot')) }}:
+      helixTypeSuffix: '/wasm'
 
     # Test job depends on the corresponding build job
     dependsOn:

--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -68,6 +68,11 @@ jobs:
       - ${{ 'build_iOS_arm64_release_iOSMono' }}
       - ${{ 'Build_iOS_arm64_release_MACiOSAndroidMaui' }}
 
+    - ${{ if eq(parameters.runtimeType, 'wasm') }}:
+      helixTypeSuffix: '/wasm'
+    - ${{ if and(eq(parameters.runtimeType, 'wasm'), eq(codeGetType, 'aot')) }}:
+      helixTypeSuffix: '/wasm/aot'
+
     ${{ if and(eq(parameters.osGroup, 'windows'), not(in(parameters.runtimeType, 'AndroidMono', 'iOSMono'))) }}:
       ${{ if eq(parameters.runtimeType, 'mono') }}:
         extraSetupParameters: -Architecture ${{ parameters.archType }} -MonoDotnet $(Build.SourcesDirectory)\.dotnet-mono

--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -70,7 +70,7 @@ jobs:
 
     - ${{ if eq(parameters.runtimeType, 'wasm') }}:
       helixTypeSuffix: '/wasm'
-    - ${{ if and(eq(parameters.runtimeType, 'wasm'), eq(codeGetType, 'aot')) }}:
+    - ${{ if and(eq(parameters.runtimeType, 'wasm'), eq(codeGenType, 'aot')) }}:
       helixTypeSuffix: '/wasm/aot'
 
     ${{ if and(eq(parameters.osGroup, 'windows'), not(in(parameters.runtimeType, 'AndroidMono', 'iOSMono'))) }}:

--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -49,6 +49,12 @@ jobs:
     pgoRunType: ${{ parameters.pgoRunType }}
     javascriptEngine: ${{ parameters.javascriptEngine }}
     iosLlvmBuild: ${{ parameters.iosLlvmBuild }}
+
+    - ${{ if eq(parameters.runtimeType, 'wasm') }}:
+      helixTypeSuffix: '/wasm'
+    - ${{ if and(eq(parameters.runtimeType, 'wasm'), eq(parameters.codeGenType, 'aot')) }}:
+      helixTypeSuffix: '/wasm/aot'
+
     # Test job depends on the corresponding build job
     dependsOn:
     - ${{ if not(in(parameters.runtimeType, 'AndroidMono', 'iOSMono', 'wasm')) }}:
@@ -67,11 +73,6 @@ jobs:
     - ${{ if eq(parameters.runtimeType, 'iOSMono')}}:
       - ${{ 'build_iOS_arm64_release_iOSMono' }}
       - ${{ 'Build_iOS_arm64_release_MACiOSAndroidMaui' }}
-
-    - ${{ if eq(parameters.runtimeType, 'wasm') }}:
-      helixTypeSuffix: '/wasm'
-    - ${{ if and(eq(parameters.runtimeType, 'wasm'), eq(parameters.codeGenType, 'aot')) }}:
-      helixTypeSuffix: '/wasm/aot'
 
     ${{ if and(eq(parameters.osGroup, 'windows'), not(in(parameters.runtimeType, 'AndroidMono', 'iOSMono'))) }}:
       ${{ if eq(parameters.runtimeType, 'mono') }}:

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -42,7 +42,7 @@ jobs:
       displayName: '${{ parameters.displayName }}'
     ${{ if eq(parameters.displayName, '') }}:
       displayName: '${{ parameters.jobName }}'
-    name: ${{ replace(replace(parameters.jobName, ' ', '_'), '-', ' ') }}
+    name: ${{ replace(replace(parameters.jobName, ' ', '_'), '-', '_') }}
 
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -40,10 +40,10 @@ jobs:
 
     ${{ if ne(parameters.displayName, '') }}:
       displayName: '${{ parameters.displayName }}'
-      name: ${{ replace(parameters.displayName, ' ', '_') }}
+      name: ${{ replace(replace(parameters.displayName, ' ', '_'), '-', ' ') }}
     ${{ if eq(parameters.displayName, '') }}:
       displayName: '${{ parameters.jobName }}'
-      name: ${{ replace(parameters.displayName, ' ', '_') }}
+      name: ${{ replace(replace(parameters.jobName, ' ', '_'), '-', ' ') }}
 
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -40,10 +40,10 @@ jobs:
 
     ${{ if ne(parameters.displayName, '') }}:
       displayName: '${{ parameters.displayName }}'
-      name: '${{ parameters.displayName }}'
+      name: '${{ replace(parameters.displayName, ' ', '_') }}'
     ${{ if eq(parameters.displayName, '') }}:
       displayName: '${{ parameters.jobName }}'
-      name: '${{ parameters.jobName }}'
+      name: '${{ replace(parameters.jobName, ' ', '_') }}'
 
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -23,6 +23,7 @@ parameters:
   runKind: ''                     # required -- test category
   logicalMachine: ''              # required -- Used to specify a which pool of machines the test should run against
   javascriptEngine: 'NoJS'
+  helixTypeSuffix: ''             # optional -- appends to HelixType
 
 jobs:
 - template: xplat-pipeline-job.yml
@@ -133,7 +134,7 @@ jobs:
     - template: /eng/pipelines/coreclr/templates/perf-send-to-helix.yml
       parameters:
         HelixSource: '$(HelixSourcePrefix)/$(Build.Repository.Name)/$(Build.SourceBranch)' # sources must start with pr/, official/, prodcon/, or agent/
-        HelixType: 'test/performance/$(Kind)/$(_Framework)/$(Architecture)'
+        HelixType: 'test/performance/$(Kind)/$(_Framework)/$(Architecture)${{ parameters.helixTypeSuffix }}'
         HelixAccessToken: $(HelixApiAccessToken)
         HelixTargetQueues: $(Queue)
         HelixPreCommands: $(HelixPreCommand)

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -42,7 +42,7 @@ jobs:
       displayName: '${{ parameters.displayName }}'
     ${{ if eq(parameters.displayName, '') }}:
       displayName: '${{ parameters.jobName }}'
-    name: ${{ parameters.jobName }}
+    name: ${{ replace(replace(parameters.jobName, ' ', '_'), '-', ' ') }}
 
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -40,10 +40,10 @@ jobs:
 
     ${{ if ne(parameters.displayName, '') }}:
       displayName: '${{ parameters.displayName }}'
-      name: '${{ replace(parameters.displayName, ' ', '_') }}'
+      name: '${{ replace(parameters.displayName, " ", "_") }}'
     ${{ if eq(parameters.displayName, '') }}:
       displayName: '${{ parameters.jobName }}'
-      name: '${{ replace(parameters.jobName, ' ', '_') }}'
+      name: '${{ replace(parameters.jobName, " ", "_") }}'
 
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -40,10 +40,9 @@ jobs:
 
     ${{ if ne(parameters.displayName, '') }}:
       displayName: '${{ parameters.displayName }}'
-      name: ${{ replace(replace(parameters.displayName, ' ', '_'), '-', ' ') }}
     ${{ if eq(parameters.displayName, '') }}:
       displayName: '${{ parameters.jobName }}'
-      name: ${{ replace(replace(parameters.jobName, ' ', '_'), '-', ' ') }}
+    name: ${{ parameters.jobName }}
 
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -39,8 +39,10 @@ jobs:
 
     ${{ if ne(parameters.displayName, '') }}:
       displayName: '${{ parameters.displayName }}'
+      name: '${{ parameters.displayName }}'
     ${{ if eq(parameters.displayName, '') }}:
       displayName: '${{ parameters.jobName }}'
+      name: '${{ parameters.jobName }}'
 
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -40,10 +40,10 @@ jobs:
 
     ${{ if ne(parameters.displayName, '') }}:
       displayName: '${{ parameters.displayName }}'
-      name: '${{ replace(parameters.displayName, " ", "_") }}'
+      name: ${{ replace(parameters.displayName, ' ', '_') }}
     ${{ if eq(parameters.displayName, '') }}:
       displayName: '${{ parameters.jobName }}'
-      name: '${{ replace(parameters.jobName, " ", "_") }}'
+      name: ${{ replace(parameters.displayName, ' ', '_') }}
 
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 


### PR DESCRIPTION
`job.yml` uses `name` instead of `displayName` to set the job's name. But perf jobs don't set that. Without this, pre-defined variables like `System.PhaseName` get value `Job1`.
This will help with differentiating builds in kusto.