### PR TITLE
Obsolete key blob support on ECDiffieHellmanPublicKey

### DIFF
--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -97,6 +97,7 @@ The PR that reveals the implementation of the `<IncludeInternalObsoleteAttribute
 |  __`SYSLIB0040`__ | EncryptionPolicy.NoEncryption and AllowEncryption significantly reduce security and should not be used in production code. |
 |  __`SYSLIB0041`__ | The default hash algorithm and iteration counts in Rfc2898DeriveBytes constructors are outdated and insecure. Use a constructor that accepts the hash algorithm and the number of iterations. |
 |  __`SYSLIB0042`__ | ToXmlString and FromXmlString have no implementation for ECC types, and are obsolete. Use a standard import and export format such as ExportSubjectPublicKeyInfo or ImportSubjectPublicKeyInfo for public keys and ExportPkcs8PrivateKey or ImportPkcs8PrivateKey for private keys. |
+|  __`SYSLIB0043`__ | ECDiffieHellmanPublicKey.ToByteArray() and the associated constructor do not have a consistent and interoperable implementation on all platforms. Use ECDiffieHellmanPublicKey.ExportSubjectPublicKeyInfo() instead. |
 
 ## Analyzer Warnings
 

--- a/src/libraries/Common/src/System/Obsoletions.cs
+++ b/src/libraries/Common/src/System/Obsoletions.cs
@@ -138,5 +138,8 @@ namespace System
 
         internal const string EccXmlExportImportMessage = "ToXmlString and FromXmlString have no implementation for ECC types, and are obsolete. Use a standard import and export format such as ExportSubjectPublicKeyInfo or ImportSubjectPublicKeyInfo for public keys and ExportPkcs8PrivateKey or ImportPkcs8PrivateKey for private keys.";
         internal const string EccXmlExportImportDiagId = "SYSLIB0042";
+
+        internal const string EcDhPublicKeyBlobMessage = "ECDiffieHellmanPublicKey.ToByteArray() and the associated constructor do not have a consistent and interoperable implementation on all platforms. Use ECDiffieHellmanPublicKey.ExportSubjectPublicKeyInfo() instead.";
+        internal const string EcDhPublicKeyBlobDiagId = "SYSLIB0043";
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanAndroidPublicKey.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanAndroidPublicKey.cs
@@ -31,7 +31,9 @@ namespace System.Security.Cryptography
                 throw new PlatformNotSupportedException();
             }
 
+#pragma warning disable 0672 // Member overrides an obsolete member.
             public override byte[] ToByteArray()
+#pragma warning restore 0672
             {
                 throw new PlatformNotSupportedException();
             }

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSslPublicKey.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSslPublicKey.cs
@@ -38,7 +38,9 @@ namespace System.Security.Cryptography
             throw new PlatformNotSupportedException();
         }
 
+#pragma warning disable 0672 // Member overrides an obsolete member.
         public override byte[] ToByteArray()
+#pragma warning restore 0672
         {
             throw new PlatformNotSupportedException();
         }

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanSecurityTransforms.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanSecurityTransforms.cs
@@ -262,7 +262,9 @@ namespace System.Security.Cryptography
                 /// There is no key blob format for OpenSSL ECDH like there is for Cng ECDH. Instead of allowing
                 /// this to return a potentially confusing empty byte array, we opt to throw instead.
                 /// </summary>
+#pragma warning disable 0672 // Member overrides an obsolete member.
                 public override byte[] ToByteArray()
+#pragma warning restore 0672
                 {
                     throw new PlatformNotSupportedException();
                 }

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1070,12 +1070,14 @@ namespace System.Security.Cryptography
     public abstract partial class ECDiffieHellmanPublicKey : System.IDisposable
     {
         protected ECDiffieHellmanPublicKey() { }
+        [System.ObsoleteAttribute("ECDiffieHellmanPublicKey.ToByteArray() and the associated constructor do not have a consistent and interoperable implementation on all platforms. Use ECDiffieHellmanPublicKey.ExportSubjectPublicKeyInfo() instead.", DiagnosticId="SYSLIB0043", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         protected ECDiffieHellmanPublicKey(byte[] keyBlob) { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public virtual System.Security.Cryptography.ECParameters ExportExplicitParameters() { throw null; }
         public virtual System.Security.Cryptography.ECParameters ExportParameters() { throw null; }
         public virtual byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        [System.ObsoleteAttribute("ECDiffieHellmanPublicKey.ToByteArray() and the associated constructor do not have a consistent and interoperable implementation on all platforms. Use ECDiffieHellmanPublicKey.ExportSubjectPublicKeyInfo() instead.", DiagnosticId="SYSLIB0043", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         public virtual byte[] ToByteArray() { throw null; }
         [System.ObsoleteAttribute("ToXmlString and FromXmlString have no implementation for ECC types, and are obsolete. Use a standard import and export format such as ExportSubjectPublicKeyInfo or ImportSubjectPublicKeyInfo for public keys and ExportPkcs8PrivateKey or ImportPkcs8PrivateKey for private keys.", DiagnosticId="SYSLIB0042", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         public virtual string ToXmlString() { throw null; }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanCngPublicKey.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanCngPublicKey.cs
@@ -17,7 +17,9 @@ namespace System.Security.Cryptography
         /// <summary>
         /// Wrap a CNG key
         /// </summary>
+#pragma warning disable SYSLIB0043 // byte[] constructor on ECDiffieHellmanPublicKey is obsolete
         internal ECDiffieHellmanCngPublicKey(byte[] keyBlob, string? curveName, CngKeyBlobFormat format) : base(keyBlob)
+#pragma warning restore SYSLIB0043
         {
             _format = format;
             // Can be null for P256, P384, P521, or an explicit blob
@@ -94,7 +96,9 @@ namespace System.Security.Cryptography
                 throw new ObjectDisposedException(nameof(ECDiffieHellmanCngPublicKey));
             }
 
+#pragma warning disable SYSLIB0043 // ToByteArray is obsolete.
             return CngKey.Import(ToByteArray(), _curveName, BlobFormat);
+#pragma warning restore SYSLIB0043
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanPublicKey.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanPublicKey.cs
@@ -15,6 +15,7 @@ namespace System.Security.Cryptography
             _keyBlob = Array.Empty<byte>();
         }
 
+        [Obsolete(Obsoletions.EcDhPublicKeyBlobMessage, DiagnosticId = Obsoletions.EcDhPublicKeyBlobDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         protected ECDiffieHellmanPublicKey(byte[] keyBlob!!)
         {
             _keyBlob = (byte[])keyBlob.Clone();
@@ -27,6 +28,7 @@ namespace System.Security.Cryptography
 
         protected virtual void Dispose(bool disposing) { }
 
+        [Obsolete(Obsoletions.EcDhPublicKeyBlobMessage, DiagnosticId = Obsoletions.EcDhPublicKeyBlobDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public virtual byte[] ToByteArray()
         {
             return (byte[])_keyBlob.Clone();

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanWrapper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanWrapper.cs
@@ -195,7 +195,9 @@ namespace System.Security.Cryptography
                 }
             }
 
+#pragma warning disable 0672, SYSLIB0043 // Member overrides an obsolete member, ToByteArray is obsolete.
             public override byte[] ToByteArray() => _wrapped.ToByteArray();
+#pragma warning restore 0672, SYSLIB0043
 
 #pragma warning disable 0672, SYSLIB0042 // Member overrides an obsolete member, ToXmlString is obsolete.
             public override string ToXmlString() => _wrapped.ToXmlString();

--- a/src/libraries/System.Security.Cryptography/tests/ECDiffieHellmanPublicKeyTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/ECDiffieHellmanPublicKeyTests.cs
@@ -10,7 +10,9 @@ namespace System.Security.Cryptography.Tests
     {
         private class TestDerived : ECDiffieHellmanPublicKey
         {
+#pragma warning disable SYSLIB0043 // byte ctor is obsolete
             public TestDerived(byte[] keyBlob) : base(keyBlob) { }
+#pragma warning restore SYSLIB0043
         }
 
         [Fact]
@@ -25,7 +27,9 @@ namespace System.Security.Cryptography.Tests
             byte[] arg = new byte[1] { 1 };
             var pk = new TestDerived(arg);
 
+#pragma warning disable SYSLIB0043 // ToByteArray is obsolete
             Assert.Equal(1, pk.ToByteArray()[0]);
+#pragma warning restore SYSLIB0043
         }
 
         [Fact]


### PR DESCRIPTION
Obsoletes:

* M:System.Security.Cryptography.ECDiffieHellmanPublicKey.#ctor(System.Byte[])
* M:System.Security.Cryptography.ECDiffieHellmanPublicKey.ToByteArray()

Closes #50528 (Last one!)