### PR TITLE
Fix createdump on Unix platforms that do not implement process_vm_readv

### DIFF
--- a/src/coreclr/debug/createdump/crashinfounix.cpp
+++ b/src/coreclr/debug/createdump/crashinfounix.cpp
@@ -345,7 +345,7 @@ CrashInfo::ReadProcessMemory(void* address, void* buffer, size_t size, size_t* r
         *read = process_vm_readv(m_pid, &local, 1, &remote, 1, 0);
     }
 
-    if (!m_canUseProcVmReadSyscall || (*read == (size_t)-1 && errno == EPERM))
+    if (!m_canUseProcVmReadSyscall || (*read == (size_t)-1 && (errno == EPERM || errno == ENOSYS)))
 #endif
     {
         // If we've failed, avoid going through expensive syscalls


### PR DESCRIPTION
Some platforms, such as [gVisor](https://gvisor.dev/docs/user_guide/compatibility/linux/amd64/#process_vm_readv), are compatible with libcs that provide a `process_vm_readv` function, but only stub out the syscall and immediately return `ENOSYS`. This change allows `createdump` to fall back to `pread64` on those platforms.