### PR TITLE
Disable readytorun/coreroot_determinism test on GCStress due to failure

### DIFF
--- a/src/tests/readytorun/coreroot_determinism/coreroot_determinism.csproj
+++ b/src/tests/readytorun/coreroot_determinism/coreroot_determinism.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
   <PropertyGroup>
     <OutputType>exe</OutputType>
+    <!-- Disabled for GCStress due to test failure tracked by https://github.com/dotnet/runtime/issues/58699 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
     <!-- This is an explicit crossgen test -->
     <CrossGenTest>false</CrossGenTest>


### PR DESCRIPTION
Tracking: https://github.com/dotnet/runtime/issues/58699