### PR TITLE
build: fix corehost.proj dac injection unquoted path

### DIFF
--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -39,7 +39,7 @@
     Condition="'$(RuntimeFlavor)' != 'Mono'">
     <Copy SourceFiles="$(SingleFileHostPath);$(SingleFileHostSymbolsPath)" DestinationFiles="$(SingleFileHostDestinationPath);$(SingleFileHostSymbolsPath)" />
     <Exec Condition="'$(TargetOS)' == 'windows'"
-          Command="&quot;$(NetCoreRoot)dotnet&quot; exec @(InjectResourceTool) --bin &quot;$(DacPath)&quot; --image &quot;$(SingleFileHostDestinationPath)&quot; --name MINIDUMP_EMBEDDED_AUXILIARY_PROVIDER" />
+          Command="&quot;$(DotNetTool)&quot; exec @(InjectResourceTool) --bin &quot;$(DacPath)&quot; --image &quot;$(SingleFileHostDestinationPath)&quot; --name MINIDUMP_EMBEDDED_AUXILIARY_PROVIDER" />
   </Target>
   
   <Target Name="PrepareSingleFileHostWithEmbeddedDac"

--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -39,7 +39,7 @@
     Condition="'$(RuntimeFlavor)' != 'Mono'">
     <Copy SourceFiles="$(SingleFileHostPath);$(SingleFileHostSymbolsPath)" DestinationFiles="$(SingleFileHostDestinationPath);$(SingleFileHostSymbolsPath)" />
     <Exec Condition="'$(TargetOS)' == 'windows'"
-          Command="$(NetCoreRoot)dotnet exec @(InjectResourceTool) --bin &quot;$(DacPath)&quot; --image &quot;$(SingleFileHostDestinationPath)&quot; --name MINIDUMP_EMBEDDED_AUXILIARY_PROVIDER" />
+          Command="&quot;$(NetCoreRoot)dotnet&quot; exec @(InjectResourceTool) --bin &quot;$(DacPath)&quot; --image &quot;$(SingleFileHostDestinationPath)&quot; --name MINIDUMP_EMBEDDED_AUXILIARY_PROVIDER" />
   </Target>
   
   <Target Name="PrepareSingleFileHostWithEmbeddedDac"


### PR DESCRIPTION
With a clean current repo running build.cmd resulted in this error:

`
E:\Programming\csharp7\runtime\src\native\corehost\corehost.proj(41,5): error MSB3073: The command "C:\Program Files\dotnet\dotnet exec E:\Programming\csharp7\runtime\artifacts\bin\coreclr\windows.x64.Debug\InjectResource\InjectResource.dll --bin "E:\Programming\csharp7\runtime\artifacts\bin\coreclr\windows.x64.Debug\/mscordaccore.dll" --image "E:\Programming\csharp7\runtime\artifacts\bin\win-x64.Debug\corehost\/singlefilehost.exe" --name MINIDUMP_EMBEDDED_AUXILIARY_PROVIDER" exited with code 9009. [E:\Programming\csharp7\runtime\src\native\corehost\corehost.proj]
`

I used the binlog to track that back to `PrepareSingleFileHostWithEmbeddedDacCore` which has an exec command that uses the systemwide location of dotnet.exe without quoting it. This fixes it.