### PR TITLE
[wasm] Unset PYTHONHOME

### DIFF
--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -256,6 +256,7 @@
 
       <EmscriptenEnvVars Include="EMSDK_PYTHON=$(EmscriptenPythonToolsPath)python.exe" Condition="'$(OS)' == 'Windows_NT'" />
       <EmscriptenEnvVars Include="PYTHONPATH=$(EmscriptenPythonToolsPath)" Condition="'$(OS)' == 'Windows_NT'" />
+      <EmscriptenEnvVars Include="PYTHONHOME=" Condition="'$(OS)' == 'Windows_NT'" />
       <EmscriptenEnvVars Include="EM_CACHE=$(WasmCachePath)" Condition="'$(WasmCachePath)' != ''" />
     </ItemGroup>
 


### PR DESCRIPTION
Unset PYTHONHOME environment variable. We don't use emsdk.bat, which
unsets PYTHONHOME and PYTHONPATH variables to not clash with emscripten
python. So we should make sure the PYTHONHOME and PYTHONPATH are not
pointing to other python locations.

Together with previous PYTHONPATH
[change](https://github.com/dotnet/runtime/pull/63894/commits/d9b8aefcbf0efc4692c9ca46b323efcf86bda961)
it should fix https://github.com/dotnet/runtime/issues/65859