### PR TITLE
Remove unnecessary remark from `ObservableCollection.CollectionChanged`

### DIFF
--- a/src/libraries/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
+++ b/src/libraries/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
@@ -80,9 +80,6 @@ namespace System.Collections.ObjectModel
         /// <summary>
         /// Occurs when the collection changes, either by adding or removing an item.
         /// </summary>
-        /// <remarks>
-        /// see <seealso cref="INotifyCollectionChanged"/>
-        /// </remarks>
         [field: NonSerialized]
         public virtual event NotifyCollectionChangedEventHandler? CollectionChanged;
 


### PR DESCRIPTION
I'm removing a remark that is unnecessary in the `CollectionChanged` event API of the `System.Collections.ObjectModel.ObservableCollection` type.

Every time we have to port new documentation for the latest released preview, using the [dotnet/api-docs-sync](https://github.com/dotnet/api-docs-sync) tool, the `ObservableCollection``1.xml` file shows up as having new documentation:

<img src="https://user-images.githubusercontent.com/1175054/160475479-9eed74e0-4ee0-433c-99e4-5b341ae84123.png" width="600" />

But it's not new, and we always have to manually revert it because such remark is not something we would like to port, mainly because we already have it indicated in the docs xml file as an `altmember`:

https://github.com/dotnet/dotnet-api-docs/blob/d67c461d2960e0c3fffe94dc30fb6751f8bd33e4/xml/System.Collections.ObjectModel/ObservableCollection%601.xml#L476-L477

