### PR TITLE
Update error message for runtime not found

### DIFF
--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -132,17 +132,17 @@ namespace HostActivation.Tests
             using (TestOnlyProductBehavior.Enable(appExe))
             {
                 Command.Create(appExe)
-                .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(projDir)
-                .MultilevelLookup(false)
-                .EnvironmentVariable(
-                    Constants.TestOnlyEnvironmentVariables.GloballyRegisteredPath,
-                    sharedTestState.InstallLocation)
-                .Execute()
-                .Should().Fail()
-                .And.HaveUsedDotNetRootInstallLocation(projDir, fixture.CurrentRid)
-                // If DOTNET_ROOT points to a folder that exists we assume that there's a dotnet installation in it
-                .And.HaveStdErrContaining($"A fatal error occurred. The required library {RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform ("hostfxr")} could not be found.");
+                    .EnableTracingAndCaptureOutputs()
+                    .DotNetRoot(projDir)
+                    .MultilevelLookup(false)
+                    .EnvironmentVariable(
+                        Constants.TestOnlyEnvironmentVariables.GloballyRegisteredPath,
+                        sharedTestState.InstallLocation)
+                    .Execute()
+                    .Should().Fail()
+                    .And.HaveUsedDotNetRootInstallLocation(projDir, fixture.CurrentRid)
+                    // If DOTNET_ROOT points to a folder that exists we assume that there's a dotnet installation in it
+                    .And.HaveStdErrContaining($"The required library {RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("hostfxr")} could not be found.");
             }
         }
 

--- a/src/native/corehost/apphost/apphost.windows.cpp
+++ b/src/native/corehost/apphost/apphost.windows.cpp
@@ -70,6 +70,16 @@ namespace
         return false;
     }
 
+    pal::string_t get_runtime_not_found_message()
+    {
+        pal::string_t msg = INSTALL_NET_DESKTOP_ERROR_MESSAGE _X("\n\n")
+            _X("Architecture: ");
+        msg.append(get_arch());
+        msg.append(_X("\n")
+            _X("App host version: ") _STRINGIFY(COMMON_HOST_PKG_VER) _X("\n\n"));
+        return msg;
+    }
+
     void show_error_dialog(const pal::char_t *executable_name, int error_code)
     {
         pal::string_t gui_errors_disabled;
@@ -80,7 +90,7 @@ namespace
         pal::string_t url;
         if (error_code == StatusCode::CoreHostLibMissingFailure)
         {
-            dialogMsg = pal::string_t(_X("To run this application, you must install .NET Desktop Runtime ")) + _STRINGIFY(COMMON_HOST_PKG_VER) + _X(" (") + get_arch() + _X(").\n\n");
+            dialogMsg = get_runtime_not_found_message();
             pal::string_t line;
             pal::stringstream_t ss(g_buffered_errors);
             while (std::getline(ss, line, _X('\n')))
@@ -130,7 +140,7 @@ namespace
             {
                 if (utils::starts_with(line, _X("Bundle header version compatibility check failed."), true))
                 {
-                    dialogMsg = pal::string_t(_X("To run this application, you must install .NET Desktop Runtime ")) + _STRINGIFY(COMMON_HOST_PKG_VER) + _X(" (") + get_arch() + _X(").\n\n");
+                    dialogMsg = get_runtime_not_found_message();
                     url = get_download_url();
                     url.append(_X("&apphost_version="));
                     url.append(_STRINGIFY(COMMON_HOST_PKG_VER));
@@ -147,8 +157,9 @@ namespace
 
         dialogMsg.append(
             _X("Would you like to download it now?\n\n")
-            _X("Learn about framework resolution:\n")
-            DOTNET_APP_LAUNCH_FAILED_URL);
+            _X("Learn about "));
+        dialogMsg.append(error_code == StatusCode::FrameworkMissingFailure ? _X("framework resolution:") : _X("runtime installation:"));
+        dialogMsg.append(_X("\n") DOTNET_APP_LAUNCH_FAILED_URL);
 
         assert(url.length() > 0);
         assert(is_gui_application());

--- a/src/native/corehost/fxr_resolver.cpp
+++ b/src/native/corehost/fxr_resolver.cpp
@@ -101,19 +101,33 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
         }
 
         pal::string_t self_registered_config_location = pal::get_dotnet_self_registered_config_location();
-        pal::string_t self_registered_message = _X(" or register the runtime location in [") + self_registered_config_location + _X("]");
-
-        trace::error(_X("A fatal error occurred. The required library %s could not be found.\n"
-            "If this is a self-contained application, that library should exist in [%s].\n"
-            "If this is a framework-dependent application, install the runtime in the global location [%s] or use the %s environment variable to specify the runtime location%s."),
+        trace::verbose(_X("The required library %s could not be found. Searched with root path [%s], environment variable [%s], default install location [%s], self-registered config location [%s]"),
             LIBFXR_NAME,
             root_path.c_str(),
-            default_install_location.c_str(),
             dotnet_root_env_var_name.c_str(),
-            self_registered_message.c_str());
-        trace::error(_X(""));
-        trace::error(_X("Download the .NET runtime:"));
-        trace::error(_X("%s&apphost_version=%s"), get_download_url().c_str(), _STRINGIFY(COMMON_HOST_PKG_VER));
+            default_install_location.c_str(),
+            self_registered_config_location.c_str());
+
+        pal::string_t host_path;
+        pal::get_own_executable_path(&host_path);
+        trace::error(
+            INSTALL_NET_ERROR_MESSAGE
+            _X("\n\n")
+            _X("App: %s\n")
+            _X("Architecture: %s\n")
+            _X("App host version: %s\n")
+            _X(".NET location: Not found\n")
+            _X("\n")
+            _X("Learn about runtime installation:\n")
+            DOTNET_APP_LAUNCH_FAILED_URL
+            _X("\n\n")
+            _X("Download the .NET runtime:\n")
+            _X("%s&apphost_version=%s"),
+            host_path.c_str(),
+            get_arch(),
+            _STRINGIFY(COMMON_HOST_PKG_VER),
+            get_download_url().c_str(),
+            _STRINGIFY(COMMON_HOST_PKG_VER));
         return false;
     }
 

--- a/src/native/corehost/hostmisc/utils.h
+++ b/src/native/corehost/hostmisc/utils.h
@@ -26,6 +26,9 @@
 // This message is defined here for consistency between errors on the command line and GUI (Windows apphost).
 #define INSTALL_OR_UPDATE_NET_ERROR_MESSAGE _X("You must install or update .NET to run this application.")
 
+#define INSTALL_NET_ERROR_MESSAGE _X("You must install .NET to run this application.")
+#define INSTALL_NET_DESKTOP_ERROR_MESSAGE _X("You must install .NET Desktop Runtime to run this application.")
+
 #define RUNTIME_STORE_DIRECTORY_NAME _X("store")
 
 bool ends_with(const pal::string_t& value, const pal::string_t& suffix, bool match_case);


### PR DESCRIPTION
Update the error message when the app host can't find a runtime. This makes it more aligned with the updated message for framework resolution failure - instead of `Framework: <...>` (which we don't know), it has `Host version: <...>`.

@richlander - with this change, the error looks like:

```
You must install .NET to run this application.

App: D:\helloworld\bin\Debug\net7.0\helloworld.exe
Architecture: x64
Host version: 7.0.0-dev
.NET location: Not found

Learn about runtime installation:
https://aka.ms/dotnet/app-launch-failed

Download the .NET runtime:
https://aka.ms/dotnet-core-applaunch?missing_runtime=true&arch=x64&rid=win10-x64&apphost_version=7.0.0-dev
```

The Windows GUI one calls out '.NET Desktop Runtime' (like it already does now).
![image](https://user-images.githubusercontent.com/47805090/161643454-6db2a756-fe42-4191-b5a5-459d9d86566f.png)
