### PR TITLE
Revert "Do not generate `TYP_STRUCT` `LCL_FLD` nodes (#66251)"

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3378,8 +3378,6 @@ public:
         return (GetSsaNum() != SsaConfig::RESERVED_SSA_NUM);
     }
 
-    FieldSeqNode* GetFieldSeq() const;
-
 #if DEBUGGABLE_GENTREE
     GenTreeLclVarCommon() : GenTreeUnOp()
     {


### PR DESCRIPTION
In #66251 I've enhanced `IsLocalAddrExpr` to look for zero-offset sequences on `ADDR`s.

This was a correctness fix.

Unfortunately, it also broke the `structreturn` test because we have the following tree there:
```scala
***** BB01, STMT00006(before)
N005 ( 10,  8) [000064] -A------R---              *  ASG       long  
N004 (  3,  2) [000062] D------N----              +--*  LCL_VAR   long   V04 tmp2         d:2
N003 (  6,  5) [000063] n-----------              \--*  IND       long  
N002 (  3,  3) [000043] ------------                 \--*  ADDR      byref  Zero Fseq[a]
N001 (  3,  2) [000044] -------N----                    \--*  LCL_VAR   struct<TestUnsafeCasts+largeStruct, 32> V00 loc0         u:6 (last use)
```
Where the field `a` does not belong to `TestUnsafeCasts+largeStruct`. This is the well-known VN problem with invalid field sequences, there is no expedient fix for it.

So I am reverting #66251, it seems `TYP_STRUCT` `LCL_FLD` is fully gated on fixing this problem (I knew it was gated at least partially, I did not anticipate it to break so quickly though).

Fixes #67346, #67355.