### PR TITLE
Disable deleting call counting stubs

### DIFF
--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -575,13 +575,11 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_HillClimbing_GainExponent,                    
 #define TC_CallCountThreshold (2)
 #define TC_CallCountingDelayMs (1)
 #define TC_DelaySingleProcMultiplier (2)
-#define TC_DeleteCallCountingStubsAfter (1)
 #else // !_DEBUG
 #define TC_BackgroundWorkerTimeoutMs (4000)
 #define TC_CallCountThreshold (30)
 #define TC_CallCountingDelayMs (100)
 #define TC_DelaySingleProcMultiplier (10)
-#define TC_DeleteCallCountingStubsAfter (4096)
 #endif // _DEBUG
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_TieredCompilation, W("TieredCompilation"), 1, "Enables tiered compilation")
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_TC_QuickJit, W("TC_QuickJit"), 1, "For methods that would be jitted, enable using quick JIT when appropriate.")
@@ -597,7 +595,7 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_TC_CallCountingDelayMs, W("TC_CallCountingDela
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_TC_DelaySingleProcMultiplier, W("TC_DelaySingleProcMultiplier"), TC_DelaySingleProcMultiplier, "Multiplier for TC_CallCountingDelayMs that is applied on a single-processor machine or when the process is affinitized to a single processor.")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_TC_CallCounting, W("TC_CallCounting"), 1, "Enabled by default (only activates when TieredCompilation is also enabled). If disabled immediately backpatches prestub, and likely prevents any promotion to higher tiers")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_TC_UseCallCountingStubs, W("TC_UseCallCountingStubs"), 1, "Uses call counting stubs for faster call counting.")
-RETAIL_CONFIG_DWORD_INFO(INTERNAL_TC_DeleteCallCountingStubsAfter, W("TC_DeleteCallCountingStubsAfter"), TC_DeleteCallCountingStubsAfter, "Deletes call counting stubs after this many have completed. Zero to disable deleting.")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_TC_DeleteCallCountingStubsAfter, W("TC_DeleteCallCountingStubsAfter"), 0, "Deletes call counting stubs after this many have completed. Zero to disable deleting.")
 #undef TC_BackgroundWorkerTimeoutMs
 #undef TC_CallCountThreshold
 #undef TC_CallCountingDelayMs


### PR DESCRIPTION
The expectations are currently incompatible with the W^X changes, and there's another rare issue that may cause a crash when checking if a precode target is a jump stub.

Memory impact on x64:

Calling and tiering up ~10 K empty methods causes the following amount of memory to remain.

```
Methods with stubs: 10139
Memory usage: ~876 KB
Memory usage per method with stub: ~88.5 B
Committed memory at the end after GC: ~9.5 MB
```

On a larger test case that compiles Roslyn sources 16 times in the same process, the numbers are similar.

```
Methods with stubs: 22141
Memory usage: ~1913 KB
Memory usage per method with stub: ~88.5 B
Committed memory at the end after GC: 90-95 MB
```

It should be possible to reduce the leaked memory per method with stub from ~88.5 B to about 10-16 B (amortized) depending on architecture in the future if necessary.

- Fixes https://github.com/dotnet/runtime/issues/66924
- Fixes https://github.com/dotnet/runtime/issues/66424