### PR TITLE
Avoid pre-allocating large arrays in some scenarios for Enumerable.Chunk

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Chunk.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Chunk.cs
@@ -55,20 +55,22 @@ namespace System.Linq
             if (e.MoveNext())
             {
                 List<TSource> chunkBuilder = new();
-                do
+                while (true)
                 {
-                    chunkBuilder.Clear();
                     do
                     {
                         chunkBuilder.Add(e.Current);
                     }
                     while (chunkBuilder.Count < size && e.MoveNext());
 
-                    TSource[] chunk = new TSource[chunkBuilder.Count];
-                    chunkBuilder.CopyTo(chunk, 0);
-                    yield return chunk;
+                    yield return chunkBuilder.ToArray();
+
+                    if (chunkBuilder.Count < size || !e.MoveNext())
+                    {
+                        yield break;
+                    }
+                    chunkBuilder.Clear();
                 }
-                while (chunkBuilder.Count == size && e.MoveNext());
             }
         }
     }

--- a/src/libraries/System.Linq/tests/ChunkTests.cs
+++ b/src/libraries/System.Linq/tests/ChunkTests.cs
@@ -142,6 +142,7 @@ namespace System.Linq.Tests
             Assert.Equal(new[] {new[] {9999, 0, 888}, new[] {-1, 66, -777}, new[] {1, 2, -12345}, new[] {10}}, chunks);
         }
 
+        // reproduces https://github.com/dotnet/runtime/issues/67132
         [Fact]
         public void DoesNotPrematurelyAllocateHugeArray()
         {

--- a/src/libraries/System.Linq/tests/ChunkTests.cs
+++ b/src/libraries/System.Linq/tests/ChunkTests.cs
@@ -141,5 +141,13 @@ namespace System.Linq.Tests
 
             Assert.Equal(new[] {new[] {9999, 0, 888}, new[] {-1, 66, -777}, new[] {1, 2, -12345}, new[] {10}}, chunks);
         }
+
+        [Fact]
+        public void DoesNotPrematurelyAllocateHugeArray()
+        {
+            int[][] chunks = Enumerable.Range(0, 10).Chunk(int.MaxValue).ToArray();
+
+            Assert.Equal(new[] { Enumerable.Range(0, 10).ToArray() }, chunks);
+        }
     }
 }


### PR DESCRIPTION
Prototype showing potential approach for improving this edge-case behavior.

Fix #67132