### PR TITLE
Fix in-process decoding of DateTime in EventSource

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1841,7 +1841,7 @@ namespace System.Diagnostics.Tracing
                         }
                         else if (typeCode == TypeCode.DateTime)
                         {
-                            decoded = *(DateTime*)dataPointer;
+                            decoded = DateTime.FromFileTimeUtc(*(long*)dataPointer);
                         }
                         else if (IntPtr.Size == 8 && dataType == typeof(IntPtr))
                         {

--- a/src/tests/tracing/eventlistener/EventListener.cs
+++ b/src/tests/tracing/eventlistener/EventListener.cs
@@ -15,6 +15,20 @@ namespace Tracing.Tests
 
         [Event(1)]
         internal void MathResult(int x, int y, int z, string formula) { this.WriteEvent(1, x, y, z, formula); }
+
+        [Event(2)]
+        internal void DateTimeEvent(DateTime dateTime) => WriteEvent(2, dateTime);
+
+
+        [NonEvent]  
+        private unsafe void WriteEvent(int eventId, DateTime dateTime)  
+        {
+            EventData* desc = stackalloc EventData[1];
+            long fileTime = dateTime.ToFileTimeUtc();
+            desc[0].DataPointer = (IntPtr)(&fileTime);
+            desc[0].Size = 8;
+            WriteEventCore(eventId, 1, desc);
+        }
     }
     
     internal sealed class SimpleEventListener : EventListener
@@ -23,6 +37,7 @@ namespace Tracing.Tests
         private readonly EventLevel _level;
         
         public int EventCount { get; private set; } = 0;
+        public DateTime DateObserved { get; private set; } = DateTime.MinValue;
 
         public SimpleEventListener(string targetSourceName, EventLevel level)
         {
@@ -41,13 +56,19 @@ namespace Tracing.Tests
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
-            EventCount++;
+            if (eventData.EventId == 2)
+            {
+                DateObserved = (DateTime)eventData.Payload[0];
+            }
+            else
+                EventCount++;
         }
     }
 
     class EventPipeSmoke
     {
         private static int messageIterations = 100;
+        private static readonly DateTime ThePast = DateTime.Now;
 
         static int Main(string[] args)
         {
@@ -68,10 +89,12 @@ namespace Tracing.Tests
                     
                     eventSource.MathResult(x, y, x+y, formula);
                 }
+                eventSource.DateTimeEvent(ThePast);
                 Console.WriteLine("\tEnd: Messaging.\n");
                 
                 Console.WriteLine($"\tEventListener received {listener.EventCount} event(s)\n");
-                pass = listener.EventCount == messageIterations;
+                Console.WriteLine($"\tEventListener received {listener.DateObserved} vs {ThePast}\n");
+                pass = listener.EventCount == messageIterations && ThePast == listener.DateObserved;
             }
 
             return pass ? 100 : -1;

--- a/src/tests/tracing/eventlistener/EventListener.cs
+++ b/src/tests/tracing/eventlistener/EventListener.cs
@@ -68,7 +68,7 @@ namespace Tracing.Tests
     class EventPipeSmoke
     {
         private static int messageIterations = 100;
-        private static readonly DateTime ThePast = DateTime.Now;
+        private static readonly DateTime ThePast = DateTime.UtcNow;
 
         static int Main(string[] args)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/61563

Will require backporting to release/6.0 since this is a regression from 5.0.

@MihaZupan root caused this issue succinctly in this comment: https://github.com/dotnet/runtime/issues/61563#issuecomment-1040146346

> @tommcdon it is a bug introduced by #52092 in .NET 6.0, but only affects in-process `EventListener`s.
>
> The difference is in how the serialized value (`long`) is de-serialized by `DecodeObjects`:
> - In 5.0, the `DateTime` would be [converted from a `long` back to a `DateTime` via `DateTime.FromFileTimeUtc`](https://github.com/dotnet/runtime/blob/2705fc02018f16cef2e99101cf8a58e16d26b692/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs#L1832-L1836)
> - In 6.0, the value is [interpreted as a `DateTime` directly](https://github.com/dotnet/runtime/blob/6dd808ff7ae62512330d2f111eb1f60f1ae40125/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs#L1840-L1843) (i.e. exact number of ticks)
> 
> Sadly this was not caught by tests since none of them uses `DateTime` with `WriteEventCore` - we are only testing the `varargs` overload.
>
> The fix here would be to change
https://github.com/dotnet/runtime/blob/a25aa6641b605f1ad28c75cddcfa204f8153abe3/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs#L1844
> to
> ```c#
> decoded = DateTime.FromFileTimeUtc(*(long*)dataPointer);
> ```
>
> -- MihaZupan