### PR TITLE
[release/6.0] improve SslStream tests on server 2022

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
@@ -55,7 +55,11 @@ namespace System
         // >= Windows 10 20H1 Update
         public static bool IsWindows10Version2004OrGreater => IsWindowsVersionOrLater(10, 0, 19041);
 
-        public static bool IsWindows10Version2004Build19573OrGreater => IsWindowsVersionOrLater(10, 0, 19573);
+        // WinHTTP update
+        public static bool IsWindows10Version19573OrGreater => IsWindowsVersionOrLater(10, 0, 19573);
+
+        // Windows Server 2022
+        public static bool IsWindows10Version20348OrGreater => IsWindowsVersionOrLater(10, 0, 20348);
 
         // Windows 11 aka 21H2
         public static bool IsWindows10Version22000OrGreater => IsWindowsVersionOrLater(10, 0, 22000);

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -194,7 +194,7 @@ namespace System
                 {
                     return true;
                 }
-                
+
                 return OpenSslVersion.Major == 1 && (OpenSslVersion.Minor >= 1 || OpenSslVersion.Build >= 2);
             }
 
@@ -341,7 +341,7 @@ namespace System
 
         private static bool GetProtocolSupportFromWindowsRegistry(SslProtocols protocol, bool defaultProtocolSupport)
         {
-            string registryProtocolName = protocol switch 
+            string registryProtocolName = protocol switch
             {
 #pragma warning disable CS0618 // Ssl2 and Ssl3 are obsolete
                 SslProtocols.Ssl3 => "SSL 3.0",
@@ -391,7 +391,7 @@ namespace System
 #pragma warning disable CS0618 // Ssl2 and Ssl3 are obsolete
                 return GetProtocolSupportFromWindowsRegistry(SslProtocols.Ssl3, ssl3DefaultSupport);
 #pragma warning restore CS0618
-                
+
             }
 
             return (IsOSX || (IsLinux && OpenSslVersion < new Version(1, 0, 2) && !IsDebian));
@@ -418,7 +418,7 @@ namespace System
             if (IsOSXLike || IsAndroid)
             {
                 return true;
-            } 
+            }
             if (IsWindows)
             {
                 return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls, true);
@@ -429,7 +429,7 @@ namespace System
 
         private static bool GetTls11Support()
         {
-            // on Windows, macOS, and Android TLS1.0/1.1 are supported.            
+            // on Windows, macOS, and Android TLS1.0/1.1 are supported.
             if (IsWindows)
             {
                 // TLS 1.1 and 1.2 can work on Windows7 but it is not enabled by default.
@@ -462,7 +462,7 @@ namespace System
                 // assume no if positive entry is missing on older Windows
                 // Latest insider builds have TLS 1.3 enabled by default.
                 // The build number is approximation.
-                bool defaultProtocolSupport = IsWindows10Version2004Build19573OrGreater;
+                bool defaultProtocolSupport = IsWindows10Version20348OrGreater;
 
 #if NETFRAMEWORK
                 return false;

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ClientCertificateTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ClientCertificateTest.cs
@@ -54,7 +54,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 
 // Disabling it for full .Net Framework due to a missing ALPN API which leads to a protocol downgrade
 #if !NETFRAMEWORK
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version2004Build19573OrGreater))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version19573OrGreater))]
         public async Task UseClientCertOnHttp2_OSSupportsIt_Success()
         {
             using X509Certificate2 clientCert = Test.Common.Configuration.Certificates.GetClientCertificate();

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -408,17 +408,12 @@ namespace System.Net.Security.Tests
 
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.SupportsTls13))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/58927", TestPlatforms.Windows)]
         [InlineData(true)]
         [InlineData(false)]
         [PlatformSpecific(TestPlatforms.Windows)]
         public async Task SslStream_NegotiateClientCertificateAsyncTls13_Succeeds(bool sendClientCertificate)
         {
-            if (PlatformDetection.IsWindows10Version22000OrGreater)
-            {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/58927")]
-                throw new SkipTestException("Unstable on Windows 11");
-            }
-
             bool negotiateClientCertificateCalled = false;
             using CancellationTokenSource cts = new CancellationTokenSource();
             cts.CancelAfter(TestConfiguration.PassingTestTimeout);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -73,7 +73,7 @@ namespace System.Net.Security.Tests
         public async Task SslStream_StreamToStream_Authentication_Success(X509Certificate serverCert = null, X509Certificate clientCert = null)
         {
 
-            if (PlatformDetection.IsWindows10Version22000OrGreater)
+            if (PlatformDetection.IsWindows10Version20348OrGreater)
             {
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/58927")]
                 throw new SkipTestException("Unstable on Windows 11");

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
@@ -76,7 +76,7 @@ namespace System.Net.Security.Tests
         [MemberData(nameof(OneOrBothUseDefaulData))]
         public async Task ClientAndServer_OneOrBothUseDefault_Ok(SslProtocols? clientProtocols, SslProtocols? serverProtocols)
         {
-            if (PlatformDetection.IsWindows10Version22000OrGreater)
+            if (PlatformDetection.IsWindows10Version20348OrGreater)
             {
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/58927")]
                 throw new SkipTestException("Unstable on Windows 11");


### PR DESCRIPTION
Backport of #64968 to release/6.0.

# Customer Impact

Test-only change needed for https://github.com/dotnet/runtime/issues/67048

cc @wfurt to add more info

# Testing

N/A

# Risk

Very low. This is test-only change.