### PR TITLE
Fix failing debug assertion in JsonTypeInfo initialization

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json.Reflection;
+using System.Threading;
 
 namespace System.Text.Json.Serialization.Metadata
 {
@@ -487,8 +488,8 @@ namespace System.Text.Json.Serialization.Metadata
                 }
             }
 
-            ParameterCache = parameterCache;
             ParameterCount = jsonParameters.Length;
+            Volatile.Write(ref ParameterCache, parameterCache);
         }
 
         private static JsonParameterInfoValues[] GetParameterInfoArray(ParameterInfo[] parameters)


### PR DESCRIPTION
Fixes a failing debug assertion in what seems to be a race when [multiple threads attempt to initialize the `JsonTypeInfo` instance](https://github.com/dotnet/runtime/blob/e9826ba3502642f825175c21fff59831106853b4/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs#L56-L66). It is likely that other initialization methods are impacted by the same issue, this PR is to unblock the CI issues as reported in #60962. 

The initialization logic should be refactored so that metadata instances get initialized by a single thread, which will likely be done in conjunction with the work for https://github.com/dotnet/runtime/issues/63686 cc @krwq.

Fix #60962.