### PR TITLE
Tests for altered references for SignedXml

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Reference.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Reference.cs
@@ -273,7 +273,7 @@ namespace System.Security.Cryptography.Xml
                                 ? transformElement.OwnerDocument
                                 : SignedXml.GetIdElement(transformElement.OwnerDocument, Utils.GetIdFromLocalUri(_uri, out bool _));
 
-                            XmlNodeList signatureList = referenceTarget.SelectNodes(".//ds:Signature", nsm);
+                            XmlNodeList signatureList = referenceTarget?.SelectNodes(".//ds:Signature", nsm);
                             if (signatureList != null)
                             {
                                 int position = 0;

--- a/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
@@ -1844,5 +1844,19 @@ namespace System.Security.Cryptography.Xml.Tests
 
             Assert.Equal(expected, subject.CheckSignature());
         }
+
+        [Theory]
+        [InlineData("a", "b")]
+        [InlineData("a", "nonexisting")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "SignedXml has been failing validation on nested signatures all the time with .NET Framework and .NET (Core) up to .NET 6. This test was added together with a fix for .NET 7.")]
+        public void CheckSignatureHandlesIncorrectOrTamperedReferenceWithMultipleEnvelopedSignatures(
+            string signatureParent, string newReference)
+        {
+            var tampered = multipleSignaturesXml.Replace($"URI=\"#{signatureParent}", $"URI=\"#{newReference}");
+
+            SignedXml subject = CreateSubjectForMultipleEnvelopedSignatures(tampered, signatureParent);
+
+            Assert.False(subject.CheckSignature());
+        }
     }
 }


### PR DESCRIPTION
Fix Null ref on non-existing reference. This is in line with how the old code, before #67010 worked, it returned false on CheckSignature but didn't throw on load.