### PR TITLE
Don't pass --minimize to Xcode 13.3 dsymutil

### DIFF
--- a/eng/native/functions.cmake
+++ b/eng/native/functions.cmake
@@ -402,10 +402,9 @@ function(strip_symbols targetName outputFilename)
         OUTPUT_VARIABLE DSYMUTIL_HELP_OUTPUT
       )
 
+      set(DSYMUTIL_OPTS "--flat")
       if ("${DSYMUTIL_HELP_OUTPUT}" MATCHES "--minimize")
-        set(DSYMUTIL_OPTS "--flat --minimize")
-      else ()
-        set(DSYMUTIL_OPTS "--flat")
+        list(APPEND DSYMUTIL_OPTS "--minimize")
       endif ()
 
       add_custom_command(

--- a/eng/native/functions.cmake
+++ b/eng/native/functions.cmake
@@ -397,11 +397,22 @@ function(strip_symbols targetName outputFilename)
         set(strip_command)
       endif ()
 
+      execute_process(
+        COMMAND ${DSYMUTIL} --help
+        OUTPUT_VARIABLE DSYMUTIL_HELP_OUTPUT
+      )
+
+      if ("${DSYMUTIL_HELP_OUTPUT}" MATCHES "--minimize")
+        set(DSYMUTIL_OPTS "--flat --minimize")
+      else ()
+        set(DSYMUTIL_OPTS "--flat")
+      endif ()
+
       add_custom_command(
         TARGET ${targetName}
         POST_BUILD
         VERBATIM
-        COMMAND ${DSYMUTIL} --flat --minimize ${strip_source_file}
+        COMMAND ${DSYMUTIL} ${DSYMUTIL_OPTS} ${strip_source_file}
         COMMAND ${strip_command}
         COMMENT "Stripping symbols from ${strip_source_file} into file ${strip_destination_file}"
         )


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/66770

New xcode command line tools dropped support for the `--minimize` option (which
is now the default).

The related LLVM change is https://github.com/llvm/llvm-project/commit/5d07dc897707f877c45cab6c7e4b65dad7d3ff6d

Co-Authored-By: Kevin Jones <vcsjones@github.com>