### PR TITLE
Detect systemd when inside a container.

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHelpers.cs
@@ -5,7 +5,7 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Text;
-#if !NET5_0_OR_GREATER
+#if !NETCOREAPP
 using System.Diagnostics;
 #endif
 
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.Hosting.Systemd
             // To support containerized systemd services, check if we're the main process (PID 1)
             // and if there are systemd environment variables defined for notifying the service
             // manager, or passing listen handles.
-#if NET5_0_OR_GREATER
+#if NETCOREAPP
             int processId = Environment.ProcessId;
 #else
             int processId = Process.GetCurrentProcess().Id;

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHelpers.cs
@@ -5,6 +5,9 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Text;
+#if !NET5_0_OR_GREATER
+using System.Diagnostics;
+#endif
 
 namespace Microsoft.Extensions.Hosting.Systemd
 {

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHelpers.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Extensions.Hosting.Systemd
             // manager, or passing listen handles.
             if (Environment.ProcessId == 1)
             {
-                return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(NOTIFY_SOCKET_ENVVAR_KEY)) ||
-                    !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(LISTEN_PID_ENVVAR_KEY));
+                return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(NOTIFY_SOCKET)) ||
+                    !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(LISTEN_PID));
             }
 
             try

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHelpers.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.Hosting.Systemd
                 int parentPid = Interop.libc.GetParentPid();
                 string ppidString = parentPid.ToString(NumberFormatInfo.InvariantInfo);
                 byte[] comm = File.ReadAllBytes("/proc/" + ppidString + "/comm");
-                return comm.AsSpan().SequenceEqual(Encoding.ASCII.GetBytes("systemd\n")); 
+                return comm.AsSpan().SequenceEqual(Encoding.ASCII.GetBytes("systemd\n"));
             }
             catch
             {

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHelpers.cs
@@ -45,7 +45,6 @@ namespace Microsoft.Extensions.Hosting.Systemd
             try
             {
                 // Check whether our direct parent is 'systemd'.
-                // This will not work for containerised applications, since our direct parent will be some container runtime
                 int parentPid = Interop.libc.GetParentPid();
                 string ppidString = parentPid.ToString(NumberFormatInfo.InvariantInfo);
                 byte[] comm = File.ReadAllBytes("/proc/" + ppidString + "/comm");

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHelpers.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.Hosting.Systemd
         /// </summary>
         /// <returns><c>True</c> if the current process is hosted as a systemd Service, otherwise <c>false</c>.</returns>
         public static bool IsSystemdService()
-            => _isSystemdService ?? (bool)(_isSystemdService = GetIsSystemdService());
+            => _isSystemdService ??= GetIsSystemdService();
 
         private static bool GetIsSystemdService()
         {
@@ -33,7 +33,13 @@ namespace Microsoft.Extensions.Hosting.Systemd
             // To support containerized systemd services, check if we're the main process (PID 1)
             // and if there are systemd environment variables defined for notifying the service
             // manager, or passing listen handles.
-            if (Environment.ProcessId == 1)
+#if NET5_0_OR_GREATER
+            int processId = Environment.ProcessId;
+#else
+            int processId = Process.GetCurrentProcess().Id;
+#endif
+
+            if (processId == 1)
             {
                 return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NOTIFY_SOCKET")) ||
                     !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("LISTEN_PID"));

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHelpers.cs
@@ -13,9 +13,6 @@ namespace Microsoft.Extensions.Hosting.Systemd
     /// </summary>
     public static partial class SystemdHelpers
     {
-        private const string NOTIFY_SOCKET = "NOTIFY_SOCKET";
-        private const string LISTEN_PID = "LISTEN_PID";
-
         private static bool? _isSystemdService;
 
         /// <summary>
@@ -23,9 +20,9 @@ namespace Microsoft.Extensions.Hosting.Systemd
         /// </summary>
         /// <returns><c>True</c> if the current process is hosted as a systemd Service, otherwise <c>false</c>.</returns>
         public static bool IsSystemdService()
-            => _isSystemdService ?? (bool)(_isSystemdService = CheckParentIsSystemd());
+            => _isSystemdService ?? (bool)(_isSystemdService = GetIsSystemdService());
 
-        private static bool CheckParentIsSystemd()
+        private static bool GetIsSystemdService()
         {
             // No point in testing anything unless it's Unix
             if (Environment.OSVersion.Platform != PlatformID.Unix)
@@ -38,8 +35,8 @@ namespace Microsoft.Extensions.Hosting.Systemd
             // manager, or passing listen handles.
             if (Environment.ProcessId == 1)
             {
-                return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(NOTIFY_SOCKET)) ||
-                    !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(LISTEN_PID));
+                return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NOTIFY_SOCKET")) ||
+                    !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("LISTEN_PID"));
             }
 
             try

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHelpers.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.Hosting.Systemd
             if (processId == 1)
             {
                 return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NOTIFY_SOCKET")) ||
-                    !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("LISTEN_PID"));
+                       !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("LISTEN_PID"));
             }
 
             try

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdNotifier.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdNotifier.cs
@@ -10,8 +10,6 @@ namespace Microsoft.Extensions.Hosting.Systemd
     [UnsupportedOSPlatform("browser")]
     public class SystemdNotifier : ISystemdNotifier
     {
-        private const string NOTIFY_SOCKET = "NOTIFY_SOCKET";
-
         private readonly string _socketPath;
 
         public SystemdNotifier() :
@@ -48,7 +46,7 @@ namespace Microsoft.Extensions.Hosting.Systemd
 
         private static string GetNotifySocketPath()
         {
-            string socketPath = Environment.GetEnvironmentVariable(NOTIFY_SOCKET);
+            string socketPath = Environment.GetEnvironmentVariable(SystemdHelpers.NOTIFY_SOCKET_ENVVAR_KEY);
 
             if (string.IsNullOrEmpty(socketPath))
             {

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdNotifier.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdNotifier.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Extensions.Hosting.Systemd
     [UnsupportedOSPlatform("browser")]
     public class SystemdNotifier : ISystemdNotifier
     {
+        private const string NOTIFY_SOCKET = "NOTIFY_SOCKET";
+
         private readonly string _socketPath;
 
         public SystemdNotifier() :
@@ -46,7 +48,7 @@ namespace Microsoft.Extensions.Hosting.Systemd
 
         private static string GetNotifySocketPath()
         {
-            string socketPath = Environment.GetEnvironmentVariable(SystemdHelpers.NOTIFY_SOCKET_ENVVAR_KEY);
+            string socketPath = Environment.GetEnvironmentVariable(NOTIFY_SOCKET);
 
             if (string.IsNullOrEmpty(socketPath))
             {


### PR DESCRIPTION
Modify IsSystemdService to function correctly
for containerised services.

Fix [#67203](https://github.com/dotnet/runtime/issues/67203)

Signed-off-by: james <judilsteve>