### PR TITLE
[AOT] Don't set the 'CorrectedSynthesize' flag in the objc_imageinfo section.

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -11886,7 +11886,7 @@ emit_objc_selectors (MonoAotCompile *acfg)
 	fprintf (acfg->fp, ".align	3\n");
 	fprintf (acfg->fp, "L_OBJC_IMAGE_INFO:\n");
 	fprintf (acfg->fp, ".long	0\n");
-	fprintf (acfg->fp, ".long	16\n");
+	fprintf (acfg->fp, ".long	0\n");
 }
 
 static void

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -7452,7 +7452,7 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 				ctx->module->objc_selector_to_var = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
 
 				LLVMValueRef info_var = LLVMAddGlobal (ctx->lmodule, LLVMArrayType (LLVMInt8Type (), 8), "@OBJC_IMAGE_INFO");
-				int32_t objc_imageinfo [] = { 0, 16 };
+				int32_t objc_imageinfo [] = { 0, 0 };
 				LLVMSetInitializer (info_var, mono_llvm_create_constant_data_array ((uint8_t *) &objc_imageinfo, 8));
 				LLVMSetLinkage (info_var, LLVMPrivateLinkage);
 				LLVMSetExternallyInitialized (info_var, TRUE);


### PR DESCRIPTION
According to Apple's headers, it's not used anymore, and ignored.

However, with Xcode 13.3, it seems Apple has re-used this value for something
else, and it's causing warnings in the linker:

> ld: warning: '[...]/arm64/Xamarin.iOS.dll.o' was built with class_ro_t pointer signing enabled, but previous .o files were not

Fixes https://github.com/mono/mono/issues/21450.

Ref: https://opensource.apple.com/source/objc4/objc4-818.2/runtime/objc-abi.h.auto.html