### PR TITLE
Skip building crossgen when running in source build

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <!-- Crossgen is not used for Mono, and does not currently create freebsd packages -->
-    <SkipBuild Condition="'$(RuntimeFlavor)' == 'Mono' or '$(DotNetBuildFromSource)' == 'true'">true</SkipBuild>
+    <SkipBuild Condition="'$(RuntimeFlavor)' == 'Mono' or '$(DotNetBuildFromSource)' == 'true' or '$(RuntimeIdentifier)' == 'freebsd-x64'">true</SkipBuild>
     <PlatformPackageType>ToolPack</PlatformPackageType>
     <SharedFrameworkName>$(SharedFrameworkName).Crossgen2</SharedFrameworkName>
     <PgoSuffix Condition="'$(PgoInstrument)' != ''">.PGO</PgoSuffix>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <!-- Crossgen is not used for Mono, and does not currently create freebsd packages -->
-    <SkipBuild Condition="'$(RuntimeFlavor)' == 'Mono' or '$(RuntimeIdentifier)' == 'freebsd-x64'">true</SkipBuild>
+    <SkipBuild Condition="'$(RuntimeFlavor)' == 'Mono' or '$(DotNetBuildFromSource)' == 'true'">true</SkipBuild>
     <PlatformPackageType>ToolPack</PlatformPackageType>
     <SharedFrameworkName>$(SharedFrameworkName).Crossgen2</SharedFrameworkName>
     <PgoSuffix Condition="'$(PgoInstrument)' != ''">.PGO</PgoSuffix>


### PR DESCRIPTION
~~I think skipping restore may help with https://github.com/dotnet/runtime/issues/67474, which appears to be some sort of race condition.~~

That didn't work. Changing the PR to disable crossgen build during source build