### PR TITLE
[arm64] Addressing modes for SIMD

### DIFF
--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -367,8 +367,10 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
             switch (intrin.numOperands)
             {
                 case 1:
-                    if (intrin.op1->isContained() && (ins == INS_ld1))
+                    if (intrin.op1->isContained())
                     {
+                        assert(ins == INS_ld1);
+
                         // Emit 'ldr target, [base, index]'
                         GenTreeAddrMode* lea = intrin.op1->AsAddrMode();
                         assert(lea->GetScale() == 1);

--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -367,7 +367,19 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
             switch (intrin.numOperands)
             {
                 case 1:
-                    GetEmitter()->emitIns_R_R(ins, emitSize, targetReg, op1Reg, opt);
+                    if (intrin.op1->isContained() && (ins == INS_ld1))
+                    {
+                        // Emit 'ldr target, [base, index]'
+                        GenTreeAddrMode* lea = intrin.op1->AsAddrMode();
+                        assert(lea->GetScale() == 1);
+                        assert(lea->Offset() == 0);
+                        GetEmitter()->emitIns_R_R_R(INS_ldr, emitSize, targetReg, lea->Base()->GetRegNum(),
+                                                    lea->Index()->GetRegNum());
+                    }
+                    else
+                    {
+                        GetEmitter()->emitIns_R_R(ins, emitSize, targetReg, op1Reg, opt);
+                    }
                     break;
 
                 case 2:

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5304,10 +5304,10 @@ bool Lowering::TryCreateAddrMode(GenTree* addr, bool isContainable, GenTree* par
     {
         return false;
     }
-    if (((scale | offset) > 0) && varTypeIsSIMD(parent->TypeGet()))
+
+    if (((scale | offset) > 0) && parent->OperIsHWIntrinsic())
     {
-        // For now we only support unscaled index without the offset
-        // for SIMD loads
+        // For now we only support unscaled indices for SIMD loads/stores
         return false;
     }
 #endif

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5307,7 +5307,7 @@ bool Lowering::TryCreateAddrMode(GenTree* addr, bool isContainable, GenTree* par
 
     if (((scale | offset) > 0) && parent->OperIsHWIntrinsic())
     {
-        // For now we only support unscaled indices for SIMD loads/stores
+        // For now we only support unscaled indices for SIMD loads
         return false;
     }
 #endif

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5304,6 +5304,12 @@ bool Lowering::TryCreateAddrMode(GenTree* addr, bool isContainable, GenTree* par
     {
         return false;
     }
+    if (((scale | offset) > 0) && varTypeIsSIMD(parent->TypeGet()))
+    {
+        // For now we only support unscaled index without the offset
+        // for SIMD loads
+        return false;
+    }
 #endif
 
     if (scale == 0)

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2070,15 +2070,15 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                 unreached();
         }
     }
-    else if (intrin.id == NI_AdvSimd_LoadVector128)
+    else if ((intrin.id == NI_AdvSimd_LoadVector128) || (intrin.id == NI_AdvSimd_LoadVector64))
     {
         assert(intrin.numOperands == 1);
+        assert(HWIntrinsicInfo::lookupCategory(intrin.id) == HW_Category_MemoryLoad);
 
         GenTree* addr = node->Op(1);
         if (TryCreateAddrMode(addr, true, node) && IsSafeToContainMem(node, addr))
         {
             assert(addr->OperIs(GT_LEA));
-            assert(IsSafeToContainMem(node, addr));
             MakeSrcContained(node, addr);
         }
     }

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2070,6 +2070,18 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                 unreached();
         }
     }
+    else if (intrin.id == NI_AdvSimd_LoadVector128)
+    {
+        assert(intrin.numOperands == 1);
+
+        GenTree* addr = node->Op(1);
+        if (TryCreateAddrMode(addr, true, node) && IsSafeToContainMem(node, addr))
+        {
+            assert(addr->OperIs(GT_LEA));
+            assert(IsSafeToContainMem(node, addr));
+            MakeSrcContained(node, addr);
+        }
+    }
 }
 #endif // FEATURE_HW_INTRINSICS
 


### PR DESCRIPTION
This PR implements addressing modes for SIMD vectors on arm64 (for now only loads with unscaled indices)
Closes https://github.com/dotnet/runtime/issues/67435

Benchmark:
```csharp
static byte[] _array1 = new byte[100000]; 
static byte[] _array2 = new byte[100000]; 
 
[Benchmark] 
public bool SequenceEqual() => _array1.AsSpan().SequenceEqual(_array2);
```

|        Method |             Toolchain |     Mean |     Error |    StdDev | Ratio |
|-------------- |---------------------- |---------:|----------:|----------:|------:|
| SequenceEqual |    /Core_Root/corerun | 3.635 us | 0.0031 us | 0.0027 us |  1.00 |
| SequenceEqual | /Core_Root_pr/corerun | **2.546 us** | 0.0224 us | 0.0210 us |  0.70 |

codegen diff example: https://www.diffchecker.com/wACQMKBT (`SpanHelpers.SequenceEqual`)