### PR TITLE
Use generic `Enum` methods in more places.

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MountPoints.FormatInfo.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MountPoints.FormatInfo.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
 #if DEBUG
         static Sys()
         {
-            foreach (string name in Enum.GetNames(typeof(UnixFileSystemTypes)))
+            foreach (string name in Enum.GetNames<UnixFileSystemTypes>())
             {
                 System.Diagnostics.Debug.Assert(GetDriveType(name) != DriveType.Unknown,
                     $"Expected {nameof(UnixFileSystemTypes)}.{name} to have an entry in {nameof(GetDriveType)}.");

--- a/src/libraries/System.Data.Common/src/System/Xml/XPathNodePointer.cs
+++ b/src/libraries/System.Data.Common/src/System/Xml/XPathNodePointer.cs
@@ -28,10 +28,10 @@ namespace System.Xml
         {
 #if DEBUG
             int max = 0, tempVal = 0;
-            Array enumValues = Enum.GetValues(typeof(XmlNodeType));
+            XmlNodeType[] enumValues = Enum.GetValues<XmlNodeType>();
             for (int i = 0; i < enumValues.Length; i++)
             {
-                tempVal = (int)enumValues.GetValue(i)!;
+                tempVal = (int)enumValues[i];
                 if (tempVal > max)
                     max = tempVal;
             }

--- a/src/libraries/System.Data.OleDb/src/OleDbConnectionStringBuilder.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbConnectionStringBuilder.cs
@@ -632,13 +632,13 @@ namespace System.Data.OleDb
                             string[] values = svalue.Split(new char[] { ',' });
                             foreach (string v in values)
                             {
-                                convertedValue |= (int)(OleDbServiceValues)Enum.Parse(typeof(OleDbServiceValues), v, true);
+                                convertedValue |= (int)Enum.Parse<OleDbServiceValues>(v, true);
                             }
-                            return (int)convertedValue;
+                            return convertedValue;
                         }
                         else
                         {
-                            return (int)(OleDbServiceValues)Enum.Parse(typeof(OleDbServiceValues), svalue, true);
+                            return (int)Enum.Parse<OleDbServiceValues>(svalue, true);
                         }
                     }
                 }
@@ -651,11 +651,11 @@ namespace System.Data.OleDb
                 return ((typeof(string) == destinationType) || base.CanConvertTo(context, destinationType));
             }
 
-            public override object? ConvertTo(ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, Type destinationType)
+            public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
             {
                 if ((typeof(string) == destinationType) && (null != value) && (typeof(int) == value.GetType()))
                 {
-                    return Enum.Format(typeof(OleDbServiceValues), ((OleDbServiceValues)(int)value), "G");
+                    return ((OleDbServiceValues)(int)(value)).ToString("G");
                 }
                 return base.ConvertTo(context, culture, value, destinationType);
             }
@@ -675,7 +675,7 @@ namespace System.Data.OleDb
                 StandardValuesCollection? standardValues = _standardValues;
                 if (null == standardValues)
                 {
-                    Array objValues = Enum.GetValues(typeof(OleDbServiceValues));
+                    OleDbServiceValues[] objValues = Enum.GetValues<OleDbServiceValues>();
                     Array.Sort(objValues, 0, objValues.Length);
                     standardValues = new StandardValuesCollection(objValues);
                     _standardValues = standardValues;

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceData/PerfProviderCollection.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceData/PerfProviderCollection.cs
@@ -33,8 +33,8 @@ namespace System.Diagnostics.PerformanceData
         private static object s_hiddenInternalSyncObject;
         private static readonly List<PerfProvider> s_providerList = new List<PerfProvider>();
         private static readonly Dictionary<object, int> s_counterSetList = new Dictionary<object, int>();
-        private static readonly CounterType[] s_counterTypes = (CounterType[])Enum.GetValues(typeof(CounterType));
-        private static readonly CounterSetInstanceType[] s_counterSetInstanceTypes = (CounterSetInstanceType[])Enum.GetValues(typeof(CounterSetInstanceType));
+        private static readonly CounterType[] s_counterTypes = Enum.GetValues<CounterType>();
+        private static readonly CounterSetInstanceType[] s_counterSetInstanceTypes = Enum.GetValues<CounterSetInstanceType>();
 
         private static object s_lockObject
         {

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
@@ -64,7 +64,7 @@ namespace System.IO
         static FileSystemWatcher()
         {
             int s_notifyFiltersValidMask = 0;
-            foreach (int enumValue in Enum.GetValues(typeof(NotifyFilters)))
+            foreach (int enumValue in Enum.GetValues<NotifyFilters>())
                 s_notifyFiltersValidMask |= enumValue;
             Debug.Assert(c_notifyFiltersValidMask == s_notifyFiltersValidMask, "The NotifyFilters enum has changed. The c_notifyFiltersValidMask must be updated to reflect the values of the NotifyFilters enum.");
         }

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/InternalRelationshipCollection.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/InternalRelationshipCollection.cs
@@ -320,7 +320,7 @@ namespace System.IO.Packaging
             {
                 try
                 {
-#if NET
+#if NET6_0_OR_GREATER
                     relationshipTargetMode = Enum.Parse<TargetMode>(targetModeAttributeValue, ignoreCase: false);
 #else
                     relationshipTargetMode = (TargetMode)(Enum.Parse(typeof(TargetMode), targetModeAttributeValue, ignoreCase: false));

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/InternalRelationshipCollection.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/InternalRelationshipCollection.cs
@@ -320,7 +320,11 @@ namespace System.IO.Packaging
             {
                 try
                 {
+#if NET
+                    relationshipTargetMode = Enum.Parse<TargetMode>(targetModeAttributeValue, ignoreCase: false);
+#else
                     relationshipTargetMode = (TargetMode)(Enum.Parse(typeof(TargetMode), targetModeAttributeValue, ignoreCase: false));
+#endif
                 }
                 catch (ArgumentNullException argNullEx)
                 {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsCipherSuiteData.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsCipherSuiteData.cs
@@ -23,10 +23,9 @@ namespace System.Net.Security
                 s_tlsLookup.Count == LookupCount,
                 $"Lookup dictionary was of size {s_tlsLookup.Count} instead of {LookupCount}");
 
-            foreach (object? value in Enum.GetValues(typeof(TlsCipherSuite)))
+            foreach (TlsCipherSuite value in Enum.GetValues<TlsCipherSuite>())
             {
-                TlsCipherSuite val = (TlsCipherSuite)value!;
-                Debug.Assert(s_tlsLookup.ContainsKey(val), $"No mapping found for {val} ({(int)val})");
+                Debug.Assert(s_tlsLookup.ContainsKey(value), $"No mapping found for {value} ({value:X})");
             }
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XmlQueryTypeFactory.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XmlQueryTypeFactory.cs
@@ -347,8 +347,8 @@ namespace System.Xml.Xsl
             static ItemType()
             {
 #if DEBUG
-                Array arrEnum = Enum.GetValues(typeof(XmlTypeCode));
-                Debug.Assert((XmlTypeCode)arrEnum.GetValue(arrEnum.Length - 1)! == XmlTypeCode.DayTimeDuration,
+                XmlTypeCode[] arrEnum = Enum.GetValues<XmlTypeCode>();
+                Debug.Assert(arrEnum[arrEnum.Length - 1] == XmlTypeCode.DayTimeDuration,
                              "DayTimeDuration is no longer the last item in XmlTypeCode.  This code expects it to be.");
 #endif
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -47,8 +47,13 @@ namespace System.Text.Json.Serialization.Converters
             _namingPolicy = namingPolicy;
             _nameCache = new ConcurrentDictionary<ulong, JsonEncodedText>();
 
+#if NET
+            string[] names = Enum.GetNames<T>();
+            T[] values = Enum.GetValues<T>();
+#else
             string[] names = Enum.GetNames(TypeToConvert);
             Array values = Enum.GetValues(TypeToConvert);
+#endif
             Debug.Assert(names.Length == values.Length);
 
             JavaScriptEncoder? encoder = serializerOptions.Encoder;
@@ -60,7 +65,11 @@ namespace System.Text.Json.Serialization.Converters
                     break;
                 }
 
+#if NET
+                T value = values[i];
+#else
                 T value = (T)values.GetValue(i)!;
+#endif
                 ulong key = ConvertToUInt64(value);
                 string name = names[i];
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -47,7 +47,7 @@ namespace System.Text.Json.Serialization.Converters
             _namingPolicy = namingPolicy;
             _nameCache = new ConcurrentDictionary<ulong, JsonEncodedText>();
 
-#if NET
+#if NET6_0_OR_GREATER
             string[] names = Enum.GetNames<T>();
             T[] values = Enum.GetValues<T>();
 #else
@@ -65,7 +65,7 @@ namespace System.Text.Json.Serialization.Converters
                     break;
                 }
 
-#if NET
+#if NET6_0_OR_GREATER
                 T value = values[i];
 #else
                 T value = (T)values.GetValue(i)!;


### PR DESCRIPTION
This PR expands the work of #64850 and uses the generic `Enum` methods in more places. I simply changed the libraries that were multi-targeting older frameworks but their actual code was targeting only modern .NET, and used compiler directives for the projects that actually multi-target to earlier frameworks.