### PR TITLE
Added the option to get the compiler version from Crossgen2

### DIFF
--- a/src/coreclr/tools/aot/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/tools/aot/crossgen2/CommandLineOptions.cs
@@ -16,6 +16,7 @@ namespace ILCompiler
 
         public bool Help;
         public string HelpText;
+        public bool Version;
 
         public IReadOnlyList<string> InputFilePaths;
         public IReadOnlyList<string> InputBubbleReferenceFilePaths;
@@ -172,6 +173,7 @@ namespace ILCompiler
                 syntax.DefineOption("make-repro-path", ref MakeReproPath, SR.MakeReproPathHelp);
 
                 syntax.DefineOption("h|help", ref Help, SR.HelpOption);
+                syntax.DefineOption("v|version", ref Version, SR.VersionOption);
 
                 syntax.DefineParameterList("in", ref InputFilePaths, SR.InputFilesToCompile);
             });

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -6,6 +6,7 @@ using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
+using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
@@ -93,7 +94,7 @@ namespace ILCompiler
             _commandLineOptions = new CommandLineOptions(args);
             PerfEventSource.StartStopEvents.CommandLineProcessingStop();
 
-            if (_commandLineOptions.Help)
+            if (_commandLineOptions.Help || _commandLineOptions.Version)
             {
                 return;
             }
@@ -176,6 +177,14 @@ namespace ILCompiler
                 };
             }
 
+        }
+
+        private string GetCompilerVersion()
+        {
+            return  Assembly
+                   .GetExecutingAssembly()
+                   .GetCustomAttribute<AssemblyFileVersionAttribute>()
+                   .Version;
         }
 
         public static TargetArchitecture GetTargetArchitectureFromArg(string archArg, out bool armelAbi)
@@ -327,6 +336,13 @@ namespace ILCompiler
             if (_commandLineOptions.Help)
             {
                 Console.WriteLine(_commandLineOptions.HelpText);
+                return 1;
+            }
+
+            if (_commandLineOptions.Version)
+            {
+                string version = GetCompilerVersion();
+                Console.WriteLine("Crossgen2 Compiler Version is {0}.", version);
                 return 1;
             }
 

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -183,8 +183,8 @@ namespace ILCompiler
         {
             return  Assembly
                    .GetExecutingAssembly()
-                   .GetCustomAttribute<AssemblyFileVersionAttribute>()
-                   .Version;
+                   .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                   .InformationalVersion;
         }
 
         public static TargetArchitecture GetTargetArchitectureFromArg(string archArg, out bool armelAbi)
@@ -342,7 +342,7 @@ namespace ILCompiler
             if (_commandLineOptions.Version)
             {
                 string version = GetCompilerVersion();
-                Console.WriteLine("Crossgen2 Compiler Version is {0}.", version);
+                Console.WriteLine(version);
                 return 1;
             }
 

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -343,7 +343,7 @@ namespace ILCompiler
             {
                 string version = GetCompilerVersion();
                 Console.WriteLine(version);
-                return 1;
+                return 0;
             }
 
             if (_commandLineOptions.OutputFilePath == null && !_commandLineOptions.OutNearInput)

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -144,6 +144,9 @@
   <data name="HelpOption" xml:space="preserve">
     <value>Display this usage message</value>
   </data>
+  <data name="VersionOption" xml:space="preserve">
+    <value>Display the Crossgen2 compiler version used</value>
+  </data>
   <data name="InputBubbleOption" xml:space="preserve">
     <value>True when the entire input forms a version bubble (default = per-assembly bubble)</value>
   </data>


### PR DESCRIPTION
This PR adds and implements a `--version` option for the Crossgen2 binary. This new flag will print the version of the compiler from where this specific crossgen2 was built from.

This is an example of how it looks with a local dev build.

```text
C:\runtime\artifacts\bin\coreclr\windows.x64.Release\crossgen2>crossgen2.exe --version
Crossgen2 Compiler Version is 42.42.42.42424.
```

In this example, the number _42.42.42.42424_ is just a placeholder that is set on development builds only. When calling this option from an official release build, it will show the actual version of the compiler, as is expected.
