### PR TITLE
[Group 5] Enable nullable annotations for `Microsoft.Extensions.Configuration.Xml`

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/ref/Microsoft.Extensions.Configuration.Xml.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/ref/Microsoft.Extensions.Configuration.Xml.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Configuration
 {
     public static partial class XmlConfigurationExtensions
     {
-        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddXmlFile(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, Microsoft.Extensions.FileProviders.IFileProvider provider, string path, bool optional, bool reloadOnChange) { throw null; }
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddXmlFile(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, Microsoft.Extensions.FileProviders.IFileProvider? provider, string path, bool optional, bool reloadOnChange) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddXmlFile(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, System.Action<Microsoft.Extensions.Configuration.Xml.XmlConfigurationSource> configureSource) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddXmlFile(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, string path) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddXmlFile(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, string path, bool optional) { throw null; }
@@ -40,7 +40,7 @@ namespace Microsoft.Extensions.Configuration.Xml
     {
         public XmlStreamConfigurationProvider(Microsoft.Extensions.Configuration.Xml.XmlStreamConfigurationSource source) : base (default(Microsoft.Extensions.Configuration.StreamConfigurationSource)) { }
         public override void Load(System.IO.Stream stream) { }
-        public static System.Collections.Generic.IDictionary<string, string> Read(System.IO.Stream stream, Microsoft.Extensions.Configuration.Xml.XmlDocumentDecryptor decryptor) { throw null; }
+        public static System.Collections.Generic.IDictionary<string, string?> Read(System.IO.Stream stream, Microsoft.Extensions.Configuration.Xml.XmlDocumentDecryptor decryptor) { throw null; }
     }
     public partial class XmlStreamConfigurationSource : Microsoft.Extensions.Configuration.StreamConfigurationSource
     {

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/ref/Microsoft.Extensions.Configuration.Xml.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/ref/Microsoft.Extensions.Configuration.Xml.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.Configuration
     public static partial class XmlConfigurationExtensions
     {
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddXmlFile(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, Microsoft.Extensions.FileProviders.IFileProvider? provider, string path, bool optional, bool reloadOnChange) { throw null; }
-        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddXmlFile(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, System.Action<Microsoft.Extensions.Configuration.Xml.XmlConfigurationSource> configureSource) { throw null; }
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddXmlFile(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, System.Action<Microsoft.Extensions.Configuration.Xml.XmlConfigurationSource>? configureSource) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddXmlFile(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, string path) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddXmlFile(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, string path, bool optional) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddXmlFile(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, string path, bool optional, bool reloadOnChange) { throw null; }
@@ -32,7 +32,7 @@ namespace Microsoft.Extensions.Configuration.Xml
     {
         public static readonly Microsoft.Extensions.Configuration.Xml.XmlDocumentDecryptor Instance;
         protected XmlDocumentDecryptor() { }
-        public System.Xml.XmlReader CreateDecryptingXmlReader(System.IO.Stream input, System.Xml.XmlReaderSettings settings) { throw null; }
+        public System.Xml.XmlReader CreateDecryptingXmlReader(System.IO.Stream input, System.Xml.XmlReaderSettings? settings) { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
         protected virtual System.Xml.XmlReader DecryptDocumentAndCreateXmlReader(System.Xml.XmlDocument document) { throw null; }
     }

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/ref/Microsoft.Extensions.Configuration.Xml.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/ref/Microsoft.Extensions.Configuration.Xml.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/Microsoft.Extensions.Configuration.Xml.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/Microsoft.Extensions.Configuration.Xml.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
+    <Nullable>enable</Nullable>
     <EnableDefaultItems>true</EnableDefaultItems>
     <!-- Use targeting pack references instead of granular ones in the project file. -->
     <DisableImplicitAssemblyReferences>false</DisableImplicitAssemblyReferences>

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationElement.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationElement.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.Configuration.Xml
     {
         public string ElementName { get; }
 
-        public string Name { get; }
+        public string? Name { get; }
 
         /// <summary>
         /// A composition of ElementName and Name, that serves as the basis for detecting siblings
@@ -20,18 +20,18 @@ namespace Microsoft.Extensions.Configuration.Xml
         /// <summary>
         /// The children of this element
         /// </summary>
-        public IDictionary<string, List<XmlConfigurationElement>> ChildrenBySiblingName { get; set; }
+        public IDictionary<string, List<XmlConfigurationElement>>? ChildrenBySiblingName { get; set; }
 
         /// <summary>
         /// Performance optimization: do not initialize a dictionary and a list for elements with a single child
         /// </summary>
-        public XmlConfigurationElement SingleChild { get; set; }
+        public XmlConfigurationElement? SingleChild { get; set; }
 
-        public XmlConfigurationElementTextContent TextContent { get; set; }
+        public XmlConfigurationElementTextContent? TextContent { get; set; }
 
-        public List<XmlConfigurationElementAttributeValue> Attributes { get; set; }
+        public List<XmlConfigurationElementAttributeValue>? Attributes { get; set; }
 
-        public XmlConfigurationElement(string elementName!!, string name)
+        public XmlConfigurationElement(string elementName!!, string? name)
         {
             ElementName = elementName;
             Name = name;

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationExtensions.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="configureSource">Configures the source.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-        public static IConfigurationBuilder AddXmlFile(this IConfigurationBuilder builder, Action<XmlConfigurationSource> configureSource)
+        public static IConfigurationBuilder AddXmlFile(this IConfigurationBuilder builder, Action<XmlConfigurationSource>? configureSource)
             => builder.Add(configureSource);
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationExtensions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="optional">Whether the file is optional.</param>
         /// <param name="reloadOnChange">Whether the configuration should be reloaded if the file changes.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-        public static IConfigurationBuilder AddXmlFile(this IConfigurationBuilder builder!!, IFileProvider provider, string path, bool optional, bool reloadOnChange)
+        public static IConfigurationBuilder AddXmlFile(this IConfigurationBuilder builder!!, IFileProvider? provider, string path, bool optional, bool reloadOnChange)
         {
             if (string.IsNullOrEmpty(path))
             {

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlDocumentDecryptor.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlDocumentDecryptor.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Extensions.Configuration.Xml
         /// <summary>
         /// Returns an XmlReader that decrypts data transparently.
         /// </summary>
-        public XmlReader CreateDecryptingXmlReader(Stream input, XmlReaderSettings settings)
+        public XmlReader CreateDecryptingXmlReader(Stream input, XmlReaderSettings? settings)
         {
             // XML-based configurations aren't really all that big, so we can buffer
             // the whole thing in memory while we determine decryption operations.

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlDocumentDecryptor.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlDocumentDecryptor.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.Configuration.Xml
         /// </summary>
         public static readonly XmlDocumentDecryptor Instance = new XmlDocumentDecryptor();
 
-        private readonly Func<XmlDocument, EncryptedXml> _encryptedXmlFactory;
+        private readonly Func<XmlDocument, EncryptedXml>? _encryptedXmlFactory;
 
         /// <summary>
         /// Initializes a XmlDocumentDecryptor.
@@ -98,7 +98,7 @@ namespace Microsoft.Extensions.Configuration.Xml
             // Finally, return the new XmlReader from the updated XmlDocument.
             // Error messages based on this XmlReader won't show line numbers,
             // but that's fine since we transformed the document anyway.
-            return document.CreateNavigator().ReadSubtree();
+            return document.CreateNavigator()!.ReadSubtree();
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlStreamConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlStreamConfigurationProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Extensions.Configuration.Xml
         /// <param name="stream">The stream of XML data.</param>
         /// <param name="decryptor">The <see cref="XmlDocumentDecryptor"/> to use to decrypt.</param>
         /// <returns>The <see cref="IDictionary{String, String}"/> which was read from the stream.</returns>
-        public static IDictionary<string, string> Read(Stream stream, XmlDocumentDecryptor decryptor)
+        public static IDictionary<string, string?> Read(Stream stream, XmlDocumentDecryptor decryptor)
         {
             var readerSettings = new XmlReaderSettings()
             {
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.Configuration.Xml
                 IgnoreWhitespace = true
             };
 
-            XmlConfigurationElement root = null;
+            XmlConfigurationElement? root = null;
 
             using (XmlReader reader = decryptor.CreateDecryptingXmlReader(stream, readerSettings))
             {
@@ -211,7 +211,7 @@ namespace Microsoft.Extensions.Configuration.Xml
                     throw new FormatException(SR.Format(SR.Error_NamespaceIsNotSupported, GetLineInfo(reader)));
                 }
 
-                element.Attributes.Add(new XmlConfigurationElementAttributeValue(reader.LocalName, reader.Value, lineNumber, linePosition));
+                element.Attributes!.Add(new XmlConfigurationElementAttributeValue(reader.LocalName, reader.Value, lineNumber, linePosition));
             }
 
             // Go back to the element containing the attributes we just processed
@@ -221,9 +221,9 @@ namespace Microsoft.Extensions.Configuration.Xml
         // The special attribute "Name" only contributes to prefix
         // This method retrieves the Name of the element, if the attribute is present
         // Unfortunately XmlReader.GetAttribute cannot be used, as it does not support looking for attributes in a case insensitive manner
-        private static string GetName(XmlReader reader)
+        private static string? GetName(XmlReader reader)
         {
-            string name = null;
+            string? name = null;
 
             while (reader.MoveToNextAttribute())
             {
@@ -245,9 +245,9 @@ namespace Microsoft.Extensions.Configuration.Xml
             return name;
         }
 
-        private static IDictionary<string, string> ProvideConfiguration(XmlConfigurationElement root)
+        private static IDictionary<string, string?> ProvideConfiguration(XmlConfigurationElement? root)
         {
-            var configuration = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, string?> configuration = new(StringComparer.OrdinalIgnoreCase);
 
             if (root == null)
             {


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/issues/43605

`System.Security.Cryptography.Xml` is not annotated yet (maybe will get around to it in some time), but it's only used in one place where there's no nullability questions (https://github.com/dotnet/runtime/pull/66892#issuecomment-1079054802).

Questions:
- `CreateNavigator()` can return `null` here
https://github.com/dotnet/runtime/blob/0ceb116d749d07017df5295001c8ea024640193b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlDocumentDecryptor.cs#L101