### PR TITLE
Don't force `TieredCompilation=0` for SuperPMI replay job

### DIFF
--- a/src/coreclr/scripts/superpmi_replay.py
+++ b/src/coreclr/scripts/superpmi_replay.py
@@ -162,7 +162,6 @@ def main(main_args):
             "replay",
             "-core_root", cwd,
             "-jitoption", jit_flag,
-            "-jitoption", "TieredCompilation=0",
             "-target_os", platform_name,
             "-target_arch", arch_name,
             "-arch", host_arch_name,


### PR DESCRIPTION
Use whatever flags already are baked into the SuperPMI collection.