### PR TITLE
Add RemoteExecutor check in TestWaitForExitValidation

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -74,7 +74,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         [InlineData(-2)]
         [InlineData((long)int.MaxValue + 1)]
         public void TestWaitForExitValidation(long milliseconds)


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/64860 added a TestWaitForExitValidation test that would fail when run on platforms that did not support RemoteExecutor.

This change adds a `ConditionalTheory` to make sure that doesn't happen.