### PR TITLE
Skip check of Notepad title on Win 11

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -1314,6 +1314,11 @@ namespace System.Diagnostics.Tests
                 return; // On Server Core, notepad exists but does not return a title
             }
 
+            if (PlatformDetection.IsWindows10Version22000OrGreater)
+            {
+                return; // On Windows 11, we aren't able to get the title for some reason; Windows 10 coverage should be sufficient
+            }
+
             // On some Windows versions, the file extension is not included in the title
             string expected = Path.GetFileNameWithoutExtension(filename);
 


### PR DESCRIPTION
Fix #67408 

Consistently and only failing to get the window title on Windows 11. We've tried to "harden" this before with retries. Remove the title check on Windows 11, leaving only the check that the process successfully started.