### PR TITLE
Fix loop cloning of array of struct with array field

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8088,8 +8088,9 @@ public:
     };
 
     bool optIsStackLocalInvariant(unsigned loopNum, unsigned lclNum);
-    bool optExtractArrIndex(GenTree* tree, ArrIndex* result, unsigned lhsNum);
-    bool optReconstructArrIndex(GenTree* tree, ArrIndex* result, unsigned lhsNum);
+    bool optExtractArrIndex(GenTree* tree, ArrIndex* result, unsigned lhsNum, bool* topLevelIsFinal);
+    bool optReconstructArrIndexHelp(GenTree* tree, ArrIndex* result, unsigned lhsNum, bool* topLevelIsFinal);
+    bool optReconstructArrIndex(GenTree* tree, ArrIndex* result);
     bool optIdentifyLoopOptInfo(unsigned loopNum, LoopCloneContext* context);
     static fgWalkPreFn optCanOptimizeByLoopCloningVisitor;
     fgWalkResult optCanOptimizeByLoopCloning(GenTree* tree, LoopCloneVisitorInfo* info);

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -3556,7 +3556,7 @@ inline bool Compiler::LoopDsc::lpArrLenLimit(Compiler* comp, ArrIndex* index) co
     // We have a[i].length, extract a[i] pattern.
     else if (limit->AsArrLen()->ArrRef()->gtOper == GT_COMMA)
     {
-        return comp->optReconstructArrIndex(limit->AsArrLen()->ArrRef(), index, BAD_VAR_NUM);
+        return comp->optReconstructArrIndex(limit->AsArrLen()->ArrRef(), index);
     }
     return false;
 }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7664,6 +7664,7 @@ GenTree* Compiler::gtCloneExpr(
                     GenTreeBoundsChk(tree->AsBoundsChk()->GetIndex(), tree->AsBoundsChk()->GetArrayLength(),
                                      tree->AsBoundsChk()->gtThrowKind);
                 copy->AsBoundsChk()->gtIndRngFailBB = tree->AsBoundsChk()->gtIndRngFailBB;
+                copy->AsBoundsChk()->gtInxType      = tree->AsBoundsChk()->gtInxType;
                 break;
 
             case GT_LEA:

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -5876,8 +5876,16 @@ struct GenTreeBoundsChk : public GenTreeOp
     BasicBlock*     gtIndRngFailBB; // Basic block to jump to for index-out-of-range
     SpecialCodeKind gtThrowKind;    // Kind of throw block to branch to on failure
 
+    // Store some information about the array element type that was in the GT_INDEX node before morphing.
+    // Note that this information is also stored in the m_arrayInfoMap of the morphed IND node (that
+    // is marked with GTF_IND_ARR_INDEX), but that can be hard to find.
+    var_types gtInxType; // Save the GT_INDEX type
+
     GenTreeBoundsChk(GenTree* index, GenTree* length, SpecialCodeKind kind)
-        : GenTreeOp(GT_BOUNDS_CHECK, TYP_VOID, index, length), gtIndRngFailBB(nullptr), gtThrowKind(kind)
+        : GenTreeOp(GT_BOUNDS_CHECK, TYP_VOID, index, length)
+        , gtIndRngFailBB(nullptr)
+        , gtThrowKind(kind)
+        , gtInxType(TYP_UNKNOWN)
     {
         gtFlags |= GTF_EXCEPT;
     }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5436,6 +5436,7 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
         }
 
         GenTreeBoundsChk* arrBndsChk = new (this, GT_BOUNDS_CHECK) GenTreeBoundsChk(index, arrLen, SCK_RNGCHK_FAIL);
+        arrBndsChk->gtInxType        = elemTyp;
 
         bndsChk = arrBndsChk;
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_66254/Runtime_66254.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_66254/Runtime_66254.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Test that loop cloning won't consider a[i].struct_field[j] to be
+// a jagged array a[i][j].
+
+using System;
+
+public class Runtime_66254
+{
+    public static void t1()
+    {
+        var a = new ValueTuple<int[], int>[]
+        {
+            new (new[] { 0 }, 1),
+            new (new[] { 2 }, 3)
+        };
+
+        for (var i1 = 0; i1 < a.Length; i1++)
+        {
+            for (var i2 = 0; i2 < a[i1].Item1.Length; i2++)
+            {
+                var elem = a[i1].Item1[i2];
+                Console.WriteLine(elem);
+            }
+        }
+    }
+
+    public static void t2()
+    {
+        var a = new ValueTuple<int[], int>[]
+        {
+            new (new[] { 0 }, 1),
+            new (new[] { 2 }, 3)
+        };
+
+        for (var i1 = 0; i1 < a.Length; i1++)
+        {
+            var length = a[i1].Item1.Length;
+            for (var i2 = 0; i2 < length; i2++)
+            {
+                var elem = a[i1].Item1[i2];
+                Console.WriteLine(elem);
+            }
+        }
+    }
+
+    public static void t3()
+    {
+        var a = new ValueTuple<int, int[]>[]
+        {
+            new (1, new[] { 2 }),
+            new (3, new[] { 4 })
+        };
+
+        for (var i1 = 0; i1 < a.Length; i1++)
+        {
+            var length = a[i1].Item2.Length;
+            for (var i2 = 0; i2 < length; i2++)
+            {
+                var elem = a[i1].Item2[i2];
+                Console.WriteLine(elem);
+            }
+        }
+    }
+
+    public static int Main()
+    {
+        int result = 100;
+
+        try
+        {
+            t1();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"t1 failed: {e}");
+            result = 101;
+        }
+
+        try
+        {
+            t2();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"t2 failed: {e}");
+            result = 101;
+        }
+
+        try
+        {
+            t3();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"t3 failed: {e}");
+            result = 101;
+        }
+
+        Console.WriteLine((result == 100) ? "PASS" : "FAIL");
+        return result;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_66254/Runtime_66254.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_66254/Runtime_66254.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Loop cloning needs to parse what morph creates from GT_INDEX nodes
to determine if there are array accesses with bounds checks that
could potentially be optimized. For jagged array access, this can
be a "comma chain" of bounds checks and array element address expressions.
For a case where an array of structs had a struct field, such as
`ValueTuple<int[], int>[]`, cloning was confusing the expression
`a[i].Item1[j]` for the jagged array access `a[i][j]`.

The fix here is to keep track of the type of the `GT_INDEX` node that is
being morphed, in the `GT_BOUNDS_CHECK` node that is created for it.
(This is the only thing cloning parses, to avoid the need to parse
the very complex trees morph can create.) This type is then checked
when parsing the "comma chain" trees. If a non-`TYP_REF` is found (such
as a `TYP_STRUCT` in the above example), no more levels of array indexing
are considered. (`TYP_REF` is what an array object would have, for a jagged
array.)

Fixes #66254.