### PR TITLE
Avoid empty array allocation in MethodBase.GetParameterTypes

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreCLR.cs
@@ -55,6 +55,10 @@ namespace System.Reflection
         internal virtual Type[] GetParameterTypes()
         {
             ParameterInfo[] paramInfo = GetParametersNoCopy();
+            if (paramInfo.Length == 0)
+            {
+                return Type.EmptyTypes;
+            }
 
             Type[] parameterTypes = new Type[paramInfo.Length];
             for (int i = 0; i < paramInfo.Length; i++)


### PR DESCRIPTION
No parameters is very common.  Avoid a `new Type[0]` array in such cases.