### PR TITLE
Make handling of invalid code more robust

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -263,6 +263,8 @@ namespace Internal.IL
             var runtimeDeterminedMethod = (MethodDesc)_methodIL.GetObject(token);
             var method = (MethodDesc)_canonMethodIL.GetObject(token);
 
+            _compilation.TypeSystemContext.EnsureLoadableMethod(method);
+
             _compilation.NodeFactory.MetadataManager.GetDependenciesDueToAccess(ref _dependencies, _compilation.NodeFactory, _canonMethodIL, method);
 
             if (method.IsRawPInvoke())


### PR DESCRIPTION
* Call `EnsureLoadableMethod` from scanner, same as we do in JitInterface.
* Make scan/compile diffing less sensitive to differences caused by invalid IL.