### PR TITLE
[Group 4] Enable nullable annotations for `Microsoft.Extensions.Logging.EventLog`

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/ref/Microsoft.Extensions.Logging.EventLog.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/ref/Microsoft.Extensions.Logging.EventLog.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.Logging.EventLog
     public partial class EventLogLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider, Microsoft.Extensions.Logging.ISupportExternalScope, System.IDisposable
     {
         public EventLogLoggerProvider() { }
-        public EventLogLoggerProvider(Microsoft.Extensions.Logging.EventLog.EventLogSettings settings) { }
+        public EventLogLoggerProvider(Microsoft.Extensions.Logging.EventLog.EventLogSettings? settings) { }
         public EventLogLoggerProvider(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Logging.EventLog.EventLogSettings> options) { }
         public Microsoft.Extensions.Logging.ILogger CreateLogger(string name) { throw null; }
         public void Dispose() { }
@@ -28,9 +28,9 @@ namespace Microsoft.Extensions.Logging.EventLog
     public partial class EventLogSettings
     {
         public EventLogSettings() { }
-        public System.Func<string, Microsoft.Extensions.Logging.LogLevel, bool> Filter { get { throw null; } set { } }
-        public string LogName { get { throw null; } set { } }
-        public string MachineName { get { throw null; } set { } }
-        public string SourceName { get { throw null; } set { } }
+        public System.Func<string, Microsoft.Extensions.Logging.LogLevel, bool>? Filter { get { throw null; } set { } }
+        public string? LogName { get { throw null; } set { } }
+        public string? MachineName { get { throw null; } set { } }
+        public string? SourceName { get { throw null; } set { } }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/ref/Microsoft.Extensions.Logging.EventLog.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/ref/Microsoft.Extensions.Logging.EventLog.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogLogger.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Logging.EventLog
     {
         private readonly string _name;
         private readonly EventLogSettings _settings;
-        private readonly IExternalScopeProvider _externalScopeProvider;
+        private readonly IExternalScopeProvider? _externalScopeProvider;
 
         private const string ContinuationString = "...";
         private readonly int _beginOrEndMessageSegmentSize;
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.Logging.EventLog
         /// <param name="name">The name of the logger.</param>
         /// <param name="settings">The <see cref="EventLogSettings"/>.</param>
         /// <param name="externalScopeProvider">The <see cref="IExternalScopeProvider"/>.</param>
-        public EventLogLogger(string name!!, EventLogSettings settings!!, IExternalScopeProvider externalScopeProvider)
+        public EventLogLogger(string name!!, EventLogSettings settings!!, IExternalScopeProvider? externalScopeProvider)
         {
             _name = name;
             _settings = settings;
@@ -48,7 +48,7 @@ namespace Microsoft.Extensions.Logging.EventLog
         public IEventLog EventLog { get; }
 
         /// <inheritdoc />
-        public IDisposable BeginScope<TState>(TState state)
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
         {
             return _externalScopeProvider?.Push(state);
         }
@@ -65,8 +65,8 @@ namespace Microsoft.Extensions.Logging.EventLog
             LogLevel logLevel,
             EventId eventId,
             TState state,
-            Exception exception,
-            Func<TState, Exception, string> formatter)
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
         {
             if (!IsEnabled(logLevel))
             {
@@ -129,7 +129,7 @@ namespace Microsoft.Extensions.Logging.EventLog
             }
 
             int startIndex = 0;
-            string messageSegment = null;
+            string? messageSegment = null;
             while (true)
             {
                 // Begin segment

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogLoggerProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Logging.EventLog
     {
         internal readonly EventLogSettings _settings;
 
-        private IExternalScopeProvider _scopeProvider;
+        private IExternalScopeProvider? _scopeProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EventLogLoggerProvider"/> class.
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.Logging.EventLog
         /// Initializes a new instance of the <see cref="EventLogLoggerProvider"/> class.
         /// </summary>
         /// <param name="settings">The <see cref="EventLogSettings"/>.</param>
-        public EventLogLoggerProvider(EventLogSettings settings)
+        public EventLogLoggerProvider(EventLogSettings? settings)
         {
             _settings = settings ?? new EventLogSettings();
         }

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogSettings.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogSettings.cs
@@ -10,27 +10,27 @@ namespace Microsoft.Extensions.Logging.EventLog
     /// </summary>
     public class EventLogSettings
     {
-        private IEventLog _eventLog;
+        private IEventLog? _eventLog;
 
         /// <summary>
         /// Name of the event log. If <c>null</c> or not specified, "Application" is the default.
         /// </summary>
-        public string LogName { get; set; }
+        public string? LogName { get; set; }
 
         /// <summary>
         /// Name of the event log source. If <c>null</c> or not specified, ".NET Runtime" is the default.
         /// </summary>
-        public string SourceName { get; set; }
+        public string? SourceName { get; set; }
 
         /// <summary>
         /// Name of the machine having the event log. If <c>null</c> or not specified, local machine is the default.
         /// </summary>
-        public string MachineName { get; set; }
+        public string? MachineName { get; set; }
 
         /// <summary>
         /// The function used to filter events based on the log level.
         /// </summary>
-        public Func<string, LogLevel, bool> Filter { get; set; }
+        public Func<string, LogLevel, bool>? Filter { get; set; }
 
         internal IEventLog EventLog
         {

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/Microsoft.Extensions.Logging.EventLog.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/Microsoft.Extensions.Logging.EventLog.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
+    <Nullable>enable</Nullable>
     <EnableDefaultItems>true</EnableDefaultItems>
     <!-- Use targeting pack references instead of granular ones in the project file. -->
     <DisableImplicitAssemblyReferences>false</DisableImplicitAssemblyReferences>


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/issues/43605

Okay, so here's the thing. `System.Diagnostics.EventLog` is not annotated yet, and a lot of effort is needed to do it.
Here it's used only in `WindowsEventLog` which is `internal`, and nothing calls it with `null`, so it's should be safe to leave everything in is as non-nullable.

I may get around to annotate `System.Diagnostics.EventLog` in the future.