### PR TITLE
Fix a case of infinite retries while allocating at LOH boundary by constraining retries

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -17909,6 +17909,8 @@ BOOL gc_heap::allocate_more_space(alloc_context* acontext, size_t size,
                                    uint32_t flags, int alloc_generation_number)
 {
     allocation_state status = a_state_start;
+    int retry_count = 0;
+
     do
     {
 #ifdef MULTIPLE_HEAPS
@@ -17923,7 +17925,7 @@ BOOL gc_heap::allocate_more_space(alloc_context* acontext, size_t size,
             if (heap_hard_limit && (status == a_state_retry_allocate))
             {
                 alloc_heap = balance_heaps_uoh_hard_limit_retry (acontext, size, alloc_generation_number);
-                if (alloc_heap == nullptr)
+                if (alloc_heap == nullptr || retry_count++ == 2)
                 {
                     return false;
                 }

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -89,7 +89,7 @@ BOOL bgc_heap_walk_for_etw_p = FALSE;
 #define LOH_PIN_QUEUE_LENGTH 100
 #define LOH_PIN_DECAY 10
 
-#define ALLOCATION_RETRY_MAX_COUNT 2
+#define UOH_ALLOCATION_RETRY_MAX_COUNT 2
 
 uint32_t yp_spin_count_unit = 0;
 size_t loh_size_threshold = LARGE_OBJECT_SIZE;
@@ -17927,7 +17927,7 @@ BOOL gc_heap::allocate_more_space(alloc_context* acontext, size_t size,
             if (heap_hard_limit && (status == a_state_retry_allocate))
             {
                 alloc_heap = balance_heaps_uoh_hard_limit_retry (acontext, size, alloc_generation_number);
-                if (alloc_heap == nullptr || retry_count++ == ALLOCATION_RETRY_MAX_COUNT)
+                if (alloc_heap == nullptr || (retry_count++ == UOH_ALLOCATION_RETRY_MAX_COUNT))
                 {
                     return false;
                 }

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -89,6 +89,8 @@ BOOL bgc_heap_walk_for_etw_p = FALSE;
 #define LOH_PIN_QUEUE_LENGTH 100
 #define LOH_PIN_DECAY 10
 
+#define ALLOCATION_RETRY_MAX_COUNT 2
+
 uint32_t yp_spin_count_unit = 0;
 size_t loh_size_threshold = LARGE_OBJECT_SIZE;
 
@@ -17925,7 +17927,7 @@ BOOL gc_heap::allocate_more_space(alloc_context* acontext, size_t size,
             if (heap_hard_limit && (status == a_state_retry_allocate))
             {
                 alloc_heap = balance_heaps_uoh_hard_limit_retry (acontext, size, alloc_generation_number);
-                if (alloc_heap == nullptr || retry_count++ == 2)
+                if (alloc_heap == nullptr || retry_count++ == ALLOCATION_RETRY_MAX_COUNT)
                 {
                     return false;
                 }


### PR DESCRIPTION
This PR fixes a case where allocating on the LOH boundary is causing an infinite number of retries thereby causing an irrecoverable hang for Server GCs.

## Summary

We are indefinitely retrying the allocation path even after BCG and a forced compaction. This is a condition where we truly don't have more memory available and therefore, rather than continuing to retry, we enter the OOM path.

## Repro

On an 8-CPU machine:

1. Setting the following Environment Variables:
```
complus_gcheapcount=12
complus_gcheaphardlimit=150000000
complus_gcserver=1
```

2. Running the following Console Application:

```csharp
        public static void Main(string[] args)
        {
            while (true)
            {
                Console.WriteLine(GCSettings.IsServerGC);
                Console.WriteLine("Cpu= " + Environment.ProcessorCount);
                List<byte[]> arrays = new(4);

                for (int i = 0; i < 4; i++)
                {
                    //Console.WriteLine($"About to allocate {size} bytes!");
                    byte[] buffer = new byte[2147483591];
                    arrays.Add(buffer);
                    //Console.WriteLine($"Allocated {buffer.Length} bytes in Main!");
                }
                System.Threading.Thread.Sleep(5000);
            }
      }
```

The original PR that mitigated this issue is (unmerged): https://github.com/dotnet/runtime/pull/62355