### PR TITLE
[wasm] Fix error when provisioning with python 3.8.

### DIFF
--- a/src/mono/wasm/sanitize.py
+++ b/src/mono/wasm/sanitize.py
@@ -21,7 +21,7 @@ def remove(*paths):
 
 
 def rewrite_package_json(path):
-    package = open(path, "rb+")
+    package = open(path, "r+")
     settings = json.load(package)
     settings["devDependencies"] = {}
     package.seek(0)


### PR DESCRIPTION
Running `make provision-wasm` on Linux with Python 3.8.2 resulted in error:
```
Traceback (most recent call last):                                                                                                                                                               File "./sanitize.py", line 79, in <module>
rewrite_package_json("package.json") 
File "./sanitize.py", line 29, in rewrite_package_json 
json.dump(settings, package, indent=4) 
File "/usr/lib/python3.8/json/__init__.py", line 180, in dump 
fp.write(chunk)
TypeError: a bytes-like object is required, not 'str'  
```
It was caused by using byte reading mode while reading *packages.json* file. In this PR it got replaced with string reading mode.