### PR TITLE
Allow mismatched assembly name and file name

### DIFF
--- a/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
@@ -135,6 +135,8 @@ namespace ILCompiler
 
         private EcmaModule GetOrAddModuleFromPath(string filePath, bool useForBinding)
         {
+            filePath = Path.GetFullPath(filePath);
+
             // This method is not expected to be called frequently. Linear search is acceptable.
             foreach (var entry in ModuleHashtable.Enumerator.Get(_moduleHashtable))
             {
@@ -182,6 +184,8 @@ namespace ILCompiler
 
         private EcmaModule AddModule(string filePath, string expectedSimpleName, bool useForBinding, ModuleData oldModuleData = null)
         {
+            filePath = Path.GetFullPath(filePath);
+
             PEReader peReader = null;
             MemoryMappedViewAccessor mappedViewAccessor = null;
             PdbSymbolReader pdbReader = null;

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -607,7 +607,6 @@ namespace ILCompiler
                 }
             }
 
-            _rootedAssemblies = new List<string>(_rootedAssemblies.Select(a => ILLinkify(a)));
             _conditionallyRootedAssemblies = new List<string>(_conditionallyRootedAssemblies.Select(a => ILLinkify(a)));
             _trimmedAssemblies = new List<string>(_trimmedAssemblies.Select(a => ILLinkify(a)));
 
@@ -626,10 +625,16 @@ namespace ILCompiler
             // Root whatever assemblies were specified on the command line
             foreach (var rootedAssembly in _rootedAssemblies)
             {
+                // For compatibility with IL Linker, the parameter could be a file name or an assembly name.
+                // This is the logic IL Linker uses to decide how to interpret the string. Really.
+                EcmaModule module = File.Exists(rootedAssembly)
+                    ? typeSystemContext.GetModuleFromPath(rootedAssembly)
+                    : typeSystemContext.GetModuleForSimpleName(Path.GetFileNameWithoutExtension(rootedAssembly));
+
                 // We only root the module type. The rest will fall out because we treat _rootedAssemblies
                 // same as conditionally rooted ones and here we're fulfilling the condition ("something is used").
                 compilationRoots.Add(
-                    new GenericRootProvider<ModuleDesc>(typeSystemContext.GetModuleForSimpleName(rootedAssembly),
+                    new GenericRootProvider<ModuleDesc>(module,
                     (ModuleDesc module, IRootingServiceProvider rooter) => rooter.AddCompilationRoot(module.GetGlobalModuleType(), "Command line root")));
             }
 

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -629,7 +629,7 @@ namespace ILCompiler
                 // This is the logic IL Linker uses to decide how to interpret the string. Really.
                 EcmaModule module = File.Exists(rootedAssembly)
                     ? typeSystemContext.GetModuleFromPath(rootedAssembly)
-                    : typeSystemContext.GetModuleForSimpleName(Path.GetFileNameWithoutExtension(rootedAssembly));
+                    : typeSystemContext.GetModuleForSimpleName(rootedAssembly);
 
                 // We only root the module type. The rest will fall out because we treat _rootedAssemblies
                 // same as conditionally rooted ones and here we're fulfilling the condition ("something is used").


### PR DESCRIPTION
`GetModuleForSimpleName` checks that the assembly name matches the file name we just opened and throws if it doesn't. Avoid this API for the `--root` command line argument.

This is needed because we have 400+ Pri-0 tests in IL where the assembly name doesn't match the file name of the test.