### PR TITLE
Disable multimodule test

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -917,9 +917,6 @@
 
       <!-- NativeAOT specific -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TestBuildMode)' == 'nativeaot' and '$(RuntimeFlavor)' == 'coreclr'">
-        <ExcludeList Include="$(XunitTestBinBase)/nativeaot/SmokeTests/MultiModule/MultiModule/*">
-            <Issue>https://github.com/dotnet/runtime/issues/66191</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/callconvs/TestCallingConventions/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/153</Issue>
         </ExcludeList>

--- a/src/tests/nativeaot/SmokeTests/MultiModule/MultiModule.csproj
+++ b/src/tests/nativeaot/SmokeTests/MultiModule/MultiModule.csproj
@@ -8,6 +8,9 @@
     <!-- This test always runs as multimodule. It's not supported if we don't have framework object files. -->
     <CLRTestTargetUnsupported Condition="'$(BuildNativeAotFrameworkObjects)' != 'true'">true</CLRTestTargetUnsupported>
     <IlcMultiModule>true</IlcMultiModule>
+
+    <!-- https://github.com/dotnet/runtime/issues/66191 -->
+    <DisableProjectBuild>true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MultiModule.cs" />

--- a/src/tests/nativeaot/SmokeTests/MultiModule/MultiModule.csproj
+++ b/src/tests/nativeaot/SmokeTests/MultiModule/MultiModule.csproj
@@ -10,7 +10,7 @@
     <IlcMultiModule>true</IlcMultiModule>
 
     <!-- https://github.com/dotnet/runtime/issues/66191 -->
-    <DisableProjectBuild>true</DisableProjectBuild>
+    <CLRTestTargetUnsupported>true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MultiModule.cs" />


### PR DESCRIPTION
Can't use issues.targets because this is a compile failure and compilation runs during test build, not execution.