### PR TITLE
Removed the hard heap limit heap balancing logic for regions + UOH and fixed infinite retries in case at the LOH boundary

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -16182,6 +16182,9 @@ BOOL gc_heap::a_fit_segment_end_p (int gen_number,
             }
             else
             {
+#ifdef USE_REGIONS
+                *commit_failed_p = TRUE;
+#endif // USE_REGIONS
                 assert (heap_hard_limit);
             }
         }
@@ -17796,6 +17799,9 @@ void gc_heap::balance_heaps (alloc_context* acontext)
 
 ptrdiff_t gc_heap::get_balance_heaps_uoh_effective_budget (int generation_num)
 {
+#ifdef USE_REGIONS
+    return dd_new_allocation (dynamic_data_of (generation_num));
+#else
     if (heap_hard_limit)
     {
         const ptrdiff_t free_list_space = generation_free_list_space (generation_of (generation_num));
@@ -17810,6 +17816,7 @@ ptrdiff_t gc_heap::get_balance_heaps_uoh_effective_budget (int generation_num)
     {
         return dd_new_allocation (dynamic_data_of (generation_num));
     }
+#endif // USE_REGIONS
 }
 
 gc_heap* gc_heap::balance_heaps_uoh (alloc_context* acontext, size_t alloc_size, int generation_num)

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -17799,9 +17799,7 @@ void gc_heap::balance_heaps (alloc_context* acontext)
 
 ptrdiff_t gc_heap::get_balance_heaps_uoh_effective_budget (int generation_num)
 {
-#ifdef USE_REGIONS
-    return dd_new_allocation (dynamic_data_of (generation_num));
-#else
+#ifndef USE_REGIONS
     if (heap_hard_limit)
     {
         const ptrdiff_t free_list_space = generation_free_list_space (generation_of (generation_num));
@@ -17813,10 +17811,10 @@ ptrdiff_t gc_heap::get_balance_heaps_uoh_effective_budget (int generation_num)
         return free_list_space - allocated;
     }
     else
+#endif // !USE_REGIONS
     {
         return dd_new_allocation (dynamic_data_of (generation_num));
     }
-#endif // USE_REGIONS
 }
 
 gc_heap* gc_heap::balance_heaps_uoh (alloc_context* acontext, size_t alloc_size, int generation_num)

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -6803,7 +6803,7 @@ bool gc_heap::virtual_alloc_commit_for_heap (void* addr, size_t size, int h_numb
     return GCToOSInterface::VirtualCommit(addr, size);
 }
 
-bool gc_heap::virtual_commit (void* address, size_t size, gc_oh_num oh, int h_number, bool* hard_limit_exceeded_p)
+bool gc_heap::virtual_commit (void* address, size_t size, gc_oh_num oh, int h_number)
 {
 #ifndef HOST_64BIT
     assert (heap_hard_limit == 0);
@@ -6840,9 +6840,6 @@ bool gc_heap::virtual_commit (void* address, size_t size, gc_oh_num oh, int h_nu
         }
 
         check_commit_cs.Leave();
-
-        if (hard_limit_exceeded_p)
-            *hard_limit_exceeded_p = exceeded_p;
 
         if (exceeded_p)
         {
@@ -14220,12 +14217,9 @@ BOOL gc_heap::a_size_fit_p (size_t size, uint8_t* alloc_pointer, uint8_t* alloc_
 }
 
 // Grow by committing more pages
-BOOL gc_heap::grow_heap_segment (heap_segment* seg, uint8_t* high_address, bool* hard_limit_exceeded_p)
+BOOL gc_heap::grow_heap_segment (heap_segment* seg, uint8_t* high_address)
 {
     assert (high_address <= heap_segment_reserved (seg));
-
-    if (hard_limit_exceeded_p)
-        *hard_limit_exceeded_p = false;
 
     //return 0 if we are at the end of the segment.
     if (align_on_page (high_address) > heap_segment_reserved (seg))
@@ -14245,7 +14239,7 @@ BOOL gc_heap::grow_heap_segment (heap_segment* seg, uint8_t* high_address, bool*
                 "Growing heap_segment: %Ix high address: %Ix\n",
                 (size_t)seg, (size_t)high_address);
 
-    bool ret = virtual_commit (heap_segment_committed (seg), c_size, heap_segment_oh (seg), heap_number, hard_limit_exceeded_p);
+    bool ret = virtual_commit (heap_segment_committed (seg), c_size, heap_segment_oh (seg), heap_number);
     if (ret)
     {
         heap_segment_committed (seg) += c_size;
@@ -16130,7 +16124,6 @@ BOOL gc_heap::a_fit_segment_end_p (int gen_number,
 {
     *commit_failed_p = FALSE;
     size_t limit = 0;
-    bool hard_limit_short_seg_end_p = false;
 #ifdef BACKGROUND_GC
     int cookie = -1;
 #endif //BACKGROUND_GC
@@ -16169,24 +16162,13 @@ BOOL gc_heap::a_fit_segment_end_p (int gen_number,
                                  (end - allocated),
                                  gen_number, align_const);
 
-        if (grow_heap_segment (seg, (allocated + limit), &hard_limit_short_seg_end_p))
+        if (grow_heap_segment (seg, (allocated + limit)))
         {
             goto found_fit;
         }
         else
         {
-            if (!hard_limit_short_seg_end_p)
-            {
-                dprintf (2, ("can't grow segment, doing a full gc"));
-                *commit_failed_p = TRUE;
-            }
-            else
-            {
-#ifdef USE_REGIONS
-                *commit_failed_p = TRUE;
-#endif // USE_REGIONS
-                assert (heap_hard_limit);
-            }
+            *commit_failed_p = TRUE;
         }
     }
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -2027,7 +2027,7 @@ protected:
     PER_HEAP_ISOLATED
     bool virtual_alloc_commit_for_heap (void* addr, size_t size, int h_number);
     PER_HEAP_ISOLATED
-    bool virtual_commit (void* address, size_t size, gc_oh_num oh, int h_number=-1, bool* hard_limit_exceeded_p=NULL);
+    bool virtual_commit (void* address, size_t size, gc_oh_num oh, int h_number=-1); 
     PER_HEAP_ISOLATED
     bool virtual_decommit (void* address, size_t size, gc_oh_num oh, int h_number=-1);
     PER_HEAP_ISOLATED
@@ -2128,7 +2128,7 @@ protected:
     BOOL find_card (uint32_t* card_table, size_t& card,
                     size_t card_word_end, size_t& end_card);
     PER_HEAP
-    BOOL grow_heap_segment (heap_segment* seg, uint8_t* high_address, bool* hard_limit_exceeded_p=NULL);
+    BOOL grow_heap_segment (heap_segment* seg, uint8_t* high_address);
     PER_HEAP
     int grow_heap_segment (heap_segment* seg, uint8_t* high_address, uint8_t* old_loc, size_t size, BOOL pad_front_p REQD_ALIGN_AND_OFFSET_DCL);
     PER_HEAP


### PR DESCRIPTION
## Summary

For regions, we no longer have the notion of a single segment as we get new regions on-demand. This PR does two main things to enforce the notion for the case of heap hard limits and regions:

1. Removes the spurious constraint that we should only have one segment for regions. 
2. Fixes a case of infinite looping when trying to allocate a very large object on the UOH.
3. Removed all instances of ``hard_limit_exceeded_p``. 

For 1, we are simply falling back to the non-heap hard limit logic in the case of balancing the UOH as it subsumes the logic that there can be only one segment. 

For 2. we are failing the commit with an oom_reason of ``oom_cant_commit`` while trying to fit a newly acquired region on the UOH in the case where we really can't commit the desired object. The rationale for adding this logic is to enforce the state of the inability to commit; without this, we are flip-flopping between ``a_start_try_fit_after_cg `` and ``a_state_acquire_seg_after_cg`` and not leaving the UOH allocation state machine. 

Following the code path, we find that despite the fact that the condition of the inability to commit was evinced, we aren't setting it when we try to fit a new region and this PR fixes that.

## Repro

Set the following environment variables:
```
complus_gcheapcount=12
complus_gcheaphardlimit=150000000
complus_gcserver=1
```

Run the following managed code:

```csharp
var ALLOC_SIZE = 2147483591;
Console.WriteLine($"Allocating first: {ALLOC_SIZE}");
byte[] buffer = new byte[ALLOC_SIZE];
Console.WriteLine($"Finished Allocating first: {ALLOC_SIZE}");
Console.WriteLine($"Allocating second: {ALLOC_SIZE}");
buffer = new byte[ALLOC_SIZE];
Console.WriteLine($"Finished Allocating second: {ALLOC_SIZE}");
Console.WriteLine($"Allocating third: {ALLOC_SIZE}");
buffer = new byte[ALLOC_SIZE];
Console.WriteLine($"Finished Allocating third: {ALLOC_SIZE}");
```

Prior to the fix, the 3rd allocation fails to return if the spurious constraint via an assert is removed thereby looping indefinitely. If the assert is not removed, it is triggered for the debug configuration or an AV takes place if we don't enable asserts.