### PR TITLE
Allow null-based `ARR_ADDR`s

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -5788,7 +5788,7 @@ public:
         , m_elemType(elemType)
         , m_firstElemOffset(firstElemOffset)
     {
-        assert(addr->TypeIs(TYP_BYREF));
+        assert(addr->TypeIs(TYP_BYREF) || addr->IsIntegralConst(0));
         assert(((elemType == TYP_STRUCT) && (elemClassHandle != NO_CLASS_HANDLE)) ||
                (elemClassHandle == NO_CLASS_HANDLE));
 


### PR DESCRIPTION
We can sometimes see trees like `ARR_ADDR(long 0)` that are the result of morph's folding logic.

In general it does not seem great to allow folding of `BYREF`s into `LONG`s like that, but it is also not incorrect per-se.

Should fix stress failures introduced in #64581.