### PR TITLE
Make it possible to do typeof of function pointers

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -293,9 +293,9 @@ namespace ILCompiler
             switch (lookupKind)
             {
                 case ReadyToRunHelperId.TypeHandle:
-                    return NodeFactory.ConstructedTypeSymbol((TypeDesc)targetOfLookup);
+                    return NodeFactory.ConstructedTypeSymbol(WithoutFunctionPointerType((TypeDesc)targetOfLookup));
                 case ReadyToRunHelperId.NecessaryTypeHandle:
-                    return NecessaryTypeSymbolIfPossible((TypeDesc)targetOfLookup);
+                    return NecessaryTypeSymbolIfPossible(WithoutFunctionPointerType((TypeDesc)targetOfLookup));
                 case ReadyToRunHelperId.TypeHandleForCasting:
                     {
                         var type = (TypeDesc)targetOfLookup;
@@ -418,6 +418,10 @@ namespace ILCompiler
             // Fixed lookup not possible - use helper.
             return GenericDictionaryLookup.CreateHelperLookup(contextSource, lookupKind, targetOfLookup);
         }
+
+        // CoreCLR compat - referring to function pointer types handled as IntPtr. No MethodTable for function pointers for now.
+        private static TypeDesc WithoutFunctionPointerType(TypeDesc type)
+            => type.IsFunctionPointer ? type.Context.GetWellKnownType(WellKnownType.IntPtr) : type;
 
         public bool IsFatPointerCandidate(MethodDesc containingMethod, MethodSignature signature)
         {


### PR DESCRIPTION
We would previously generate a method body that throws InvalidProgramException. Do what CoreCLR does and pretend it was an IntPtr. There's an odd System.Reflection test that tests kind of this because yeah IntPtr is public: https://github.com/dotnet/runtime/blob/3e01d11fd1722450d326f90b4913f3831ce132bb/src/libraries/System.Reflection/tests/TypeInfoTests.cs#L1217-L1222.