### PR TITLE
Fix incorrect format string arguments

### DIFF
--- a/src/coreclr/tools/metainfo/mdinfo.cpp
+++ b/src/coreclr/tools/metainfo/mdinfo.cpp
@@ -13,7 +13,6 @@
 #include "corerror.h"
 #include <winwrap.h>
 #include <prettyprintsig.h>
-#include <cinttypes>
 
 #include <cahlpr.h>
 #include <limits.h>
@@ -361,7 +360,7 @@ void MDInfo::DisplayMD()
         // WriteLine("Unresolved MemberRefs");
         // DisplayMemberRefs(0x00000001, "\t");
 
-        VWrite("\n\nCoff symbol name overhead:  %zd\n", g_cbCoffNames);
+        VWrite("\n\nCoff symbol name overhead:  %zu\n", g_cbCoffNames);
     }
     WriteLine("===========================================================");
     if (m_DumpFilter & dumpUnsat)
@@ -2040,7 +2039,7 @@ void MDInfo::DisplayCustomAttributeInfo(mdCustomAttribute inValue, const char *p
                 case ELEMENT_TYPE_U8:
                     CA.GetU8(&u8);
                     uI64 = u8;
-                    VWrite("%#" PRIu64, uI64);
+                    VWrite("%#I64x", uI64);
                     break;
                 case ELEMENT_TYPE_R4:
                     dblVal = CA.GetR4();

--- a/src/coreclr/tools/metainfo/mdinfo.cpp
+++ b/src/coreclr/tools/metainfo/mdinfo.cpp
@@ -13,6 +13,7 @@
 #include "corerror.h"
 #include <winwrap.h>
 #include <prettyprintsig.h>
+#include <cinttypes>
 
 #include <cahlpr.h>
 #include <limits.h>
@@ -360,7 +361,7 @@ void MDInfo::DisplayMD()
         // WriteLine("Unresolved MemberRefs");
         // DisplayMemberRefs(0x00000001, "\t");
 
-        VWrite("\n\nCoff symbol name overhead:  %d\n", g_cbCoffNames);
+        VWrite("\n\nCoff symbol name overhead:  %zd\n", g_cbCoffNames);
     }
     WriteLine("===========================================================");
     if (m_DumpFilter & dumpUnsat)
@@ -1939,7 +1940,7 @@ void MDInfo::DisplayCustomAttributeInfo(mdCustomAttribute inValue, const char *p
 
     VWrite("%s\tCustomAttributeName: %ls", preFix, rcName);
     if (pSig && pMethName)
-        VWrite(" :: %S", qSigName.Ptr());
+        VWrite(" :: %S", (LPWSTR)qSigName.Ptr());
 
     // Keep track of coff overhead.
     if (!wcscmp(W("__DecoratedName"), rcName))
@@ -2039,7 +2040,7 @@ void MDInfo::DisplayCustomAttributeInfo(mdCustomAttribute inValue, const char *p
                 case ELEMENT_TYPE_U8:
                     CA.GetU8(&u8);
                     uI64 = u8;
-                    VWrite("%#lx", uI64);
+                    VWrite("%#" PRIu64, uI64);
                     break;
                 case ELEMENT_TYPE_R4:
                     dblVal = CA.GetR4();

--- a/src/coreclr/tools/metainfo/mdinfo.cpp
+++ b/src/coreclr/tools/metainfo/mdinfo.cpp
@@ -360,7 +360,7 @@ void MDInfo::DisplayMD()
         // WriteLine("Unresolved MemberRefs");
         // DisplayMemberRefs(0x00000001, "\t");
 
-        VWrite("\n\nCoff symbol name overhead:  %zu\n", g_cbCoffNames);
+        VWrite("\n\nCoff symbol name overhead:  %Iu\n", g_cbCoffNames);
     }
     WriteLine("===========================================================");
     if (m_DumpFilter & dumpUnsat)

--- a/src/coreclr/vm/clrex.cpp
+++ b/src/coreclr/vm/clrex.cpp
@@ -1138,7 +1138,7 @@ void EEResourceException::GetMessage(SString &result)
     // since we don't want to call managed code here.
     //
 
-    result.Printf("%s (message resource %s)",
+    result.Printf("%s (message resource %S)",
                   CoreLibBinder::GetExceptionName(m_kind), m_resourceName.GetUnicode());
 }
 

--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -486,7 +486,7 @@ void EEPolicy::LogFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pszMessage
                 if(!ssErrorFormat.LoadResource(CCompRC::Optional, IDS_ER_UNMANAGEDFAILFASTMSG ))
                     ssErrorFormat.Set(W("at IP 0x%x (0x%x) with exit code 0x%x."));
                 SmallStackSString addressString;
-                addressString.Printf(W("%p"), pExceptionInfo? (UINT_PTR)pExceptionInfo->ExceptionRecord->ExceptionAddress : address);
+                addressString.Printf(W("%p"), pExceptionInfo? (PVOID)pExceptionInfo->ExceptionRecord->ExceptionAddress : (PVOID)address);
 
                 // We should always have the reference to the runtime's instance
                 _ASSERTE(GetClrModuleBase() != NULL);

--- a/src/coreclr/vm/eventreporter.cpp
+++ b/src/coreclr/vm/eventreporter.cpp
@@ -679,7 +679,7 @@ void DoReportForUnhandledNativeException(PEXCEPTION_POINTERS pExceptionInfo)
         SmallStackSString exceptionCodeString;
         exceptionCodeString.Printf(W("%x"), pExceptionInfo->ExceptionRecord->ExceptionCode);
         SmallStackSString addressString;
-        addressString.Printf(W("%p"), (UINT_PTR)pExceptionInfo->ExceptionRecord->ExceptionAddress);
+        addressString.Printf(W("%p"), (PVOID)pExceptionInfo->ExceptionRecord->ExceptionAddress);
         s.FormatMessage(FORMAT_MESSAGE_FROM_STRING, (LPCWSTR)ssErrorFormat, 0, 0, exceptionCodeString, addressString);
         reporter.AddDescription(s);
         if (pThread)

--- a/src/coreclr/vm/stubgen.cpp
+++ b/src/coreclr/vm/stubgen.cpp
@@ -466,7 +466,7 @@ ILStubLinker::LogILInstruction(
 
     if (isLabeled)
     {
-        strLabel.Printf(W("IL_%04zx:"), curOffset);
+        strLabel.Printf(W("IL_%04Ix:"), curOffset);
     }
     else
     {
@@ -502,7 +502,7 @@ ILStubLinker::LogILInstruction(
     {
         size_t branchDistance = (size_t)pInstruction->uArg;
         size_t targetOffset = curOffset + s_rgbOpcodeSizes[instr] + branchDistance;
-        strArgument.Printf(W("IL_%04zx"), targetOffset);
+        strArgument.Printf(W("IL_%04Ix"), targetOffset);
     }
     else if ((ILCodeStream::ILInstrEnum)CEE_NOP == instr)
     {
@@ -520,7 +520,7 @@ ILStubLinker::LogILInstruction(
         case ShortInlineVar:
         case ShortInlineI:
         case InlineI:
-            strArgument.Printf(W("0x%zx"), pInstruction->uArg);
+            strArgument.Printf(W("0x%Ix"), pInstruction->uArg);
             break;
 
         case InlineI8:
@@ -536,7 +536,7 @@ ILStubLinker::LogILInstruction(
         case InlineTok:
             // No token value when we dump IL for ETW
             if (pDumpILStubCode == NULL)
-                strArgument.Printf(W("0x%08zx"), pInstruction->uArg);
+                strArgument.Printf(W("0x%08Ix"), pInstruction->uArg);
 
             // Dump to szTokenNameBuffer if logging, otherwise dump to szArgumentBuffer to avoid an extra space because we are omitting the token
             _ASSERTE(FitsIn<mdToken>(pInstruction->uArg));
@@ -620,11 +620,11 @@ ILStubLinker::LogILStubWorker(
     {
         if (pDumpILStubCode)
         {
-            pDumpILStubCode->AppendPrintf(W("IL_%04zx:\n"), *pcbCode);
+            pDumpILStubCode->AppendPrintf(W("IL_%04Ix:\n"), *pcbCode);
         }
         else
         {
-            LOG((LF_STUBS, LL_INFO1000, "IL_%04x:\n", *pcbCode));
+            LOG((LF_STUBS, LL_INFO1000, "IL_%04Ix:\n", *pcbCode));
         }
     }
 }

--- a/src/coreclr/vm/stubgen.cpp
+++ b/src/coreclr/vm/stubgen.cpp
@@ -466,7 +466,7 @@ ILStubLinker::LogILInstruction(
 
     if (isLabeled)
     {
-        strLabel.Printf(W("IL_%04x:"), curOffset);
+        strLabel.Printf(W("IL_%04zx:"), curOffset);
     }
     else
     {
@@ -502,7 +502,7 @@ ILStubLinker::LogILInstruction(
     {
         size_t branchDistance = (size_t)pInstruction->uArg;
         size_t targetOffset = curOffset + s_rgbOpcodeSizes[instr] + branchDistance;
-        strArgument.Printf(W("IL_%04x"), targetOffset);
+        strArgument.Printf(W("IL_%04zx"), targetOffset);
     }
     else if ((ILCodeStream::ILInstrEnum)CEE_NOP == instr)
     {
@@ -520,7 +520,7 @@ ILStubLinker::LogILInstruction(
         case ShortInlineVar:
         case ShortInlineI:
         case InlineI:
-            strArgument.Printf(W("0x%x"), pInstruction->uArg);
+            strArgument.Printf(W("0x%zx"), pInstruction->uArg);
             break;
 
         case InlineI8:
@@ -536,7 +536,7 @@ ILStubLinker::LogILInstruction(
         case InlineTok:
             // No token value when we dump IL for ETW
             if (pDumpILStubCode == NULL)
-                strArgument.Printf(W("0x%08x"), pInstruction->uArg);
+                strArgument.Printf(W("0x%08zx"), pInstruction->uArg);
 
             // Dump to szTokenNameBuffer if logging, otherwise dump to szArgumentBuffer to avoid an extra space because we are omitting the token
             _ASSERTE(FitsIn<mdToken>(pInstruction->uArg));
@@ -620,7 +620,7 @@ ILStubLinker::LogILStubWorker(
     {
         if (pDumpILStubCode)
         {
-            pDumpILStubCode->AppendPrintf(W("IL_%04x:\n"), *pcbCode);
+            pDumpILStubCode->AppendPrintf(W("IL_%04zx:\n"), *pcbCode);
         }
         else
         {

--- a/src/native/corehost/bundle/extractor.cpp
+++ b/src/native/corehost/bundle/extractor.cpp
@@ -6,6 +6,7 @@
 #include "dir_utils.h"
 #include "pal.h"
 #include "utils.h"
+#include <cinttypes>
 
 #ifdef __sun
 #include <alloca.h>
@@ -178,7 +179,7 @@ void extractor_t::extract(const file_entry_t &entry, reader_t &reader)
 
     if (extracted_size != cast_size)
     {
-        trace::error(_X("Failure extracting contents of the application bundle. Expected size:%d Actual size:%d"), size, extracted_size);
+        trace::error(_X("Failure extracting contents of the application bundle. Expected size:%" PRId64 " Actual size:%zd"), size, extracted_size);
         trace::error(_X("I/O failure when writing extracted files."));
         throw StatusCode::BundleExtractionIOError;
     }

--- a/src/native/corehost/bundle/extractor.cpp
+++ b/src/native/corehost/bundle/extractor.cpp
@@ -179,7 +179,7 @@ void extractor_t::extract(const file_entry_t &entry, reader_t &reader)
 
     if (extracted_size != cast_size)
     {
-        trace::error(_X("Failure extracting contents of the application bundle. Expected size:%" PRId64 " Actual size:%zd"), size, extracted_size);
+        trace::error(_X("Failure extracting contents of the application bundle. Expected size:%" PRId64 " Actual size:%zu"), size, extracted_size);
         trace::error(_X("I/O failure when writing extracted files."));
         throw StatusCode::BundleExtractionIOError;
     }

--- a/src/native/corehost/bundle/info.cpp
+++ b/src/native/corehost/bundle/info.cpp
@@ -4,6 +4,7 @@
 #include "trace.h"
 #include "info.h"
 #include "utils.h"
+#include <cinttypes>
 
 using namespace bundle;
 
@@ -48,8 +49,8 @@ StatusCode info_t::process_bundle(const pal::char_t* bundle_path, const pal::cha
     }
 
     trace::info(_X("Single-File bundle details:"));
-    trace::info(_X("DepsJson Offset:[%lx] Size[%lx]"), info.m_header.deps_json_location().offset, info.m_header.deps_json_location().size);
-    trace::info(_X("RuntimeConfigJson Offset:[%lx] Size[%lx]"), info.m_header.runtimeconfig_json_location().offset, info.m_header.runtimeconfig_json_location().size);
+    trace::info(_X("DepsJson Offset:[%" PRIx64 "] Size[%" PRIx64 "]"), info.m_header.deps_json_location().offset, info.m_header.deps_json_location().size);
+    trace::info(_X("RuntimeConfigJson Offset:[%" PRIx64 "] Size[%" PRIx64 "]"), info.m_header.runtimeconfig_json_location().offset, info.m_header.runtimeconfig_json_location().size);
     trace::info(_X(".net core 3 compatibility mode: [%s]"), info.m_header.is_netcoreapp3_compat_mode() ? _X("Yes") : _X("No"));
 
     the_app = &info;

--- a/src/native/corehost/corehost.cpp
+++ b/src/native/corehost/corehost.cpp
@@ -9,6 +9,7 @@
 #include "trace.h"
 #include "utils.h"
 #include "hostfxr_resolver.h"
+#include <cinttypes>
 
 #if defined(FEATURE_APPHOST)
 #include "bundle_marker.h"
@@ -200,7 +201,7 @@ int exe_start(const int argc, const pal::char_t* argv[])
             trace::info(_X("Host path: [%s]"), host_path.c_str());
             trace::info(_X("Dotnet path: [%s]"), fxr.dotnet_root().c_str());
             trace::info(_X("App path: [%s]"), app_path.c_str());
-            trace::info(_X("Bundle Header Offset: [%lx]"), bundle_header_offset);
+            trace::info(_X("Bundle Header Offset: [%" PRId64 "]"), bundle_header_offset);
 
             auto set_error_writer = fxr.resolve_set_error_writer();
             propagate_error_writer_t propagate_error_writer_to_hostfxr(set_error_writer);

--- a/src/native/corehost/deps_format.cpp
+++ b/src/native/corehost/deps_format.cpp
@@ -98,7 +98,7 @@ void deps_json_t::reconcile_libraries_with_targets(
 
                 if (trace::is_enabled())
                 {
-                    trace::info(_X("Parsed %s deps entry %d for asset name: %s from %s: %s, library version: %s, relpath: %s, assemblyVersion %s, fileVersion %s"),
+                    trace::info(_X("Parsed %s deps entry %zd for asset name: %s from %s: %s, library version: %s, relpath: %s, assemblyVersion %s, fileVersion %s"),
                         deps_entry_t::s_known_asset_types[i],
                         m_deps_entries[i].size() - 1,
                         entry.asset.name.c_str(),

--- a/src/native/corehost/deps_format.cpp
+++ b/src/native/corehost/deps_format.cpp
@@ -98,7 +98,7 @@ void deps_json_t::reconcile_libraries_with_targets(
 
                 if (trace::is_enabled())
                 {
-                    trace::info(_X("Parsed %s deps entry %zd for asset name: %s from %s: %s, library version: %s, relpath: %s, assemblyVersion %s, fileVersion %s"),
+                    trace::info(_X("Parsed %s deps entry %zu for asset name: %s from %s: %s, library version: %s, relpath: %s, assemblyVersion %s, fileVersion %s"),
                         deps_entry_t::s_known_asset_types[i],
                         m_deps_entries[i].size() - 1,
                         entry.asset.name.c_str(),

--- a/src/native/corehost/fxr/command_line.cpp
+++ b/src/native/corehost/fxr/command_line.cpp
@@ -134,7 +134,7 @@ namespace
             for (const auto& opt : known_opts)
             {
                 const host_option &arg = get_host_option(opt);
-                trace::error(_X("  %s %-*s  %s"), arg.option, 36 - pal::strlen(arg.option), arg.argument, arg.description);
+                trace::error(_X("  %s %-*s  %s"), arg.option, 36 - (int)pal::strlen(arg.option), arg.argument, arg.description);
             }
             return StatusCode::InvalidArgFailure;
         }
@@ -329,7 +329,7 @@ void command_line::print_muxer_usage(bool is_sdk_present)
     for (const auto& opt : known_opts)
     {
         const host_option &arg = get_host_option(opt);
-        trace::println(_X("  %s %-*s  %s"), arg.option, 29 - pal::strlen(arg.option), arg.argument, arg.description);
+        trace::println(_X("  %s %-*s  %s"), arg.option, 29 - (int)pal::strlen(arg.option), arg.argument, arg.description);
     }
     trace::println(_X("  --list-runtimes                 Display the installed runtimes"));
     trace::println(_X("  --list-sdks                     Display the installed SDKs"));

--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -812,7 +812,7 @@ bool pal::is_emulating_x64()
         if (!isWow64Process2Func(GetCurrentProcess(), &pProcessMachine, &pNativeMachine))
         {
             // IsWow64Process2 failed. Log the error and continue.
-            trace::info(_X("Call to IsWow64Process2 failed: %s"), GetLastError());
+            trace::info(_X("Call to IsWow64Process2 failed: %u"), GetLastError());
             return false;
         }
 
@@ -821,7 +821,7 @@ bool pal::is_emulating_x64()
     }
 
     // Loading kernel32.dll failed, log the error and continue.
-    trace::info(_X("Could not load 'kernel32.dll': %s"), GetLastError());
+    trace::info(_X("Could not load 'kernel32.dll': %u"), GetLastError());
 
     return false;
 }

--- a/src/native/corehost/hostpolicy/hostpolicy_context.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_context.cpp
@@ -36,7 +36,7 @@ namespace
         if (!pal::clr_palstring(path, &file_path))
         {
             trace::warning(_X("Failure probing contents of the application bundle."));
-            trace::warning(_X("Failed to convert path [%ls] to UTF8"), path);
+            trace::warning(_X("Failed to convert path [%hs] to UTF8"), path);
 
             return false;
         }

--- a/src/native/corehost/hostpolicy/hostpolicy_init.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_init.cpp
@@ -19,11 +19,11 @@ bool hostpolicy_init_t::init(host_interface_t* input, hostpolicy_init_t* init)
     // Check if there are any breaking changes.
     if (input->version_hi != HOST_INTERFACE_LAYOUT_VERSION_HI)
     {
-        trace::error(_X("The version of the data layout used to initialize %s is [0x%04x]; expected version [0x%04x]"), LIBHOSTPOLICY_NAME, input->version_hi, HOST_INTERFACE_LAYOUT_VERSION_HI);
+        trace::error(_X("The version of the data layout used to initialize %s is [0x%04zx]; expected version [0x%04x]"), LIBHOSTPOLICY_NAME, input->version_hi, HOST_INTERFACE_LAYOUT_VERSION_HI);
         return false;
     }
 
-    trace::verbose(_X("Reading from host interface version: [0x%04x:%d] to initialize policy version: [0x%04x:%d]"), input->version_hi, input->version_lo, HOST_INTERFACE_LAYOUT_VERSION_HI, HOST_INTERFACE_LAYOUT_VERSION_LO);
+    trace::verbose(_X("Reading from host interface version: [0x%04zx:%zd] to initialize policy version: [0x%04x:%d]"), input->version_hi, input->version_lo, HOST_INTERFACE_LAYOUT_VERSION_HI, HOST_INTERFACE_LAYOUT_VERSION_LO);
 
     // This check is to ensure is an old hostfxr can still load new hostpolicy.
     // We should not read garbage due to potentially shorter struct size
@@ -46,7 +46,7 @@ bool hostpolicy_init_t::init(host_interface_t* input, hostpolicy_init_t* init)
     }
     else
     {
-        trace::error(_X("The size of the data layout used to initialize %s is %d; expected at least %d"), LIBHOSTPOLICY_NAME, input->version_lo, 
+        trace::error(_X("The size of the data layout used to initialize %s is %zd; expected at least %d"), LIBHOSTPOLICY_NAME, input->version_lo, 
             offsetof(host_interface_t, host_mode) + sizeof(input->host_mode));
     }
 


### PR DESCRIPTION
Handles issues like wide-char strings being passed as `%s`, narrow-char strings being passed as `%S`, 64-bit integers being passed as `%d`, etc. It's likely we'll need to make a second pass at these in a few weeks so that we can cover other configurations, but this is an initial list of matches from my dev box.

Fixes violation of CodeQL rule __cpp/wrong-type-format-argument__ (https://lgtm.com/rules/2160310550/).