### PR TITLE
[release/6.0] Avoid issuing connection attempts for already cancelled requests

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
@@ -11,6 +11,7 @@ using Xunit.Abstractions;
 
 namespace System.Net.Http.Functional.Tests
 {
+    [ConditionalClass(typeof(SocketsHttpHandler), nameof(SocketsHttpHandler.IsSupported))]
     public abstract class SocketsHttpHandler_Cancellation_Test : HttpClientHandler_Cancellation_Test
     {
         protected SocketsHttpHandler_Cancellation_Test(ITestOutputHelper output) : base(output) { }
@@ -102,6 +103,70 @@ namespace System.Net.Http.Functional.Tests
                 }
             }, server => Task.CompletedTask, // doesn't actually connect to server
             options: new GenericLoopbackOptions() { UseSsl = false });
+        }
+
+        [Fact]
+        public async Task RequestsCanceled_NoConnectionAttemptForCanceledRequests()
+        {
+            if (UseVersion == HttpVersion.Version30)
+            {
+                // HTTP3 does not support ConnectCallback
+                return;
+            }
+
+            bool seenRequest1 = false;
+            bool seenRequest2 = false;
+            bool seenRequest3 = false;
+
+            var uri = new Uri("https://example.com");
+            HttpRequestMessage request1 = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true);
+            HttpRequestMessage request2 = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true);
+            HttpRequestMessage request3 = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true);
+
+            TaskCompletionSource connectCallbackEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource connectCallbackGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using HttpClientHandler handler = CreateHttpClientHandler();
+            handler.MaxConnectionsPerServer = 1;
+            GetUnderlyingSocketsHttpHandler(handler).ConnectCallback = async (context, cancellation) =>
+            {
+                if (context.InitialRequestMessage == request1) seenRequest1 = true;
+                if (context.InitialRequestMessage == request2) seenRequest2 = true;
+                if (context.InitialRequestMessage == request3) seenRequest3 = true;
+
+                connectCallbackEntered.TrySetResult();
+
+                await connectCallbackGate.Task.WaitAsync(TestHelper.PassingTestTimeout);
+
+                throw new Exception("No connection");
+            };
+            using HttpClient client = CreateHttpClient(handler);
+
+            Task request1Task = client.SendAsync(TestAsync, request1);
+            await connectCallbackEntered.Task.WaitAsync(TestHelper.PassingTestTimeout);
+            Assert.True(seenRequest1);
+
+            using var request2Cts = new CancellationTokenSource();
+            Task request2Task = client.SendAsync(TestAsync, request2, request2Cts.Token);
+            Assert.False(seenRequest2);
+
+            Task request3Task = client.SendAsync(TestAsync, request3);
+            Assert.False(seenRequest2);
+            Assert.False(seenRequest3);
+
+            request2Cts.Cancel();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() => request2Task).WaitAsync(TestHelper.PassingTestTimeout);
+            Assert.False(seenRequest2);
+            Assert.False(seenRequest3);
+
+            connectCallbackGate.SetResult();
+
+            await Assert.ThrowsAsync<HttpRequestException>(() => request1Task).WaitAsync(TestHelper.PassingTestTimeout);
+            await Assert.ThrowsAsync<HttpRequestException>(() => request3Task).WaitAsync(TestHelper.PassingTestTimeout);
+
+            Assert.False(seenRequest2);
+            Assert.True(seenRequest3);
         }
 
         [OuterLoop("Incurs significant delay")]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1044,7 +1044,7 @@ namespace System.Net.Http.Functional.Tests
         public SocketsHttpHandlerTest_Cookies_Http11(ITestOutputHelper output) : base(output) { }
     }
 
-    [SkipOnPlatform(TestPlatforms.Browser, "ConnectTimeout is not supported on Browser")]
+    [ConditionalClass(typeof(SocketsHttpHandler), nameof(SocketsHttpHandler.IsSupported))]
     public sealed class SocketsHttpHandler_HttpClientHandler_Http11_Cancellation_Test : SocketsHttpHandler_Cancellation_Test
     {
         public SocketsHttpHandler_HttpClientHandler_Http11_Cancellation_Test(ITestOutputHelper output) : base(output) { }


### PR DESCRIPTION
Fixes #66990
Backport of #66992 to release/6.0

## Customer Impact

Discovered when analyzing Dynamics memory leak when upgrading .NET Core 3.1 to 6.0 - see details in https://github.com/dotnet/runtime/issues/66673#issuecomment-1073811798.
Reduces the chance of a memory leak if an endpoint becomes unresponsive and new connections can't be established.

Greatly reduces the amount of work & time needed to process already-cancelled requests when no connections are available.

## Testing

Added a targeted test case for the new behavior.
We have existing test coverage to ensure nothing regressed.

## Risk

Low -- small change affecting only already-canceled requests.