### PR TITLE
JIT: Use small register types for some enregisterable locals

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -3827,23 +3827,25 @@ var_types LclVarDsc::GetRegisterType() const
 //
 // Notes:
 //    Special cases are small OSX ARM64 memory params (where args are not widened)
-//    and small local promoted fields (which use Tier0 frame space as stack homes)
+//    and small local promoted fields (which use Tier0 frame space as stack homes).
 //
 var_types LclVarDsc::GetActualRegisterType() const
 {
     if (varTypeIsSmall(TypeGet()))
     {
-
-#ifdef OSX_ARM64_ABI
-        if (lvIsParam && !lvIsRegArg)
+        if (compMacOsArm64Abi() && lvIsParam && !lvIsRegArg)
         {
             return GetRegisterType();
         }
-#endif
 
         if (lvIsOSRLocal && lvIsStructField)
         {
+#if defined(TARGET_X86)
+            // Revisit when we support OSR on x86
+            unreached();
+#else
             return GetRegisterType();
+#endif
         }
     }
 

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -3825,8 +3825,28 @@ var_types LclVarDsc::GetRegisterType() const
 // Return Value:
 //    TYP_UNDEF if the layout is not enregistrable, the register type otherwise.
 //
+// Notes:
+//    Special cases are small OSX ARM64 memory params (where args are not widened)
+//    and small local promoted fields (which use Tier0 frame space as stack homes)
+//
 var_types LclVarDsc::GetActualRegisterType() const
 {
+    if (varTypeIsSmall(TypeGet()))
+    {
+
+#ifdef OSX_ARM64_ABI
+        if (lvIsParam && !lvIsRegArg)
+        {
+            return GetRegisterType();
+        }
+#endif
+
+        if (lvIsOSRLocal && lvIsStructField)
+        {
+            return GetRegisterType();
+        }
+    }
+
     return genActualType(GetRegisterType());
 }
 


### PR DESCRIPTION
Fix two cases where small enregisterable locals can't be saved to the stack
using actual (widened) types:
* small memory args for OSX ARM64
* promoted fields of OSR locals

Closes #67152.
Closes #67188.