### PR TITLE
Always commit X.509 chain before Finish

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.OpenSsl.cs
@@ -160,6 +160,8 @@ namespace System.Security.Cryptography.X509Certificates
                 }
             }
 
+            chainPal.CommitToChain();
+
             if (revocationMode != X509RevocationMode.NoCheck)
             {
                 if (OpenSslX509ChainProcessor.IsCompleteChain(status))
@@ -179,7 +181,6 @@ namespace System.Security.Cryptography.X509Certificates
                         revocationMode = X509RevocationMode.NoCheck;
                     }
 
-                    chainPal.CommitToChain();
                     chainPal.ProcessRevocation(revocationMode, revocationFlag);
                 }
             }


### PR DESCRIPTION
For OpenSSL 3, we need to always commit the chain to clear out the untrusted
intermediates. Otherwise, we started getting details about the partial chain
that we don't map to codes.

This fixes the behavior so that an AKI/SKI mismatch reports as a partial chain.

Fixes #67304 