### PR TITLE
Use MemoryMappedFileAccess.Read when searching a memory mapped file

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/AppHost/BinaryUtils.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/AppHost/BinaryUtils.cs
@@ -82,7 +82,7 @@ namespace Microsoft.NET.HostModel.AppHost
 
         public static unsafe int SearchInFile(string filePath, byte[] searchPattern)
         {
-            using (var mappedFile = MemoryMappedFile.CreateFromFile(filePath))
+            using (var mappedFile = MemoryMappedFile.CreateFromFile(filePath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read))
             {
                 using (var accessor = mappedFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read))
                 {

--- a/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
@@ -224,9 +224,9 @@ namespace Microsoft.NET.HostModel.AppHost
             long headerOffset = 0;
             void FindBundleHeader()
             {
-                using (var memoryMappedFile = MemoryMappedFile.CreateFromFile(appHostFilePath))
+                using (var memoryMappedFile = MemoryMappedFile.CreateFromFile(appHostFilePath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read))
                 {
-                    using (MemoryMappedViewAccessor accessor = memoryMappedFile.CreateViewAccessor())
+                    using (MemoryMappedViewAccessor accessor = memoryMappedFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read))
                     {
                         int position = BinaryUtils.SearchInFile(accessor, bundleSignature);
                         if (position == -1)


### PR DESCRIPTION
Since we're only interested in searching for a pattern inside a memory mapped file, explicitly specify `MemoryMappedFileAccess.Read` (instead of the default `MemoryMappedFileAccess.ReadWrite`) in order to avoid IO exceptions on Windows.