### PR TITLE
Design to support ByRefLike types in Generics

### DIFF
--- a/docs/design/features/byreflike-generics.md
+++ b/docs/design/features/byreflike-generics.md
@@ -17,7 +17,7 @@ Supporting ByRefLike type as Generic parameters will impact the following IL ins
 
 If any of the above instructions are attempted to be used with a ByRefLike type, the runtime will throw an `InvalidProgramException`.
 
-The following instructions are already set up to support this feature since their behavior will be to fail as currently defined due to the inability to box a ByRefLike type.
+The following instructions are already set up to support this feature since their behavior will fail as currently defined due to the inability to box a ByRefLike type.
 
 - `throw` &ndash; Requires an object reference to be on stack, which can never be a ByRefLike type.
 - `unbox` / `unbox.any` &ndash; Requires an object reference to be on stack, which can never be a ByRefLike type.

--- a/docs/design/features/byreflike-generics.md
+++ b/docs/design/features/byreflike-generics.md
@@ -73,7 +73,7 @@ Troublesome APIs:
     - `public static implicit operator ReadOnlySpan<T>(ArraySegment<T> segment);`
     - `public static implicit operator ReadOnlySpan<T>(T[]? array);`
 
-A new `GenericParameterAttributes` value will be defined which also represents metadata defined in the `CorGenericParamAttr` enumeration. Space is provided between the existing constraints group to permit constraint growth while keeping the bit-mask contiguous.
+A new `GenericParameterAttributes` value will be defined which also represents metadata defined in the `CorGenericParamAttr` enumeration.
 
 ```diff
 namespace System.Reflection
@@ -81,7 +81,7 @@ namespace System.Reflection
     [Flags]
     public enum GenericParameterAttributes
     {
-+        AcceptByRefLike = 0x0100
++        AcceptByRefLike = 0x0020
     }
 }
 ```
@@ -89,7 +89,7 @@ namespace System.Reflection
 ```diff
 typedef enum CorGenericParamAttr
 {
-+   gpAcceptByRefLike = 0x0100 // type argument can be ByRefLike
++   gpAcceptByRefLike = 0x0020 // type argument can be ByRefLike
 } CorGenericParamAttr;
 ```
 

--- a/docs/design/features/byreflike-generics.md
+++ b/docs/design/features/byreflike-generics.md
@@ -118,7 +118,7 @@ Enumerating of constructors/methods on `Span<T>` and `ReadOnlySpan<T>` may throw
 
 ## Special IL Sequences
 
-The following are IL sequences involving the `box` instruction. They are used for common C# language constructs and shall continue to be valid, even with ByRefLike types, in cases where the result can be computed at JIT time and elided safely. The conditions where each sequence is elided are described below and each condition will be added to the ECMA-335 addendum.
+The following are IL sequences involving the `box` instruction. They are used for common C# language constructs and shall continue to be valid, even with ByRefLike types, in cases where the result can be computed at JIT time and elided safely. These sequences must now be elided when the target type is ByRefLike. The conditions where each sequence is elided are described below and each condition will be added to the ECMA-335 addendum.
 
 `box` ; `unbox.any` &ndash; The box target type is equal to the unboxed target type.
 

--- a/docs/design/features/byreflike-generics.md
+++ b/docs/design/features/byreflike-generics.md
@@ -68,7 +68,7 @@ newobj instance void System.InvalidProgramException::.ctor()
 throw
 ```
 
-When boxing due to a constrained call that cannot be made, instead of allocating a normal boxed object, an object of `InvalidBoxedObject` type will be created. It will have implementations of the various overridable object methods which throw `InvalidProgramException`, and interface dispatch shall have a special case for attempting to invoke an interface method on such an object, that will also throw an `InvalidProgramException`. 
+When boxing due to a constrained call that cannot be made, instead of allocating a normal boxed object, an object of `InvalidBoxedObject` type will be created. It will have implementations of the various overridable object methods which throw `InvalidProgramException`, and interface dispatch shall have a special case for attempting to invoke an interface method on such an object, that will also throw an `InvalidProgramException`.
 
 ## Open questions
 

--- a/docs/design/features/byreflike-generics.md
+++ b/docs/design/features/byreflike-generics.md
@@ -99,25 +99,25 @@ The expansion of metadata will impact at least the following:
 
 ## Semantic Proposal
 
-An API that is a JIT-time intrinsic will be needed to determine if a parameter is ByRefLike. This API would represent a check to occur at JIT time code-gen to avoid taking paths that would be invalid for some values of `T`. The existing `Type.IsByRefLike` property will be made an intrinsic (e.g., `typeof(T).IsByRefLike`).
+An API that is a JIT-time intrinsic will be needed to determine if a parameter is ByRefLike. This API would represent a check to occur at JIT time to avoid taking paths that would be invalid for some values of `T`. The existing `Type.IsByRefLike` property will be made an intrinsic (e.g., `typeof(T).IsByRefLike`).
 
-For dispatch to object implemented methods and to default interface methods, the behavior shall be that an `InvalidProgramException` should be thrown. The JIT would insert the following IL at code-gen time.
+For dispatch to object implemented methods and to default interface methods, the behavior shall be that an `InvalidProgramException` should be thrown. The JIT will insert the following IL at code-gen time.
 
 ```
 newobj instance void System.InvalidProgramException::.ctor()
 throw
 ```
 
-The `Reflection.Emit` API will need to be updated to respect the behavior of this flag. The current Reflection API requires boxing of all types which makes usage of ByRefLike types impossible. Until the Reflection API can fully support ByRefLike types, this feature must be blocked when using Reflection. For example, API calls such as `MakeGenericType` / `MakeGenericMethod` are invalid.
+The `Reflection.Emit` API will be updated to respect ByRefLike support in Generics. The current Reflection API requires boxing of all types which makes usage of ByRefLike types impossible. Until the Reflection API can fully support ByRefLike types, this feature must be blocked when using Reflection. For example, API calls such as `MakeGenericType` / `MakeGenericMethod` will be invalid when `T` is ByRefLike.
 
 ## Special IL Sequences
 
-The following are IL sequences involving the `box` instruction. They are used for optimized scenarios and shall continue to be valid, even with ByRefLike types, in cases where the result can be computed at JIT time and elided safely. They will be added to the ECMA-335 addendum.
+The following are IL sequences involving the `box` instruction. They are used in scenario optimizations and shall continue to be valid, even with ByRefLike types, in cases where the result can be computed at JIT time and elided safely. They will be added to the ECMA-335 addendum.
 
 `box` ; `unbox.any`
 
 `box` ; `br_true/false`
 
-`box` ; `isinst` ; `br_true/false`
-
 `box` ; `isinst` ; `unbox.any`
+
+`box` ; `isinst` ; `br_true/false`

--- a/docs/design/features/byreflike-generics.md
+++ b/docs/design/features/byreflike-generics.md
@@ -50,6 +50,7 @@ namespace System.Runtime.CompilerServices
     /// Indicates to the compiler that constrain checks should be suppressed
     /// and will instead be enforced at run-time.
     /// </summary>
+    [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property)]
     public sealed class SuppressConstraintChecksAttribute : Attribute
     { }
 }

--- a/docs/design/features/byreflike-generics.md
+++ b/docs/design/features/byreflike-generics.md
@@ -49,7 +49,7 @@ The compiler will need an indication for existing troublesome APIs where ByRefLi
 namespace System.Runtime.CompilerServices
 {
     /// <summary>
-    /// Indicates to the compiler that constrain checks should be suppressed
+    /// Indicates to the compiler that constraint checks should be suppressed
     /// and will instead be enforced at run-time.
     /// </summary>
     [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property)]

--- a/docs/design/features/byreflike-generics.md
+++ b/docs/design/features/byreflike-generics.md
@@ -53,6 +53,7 @@ The expansion of metadata will impact at least the following:
 - ILDasm/ILAsm &ndash; https://github.com/dotnet/runtime
 - Cecil &ndash; https://github.com/jbevain/cecil
 - IL Trimmer &ndash; https://github.com/dotnet/linker
+- F# &ndash; https://github.com/fsharp/fsharp
 - C++/CLI &ndash; The MSVC team
 
 An API that is a JIT-time intrinsic will be needed to determine if a parameter is ByRefLike. This API would represent a check to occur at JIT time code-gen to avoid taking paths that would be invalid for some values of `T`. The existing `Type.IsByRefLike` property will be made an intrinsic (e.g., `typeof(T).IsByRefLike`).

--- a/docs/design/features/byreflike-generics.md
+++ b/docs/design/features/byreflike-generics.md
@@ -1,0 +1,75 @@
+# Generics parameters of ByRefLike types
+
+Using ByRefLike types in Generic parameters is possible by building upon support added for `ref` fields. Scenarios that would benefit most from this are those involving `Span<T>`. For example, consider the following examples:
+
+- `Span<TypedReference>` &ndash; Represents the general case where a ByRefLike type is used as a Generic parameter. This specific case would be desirable for a more efficient Reflection API.
+- `Span<Span<char>>` &ndash; Nested `Span<T>` types would be of benefit in the parsing result of strings.
+
+## Runtime impact
+
+Supporting ByRefLike type as Generic parameters will impact the following IL instructions:
+
+- `box` &ndash; Types with ByRefLike parameters used in fields cannot be boxed.
+- `throw` &ndash; Requires an object reference on the stack so not directly impacted since boxing is not permitted.
+- `stsfld` / `ldsfld` &ndash; Type fields of a ByRefLike parameter cannot be marked `static`.
+- `newarr` / `stelem` / `ldelem` / `ldelema` &ndash; Arrays are not able to contain ByRefLike types.
+    - `newobj` &ndash; For multi-dimensional array construction.
+- `constrained.callvirt` &ndash; This IL sequence must resolve to a method implemented on `object`, or a default interface method.
+- Use of any Generic which doesn’t expect a ByRefLike parameter as a Generic parameter.
+
+## Proposal
+
+A new Attribute API will be defined to indicate which Generic parameters are permissible to be of any type&mdash;including ByRefLike types. The Attribute could be used by the compiler to implement a generic non-constraint.
+
+```csharp
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
+    public class GenericParameterSupportsAnyTypeAttribute : Attribute
+    {
+        /// </summary>
+        /// Constructs an instance with a Generic parameter index of 0.
+        /// </summary>
+        public GenericParameterSupportsAnyTypeAttribute()
+            => ParameterIndex = 0;
+
+        /// </summary>
+        /// Constructs an instance with a Generic parameter index.
+        /// </summary>
+        /// <param name="parameterIndex">Non-negative index of Generic parameter to apply to.</param>
+        public GenericParameterSupportsAnyTypeAttribute(int parameterIndex)
+            => ParameterIndex = parameterIndex;
+
+        /// <summary>
+        /// Generic Parameter Index.
+        /// </summary>
+        public int ParameterIndex { get; set; }
+    }
+}
+```
+
+A new API will be implemented as a JIT intrinsic for determining if a parameter is ByRefLike. This API would represent a check to occur at JIT time code-gen to avoid taking paths that would be invalid for some values of `T`.
+
+```diff
+namespace System
+{
+    public abstract partial class Type
+    {
++        [Intrinsic]
++        public static bool IsByRefLike<T>();
+    }
+}
+```
+
+For dispatch to object implemented methods and to default interface methods, the behavior shall be that an `InvalidProgramException` should be thrown. The JIT would insert the following IL at code-gen time.
+
+```
+newobj instance void System.InvalidProgramException::.ctor()
+throw
+```
+
+When boxing due to a constrained call that cannot be made, instead of allocating a normal boxed object, an object of `InvalidBoxedObject` type will be created. It will have implementations of the various overridable object methods which throw `InvalidProgramException`, and interface dispatch shall have a special case for attempting to invoke an interface method on such an object, that will also throw an `InvalidProgramException`. 
+
+## Open questions
+
+- This scenario is the inverse of [Generic constraints](https://docs.microsoft.com/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters) as it is an "allow". What does this look like as a general case as to potentially support pointers in the future? See https://github.com/dotnet/runtime/issues/13627.

--- a/docs/design/features/byreflike-generics.md
+++ b/docs/design/features/byreflike-generics.md
@@ -26,7 +26,7 @@ The following instructions are already set up to support this feature since thei
 
 ## Proposal
 
-Support for the following would be indicated by the existing `RuntimeFeature.ByRefFields` mechanism.
+Support for the following will be indicated by the `RuntimeFeature.GenericsAcceptByRefLike` property.
 
 A new `GenericParameterAttributes` value will be defined which also represents metadata defined in the `CorGenericParamAttr` enumeration. Space is provided between the existing constraints group to permit constraint growth.
 
@@ -36,7 +36,7 @@ namespace System.Reflection
     [Flags]
     public enum GenericParameterAttributes
     {
-+        SupportsByRefLike = 0x0100
++        AcceptByRefLike = 0x0100
     }
 }
 ```
@@ -44,7 +44,7 @@ namespace System.Reflection
 ```diff
 typedef enum CorGenericParamAttr
 {
-+   gpSupportsByRefLike = 0x0100 // type argument can be ByRefLike
++   gpAcceptByRefLike = 0x0100 // type argument can be ByRefLike
 } CorGenericParamAttr;
 ```
 


### PR DESCRIPTION
Adding in a proposal to support ByRefLike type in Generics. This work is supported by https://github.com/dotnet/runtime/issues/63768 and contributes toward https://github.com/dotnet/runtime/issues/65112.

/cc @jkotas @davidwrighton @jaredpar @cston @RikkiGibson @AlekseyTs 