### PR TITLE
Single-file debugging support in DBI and createdump

### DIFF
--- a/src/coreclr/debug/createdump/crashinfo.h
+++ b/src/coreclr/debug/createdump/crashinfo.h
@@ -31,6 +31,7 @@ typedef __typeof__(((elf_aux_entry*) 0)->a_un.a_val) elf_aux_val_t;
 #endif
 
 extern const std::string GetFileName(const std::string& fileName);
+extern const std::string GetDirectory(const std::string& fileName);
 extern std::string FormatString(const char* format, ...);
 extern std::string FormatGuid(const GUID* guid);
 
@@ -60,6 +61,7 @@ private:
     int m_fd;                                       // /proc/<pid>/mem handle
 #endif
     std::string m_coreclrPath;                      // the path of the coreclr module or empty if none
+    uint64_t m_runtimeBaseAddress;
 #ifdef __APPLE__
     std::set<MemoryRegion> m_allMemoryRegions;      // all memory regions on MacOS
 #else
@@ -108,6 +110,7 @@ public:
     inline const uint32_t Signal() const { return m_signal; }
     inline const std::string& Name() const { return m_name; }
     inline const ModuleInfo* MainModule() const { return m_mainModule; }
+    inline const uint64_t RuntimeBaseAddress() const { return m_runtimeBaseAddress; }
 
     inline const std::vector<ThreadInfo*>& Threads() const { return m_threads; }
     inline const std::set<MemoryRegion>& ModuleMappings() const { return m_moduleMappings; }

--- a/src/coreclr/debug/createdump/crashinfomac.cpp
+++ b/src/coreclr/debug/createdump/crashinfomac.cpp
@@ -248,13 +248,33 @@ void CrashInfo::VisitModule(MachOModule& module)
     if (m_coreclrPath.empty())
     {
         size_t last = module.Name().rfind(DIRECTORY_SEPARATOR_STR_A MAKEDLLNAME_A("coreclr"));
-        if (last != std::string::npos) {
+        if (last != std::string::npos)
+        {
             m_coreclrPath = module.Name().substr(0, last + 1);
+            m_runtimeBaseAddress = module.BaseAddress();
 
             uint64_t symbolOffset;
             if (!module.TryLookupSymbol("g_dacTable", &symbolOffset))
             {
                 TRACE("TryLookupSymbol(g_dacTable) FAILED\n");
+            }
+        }
+        else
+        {
+            uint64_t symbolOffset;
+            if (module.TryLookupSymbol("DotNetRuntimeInfo", &symbolOffset))
+            {
+                m_coreclrPath = GetDirectory(module.Name());
+                m_runtimeBaseAddress = module.BaseAddress();
+
+                RuntimeInfo runtimeInfo { };
+                if (ReadMemory((void*)(module.BaseAddress() + symbolOffset), &runtimeInfo, sizeof(RuntimeInfo)))
+                {
+                    if (strcmp(runtimeInfo.Signature, RUNTIME_INFO_SIGNATURE) == 0)
+                    {
+                        TRACE("Found valid single-file runtime info\n");
+                    }
+                }
             }
         }
     }
@@ -328,7 +348,7 @@ CrashInfo::VisitSection(MachOModule& module, const section_64& section)
 uint32_t
 CrashInfo::GetMemoryRegionFlags(uint64_t start)
 {
-    MemoryRegion search(0, start, start + PAGE_SIZE);
+    MemoryRegion search(0, start, start + PAGE_SIZE, 0);
     const MemoryRegion* region = SearchMemoryRegions(m_allMemoryRegions, search);
     if (region != nullptr) {
         return region->Flags();

--- a/src/coreclr/debug/createdump/crashinfomac.cpp
+++ b/src/coreclr/debug/createdump/crashinfomac.cpp
@@ -259,7 +259,7 @@ void CrashInfo::VisitModule(MachOModule& module)
                 TRACE("TryLookupSymbol(g_dacTable) FAILED\n");
             }
         }
-        else
+        else if (g_checkForSingleFile)
         {
             uint64_t symbolOffset;
             if (module.TryLookupSymbol("DotNetRuntimeInfo", &symbolOffset))

--- a/src/coreclr/debug/createdump/crashinfounix.cpp
+++ b/src/coreclr/debug/createdump/crashinfounix.cpp
@@ -296,7 +296,7 @@ CrashInfo::VisitModule(uint64_t baseAddress, std::string& moduleName)
                 }
             }
         }
-        else
+        else if (g_checkForSingleFile)
         {
             if (PopulateForSymbolLookup(baseAddress))
             {

--- a/src/coreclr/debug/createdump/crashinfounix.cpp
+++ b/src/coreclr/debug/createdump/crashinfounix.cpp
@@ -263,21 +263,57 @@ CrashInfo::VisitModule(uint64_t baseAddress, std::string& moduleName)
     if (baseAddress == 0 || baseAddress == m_auxvValues[AT_SYSINFO_EHDR]) {
         return;
     }
+    // For reasons unknown the main app singlefile module name is empty in the DSO. This replaces
+    // it with the one found in the /proc/<pid>/maps.
+    if (moduleName.empty())
+    {
+        MemoryRegion search(0, baseAddress, baseAddress + PAGE_SIZE);
+        const MemoryRegion* region = SearchMemoryRegions(m_moduleMappings, search);
+        if (region != nullptr)
+        {
+            moduleName = region->FileName();
+            TRACE("VisitModule using module name from mappings '%s'\n", moduleName.c_str());
+        }
+    }
     AddModuleInfo(false, baseAddress, nullptr, moduleName);
     if (m_coreclrPath.empty())
     {
         size_t last = moduleName.rfind(DIRECTORY_SEPARATOR_STR_A MAKEDLLNAME_A("coreclr"));
-        if (last != std::string::npos) {
+        if (last != std::string::npos)
+        {
             m_coreclrPath = moduleName.substr(0, last + 1);
+            m_runtimeBaseAddress = baseAddress;
 
             // Now populate the elfreader with the runtime module info and
             // lookup the DAC table symbol to ensure that all the memory
             // necessary is in the core dump.
-            if (PopulateForSymbolLookup(baseAddress)) {
+            if (PopulateForSymbolLookup(baseAddress))
+            {
                 uint64_t symbolOffset;
                 if (!TryLookupSymbol("g_dacTable", &symbolOffset))
                 {
                     TRACE("TryLookupSymbol(g_dacTable) FAILED\n");
+                }
+            }
+        }
+        else
+        {
+            if (PopulateForSymbolLookup(baseAddress))
+            {
+                uint64_t symbolOffset;
+                if (TryLookupSymbol("DotNetRuntimeInfo", &symbolOffset))
+                {
+                    m_coreclrPath = GetDirectory(moduleName);
+                    m_runtimeBaseAddress = baseAddress;
+
+                    RuntimeInfo runtimeInfo { };
+                    if (ReadMemory((void*)(baseAddress + symbolOffset), &runtimeInfo, sizeof(RuntimeInfo)))
+                    {
+                        if (strcmp(runtimeInfo.Signature, RUNTIME_INFO_SIGNATURE) == 0)
+                        {
+                            TRACE("Found valid single-file runtime info\n");
+                        }
+                    }
                 }
             }
         }
@@ -314,7 +350,7 @@ CrashInfo::VisitProgramHeader(uint64_t loadbias, uint64_t baseAddress, Phdr* phd
 uint32_t
 CrashInfo::GetMemoryRegionFlags(uint64_t start)
 {
-    MemoryRegion search(0, start, start + PAGE_SIZE);
+    MemoryRegion search(0, start, start + PAGE_SIZE, 0);
     const MemoryRegion* region = SearchMemoryRegions(m_moduleMappings, search);
     if (region != nullptr) {
         return region->Flags();

--- a/src/coreclr/debug/createdump/crashinfounix.cpp
+++ b/src/coreclr/debug/createdump/crashinfounix.cpp
@@ -178,7 +178,7 @@ CrashInfo::EnumerateModuleMappings()
         char* permissions = nullptr;
         char* moduleName = nullptr;
 
-        int c = sscanf(line, "%" PRIx64 "-%" PRIx64 " %m[-rwxsp] %" PRIx64 " %*[:0-9a-f] %*d %ms\n", &start, &end, &permissions, &offset, &moduleName);
+        int c = sscanf(line, "%" PRIx64 "-%" PRIx64 " %m[-rwxsp] %" PRIx64 " %*[:0-9a-f] %*d %m[^\n]\n", &start, &end, &permissions, &offset, &moduleName);
         if (c == 4 || c == 5)
         {
             // r = read

--- a/src/coreclr/debug/createdump/createdump.h
+++ b/src/coreclr/debug/createdump/createdump.h
@@ -10,6 +10,7 @@ extern bool g_diagnostics;
 extern bool g_diagnosticsVerbose;
 
 #ifdef HOST_UNIX
+extern bool g_checkForSingleFile;
 extern void trace_printf(const char* format, ...);
 extern void trace_verbose_printf(const char* format, ...);
 #define TRACE(args...) trace_printf(args)

--- a/src/coreclr/debug/createdump/createdump.h
+++ b/src/coreclr/debug/createdump/createdump.h
@@ -98,6 +98,7 @@ typedef int T_CONTEXT;
 #include "crashinfo.h"
 #include "crashreportwriter.h"
 #include "dumpwriter.h"
+#include "runtimeinfo.h"
 #endif
 
 #ifndef MAX_LONGPATH

--- a/src/coreclr/debug/createdump/datatarget.cpp
+++ b/src/coreclr/debug/createdump/datatarget.cpp
@@ -26,6 +26,12 @@ DumpDataTarget::QueryInterface(
         AddRef();
         return S_OK;
     }
+    else if (InterfaceId == IID_ICLRRuntimeLocator)
+    {
+        *Interface = (ICLRRuntimeLocator*)this;
+        AddRef();
+        return S_OK;
+    }
     else
     {
         *Interface = NULL;
@@ -201,4 +207,14 @@ DumpDataTarget::Request(
 {
     assert(false);
     return E_NOTIMPL;
+}
+
+// ICLRRuntimeLocator
+
+HRESULT STDMETHODCALLTYPE 
+DumpDataTarget::GetRuntimeBase(
+    /* [out] */ CLRDATA_ADDRESS* baseAddress)
+{
+    *baseAddress = m_crashInfo.RuntimeBaseAddress();
+    return S_OK;
 }

--- a/src/coreclr/debug/createdump/datatarget.h
+++ b/src/coreclr/debug/createdump/datatarget.h
@@ -3,7 +3,7 @@
 
 class CrashInfo;
 
-class DumpDataTarget : public ICLRDataTarget
+class DumpDataTarget : public ICLRDataTarget, ICLRRuntimeLocator
 {
 private:
     LONG m_ref;                         // reference count
@@ -79,4 +79,9 @@ public:
         /* [size_is][in] */ BYTE *inBuffer,
         /* [in] */ ULONG32 outBufferSize,
         /* [size_is][out] */ BYTE *outBuffer);
+
+    // ICLRRuntimeLocator
+
+    virtual HRESULT STDMETHODCALLTYPE GetRuntimeBase(
+        /* [out] */ CLRDATA_ADDRESS* baseAddress);
 };

--- a/src/coreclr/debug/createdump/main.cpp
+++ b/src/coreclr/debug/createdump/main.cpp
@@ -28,6 +28,7 @@ const char* g_help = "createdump [options] pid\n"
 "--crashreport - write crash report file (dump file path + .crashreport.json).\n"
 "--crashthread <id> - the thread id of the crashing thread.\n"
 "--signal <code> - the signal code of the crash.\n"
+"--singlefile - enable single-file app check.\n"
 #endif
 ;
 
@@ -37,6 +38,7 @@ FILE *g_stderr = stderr;
 bool g_diagnostics = false;
 bool g_diagnosticsVerbose = false;
 #ifdef HOST_UNIX
+bool g_checkForSingleFile = false;
 uint64_t g_ticksPerMS = 0;
 uint64_t GetTickFrequency();
 #endif
@@ -134,6 +136,10 @@ int __cdecl main(const int argc, const char* argv[])
             else if (strcmp(*argv, "--signal") == 0)
             {
                 signal = atoi(*++argv);
+            }
+            else if (strcmp(*argv, "--singlefile") == 0)
+            {
+                g_checkForSingleFile = true;
             }
 #endif
             else if ((strcmp(*argv, "-d") == 0) || (strcmp(*argv, "--diag") == 0))

--- a/src/coreclr/debug/dbgutil/elfreader.cpp
+++ b/src/coreclr/debug/dbgutil/elfreader.cpp
@@ -387,10 +387,9 @@ ElfReader::EnumerateLinkMapEntries(Elf_Dyn* dynamicAddr)
         }
         // Read the module's name and make sure the memory is added to the core dump
         std::string moduleName;
-        int i = 0;
-        if (map.l_name != nullptr)
+        if (map.l_name != 0)
         {
-            for (; i < PATH_MAX; i++)
+            for (int i = 0; i < PATH_MAX; i++)
             {
                 char ch;
                 if (!ReadMemory(map.l_name + i, &ch, sizeof(ch))) {
@@ -403,7 +402,7 @@ ElfReader::EnumerateLinkMapEntries(Elf_Dyn* dynamicAddr)
                 moduleName.append(1, ch);
             }
         }
-        Trace("\nDSO: link_map entry %p l_ld %p l_addr (Ehdr) %" PRIx " %s\n", linkMapAddr, map.l_ld, map.l_addr, moduleName.c_str());
+        Trace("\nDSO: link_map entry %p l_ld %p l_addr (Ehdr) %p l_name %p %s\n", linkMapAddr, map.l_ld, map.l_addr, map.l_name, moduleName.c_str());
 
         // Call the derived class for each module
         VisitModule(map.l_addr, moduleName);

--- a/src/coreclr/debug/di/cordb.cpp
+++ b/src/coreclr/debug/di/cordb.cpp
@@ -92,29 +92,29 @@ STDAPI CreateCordbObject(int iDebuggerVersion, IUnknown ** ppCordb)
     {
         return E_INVALIDARG;
     }
-
     return Cordb::CreateObject(
-        (CorDebugInterfaceVersion)iDebuggerVersion, ProcessDescriptor::UNINITIALIZED_PID, /*lpApplicationGroupId*/ NULL, IID_ICorDebug, (void **) ppCordb);
+        (CorDebugInterfaceVersion)iDebuggerVersion, ProcessDescriptor::UNINITIALIZED_PID, /*lpApplicationGroupId*/ NULL,  /*dacModulePath*/ NULL, IID_ICorDebug, (void **) ppCordb);
 }
 
 //
 // Public API.
-// Telesto Creation path with Mac sandbox support - only way to debug a sandboxed application on Mac.
-// This supercedes code:CoreCLRCreateCordbObject
+// Creation path with Mac sandbox support and explicit DAC module path for single-file apps
+// This supercedes code:CoreCLRCreateCordbObjectEx
 //
 // Arguments:
 //    iDebuggerVersion - version of ICorDebug interfaces that the debugger is requesting
 //    pid - pid of debuggee that we're attaching to.
-//    lpApplicationGroupId - A string representing the application group ID of a sandboxed
+//    lpApplicationGroupId - a string representing the application group ID of a sandboxed
 //                           process running in Mac. Pass NULL if the process is not
 //                           running in a sandbox and other platforms.
+//    dacModulePath - the full module path of the DAC module or NULL.
 //    hmodTargetCLR - module handle to clr in target pid that we're attaching to.
 //    ppCordb - (out) the resulting ICorDebug object.
 //
 // Notes:
 //    It's inconsistent that this takes a (handle, pid) but hands back an ICorDebug instead of an ICorDebugProcess.
 //    Callers will need to call *ppCordb->DebugActiveProcess(pid).
-STDAPI DLLEXPORT CoreCLRCreateCordbObjectEx(int iDebuggerVersion, DWORD pid, LPCWSTR lpApplicationGroupId, HMODULE hmodTargetCLR, IUnknown ** ppCordb)
+STDAPI DLLEXPORT CoreCLRCreateCordbObject3(int iDebuggerVersion, DWORD pid, LPCWSTR lpApplicationGroupId, LPCWSTR dacModulePath, HMODULE hmodTargetCLR, IUnknown** ppCordb)
 {
     if (ppCordb == NULL)
     {
@@ -130,7 +130,7 @@ STDAPI DLLEXPORT CoreCLRCreateCordbObjectEx(int iDebuggerVersion, DWORD pid, LPC
     // Create the ICorDebug object
     //
     RSExtSmartPtr<ICorDebug> pCordb;
-    Cordb::CreateObject((CorDebugInterfaceVersion)iDebuggerVersion, pid, lpApplicationGroupId, IID_ICorDebug, (void **) &pCordb);
+    Cordb::CreateObject((CorDebugInterfaceVersion)iDebuggerVersion, pid, lpApplicationGroupId, dacModulePath, IID_ICorDebug, (void **) &pCordb);
 
     //
     // Associate it with the target instance
@@ -152,7 +152,29 @@ STDAPI DLLEXPORT CoreCLRCreateCordbObjectEx(int iDebuggerVersion, DWORD pid, LPC
 
 //
 // Public API.
-// Telesto Creation path - only way to debug multi-instance.
+// Creation path with Mac sandbox support - only way to debug a sandboxed application on Mac.
+// This supercedes code:CoreCLRCreateCordbObject
+//
+// Arguments:
+//    iDebuggerVersion - version of ICorDebug interfaces that the debugger is requesting
+//    pid - pid of debuggee that we're attaching to.
+//    lpApplicationGroupId - a string representing the application group ID of a sandboxed
+//                           process running in Mac. Pass NULL if the process is not
+//                           running in a sandbox and other platforms.
+//    hmodTargetCLR - module handle to clr in target pid that we're attaching to.
+//    ppCordb - (out) the resulting ICorDebug object.
+//
+// Notes:
+//    It's inconsistent that this takes a (handle, pid) but hands back an ICorDebug instead of an ICorDebugProcess.
+//    Callers will need to call *ppCordb->DebugActiveProcess(pid).
+STDAPI DLLEXPORT CoreCLRCreateCordbObjectEx(int iDebuggerVersion, DWORD pid, LPCWSTR lpApplicationGroupId, HMODULE hmodTargetCLR, IUnknown ** ppCordb)
+{
+    return CoreCLRCreateCordbObject3(iDebuggerVersion, pid, lpApplicationGroupId, NULL, hmodTargetCLR, ppCordb);
+}
+
+//
+// Public API.
+// Creation path - only way to debug multi-instance.
 // This supercedes code:CreateCordbObject
 //
 // Arguments:
@@ -168,9 +190,6 @@ STDAPI DLLEXPORT CoreCLRCreateCordbObject(int iDebuggerVersion, DWORD pid, HMODU
 {
     return CoreCLRCreateCordbObjectEx(iDebuggerVersion, pid, NULL, hmodTargetCLR, ppCordb);
 }
-
-
-
 
 
 //*****************************************************************************
@@ -433,10 +452,10 @@ STDAPI GetRequestedRuntimeInfo(LPCWSTR pExe,
                                LPCWSTR pConfigurationFile,
                                DWORD startupFlags,
                                DWORD runtimeInfoFlags,
-                               _Out_writes_bytes_opt_(dwDirectory) LPWSTR pDirectory,
+                               __out_ecount_opt(dwDirectory) LPWSTR pDirectory,
                                DWORD dwDirectory,
                                DWORD *dwDirectoryLength,
-                               _Out_writes_bytes_opt_(cchBuffer)   LPWSTR pVersion,
+                               __out_ecount_opt(cchBuffer)   LPWSTR pVersion,
                                DWORD cchBuffer,
                                DWORD* dwlength)
 {

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -684,9 +684,9 @@ CordbProcess::CreateDacDbiInterface()
     // in the new arch we can get the module from OpenVirtualProcess2 but in the shim case
     // and the deprecated OpenVirtualProcess case we must assume it comes from DAC in the
     // same directory as DBI
-    if(m_hDacModule == NULL)
+    if (m_hDacModule == NULL)
     {
-        m_hDacModule.Assign(ShimProcess::GetDacModule());
+        m_hDacModule.Assign(ShimProcess::GetDacModule(m_cordb->GetDacModulePath()));
     }
 
     //

--- a/src/coreclr/debug/di/rsmain.cpp
+++ b/src/coreclr/debug/di/rsmain.cpp
@@ -956,17 +956,18 @@ namespace
  * Cordb class
  * ------------------------------------------------------------------------- */
 Cordb::Cordb(CorDebugInterfaceVersion iDebuggerVersion)
-  : Cordb(iDebuggerVersion, ProcessDescriptor::CreateUninitialized())
+  : Cordb(iDebuggerVersion, ProcessDescriptor::CreateUninitialized(), NULL)
 {
 }
 
-Cordb::Cordb(CorDebugInterfaceVersion iDebuggerVersion, const ProcessDescriptor& pd)
-  : CordbBase(NULL, 0, enumCordb)
-  , m_processes(11)
-  , m_initialized(false)
-  , m_debuggerSpecifiedVersion(iDebuggerVersion)
-  , m_pd(pd)
-  , m_targetCLR(0)
+Cordb::Cordb(CorDebugInterfaceVersion iDebuggerVersion, const ProcessDescriptor& pd, LPCWSTR dacModulePath)
+  : CordbBase(NULL, 0, enumCordb),
+    m_processes(11),
+    m_initialized(false),
+    m_debuggerSpecifiedVersion(iDebuggerVersion),
+    m_pd(pd),
+    m_dacModulePath(dacModulePath),
+    m_targetCLR(0)
 {
     g_pRSDebuggingInfo->m_Cordb = this;
 
@@ -2049,7 +2050,7 @@ void Cordb::EnsureCanLaunchOrAttach(BOOL fWin32DebuggingEnabled)
 
 HRESULT Cordb::CreateObjectV1(REFIID id, void **object)
 {
-    return CreateObject(CorDebugVersion_1_0, ProcessDescriptor::UNINITIALIZED_PID, NULL, id, object);
+    return CreateObject(CorDebugVersion_1_0, ProcessDescriptor::UNINITIALIZED_PID, NULL, NULL, id, object);
 }
 
 #if defined(FEATURE_DBGIPC_TRANSPORT_DI)
@@ -2057,13 +2058,13 @@ HRESULT Cordb::CreateObjectV1(REFIID id, void **object)
 // same debug engine version as V2, though this may change in the future.
 HRESULT Cordb::CreateObjectTelesto(REFIID id, void ** pObject)
 {
-    return CreateObject(CorDebugVersion_2_0, ProcessDescriptor::UNINITIALIZED_PID, NULL, id, pObject);
+    return CreateObject(CorDebugVersion_2_0, ProcessDescriptor::UNINITIALIZED_PID, NULL, NULL, id, pObject);
 }
 #endif // FEATURE_DBGIPC_TRANSPORT_DI
 
 // Static
 // Used to create an instance for a ClassFactory (thus an external ref).
-HRESULT Cordb::CreateObject(CorDebugInterfaceVersion iDebuggerVersion, DWORD pid, LPCWSTR lpApplicationGroupId, REFIID id, void **object)
+HRESULT Cordb::CreateObject(CorDebugInterfaceVersion iDebuggerVersion, DWORD pid, LPCWSTR lpApplicationGroupId, LPCWSTR dacModulePath, REFIID id, void **object)
 {
     if (id != IID_IUnknown && id != IID_ICorDebug)
         return (E_NOINTERFACE);
@@ -2095,7 +2096,7 @@ HRESULT Cordb::CreateObject(CorDebugInterfaceVersion iDebuggerVersion, DWORD pid
 
     ProcessDescriptor pd = ProcessDescriptor::Create(pid, applicationGroupId);
 
-    Cordb *db = new (nothrow) Cordb(iDebuggerVersion, pd);
+    Cordb *db = new (nothrow) Cordb(iDebuggerVersion, pd, dacModulePath);
 
     if (db == NULL)
     {

--- a/src/coreclr/debug/di/rspriv.h
+++ b/src/coreclr/debug/di/rspriv.h
@@ -2235,7 +2235,7 @@ public:
 #if defined(FEATURE_DBGIPC_TRANSPORT_DI)
     static COM_METHOD CreateObjectTelesto(REFIID id, void ** pObject);
 #endif // FEATURE_DBGIPC_TRANSPORT_DI
-    static COM_METHOD CreateObject(CorDebugInterfaceVersion iDebuggerVersion, DWORD pid, LPCWSTR lpApplicationGroupId, REFIID id, void **object);
+    static COM_METHOD CreateObject(CorDebugInterfaceVersion iDebuggerVersion, DWORD pid, LPCWSTR lpApplicationGroupId, LPCWSTR lpwstrDacModulePath, REFIID id, void** object);
 
     //-----------------------------------------------------------
     // ICorDebugRemote
@@ -2308,6 +2308,7 @@ public:
 
 private:
     Cordb(CorDebugInterfaceVersion iDebuggerVersion, const ProcessDescriptor& pd);
+    Cordb(CorDebugInterfaceVersion iDebuggerVersion, const ProcessDescriptor& pd, LPCWSTR dacModulePath);
 
     //-----------------------------------------------------------
     // Data members
@@ -2323,6 +2324,8 @@ public:
     CordbRCEventThread*         m_rcEventThread;
 
     CorDebugInterfaceVersion    GetDebuggerVersion() const;
+
+    PathString& GetDacModulePath() { return m_dacModulePath; }
 
     HMODULE GetTargetCLR() { return m_targetCLR; }
 
@@ -2344,6 +2347,8 @@ private:
 
     // Store information about the process to be debugged
     ProcessDescriptor m_pd;
+
+    PathString m_dacModulePath;
 
     HMODULE m_targetCLR;
 };

--- a/src/coreclr/debug/di/shimpriv.h
+++ b/src/coreclr/debug/di/shimpriv.h
@@ -389,7 +389,7 @@ public:
     );
 
     // Locates the DAC module adjacent to DBI
-    static HMODULE GetDacModule();
+    static HMODULE GetDacModule(PathString& dacModulePath);
 
     //
     // Functions used by CordbProcess

--- a/src/coreclr/debug/di/shimprocess.cpp
+++ b/src/coreclr/debug/di/shimprocess.cpp
@@ -1594,28 +1594,30 @@ void ShimProcess::PreDispatchEvent(bool fRealCreateProcessEvent /*= false*/)
 //    Throws on errors.
 //
 
-HMODULE ShimProcess::GetDacModule()
+HMODULE ShimProcess::GetDacModule(PathString& dacModulePath)
 {
-    HModuleHolder hDacDll;
-    PathString wszAccessDllPath;
+    HMODULE hDacDll;
+    PathString wszAccessDllPath(dacModulePath);
 
-    //
-    // Load the access DLL from the same directory as the the current CLR Debugging Services DLL.
-    //
-    if (GetClrModuleDirectory(wszAccessDllPath) != S_OK)
+    if (wszAccessDllPath.IsEmpty())
     {
-        ThrowLastError();
+        //
+        // Load the access DLL from the same directory as the the current CLR Debugging Services DLL.
+        //
+        if (GetClrModuleDirectory(wszAccessDllPath) != S_OK)
+        {
+            ThrowLastError();
+        }
+
+        // Dac Dll is named:
+        //   mscordaccore.dll  <-- coreclr
+        //   mscordacwks.dll   <-- desktop
+        PCWSTR eeFlavor = MAKEDLLNAME_W(W("mscordaccore"));
+
+        wszAccessDllPath.Append(eeFlavor);
     }
-
-    // Dac Dll is named:
-    //   mscordaccore.dll  <-- coreclr
-    //   mscordacwks.dll   <-- desktop
-    PCWSTR eeFlavor = MAKEDLLNAME_W(W("mscordaccore"));
-
-    wszAccessDllPath.Append(eeFlavor);
-
-    hDacDll.Assign(WszLoadLibrary(wszAccessDllPath));
-    if (!hDacDll)
+    hDacDll = WszLoadLibrary(wszAccessDllPath);
+    if (hDacDll == NULL)
     {
         DWORD dwLastError = GetLastError();
         if (dwLastError == ERROR_MOD_NOT_FOUND)
@@ -1628,8 +1630,7 @@ HMODULE ShimProcess::GetDacModule()
             ThrowWin32(dwLastError);
         }
     }
-    hDacDll.SuppressRelease();
-    return (HMODULE) hDacDll;
+    return hDacDll;
 }
 
 MachineInfo ShimProcess::GetMachineInfo()

--- a/src/coreclr/dlls/mscordbi/mscordbi.src
+++ b/src/coreclr/dlls/mscordbi/mscordbi.src
@@ -20,6 +20,7 @@ EXPORTS
 
     CoreCLRCreateCordbObject private
     CoreCLRCreateCordbObjectEx private
+    CoreCLRCreateCordbObject3 private
 
 #if defined(FEATURE_DBGIPC_TRANSPORT_DI)
     DllGetClassObject private

--- a/src/coreclr/dlls/mscordbi/mscordbi_unixexports.src
+++ b/src/coreclr/dlls/mscordbi/mscordbi_unixexports.src
@@ -8,6 +8,7 @@ DllGetClassObject
 ; CoreClr API
 CoreCLRCreateCordbObject
 CoreCLRCreateCordbObjectEx
+CoreCLRCreateCordbObject3
 
 ; Out-of-proc creation path from the shim - ICLRDebugging
 OpenVirtualProcessImpl

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -117,6 +117,7 @@ extern "C"
 #endif
 
 extern char *g_szCoreCLRPath;
+extern bool g_running_in_exe;
 
 using namespace CorUnix;
 
@@ -2340,6 +2341,11 @@ PROCBuildCreateDumpCommandLine(
     if (flags & GenerateDumpFlagsCrashReportEnabled)
     {
         argv.push_back("--crashreport");
+    }
+
+    if (g_running_in_exe)
+    {
+        argv.push_back("--singlefile");
     }
 
     if (logFileName != nullptr)


### PR DESCRIPTION
Add single-file debugging to DBI

Add new CoreCLRCreateCordbObjectEx2 API that takes the DAC module path instead of
assuming the DAC module is in the same directory as DBI.

Add ICLRDebuggingLibraryProvider3 to metahost.idl

Add createdump single-file support. This allows dumps to be created for single-file apps if createdump and libmscordaccore are copied side-by-side with the app binary.  This is the first step in the final dump support on Linux/MacOS.

Use module name from /proc/<pid>/maps when the DSO module name is empty.

Make sure the DotNetRuntimeInfo block is in the core dump.

Fix bug with spaces in module names in createdump on Linux.