### PR TITLE
[release/6.0] Load R2R images on osx-arm64 according to Apple's guidelines

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -6960,7 +6960,9 @@ void Compiler::impImportNewObjArray(CORINFO_RESOLVED_TOKEN* pResolvedToken, CORI
     //
     CLANG_FORMAT_COMMENT_ANCHOR;
 
+#ifndef OSX_ARM64_ABI
     if (!opts.IsReadyToRun() || IsTargetAbi(CORINFO_CORERT_ABI))
+#endif // !OSX_ARM64_ABI
     {
 
         // Reuse the temp used to pass the array dimensions to avoid bloating
@@ -7017,6 +7019,7 @@ void Compiler::impImportNewObjArray(CORINFO_RESOLVED_TOKEN* pResolvedToken, CORI
 
         node = gtNewHelperCallNode(CORINFO_HELP_NEW_MDARR_NONVARARG, TYP_REF, args);
     }
+#ifndef OSX_ARM64_ABI
     else
     {
         //
@@ -7046,6 +7049,7 @@ void Compiler::impImportNewObjArray(CORINFO_RESOLVED_TOKEN* pResolvedToken, CORI
         }
 #endif
     }
+#endif // !OSX_ARM64_ABI
 
     for (GenTreeCall::Use& use : node->AsCall()->Args())
     {

--- a/src/coreclr/pal/src/map/map.cpp
+++ b/src/coreclr/pal/src/map/map.cpp
@@ -2045,14 +2045,48 @@ MAPmmapAndRecord(
         // Mojave hardened runtime doesn't allow executable mappings of a file. So we have to create an
         // anonymous mapping and read the file contents into it instead.
 
+#if defined(HOST_ARM64)
+        // Set the requested mapping with forced PROT_WRITE, mmap the file, and copy its contents there.
+        // Once PROT_WRITE and PROT_EXEC are set together, Apple Silicon will require the use of
+        // PAL_JitWriteProtect to switch between executable and writable.
+        LPVOID pvMappedFile = mmap(NULL, len + adjust, PROT_READ, MAP_PRIVATE, fd, offset - adjust);
+        if (MAP_FAILED == pvMappedFile)
+        {
+            ERROR_(LOADER)("mmap failed with code %d: %s.\n", errno, strerror(errno));
+            palError = FILEGetLastErrorFromErrno();
+        }
+        else
+        {
+            if (-1 == mprotect(pvBaseAddress, len + adjust, prot | PROT_WRITE))
+            {
+                ERROR_(LOADER)("mprotect failed with code %d: %s.\n", errno, strerror(errno));
+                palError = FILEGetLastErrorFromErrno();
+            }
+            else
+            {
+                PAL_JitWriteProtect(true);
+                memcpy(pvBaseAddress, pvMappedFile, len + adjust);
+                PAL_JitWriteProtect(false);
+            }
+            if (-1 == munmap(pvMappedFile, len + adjust))
+            {
+                ERROR_(LOADER)("Unable to unmap the file. Expect trouble.\n");
+                if (NO_ERROR == palError)
+                    palError = FILEGetLastErrorFromErrno();
+            }
+        }
+#else
         // Set the requested mapping with forced PROT_WRITE to ensure data from the file can be read there,
-        // read the data in and finally remove the forced PROT_WRITE
+        // read the data in and finally remove the forced PROT_WRITE. On Intel we can still switch the
+        // protection later with mprotect.
         if ((mprotect(pvBaseAddress, len + adjust, prot | PROT_WRITE) == -1) ||
             (pread(fd, pvBaseAddress, len + adjust, offset - adjust) == -1) ||
             (((prot & PROT_WRITE) == 0) && mprotect(pvBaseAddress, len + adjust, prot) == -1))
         {
             palError = FILEGetLastErrorFromErrno();
         }
+#endif
+
     }
     else
 #endif

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -14200,6 +14200,13 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
             CorInfoHelpFunc corInfoHelpFunc = MapReadyToRunHelper((ReadyToRunHelper)helperNum);
             if (corInfoHelpFunc != CORINFO_HELP_UNDEF)
             {
+#ifdef OSX_ARM64_ABI
+                if (corInfoHelpFunc == CORINFO_HELP_NEW_MDARR)
+                {
+                    STRESS_LOG(LF_ZAP, LL_WARNING, "CORINFO_HELP_NEW_MDARR is not supported on osx-arm64\n");
+                    return FALSE;
+                }
+#endif // OSX_ARM64_ABI
                 result = (size_t)CEEJitInfo::getHelperFtnStatic(corInfoHelpFunc);
             }
             else


### PR DESCRIPTION
## Customer Impact
Slow startup of .NET applications on Apple Silicon. ReadyToRun images are not loaded correctly on Apple Silicon. All methods are JITed during startup.

For reference, compiling a medium-size project like [ILGPU](https://github.com/m4rs-mt/ILGPU) takes ~17s on a Mac Mini M1 before this change, and ~13s after this change (about 30% faster).

## Testing
crossgen2 outerloop tests. Manually verified that the ReadyToRun images are loaded correctly on Apple Silicon and Debugging of managed apps works. 

## Risk
Low risk. These fixes have been in dotnet/runtime:main for more than a month, however there is a risk of discovering latent Apple Silicon specific bugs in ReadyToRun with this fix.

------- 
Closes #64103.

This PR reactivates the previously backported #64104 and fixes its impact on debugging by backporting #67118.
I believe that this change would be limited to osx-arm64 and introduce a substantial performance gain by enabling ReadyToRun on Apple Silicon, which was supposed to work in .NET 6 in the first place but never did.

More details about the rationale of this change can be found in #64103, #64104, #65341, and #67118.