### PR TITLE
System.Runtime no longer needs to enable preview features

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/ReadWriteAdapter.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/ReadWriteAdapter.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 
 namespace System.Net.Security
 {
-#pragma warning disable CA2252 // This API requires opting into preview features
     internal interface IReadWriteAdapter
     {
         static abstract ValueTask<int> ReadAsync(Stream stream, Memory<byte> buffer, CancellationToken cancellationToken);
@@ -15,7 +14,6 @@ namespace System.Net.Security
         static abstract Task FlushAsync(Stream stream, CancellationToken cancellationToken);
         static abstract Task WaitAsync(TaskCompletionSource<bool> waiter);
     }
-#pragma warning restore CA2252
 
     internal readonly struct AsyncReadWriteAdapter : IReadWriteAdapter
     {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.cs
@@ -49,9 +49,7 @@ namespace System.Runtime.CompilerServices
                 case ByRefFields:
                 case UnmanagedSignatureCallingConvention:
                 case DefaultImplementationsOfInterfaces:
-#pragma warning disable CA2252
                 case VirtualStaticsInInterfaces:
-#pragma warning restore CA2252
                     return true;
                 case nameof(IsDynamicCodeSupported):
                     return IsDynamicCodeSupported;

--- a/src/libraries/System.Runtime/src/System.Runtime.csproj
+++ b/src/libraries/System.Runtime/src/System.Runtime.csproj
@@ -3,9 +3,6 @@
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <Nullable>enable</Nullable>
-    <!-- The following 2 lines disable the automatic generation of the [RequiresPreviewFeatures] assembly level attribute and set LangVersion to Preview on the latest TFM-->
-    <EnablePreviewFeatures>True</EnablePreviewFeatures>
-    <GenerateRequiresPreviewFeaturesAttribute>False</GenerateRequiresPreviewFeaturesAttribute>
   </PropertyGroup>
   <ItemGroup>
     <!-- Compiler throws error if you try to use System.Void and instructs you to use void keyword instead. So we have manually added a typeforward for this type. -->

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -1138,14 +1138,12 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <summary>Represents a set of routines for operating over a <see cref="CurrentState"/>.</summary>
         private interface IStateHandler
         {
-#pragma warning disable CA2252 // This API requires opting into preview features
             public static abstract bool StartsWithLineAnchor(ref CurrentState state);
             public static abstract bool IsNullable(ref CurrentState state, uint nextCharKind);
             public static abstract bool IsDeadend(ref CurrentState state);
             public static abstract int FixedLength(ref CurrentState state);
             public static abstract bool IsInitialState(ref CurrentState state);
             public static abstract bool TakeTransition(SymbolicRegexBuilder<TSetType> builder, ref CurrentState state, int mintermId);
-#pragma warning restore CA2252 // This API requires opting into preview features
         }
 
         /// <summary>An <see cref="IStateHandler"/> for operating over <see cref="CurrentState"/> instances configured as DFA states.</summary>


### PR DESCRIPTION
As was noted in https://github.com/dotnet/runtime/pull/66819#issuecomment-1072186578, we no longer need to have preview features enabled in System.Runtime now that the attribute has been removed from the generic math APIs.