### PR TITLE
[arm64] JIT: Move LowerSIMD to shared lower.cpp

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -7407,9 +7407,9 @@ void Lowering::LowerSIMD(GenTreeSIMD* simdNode)
     {
         assert(simdNode->GetSimdBaseType() == TYP_FLOAT);
 
-        size_t argCount = simdNode->GetOperandCount();
+        size_t argCount      = simdNode->GetOperandCount();
         size_t constArgCount = 0;
-        float  constArgValues[4]{ 0, 0, 0, 0 };
+        float  constArgValues[4]{0, 0, 0, 0};
 
         for (GenTree* arg : simdNode->Operands())
         {
@@ -7431,7 +7431,7 @@ void Lowering::LowerSIMD(GenTreeSIMD* simdNode)
 
             assert(sizeof(constArgValues) == 16);
 
-            unsigned cnsSize = sizeof(constArgValues);
+            unsigned cnsSize  = sizeof(constArgValues);
             unsigned cnsAlign = (comp->compCodeOpt() != Compiler::SMALL_CODE) ? cnsSize : 1;
 
             CORINFO_FIELD_HANDLE hnd =

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -7386,3 +7386,66 @@ bool Lowering::TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode)
     LowerStoreIndirCommon(blkNode->AsStoreInd());
     return true;
 }
+
+#ifdef FEATURE_SIMD
+//----------------------------------------------------------------------------------------------
+// Lowering::LowerSIMD: Perform containment analysis for a SIMD intrinsic node.
+//
+//  Arguments:
+//     simdNode - The SIMD intrinsic node.
+//
+void Lowering::LowerSIMD(GenTreeSIMD* simdNode)
+{
+    if (simdNode->TypeGet() == TYP_SIMD12)
+    {
+        // GT_SIMD node requiring to produce TYP_SIMD12 in fact
+        // produces a TYP_SIMD16 result
+        simdNode->gtType = TYP_SIMD16;
+    }
+
+    if (simdNode->GetSIMDIntrinsicId() == SIMDIntrinsicInitN)
+    {
+        assert(simdNode->GetSimdBaseType() == TYP_FLOAT);
+
+        size_t argCount = simdNode->GetOperandCount();
+        size_t constArgCount = 0;
+        float  constArgValues[4]{ 0, 0, 0, 0 };
+
+        for (GenTree* arg : simdNode->Operands())
+        {
+            assert(arg->TypeIs(simdNode->GetSimdBaseType()));
+
+            if (arg->IsCnsFltOrDbl())
+            {
+                constArgValues[constArgCount] = static_cast<float>(arg->AsDblCon()->gtDconVal);
+                constArgCount++;
+            }
+        }
+
+        if (constArgCount == argCount)
+        {
+            for (GenTree* arg : simdNode->Operands())
+            {
+                BlockRange().Remove(arg);
+            }
+
+            assert(sizeof(constArgValues) == 16);
+
+            unsigned cnsSize = sizeof(constArgValues);
+            unsigned cnsAlign = (comp->compCodeOpt() != Compiler::SMALL_CODE) ? cnsSize : 1;
+
+            CORINFO_FIELD_HANDLE hnd =
+                comp->GetEmitter()->emitBlkConst(constArgValues, cnsSize, cnsAlign, simdNode->GetSimdBaseType());
+            GenTree* clsVarAddr = new (comp, GT_CLS_VAR_ADDR) GenTreeClsVar(GT_CLS_VAR_ADDR, TYP_I_IMPL, hnd, nullptr);
+            BlockRange().InsertBefore(simdNode, clsVarAddr);
+            simdNode->ChangeOper(GT_IND);
+            simdNode->AsOp()->gtOp1 = clsVarAddr;
+            ContainCheckIndir(simdNode->AsIndir());
+
+            return;
+        }
+    }
+
+    ContainCheckSIMD(simdNode);
+}
+#endif // FEATURE_SIMD

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -612,28 +612,6 @@ void Lowering::LowerRotate(GenTree* tree)
     ContainCheckShiftRotate(tree->AsOp());
 }
 
-#ifdef FEATURE_SIMD
-//----------------------------------------------------------------------------------------------
-// Lowering::LowerSIMD: Perform containment analysis for a SIMD intrinsic node.
-//
-//  Arguments:
-//     simdNode - The SIMD intrinsic node.
-//
-void Lowering::LowerSIMD(GenTreeSIMD* simdNode)
-{
-    assert(simdNode->gtType != TYP_SIMD32);
-
-    if (simdNode->TypeGet() == TYP_SIMD12)
-    {
-        // GT_SIMD node requiring to produce TYP_SIMD12 in fact
-        // produces a TYP_SIMD16 result
-        simdNode->gtType = TYP_SIMD16;
-    }
-
-    ContainCheckSIMD(simdNode);
-}
-#endif // FEATURE_SIMD
-
 #ifdef FEATURE_HW_INTRINSICS
 
 //----------------------------------------------------------------------------------------------

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -755,69 +755,6 @@ void Lowering::LowerCast(GenTree* tree)
     ContainCheckCast(tree->AsCast());
 }
 
-#ifdef FEATURE_SIMD
-//----------------------------------------------------------------------------------------------
-// Lowering::LowerSIMD: Perform containment analysis for a SIMD intrinsic node.
-//
-//  Arguments:
-//     simdNode - The SIMD intrinsic node.
-//
-void Lowering::LowerSIMD(GenTreeSIMD* simdNode)
-{
-    if (simdNode->TypeGet() == TYP_SIMD12)
-    {
-        // GT_SIMD node requiring to produce TYP_SIMD12 in fact
-        // produces a TYP_SIMD16 result
-        simdNode->gtType = TYP_SIMD16;
-    }
-
-    if (simdNode->GetSIMDIntrinsicId() == SIMDIntrinsicInitN)
-    {
-        assert(simdNode->GetSimdBaseType() == TYP_FLOAT);
-
-        size_t argCount      = simdNode->GetOperandCount();
-        size_t constArgCount = 0;
-        float  constArgValues[4]{0, 0, 0, 0};
-
-        for (GenTree* arg : simdNode->Operands())
-        {
-            assert(arg->TypeIs(simdNode->GetSimdBaseType()));
-
-            if (arg->IsCnsFltOrDbl())
-            {
-                constArgValues[constArgCount] = static_cast<float>(arg->AsDblCon()->gtDconVal);
-                constArgCount++;
-            }
-        }
-
-        if (constArgCount == argCount)
-        {
-            for (GenTree* arg : simdNode->Operands())
-            {
-                BlockRange().Remove(arg);
-            }
-
-            assert(sizeof(constArgValues) == 16);
-
-            unsigned cnsSize  = sizeof(constArgValues);
-            unsigned cnsAlign = (comp->compCodeOpt() != Compiler::SMALL_CODE) ? cnsSize : 1;
-
-            CORINFO_FIELD_HANDLE hnd =
-                comp->GetEmitter()->emitBlkConst(constArgValues, cnsSize, cnsAlign, simdNode->GetSimdBaseType());
-            GenTree* clsVarAddr = new (comp, GT_CLS_VAR_ADDR) GenTreeClsVar(GT_CLS_VAR_ADDR, TYP_I_IMPL, hnd, nullptr);
-            BlockRange().InsertBefore(simdNode, clsVarAddr);
-            simdNode->ChangeOper(GT_IND);
-            simdNode->AsOp()->gtOp1 = clsVarAddr;
-            ContainCheckIndir(simdNode->AsIndir());
-
-            return;
-        }
-    }
-
-    ContainCheckSIMD(simdNode);
-}
-#endif // FEATURE_SIMD
-
 #ifdef FEATURE_HW_INTRINSICS
 
 //----------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR moves `Lowering::LowerSIMD(GenTreeSIMD* simdNode)` from `lowerxarch.cpp` to common `lower.cpp` in order to share "load constant vectors from data section" path with arm64.

```csharp
Vector4 Test() => Vector4.UnitX;
```
Codegen diff (on osx-arm64):
```diff
; Assembly listing for method Proga:Test():System.Numerics.Vector4:this
; Emitting BLENDED_CODE for generic ARM64 CPU - MacOS
; ReadyToRun compilation
; optimized code
G_M40426_IG01:              
        A9BF7BFD          stp     fp, lr, [sp,#-16]!
        910003FD          mov     fp, sp
G_M40426_IG02:              
-       1E2E1010          fmov    s16, #1.0000
-       4F00E411          movi    v17.16b, #0x00
-       4F00E412          movi    v18.16b, #0x00
-       4F00E413          movi    v19.16b, #0x00
-       6E040614          ins     v20.s[0], v16.s[0]
-       6E0C0634          ins     v20.s[1], v17.s[0]
-       6E140654          ins     v20.s[2], v18.s[0]
-       6E1C0674          ins     v20.s[3], v19.s[0]
-       4EB41E90          mov     v16.16b, v20.16b
+       9C0000F0          ldr     q16, [@RWD00]
        6E040600          mov     v0.s[0], v16.s[0] ;; TODO: fix these
        6E042601          mov     v1.s[0], v16.s[1]
        6E044602          mov     v2.s[0], v16.s[2]
        6E046603          mov     v3.s[0], v16.s[3]
G_M40426_IG03:              
        A8C17BFD          ldp     fp, lr, [sp],#16
        D65F03C0          ret     lr
-; Total bytes of code 68
+; Total bytes of code 36
```
```
benchmarks.run.OSX.arm64.checked.mch:
Total bytes of delta: -1856 (-0.01 % of base)

coreclr_tests.pmi.OSX.arm64.checked.mch:
Total bytes of delta: -3980 (-0.00 % of base)

libraries.crossgen2.OSX.arm64.checked.mch:
Total bytes of delta: -388 (-0.00 % of base)

libraries_tests.pmi.OSX.arm64.checked.mch:
Total bytes of delta: -20424 (-0.01 % of base)

```