### PR TITLE
Bump Intellisense to Preview2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -166,7 +166,7 @@
     <SdkVersionForWorkloadTesting>7.0.100-preview.3.22151.18</SdkVersionForWorkloadTesting>
     <CompilerPlatformTestingVersion>1.1.2-beta1.22122.4</CompilerPlatformTestingVersion>
     <!-- Docs -->
-    <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20220316.2</MicrosoftPrivateIntellisenseVersion>
+    <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20220331.1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->
     <MicrosoftNETILLinkTasksVersion>7.0.100-1.22178.1</MicrosoftNETILLinkTasksVersion>
     <MicrosoftNETILLinkAnalyzerPackageVersion>$(MicrosoftNETILLinkTasksVersion)</MicrosoftNETILLinkAnalyzerPackageVersion>


### PR DESCRIPTION
The intellisense package for Preview2 has been generated. Here is the pipeline result: https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=285734&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=11e7ea89-affe-5194-cdc6-0171c3394706&l=25

The nuget package name and number is: Microsoft.Private.Intellisense.7.0.0-preview-20220331.1.nupkg

It was pushed to the dotnet7-transport feed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json
