### PR TITLE
Fix a few issues with merged wrappers uncovered by local testing

### DIFF
--- a/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
@@ -354,6 +354,6 @@ sealed class WrapperLibraryTestSummaryReporting : ITestReporterWrapper
 
     public string GenerateSkippedTestReporting(ITestInfo skippedTest)
     {
-        return $"{_summaryLocalIdentifier}.ReportSkippedTest({skippedTest.TestNameExpression}, \"{skippedTest.ContainingType}\", \"{skippedTest.Method}\", System.TimeSpan.Zero, string.Empty);";
+        return $"{_summaryLocalIdentifier}.ReportSkippedTest({skippedTest.TestNameExpression}, \"{skippedTest.ContainingType}\", @\"{skippedTest.Method}\", System.TimeSpan.Zero, string.Empty);";
     }
 }

--- a/src/tests/Common/mergedrunner.targets
+++ b/src/tests/Common/mergedrunner.targets
@@ -1,8 +1,14 @@
 <Project>
   <Target Name="_ValidateNoTestProjectsDroppedByConflictResolution" AfterTargets="ResolveReferences">
+
+    <MSBuild Projects="@(ProjectReference)" Targets="GetDisableProjectBuild" SkipNonexistentTargets="true">
+      <Output TaskParameter="TargetOutputs" ItemName="_ReferenceWithDisabledBuild" />
+    </MSBuild>
+
     <ItemGroup>
       <_ProjectReferencesUsedByReferencePaths Include="@(ReferencePath->Metadata('ProjectReferenceOriginalItemSpec'))" />
       <_ProjectAssemblyReferences Include="@(ProjectReference)" Condition="'%(ProjectReference.OutputItemType)' == ''" />
+      <_ProjectAssemblyReferences Remove="@(_ReferenceWithDisabledBuild->Metadata('OriginalItemSpec'))" />
       <_ProjectReferencesRemovedDueToConflictResolution Include="@(_ProjectAssemblyReferences)" Exclude="@(_ProjectReferencesUsedByReferencePaths)" />
     </ItemGroup>
     <!--

--- a/src/tests/Common/mergedrunner.targets
+++ b/src/tests/Common/mergedrunner.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="_ValidateNoTestProjectsDroppedByConflictResolution" AfterTargets="ResolveReferences">
 
-    <MSBuild Projects="@(ProjectReference)" Targets="GetDisableProjectBuild" SkipNonexistentTargets="true">
+    <MSBuild Projects="@(ProjectReference)" Targets="GetProjectsWithDisabledBuild" SkipNonexistentTargets="true">
       <Output TaskParameter="TargetOutputs" ItemName="_ReferenceWithDisabledBuild" />
     </MSBuild>
 

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -430,6 +430,12 @@
 
   </Target>
 
+  <Target Name="GetDisableProjectBuild" Returns="@(ProjectWithDisableProjectBuildProperty)">
+    <ItemGroup Condition="'$(DisableProjectBuild)' == 'true'">
+      <ProjectWithDisableProjectBuildProperty Include="$(MSBuildProjectFullPath)" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="GetRequiresProcessIsolation" Returns="@(ProjectRequiringProcessIsolation)">
     <ItemGroup Condition="'$(RequiresProcessIsolation)' == 'true'">
       <ProjectRequiringProcessIsolation Include="$(MSBuildProjectFullPath)" />

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -430,9 +430,9 @@
 
   </Target>
 
-  <Target Name="GetDisableProjectBuild" Returns="@(ProjectWithDisableProjectBuildProperty)">
-    <ItemGroup Condition="'$(DisableProjectBuild)' == 'true'">
-      <ProjectWithDisableProjectBuildProperty Include="$(MSBuildProjectFullPath)" />
+  <Target Name="GetProjectsWithDisabledBuild" Returns="@(ProjectWithDisabledBuild)">
+    <ItemGroup Condition="'$(_WillCLRTestProjectBuild)' != 'true'">
+      <ProjectWithDisabledBuild Include="$(MSBuildProjectFullPath)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
After merging in the last preparatory change (deduplication of
tests with the same assembly names) I'm now testing the "final"
JIT/Methodical switchover change; this testing uncovered a few
previously unseen issues related to the merged wrappers and I'm
sending them for a separate PR to decouple them from the big
mechanical switchover change.

1) For out-of-process tests, "Method" contains the relative test
execution script path; we need to prefix the string with "@"
to avoid complaining about backslashes on Windows.

2) Jeremy recently added a consistency check to catch multiple
projects producing assemblies with the same simple name; turns
out there was a subtle bug where the check blew up on projects
with DisableProjectBuild set to true.

3) A similar problem exists for projects with the property
CLRTestTargetUnsupported but I haven't added it to the fix;
I believe it is healthy to receive this type of error in the build
as with the merged wrappers the CLRTestTargetUnsupported clauses
need to be removed and replaced with ConditionalFactAttribute
annotations, otherwise we could lose part of the conditional
code coverage as in the lab the managed tests are built only
once on an arbitrary platform so their individual platform-specific
exclusions must be postponed to execution time.

Thanks

Tomas