### PR TITLE
[HTTP/3] Reenable ResponseCancellation_ServerReceivesCancellation

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -679,7 +679,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalTheory(nameof(IsMsQuicSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/56194")]
         [InlineData(CancellationType.Dispose)]
         [InlineData(CancellationType.CancellationToken)]
         public async Task ResponseCancellation_ServerReceivesCancellation(CancellationType type)
@@ -701,7 +700,7 @@ namespace System.Net.Http.Functional.Tests
 
                 HttpRequestData request = await stream.ReadRequestDataAsync().ConfigureAwait(false);
 
-                int contentLength = 2*1024*1024;
+                int contentLength = 2 * 1024 * 1024;
                 var headers = new List<HttpHeaderData>();
                 headers.Append(new HttpHeaderData("Content-Length", contentLength.ToString(CultureInfo.InvariantCulture)));
 
@@ -715,7 +714,7 @@ namespace System.Net.Http.Functional.Tests
                 // We are asserting that PEER_RECEIVE_ABORTED would still arrive eventually
 
                 var ex = await Assert.ThrowsAsync<QuicStreamAbortedException>(() => SendDataForever(stream).WaitAsync(TimeSpan.FromSeconds(10)));
-                Assert.Equal((type == CancellationType.CancellationToken ? 268 : 0xffffffff), ex.ErrorCode);
+                Assert.Equal(268, ex.ErrorCode);
 
                 serverDone.Release();
             });


### PR DESCRIPTION
Since #57156 enforced sending RequestCancelled HTTP response code when disposing the stream, we no longer need to check for the 0xffffffff error code.

Fixes #56194