### PR TITLE
Consistently use AssemblyName in execution script generator

### DIFF
--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -61,7 +61,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
     if [ ! -d IL-CG2 ]%3B then
       mkdir IL-CG2
       if [ ! -z ${CompositeBuildMode+x} ]%3B then
-        cp $(MSBuildProjectName).dll IL-CG2/
+        cp $(AssemblyName).dll IL-CG2/
         cp $CORE_ROOT/lib*.so $CORE_ROOT/lib*.dylib $(scriptPath)
       else
         cp *.dll IL-CG2/
@@ -143,7 +143,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
   fi
 
   export COMPlus_ZapRequire=$(ZapRequire)
-  export COMPlus_ZapRequireList=$(MSBuildProjectName)
+  export COMPlus_ZapRequireList=$(AssemblyName)
 fi
         ]]>
       </CrossgenBashScript>
@@ -265,7 +265,7 @@ if defined RunCrossGen2 (
     )
 
   set COMPlus_ZapRequire=$(ZapRequire)
-  set COMPlus_ZapRequireList=$(MSBuildProjectName)
+  set COMPlus_ZapRequireList=$(AssemblyName)
 )
         ]]>
       </CrossgenBatchScript>

--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -18,17 +18,6 @@ WARNING:   When setting properties based on their current state (for example:
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- This is here because of this bug: https://docs.microsoft.com/en-us/archive/blogs/msbuild/well-known-limitation-dynamic-items-and-properties-not-emitted-until-target-execution-completes -->
-  <Target Name="FetchExternalPropertiesForXplat">
-    <!--Call GetExecuteShFullPath to get ToRunProject cmd file Path  -->
-    <MSBuild Projects="$(CLRTestProjectToRun)"
-             Targets="GetExecuteShFullPath"
-             Properties="GenerateRunScript=True"
-             Condition="'$(_CLRTestNeedsProjectToRun)' == 'True'">
-      <Output TaskParameter="TargetOutputs" PropertyName="_CLRTestToRunFileFullPath"/>
-    </MSBuild>
-  </Target>
-
   <!--
     Target: GetExecuteShFullPath
     Return Executed Sh Relative Full Path
@@ -38,14 +27,14 @@ WARNING:   When setting properties based on their current state (for example:
     Name="GetExecuteShFullPath"
     Returns="$(ExecuteShFullPath)">
     <PropertyGroup Condition="$(GenerateRunScript)">
-      <ExecuteShFullPath>$(OutputPath)$(MSBuildProjectName).sh</ExecuteShFullPath>
+      <ExecuteShFullPath>$(OutputPath)$(AssemblyName).sh</ExecuteShFullPath>
     </PropertyGroup>
     <!-- In order to avoid the overhead of calling MSBuild (as it may result in chains of MSBuild calls) I am assuming the extension in this circumstance. -->
     <PropertyGroup Condition="$(CLRTestProjectToRun) != '' AND $(GenerateRunScript)">
       <ExecuteShFullPath>$(OutputPath)$([System.IO.Path]::GetFilenameWithoutExtension(&quot;$(CLRTestProjectToRun)&quot;)).dll</ExecuteShFullPath>
     </PropertyGroup>
     <PropertyGroup Condition="!$(GenerateRunScript)">
-      <ExecuteShFullPath>$(OutputPath)$(MSBuildProjectName).$(OutputType.ToLower())</ExecuteShFullPath>
+      <ExecuteShFullPath>$(OutputPath)$(AssemblyName).$(OutputType.ToLower())</ExecuteShFullPath>
     </PropertyGroup>
   </Target>
 
@@ -63,8 +52,8 @@ WARNING:   When setting properties based on their current state (for example:
   -->
   <Target Name="GenerateBashExecutionScript"
     Inputs="$(MSBuildProjectFullPath)"
-    Outputs="$(OutputPath)\$(MSBuildProjectName).sh"
-    DependsOnTargets="FetchExternalPropertiesForXplat;$(BashScriptSnippetGen);GetIlasmRoundTripBashScript">
+    Outputs="$(OutputPath)\$(AssemblyName).sh"
+    DependsOnTargets="$(BashScriptSnippetGen);GetIlasmRoundTripBashScript">
 
     <Message Text="Project depends on $(_CLRTestToRunFileFullPath)." Condition="'$(_CLRTestNeedsProjectToRun)' == 'True'" />
 
@@ -160,7 +149,7 @@ fi
     </PropertyGroup>
 
     <ItemGroup Condition="$(_CLRTestNeedsToRun)">
-      <Clean Include="$(OutputPath)\$(MSBuildProjectName).sh"/>
+      <Clean Include="$(OutputPath)\$(AssemblyName).sh"/>
 
       <BashCLRTestExecutionScriptArgument Include="debug">
         <HasParam>true</HasParam>
@@ -199,7 +188,7 @@ fi
     </ItemGroup>
 
       <PropertyGroup>
-          <ReflectionRootsXml>$(MSBuildProjectName).reflect.xml</ReflectionRootsXml>
+          <ReflectionRootsXml>$(AssemblyName).reflect.xml</ReflectionRootsXml>
           <BashLinkerTestLaunchCmds>
               <![CDATA[
 # Linker commands
@@ -561,7 +550,7 @@ $(BashCLRTestExitCodeCheck)
     </PropertyGroup>
 
     <PropertyGroup>
-      <ExecutionBashScriptPath>$(OutputPath)/$(MSBuildProjectName).sh</ExecutionBashScriptPath>
+      <ExecutionBashScriptPath>$(OutputPath)/$(AssemblyName).sh</ExecutionBashScriptPath>
     </PropertyGroup>
 
     <!-- Write the file.

--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -18,17 +18,6 @@ WARNING:   When setting properties based on their current state (for example:
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- This is here because of this bug: https://docs.microsoft.com/en-us/archive/blogs/msbuild/well-known-limitation-dynamic-items-and-properties-not-emitted-until-target-execution-completes -->
-  <Target Name="FetchExternalProperties">
-    <!--Call GetExecuteCmdFullPath to get ToRunProject cmd file Path  -->
-    <MSBuild Projects="$(CLRTestProjectToRun)"
-             Targets="GetExecuteCmdFullPath"
-             Properties="GenerateRunScript=True"
-             Condition="'$(_CLRTestNeedsProjectToRun)' == 'True'">
-      <Output TaskParameter="TargetOutputs" PropertyName="_CLRTestToRunFileFullPath"/>
-    </MSBuild>
-  </Target>
-
   <!--
     Target: GetExecuteCmdFullPath
     Return Executed Cmd Relative Full Path
@@ -38,14 +27,14 @@ WARNING:   When setting properties based on their current state (for example:
     Name="GetExecuteCmdFullPath"
     Returns="$(ExecuteCmdFullPath)">
     <PropertyGroup Condition="$(GenerateRunScript)">
-        <ExecuteCmdFullPath>$(OutputPath)$(MSBuildProjectName).cmd</ExecuteCmdFullPath>
+        <ExecuteCmdFullPath>$(OutputPath)$(AssemblyName).cmd</ExecuteCmdFullPath>
     </PropertyGroup>
     <!-- In order to avoid the overhead of calling MSBuild (as it may result in chains of MSBuild calls) I am assuming the extension in this circumstance. -->
     <PropertyGroup Condition="$(CLRTestProjectToRun) != '' AND $(GenerateRunScript)">
       <ExecuteCmdFullPath>$(OutputPath)$([System.IO.Path]::GetFilenameWithoutExtension(&quot;$(CLRTestProjectToRun)&quot;)).dll</ExecuteCmdFullPath>
     </PropertyGroup>
     <PropertyGroup Condition="!$(GenerateRunScript)">
-        <ExecuteCmdFullPath>$(OutputPath)$(MSBuildProjectName).$(OutputType.ToLower())</ExecuteCmdFullPath>
+        <ExecuteCmdFullPath>$(OutputPath)$(AssemblyName).$(OutputType.ToLower())</ExecuteCmdFullPath>
     </PropertyGroup>
   </Target>
 
@@ -62,8 +51,8 @@ WARNING:   When setting properties based on their current state (for example:
   -->
   <Target Name="GenerateBatchExecutionScript"
     Inputs="$(MSBuildProjectFullPath)"
-    Outputs="$(OutputPath)\$(MSBuildProjectName).cmd"
-    DependsOnTargets="FetchExternalProperties;$(BatchScriptSnippetGen);GetIlasmRoundTripBatchScript">
+    Outputs="$(OutputPath)\$(AssemblyName).cmd"
+    DependsOnTargets="$(BatchScriptSnippetGen);GetIlasmRoundTripBatchScript">
 
     <Message Text="Project depends on $(_CLRTestToRunFileFullPath)." Condition="'$(_CLRTestNeedsProjectToRun)' == 'True'" />
 
@@ -179,7 +168,7 @@ Exit /b 0
     </PropertyGroup>
 
     <ItemGroup Condition="$(_CLRTestNeedsToRun)">
-      <Clean Include="$(OutputPath)\$(MSBuildProjectName).cmd"/>
+      <Clean Include="$(OutputPath)\$(AssemblyName).cmd"/>
 
       <BatchCLRTestExecutionScriptArgument Include="debug">
         <HasParam>true</HasParam>
@@ -221,7 +210,7 @@ Exit /b 0
     </ItemGroup>
 
       <PropertyGroup>
-          <ReflectionRootsXml>$(MSBuildProjectName).reflect.xml</ReflectionRootsXml>
+          <ReflectionRootsXml>$(AssemblyName).reflect.xml</ReflectionRootsXml>
           <BatchLinkerTestLaunchCmds><![CDATA[
 REM Linker commands
 
@@ -460,7 +449,7 @@ $(BatchCLRTestExitCodeCheck)
     </PropertyGroup>
     <!-- Write the file -->
     <WriteLinesToFile
-      File="$(OutputPath)\$(MSBuildProjectName).cmd"
+      File="$(OutputPath)\$(AssemblyName).cmd"
       Lines="$(_CLRTestExecutionScriptText)"
       Overwrite="true" />
   </Target>

--- a/src/tests/Common/CLRTest.Execute.targets
+++ b/src/tests/Common/CLRTest.Execute.targets
@@ -74,6 +74,8 @@ This file contains the logic for providing Execution Script generation.
   <PropertyGroup>
     <BashScriptSnippetGen></BashScriptSnippetGen>
     <BatchScriptSnippetGen></BatchScriptSnippetGen>
+    <GetExecuteScriptTarget>GetExecuteShFullPath</GetExecuteScriptTarget>
+    <GetExecuteScriptTarget Condition="'$(TestWrapperTargetsWindows)' == 'true'">GetExecuteCmdFullPath</GetExecuteScriptTarget>
   </PropertyGroup>
 
   <Import Project="CLRTest.Jit.targets" />
@@ -82,8 +84,23 @@ This file contains the logic for providing Execution Script generation.
   <Import Project="CLRTest.Execute.*.targets" />
   <Import Project="CLRTest.MockHosting.targets" Condition="'$(RequiresMockHostPolicy)' == 'true'" />
 
+  <Target Name="FetchExternalProperties">
+    <!--Call GetExecuteShFullPath to get ToRunProject cmd file Path  -->
+    <MSBuild Projects="$(CLRTestProjectToRun)"
+             Targets="$(GetExecuteScriptTarget)"
+             Properties="GenerateRunScript=True"
+             Condition="'$(_CLRTestNeedsProjectToRun)' == 'True'">
+      <Output TaskParameter="TargetOutputs" PropertyName="_CLRTestToRunFileFullPath"/>
+    </MSBuild>
+
+    <PropertyGroup>
+      <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)))</InputAssemblyName>
+      <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(AssemblyName).dll</InputAssemblyName>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="GenerateExecutionScriptsInternal"
     Condition="$(_CLRTestNeedsToRun) or $(_CLRTestBuildsExecutable)"
-    DependsOnTargets="Generate@(ExecutionScriptKind, 'ExecutionScript;Generate')ExecutionScript;" />
+    DependsOnTargets="FetchExternalProperties;Generate@(ExecutionScriptKind, 'ExecutionScript;Generate')ExecutionScript;" />
 
 </Project>

--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -32,10 +32,8 @@ WARNING:   When setting properties based on their current state (for example:
   <Target Name="GetIlasmRoundTripBashScript"
           Returns="$(IlasmRoundTripBashScript);$(BashIlrtTestLaunchCmds)">
     <PropertyGroup>
-      <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)).Replace("\","/"))</InputAssemblyName>
-      <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).dll</InputAssemblyName>
-      <DisassemblyName>$(MSBuildProjectName).dasm.il</DisassemblyName>
-      <TargetAssemblyName>$(MSBuildProjectName).asm.dll</TargetAssemblyName>
+      <DisassemblyName>$(AssemblyName).dasm.il</DisassemblyName>
+      <TargetAssemblyName>$(AssemblyName).asm.dll</TargetAssemblyName>
 
       <IlasmRoundTripBashScript Condition="'$(CLRTestKind)' == 'RunOnly'"><![CDATA[
 # IlasmRoundTrip Script
@@ -117,10 +115,8 @@ fi
   <Target Name="GetIlasmRoundTripBatchScript"
           Returns="$(IlasmRoundTripBatchScript);$(BatchIlrtTestLaunchCmds)">
     <PropertyGroup>
-      <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)))</InputAssemblyName>
-      <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).dll</InputAssemblyName>
-      <DisassemblyName>$(MSBuildProjectName).dasm.il</DisassemblyName>
-      <TargetAssemblyName>$(MSBuildProjectName).asm.dll</TargetAssemblyName>
+      <DisassemblyName>$(AssemblyName).dasm.il</DisassemblyName>
+      <TargetAssemblyName>$(AssemblyName).asm.dll</TargetAssemblyName>
 
       <IlasmRoundTripBatchScript Condition="'$(CLRTestKind)' == 'RunOnly'"><![CDATA[
 REM IlasmRoundTrip Script


### PR DESCRIPTION
Before this change the execution script generator arbitrarily
referred to "InputAssemblyName", "AssemblyName" and
"MSBuildProjectName" w.r.t. names of the scripts and the
executables. This is unfortunate because for merged
ILPROJ projects we need to adjust the assembly name during build.
This simple change makes the scripts consistently refer to
AssemblyName everywhere.

Thanks

Tomas