### PR TITLE
Revert "[mono][workload] add workloads for win-arm64 using emulation again"

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in
@@ -13,7 +13,7 @@
         "Microsoft.NETCore.App.Runtime.AOT.Cross.browser-wasm"
       ],
       "extends": [ "microsoft-net-runtime-mono-tooling", "microsoft-net-sdk-emscripten" ],
-      "platforms": [ "win-x64", "win-arm64", "linux-x64", "osx-x64", "osx-arm64" ]
+      "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ]
     },
     "microsoft-net-runtime-android": {
       "abstract": true,
@@ -25,7 +25,7 @@
         "Microsoft.NETCore.App.Runtime.Mono.android-x86"
       ],
       "extends": [ "microsoft-net-runtime-mono-tooling" ],
-      "platforms": [ "win-x64", "win-arm64", "linux-x64", "osx-x64", "osx-arm64" ]
+      "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ]
     },
     "microsoft-net-runtime-android-aot": {
       "abstract": true,
@@ -37,7 +37,7 @@
         "Microsoft.NETCore.App.Runtime.AOT.Cross.android-arm64"
       ],
       "extends": [ "microsoft-net-runtime-android" ],
-      "platforms": [ "win-x64", "win-arm64", "linux-x64", "osx-x64", "osx-arm64" ]
+      "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ]
     },
     "microsoft-net-runtime-ios": {
       "abstract": true,
@@ -50,7 +50,7 @@
         "Microsoft.NETCore.App.Runtime.AOT.Cross.iossimulator-x86"
       ],
       "extends": [ "runtimes-ios" ],
-      "platforms": [ "win-x64", "win-arm64", "osx-arm64", "osx-x64" ]
+      "platforms": [ "win-x64", "osx-arm64", "osx-x64" ]
     },
     "runtimes-ios": {
       "abstract": true,
@@ -63,7 +63,7 @@
         "Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86"
       ],
       "extends": [ "microsoft-net-runtime-mono-tooling" ],
-      "platforms": [ "win-x64", "win-arm64", "osx-arm64", "osx-x64" ]
+      "platforms": [ "win-x64", "osx-arm64", "osx-x64" ]
     },
     "microsoft-net-runtime-maccatalyst": {
       "abstract": true,
@@ -73,7 +73,7 @@
         "Microsoft.NETCore.App.Runtime.AOT.Cross.maccatalyst-x64"
       ],
       "extends": [ "runtimes-maccatalyst" ],
-      "platforms": [ "win-x64", "win-arm64", "osx-arm64", "osx-x64" ]
+      "platforms": [ "win-x64", "osx-arm64", "osx-x64" ]
     },
     "runtimes-maccatalyst": {
       "abstract": true,
@@ -83,7 +83,7 @@
         "Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64"
       ],
       "extends": [ "microsoft-net-runtime-mono-tooling" ],
-      "platforms": [ "win-x64", "win-arm64", "osx-arm64", "osx-x64" ]
+      "platforms": [ "win-x64", "osx-arm64", "osx-x64" ]
     },
     "microsoft-net-runtime-macos": {
       "abstract": true,
@@ -106,7 +106,7 @@
         "Microsoft.NETCore.App.Runtime.AOT.Cross.tvossimulator-x64"
       ],
       "extends": [ "runtimes-tvos" ],
-      "platforms": [ "win-x64", "win-arm64", "osx-arm64", "osx-x64" ]
+      "platforms": [ "win-x64", "osx-arm64", "osx-x64" ]
     },
     "runtimes-tvos": {
       "abstract": true,
@@ -117,7 +117,7 @@
         "Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64"
       ],
       "extends": [ "microsoft-net-runtime-mono-tooling" ],
-      "platforms": [ "win-x64", "win-arm64", "osx-arm64", "osx-x64" ]
+      "platforms": [ "win-x64", "osx-arm64", "osx-x64" ]
     },
     "microsoft-net-runtime-mono-tooling": {
       "abstract": true,
@@ -166,7 +166,6 @@
       "version": "${PackageVersion}",
       "alias-to": {
         "win-x64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-x86",
-        "win-arm64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-x86",
         "linux-x64": "Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.android-x86",
         "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-x86",
         "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-x86"
@@ -177,7 +176,6 @@
       "version": "${PackageVersion}",
       "alias-to": {
         "win-x64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-x64",
-        "win-arm64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-x64",
         "linux-x64": "Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.android-x64",
         "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-x64",
         "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-x64"
@@ -188,7 +186,6 @@
       "version": "${PackageVersion}",
       "alias-to": {
         "win-x64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm",
-        "win-arm64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm",
         "linux-x64": "Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.android-arm",
         "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-arm",
         "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-arm"
@@ -199,7 +196,6 @@
       "version": "${PackageVersion}",
       "alias-to": {
         "win-x64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm64",
-        "win-arm64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm64",
         "linux-x64": "Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.android-arm64",
         "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-arm64",
         "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-arm64"
@@ -346,7 +342,6 @@
       "version": "${PackageVersion}",
       "alias-to": {
         "win-x64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.browser-wasm",
-        "win-arm64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.browser-wasm",
         "linux-x64": "Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.browser-wasm",
         "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.browser-wasm",
         "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.browser-wasm"


### PR DESCRIPTION
In the never ending drama of workload tooling the workload packaging steps appear to be racy between x64 and arm64 when using the same artifacts and this can cause the packaging step to fail so we'll revert this yet again until there is a tooling fix.

Reverts dotnet/runtime#67267