### PR TITLE
Don't consider ShadowMethods reflectable

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -184,16 +184,18 @@ namespace ILCompiler
             }
 
             IMethodNode methodNode = methodBodyNode;
+            if (methodNode != null)
+            {
+                if (AllMethodsCanBeReflectable)
+                    _reflectableMethods.Add(methodNode.Method);
+            }
+
             if (methodNode == null)
                 methodNode = obj as ShadowConcreteMethodNode;
 
             if (methodNode != null)
             {
                 _methodsGenerated.Add(methodNode.Method);
-
-                if (AllMethodsCanBeReflectable)
-                    _reflectableMethods.Add(methodNode.Method);
-
                 return;
             }
 

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
@@ -45,6 +45,7 @@ class Generics
         TestRecursionInGenericVirtualMethods.Run();
         TestRecursionThroughGenericLookups.Run();
         TestGvmLookupDependency.Run();
+        TestInvokeMemberCornerCaseInGenerics.Run();
 #if !CODEGEN_CPP
         TestNullableCasting.Run();
         TestVariantCasting.Run();
@@ -3166,6 +3167,28 @@ class Generics
         {
             CatConcepts<Technique, int>();
             CatConcepts<Technique, object>();
+        }
+    }
+
+    class TestInvokeMemberCornerCaseInGenerics
+    {
+        class Generic<T>
+        {
+            public void Method(params T[] ts) { }
+        }
+
+        class Atom { }
+
+        static Generic<Atom> s_instance = new Generic<Atom>();
+        static Type s_atomType = typeof(Atom);
+
+        public static void Run()
+        {
+            s_instance.Method(null);
+
+            // Regression test for https://github.com/dotnet/runtime/issues/65612
+            // This requires MethodTable for "Atom[]" - just make sure the compiler didn't crash and we can invoke
+            typeof(Generic<>).MakeGenericType(s_atomType).InvokeMember("Method", BindingFlags.Public | BindingFlags.InvokeMethod | BindingFlags.Instance, null, s_instance, new object[] { new Atom() });
         }
     }
 }


### PR DESCRIPTION
Fixes #65612. This regression was exposed in #62891 - we had a mismatch between what methods are considered reflectable during scanning vs during optimized compilation due to extra array being injected for reflectable `params` methods on instantiated generic types.

There are two potential fixes - either expand the set of methods considered reflectable during scanning, or limit the number of methods considered reflectable in optimized compilation. It doesn't look like we need the expanded set, so going with a restriction instead. The CI may prove me otherwise, so keeping an open mind about this.