### PR TITLE
Disable ArrBoundBinaryOp under GCStress due to failure

### DIFF
--- a/src/tests/JIT/opt/AssertionPropagation/ArrBoundBinaryOp.csproj
+++ b/src/tests/JIT/opt/AssertionPropagation/ArrBoundBinaryOp.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <!-- Disabled for GCStress due to test failure tracked by https://github.com/dotnet/runtime/issues/66279 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>


### PR DESCRIPTION
Tracking: https://github.com/dotnet/runtime/issues/66279