### PR TITLE
Remove dead code in `System.Linq.Expressions`

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -84,17 +84,17 @@ namespace System.Dynamic.Utils
         private static MethodInfo[] GetActionThunks()
         {
             Type delHelpers = typeof(DelegateHelpers);
-            return new MethodInfo[]{delHelpers.GetMethod("ActionThunk")!,
-                                    delHelpers.GetMethod("ActionThunk1")!,
-                                    delHelpers.GetMethod("ActionThunk2")!};
+            return new MethodInfo[]{delHelpers.GetMethod(nameof(ActionThunk))!,
+                                    delHelpers.GetMethod(nameof(ActionThunk1))!,
+                                    delHelpers.GetMethod(nameof(ActionThunk2))!};
         }
 
         private static MethodInfo[] GetFuncThunks()
         {
             Type delHelpers = typeof(DelegateHelpers);
-            return new MethodInfo[]{delHelpers.GetMethod("FuncThunk")!,
-                                    delHelpers.GetMethod("FuncThunk1")!,
-                                    delHelpers.GetMethod("FuncThunk2")!};
+            return new MethodInfo[]{delHelpers.GetMethod(nameof(FuncThunk))!,
+                                    delHelpers.GetMethod(nameof(FuncThunk1))!,
+                                    delHelpers.GetMethod(nameof(FuncThunk2))!};
         }
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -11,12 +11,7 @@ namespace System.Linq.Expressions.Compiler
 {
     internal sealed partial class LambdaCompiler
     {
-        private void EmitBinaryExpression(Expression expr)
-        {
-            EmitBinaryExpression(expr, CompilationFlags.EmitAsNoTail);
-        }
-
-        private void EmitBinaryExpression(Expression expr, CompilationFlags flags)
+        private void EmitBinaryExpression(Expression expr, CompilationFlags flags = CompilationFlags.EmitAsNoTail)
         {
             BinaryExpression b = (BinaryExpression)expr;
 

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -71,16 +71,7 @@ namespace System.Linq.Expressions.Compiler
             EmitExpression(node, CompilationFlags.EmitAsNoTail | CompilationFlags.EmitExpressionStart);
         }
 
-        /// <summary>
-        /// Emits an expression and discards the result.  For some nodes this emits
-        /// more optimal code then EmitExpression/Pop
-        /// </summary>
-        private void EmitExpressionAsVoid(Expression node)
-        {
-            EmitExpressionAsVoid(node, CompilationFlags.EmitAsNoTail);
-        }
-
-        private void EmitExpressionAsVoid(Expression node, CompilationFlags flags)
+        private void EmitExpressionAsVoid(Expression node, CompilationFlags flags = CompilationFlags.EmitAsNoTail)
         {
             Debug.Assert(node != null);
 

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -71,13 +71,9 @@ namespace System.Linq.Expressions.Interpreter
             }
 
             // see if we've created one w/ a delegate
-            CallInstruction? res;
-            if (ShouldCache(info))
+            if (s_cache.TryGetValue(info, out CallInstruction? res))
             {
-                if (s_cache.TryGetValue(info, out res))
-                {
-                    return res;
-                }
+                return res;
             }
 
             // create it
@@ -113,10 +109,7 @@ namespace System.Linq.Expressions.Interpreter
             }
 
             // cache it for future users if it's a reasonable method to cache
-            if (ShouldCache(info))
-            {
-                s_cache[info] = res;
-            }
+            s_cache[info] = res;
 
             return res;
         }
@@ -169,11 +162,6 @@ namespace System.Linq.Expressions.Interpreter
         public static void ArrayItemSetter3(Array array, int index0, int index1, int index2, object value)
         {
             array.SetValue(value, index0, index1, index2);
-        }
-
-        private static bool ShouldCache(MethodInfo info)
-        {
-            return true;
         }
 
 #if FEATURE_FAST_CREATE

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
@@ -25,8 +25,6 @@ namespace System.Linq.Expressions.Interpreter
 
         public virtual string ToDebugString(int instructionIndex, object? cookie, Func<int, int> labelIndexer, IReadOnlyList<object>? objects) => ToString();
 
-        public virtual object? GetDebugCookie(LightCompiler compiler) => null;
-
         // throws NRE when o is null
         protected static void NullCheck(object? o)
         {

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 
 namespace System.Linq.Expressions.Interpreter
@@ -124,12 +123,6 @@ namespace System.Linq.Expressions.Interpreter
 
         public InterpretedFrame? Parent => _parent;
 
-        public static bool IsInterpretedFrame(MethodBase method)
-        {
-            //ContractUtils.RequiresNotNull(method, nameof(method));
-            return method.DeclaringType == typeof(Interpreter) && method.Name == "Run";
-        }
-
         public IEnumerable<InterpretedFrameInfo> GetStackTraceDebugInfo()
         {
             InterpretedFrame? frame = this;
@@ -146,11 +139,6 @@ namespace System.Linq.Expressions.Interpreter
             {
                 exception.Data[typeof(InterpretedFrameInfo)] = new List<InterpretedFrameInfo>(GetStackTraceDebugInfo()).ToArray();
             }
-        }
-
-        public static InterpretedFrameInfo[]? GetExceptionStackTrace(Exception exception)
-        {
-            return exception.Data[typeof(InterpretedFrameInfo)] as InterpretedFrameInfo[];
         }
 
 #if DEBUG

--- a/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/DebugInfoGenerator.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/DebugInfoGenerator.cs
@@ -31,15 +31,5 @@ namespace System.Runtime.CompilerServices
         /// <param name="ilOffset">IL offset where to mark the sequence point.</param>
         /// <param name="sequencePoint">Debug information corresponding to the sequence point.</param>
         public abstract void MarkSequencePoint(LambdaExpression method, int ilOffset, DebugInfoExpression sequencePoint);
-
-        internal virtual void MarkSequencePoint(LambdaExpression method, MethodBase methodBase, ILGenerator ilg, DebugInfoExpression sequencePoint)
-        {
-            MarkSequencePoint(method, ilg.ILOffset, sequencePoint);
-        }
-
-        internal virtual void SetLocalName(LocalBuilder localBuilder, string name)
-        {
-            // nop
-        }
     }
 }


### PR DESCRIPTION
Closes #15440

I have tried my best to remove dead code.

There are of course still unnecessary casts but these do not change the size of the binary.
In my opinion you should refactor the whole code (but style changes are not welcome in the runtime, so I only removed the methods for now).

According to static code analysis tools (ReSharper), that was all the dead code.

/cc @bartdesmet