### PR TITLE
Add tighter bound to range check for matching Regex char classes

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -4006,8 +4006,8 @@ namespace System.Text.RegularExpressions.Generator
                 // character class were [A-Za-z0-9], so since the ch is now known to be >= 128, we
                 // can just fail the comparison.
                 return negate ?
-                    $"((ch = {chExpr}) >= 128 || ({Literal(bitVectorString)}[ch >> 4] & (1 << (ch & 0xF))) == 0)" :
-                    $"((ch = {chExpr}) < 128 && ({Literal(bitVectorString)}[ch >> 4] & (1 << (ch & 0xF))) != 0)";
+                    $"((ch = {chExpr}) >= {Literal((char)analysis.UpperBoundExclusiveIfContainsOnlyAscii)} || ({Literal(bitVectorString)}[ch >> 4] & (1 << (ch & 0xF))) == 0)" :
+                    $"((ch = {chExpr}) < {Literal((char)analysis.UpperBoundExclusiveIfContainsOnlyAscii)} && ({Literal(bitVectorString)}[ch >> 4] & (1 << (ch & 0xF))) != 0)";
             }
 
             if (analysis.AllNonAsciiContained)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -921,6 +921,8 @@ namespace System.Text.RegularExpressions
             public bool AllAsciiContained;
             /// <summary>true if we know for sure that all non-ASCII values are in the set; otherwise, false.</summary>
             public bool AllNonAsciiContained;
+            /// <summary>The exclusive upper bound. Only valid if <see cref="ContainsOnlyAscii"/> is true.</summary>
+            public int UpperBoundExclusiveIfContainsOnlyAscii;
         }
 
         /// <summary>Analyzes the set to determine some basic properties that can be used to optimize usage.</summary>
@@ -962,6 +964,7 @@ namespace System.Text.RegularExpressions
                 AllAsciiContained = false,
                 ContainsOnlyAscii = set[set.Length - 1] <= 128,
                 ContainsNoAscii = set[SetStartIndex] >= 128,
+                UpperBoundExclusiveIfContainsOnlyAscii = set[set.Length - 1],
             };
         }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -5021,7 +5021,7 @@ namespace System.Text.RegularExpressions
 
             // ch < 128 ? (bitVectorString[ch >> 4] & (1 << (ch & 0xF))) != 0 :
             Ldloc(tempLocal);
-            Ldc(128);
+            Ldc(analysis.ContainsOnlyAscii ? analysis.UpperBoundExclusiveIfContainsOnlyAscii : 128);
             Bge(comparisonLabel);
             Ldstr(bitVectorString);
             Ldloc(tempLocal);


### PR DESCRIPTION
When we emit a bitmap lookup for character classes containing only ASCII characters, we currently bound the check by 128, e.g.
```C#
if (ch < 128 && lookupTable[...])
```
but we can easily lower that 128 to instead be the actual exclusive upper bound based on the char set.  Doing so means we don't need to hit the lookup table for a larger set of characters.

(We could also actually shrink the size of the lookup table itself, but doing so would only save a few bytes, and it didn't seem worth the complexity right now.  We could also add a lower range check, but that's also additional checks to execute whereas this one is just improving an existing check that's also required for correctness.)

Contributes to https://github.com/dotnet/runtime/issues/67056