### PR TITLE
Mark architecture-specific tests as requiring process isolation

### DIFF
--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_32BIT_il_d.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_32BIT_il_d.ilproj
@@ -4,6 +4,7 @@
     <RestorePackages>true</RestorePackages>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '32'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_32BIT_il_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_32BIT_il_r.ilproj
@@ -4,6 +4,7 @@
     <RestorePackages>true</RestorePackages>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '32'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_64BIT_il_d.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_64BIT_il_d.ilproj
@@ -4,6 +4,7 @@
     <RestorePackages>true</RestorePackages>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_64BIT_il_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_64BIT_il_r.ilproj
@@ -4,6 +4,7 @@
     <RestorePackages>true</RestorePackages>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_32BIT_il_d.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_32BIT_il_d.ilproj
@@ -4,6 +4,7 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '32'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_32BIT_il_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_32BIT_il_r.ilproj
@@ -4,6 +4,7 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '32'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_64BIT_il_d.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_64BIT_il_d.ilproj
@@ -4,6 +4,7 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_64BIT_il_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_64BIT_il_r.ilproj
@@ -4,6 +4,7 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_32BIT_il_d.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_32BIT_il_d.ilproj
@@ -4,6 +4,7 @@
     <RestorePackages>true</RestorePackages>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '32'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_32BIT_il_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_32BIT_il_r.ilproj
@@ -4,6 +4,7 @@
     <RestorePackages>true</RestorePackages>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '32'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_64BIT_il_d.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_64BIT_il_d.ilproj
@@ -4,6 +4,7 @@
     <RestorePackages>true</RestorePackages>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_64BIT_il_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_64BIT_il_r.ilproj
@@ -4,6 +4,7 @@
     <RestorePackages>true</RestorePackages>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_32Bit_x86_il_d.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_32Bit_x86_il_d.ilproj
@@ -5,6 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There are arch-specific versions of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x86'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_32Bit_x86_il_r.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_32Bit_x86_il_r.ilproj
@@ -5,6 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There are arch-specific versions of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x86'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_64Bit_and_arm_il_d.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_64Bit_and_arm_il_d.ilproj
@@ -5,6 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'x86'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_64Bit_and_arm_il_r.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_64Bit_and_arm_il_r.ilproj
@@ -5,6 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'x86'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_32Bit_x86_il_d.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_32Bit_x86_il_d.ilproj
@@ -6,6 +6,7 @@
     <DebugType>Full</DebugType>
     <!-- There are arch-specific versions of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x86'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sizeof64_Target_32Bit_x86.il" />

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_32Bit_x86_il_r.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_32Bit_x86_il_r.ilproj
@@ -5,6 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There are arch-specific versions of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x86'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_64Bit_and_arm_il_d.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_64Bit_and_arm_il_d.ilproj
@@ -6,6 +6,7 @@
     <DebugType>Full</DebugType>
     <!-- There are arch-specific versions of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'x86'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sizeof64_Target_64Bit_and_arm.il" />

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_64Bit_and_arm_il_r.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_64Bit_and_arm_il_r.ilproj
@@ -5,6 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'x86'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_32Bit_x86_il_d.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_32Bit_x86_il_d.ilproj
@@ -5,6 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There are arch-specific versions of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x86'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_32Bit_x86_il_r.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_32Bit_x86_il_r.ilproj
@@ -5,6 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There are arch-specific versions of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x86'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_64Bit_and_arm_il_d.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_64Bit_and_arm_il_d.ilproj
@@ -5,6 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_64Bit_and_arm_il_r.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_64Bit_and_arm_il_r.ilproj
@@ -5,6 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
As discussed offline, according to the current merged wrapper
architecture, for architecture-variant tests all versions
are compiled and the "wrong" variants get skipped at runtime
using the ConditionalFact attribute. Sadly for some of the ILPROJ
tests JITting the "wrong" variant ends up crashing the JIT during
Crossgen2 compilation. We can follow up by figuring out whether
the crash is intentional but for now a simple way to work around
this problem (hitting just a small number of tests) is to mark
them as out-of-process tests so that the wrong variants get
filtered out early and R2R compilation is not triggered for them.

Thanks

Tomas

/cc @dotnet/jit-contrib 