### PR TITLE
Stop using `CLS_VAR` on x86

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6345,7 +6345,7 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
             // should be unified to always use the IND(<address>) form.
             CLANG_FORMAT_COMMENT_ANCHOR;
 
-#ifdef TARGET_64BIT
+#if defined(TARGET_64BIT) || defined(TARGET_X86)
             bool preferIndir = true;
 #else  // !TARGET_64BIT
             bool preferIndir = isBoxedStatic;


### PR DESCRIPTION
We are expecting sizeable positive diffs:
1) Decomposition created `TYP_BYREF` locals when decomposing `LONG` loads because `CLS_VAR_ADDR` was typed as `TYP_BYREF`. The constant nodes are typed `TYP_I_IMPL`, thus the created locals do not need zero-initialization.
2) `mov static_addr` turns out to have a smaller encoding than `lea [static_addr]`.

We will also see some regressions:
1) The aforementioned lack of zero-initialization can perturb the RA -- these are the two large (in absolute terms) regressions in the runtime tests.
2) More aggressive swapping of `ASG(..., <former CLS_VAR>)` does not always pay off.

[Diffs](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-67335/win-x86.md) (locally obtained).