### PR TITLE
Disable `Microsoft.Extensions.Hosting.WindowsServices.Tests` for

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/UseWindowsServiceTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/UseWindowsServiceTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting.Internal;
 using Xunit;

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/UseWindowsServiceTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/UseWindowsServiceTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.Hosting
 {
     public class UseWindowsServiceTests
     {
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
         public void DefaultsToOffOutsideOfService()
         {
             var host = new HostBuilder()

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -112,6 +112,11 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Drawing.Common\tests\System.Drawing.Common.Tests.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetOS)' != 'Windows'">
+    <!-- windows specific tests -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Hosting.WindowsServices/tests/Microsoft.Extensions.Hosting.WindowsServices.Tests.csproj" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetOS)' == 'Android'">
     <!-- Never going to run on Android -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.OpenSsl\tests\System.Security.Cryptography.OpenSsl.Tests.csproj" />


### PR DESCRIPTION
.. non-windows platforms. This breaks on non-windows platforms, for example, with wasm:

```
[17:25:27] fail: [FAIL] Microsoft.Extensions.Hosting.UseWindowsServiceTests.DefaultsToOffOutsideOfService
[17:25:27] info: Assert.IsType() Failure
[17:25:27] info: Expected: Microsoft.Extensions.Hosting.Internal.ConsoleLifetime
[17:25:27] info: Actual:   Microsoft.Extensions.Hosting.Internal.NullLifetime
[17:25:27] info:    at Microsoft.Extensions.Hosting.UseWindowsServiceTests.DefaultsToOffOutsideOfService()
[17:25:27] info:    at System.Reflection.RuntimeMethodInfo.InvokeWorker(Object , BindingFlags , Span`1 )
```

It was enabled in https://github.com/dotnet/runtime/pull/67528 .