### PR TITLE
Fix Wrong exception for Open*Stream after connection is closed

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -173,7 +173,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                     GCHandle.ToIntPtr(_state.StateGCHandle),
                     out _state.Handle);
 
-                if (status == MsQuicStatusCodes.Aborted || status == MsQuicStatusCodes.InvalidState)
+                if (status == MsQuicStatusCodes.Aborted)
                 {
                     // connection already aborted (from either direction), throw relevant exception
                     throw ThrowHelper.GetConnectionAbortedException(connectionState.AbortErrorCode);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -173,6 +173,12 @@ namespace System.Net.Quic.Implementations.MsQuic
                     GCHandle.ToIntPtr(_state.StateGCHandle),
                     out _state.Handle);
 
+                if (status == MsQuicStatusCodes.Aborted || status == MsQuicStatusCodes.InvalidState)
+                {
+                    // connection already aborted (from either direction), throw relevant exception
+                    throw ThrowHelper.GetConnectionAbortedException(connectionState.AbortErrorCode);
+                }
+
                 QuicExceptionHelpers.ThrowIfFailed(status, "Failed to open stream to peer.");
 
                 Debug.Assert(!Monitor.IsEntered(_state), "!Monitor.IsEntered(_state)");

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -175,7 +175,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
                 if (status == MsQuicStatusCodes.Aborted)
                 {
-                    // connection already aborted (from either direction), throw relevant exception
+                    // connection already aborted by peer, throw relevant exception
                     throw ThrowHelper.GetConnectionAbortedException(connectionState.AbortErrorCode);
                 }
 

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -86,11 +86,7 @@ namespace System.Net.Quic.Tests
                     else
                     {
                         await Assert.ThrowsAsync<QuicOperationAbortedException>(async () => await serverConnection.AcceptStreamAsync());
-
-                        // TODO: ActiveIssue https://github.com/dotnet/runtime/issues/56133
-                        // MsQuic fails with System.Net.Quic.QuicException: Failed to open stream to peer. Error Code: INVALID_STATE
-                        //await Assert.ThrowsAsync<QuicOperationAbortedException>(async () => await OpenAndUseStreamAsync(serverConnection));
-                        await Assert.ThrowsAsync<QuicException>(() => OpenAndUseStreamAsync(serverConnection));
+                        await Assert.ThrowsAsync<QuicOperationAbortedException>(() => OpenAndUseStreamAsync(serverConnection));
                     }
                 });
         }
@@ -166,17 +162,8 @@ namespace System.Net.Quic.Tests
                     // Subsequent attempts should fail
                     ex = await Assert.ThrowsAsync<QuicConnectionAbortedException>(() => serverConnection.AcceptStreamAsync().AsTask());
                     Assert.Equal(ExpectedErrorCode, ex.ErrorCode);
-                    // TODO: ActiveIssue https://github.com/dotnet/runtime/issues/56133
-                    // MsQuic fails with System.Net.Quic.QuicException: Failed to open stream to peer. Error Code: INVALID_STATE
-                    if (IsMsQuicProvider)
-                    {
-                        await Assert.ThrowsAsync<QuicException>(() => OpenAndUseStreamAsync(serverConnection));
-                    }
-                    else
-                    {
-                        ex = await Assert.ThrowsAsync<QuicConnectionAbortedException>(() => OpenAndUseStreamAsync(serverConnection));
-                        Assert.Equal(ExpectedErrorCode, ex.ErrorCode);
-                    }
+                    ex = await Assert.ThrowsAsync<QuicConnectionAbortedException>(() => OpenAndUseStreamAsync(serverConnection));
+                    Assert.Equal(ExpectedErrorCode, ex.ErrorCode);
                 });
         }
 

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -86,7 +86,7 @@ namespace System.Net.Quic.Tests
                     else
                     {
                         await Assert.ThrowsAsync<QuicOperationAbortedException>(async () => await serverConnection.AcceptStreamAsync());
-                        await Assert.ThrowsAsync<QuicOperationAbortedException>(() => OpenAndUseStreamAsync(serverConnection));
+                        await Assert.ThrowsAsync<QuicException>(() => OpenAndUseStreamAsync(serverConnection));
                     }
                 });
         }


### PR DESCRIPTION
I considered adding guards into individual `Open*Stream` methods, but that still leaves a data race between the stream-creating thread and incoming connection aborts, so it seems best to me to use the status code from `MsQuicStreamOpen` to detect connection abort/close.

Fixes #56133