### PR TITLE
Concatenate multiple cookies with semicolon

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
@@ -172,7 +172,12 @@ namespace System.Net.Http.Functional.Tests
 
                     string cookieHeaderValue = requestData.GetSingleHeaderValue("Cookie");
 
-                    var cookieValues = cookieHeaderValue.Split(new string[] { "; " }, StringSplitOptions.None);
+#if NETFRAMEWORK
+                    var separator = ", ";
+#else
+                    var separator = "; ";
+#endif
+                    var cookieValues = cookieHeaderValue.Split(new string[] { separator }, StringSplitOptions.None);
                     Assert.Contains("A=1", cookieValues);
                     Assert.Contains("B=2", cookieValues);
                     Assert.Contains("C=3", cookieValues);
@@ -261,14 +266,40 @@ namespace System.Net.Http.Functional.Tests
                     HttpRequestData requestData = await serverTask;
                     string cookieHeaderValue = GetCookieValue(requestData);
 
+#if NETFRAMEWORK
+                    // Multiple Cookie header values are treated as any other header values and are
+                    // concatenated using ", " as the separator.  The container cookie is concatenated to
+                    // one of these values using the "; " cookie separator.
+
+                    var cookieValues = cookieHeaderValue.Split(new string[] { ", " }, StringSplitOptions.None);
+                    Assert.Equal(2, cookieValues.Count());
+
+                    // Find container cookie and remove it so we can validate the rest of the cookie header values
+                    bool sawContainerCookie = false;
+                    for (int i = 0; i < cookieValues.Length; i++)
+                    {
+                        if (cookieValues[i].Contains(';'))
+                        {
+                            Assert.False(sawContainerCookie);
+
+                            var cookies = cookieValues[i].Split(new string[] { "; " }, StringSplitOptions.None);
+                            Assert.Equal(2, cookies.Count());
+                            Assert.Contains(s_expectedCookieHeaderValue, cookies);
+
+                            sawContainerCookie = true;
+                            cookieValues[i] = cookies.Where(c => c != s_expectedCookieHeaderValue).Single();
+                        }
+                    }
+#else
                     // Multiple Cookie header values as well as container cookies are
                     // concatenated using "; " as the separator.
 
                     var cookieValues = cookieHeaderValue.Split(new string[] { "; " }, StringSplitOptions.None);
-                    Assert.Contains("A=1", cookieValues);
-                    Assert.Contains("B=2", cookieValues);
                     Assert.Contains(s_expectedCookieHeaderValue, cookieValues);
                     Assert.Equal(3, cookieValues.Count());
+#endif
+                    Assert.Contains("A=1", cookieValues);
+                    Assert.Contains("B=2", cookieValues);
                 }
             });
         }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
@@ -267,39 +267,19 @@ namespace System.Net.Http.Functional.Tests
                     string cookieHeaderValue = GetCookieValue(requestData);
 
 #if NETFRAMEWORK
-                    // Multiple Cookie header values are treated as any other header values and are
+                    // On .NET Framework multiple Cookie header values are treated as any other header values and are
                     // concatenated using ", " as the separator.  The container cookie is concatenated to
                     // one of these values using the "; " cookie separator.
 
-                    var cookieValues = cookieHeaderValue.Split(new string[] { ", " }, StringSplitOptions.None);
-                    Assert.Equal(2, cookieValues.Count());
-
-                    // Find container cookie and remove it so we can validate the rest of the cookie header values
-                    bool sawContainerCookie = false;
-                    for (int i = 0; i < cookieValues.Length; i++)
-                    {
-                        if (cookieValues[i].Contains(';'))
-                        {
-                            Assert.False(sawContainerCookie);
-
-                            var cookies = cookieValues[i].Split(new string[] { "; " }, StringSplitOptions.None);
-                            Assert.Equal(2, cookies.Count());
-                            Assert.Contains(s_expectedCookieHeaderValue, cookies);
-
-                            sawContainerCookie = true;
-                            cookieValues[i] = cookies.Where(c => c != s_expectedCookieHeaderValue).Single();
-                        }
-                    }
+                    var separators = new string[] { "; ", ", " };
 #else
-                    // Multiple Cookie header values as well as container cookies are
-                    // concatenated using "; " as the separator.
-
-                    var cookieValues = cookieHeaderValue.Split(new string[] { "; " }, StringSplitOptions.None);
-                    Assert.Contains(s_expectedCookieHeaderValue, cookieValues);
-                    Assert.Equal(3, cookieValues.Count());
+                    var separators = new string[] { "; " };
 #endif
+                    var cookieValues = cookieHeaderValue.Split(separators, StringSplitOptions.None);
+                    Assert.Contains(s_expectedCookieHeaderValue, cookieValues);
                     Assert.Contains("A=1", cookieValues);
                     Assert.Contains("B=2", cookieValues);
+                    Assert.Equal(3, cookieValues.Count());
                 }
             });
         }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
@@ -168,12 +168,11 @@ namespace System.Net.Http.Functional.Tests
                 {
                     HttpRequestData requestData = await server.HandleRequestAsync();
 
-                    // Multiple Cookie header values are treated as any other header values and are
-                    // concatenated using ", " as the separator.
+                    // Multiple Cookie header values are concatenated using "; " as the separator.
 
                     string cookieHeaderValue = requestData.GetSingleHeaderValue("Cookie");
 
-                    var cookieValues = cookieHeaderValue.Split(new string[] { ", " }, StringSplitOptions.None);
+                    var cookieValues = cookieHeaderValue.Split(new string[] { "; " }, StringSplitOptions.None);
                     Assert.Contains("A=1", cookieValues);
                     Assert.Contains("B=2", cookieValues);
                     Assert.Contains("C=3", cookieValues);
@@ -262,32 +261,14 @@ namespace System.Net.Http.Functional.Tests
                     HttpRequestData requestData = await serverTask;
                     string cookieHeaderValue = GetCookieValue(requestData);
 
-                    // Multiple Cookie header values are treated as any other header values and are
-                    // concatenated using ", " as the separator.  The container cookie is concatenated to
-                    // one of these values using the "; " cookie separator.
+                    // Multiple Cookie header values as well as container cookies are
+                    // concatenated using "; " as the separator.
 
-                    var cookieValues = cookieHeaderValue.Split(new string[] { ", " }, StringSplitOptions.None);
-                    Assert.Equal(2, cookieValues.Count());
-
-                    // Find container cookie and remove it so we can validate the rest of the cookie header values
-                    bool sawContainerCookie = false;
-                    for (int i = 0; i < cookieValues.Length; i++)
-                    {
-                        if (cookieValues[i].Contains(';'))
-                        {
-                            Assert.False(sawContainerCookie);
-
-                            var cookies = cookieValues[i].Split(new string[] { "; " }, StringSplitOptions.None);
-                            Assert.Equal(2, cookies.Count());
-                            Assert.Contains(s_expectedCookieHeaderValue, cookies);
-
-                            sawContainerCookie = true;
-                            cookieValues[i] = cookies.Where(c => c != s_expectedCookieHeaderValue).Single();
-                        }
-                    }
-
+                    var cookieValues = cookieHeaderValue.Split(new string[] { "; " }, StringSplitOptions.None);
                     Assert.Contains("A=1", cookieValues);
                     Assert.Contains("B=2", cookieValues);
+                    Assert.Contains(s_expectedCookieHeaderValue, cookieValues);
+                    Assert.Equal(3, cookieValues.Count());
                 }
             });
         }

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <WindowsRID>win</WindowsRID>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -83,6 +83,7 @@
     <Compile Include="System\Net\Http\Headers\CacheControlHeaderValue.cs" />
     <Compile Include="System\Net\Http\Headers\ContentDispositionHeaderValue.cs" />
     <Compile Include="System\Net\Http\Headers\ContentRangeHeaderValue.cs" />
+    <Compile Include="System\Net\Http\Headers\CookieHeaderParser.cs" />
     <Compile Include="System\Net\Http\Headers\DateHeaderParser.cs" />
     <Compile Include="System\Net\Http\Headers\EntityTagHeaderValue.cs" />
     <Compile Include="System\Net\Http\Headers\GenericHeaderParser.cs" />

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/CookieHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/CookieHeaderParser.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Net.Http.Headers
+{
+    internal sealed class CookieHeaderParser : HttpHeaderParser
+    {
+        internal static readonly CookieHeaderParser Parser = new CookieHeaderParser();
+
+        // According to RFC 6265 Section 4.2 multiple cookies have
+        // to be concatenated using "; " as the separator.
+        private CookieHeaderParser()
+            : base(true, "; ")
+        {
+        }
+
+        public override bool TryParseValue(string? value, object? storeValue, ref int index, [NotNullWhen(true)] out object? parsedValue)
+        {
+            // Some headers support empty/null values. This one doesn't.
+            if (string.IsNullOrEmpty(value) || (index == value.Length))
+            {
+                parsedValue = null;
+                return false;
+            }
+
+            parsedValue = value;
+            index = value.Length;
+
+            return true;
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/KnownHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/KnownHeaders.cs
@@ -40,7 +40,7 @@ namespace System.Net.Http.Headers
         public static readonly KnownHeader ContentRange = new KnownHeader("Content-Range", HttpHeaderType.Content | HttpHeaderType.NonTrailing, GenericHeaderParser.ContentRangeParser, null, H2StaticTable.ContentRange);
         public static readonly KnownHeader ContentSecurityPolicy = new KnownHeader("Content-Security-Policy", http3StaticTableIndex: H3StaticTable.ContentSecurityPolicyAllNone);
         public static readonly KnownHeader ContentType = new KnownHeader("Content-Type", HttpHeaderType.Content | HttpHeaderType.NonTrailing, MediaTypeHeaderParser.SingleValueParser, null, H2StaticTable.ContentType, H3StaticTable.ContentTypeApplicationDnsMessage);
-        public static readonly KnownHeader Cookie = new KnownHeader("Cookie", H2StaticTable.Cookie, H3StaticTable.Cookie);
+        public static readonly KnownHeader Cookie = new KnownHeader("Cookie", HttpHeaderType.Request, CookieHeaderParser.Parser, null, H2StaticTable.Cookie, H3StaticTable.Cookie);
         public static readonly KnownHeader Cookie2 = new KnownHeader("Cookie2");
         public static readonly KnownHeader Date = new KnownHeader("Date", HttpHeaderType.General | HttpHeaderType.NonTrailing, DateHeaderParser.Parser, null, H2StaticTable.Date, H3StaticTable.Date);
         public static readonly KnownHeader ETag = new KnownHeader("ETag", HttpHeaderType.Response, GenericHeaderParser.SingleValueEntityTagParser, null, H2StaticTable.ETag, H3StaticTable.ETag);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/KnownHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/KnownHeaders.cs
@@ -40,7 +40,7 @@ namespace System.Net.Http.Headers
         public static readonly KnownHeader ContentRange = new KnownHeader("Content-Range", HttpHeaderType.Content | HttpHeaderType.NonTrailing, GenericHeaderParser.ContentRangeParser, null, H2StaticTable.ContentRange);
         public static readonly KnownHeader ContentSecurityPolicy = new KnownHeader("Content-Security-Policy", http3StaticTableIndex: H3StaticTable.ContentSecurityPolicyAllNone);
         public static readonly KnownHeader ContentType = new KnownHeader("Content-Type", HttpHeaderType.Content | HttpHeaderType.NonTrailing, MediaTypeHeaderParser.SingleValueParser, null, H2StaticTable.ContentType, H3StaticTable.ContentTypeApplicationDnsMessage);
-        public static readonly KnownHeader Cookie = new KnownHeader("Cookie", HttpHeaderType.Request, CookieHeaderParser.Parser, null, H2StaticTable.Cookie, H3StaticTable.Cookie);
+        public static readonly KnownHeader Cookie = new KnownHeader("Cookie", HttpHeaderType.Custom, CookieHeaderParser.Parser, null, H2StaticTable.Cookie, H3StaticTable.Cookie);
         public static readonly KnownHeader Cookie2 = new KnownHeader("Cookie2");
         public static readonly KnownHeader Date = new KnownHeader("Date", HttpHeaderType.General | HttpHeaderType.NonTrailing, DateHeaderParser.Parser, null, H2StaticTable.Date, H3StaticTable.Date);
         public static readonly KnownHeader ETag = new KnownHeader("ETag", HttpHeaderType.Response, GenericHeaderParser.SingleValueEntityTagParser, null, H2StaticTable.ETag, H3StaticTable.ETag);

--- a/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -99,6 +99,8 @@
              Link="ProductionCode\System\Net\Http\Headers\ContentDispositionHeaderValue.cs" />
     <Compile Include="..\..\src\System\Net\Http\Headers\ContentRangeHeaderValue.cs"
              Link="ProductionCode\System\Net\Http\Headers\ContentRangeHeaderValue.cs" />
+    <Compile Include="..\..\src\System\Net\Http\Headers\CookieHeaderParser.cs"
+             Link="ProductionCode\System\Net\Http\Headers\CookieHeaderParser.cs" />
     <Compile Include="..\..\src\System\Net\Http\Headers\DateHeaderParser.cs"
              Link="ProductionCode\System\Net\Http\Headers\DateHeaderParser.cs" />
     <Compile Include="..\..\src\System\Net\Http\Headers\EntityTagHeaderValue.cs"


### PR DESCRIPTION
Fixes #42856 

According to [RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265#section-4.2) multiple cookies must be concatenated with `";" SP` when writing the `Cookie` header.
The existing implementation complies to this when writing the cookies that are added to a `CookieContainer` but all cookies that are added directly to the `HttpRequestHeaders` collection are concatenated with a comma. 
This PR ensures that all cookies are concatenated with a semicolon.