### PR TITLE
Fix a PAL filemapping test for macOS arm64

### DIFF
--- a/src/coreclr/pal/tests/palsuite/filemapping_memmgt/VirtualProtect/test4/VirtualProtect.cpp
+++ b/src/coreclr/pal/tests/palsuite/filemapping_memmgt/VirtualProtect/test4/VirtualProtect.cpp
@@ -31,7 +31,7 @@ PALTEST(filemapping_memmgt_VirtualProtect_test4_paltest_virtualprotect_test4, "f
     //Allocate the physical storage in memory or in the paging file on disk 
     lpVirtualAddress = VirtualAlloc(NULL,//determine where to allocate the region
             REGIONSIZE,      //specify the size
-            MEM_COMMIT,      //allocation type
+            MEM_COMMIT | MEM_RESERVE_EXECUTABLE,      //allocation type
             PAGE_READONLY);  //access protection
     if(NULL == lpVirtualAddress)
     {

--- a/src/coreclr/pal/tests/palsuite/issues.targets
+++ b/src/coreclr/pal/tests/palsuite/issues.targets
@@ -30,10 +30,4 @@
         </ExcludeList>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'OSX'">
-        <ExcludeList Include="filemapping_memmgt/VirtualProtect/test4/paltest_virtualprotect_test4">
-            <!-- Test tries to set RWX on general memory page -->
-            <Issue>https://github.com/dotnet/runtime/issues/48783</Issue>
-        </ExcludeList>
-    </ItemGroup>
 </Project>


### PR DESCRIPTION
This test was the last one disabled for macOS arm64, adding MEM_RESERVE_EXECUTABLE fixes the issue.
Close #48783