### PR TITLE
Update Ubuntu version names in the workflow docs

### DIFF
--- a/docs/workflow/requirements/linux-requirements.md
+++ b/docs/workflow/requirements/linux-requirements.md
@@ -18,7 +18,7 @@ All the required build tools are included in the Docker images used to do the bu
 Environment
 ===========
 
-These instructions are written assuming the Ubuntu 16.04/18.04 LTS, since that's the distro the team uses. Pull Requests are welcome to address other environments as long as they don't break the ability to use Ubuntu 16.04/18.04 LTS.
+These instructions are written assuming the current Ubuntu LTS, since that's the distro the team uses. Pull Requests are welcome to address other environments as long as they don't break the ability to use Ubuntu LTS.
 
 Minimum RAM required to build is 1GB. The build is known to fail on 512 MB VMs ([dotnet/runtime#4069](https://github.com/dotnet/runtime/issues/4069)).
 


### PR DESCRIPTION
16.04 and 18.04 are out of support, but we always support the latest Ubuntu LTS