### PR TITLE
Handle final elements in SpanHelpers.Contains for byte and char vectorized

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -341,26 +341,26 @@ namespace System
 
             uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             nuint offset = 0; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
-            nuint lengthToExamine = (nuint)(uint)length;
+            nuint lengthToExamine = (uint)length;
 
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
                 lengthToExamine = UnalignedCountVector(ref searchSpace);
             }
 
-        SequentialScan:
             while (lengthToExamine >= 8)
             {
                 lengthToExamine -= 8;
+                ref byte start = ref Unsafe.AddByteOffset(ref searchSpace, offset);
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 0) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 4) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 5) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 6) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 7))
+                if (uValue == Unsafe.AddByteOffset(ref start, 0) ||
+                    uValue == Unsafe.AddByteOffset(ref start, 1) ||
+                    uValue == Unsafe.AddByteOffset(ref start, 2) ||
+                    uValue == Unsafe.AddByteOffset(ref start, 3) ||
+                    uValue == Unsafe.AddByteOffset(ref start, 4) ||
+                    uValue == Unsafe.AddByteOffset(ref start, 5) ||
+                    uValue == Unsafe.AddByteOffset(ref start, 6) ||
+                    uValue == Unsafe.AddByteOffset(ref start, 7))
                 {
                     goto Found;
                 }
@@ -371,11 +371,12 @@ namespace System
             if (lengthToExamine >= 4)
             {
                 lengthToExamine -= 4;
+                ref byte start = ref Unsafe.AddByteOffset(ref searchSpace, offset);
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 0) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
+                if (uValue == Unsafe.AddByteOffset(ref start, 0) ||
+                    uValue == Unsafe.AddByteOffset(ref start, 1) ||
+                    uValue == Unsafe.AddByteOffset(ref start, 2) ||
+                    uValue == Unsafe.AddByteOffset(ref start, 3))
                 {
                     goto Found;
                 }
@@ -385,24 +386,26 @@ namespace System
 
             while (lengthToExamine > 0)
             {
-                lengthToExamine -= 1;
+                lengthToExamine--;
 
                 if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
 
-                offset += 1;
+                offset++;
             }
 
-            if (Vector.IsHardwareAccelerated && (offset < (nuint)(uint)length))
+            if (Vector.IsHardwareAccelerated && (offset < (uint)length))
             {
-                lengthToExamine = (((nuint)(uint)length - offset) & (nuint)~(Vector<byte>.Count - 1));
+                lengthToExamine = ((uint)length - offset) & (nuint)~(Vector<byte>.Count - 1);
 
-                Vector<byte> values = new Vector<byte>(value);
+                Vector<byte> zero = Vector<byte>.Zero;  // JIT won't hoist that vector outside the loop
+                Vector<byte> values = new(value);
+                Vector<byte> matches;
 
-                while (lengthToExamine > offset)
+                while (offset < lengthToExamine)
                 {
-                    var matches = Vector.Equals(values, LoadVector(ref searchSpace, offset));
-                    if (Vector<byte>.Zero.Equals(matches))
+                    matches = Vector.Equals(values, LoadVector(ref searchSpace, offset));
+                    if (zero.Equals(matches))
                     {
                         offset += (nuint)Vector<byte>.Count;
                         continue;
@@ -411,10 +414,17 @@ namespace System
                     goto Found;
                 }
 
-                if (offset < (nuint)(uint)length)
+                // The total length is at least Vector<byte>.Count, so instead of falling back to a 
+                // sequential scan for the remainder, we check the vector read from the end -- note: unaligned read necessary.
+                // We do this only if at least one element is left.
+                if (offset < (uint)length)
                 {
-                    lengthToExamine = ((nuint)(uint)length - offset);
-                    goto SequentialScan;
+                    offset = (uint)(length - Vector<byte>.Count);
+                    matches = Vector.Equals(values, LoadVector(ref searchSpace, offset));
+                    if (!zero.Equals(matches))
+                    {
+                        goto Found;
+                    }
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -398,14 +398,13 @@ namespace System
             {
                 lengthToExamine = ((uint)length - offset) & (nuint)~(Vector<byte>.Count - 1);
 
-                Vector<byte> zero = Vector<byte>.Zero;  // JIT won't hoist that vector outside the loop
                 Vector<byte> values = new(value);
                 Vector<byte> matches;
 
                 while (offset < lengthToExamine)
                 {
                     matches = Vector.Equals(values, LoadVector(ref searchSpace, offset));
-                    if (zero.Equals(matches))
+                    if (matches == Vector<byte>.Zero)
                     {
                         offset += (nuint)Vector<byte>.Count;
                         continue;
@@ -421,7 +420,7 @@ namespace System
                 {
                     offset = (uint)(length - Vector<byte>.Count);
                     matches = Vector.Equals(values, LoadVector(ref searchSpace, offset));
-                    if (!zero.Equals(matches))
+                    if (matches != Vector<byte>.Zero)
                     {
                         goto Found;
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -414,7 +414,7 @@ namespace System
                     goto Found;
                 }
 
-                // The total length is at least Vector<byte>.Count, so instead of falling back to a 
+                // The total length is at least Vector<byte>.Count, so instead of falling back to a
                 // sequential scan for the remainder, we check the vector read from the end -- note: unaligned read necessary.
                 // We do this only if at least one element is left.
                 if (offset < (uint)length)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -428,83 +428,89 @@ namespace System
 
             fixed (char* pChars = &searchSpace)
             {
-                char* pCh = pChars;
-                char* pEndCh = pCh + length;
+                nuint offset = 0; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
+                nuint lengthToExamine = (uint)length;
 
                 if (Vector.IsHardwareAccelerated && length >= Vector<ushort>.Count * 2)
                 {
                     // Figure out how many characters to read sequentially until we are vector aligned
                     // This is equivalent to:
-                    //         unaligned = ((int)pCh % Unsafe.SizeOf<Vector<ushort>>()) / elementsPerByte
+                    //         unaligned = ((int)pCh % Unsafe.SizeOf<Vector<ushort>>()) / ElementsPerByte
                     //         length = (Vector<ushort>.Count - unaligned) % Vector<ushort>.Count
-                    const int elementsPerByte = sizeof(ushort) / sizeof(byte);
-                    int unaligned = ((int)pCh & (Unsafe.SizeOf<Vector<ushort>>() - 1)) / elementsPerByte;
-                    length = (Vector<ushort>.Count - unaligned) & (Vector<ushort>.Count - 1);
+                    const int ElementsPerByte = sizeof(ushort) / sizeof(byte);
+                    int unaligned = (int)((uint)((int)pChars & (Unsafe.SizeOf<Vector<ushort>>() - 1)) / ElementsPerByte);
+                    lengthToExamine = (uint)((Vector<ushort>.Count - unaligned) & (Vector<ushort>.Count - 1));
                 }
 
-        SequentialScan:
-                while (length >= 4)
+                while (lengthToExamine >= 4)
                 {
-                    length -= 4;
+                    lengthToExamine -= 4;
+                    char* pStart = pChars + offset;
 
-                    if (value == *pCh ||
-                        value == *(pCh + 1) ||
-                        value == *(pCh + 2) ||
-                        value == *(pCh + 3))
+                    if (value == pStart[0] ||
+                        value == pStart[1] ||
+                        value == pStart[2] ||
+                        value == pStart[3])
                     {
                         goto Found;
                     }
 
-                    pCh += 4;
+                    offset += 4;
                 }
 
-                while (length > 0)
+                while (lengthToExamine > 0)
                 {
-                    length--;
+                    lengthToExamine--;
 
-                    if (value == *pCh)
+                    if (value == pChars[offset])
                         goto Found;
 
-                    pCh++;
+                    offset++;
                 }
 
                 // We get past SequentialScan only if IsHardwareAccelerated is true. However, we still have the redundant check to allow
-                // the JIT to see that the code is unreachable and eliminate it when the platform does not have hardware accelerated.
-                if (Vector.IsHardwareAccelerated && pCh < pEndCh)
+                // the JIT to see that the code is unreachable and eliminate it when the platform does not have hardware acceleration.
+                if (Vector.IsHardwareAccelerated && (offset < (uint)length))
                 {
                     // Get the highest multiple of Vector<ushort>.Count that is within the search space.
                     // That will be how many times we iterate in the loop below.
-                    // This is equivalent to: length = Vector<ushort>.Count * ((int)(pEndCh - pCh) / Vector<ushort>.Count)
-                    length = (int)((pEndCh - pCh) & ~(Vector<ushort>.Count - 1));
+                    // This is equivalent to: lengthToExamine = Vector<ushort>.Count + ((uint)length - offset) / Vector<ushort>.Count)
+                    lengthToExamine = ((uint)length - offset) & (nuint)~(Vector<ushort>.Count - 1);
 
-                    // Get comparison Vector
-                    Vector<ushort> vComparison = new Vector<ushort>(value);
+                    Vector<ushort> zero = Vector<ushort>.Zero;  // JIT won't hoist that vector outside the loop
+                    Vector<ushort> values = new(value);
+                    Vector<ushort> matches;
 
-                    while (length > 0)
+                    while (offset < lengthToExamine)
                     {
                         // Using Unsafe.Read instead of ReadUnaligned since the search space is pinned and pCh is always vector aligned
-                        Debug.Assert(((int)pCh & (Unsafe.SizeOf<Vector<ushort>>() - 1)) == 0);
-                        Vector<ushort> vMatches = Vector.Equals(vComparison, Unsafe.Read<Vector<ushort>>(pCh));
-                        if (Vector<ushort>.Zero.Equals(vMatches))
+                        Debug.Assert(((int)(pChars + offset) % Unsafe.SizeOf<Vector<ushort>>()) == 0);
+                        matches = Vector.Equals(values, Unsafe.Read<Vector<ushort>>(pChars + offset));
+                        if (zero.Equals(matches))
                         {
-                            pCh += Vector<ushort>.Count;
-                            length -= Vector<ushort>.Count;
+                            offset += (nuint)Vector<ushort>.Count;
                             continue;
                         }
 
                         goto Found;
                     }
 
-                    if (pCh < pEndCh)
+                    // The total length is at least Vector<ushort>.Count, so instead of falling back to a 
+                    // sequential scan for the remainder, we check the vector read from the end -- note: unaligned read necessary.
+                    // We do this only if at least one element is left.
+                    if (offset < (uint)length)
                     {
-                        length = (int)(pEndCh - pCh);
-                        goto SequentialScan;
+                        matches = Vector.Equals(values, Unsafe.ReadUnaligned<Vector<ushort>>(pChars + (uint)length - (uint)Vector<ushort>.Count));
+                        if (!zero.Equals(matches))
+                        {
+                            goto Found;
+                        }
                     }
                 }
 
                 return false;
 
-        Found:
+            Found:
                 return true;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -477,7 +477,6 @@ namespace System
                     // This is equivalent to: lengthToExamine = Vector<ushort>.Count + ((uint)length - offset) / Vector<ushort>.Count)
                     lengthToExamine = ((uint)length - offset) & (nuint)~(Vector<ushort>.Count - 1);
 
-                    Vector<ushort> zero = Vector<ushort>.Zero;  // JIT won't hoist that vector outside the loop
                     Vector<ushort> values = new(value);
                     Vector<ushort> matches;
 
@@ -486,7 +485,7 @@ namespace System
                         // Using Unsafe.Read instead of ReadUnaligned since the search space is pinned and pCh is always vector aligned
                         Debug.Assert(((int)(pChars + offset) % Unsafe.SizeOf<Vector<ushort>>()) == 0);
                         matches = Vector.Equals(values, Unsafe.Read<Vector<ushort>>(pChars + offset));
-                        if (zero.Equals(matches))
+                        if (matches == Vector<ushort>.Zero)
                         {
                             offset += (nuint)Vector<ushort>.Count;
                             continue;
@@ -501,7 +500,7 @@ namespace System
                     if (offset < (uint)length)
                     {
                         matches = Vector.Equals(values, Unsafe.ReadUnaligned<Vector<ushort>>(pChars + (uint)length - (uint)Vector<ushort>.Count));
-                        if (!zero.Equals(matches))
+                        if (matches != Vector<ushort>.Zero)
                         {
                             goto Found;
                         }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -388,7 +388,7 @@ namespace System
 
                 while (minLength >= (i + (nuint)(sizeof(nuint) / sizeof(char))))
                 {
-                    if (Unsafe.ReadUnaligned<nuint> (ref Unsafe.As<char, byte>(ref Unsafe.Add(ref first, (nint)i))) !=
+                    if (Unsafe.ReadUnaligned<nuint>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref first, (nint)i))) !=
                         Unsafe.ReadUnaligned<nuint>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref second, (nint)i))))
                     {
                         break;
@@ -495,7 +495,7 @@ namespace System
                         goto Found;
                     }
 
-                    // The total length is at least Vector<ushort>.Count, so instead of falling back to a 
+                    // The total length is at least Vector<ushort>.Count, so instead of falling back to a
                     // sequential scan for the remainder, we check the vector read from the end -- note: unaligned read necessary.
                     // We do this only if at least one element is left.
                     if (offset < (uint)length)


### PR DESCRIPTION
## Description

Let's assume we have a `searchSpace` of length `(n + 1) * Vector<T>.Count - k`, where `T` is either `byte` or `char`, and `k in (0, Vector<T>.Count)`.
So current implementation -- ignoring alignment for a moment -- can perform `n` vectorized operations, then falls back to sequential processing of the remaining `Vector<T>.Count - k` elements.

In numbers for byte, AVX2, n = 2, and k = 1:
```
Vector<byte>.Count = 32
length     = 95
vectorized = 64
sequential = 31
```
So as ratio there are `(Vector<T>.Count - k) / (n * Vector<T>.Count)` elements that need to processed sequential.
The worst case is for `k = 1` and small `n`, i.e. for AVX2 and `k = 1` 31 elements need to be processed sequential.

The proposed change avoids the sequential processing of the remaining elements by reading a final vector from the end of the `searchSpace`.
When exiting the standard vectorized loop, we know that the `searchSpace` is at least `Vector<T>.Count` long, so it is safe to read from that end, and the operation is idempotent too.
Thus in total we do `n + 1` vectorized operations.

(Note: the same / similar approach is used in https://github.com/dotnet/runtime/pull/67049, and some other places where idempotency can be used (I commented quite a few times on this :wink:))

## Benchmark results

### Notes

* JIT doesn't hoist `Vector<T>.Zero` outside the loop, this is done manually with this PR and that's why for length 64 (byte) and 32 (char) a speedup is shown
* for length 95 (byte) and 47 (char) the described effect is most visible, as this is the worst case, meaning most elements were processed sequential before this PR
* by not jumping back to the sequential path quite a lot of comparisons get saved too, resulting in a more streamlined and predicatable instruction-flow

For the benchmarks the `searchSpace` is aligned to 32 bytes, to have reproducable results.

<details>
  <summary>machine info</summary>

``` ini
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1586 (21H1/May2021Update)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET SDK=7.0.100-preview.4.22181.7
  [Host]     : .NET 7.0.0 (7.0.22.17907), X64 RyuJIT
  DefaultJob : .NET 7.0.0 (7.0.22.17907), X64 RyuJIT
```
</details>

### bool Contains(ref byte searchSpace, byte value, int length)

```
|  Method | Length |      Mean |     Error |    StdDev | Ratio |
|-------- |------- |----------:|----------:|----------:|------:|
| Default |     63 | 14.623 ns | 0.3486 ns | 0.9946 ns |  1.00 |
|      PR |     63 | 14.479 ns | 0.2283 ns | 0.2135 ns |  0.99 |
|         |        |           |           |           |       |
| Default |     64 |  4.419 ns | 0.1277 ns | 0.1790 ns |  1.00 |
|      PR |     64 |  3.963 ns | 0.0494 ns | 0.0462 ns |  0.87 |
|         |        |           |           |           |       |
| Default |     65 |  6.412 ns | 0.1566 ns | 0.1608 ns |  1.00 |
|      PR |     65 |  4.469 ns | 0.0229 ns | 0.0203 ns |  0.70 |
|         |        |           |           |           |       |
| Default |     95 | 11.318 ns | 0.1033 ns | 0.0966 ns |  1.00 |
|      PR |     95 |  4.502 ns | 0.0543 ns | 0.0508 ns |  0.40 |
|         |        |           |           |           |       |
| Default |    100 |  8.343 ns | 0.1312 ns | 0.1096 ns |  1.00 |
|      PR |    100 |  5.246 ns | 0.1376 ns | 0.1287 ns |  0.63 |
```

### bool Contains(ref char searchSpace, char value, int length)

```
|  Method | Length |      Mean |     Error |    StdDev | Ratio |
|-------- |------- |----------:|----------:|----------:|------:|
| Default |     31 | 10.349 ns | 0.2485 ns | 0.6325 ns |  1.00 |
|      PR |     31 | 10.232 ns | 0.2426 ns | 0.5998 ns |  0.99 |
|         |        |           |           |           |       |
| Default |     32 |  8.498 ns | 0.1741 ns | 0.1454 ns |  1.00 |
|      PR |     32 |  6.177 ns | 0.1473 ns | 0.1967 ns |  0.71 |
|         |        |           |           |           |       |
| Default |     33 |  8.751 ns | 0.2081 ns | 0.1946 ns |  1.00 |
|      PR |     33 |  4.655 ns | 0.1279 ns | 0.1313 ns |  0.53 |
|         |        |           |           |           |       |
| Default |     47 |  9.665 ns | 0.2301 ns | 0.3373 ns |  1.00 |
|      PR |     47 |  4.563 ns | 0.0421 ns | 0.0374 ns |  0.46 |
|         |        |           |           |           |       |
| Default |    100 |  9.096 ns | 0.1002 ns | 0.0937 ns |  1.00 |
|      PR |    100 |  8.182 ns | 0.1001 ns | 0.0836 ns |  0.90 |
```

## Machine code (x64)

<details>
  <summary>SpanHelpers.Contains(byte)</summary>

```assembly
; SpanHelpersContainsByteBenchmark.Default()
       mov       rdx,[rcx+8]
       movzx     eax,byte ptr [rcx+14]
       mov       r8d,[rcx+10]
       mov       rcx,rdx
       mov       edx,eax
       jmp       qword ptr [7FFB35F51420]
; Total bytes of code 23

; SpanHelpersContainsByteBenchmark.Contains(Byte ByRef, Byte, Int32)
       vzeroupper
       movzx     eax,dl
       mov       edx,eax
       xor       r9d,r9d
       mov       r10d,r8d
       mov       r11,r10
       cmp       r8d,40
       jl        short M01_L00
       mov       r11,rcx
       and       r11,1F
       neg       r11
       add       r11,20
       and       r11,1F
M01_L00:
       cmp       r11,8
       jb        near ptr M01_L02
M01_L01:
       add       r11,0FFFFFFFFFFFFFFF8
       movzx     r8d,byte ptr [rcx+r9]
       cmp       r8d,edx
       je        near ptr M01_L09
       movzx     r8d,byte ptr [rcx+r9+1]
       cmp       r8d,edx
       je        near ptr M01_L09
       movzx     r8d,byte ptr [rcx+r9+2]
       cmp       r8d,edx
       je        near ptr M01_L09
       movzx     r8d,byte ptr [rcx+r9+3]
       cmp       r8d,edx
       je        near ptr M01_L09
       movzx     r8d,byte ptr [rcx+r9+4]
       cmp       r8d,edx
       je        near ptr M01_L09
       movzx     r8d,byte ptr [rcx+r9+5]
       cmp       r8d,edx
       je        near ptr M01_L09
       movzx     r8d,byte ptr [rcx+r9+6]
       cmp       r8d,edx
       je        near ptr M01_L09
       movzx     r8d,byte ptr [rcx+r9+7]
       cmp       r8d,edx
       je        near ptr M01_L09
       add       r9,8
       cmp       r11,8
       jae       near ptr M01_L01
M01_L02:
       cmp       r11,4
       jb        short M01_L03
       add       r11,0FFFFFFFFFFFFFFFC
       movzx     r8d,byte ptr [rcx+r9]
       cmp       r8d,edx
       je        near ptr M01_L09
       movzx     r8d,byte ptr [rcx+r9+1]
       cmp       r8d,edx
       je        near ptr M01_L09
       movzx     r8d,byte ptr [rcx+r9+2]
       cmp       r8d,edx
       je        near ptr M01_L09
       movzx     r8d,byte ptr [rcx+r9+3]
       cmp       r8d,edx
       je        near ptr M01_L09
       add       r9,4
M01_L03:
       test      r11,r11
       je        short M01_L05
M01_L04:
       dec       r11
       movzx     r8d,byte ptr [rcx+r9]
       cmp       r8d,edx
       je        short M01_L09
       inc       r9
       test      r11,r11
       jne       short M01_L04
M01_L05:
       cmp       r9,r10
       jae       short M01_L08
       mov       r11,r10
       sub       r11,r9
       and       r11,0FFFFFFFFFFFFFFE0
       imul      r8d,eax,1010101
       vmovd     xmm0,r8d
       vpbroadcastd ymm0,xmm0
       cmp       r11,r9
       jbe       short M01_L07
       nop       dword ptr [rax]
       nop       dword ptr [rax+rax]
M01_L06:
       vpcmpeqb  ymm1,ymm0,[rcx+r9]
       vxorps    ymm2,ymm2,ymm2
       vpxor     ymm1,ymm2,ymm1
       vptest    ymm1,ymm1
       jne       short M01_L09
       add       r9,20
       cmp       r11,r9
       ja        short M01_L06
M01_L07:
       cmp       r9,r10
       jae       short M01_L08
       mov       r11,r10
       sub       r11,r9
       jmp       near ptr M01_L00
M01_L08:
       xor       eax,eax
       vzeroupper
       ret
M01_L09:
       mov       eax,1
       vzeroupper
       ret
; Total bytes of code 397
```

```assembly
; SpanHelpersContainsByteBenchmark.PR()
       mov       rdx,[rcx+8]
       movzx     eax,byte ptr [rcx+14]
       mov       r8d,[rcx+10]
       mov       rcx,rdx
       mov       edx,eax
       jmp       qword ptr [7FFB35F61438]
; Total bytes of code 23

; SpanHelpersContainsByteBenchmark.Contains_PR(Byte ByRef, Byte, Int32)
       push      rdi
       push      rsi
       vzeroupper
       movzx     eax,dl
       mov       edx,eax
       xor       r9d,r9d
       mov       r10d,r8d
       mov       r11,r10
       cmp       r8d,40
       jl        short M01_L00
       mov       r11,rcx
       and       r11,1F
       neg       r11
       add       r11,20
       and       r11,1F
M01_L00:
       cmp       r11,8
       jb        short M01_L02
       nop       dword ptr [rax]
M01_L01:
       add       r11,0FFFFFFFFFFFFFFF8
       lea       rsi,[rcx+r9]
       movzx     edi,byte ptr [rsi]
       cmp       edx,edi
       je        near ptr M01_L09
       movzx     edi,byte ptr [rsi+1]
       cmp       edx,edi
       je        near ptr M01_L09
       movzx     edi,byte ptr [rsi+2]
       cmp       edx,edi
       je        near ptr M01_L09
       movzx     edi,byte ptr [rsi+3]
       cmp       edx,edi
       je        near ptr M01_L09
       movzx     edi,byte ptr [rsi+4]
       cmp       edx,edi
       je        near ptr M01_L09
       movzx     edi,byte ptr [rsi+5]
       cmp       edx,edi
       je        near ptr M01_L09
       movzx     edi,byte ptr [rsi+6]
       cmp       edx,edi
       je        near ptr M01_L09
       movzx     esi,byte ptr [rsi+7]
       cmp       edx,esi
       je        near ptr M01_L09
       add       r9,8
       cmp       r11,8
       jae       short M01_L01
M01_L02:
       cmp       r11,4
       jb        short M01_L03
       add       r11,0FFFFFFFFFFFFFFFC
       lea       rsi,[rcx+r9]
       movzx     edi,byte ptr [rsi]
       cmp       edx,edi
       je        near ptr M01_L09
       movzx     edi,byte ptr [rsi+1]
       cmp       edx,edi
       je        near ptr M01_L09
       movzx     edi,byte ptr [rsi+2]
       cmp       edx,edi
       je        near ptr M01_L09
       movzx     esi,byte ptr [rsi+3]
       cmp       edx,esi
       je        near ptr M01_L09
       add       r9,4
M01_L03:
       test      r11,r11
       je        short M01_L05
       nop       dword ptr [rax+rax]
M01_L04:
       dec       r11
       movzx     esi,byte ptr [rcx+r9]
       cmp       esi,edx
       je        short M01_L09
       inc       r9
       test      r11,r11
       jne       short M01_L04
M01_L05:
       cmp       r9,r10
       jae       short M01_L08
       mov       r11,r10
       sub       r11,r9
       and       r11,0FFFFFFFFFFFFFFE0
       vxorps    ymm0,ymm0,ymm0
       imul      eax,1010101
       vmovd     xmm1,eax
       vpbroadcastd ymm1,xmm1
       cmp       r9,r11
       jae       short M01_L07
M01_L06:
       vpcmpeqb  ymm2,ymm1,[rcx+r9]
       vpxor     ymm2,ymm0,ymm2
       vptest    ymm2,ymm2
       jne       short M01_L09
       add       r9,20
       cmp       r9,r11
       jb        short M01_L06
M01_L07:
       cmp       r9,r10
       jae       short M01_L08
       add       r8d,0FFFFFFE0
       mov       r9d,r8d
       vpcmpeqb  ymm2,ymm1,[rcx+r9]
       vpxor     ymm0,ymm0,ymm2
       vptest    ymm0,ymm0
       jne       short M01_L09
M01_L08:
       xor       eax,eax
       vzeroupper
       pop       rsi
       pop       rdi
       ret
M01_L09:
       mov       eax,1
       vzeroupper
       pop       rsi
       pop       rdi
       ret
; Total bytes of code 389
```
</details>

<details>
  <summary>SpanHelpers.Contains(char)</summary>

```assembly
; SpanHelpersContainsCharBenchmark.Default()
       mov       rdx,[rcx+8]
       movzx     eax,word ptr [rcx+14]
       mov       r8d,[rcx+10]
       mov       rcx,rdx
       mov       edx,eax
       jmp       qword ptr [7FFB35F51420]
; Total bytes of code 23

; SpanHelpersContainsCharBenchmark.Contains(Char ByRef, Char, Int32)
       push      rax
       vzeroupper
       xor       eax,eax
       mov       [rsp],rax
       mov       [rsp],rcx
       movsxd    rax,r8d
       lea       r9,[rcx+rax*2]
       cmp       r8d,20
       jl        short M01_L00
       mov       r8d,ecx
       and       r8d,1F
       mov       eax,r8d
       shr       eax,1F
       add       eax,r8d
       sar       eax,1
       mov       r8d,eax
       neg       r8d
       add       r8d,10
       and       r8d,0F
M01_L00:
       cmp       r8d,4
       jl        short M01_L02
       movzx     r10d,dx
M01_L01:
       add       r8d,0FFFFFFFC
       movzx     eax,word ptr [rcx]
       cmp       r10d,eax
       je        near ptr M01_L08
       movzx     eax,word ptr [rcx+2]
       cmp       r10d,eax
       je        near ptr M01_L08
       movzx     eax,word ptr [rcx+4]
       cmp       r10d,eax
       je        near ptr M01_L08
       movzx     eax,word ptr [rcx+6]
       cmp       r10d,eax
       je        near ptr M01_L08
       add       rcx,8
       cmp       r8d,4
       jge       short M01_L01
M01_L02:
       test      r8d,r8d
       jle       short M01_L04
       movzx     r10d,dx
       nop
M01_L03:
       dec       r8d
       movzx     eax,word ptr [rcx]
       cmp       r10d,eax
       je        near ptr M01_L08
       add       rcx,2
       test      r8d,r8d
       jg        short M01_L03
M01_L04:
       cmp       rcx,r9
       jae       short M01_L07
       mov       r8,r9
       sub       r8,rcx
       mov       rax,r8
       shr       rax,3F
       add       rax,r8
       sar       rax,1
       mov       r8d,eax
       and       r8d,0FFFFFFF0
       movzx     r10d,dx
       imul      eax,r10d,10001
       vmovd     xmm0,eax
       vpbroadcastd ymm0,xmm0
       test      r8d,r8d
       jle       short M01_L06
M01_L05:
       vpcmpeqw  ymm1,ymm0,[rcx]
       vxorps    ymm2,ymm2,ymm2
       vpxor     ymm1,ymm2,ymm1
       vptest    ymm1,ymm1
       jne       short M01_L08
       add       rcx,20
       add       r8d,0FFFFFFF0
       test      r8d,r8d
       jg        short M01_L05
M01_L06:
       cmp       rcx,r9
       jae       short M01_L07
       mov       r8,r9
       sub       r8,rcx
       mov       rax,r8
       shr       rax,3F
       add       rax,r8
       sar       rax,1
       mov       r8d,eax
       jmp       near ptr M01_L00
M01_L07:
       xor       eax,eax
       vzeroupper
       add       rsp,8
       ret
M01_L08:
       mov       eax,1
       vzeroupper
       add       rsp,8
       ret
; Total bytes of code 311
```

```assembly
; SpanHelpersContainsCharBenchmark.PR()
       mov       rdx,[rcx+8]
       movzx     eax,word ptr [rcx+14]
       mov       r8d,[rcx+10]
       mov       rcx,rdx
       mov       edx,eax
       jmp       qword ptr [7FFB35F51438]
; Total bytes of code 23

; SpanHelpersContainsCharBenchmark.Contains_PR(Char ByRef, Char, Int32)
       push      rsi
       sub       rsp,10
       vzeroupper
       xor       eax,eax
       mov       [rsp+8],rax
       mov       [rsp+8],rcx
       xor       r9d,r9d
       mov       r10d,r8d
       mov       r11,r10
       cmp       r8d,20
       jl        short M01_L00
       mov       r11d,ecx
       and       r11d,1F
       shr       r11d,1
       mov       eax,r11d
       neg       eax
       add       eax,10
       and       eax,0F
       mov       r11d,eax
M01_L00:
       cmp       r11,4
       jb        short M01_L02
       movzx     r8d,dx
M01_L01:
       add       r11,0FFFFFFFFFFFFFFFC
       lea       rax,[rcx+r9*2]
       movzx     esi,word ptr [rax]
       cmp       r8d,esi
       je        near ptr M01_L08
       movzx     esi,word ptr [rax+2]
       cmp       r8d,esi
       je        near ptr M01_L08
       movzx     esi,word ptr [rax+4]
       cmp       r8d,esi
       je        near ptr M01_L08
       movzx     eax,word ptr [rax+6]
       cmp       r8d,eax
       je        near ptr M01_L08
       add       r9,4
       cmp       r11,4
       jae       short M01_L01
M01_L02:
       test      r11,r11
       je        short M01_L04
       movzx     r8d,dx
       nop       dword ptr [rax+rax]
       nop       dword ptr [rax+rax]
M01_L03:
       dec       r11
       movzx     eax,word ptr [rcx+r9*2]
       cmp       eax,r8d
       je        near ptr M01_L08
       inc       r9
       test      r11,r11
       jne       short M01_L03
M01_L04:
       cmp       r9,r10
       jae       short M01_L07
       mov       r11,r10
       sub       r11,r9
       and       r11,0FFFFFFFFFFFFFFF0
       vxorps    ymm0,ymm0,ymm0
       movzx     r8d,dx
       imul      eax,r8d,10001
       vmovd     xmm1,eax
       vpbroadcastd ymm1,xmm1
       cmp       r9,r11
       jae       short M01_L06
       nop       word ptr [rax+rax]
M01_L05:
       vpcmpeqw  ymm2,ymm1,[rcx+r9*2]
       vpxor     ymm2,ymm0,ymm2
       vptest    ymm2,ymm2
       jne       short M01_L08
       add       r9,10
       cmp       r9,r11
       jb        short M01_L05
M01_L06:
       cmp       r9,r10
       jae       short M01_L07
       vpcmpeqw  ymm2,ymm1,[rcx+r10*2+0FFE0]
       vpxor     ymm0,ymm0,ymm2
       vptest    ymm0,ymm0
       jne       short M01_L08
M01_L07:
       xor       eax,eax
       vzeroupper
       add       rsp,10
       pop       rsi
       ret
M01_L08:
       mov       eax,1
       vzeroupper
       add       rsp,10
       pop       rsi
       ret
; Total bytes of code 314
```
</details>

---

:point_right: If this looks good, I'd like to look into IndexOf, etc. too.
