### PR TITLE
Account for global stores in hoisting properly

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -6900,22 +6900,15 @@ void Compiler::optHoistLoopBlocks(unsigned loopNum, ArrayStack<BasicBlock*>* blo
                         }
                     }
                 }
-                else if (tree->OperIs(GT_ASG))
+                else if (tree->OperRequiresAsgFlag())
                 {
-                    // If the LHS of the assignment has a global reference, then assume it's a global side effect.
-                    GenTree* lhs = tree->AsOp()->gtOp1;
-                    if (lhs->gtFlags & GTF_GLOB_REF)
+                    // Assume "ASG(<not marked with GLOB_REF>, ...)" stores are not globally visible.
+                    if (!tree->OperIs(GT_ASG) || ((tree->gtGetOp1()->gtFlags & GTF_GLOB_REF) != 0))
                     {
+                        INDEBUG(failReason = "store to globally visible memory");
+                        treeIsHoistable    = false;
                         m_beforeSideEffect = false;
                     }
-                }
-                else if (tree->OperIs(GT_XADD, GT_XORR, GT_XAND, GT_XCHG, GT_LOCKADD, GT_CMPXCHG, GT_MEMORYBARRIER))
-                {
-                    // If this node is a MEMORYBARRIER or an Atomic operation
-                    // then don't hoist and stop any further hoisting after this node
-                    INDEBUG(failReason = "atomic op or memory barrier";)
-                    treeIsHoistable    = false;
-                    m_beforeSideEffect = false;
                 }
             }
 

--- a/src/tests/JIT/opt/Hoisting/Hoisting.cs
+++ b/src/tests/JIT/opt/Hoisting/Hoisting.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.Intrinsics.Arm;
+
+unsafe class Hoisting
+{
+    public static int Main()
+    {
+        var p = stackalloc int[4];
+        p[0] = 1;
+        try
+        {
+            ProblemWithHwiStore(p, -1);
+            return 101;
+        }
+        catch (OverflowException)
+        {
+            if (p[0] != 0)
+            {
+                return 102;
+            }
+        }
+
+        try
+        {
+            ProblemWithNormalStore(p, -1);
+            return 103;
+        }
+        catch (OverflowException)
+        {
+            if (p[0] != -1)
+            {
+                return 104;
+            }
+        }
+
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ProblemWithHwiStore(int* p, int b)
+    {
+        // Make sure we don't hoist the checked cast.
+        for (int i = 0; i < 10; i++)
+        {
+            Vector128.Store(Vector128<int>.Zero, p);
+            *p = (int)checked((uint)b);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ProblemWithNormalStore(int* p, int b)
+    {
+        // Make sure we don't hoist the checked cast.
+        for (int i = 0; i < 10; i++)
+        {
+            *p = b;
+            *p = (int)checked((uint)b);
+        }
+    }
+}

--- a/src/tests/JIT/opt/Hoisting/Hoisting.csproj
+++ b/src/tests/JIT/opt/Hoisting/Hoisting.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
We were not doing so in all cases, which could lead to reordering a throw with a store.

Small [diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1684999&view=ms.vss-build-web.run-extensions-tab) where we no longer hoist across a global store.