### PR TITLE
Ignore X509_V_ERR_AKID_SKID_MISMATCH

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainProcessor.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainProcessor.cs
@@ -1388,9 +1388,12 @@ namespace System.Security.Cryptography.X509Certificates
                         // * For compatibility with Windows / .NET Framework, do not report X509_V_CRL_NOT_YET_VALID.
                         // * X509_V_ERR_DIFFERENT_CRL_SCOPE will result in X509_V_ERR_UNABLE_TO_GET_CRL
                         //   which will trigger OCSP, so is ignorable.
+                        // * X509_V_ERR_AKID_SKID_MISMATCH does not map to anything, and will result in a
+                        //   partial chain, so let PartialChain be what gets reported.
                         if (errorCode != X509VerifyStatusCodeUniversal.X509_V_OK &&
                             errorCode != X509VerifyStatusCodeUniversal.X509_V_ERR_CRL_NOT_YET_VALID &&
-                            errorCode != X509VerifyStatusCodeUniversal.X509_V_ERR_DIFFERENT_CRL_SCOPE)
+                            errorCode != X509VerifyStatusCodeUniversal.X509_V_ERR_DIFFERENT_CRL_SCOPE &&
+                            errorCode != X509VerifyStatusCodeUniversal.X509_V_ERR_AKID_SKID_MISMATCH)
                         {
                             if (_errors == null)
                             {


### PR DESCRIPTION
OpenSSL 3 started reporting X509_V_ERR_AKID_SKID_MISMATCH when building an X.509 chain that had mismatched AKID/SKIDs.
Previously, this resulted in a PartialChain. This changes the verify callback to ignore X509_V_ERR_AKID_SKID_MISMATCH, and let PartialChain be what ends up getting reported. This is consistent with OpenSSL 1.x.

Closes #67304 