### PR TITLE
Regex.Tests: Disable test that tries to blow the stack, on AOT

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -28,267 +28,267 @@ parameters:
 jobs:
 
 # Linux arm
-- ${{ if or(containsValue(parameters.platforms, 'Linux_arm'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: Linux
-      archType: arm
-      targetRid: linux-arm
-      platform: Linux_arm
-      container:
-        image: ubuntu-16.04-cross-20210719121212-8a8d3be
-        registry: mcr
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        crossrootfsDir: '/crossrootfs/arm'
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if or(containsValue(parameters.platforms, 'Linux_arm'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: Linux
+      #archType: arm
+      #targetRid: linux-arm
+      #platform: Linux_arm
+      #container:
+        #image: ubuntu-16.04-cross-20210719121212-8a8d3be
+        #registry: mcr
+      #jobParameters:
+        #runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #crossBuild: true
+        #crossrootfsDir: '/crossrootfs/arm'
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux armv6
-- ${{ if containsValue(parameters.platforms, 'Linux_armv6') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: Linux
-      archType: armv6
-      targetRid: linux-armv6
-      platform: Linux_armv6
-      container:
-        image: ubuntu-20.04-cross-armv6-raspbian-10-20211208135931-e6e3ac4
-        registry: mcr
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        crossrootfsDir: '/crossrootfs/armv6'
-        ${{ insert }}: ${{ parameters.jobParameters }}
+## Linux armv6
+#- ${{ if containsValue(parameters.platforms, 'Linux_armv6') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: Linux
+      #archType: armv6
+      #targetRid: linux-armv6
+      #platform: Linux_armv6
+      #container:
+        #image: ubuntu-20.04-cross-armv6-raspbian-10-20211208135931-e6e3ac4
+        #registry: mcr
+      #jobParameters:
+        #runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #crossBuild: true
+        #crossrootfsDir: '/crossrootfs/armv6'
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux arm64
+## Linux arm64
 
-- ${{ if or(containsValue(parameters.platforms, 'Linux_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: Linux
-      archType: arm64
-      targetRid: linux-arm64
-      platform: Linux_arm64
-      container:
-        ${{ if eq(parameters.container, '') }}:
-          image: ubuntu-16.04-cross-arm64-20210719121212-8a8d3be
-        ${{ if ne(parameters.container, '') }}:
-          image: ${{ parameters.container }}
-        registry: mcr
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        crossrootfsDir: '/crossrootfs/arm64'
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if or(containsValue(parameters.platforms, 'Linux_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: Linux
+      #archType: arm64
+      #targetRid: linux-arm64
+      #platform: Linux_arm64
+      #container:
+        #${{ if eq(parameters.container, '') }}:
+          #image: ubuntu-16.04-cross-arm64-20210719121212-8a8d3be
+        #${{ if ne(parameters.container, '') }}:
+          #image: ${{ parameters.container }}
+        #registry: mcr
+      #jobParameters:
+        #runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #crossBuild: true
+        #crossrootfsDir: '/crossrootfs/arm64'
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux musl x64
+## Linux musl x64
 
-- ${{ if or(containsValue(parameters.platforms, 'Linux_musl_x64'), eq(parameters.platformGroup, 'all')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: Linux
-      osSubgroup: _musl
-      archType: x64
-      targetRid: linux-musl-x64
-      platform: Linux_musl_x64
-      container:
-        image: alpine-3.13-WithNode-20210910135845-c401c85
-        registry: mcr
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if or(containsValue(parameters.platforms, 'Linux_musl_x64'), eq(parameters.platformGroup, 'all')) }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: Linux
+      #osSubgroup: _musl
+      #archType: x64
+      #targetRid: linux-musl-x64
+      #platform: Linux_musl_x64
+      #container:
+        #image: alpine-3.13-WithNode-20210910135845-c401c85
+        #registry: mcr
+      #jobParameters:
+        #runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux musl arm
+## Linux musl arm
 
-- ${{ if or(containsValue(parameters.platforms, 'Linux_musl_arm'), eq(parameters.platformGroup, 'all')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: Linux
-      osSubgroup: _musl
-      archType: arm
-      targetRid: linux-musl-arm
-      platform: Linux_musl_arm
-      container:
-        image: ubuntu-16.04-cross-arm-alpine-20210923140502-78f7860
-        registry: mcr
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        crossrootfsDir: '/crossrootfs/arm'
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if or(containsValue(parameters.platforms, 'Linux_musl_arm'), eq(parameters.platformGroup, 'all')) }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: Linux
+      #osSubgroup: _musl
+      #archType: arm
+      #targetRid: linux-musl-arm
+      #platform: Linux_musl_arm
+      #container:
+        #image: ubuntu-16.04-cross-arm-alpine-20210923140502-78f7860
+        #registry: mcr
+      #jobParameters:
+        #runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #crossBuild: true
+        #crossrootfsDir: '/crossrootfs/arm'
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux musl arm64
+## Linux musl arm64
 
-- ${{ if or(containsValue(parameters.platforms, 'Linux_musl_arm64'), eq(parameters.platformGroup, 'all')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: Linux
-      osSubgroup: _musl
-      archType: arm64
-      targetRid: linux-musl-arm64
-      platform: Linux_musl_arm64
-      container:
-        image: ubuntu-16.04-cross-arm64-alpine-20210923140502-78f7860
-        registry: mcr
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        crossrootfsDir: '/crossrootfs/arm64'
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if or(containsValue(parameters.platforms, 'Linux_musl_arm64'), eq(parameters.platformGroup, 'all')) }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: Linux
+      #osSubgroup: _musl
+      #archType: arm64
+      #targetRid: linux-musl-arm64
+      #platform: Linux_musl_arm64
+      #container:
+        #image: ubuntu-16.04-cross-arm64-alpine-20210923140502-78f7860
+        #registry: mcr
+      #jobParameters:
+        #runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #crossBuild: true
+        #crossrootfsDir: '/crossrootfs/arm64'
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux x64
+## Linux x64
 
-- ${{ if or(containsValue(parameters.platforms, 'Linux_x64'), containsValue(parameters.platforms, 'CoreClrTestBuildHost'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: Linux
-      archType: x64
-      targetRid: linux-x64
-      platform: Linux_x64
-      container:
-        ${{ if eq(parameters.container, '') }}:
-          image: centos-7-20210714125435-9b5bbc2
-        ${{ if ne(parameters.container, '') }}:
-          image: ${{ parameters.container }}
-        registry: mcr
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if or(containsValue(parameters.platforms, 'Linux_x64'), containsValue(parameters.platforms, 'CoreClrTestBuildHost'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: Linux
+      #archType: x64
+      #targetRid: linux-x64
+      #platform: Linux_x64
+      #container:
+        #${{ if eq(parameters.container, '') }}:
+          #image: centos-7-20210714125435-9b5bbc2
+        #${{ if ne(parameters.container, '') }}:
+          #image: ${{ parameters.container }}
+        #registry: mcr
+      #jobParameters:
+        #runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux x86
+## Linux x86
 
-- ${{ if containsValue(parameters.platforms, 'Linux_x86') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: Linux
-      archType: x86
-      targetRid: linux-x86
-      platform: Linux_x86
-      container:
-        image: ubuntu-18.04-cross-x86-linux-20211022152824-f853169
-        registry: mcr
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        crossrootfsDir: '/crossrootfs/x86'
-        disableClrTest: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'Linux_x86') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: Linux
+      #archType: x86
+      #targetRid: linux-x86
+      #platform: Linux_x86
+      #container:
+        #image: ubuntu-18.04-cross-x86-linux-20211022152824-f853169
+        #registry: mcr
+      #jobParameters:
+        #runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #crossBuild: true
+        #crossrootfsDir: '/crossrootfs/x86'
+        #disableClrTest: true
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux x64 Source Build
+## Linux x64 Source Build
 
-- ${{ if containsValue(parameters.platforms, 'SourceBuild_Linux_x64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: Linux
-      archType: x64
-      targetRid: linux-x64
-      platform: Linux_x64
-      container:
-        image: centos-7-source-build-20210714125450-5d87b80
-        registry: mcr
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
-        buildingOnSourceBuildImage: true
+#- ${{ if containsValue(parameters.platforms, 'SourceBuild_Linux_x64') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: Linux
+      #archType: x64
+      #targetRid: linux-x64
+      #platform: Linux_x64
+      #container:
+        #image: centos-7-source-build-20210714125450-5d87b80
+        #registry: mcr
+      #jobParameters:
+        #runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
+        #buildingOnSourceBuildImage: true
 
-# Linux s390x
+## Linux s390x
 
-- ${{ if containsValue(parameters.platforms, 'Linux_s390x') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: Linux
-      archType: s390x
-      targetRid: linux-s390x
-      platform: Linux_s390x
-      container:
-        image: ubuntu-18.04-cross-s390x-20201102145728-d6e0352
-        registry: mcr
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        crossrootfsDir: '/crossrootfs/s390x'
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'Linux_s390x') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: Linux
+      #archType: s390x
+      #targetRid: linux-s390x
+      #platform: Linux_s390x
+      #container:
+        #image: ubuntu-18.04-cross-s390x-20201102145728-d6e0352
+        #registry: mcr
+      #jobParameters:
+        #runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #crossBuild: true
+        #crossrootfsDir: '/crossrootfs/s390x'
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
 # WebAssembly
 
@@ -336,485 +336,485 @@ jobs:
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # FreeBSD
-- ${{ if containsValue(parameters.platforms, 'FreeBSD_x64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: FreeBSD
-      archType: x64
-      targetRid: freebsd-x64
-      platform: FreeBSD_x64
-      container:
-        image: ubuntu-18.04-cross-freebsd-12-20210917001307-f13d79e
-        registry: mcr
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        crossrootfsDir: '/crossrootfs/x64'
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'FreeBSD_x64') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: FreeBSD
+      #archType: x64
+      #targetRid: freebsd-x64
+      #platform: FreeBSD_x64
+      #container:
+        #image: ubuntu-18.04-cross-freebsd-12-20210917001307-f13d79e
+        #registry: mcr
+      #jobParameters:
+        #runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #crossBuild: true
+        #crossrootfsDir: '/crossrootfs/x64'
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Android x64
+## Android x64
 
-- ${{ if containsValue(parameters.platforms, 'Android_x64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: Android
-      archType: x64
-      targetRid: android-x64
-      platform: Android_x64
-      container:
-        image: ubuntu-18.04-android-20220131172314-3983b4e
-        registry: mcr
-      jobParameters:
-        runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'Android_x64') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: Android
+      #archType: x64
+      #targetRid: android-x64
+      #platform: Android_x64
+      #container:
+        #image: ubuntu-18.04-android-20220131172314-3983b4e
+        #registry: mcr
+      #jobParameters:
+        #runtimeFlavor: mono
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Android x86
+## Android x86
 
-- ${{ if containsValue(parameters.platforms, 'Android_x86') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: Android
-      archType: x86
-      targetRid: android-x86
-      platform: Android_x86
-      container:
-        image: ubuntu-18.04-android-20220131172314-3983b4e
-        registry: mcr
-      jobParameters:
-        runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'Android_x86') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: Android
+      #archType: x86
+      #targetRid: android-x86
+      #platform: Android_x86
+      #container:
+        #image: ubuntu-18.04-android-20220131172314-3983b4e
+        #registry: mcr
+      #jobParameters:
+        #runtimeFlavor: mono
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Android arm
+## Android arm
 
-- ${{ if containsValue(parameters.platforms, 'Android_arm') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: Android
-      archType: arm
-      targetRid: android-arm
-      platform: Android_arm
-      container:
-        image: ubuntu-18.04-android-20220131172314-3983b4e
-        registry: mcr
-      jobParameters:
-        runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'Android_arm') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: Android
+      #archType: arm
+      #targetRid: android-arm
+      #platform: Android_arm
+      #container:
+        #image: ubuntu-18.04-android-20220131172314-3983b4e
+        #registry: mcr
+      #jobParameters:
+        #runtimeFlavor: mono
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Android arm64
+## Android arm64
 
-- ${{ if containsValue(parameters.platforms, 'Android_arm64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: Android
-      archType: arm64
-      targetRid: android-arm64
-      platform: Android_arm64
-      container:
-        image: ubuntu-18.04-android-20220131172314-3983b4e
-        registry: mcr
-      jobParameters:
-        runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'Android_arm64') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: Android
+      #archType: arm64
+      #targetRid: android-arm64
+      #platform: Android_arm64
+      #container:
+        #image: ubuntu-18.04-android-20220131172314-3983b4e
+        #registry: mcr
+      #jobParameters:
+        #runtimeFlavor: mono
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Mac Catalyst x64
+## Mac Catalyst x64
 
-- ${{ if containsValue(parameters.platforms, 'MacCatalyst_x64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: MacCatalyst
-      archType: x64
-      targetRid: maccatalyst-x64
-      platform: MacCatalyst_x64
-      jobParameters:
-        runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'MacCatalyst_x64') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: MacCatalyst
+      #archType: x64
+      #targetRid: maccatalyst-x64
+      #platform: MacCatalyst_x64
+      #jobParameters:
+        #runtimeFlavor: mono
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Mac Catalyst arm64
+## Mac Catalyst arm64
 
-- ${{ if containsValue(parameters.platforms, 'MacCatalyst_arm64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: MacCatalyst
-      archType: arm64
-      targetRid: maccatalyst-arm64
-      platform: MacCatalyst_arm64
-      jobParameters:
-        runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'MacCatalyst_arm64') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: MacCatalyst
+      #archType: arm64
+      #targetRid: maccatalyst-arm64
+      #platform: MacCatalyst_arm64
+      #jobParameters:
+        #runtimeFlavor: mono
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# tvOS arm64
+## tvOS arm64
 
-- ${{ if containsValue(parameters.platforms, 'tvOS_arm64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: tvOS
-      archType: arm64
-      targetRid: tvos-arm64
-      platform: tvOS_arm64
-      jobParameters:
-        runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'tvOS_arm64') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: tvOS
+      #archType: arm64
+      #targetRid: tvos-arm64
+      #platform: tvOS_arm64
+      #jobParameters:
+        #runtimeFlavor: mono
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# tvOS Simulator x64
+## tvOS Simulator x64
 
-- ${{ if containsValue(parameters.platforms, 'tvOSSimulator_x64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: tvOSSimulator
-      archType: x64
-      targetRid: tvossimulator-x64
-      platform: tvOSSimulator_x64
-      jobParameters:
-        runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'tvOSSimulator_x64') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: tvOSSimulator
+      #archType: x64
+      #targetRid: tvossimulator-x64
+      #platform: tvOSSimulator_x64
+      #jobParameters:
+        #runtimeFlavor: mono
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# tvOS Simulator arm64
+## tvOS Simulator arm64
 
-- ${{ if containsValue(parameters.platforms, 'tvOSSimulator_arm64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: tvOSSimulator
-      archType: arm64
-      targetRid: tvossimulator-arm64
-      platform: tvOSSimulator_arm64
-      jobParameters:
-        runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'tvOSSimulator_arm64') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: tvOSSimulator
+      #archType: arm64
+      #targetRid: tvossimulator-arm64
+      #platform: tvOSSimulator_arm64
+      #jobParameters:
+        #runtimeFlavor: mono
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# iOS arm
+## iOS arm
 
-- ${{ if containsValue(parameters.platforms, 'iOS_arm') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: iOS
-      archType: arm
-      targetRid: ios-arm
-      platform: iOS_arm
-      jobParameters:
-        runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'iOS_arm') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: iOS
+      #archType: arm
+      #targetRid: ios-arm
+      #platform: iOS_arm
+      #jobParameters:
+        #runtimeFlavor: mono
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# iOS arm64
+## iOS arm64
 
-- ${{ if containsValue(parameters.platforms, 'iOS_arm64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: iOS
-      archType: arm64
-      targetRid: ios-arm64
-      platform: iOS_arm64
-      jobParameters:
-        runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'iOS_arm64') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: iOS
+      #archType: arm64
+      #targetRid: ios-arm64
+      #platform: iOS_arm64
+      #jobParameters:
+        #runtimeFlavor: mono
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# iOS Simulator x64
+## iOS Simulator x64
 
-- ${{ if containsValue(parameters.platforms, 'iOSSimulator_x64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: iOSSimulator
-      archType: x64
-      targetRid: iossimulator-x64
-      platform: iOSSimulator_x64
-      jobParameters:
-        runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'iOSSimulator_x64') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: iOSSimulator
+      #archType: x64
+      #targetRid: iossimulator-x64
+      #platform: iOSSimulator_x64
+      #jobParameters:
+        #runtimeFlavor: mono
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# iOS Simulator x86
+## iOS Simulator x86
 
-- ${{ if containsValue(parameters.platforms, 'iOSSimulator_x86') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: iOSSimulator
-      archType: x86
-      targetRid: iossimulator-x86
-      platform: iOSsimulator_x86
-      jobParameters:
-        runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        managedTestBuildOsGroup: OSX
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'iOSSimulator_x86') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: iOSSimulator
+      #archType: x86
+      #targetRid: iossimulator-x86
+      #platform: iOSsimulator_x86
+      #jobParameters:
+        #runtimeFlavor: mono
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #managedTestBuildOsGroup: OSX
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# iOS Simulator arm64
+## iOS Simulator arm64
 
-- ${{ if containsValue(parameters.platforms, 'iOSSimulator_arm64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: iOSSimulator
-      archType: arm64
-      targetRid: iossimulator-arm64
-      platform: iOSSimulator_arm64
-      jobParameters:
-        runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'iOSSimulator_arm64') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: iOSSimulator
+      #archType: arm64
+      #targetRid: iossimulator-arm64
+      #platform: iOSSimulator_arm64
+      #jobParameters:
+        #runtimeFlavor: mono
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# macOS arm64
+## macOS arm64
 
-- ${{ if containsValue(parameters.platforms, 'OSX_arm64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: OSX
-      archType: arm64
-      targetRid: osx-arm64
-      platform: OSX_arm64
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'OSX_arm64') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: OSX
+      #archType: arm64
+      #targetRid: osx-arm64
+      #platform: OSX_arm64
+      #jobParameters:
+        #runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #crossBuild: true
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# macOS x64
+## macOS x64
 
-- ${{ if or(containsValue(parameters.platforms, 'OSX_x64'), eq(parameters.platformGroup, 'all')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: OSX
-      archType: x64
-      targetRid: osx-x64
-      platform: OSX_x64
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if or(containsValue(parameters.platforms, 'OSX_x64'), eq(parameters.platformGroup, 'all')) }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: OSX
+      #archType: x64
+      #targetRid: osx-x64
+      #platform: OSX_x64
+      #jobParameters:
+        #runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Tizen armel
+## Tizen armel
 
-- ${{ if containsValue(parameters.platforms, 'Tizen_armel') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: Tizen
-      archType: armel
-      targetRid: tizen-armel
-      platform: Tizen_armel
-      container:
-        image: ubuntu-18.04-cross-armel-tizen-20210719212651-8b02f56
-        registry: mcr
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        crossrootfsDir: '/crossrootfs/armel'
-        disableClrTest: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if containsValue(parameters.platforms, 'Tizen_armel') }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: Tizen
+      #archType: armel
+      #targetRid: tizen-armel
+      #platform: Tizen_armel
+      #container:
+        #image: ubuntu-18.04-cross-armel-tizen-20210719212651-8b02f56
+        #registry: mcr
+      #jobParameters:
+        #runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #crossBuild: true
+        #crossrootfsDir: '/crossrootfs/armel'
+        #disableClrTest: true
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Windows x64
+## Windows x64
 
-- ${{ if or(containsValue(parameters.platforms, 'windows_x64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: windows
-      archType: x64
-      targetRid: win-x64
-      platform: windows_x64
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if or(containsValue(parameters.platforms, 'windows_x64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: windows
+      #archType: x64
+      #targetRid: win-x64
+      #platform: windows_x64
+      #jobParameters:
+        #runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Windows x86
+## Windows x86
 
-- ${{ if or(containsValue(parameters.platforms, 'windows_x86'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: windows
-      archType: x86
-      targetRid: win-x86
-      platform: windows_x86
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if or(containsValue(parameters.platforms, 'windows_x86'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: windows
+      #archType: x86
+      #targetRid: win-x86
+      #platform: windows_x86
+      #jobParameters:
+        #runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Windows arm
-- ${{ if or(containsValue(parameters.platforms, 'windows_arm'), eq(parameters.platformGroup, 'all')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: windows
-      archType: arm
-      targetRid: win-arm
-      platform: windows_arm
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+## Windows arm
+#- ${{ if or(containsValue(parameters.platforms, 'windows_arm'), eq(parameters.platformGroup, 'all')) }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: windows
+      #archType: arm
+      #targetRid: win-arm
+      #platform: windows_arm
+      #jobParameters:
+        #runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}
 
-# Windows arm64
+## Windows arm64
 
-- ${{ if or(containsValue(parameters.platforms, 'windows_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: windows
-      archType: arm64
-      targetRid: win-arm64
-      platform: windows_arm64
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ if eq(parameters.passPlatforms, true) }}:
-          platforms: ${{ parameters.platforms }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+#- ${{ if or(containsValue(parameters.platforms, 'windows_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+  #- template: xplat-setup.yml
+    #parameters:
+      #jobTemplate: ${{ parameters.jobTemplate }}
+      #helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      #variables: ${{ parameters.variables }}
+      #osGroup: windows
+      #archType: arm64
+      #targetRid: win-arm64
+      #platform: windows_arm64
+      #jobParameters:
+        #runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        #stagedBuild: ${{ parameters.stagedBuild }}
+        #buildConfig: ${{ parameters.buildConfig }}
+        #${{ if eq(parameters.passPlatforms, true) }}:
+          #platforms: ${{ parameters.platforms }}
+        #helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        #${{ insert }}: ${{ parameters.jobParameters }}

--- a/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -179,6 +179,7 @@ namespace System.Runtime.CompilerServices.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/66118", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
         public static void TryEnsureSufficientExecutionStack_NoSpaceAvailable_ReturnsFalse()
         {
             FillStack(depth: 0);

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -52,9 +52,6 @@
 
   <!-- Wasm aot on all platforms -->
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(BuildAOTTestsOnHelix)' == 'true' and '$(RunDisabledWasmTests)' != 'true' and '$(RunAOTCompilation)' == 'true'">
-    <!-- https://github.com/dotnet/runtime/issues/66118 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\UnitTests\System.Text.RegularExpressions.Unit.Tests.csproj" />
-
     <!-- https://github.com/dotnet/runtime/issues/61756 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\FunctionalTests\System.Text.RegularExpressions.Tests.csproj" />
   </ItemGroup>


### PR DESCRIPTION
And re-enable `System.Text.RegularExpressions.Unit.Tests`.

`TryEnsureSufficientExecutionStack` doesn't work correctly on wasm/aot, which causes a stack overflow.

Issue: [#66118](https://github.com/dotnet/runtime/issues/66118)