### PR TITLE
[release/6.0] [infrastructure] Update Windows server queue

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -133,7 +133,7 @@ jobs:
               - (Windows.Server.Core.1909.Amd64.Open)windows.10.amd64.server20H2.open@mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-2004-helix-amd64-20200904200251-272704c
           - ${{ if ne(parameters.jobParameters.isFullMatrix, true) }}:
             - Windows.81.Amd64.Open
-            - Windows.10.Amd64.Server19H1.ES.Open
+            - Windows.10.Amd64.Server2022.ES.Open
             - Windows.11.Amd64.ClientPre.Open
             - ${{ if eq(parameters.jobParameters.testScope, 'outerloop') }}:
               - (Windows.Server.Core.1909.Amd64.Open)windows.10.amd64.server20H2.open@mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-2004-helix-amd64-20200904200251-272704c
@@ -158,7 +158,7 @@ jobs:
             - Windows.10.Amd64.Server20H2.Open
           - ${{ if ne(parameters.jobParameters.isFullMatrix, true) }}:
             - ${{ if eq(parameters.jobParameters.buildConfig, 'Release') }}:
-              - Windows.10.Amd64.Server19H1.ES.Open
+              - Windows.10.Amd64.Server2022.ES.Open
             - ${{ if eq(parameters.jobParameters.buildConfig, 'Debug') }}:
               - Windows.7.Amd64.Open
               - Windows.10.Amd64.Server20H2.Open


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/8740

A recent Arcade rollout deprecated the Windows.10.Amd64.Server19H1.ES.Open queue for Windows.10.Amd64.Server2022.ES.Open. All release/6.0 CI is failing due to this change. This patch updates the queue to the new one.