### PR TITLE
Makes GetChildKeys more efficient

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
@@ -51,9 +51,9 @@ namespace Microsoft.Extensions.Configuration
                 }
 
                 xSpan = xDelimiterIndex == -1 ? default :
-                    SkipAheadOnDelimiter(xSpan.Slice(xDelimiterIndex));
+                    SkipAheadOnDelimiter(xSpan.Slice(xDelimiterIndex + 1));
                 ySpan = yDelimiterIndex == -1 ? default :
-                    SkipAheadOnDelimiter(ySpan.Slice(yDelimiterIndex));
+                    SkipAheadOnDelimiter(ySpan.Slice(yDelimiterIndex + 1));
             }
 
             return xSpan.IsEmpty ? (ySpan.IsEmpty ? 0 : -1) : 1;

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
@@ -31,21 +31,50 @@ namespace Microsoft.Extensions.Configuration
         {
             if (x is not null && y is not null)
             {
-                if (x.Contains(ConfigurationPath.KeyDelimiter) && y!.Contains(ConfigurationPath.KeyDelimiter))
+                if (x.Contains(ConfigurationPath.KeyDelimiter) && y.Contains(ConfigurationPath.KeyDelimiter))
                 {
-                    string[] xParts = x!.Split(_keyDelimiterArray, StringSplitOptions.RemoveEmptyEntries);
-                    string[] yParts = y!.Split(_keyDelimiterArray, StringSplitOptions.RemoveEmptyEntries);
+                    int xIndex = 0;
+                    int yIndex = 0;
 
                     // Compare each part until we get two parts that are not equal
-                    for (int i = 0; i < Math.Min(xParts.Length, yParts.Length); i++)
+                    while (xIndex < x.Length && yIndex < y.Length)
                     {
-                        int result = Compare(xParts[i], yParts[i]);
-                        if (result != 0)
+                        int nextXIndex = x.IndexOf(ConfigurationPath.KeyDelimiter, xIndex);
+                        int nextYIndex = y.IndexOf(ConfigurationPath.KeyDelimiter, yIndex);
+
+                        ReadOnlySpan<char> xSpan;
+                        if (nextXIndex >= 0)
                         {
-                            // One of them is different
-                            return result;
+                            xSpan = x.AsSpan().Slice(xIndex, nextXIndex - xIndex);
+                            xIndex = nextXIndex + 1;
+                        }
+                        else
+                        {
+                            xSpan = x.AsSpan().Slice(xIndex, x.Length - xIndex);
+                            xIndex = x.Length;
+                        }
+
+                        ReadOnlySpan<char> ySpan;
+                        if (nextYIndex >= 0)
+                        {
+                            ySpan = y.AsSpan().Slice(yIndex, nextYIndex - yIndex);
+                            yIndex = nextYIndex + 1;
+                        }
+                        else
+                        {
+                            ySpan = y.AsSpan().Slice(yIndex, y.Length - yIndex);
+                            yIndex = y.Length;
+                        }
+
+                        int compareResult = Compare(xSpan, ySpan);
+                        if (compareResult != 0)
+                        {
+                            return compareResult;
                         }
                     }
+
+                    string[] xParts = x.Split(_keyDelimiterArray, StringSplitOptions.RemoveEmptyEntries);
+                    string[] yParts = y.Split(_keyDelimiterArray, StringSplitOptions.RemoveEmptyEntries);
 
                     // If we get here, the common parts are equal.
                     // If they are of the same length, then they are totally identical
@@ -53,23 +82,27 @@ namespace Microsoft.Extensions.Configuration
                 }
                 else
                 {
-                    return Compare(x, y);
+                    return Compare(x.AsSpan(), y.AsSpan());
                 }
             }
 
             return x?.Length ?? 0 - y?.Length ?? 0;
 
-            static int Compare(string? a, string? b)
+            static int Compare(ReadOnlySpan<char> a, ReadOnlySpan<char> b)
             {
+#if NETCOREAPP
                 bool aIsInt = int.TryParse(a, out int value1);
                 bool bIsInt = int.TryParse(b, out int value2);
-
+#else
+                bool aIsInt = int.TryParse(a.ToString(), out int value1);
+                bool bIsInt = int.TryParse(b.ToString(), out int value2);
+#endif
                 int result;
 
                 if (!aIsInt && !bIsInt)
                 {
                     // Both are strings
-                    result = string.Compare(a, b, StringComparison.OrdinalIgnoreCase);
+                    result = a.CompareTo(b, StringComparison.OrdinalIgnoreCase);
                 }
                 else if (aIsInt && bIsInt)
                 {

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
@@ -29,49 +29,35 @@ namespace Microsoft.Extensions.Configuration
         /// <returns>Less than 0 if x is less than y, 0 if x is equal to y and greater than 0 if x is greater than y.</returns>
         public int Compare(string? x, string? y)
         {
-            if (string.IsNullOrWhiteSpace(x))
+            if (x is not null && y is not null)
             {
-                if (string.IsNullOrWhiteSpace(y))
+                if (x!.Contains(ConfigurationPath.KeyDelimiter) && y!.Contains(ConfigurationPath.KeyDelimiter))
                 {
-                    return 0;
+                    string[] xParts = x!.Split(_keyDelimiterArray, StringSplitOptions.RemoveEmptyEntries);
+                    string[] yParts = y!.Split(_keyDelimiterArray, StringSplitOptions.RemoveEmptyEntries);
+
+                    // Compare each part until we get two parts that are not equal
+                    for (int i = 0; i < Math.Min(xParts.Length, yParts.Length); i++)
+                    {
+                        int result = compare(xParts[i], yParts[i]);
+                        if (result != 0)
+                        {
+                            // One of them is different
+                            return result;
+                        }
+                    }
+
+                    // If we get here, the common parts are equal.
+                    // If they are of the same length, then they are totally identical
+                    return xParts.Length - yParts.Length;
                 }
-
-                return -y!.Length;
-            }
-
-            if (string.IsNullOrWhiteSpace(y))
-            {
-                return x!.Length;
-            }
-
-            int result;
-            if (!x!.Contains(ConfigurationPath.KeyDelimiter) || !y!.Contains(ConfigurationPath.KeyDelimiter))
-            {
-                result = compare(x, y);
-                if (result != 0)
+                else
                 {
-                    // One of them is different
-                    return result;
-                }
-            }
-
-            string[] xParts = x.Split(_keyDelimiterArray, StringSplitOptions.RemoveEmptyEntries);
-            string[] yParts = y.Split(_keyDelimiterArray, StringSplitOptions.RemoveEmptyEntries);
-
-            // Compare each part until we get two parts that are not equal
-            for (int i = 0; i < Math.Min(xParts.Length, yParts.Length); i++)
-            {
-                result = compare(xParts[i], yParts[i]);
-                if (result != 0)
-                {
-                    // One of them is different
-                    return result;
+                    return compare(x, y);
                 }
             }
 
-            // If we get here, the common parts are equal.
-            // If they are of the same length, then they are totally identical
-            return xParts.Length - yParts.Length;
+            return x?.Length ?? 0 - y?.Length ?? 0;
 
             static int compare(string? a, string? b)
             {

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
@@ -38,7 +38,8 @@ namespace Microsoft.Extensions.Configuration
 
                 return -y!.Length;
             }
-            else if (string.IsNullOrWhiteSpace(y))
+
+            if (string.IsNullOrWhiteSpace(y))
             {
                 return x!.Length;
             }

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.Configuration
     /// </summary>
     public class ConfigurationKeyComparer : IComparer<string>
     {
-        private static readonly char s_keyDelimiter = ConfigurationPath.KeyDelimiter[0];
+        private const char KeyDelimiter = ':';
 
         /// <summary>
         /// The default instance.

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
@@ -52,26 +52,26 @@ namespace Microsoft.Extensions.Configuration
                     continue;
                 }
 
-                int nextXIndex = xSpan.IndexOf(s_keyDelimiter);
-                if (nextXIndex < 0)
+                int xSegmentLength = xSpan.IndexOf(s_keyDelimiter);
+                if (xSegmentLength < 0)
                 {
-                    nextXIndex = xSpan.Length;
+                    xSegmentLength = xSpan.Length;
                 }
 
-                int nextYIndex = ySpan.IndexOf(s_keyDelimiter);
-                if (nextYIndex < 0)
+                int ySegmentLength = ySpan.IndexOf(s_keyDelimiter);
+                if (ySegmentLength < 0)
                 {
-                    nextYIndex = ySpan.Length;
+                    ySegmentLength = ySpan.Length;
                 }
 
-                int compareResult = Compare(xSpan.Slice(0, nextXIndex), ySpan.Slice(0, nextYIndex));
+                int compareResult = Compare(xSpan.Slice(0, xSegmentLength), ySpan.Slice(0, ySegmentLength));
                 if (compareResult != 0)
                 {
                     return compareResult;
                 }
 
-                xSpan = xSpan.Slice(nextXIndex);
-                ySpan = ySpan.Slice(nextYIndex);
+                xSpan = xSpan.Slice(xSegmentLength);
+                ySpan = ySpan.Slice(ySegmentLength);
             }
 
             if (xSpan.IsEmpty)
@@ -83,22 +83,22 @@ namespace Microsoft.Extensions.Configuration
 
             static int CountPartsIn(ReadOnlySpan<char> a)
             {
-                int count = 0, aIndex = 0;
-                while (aIndex < a.Length)
+                int count = 0;
+                while (!a.IsEmpty)
                 {
-                    int nextAIndex = a.Slice(aIndex).IndexOf(s_keyDelimiter);
-                    if (nextAIndex < 0)
+                    int segmentLength = a.IndexOf(s_keyDelimiter);
+                    if (segmentLength < 0)
                     {
                         return count + 1;
                     }
 
-                    if (a[aIndex] == s_keyDelimiter)
+                    if (a[0] == s_keyDelimiter)
                     {
-                        aIndex++;
+                        a = a.Slice(1);
                         continue;
                     }
 
-                    aIndex += nextAIndex + 1;
+                    a = a.Slice(segmentLength);
                     count++;
                 }
 

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.Configuration
         {
             if (x is not null && y is not null)
             {
-                if (x!.Contains(ConfigurationPath.KeyDelimiter) && y!.Contains(ConfigurationPath.KeyDelimiter))
+                if (x.Contains(ConfigurationPath.KeyDelimiter) && y!.Contains(ConfigurationPath.KeyDelimiter))
                 {
                     string[] xParts = x!.Split(_keyDelimiterArray, StringSplitOptions.RemoveEmptyEntries);
                     string[] yParts = y!.Split(_keyDelimiterArray, StringSplitOptions.RemoveEmptyEntries);
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.Configuration
                     // Compare each part until we get two parts that are not equal
                     for (int i = 0; i < Math.Min(xParts.Length, yParts.Length); i++)
                     {
-                        int result = compare(xParts[i], yParts[i]);
+                        int result = Compare(xParts[i], yParts[i]);
                         if (result != 0)
                         {
                             // One of them is different
@@ -53,19 +53,19 @@ namespace Microsoft.Extensions.Configuration
                 }
                 else
                 {
-                    return compare(x, y);
+                    return Compare(x, y);
                 }
             }
 
             return x?.Length ?? 0 - y?.Length ?? 0;
 
-            static int compare(string? a, string? b)
+            static int Compare(string? a, string? b)
             {
                 int value1 = 0;
                 int value2 = 0;
 
-                bool aIsInt = a != null && int.TryParse(a, out value1);
-                bool bIsInt = b != null && int.TryParse(b, out value2);
+                bool aIsInt = int.TryParse(a, out value1);
+                bool bIsInt = int.TryParse(b, out value2);
 
                 int result;
 

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
@@ -61,11 +61,8 @@ namespace Microsoft.Extensions.Configuration
 
             static int Compare(string? a, string? b)
             {
-                int value1 = 0;
-                int value2 = 0;
-
-                bool aIsInt = int.TryParse(a, out value1);
-                bool bIsInt = int.TryParse(b, out value2);
+                bool aIsInt = int.TryParse(a, out int value1);
+                bool bIsInt = int.TryParse(b, out int value2);
 
                 int result;
 

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
@@ -29,39 +29,38 @@ namespace Microsoft.Extensions.Configuration
         /// <returns>Less than 0 if x is less than y, 0 if x is equal to y and greater than 0 if x is greater than y.</returns>
         public int Compare(string? x, string? y)
         {
-            string[] xParts = x?.Split(_keyDelimiterArray, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
-            string[] yParts = y?.Split(_keyDelimiterArray, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
+            if (string.IsNullOrWhiteSpace(x))
+            {
+                if (string.IsNullOrWhiteSpace(y))
+                {
+                    return 0;
+                }
+
+                return -y!.Length;
+            }
+            else if (string.IsNullOrWhiteSpace(y))
+            {
+                return x!.Length;
+            }
+
+            int result;
+            if (!x!.Contains(ConfigurationPath.KeyDelimiter) || !y!.Contains(ConfigurationPath.KeyDelimiter))
+            {
+                result = compare(x, y);
+                if (result != 0)
+                {
+                    // One of them is different
+                    return result;
+                }
+            }
+
+            string[] xParts = x.Split(_keyDelimiterArray, StringSplitOptions.RemoveEmptyEntries);
+            string[] yParts = y.Split(_keyDelimiterArray, StringSplitOptions.RemoveEmptyEntries);
 
             // Compare each part until we get two parts that are not equal
             for (int i = 0; i < Math.Min(xParts.Length, yParts.Length); i++)
             {
-                x = xParts[i];
-                y = yParts[i];
-
-                int value1 = 0;
-                int value2 = 0;
-
-                bool xIsInt = x != null && int.TryParse(x, out value1);
-                bool yIsInt = y != null && int.TryParse(y, out value2);
-
-                int result;
-
-                if (!xIsInt && !yIsInt)
-                {
-                    // Both are strings
-                    result = string.Compare(x, y, StringComparison.OrdinalIgnoreCase);
-                }
-                else if (xIsInt && yIsInt)
-                {
-                    // Both are int
-                    result = value1 - value2;
-                }
-                else
-                {
-                    // Only one of them is int
-                    result = xIsInt ? -1 : 1;
-                }
-
+                result = compare(xParts[i], yParts[i]);
                 if (result != 0)
                 {
                     // One of them is different
@@ -72,6 +71,35 @@ namespace Microsoft.Extensions.Configuration
             // If we get here, the common parts are equal.
             // If they are of the same length, then they are totally identical
             return xParts.Length - yParts.Length;
+
+            static int compare(string? a, string? b)
+            {
+                int value1 = 0;
+                int value2 = 0;
+
+                bool aIsInt = a != null && int.TryParse(a, out value1);
+                bool bIsInt = b != null && int.TryParse(b, out value2);
+
+                int result;
+
+                if (!aIsInt && !bIsInt)
+                {
+                    // Both are strings
+                    result = string.Compare(a, b, StringComparison.OrdinalIgnoreCase);
+                }
+                else if (aIsInt && bIsInt)
+                {
+                    // Both are int
+                    result = value1 - value2;
+                }
+                else
+                {
+                    // Only one of them is int
+                    result = aIsInt ? -1 : 1;
+                }
+
+                return result;
+            }
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
@@ -38,36 +38,29 @@ namespace Microsoft.Extensions.Configuration
             // Compare each part until we get two parts that are not equal
             while (!xSpan.IsEmpty && !ySpan.IsEmpty)
             {
-                int xSegmentLength = xSpan.IndexOf(s_keyDelimiter);
-                if (xSegmentLength < 0)
-                {
-                    xSegmentLength = xSpan.Length;
-                }
+                int xDelimiterIndex = xSpan.IndexOf(KeyDelimiter);
+                int yDelimiterIndex = ySpan.IndexOf(KeyDelimiter);
 
-                int ySegmentLength = ySpan.IndexOf(s_keyDelimiter);
-                if (ySegmentLength < 0)
-                {
-                    ySegmentLength = ySpan.Length;
-                }
+                int compareResult = Compare(
+                    xDelimiterIndex == -1 ? xSpan : xSpan.Slice(0, xDelimiterIndex),
+                    yDelimiterIndex == -1 ? ySpan : ySpan.Slice(0, yDelimiterIndex));
 
-                int compareResult = Compare(xSpan.Slice(0, xSegmentLength), ySpan.Slice(0, ySegmentLength));
                 if (compareResult != 0)
                 {
                     return compareResult;
                 }
 
-                xSpan = xSpan.Slice(xSegmentLength);
-                ySpan = ySpan.Slice(ySegmentLength);
-
-                xSpan = SkipAheadOnDelimiter(xSpan);
-                ySpan = SkipAheadOnDelimiter(ySpan);
+                xSpan = xDelimiterIndex == -1 ? default :
+                    SkipAheadOnDelimiter(xSpan.Slice(xDelimiterIndex));
+                ySpan = yDelimiterIndex == -1 ? default :
+                    SkipAheadOnDelimiter(ySpan.Slice(yDelimiterIndex));
             }
 
             return xSpan.IsEmpty ? (ySpan.IsEmpty ? 0 : -1) : 1;
 
             static ReadOnlySpan<char> SkipAheadOnDelimiter(ReadOnlySpan<char> a)
             {
-                while (!a.IsEmpty && a[0] == s_keyDelimiter)
+                while (!a.IsEmpty && a[0] == KeyDelimiter)
                 {
                     a = a.Slice(1);
                 }

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationPathComparerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationPathComparerTest.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Extensions.Configuration.Test
             ComparerTest(null, null, 0);
             ComparerTest(null, "a", -1);
             ComparerTest("b", null, 1);
+            ComparerTest(null, "a:b", -1);
+            ComparerTest(null, "a:b:c", -1);
         }
 
         [Fact]
@@ -30,6 +32,20 @@ namespace Microsoft.Extensions.Configuration.Test
         {
             ComparerTest("a", "aa", -1);
             ComparerTest("aa", "a", 1);
+        }
+
+        [Fact]
+        public void CompareWithEmpty()
+        {
+            ComparerTest(":", "", 0);
+            ComparerTest(":", "::", 0);
+            ComparerTest(null, "", 0);
+            ComparerTest(":", null, 0);
+            ComparerTest("::", null, 0);
+            ComparerTest(" : : ", null, 1);
+            ComparerTest("b: :a", "b::a", -1);
+            ComparerTest("b:\t:a", "b::a", -1);
+            ComparerTest("b::a: ", "b::a:", 1);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationTest.cs
@@ -60,6 +60,64 @@ namespace Microsoft.Extensions.Configuration.Test
         }
 
         [Fact]
+        private void GetChildKeys_CanChainEmptyKeys()
+        {
+            var input = new Dictionary<string, string>() { };
+            for (int i = 0; i < 1000; i++)
+            {
+                input.Add(new string(' ', i), string.Empty);
+            }
+
+            IConfigurationRoot configurationRoot = new ConfigurationBuilder()
+                .Add(new MemoryConfigurationSource
+                {
+                    InitialData = input
+                })
+                .Build();
+
+            var chainedConfigurationSource = new ChainedConfigurationSource
+            {
+                Configuration = configurationRoot,
+                ShouldDisposeConfiguration = false,
+            };
+            
+            var chainedConfiguration = new ChainedConfigurationProvider(chainedConfigurationSource);
+            IEnumerable<string> childKeys = chainedConfiguration.GetChildKeys(new string[0], null);
+            Assert.Equal(1000, childKeys.Count());
+            Assert.Equal(string.Empty, childKeys.First());
+            Assert.Equal(999, childKeys.Last().Length);
+        }
+
+        [Fact]
+        private void GetChildKeys_CanChainKeyWithNoDelimiter()
+        {
+            var input = new Dictionary<string, string>() { };
+            for (int i = 1000; i < 2000; i++)
+            {
+                input.Add(i.ToString(), string.Empty);
+            }
+
+            IConfigurationRoot configurationRoot = new ConfigurationBuilder()
+                .Add(new MemoryConfigurationSource
+                {
+                    InitialData = input
+                })
+                .Build();
+
+            var chainedConfigurationSource = new ChainedConfigurationSource
+            {
+                Configuration = configurationRoot,
+                ShouldDisposeConfiguration = false,
+            };
+            
+            var chainedConfiguration = new ChainedConfigurationProvider(chainedConfigurationSource);
+            IEnumerable<string> childKeys = chainedConfiguration.GetChildKeys(new string[0], null);
+            Assert.Equal(1000, childKeys.Count());
+            Assert.Equal("1000", childKeys.First());
+            Assert.Equal("1999", childKeys.Last());
+        }
+
+        [Fact]
         public void CanChainConfiguration()
         {
             // Arrange


### PR DESCRIPTION
### Details

Prevents [`ChainedConfigurationProvider.GetChildKeys`](https://github.com/dotnet/runtime/blob/12a8819eee9865eb38bca6c05fdece1053102854/src/libraries/Microsoft.Extensions.Configuration/src/ChainedConfigurationProvider.cs#L75) from [splitting strings](https://github.com/dotnet/runtime/blob/12a8819eee9865eb38bca6c05fdece1053102854/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs#L32-L33) or making unnecessary allocation when keys do not contain delimiter or when keys are empty.

Fixes #62510

### Benchmarks

Benchmark code: [link to gist](https://gist.github.com/maryamariyan/aae2baa69c054cc37ebb0940e0770abd)
Also dotnet/performance PR: https://github.com/dotnet/performance/pull/2336

Without diff:

```
|                                     Method |        Mean |     Error |      StdDev |    Gen 0 |  Gen 1 | Allocated |
|------------------------------------------- |------------:|----------:|------------:|---------:|-------:|----------:|
|         AddChainedConfigurationNoDelimiter |  1,255.4 us |  24.20 us |    50.52 us | 130.8594 | 5.8594 |  1,011 KB |
|               AddChainedConfigurationEmpty | 37,957.7 us | 718.05 us | 1,466.79 us |  76.9231 |      - |  1,010 KB |
|       AddChainedConfigurationWithSplitting |    563.1 us |  11.11 us |    27.88 us |  61.5234 | 5.8594 |    472 KB |
| AddChainedConfigurationWithSplittingLooped |    557.0 us |  11.01 us |    23.69 us |  61.5234 | 5.8594 |    472 KB |
```

UPDATED TO LATEST:
With latest PR diff (updated using [b128f63](https://github.com/dotnet/runtime/pull/67186/commits/b128f6325108f2e3dd22834d9fef76e37b53695f)):

```
|                                     Method |        Mean |     Error |    StdDev |   Gen 0 |  Gen 1 | Allocated |
|------------------------------------------- |------------:|----------:|----------:|--------:|-------:|----------:|
|         AddChainedConfigurationNoDelimiter |    838.2 us |  16.30 us |  21.19 us | 18.5547 | 2.9297 |    143 KB |
|               AddChainedConfigurationEmpty | 20,030.8 us | 398.32 us | 545.23 us |       - |      - |    143 KB |
|       AddChainedConfigurationWithSplitting |    445.4 us |   8.12 us |   7.20 us |  4.8828 | 0.4883 |     40 KB |
| AddChainedConfigurationWithSplittingLooped |    430.9 us |   8.54 us |  22.50 us |  4.8828 |      - |     40 KB |
```

