### PR TITLE
Fix handling of makeref/refvalue in generic code

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -827,12 +827,27 @@ namespace Internal.IL
         private void ImportRefAnyVal(int token)
         {
             _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.GetRefAny), "refanyval");
+            ImportTypedRefOperationDependencies(token, "refanyval");
         }
 
         private void ImportMkRefAny(int token)
         {
             _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.TypeHandleToRuntimeType), "mkrefany");
             _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.TypeHandleToRuntimeTypeHandle), "mkrefany");
+            ImportTypedRefOperationDependencies(token, "mkrefany");
+        }
+
+        private void ImportTypedRefOperationDependencies(int token, string reason)
+        {
+            var type = (TypeDesc)_methodIL.GetObject(token);
+            if (type.IsRuntimeDeterminedSubtype)
+            {
+                _dependencies.Add(GetGenericLookupHelper(ReadyToRunHelperId.TypeHandle, type), reason);
+            }
+            else
+            {
+                _dependencies.Add(_factory.ConstructedTypeSymbol(type), reason);
+            }
         }
 
         private void ImportLdToken(int token)

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
@@ -3204,7 +3204,7 @@ class Generics
             return __refvalue(typedRef, T);
         }
 
-        public static void Main()
+        public static void Run()
         {
             string classValue = "Hello";
             int structValue = 123;

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
@@ -46,6 +46,7 @@ class Generics
         TestRecursionThroughGenericLookups.Run();
         TestGvmLookupDependency.Run();
         TestInvokeMemberCornerCaseInGenerics.Run();
+        TestRefAny.Run();
 #if !CODEGEN_CPP
         TestNullableCasting.Run();
         TestVariantCasting.Run();
@@ -3189,6 +3190,30 @@ class Generics
             // Regression test for https://github.com/dotnet/runtime/issues/65612
             // This requires MethodTable for "Atom[]" - just make sure the compiler didn't crash and we can invoke
             typeof(Generic<>).MakeGenericType(s_atomType).InvokeMember("Method", BindingFlags.Public | BindingFlags.InvokeMethod | BindingFlags.Instance, null, s_instance, new object[] { new Atom() });
+        }
+    }
+
+    static class TestRefAny
+    {
+        static T TestAll<T>(ref T value, Type expectedType)
+        {
+            TypedReference typedRef = __makeref(value);
+            if (__reftype(typedRef) != expectedType)
+                throw new Exception();
+
+            return __refvalue(typedRef, T);
+        }
+
+        public static void Main()
+        {
+            string classValue = "Hello";
+            int structValue = 123;
+
+            if (TestAll(ref classValue, typeof(string)) != classValue)
+                throw new Exception();
+
+            if (TestAll(ref structValue, typeof(int)) != structValue)
+                throw new Exception();
         }
     }
 }


### PR DESCRIPTION
Found in Pri0 tests. We didn't have any coverage for TypedReference in smoke tests.