### PR TITLE
Add missing SUCCEEDED() within conditional

### DIFF
--- a/src/coreclr/ildasm/dasm.cpp
+++ b/src/coreclr/ildasm/dasm.cpp
@@ -6964,8 +6964,8 @@ void DumpMetaInfo(_In_ __nullterminated const WCHAR* pwzFileName, _In_opt_z_ con
     if(pch && (!_wcsicmp(pch+1,W("lib")) || !_wcsicmp(pch+1,W("obj"))))
     {   // This works only when all the rest does not
         // Init and run.
-        if (MetaDataGetDispenser(CLSID_CorMetaDataDispenser,
-            IID_IMetaDataDispenserEx, (void **)&g_pDisp))
+        if (SUCCEEDED(MetaDataGetDispenser(CLSID_CorMetaDataDispenser,
+            IID_IMetaDataDispenserEx, (void **)&g_pDisp)))
                 {
                     WCHAR *pwzObjFileName=NULL;
                     if (pszObjFileName)


### PR DESCRIPTION
We were missing a `SUCCEEDED(...)` macro surrounding an `HRESULT` return value, which was causing the true / false conditions to be reversed. @davidwrighton helped debug offline.

Fixes violation of CodeQL rule __cpp/hresult-boolean-conversion__ (https://lgtm.com/rules/1506585566510/).