### PR TITLE
Improve handling of common Regex sets

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -885,6 +885,20 @@ namespace System.Text.RegularExpressions
                     RegexNodeKind.Notonelazy;
             }
 
+            // Normalize some well-known sets
+            switch (Str)
+            {
+                // Different ways of saying "match anything"
+                case RegexCharClass.WordNotWordClass:
+                case RegexCharClass.NotWordWordClass:
+                case RegexCharClass.DigitNotDigitClass:
+                case RegexCharClass.NotDigitDigitClass:
+                case RegexCharClass.SpaceNotSpaceClass:
+                case RegexCharClass.NotSpaceSpaceClass:
+                    Str = RegexCharClass.AnyClass;
+                    break;
+            }
+
             return this;
         }
 


### PR DESCRIPTION
This improves how many of the most common character classes are emitted.

- Today for a set like [\r\n], we'll emit a comparison that compares the char to each of '\r' and '\n', but for a set like [^\r\n], we end up falling back to emitting a lookup table.  With this PR, we simply use the existing support for the non-negating case, just negating the result.
- Today for a set like [\p{IsGreek}\p{IsGreekExtended}] that ends up being two ranges, we'll fall back to our lookup table.  With this PR, we'll emit it as two range checks.
- Today for a set like [A-Za-z], we'll fall back to our lookup table.  As a special case of two-range support, with this PR we'll now recognize that these ranges are just one bit flip away from each other, and we'll employ the normal ASCII casing to do a single range comparison against the input or'd with a mask.
- Today as a fallback, we employ a lookup table stored in a string; this requires a bounds check, dereferencing the string object, doing the math to find the right index, doing the math to find the right bit, etc.  With this PR, for sets composed only of ranges where the exclusiveMax - inclusiveMin <= 64, with this PR we'll now emit it as a lookup into a ulong that's done in a branchless fashion and is much faster.
- It appears to be relatively common for folks to use [\d\D], [\w\W], or [\s\S] as a simple way of saying "match anything"; RegexOptions.Singleline changes '.' to mean this as well.  We already have special handling for '.' with Singleline as "AnyClass"... this just normalizes those other common representations into the same shape so that everyhing else recognizes them accordingly.
- Today when we see an AnyClass, we emit a nonsense comparison that always results in true (or false for negations); that's because, for a while, the expression given to the matching routine may have had side effects.  There are no longer side effects, though, so it's ok to just emit "true" or "false" directly and make the operation cheaper.

Fixes https://github.com/dotnet/runtime/issues/67056
Fixes https://github.com/dotnet/runtime/issues/62647
@joperezr, this will have conflicts with your https://github.com/dotnet/runtime/pull/67184.  I'll wait until that goes in to merge this.