### PR TITLE
Increase timeout on regex count test

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Count.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Count.Tests.cs
@@ -119,7 +119,7 @@ namespace System.Text.RegularExpressions.Tests
             Stopwatch sw = Stopwatch.StartNew();
             Assert.Throws<RegexMatchTimeoutException>(() => r.Count(Input));
             Assert.Throws<RegexMatchTimeoutException>(() => r.Count(Input.AsSpan()));
-            Assert.InRange(sw.Elapsed.TotalSeconds, 0, 20); // arbitrary upper bound that should be well above what's needed with a 1ms timeout
+            Assert.InRange(sw.Elapsed.TotalSeconds, 0, 30); // arbitrary upper bound that should be well above what's needed with a 1ms timeout
 
             switch (engine)
             {
@@ -128,7 +128,7 @@ namespace System.Text.RegularExpressions.Tests
                     sw = Stopwatch.StartNew();
                     Assert.Throws<RegexMatchTimeoutException>(() => Regex.Count(Input, Pattern, RegexHelpers.OptionsFromEngine(engine), TimeSpan.FromMilliseconds(1)));
                     Assert.Throws<RegexMatchTimeoutException>(() => Regex.Count(Input.AsSpan(), Pattern, RegexHelpers.OptionsFromEngine(engine), TimeSpan.FromMilliseconds(1)));
-                    Assert.InRange(sw.Elapsed.TotalSeconds, 0, 20); // arbitrary upper bound that should be well above what's needed with a 1ms timeout
+                    Assert.InRange(sw.Elapsed.TotalSeconds, 0, 30); // arbitrary upper bound that should be well above what's needed with a 1ms timeout
                     break;
             }
         }

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Count.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Count.Tests.cs
@@ -119,7 +119,7 @@ namespace System.Text.RegularExpressions.Tests
             Stopwatch sw = Stopwatch.StartNew();
             Assert.Throws<RegexMatchTimeoutException>(() => r.Count(Input));
             Assert.Throws<RegexMatchTimeoutException>(() => r.Count(Input.AsSpan()));
-            Assert.InRange(sw.Elapsed.TotalSeconds, 0, 10); // arbitrary upper bound that should be well above what's needed with a 1ms timeout
+            Assert.InRange(sw.Elapsed.TotalSeconds, 0, 20); // arbitrary upper bound that should be well above what's needed with a 1ms timeout
 
             switch (engine)
             {
@@ -128,7 +128,7 @@ namespace System.Text.RegularExpressions.Tests
                     sw = Stopwatch.StartNew();
                     Assert.Throws<RegexMatchTimeoutException>(() => Regex.Count(Input, Pattern, RegexHelpers.OptionsFromEngine(engine), TimeSpan.FromMilliseconds(1)));
                     Assert.Throws<RegexMatchTimeoutException>(() => Regex.Count(Input.AsSpan(), Pattern, RegexHelpers.OptionsFromEngine(engine), TimeSpan.FromMilliseconds(1)));
-                    Assert.InRange(sw.Elapsed.TotalSeconds, 0, 10); // arbitrary upper bound that should be well above what's needed with a 1ms timeout
+                    Assert.InRange(sw.Elapsed.TotalSeconds, 0, 20); // arbitrary upper bound that should be well above what's needed with a 1ms timeout
                     break;
             }
         }


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/67225

I'm assuming here that this does not imply that the timeout mechanism is not working, since without a timeout this pattern would be expected to be much slower.