### PR TITLE
Fix IsPrefix and IsSuffix with ignored characters

### DIFF
--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
@@ -181,5 +181,12 @@ namespace System.Globalization.Tests
         {
             IsPrefix(s_invariantCompare, "Hello", "", (CompareOptions)(-1), true, 0);
         }
+
+        [Fact]
+        public void IsPrefixWithAsciiAndIgnoredCharacters()
+        {
+            Assert.StartsWith("A", "A\0");
+            Assert.StartsWith("A\0", "A");
+        }
     }
 }

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
@@ -182,7 +182,7 @@ namespace System.Globalization.Tests
             IsPrefix(s_invariantCompare, "Hello", "", (CompareOptions)(-1), true, 0);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
         public void IsPrefixWithAsciiAndIgnoredCharacters()
         {
             Assert.StartsWith("A", "A\0");

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
@@ -187,6 +187,8 @@ namespace System.Globalization.Tests
         {
             Assert.StartsWith("A", "A\0");
             Assert.StartsWith("A\0", "A");
+            Assert.StartsWith("a", "A\0", StringComparison.CurrentCultureIgnoreCase);
+            Assert.StartsWith("a\0", "A", StringComparison.CurrentCultureIgnoreCase);
         }
     }
 }

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsSuffix.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsSuffix.cs
@@ -183,7 +183,7 @@ namespace System.Globalization.Tests
             IsSuffix(s_invariantCompare, "Hello", "", (CompareOptions)(-1), true, 0);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
         public void IsSuffixWithAsciiAndIgnoredCharacters()
         {
             Assert.EndsWith("A", "A\0");

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsSuffix.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsSuffix.cs
@@ -188,6 +188,8 @@ namespace System.Globalization.Tests
         {
             Assert.EndsWith("A", "A\0");
             Assert.EndsWith("A\0", "A");
+            Assert.EndsWith("a", "A\0", StringComparison.CurrentCultureIgnoreCase);
+            Assert.EndsWith("a\0", "A", StringComparison.CurrentCultureIgnoreCase);
         }
     }
 }

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsSuffix.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsSuffix.cs
@@ -182,5 +182,12 @@ namespace System.Globalization.Tests
         {
             IsSuffix(s_invariantCompare, "Hello", "", (CompareOptions)(-1), true, 0);
         }
+
+        [Fact]
+        public void IsSuffixWithAsciiAndIgnoredCharacters()
+        {
+            Assert.EndsWith("A", "A\0");
+            Assert.EndsWith("A\0", "A");
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
@@ -362,14 +362,17 @@ namespace System.Globalization
 
                 if (source.Length < prefix.Length)
                 {
-                    if (*b >= 0x80 || HighCharTable[*b])
+                    int charB = *b;
+
+                    if (charB >= 0x80 || HighCharTable[charB])
                         goto InteropCall;
                     return false;
                 }
 
                 if (source.Length > prefix.Length)
                 {
-                    if (*a >= 0x80  || HighCharTable[*a])
+                    int charA = *a;
+                    if (charA >= 0x80  || HighCharTable[charA])
                         goto InteropCall;
                 }
 
@@ -426,14 +429,18 @@ namespace System.Globalization
 
                 if (source.Length < prefix.Length)
                 {
-                    if (*b >= 0x80 || HighCharTable[*b])
+                    int charB = *b;
+
+                    if (charB >= 0x80 || HighCharTable[charB])
                         goto InteropCall;
                     return false;
                 }
 
                 if (source.Length > prefix.Length)
                 {
-                    if (*a >= 0x80 || HighCharTable[*a])
+                    int charA = *a;
+
+                    if (charA >= 0x80 || HighCharTable[charA])
                         goto InteropCall;
                 }
 
@@ -527,14 +534,18 @@ namespace System.Globalization
 
                 if (source.Length < suffix.Length)
                 {
-                    if (*b >= 0x80 || HighCharTable[*b])
+                    int charB = *b;
+
+                    if (charB >= 0x80 || HighCharTable[charB])
                         goto InteropCall;
                     return false;
                 }
 
                 if (source.Length > suffix.Length)
                 {
-                    if (*a >= 0x80 || HighCharTable[*a])
+                    int charA = *a;
+
+                    if (charA >= 0x80 || HighCharTable[charA])
                         goto InteropCall;
                 }
 
@@ -591,14 +602,18 @@ namespace System.Globalization
 
                 if (source.Length < suffix.Length)
                 {
-                    if (*b >= 0x80 || HighCharTable[*b])
+                    int charB = *b;
+
+                    if (charB >= 0x80 || HighCharTable[charB])
                         goto InteropCall;
                     return false;
                 }
 
                 if (source.Length > suffix.Length)
                 {
-                    if (*a >= 0x80 || HighCharTable[*a])
+                    int charA = *a;
+
+                    if (charA >= 0x80 || HighCharTable[charA])
                         goto InteropCall;
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
@@ -362,14 +362,14 @@ namespace System.Globalization
 
                 if (source.Length < prefix.Length)
                 {
-                    if (*b >= 0x80)
+                    if (*b >= 0x80 || HighCharTable[*b])
                         goto InteropCall;
                     return false;
                 }
 
                 if (source.Length > prefix.Length)
                 {
-                    if (*a >= 0x80)
+                    if (*a >= 0x80  || HighCharTable[*a])
                         goto InteropCall;
                 }
 
@@ -426,14 +426,14 @@ namespace System.Globalization
 
                 if (source.Length < prefix.Length)
                 {
-                    if (*b >= 0x80)
+                    if (*b >= 0x80 || HighCharTable[*b])
                         goto InteropCall;
                     return false;
                 }
 
                 if (source.Length > prefix.Length)
                 {
-                    if (*a >= 0x80)
+                    if (*a >= 0x80 || HighCharTable[*a])
                         goto InteropCall;
                 }
 
@@ -527,14 +527,14 @@ namespace System.Globalization
 
                 if (source.Length < suffix.Length)
                 {
-                    if (*b >= 0x80)
+                    if (*b >= 0x80 || HighCharTable[*b])
                         goto InteropCall;
                     return false;
                 }
 
                 if (source.Length > suffix.Length)
                 {
-                    if (*a >= 0x80)
+                    if (*a >= 0x80 || HighCharTable[*a])
                         goto InteropCall;
                 }
 
@@ -591,14 +591,14 @@ namespace System.Globalization
 
                 if (source.Length < suffix.Length)
                 {
-                    if (*b >= 0x80)
+                    if (*b >= 0x80 || HighCharTable[*b])
                         goto InteropCall;
                     return false;
                 }
 
                 if (source.Length > suffix.Length)
                 {
-                    if (*a >= 0x80)
+                    if (*a >= 0x80 || HighCharTable[*a])
                         goto InteropCall;
                 }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/67313

While performing string `StartsWith` or `EndsWith` operations we try to optimize when having ASCII characters. We apply the optimization only if we don't have characters outside ASCII range nor we don't have characters need special handling (like `\0` which treated as ignored character). We detect the special character by using the internal table `HighCharTable`.  In some cases, we can have the source string be shorter than string we check (e.g. doing something like `"A".StartsWith("A\0")` , we check the remaining character `\0` if it is ASCII but we don't check if it is special character using `HighCharTable`. This cause StartsWith/EndsWith return the wrong result. 
The fix is simply adding the check using `HighCharTable` to ensure the correct result.