### PR TITLE
LoggingSourceGenerator - Fixes InvalidCastException when using other attributes

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -141,15 +141,20 @@ namespace Microsoft.Extensions.Logging.Generators
                                     }
 
                                     bool hasMisconfiguredInput = false;
-                                    ImmutableArray<AttributeData>? boundAttrbutes = logMethodSymbol?.GetAttributes();
+                                    ImmutableArray<AttributeData>? boundAttributes = logMethodSymbol?.GetAttributes();
 
-                                    if (boundAttrbutes == null)
+                                    if (boundAttributes == null || boundAttributes!.Value.Length == 0)
                                     {
                                         continue;
                                     }
 
-                                    foreach (AttributeData attributeData in boundAttrbutes)
+                                    foreach (AttributeData attributeData in boundAttributes)
                                     {
+                                        if (attributeData.AttributeClass?.Equals(loggerMessageAttribute) != true)
+                                        {
+                                            continue;
+                                        }
+
                                         // supports: [LoggerMessage(0, LogLevel.Warning, "custom message")]
                                         // supports: [LoggerMessage(eventId: 0, level: LogLevel.Warning, message: "custom message")]
                                         if (attributeData.ConstructorArguments.Any())

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
@@ -17,6 +17,21 @@ namespace Microsoft.Extensions.Logging.Generators.Tests
     public class LoggerMessageGeneratorParserTests
     {
         [Fact]
+        public async Task Valid_AdditionalAttributes()
+        {
+            Assert.Empty(await RunGenerator($@"
+                using System.Diagnostics.CodeAnalysis;
+                partial class C
+                {{
+                    [SuppressMessage(""CATEGORY1"", ""SOMEID1"")]
+                    [LoggerMessage(EventId = 0, Level = LogLevel.Debug, Message = ""M1"")]
+                    [SuppressMessage(""CATEGORY2"", ""SOMEID2"")]
+                    static partial void M1(ILogger logger);
+                }}
+            "));
+        }
+
+        [Fact]
         public async Task InvalidMethodName()
         {
             IReadOnlyList<Diagnostic> diagnostics = await RunGenerator(@"


### PR DESCRIPTION
- alongside LoggerMessageAttribute

Fixes #67167