### PR TITLE
Port SequenceEqual to crossplat Vectors, optimize vector compare on x64

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -1779,21 +1779,19 @@ namespace System
             return true;
 
         Vector:
-            if (Sse2.IsSupported)
+            if (Vector128.IsHardwareAccelerated)
             {
-                if (Avx2.IsSupported && length >= (nuint)Vector256<byte>.Count)
+                if (Vector256.IsHardwareAccelerated && length >= (nuint)Vector256<byte>.Count)
                 {
-                    Vector256<byte> vecResult;
                     nuint offset = 0;
                     nuint lengthToExamine = length - (nuint)Vector256<byte>.Count;
                     // Unsigned, so it shouldn't have overflowed larger than length (rather than negative)
-                    Debug.Assert(lengthToExamine < length);
+                    //Debug.Assert(lengthToExamine < length);
                     if (lengthToExamine != 0)
                     {
                         do
                         {
-                            vecResult = Avx2.CompareEqual(LoadVector256(ref first, offset), LoadVector256(ref second, offset));
-                            if (Avx2.MoveMask(vecResult) != -1)
+                            if (LoadVector256(ref first, offset) != LoadVector256(ref second, offset))
                             {
                                 goto NotEqual;
                             }
@@ -1802,8 +1800,7 @@ namespace System
                     }
 
                     // Do final compare as Vector256<byte>.Count from end rather than start
-                    vecResult = Avx2.CompareEqual(LoadVector256(ref first, lengthToExamine), LoadVector256(ref second, lengthToExamine));
-                    if (Avx2.MoveMask(vecResult) == -1)
+                    if (LoadVector256(ref first, lengthToExamine) == LoadVector256(ref second, lengthToExamine))
                     {
                         // C# compiler inverts this test, making the outer goto the conditional jmp.
                         goto Equal;
@@ -1814,19 +1811,15 @@ namespace System
                 }
                 else if (length >= (nuint)Vector128<byte>.Count)
                 {
-                    Vector128<byte> vecResult;
                     nuint offset = 0;
                     nuint lengthToExamine = length - (nuint)Vector128<byte>.Count;
                     // Unsigned, so it shouldn't have overflowed larger than length (rather than negative)
-                    Debug.Assert(lengthToExamine < length);
+                    //Debug.Assert(lengthToExamine < length);
                     if (lengthToExamine != 0)
                     {
                         do
                         {
-                            // We use instrincs directly as .Equals calls .AsByte() which doesn't inline at R2R time
-                            // https://github.com/dotnet/runtime/issues/32714
-                            vecResult = Sse2.CompareEqual(LoadVector128(ref first, offset), LoadVector128(ref second, offset));
-                            if (Sse2.MoveMask(vecResult) != 0xFFFF)
+                            if (LoadVector128(ref first, offset) != LoadVector128(ref second, offset))
                             {
                                 goto NotEqual;
                             }
@@ -1835,8 +1828,7 @@ namespace System
                     }
 
                     // Do final compare as Vector128<byte>.Count from end rather than start
-                    vecResult = Sse2.CompareEqual(LoadVector128(ref first, lengthToExamine), LoadVector128(ref second, lengthToExamine));
-                    if (Sse2.MoveMask(vecResult) == 0xFFFF)
+                    if (LoadVector128(ref first, lengthToExamine) == LoadVector128(ref second, lengthToExamine))
                     {
                         // C# compiler inverts this test, making the outer goto the conditional jmp.
                         goto Equal;
@@ -1846,19 +1838,12 @@ namespace System
                     goto NotEqual;
                 }
             }
-            //else if (AdvSimd.Arm64.IsSupported)
-            //{
-            //    // This API is not optimized with ARM64 intrinsics because there is not much performance win seen
-            //    // when compared to the vectorized implementation below. In addition to comparing the bytes in chunks of
-            //    // 16-bytes, the only check that is done is if there is a mismatch and if yes, return false. This check
-            //    // done with Vector<T> will generate same code by JIT as that if used ARM64 intrinsic instead.
-            //}
             else if (Vector.IsHardwareAccelerated && length >= (nuint)Vector<byte>.Count)
             {
                 nuint offset = 0;
                 nuint lengthToExamine = length - (nuint)Vector<byte>.Count;
                 // Unsigned, so it shouldn't have overflowed larger than length (rather than negative)
-                Debug.Assert(lengthToExamine < length);
+                //Debug.Assert(lengthToExamine < length);
                 if (lengthToExamine > 0)
                 {
                     do
@@ -1885,7 +1870,7 @@ namespace System
 #if TARGET_64BIT
             if (Sse2.IsSupported)
             {
-                Debug.Assert(length <= (nuint)sizeof(nuint) * 2);
+                //Debug.Assert(length <= (nuint)sizeof(nuint) * 2);
 
                 nuint offset = length - (nuint)sizeof(nuint);
                 nuint differentBits = LoadNUInt(ref first) - LoadNUInt(ref second);
@@ -1896,12 +1881,12 @@ namespace System
             else
 #endif
             {
-                Debug.Assert(length >= (nuint)sizeof(nuint));
+                //Debug.Assert(length >= (nuint)sizeof(nuint));
                 {
                     nuint offset = 0;
                     nuint lengthToExamine = length - (nuint)sizeof(nuint);
                     // Unsigned, so it shouldn't have overflowed larger than length (rather than negative)
-                    Debug.Assert(lengthToExamine < length);
+                    //Debug.Assert(lengthToExamine < length);
                     if (lengthToExamine > 0)
                     {
                         do

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -1791,7 +1791,8 @@ namespace System
                     {
                         do
                         {
-                            if (LoadVector256(ref first, offset) != LoadVector256(ref second, offset))
+                            if (Vector256.LoadUnsafe(ref first, offset) !=
+                                Vector256.LoadUnsafe(ref second, offset))
                             {
                                 goto NotEqual;
                             }
@@ -1800,7 +1801,8 @@ namespace System
                     }
 
                     // Do final compare as Vector256<byte>.Count from end rather than start
-                    if (LoadVector256(ref first, lengthToExamine) == LoadVector256(ref second, lengthToExamine))
+                    if (Vector256.LoadUnsafe(ref first, lengthToExamine) ==
+                        Vector256.LoadUnsafe(ref second, lengthToExamine))
                     {
                         // C# compiler inverts this test, making the outer goto the conditional jmp.
                         goto Equal;
@@ -1819,7 +1821,8 @@ namespace System
                     {
                         do
                         {
-                            if (LoadVector128(ref first, offset) != LoadVector128(ref second, offset))
+                            if (Vector128.LoadUnsafe(ref first, offset) !=
+                                Vector128.LoadUnsafe(ref second, offset))
                             {
                                 goto NotEqual;
                             }
@@ -1828,7 +1831,8 @@ namespace System
                     }
 
                     // Do final compare as Vector128<byte>.Count from end rather than start
-                    if (LoadVector128(ref first, lengthToExamine) == LoadVector128(ref second, lengthToExamine))
+                    if (Vector128.LoadUnsafe(ref first, lengthToExamine) ==
+                        Vector128.LoadUnsafe(ref second, lengthToExamine))
                     {
                         // C# compiler inverts this test, making the outer goto the conditional jmp.
                         goto Equal;

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -1786,7 +1786,7 @@ namespace System
                     nuint offset = 0;
                     nuint lengthToExamine = length - (nuint)Vector256<byte>.Count;
                     // Unsigned, so it shouldn't have overflowed larger than length (rather than negative)
-                    //Debug.Assert(lengthToExamine < length);
+                    Debug.Assert(lengthToExamine < length);
                     if (lengthToExamine != 0)
                     {
                         do
@@ -1816,7 +1816,7 @@ namespace System
                     nuint offset = 0;
                     nuint lengthToExamine = length - (nuint)Vector128<byte>.Count;
                     // Unsigned, so it shouldn't have overflowed larger than length (rather than negative)
-                    //Debug.Assert(lengthToExamine < length);
+                    Debug.Assert(lengthToExamine < length);
                     if (lengthToExamine != 0)
                     {
                         do
@@ -1847,7 +1847,7 @@ namespace System
                 nuint offset = 0;
                 nuint lengthToExamine = length - (nuint)Vector<byte>.Count;
                 // Unsigned, so it shouldn't have overflowed larger than length (rather than negative)
-                //Debug.Assert(lengthToExamine < length);
+                Debug.Assert(lengthToExamine < length);
                 if (lengthToExamine > 0)
                 {
                     do
@@ -1872,9 +1872,9 @@ namespace System
             }
 
 #if TARGET_64BIT
-            if (Sse2.IsSupported)
+            if (Vector128.IsHardwareAccelerated)
             {
-                //Debug.Assert(length <= (nuint)sizeof(nuint) * 2);
+                Debug.Assert(length <= (nuint)sizeof(nuint) * 2);
 
                 nuint offset = length - (nuint)sizeof(nuint);
                 nuint differentBits = LoadNUInt(ref first) - LoadNUInt(ref second);
@@ -1885,12 +1885,12 @@ namespace System
             else
 #endif
             {
-                //Debug.Assert(length >= (nuint)sizeof(nuint));
+                Debug.Assert(length >= (nuint)sizeof(nuint));
                 {
                     nuint offset = 0;
                     nuint lengthToExamine = length - (nuint)sizeof(nuint);
                     // Unsigned, so it shouldn't have overflowed larger than length (rather than negative)
-                    //Debug.Assert(lengthToExamine < length);
+                    Debug.Assert(lengthToExamine < length);
                     if (lengthToExamine > 0)
                     {
                         do


### PR DESCRIPTION
This PR does:
1) Ports `SequenceEqual` to use cross-plat vectors
2) Optimizes it for arm64 for <16 elements (the path to handle them was guarded with Sse2.IsSupported for some reason)
3) Optimizes `vec1 == vec2` with xor+vptest if available:

```csharp
bool Test(Vector128<int> v1, Vector128<int> v2) => v1 == v2;
bool Test(Vector256<int> v1, Vector256<int> v2) => v1 == v2;
```
codegen diff:
```diff
; Method Proga:Test
G_M56888_IG01:
       vzeroupper 
G_M56888_IG02:
       vmovupd  xmm0, xmmword ptr [rdx]
-      vpcmpeqd xmm0, xmm0, xmmword ptr [r8]
-      vpmovmskb eax, xmm0
-      cmp      eax, 0xFFFF
+      vpxor    xmm0, xmm0, xmmword ptr [r8]
+      vptest   xmm0, xmm0
       sete     al
       movzx    rax, al
G_M56888_IG03:
       ret      
-; Total bytes of code: 28
+; Total bytes of code: 24


; Method Proga:Test
G_M5176_IG01:
       vzeroupper 
G_M5176_IG02:
       vmovupd  ymm0, ymmword ptr[rdx]
-      vpcmpeqd ymm0, ymm0, ymmword ptr[r8]
-      vpmovmskb eax, ymm0
-      cmp      eax, -1
+      vpxor    ymm0, ymm0, ymmword ptr[r8]
+      vptest   ymm0, ymm0
       sete     al
       movzx    rax, al
G_M5176_IG03:
       vzeroupper 
       ret      
-; Total bytes of code: 29
+; Total bytes of code: 27
```
However, it seems like in some cases/on some CPUs movmsk is faster 🤔 

cc @tannergooding 

PS: seems like the main loop in  `SequenceEqual`  is not properly aligned and hits JCC erratum each iteration