### PR TITLE
Minor refactoring in MarshallingAttributeInfoParser

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
@@ -75,6 +75,24 @@ namespace Microsoft.Interop
             return (true, managedType, new CustomTypeMarshallerData(kind, direction, features, bufferSize));
         }
 
+
+        public static CustomTypeMarshallerPinning GetMarshallerPinningFeatures(ITypeSymbol marshallerType, ITypeSymbol? managedType)
+        {
+            CustomTypeMarshallerPinning pinning = CustomTypeMarshallerPinning.None;
+
+            if (FindGetPinnableReference(marshallerType) is not null)
+            {
+                pinning |= CustomTypeMarshallerPinning.NativeType;
+            }
+
+            if (managedType is not null && FindGetPinnableReference(managedType) is not null)
+            {
+                pinning |= CustomTypeMarshallerPinning.ManagedType;
+            }
+
+            return pinning;
+        }
+
         /// <summary>
         /// Resolve a non-<see cref="INamedTypeSymbol"/> <paramref name="managedType"/> to the correct managed type if <paramref name="marshallerType"/> is generic and <paramref name="managedType"/> is using any placeholder types.
         /// </summary>

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
@@ -75,7 +75,12 @@ namespace Microsoft.Interop
             return (true, managedType, new CustomTypeMarshallerData(kind, direction, features, bufferSize));
         }
 
-
+        /// <summary>
+        /// Get the supported <see cref="CustomTypeMarshallerPinning"/> for a marshaller type
+        /// </summary>
+        /// <param name="marshallerType">The marshaller type.</param>
+        /// <param name="managedType">The mananged type that would be marshalled.</param>
+        /// <returns>Supported <see cref="CustomTypeMarshallerPinning"/></returns>
         public static CustomTypeMarshallerPinning GetMarshallerPinningFeatures(ITypeSymbol marshallerType, ITypeSymbol? managedType)
         {
             CustomTypeMarshallerPinning pinning = CustomTypeMarshallerPinning.None;


### PR DESCRIPTION
Mostly just pulled out helpers for determining the pinning support and creating the marshalling info for arrays using our `[Ptr]ArrayMarshaller` (in preparation for getting strings on `CustomTypeMarshaller` implementations).