### PR TITLE
Block implementation details on System.Object

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3868,11 +3868,11 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
             mustExpand |= IsTargetAbi(CORINFO_CORERT_ABI);
             break;
 
+        case NI_Internal_Runtime_MethodTable_Of:
         case NI_System_ByReference_ctor:
         case NI_System_ByReference_get_Value:
         case NI_System_Activator_AllocatorOf:
         case NI_System_Activator_DefaultConstructorOf:
-        case NI_System_Object_MethodTableOf:
         case NI_System_EETypePtr_EETypePtrOf:
             mustExpand = true;
             break;
@@ -4037,9 +4037,9 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 break;
             }
 
+            case NI_Internal_Runtime_MethodTable_Of:
             case NI_System_Activator_AllocatorOf:
             case NI_System_Activator_DefaultConstructorOf:
-            case NI_System_Object_MethodTableOf:
             case NI_System_EETypePtr_EETypePtrOf:
             {
                 assert(IsTargetAbi(CORINFO_CORERT_ABI)); // Only CoreRT supports it.
@@ -5233,10 +5233,6 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
             {
                 result = NI_System_Object_GetType;
             }
-            else if (strcmp(methodName, "MethodTableOf") == 0)
-            {
-                result = NI_System_Object_MethodTableOf;
-            }
         }
         else if (strcmp(className, "RuntimeTypeHandle") == 0)
         {
@@ -5333,6 +5329,16 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
             if (strcmp(methodName, "EETypePtrOf") == 0)
             {
                 result = NI_System_EETypePtr_EETypePtrOf;
+            }
+        }
+    }
+    else if (strcmp(namespaceName, "Internal.Runtime") == 0)
+    {
+        if (strcmp(className, "MethodTable") == 0)
+        {
+            if (strcmp(methodName, "Of") == 0)
+            {
+                result = NI_Internal_Runtime_MethodTable_Of;
             }
         }
     }

--- a/src/coreclr/jit/namedintrinsiclist.h
+++ b/src/coreclr/jit/namedintrinsiclist.h
@@ -79,8 +79,9 @@ enum NamedIntrinsic : unsigned short
     NI_System_ByReference_get_Value,
     NI_System_Activator_AllocatorOf,
     NI_System_Activator_DefaultConstructorOf,
-    NI_System_Object_MethodTableOf,
     NI_System_EETypePtr_EETypePtrOf,
+
+    NI_Internal_Runtime_MethodTable_Of,
 
     NI_System_Runtime_CompilerServices_RuntimeHelpers_CreateSpan,
     NI_System_Runtime_CompilerServices_RuntimeHelpers_InitializeArray,

--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
@@ -239,7 +239,7 @@ namespace Internal.Runtime.CompilerHelpers
                         // It actually has all GC fields including non-preinitialized fields and we simply copy over the
                         // entire blob to this object, overwriting everything.
                         IntPtr pPreInitDataAddr = *(pBlock + 1);
-                        RuntimeImports.RhBulkMoveWithWriteBarrier(ref obj.GetRawData(), ref *(byte *)pPreInitDataAddr, obj.GetRawDataSize());
+                        RuntimeImports.RhBulkMoveWithWriteBarrier(ref obj.GetRawData(), ref *(byte *)pPreInitDataAddr, obj.GetRawObjectDataSize());
                     }
 
                     // Call write barrier directly. Assigning object reference does a type check.

--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -201,6 +201,9 @@ namespace Internal.Runtime
             }
         }
 
+        [Intrinsic]
+        internal static extern MethodTable* Of<T>();
+
         private ushort _usComponentSize;
         private ushort _usFlags;
         private uint _uBaseSize;

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CachedInterfaceDispatch.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CachedInterfaceDispatch.cs
@@ -31,9 +31,9 @@ namespace System.Runtime
                 // We don't update the dispatch cell cache if this is IDynamicInterfaceCastable because this
                 // scenario is by-design dynamic. There is no guarantee that another instance with the same MethodTable
                 // as the one we just resolved would do the resolution the same way. We will need to ask again.
-                if (!pObject.MethodTable->IsIDynamicInterfaceCastable)
+                if (!pObject.GetMethodTable()->IsIDynamicInterfaceCastable)
                 {
-                    return InternalCalls.RhpUpdateDispatchCellCache(pCell, pTargetCode, pObject.MethodTable, ref cellInfo);
+                    return InternalCalls.RhpUpdateDispatchCellCache(pCell, pTargetCode, pObject.GetMethodTable(), ref cellInfo);
                 }
                 else
                 {
@@ -56,7 +56,7 @@ namespace System.Runtime
                 return IntPtr.Zero;
             }
 
-            MethodTable* pInstanceType = pObject.MethodTable;
+            MethodTable* pInstanceType = pObject.GetMethodTable();
 
             // This method is used for the implementation of LOAD_VIRT_FUNCTION and in that case the mapping we want
             // may already be in the cache.
@@ -98,7 +98,7 @@ namespace System.Runtime
         private static unsafe IntPtr RhResolveDispatchWorker(object pObject, void* cell, ref DispatchCellInfo cellInfo)
         {
             // Type of object we're dispatching on.
-            MethodTable* pInstanceType = pObject.MethodTable;
+            MethodTable* pInstanceType = pObject.GetMethodTable();
 
             if (cellInfo.CellType == DispatchCellType.InterfaceAndSlot)
             {

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -141,7 +141,7 @@ namespace System.Runtime
         private static void OnFirstChanceExceptionViaClassLib(object exception)
         {
             IntPtr pOnFirstChanceFunction =
-                (IntPtr)InternalCalls.RhpGetClasslibFunctionFromEEType(exception.MethodTable, ClassLibFunctionId.OnFirstChance);
+                (IntPtr)InternalCalls.RhpGetClasslibFunctionFromEEType(exception.GetMethodTable(), ClassLibFunctionId.OnFirstChance);
 
             if (pOnFirstChanceFunction == IntPtr.Zero)
             {
@@ -161,7 +161,7 @@ namespace System.Runtime
         private static void OnUnhandledExceptionViaClassLib(object exception)
         {
             IntPtr pOnUnhandledExceptionFunction =
-                (IntPtr)InternalCalls.RhpGetClasslibFunctionFromEEType(exception.MethodTable, ClassLibFunctionId.OnUnhandledException);
+                (IntPtr)InternalCalls.RhpGetClasslibFunctionFromEEType(exception.GetMethodTable(), ClassLibFunctionId.OnUnhandledException);
 
             if (pOnUnhandledExceptionFunction == IntPtr.Zero)
             {

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeExports.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeExports.cs
@@ -171,11 +171,11 @@ namespace System.Runtime
 
                 if (ptrUnboxToEEType->IsNullable)
                 {
-                    isValid = (o == null) || TypeCast.AreTypesEquivalent(o.MethodTable, ptrUnboxToEEType->NullableType);
+                    isValid = (o == null) || TypeCast.AreTypesEquivalent(o.GetMethodTable(), ptrUnboxToEEType->NullableType);
                 }
                 else
                 {
-                    isValid = (o != null) && UnboxAnyTypeCompare(o.MethodTable, ptrUnboxToEEType);
+                    isValid = (o != null) && UnboxAnyTypeCompare(o.GetMethodTable(), ptrUnboxToEEType);
                 }
 
                 if (!isValid)
@@ -207,7 +207,7 @@ namespace System.Runtime
         [RuntimeExport("RhUnbox2")]
         public static unsafe ref byte RhUnbox2(MethodTable* pUnboxToEEType, object obj)
         {
-            if ((obj == null) || !UnboxAnyTypeCompare(obj.MethodTable, pUnboxToEEType))
+            if ((obj == null) || !UnboxAnyTypeCompare(obj.GetMethodTable(), pUnboxToEEType))
             {
                 ExceptionIDs exID = obj == null ? ExceptionIDs.NullReference : ExceptionIDs.InvalidCast;
                 throw pUnboxToEEType->GetClasslibException(exID);
@@ -218,7 +218,7 @@ namespace System.Runtime
         [RuntimeExport("RhUnboxNullable")]
         public static unsafe void RhUnboxNullable(ref byte data, MethodTable* pUnboxToEEType, object obj)
         {
-            if ((obj != null) && !TypeCast.AreTypesEquivalent(obj.MethodTable, pUnboxToEEType->NullableType))
+            if ((obj != null) && !TypeCast.AreTypesEquivalent(obj.GetMethodTable(), pUnboxToEEType->NullableType))
             {
                 throw pUnboxToEEType->GetClasslibException(ExceptionIDs.InvalidCast);
             }
@@ -242,7 +242,7 @@ namespace System.Runtime
                 return;
             }
 
-            MethodTable* pEEType = obj.MethodTable;
+            MethodTable* pEEType = obj.GetMethodTable();
 
             // Can unbox value types only.
             Debug.Assert(pEEType->IsValueType);
@@ -282,10 +282,10 @@ namespace System.Runtime
         {
             object objClone;
 
-            if (src.MethodTable->IsArray)
-                objClone = RhNewArray(src.MethodTable, Unsafe.As<Array>(src).Length);
+            if (src.GetMethodTable()->IsArray)
+                objClone = RhNewArray(src.GetMethodTable(), Unsafe.As<Array>(src).Length);
             else
-                objClone = RhNewObject(src.MethodTable);
+                objClone = RhNewObject(src.GetMethodTable());
 
             InternalCalls.RhpCopyObjectContents(objClone, src);
 

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -44,12 +44,12 @@ namespace System.Runtime
         [RuntimeExport("RhTypeCast_IsInstanceOfClass")]
         public static unsafe object IsInstanceOfClass(MethodTable* pTargetType, object obj)
         {
-            if (obj == null || obj.MethodTable == pTargetType)
+            if (obj == null || obj.GetMethodTable() == pTargetType)
             {
                 return obj;
             }
 
-            MethodTable* pObjType = obj.MethodTable;
+            MethodTable* pObjType = obj.GetMethodTable();
 
             Debug.Assert(!pTargetType->IsParameterizedType, "IsInstanceOfClass called with parameterized MethodTable");
             Debug.Assert(!pTargetType->IsInterface, "IsInstanceOfClass called with interface MethodTable");
@@ -177,7 +177,7 @@ namespace System.Runtime
                 return null;
             }
 
-            MethodTable* pObjType = obj.MethodTable;
+            MethodTable* pObjType = obj.GetMethodTable();
 
             Debug.Assert(pTargetType->IsArray, "IsInstanceOfArray called with non-array MethodTable");
             Debug.Assert(!pTargetType->IsCloned, "cloned array types are disallowed");
@@ -244,7 +244,7 @@ namespace System.Runtime
                 return null;
             }
 
-            MethodTable* pObjType = obj.MethodTable;
+            MethodTable* pObjType = obj.GetMethodTable();
 
             if (CastCache.AreTypesAssignableInternal_SourceNotTarget_BoxedSource(pObjType, pTargetType, null))
                 return obj;
@@ -661,7 +661,7 @@ namespace System.Runtime
                 return null;
             }
 
-            MethodTable* pObjType = obj.MethodTable;
+            MethodTable* pObjType = obj.GetMethodTable();
 
             if (CastCache.AreTypesAssignableInternal_SourceNotTarget_BoxedSource(pObjType, pTargetType, null))
                 return obj;
@@ -687,21 +687,21 @@ namespace System.Runtime
                 return;
             }
 
-            Debug.Assert(array.MethodTable->IsArray, "first argument must be an array");
+            Debug.Assert(array.GetMethodTable()->IsArray, "first argument must be an array");
 
-            MethodTable* arrayElemType = array.MethodTable->RelatedParameterType;
-            if (CastCache.AreTypesAssignableInternal(obj.MethodTable, arrayElemType, AssignmentVariation.BoxedSource, null))
+            MethodTable* arrayElemType = array.GetMethodTable()->RelatedParameterType;
+            if (CastCache.AreTypesAssignableInternal(obj.GetMethodTable(), arrayElemType, AssignmentVariation.BoxedSource, null))
                 return;
 
             // If object type implements IDynamicInterfaceCastable then there's one more way to check whether it implements
             // the interface.
-            if (obj.MethodTable->IsIDynamicInterfaceCastable && IsInstanceOfInterfaceViaIDynamicInterfaceCastable(arrayElemType, obj, throwing: false))
+            if (obj.GetMethodTable()->IsIDynamicInterfaceCastable && IsInstanceOfInterfaceViaIDynamicInterfaceCastable(arrayElemType, obj, throwing: false))
                 return;
 
             // Throw the array type mismatch exception defined by the classlib, using the input array's MethodTable*
             // to find the correct classlib.
 
-            throw array.MethodTable->GetClasslibException(ExceptionIDs.ArrayTypeMismatch);
+            throw array.GetMethodTable()->GetClasslibException(ExceptionIDs.ArrayTypeMismatch);
         }
 
         [RuntimeExport("RhTypeCast_CheckVectorElemAddr")]
@@ -712,9 +712,9 @@ namespace System.Runtime
                 return;
             }
 
-            Debug.Assert(array.MethodTable->IsArray, "second argument must be an array");
+            Debug.Assert(array.GetMethodTable()->IsArray, "second argument must be an array");
 
-            MethodTable* arrayElemType = array.MethodTable->RelatedParameterType;
+            MethodTable* arrayElemType = array.GetMethodTable()->RelatedParameterType;
 
             if (!AreTypesEquivalent(elemType, arrayElemType)
             // In addition to the exactness check, add another check to allow non-exact matches through
@@ -730,7 +730,7 @@ namespace System.Runtime
                 // Throw the array type mismatch exception defined by the classlib, using the input array's MethodTable*
                 // to find the correct classlib.
 
-                throw array.MethodTable->GetClasslibException(ExceptionIDs.ArrayTypeMismatch);
+                throw array.GetMethodTable()->GetClasslibException(ExceptionIDs.ArrayTypeMismatch);
             }
         }
 
@@ -746,7 +746,7 @@ namespace System.Runtime
         public static unsafe void StelemRef(Array array, int index, object obj)
         {
             // This is supported only on arrays
-            Debug.Assert(array.MethodTable->IsArray, "first argument must be an array");
+            Debug.Assert(array.GetMethodTable()->IsArray, "first argument must be an array");
 
 #if INPLACE_RUNTIME
             // this will throw appropriate exceptions if array is null or access is out of range.
@@ -766,12 +766,12 @@ namespace System.Runtime
             ref object element = ref Unsafe.Add(ref rawData, index);
 #endif
 
-            MethodTable* elementType = array.MethodTable->RelatedParameterType;
+            MethodTable* elementType = array.GetMethodTable()->RelatedParameterType;
 
             if (obj == null)
                 goto assigningNull;
 
-            if (elementType != obj.MethodTable)
+            if (elementType != obj.GetMethodTable())
                 goto notExactMatch;
 
 doWrite:
@@ -785,7 +785,7 @@ assigningNull:
         notExactMatch:
 #if INPLACE_RUNTIME
             // This optimization only makes sense for inplace runtime where there's only one System.Object.
-            if (array.MethodTable == MethodTableOf<object[]>())
+            if (array.GetMethodTable() == MethodTable.Of<object[]>())
                 goto doWrite;
 #endif
 
@@ -795,7 +795,7 @@ assigningNull:
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static unsafe void StelemRef_Helper(ref object element, MethodTable* elementType, object obj)
         {
-            if (CastCache.AreTypesAssignableInternal(obj.MethodTable, elementType, AssignmentVariation.BoxedSource, null))
+            if (CastCache.AreTypesAssignableInternal(obj.GetMethodTable(), elementType, AssignmentVariation.BoxedSource, null))
             {
                 InternalCalls.RhpAssignRef(ref element, obj);
             }
@@ -803,7 +803,7 @@ assigningNull:
             {
                 // If object type implements IDynamicInterfaceCastable then there's one more way to check whether it implements
                 // the interface.
-                if (!obj.MethodTable->IsIDynamicInterfaceCastable || !IsInstanceOfInterfaceViaIDynamicInterfaceCastable(elementType, obj, throwing: false))
+                if (!obj.GetMethodTable()->IsIDynamicInterfaceCastable || !IsInstanceOfInterfaceViaIDynamicInterfaceCastable(elementType, obj, throwing: false))
                 {
                     // Throw the array type mismatch exception defined by the classlib, using the input array's
                     // MethodTable* to find the correct classlib.
@@ -816,17 +816,17 @@ assigningNull:
         [RuntimeExport("RhpLdelemaRef")]
         public static unsafe ref object LdelemaRef(Array array, int index, IntPtr elementType)
         {
-            Debug.Assert(array.MethodTable->IsArray, "first argument must be an array");
+            Debug.Assert(array.GetMethodTable()->IsArray, "first argument must be an array");
 
             MethodTable* elemType = (MethodTable*)elementType;
-            MethodTable* arrayElemType = array.MethodTable->RelatedParameterType;
+            MethodTable* arrayElemType = array.GetMethodTable()->RelatedParameterType;
 
             if (!AreTypesEquivalent(elemType, arrayElemType))
             {
                 // Throw the array type mismatch exception defined by the classlib, using the input array's MethodTable*
                 // to find the correct classlib.
 
-                throw array.MethodTable->GetClasslibException(ExceptionIDs.ArrayTypeMismatch);
+                throw array.GetMethodTable()->GetClasslibException(ExceptionIDs.ArrayTypeMismatch);
             }
 
             ref object rawData = ref Unsafe.As<byte, object>(ref Unsafe.As<RawArrayData>(array).Data);

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/__Finalizer.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/__Finalizer.cs
@@ -60,7 +60,7 @@ namespace System.Runtime
                 // Call the finalizer on the current target object. If the finalizer throws we'll fail
                 // fast via normal Redhawk exception semantics (since we don't attempt to catch
                 // anything).
-                ((delegate*<object, void>)target.MethodTable->FinalizerCode)(target);
+                ((delegate*<object, void>)target.GetMethodTable()->FinalizerCode)(target);
             }
         }
     }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -703,7 +703,7 @@ namespace Internal.Runtime.Augments
 
         public static bool IsAssignable(object srcObject, RuntimeTypeHandle dstType)
         {
-            EETypePtr srcEEType = srcObject.EETypePtr;
+            EETypePtr srcEEType = srcObject.GetEETypePtr();
             return RuntimeImports.AreTypesAssignable(srcEEType, dstType.ToEETypePtr());
         }
 
@@ -851,7 +851,7 @@ namespace Internal.Runtime.Augments
 
         public static unsafe RuntimeTypeHandle GetRuntimeTypeHandleFromObjectReference(object obj)
         {
-            return new RuntimeTypeHandle(obj.EETypePtr);
+            return new RuntimeTypeHandle(obj.GetEETypePtr());
         }
 
         // Move memory which may be on the heap which may have object references in it.

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -508,7 +508,7 @@ namespace Internal.Runtime.CompilerHelpers
         internal static int AsAnyGetNativeSize(object o)
         {
             // Array, string and StringBuilder are not implemented.
-            if (o.EETypePtr.IsArray ||
+            if (o.GetEETypePtr().IsArray ||
                 o is string ||
                 o is StringBuilder)
             {
@@ -524,7 +524,7 @@ namespace Internal.Runtime.CompilerHelpers
         internal static void AsAnyMarshalManagedToNative(object o, IntPtr address)
         {
             // Array, string and StringBuilder are not implemented.
-            if (o.EETypePtr.IsArray ||
+            if (o.GetEETypePtr().IsArray ||
                 o is string ||
                 o is StringBuilder)
             {
@@ -537,7 +537,7 @@ namespace Internal.Runtime.CompilerHelpers
         internal static void AsAnyMarshalNativeToManaged(IntPtr address, object o)
         {
             // Array, string and StringBuilder are not implemented.
-            if (o.EETypePtr.IsArray ||
+            if (o.GetEETypePtr().IsArray ||
                 o is string ||
                 o is StringBuilder)
             {
@@ -552,7 +552,7 @@ namespace Internal.Runtime.CompilerHelpers
         internal static void AsAnyCleanupNative(IntPtr address, object o)
         {
             // Array, string and StringBuilder are not implemented.
-            if (o.EETypePtr.IsArray ||
+            if (o.GetEETypePtr().IsArray ||
                 o is string ||
                 o is StringBuilder)
             {
@@ -619,7 +619,7 @@ namespace Internal.Runtime.CompilerHelpers
                 throw new ApplicationException();
             }
 
-            if (!RuntimeImports.AreTypesAssignable(marshaller.EETypePtr, EETypePtr.EETypePtrOf<ICustomMarshaler>()))
+            if (!RuntimeImports.AreTypesAssignable(marshaller.GetEETypePtr(), EETypePtr.EETypePtrOf<ICustomMarshaler>()))
             {
                 throw new ApplicationException();
             }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Array.CoreRT.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Array.CoreRT.cs
@@ -51,7 +51,7 @@ namespace System
         {
             get
             {
-                return this.EETypePtr.BaseSize == SZARRAY_BASE_SIZE;
+                return this.GetEETypePtr().BaseSize == SZARRAY_BASE_SIZE;
             }
         }
 
@@ -139,8 +139,8 @@ namespace System
             if (destinationArray is null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.destinationArray);
 
-            EETypePtr eeType = sourceArray.EETypePtr;
-            if (eeType.FastEquals(destinationArray.EETypePtr) &&
+            EETypePtr eeType = sourceArray.GetEETypePtr();
+            if (eeType.FastEquals(destinationArray.GetEETypePtr()) &&
                 eeType.IsSzArray &&
                 (uint)length <= sourceArray.NativeLength &&
                 (uint)length <= destinationArray.NativeLength)
@@ -166,8 +166,8 @@ namespace System
         {
             if (sourceArray != null && destinationArray != null)
             {
-                EETypePtr eeType = sourceArray.EETypePtr;
-                if (eeType.FastEquals(destinationArray.EETypePtr) &&
+                EETypePtr eeType = sourceArray.GetEETypePtr();
+                if (eeType.FastEquals(destinationArray.GetEETypePtr()) &&
                     eeType.IsSzArray &&
                     length >= 0 && sourceIndex >= 0 && destinationIndex >= 0 &&
                     (uint)(sourceIndex + length) <= sourceArray.NativeLength &&
@@ -269,7 +269,7 @@ namespace System
                 }
                 else if (sourceElementEEType.IsPrimitive && destinationElementEEType.IsPrimitive)
                 {
-                    if (RuntimeImports.AreTypesAssignable(sourceArray.EETypePtr, destinationArray.EETypePtr))
+                    if (RuntimeImports.AreTypesAssignable(sourceArray.GetEETypePtr(), destinationArray.GetEETypePtr()))
                     {
                         // If we're okay casting between these two, we're also okay blitting the values over
                         CopyImplValueTypeArrayNoInnerGcRefs(sourceArray, sourceIndex, destinationArray, destinationIndex, length);
@@ -422,7 +422,7 @@ namespace System
                     }
                     else
                     {
-                        EETypePtr eeType = boxedValue.EETypePtr;
+                        EETypePtr eeType = boxedValue.GetEETypePtr();
                         if (!(RuntimeImports.AreTypesAssignable(eeType, destinationElementEEType)))
                             throw new InvalidCastException(SR.InvalidCast_DownCastArrayElement);
                     }
@@ -439,10 +439,10 @@ namespace System
         //
         private static unsafe void CopyImplValueTypeArrayWithInnerGcRefs(Array sourceArray, int sourceIndex, Array destinationArray, int destinationIndex, int length, bool reliable)
         {
-            Debug.Assert(RuntimeImports.AreTypesEquivalent(sourceArray.EETypePtr, destinationArray.EETypePtr));
+            Debug.Assert(RuntimeImports.AreTypesEquivalent(sourceArray.GetEETypePtr(), destinationArray.GetEETypePtr()));
             Debug.Assert(sourceArray.ElementEEType.IsValueType);
 
-            EETypePtr sourceElementEEType = sourceArray.EETypePtr.ArrayElementType;
+            EETypePtr sourceElementEEType = sourceArray.GetEETypePtr().ArrayElementType;
             bool reverseCopy = ((object)sourceArray == (object)destinationArray) && (sourceIndex < destinationIndex);
 
             // Copy scenario: ValueType-array to value-type array with embedded gc-refs.
@@ -803,7 +803,7 @@ namespace System
             if (array == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
 
-            EETypePtr eeType = array.EETypePtr;
+            EETypePtr eeType = array.GetEETypePtr();
             nuint totalByteLength = eeType.ComponentSize * array.NativeLength;
             ref byte pStart = ref MemoryMarshal.GetArrayDataReference(array);
 
@@ -826,7 +826,7 @@ namespace System
             ref byte p = ref Unsafe.As<RawArrayData>(array).Data;
             int lowerBound = 0;
 
-            EETypePtr eeType = array.EETypePtr;
+            EETypePtr eeType = array.GetEETypePtr();
             if (!eeType.IsSzArray)
             {
                 int rank = eeType.ArrayRank;
@@ -870,7 +870,7 @@ namespace System
         {
             get
             {
-                return this.EETypePtr.ArrayRank;
+                return this.GetEETypePtr().ArrayRank;
             }
         }
 
@@ -1018,11 +1018,11 @@ namespace System
             if (pElementEEType.IsValueType)
             {
                 // Unlike most callers of InvokeUtils.ChangeType(), Array.SetValue() does *not* permit conversion from a primitive to an Enum.
-                if (value != null && !(value.EETypePtr == pElementEEType) && pElementEEType.IsEnum)
+                if (value != null && !(value.GetEETypePtr() == pElementEEType) && pElementEEType.IsEnum)
                     throw new InvalidCastException(SR.Format(SR.Arg_ObjObjEx, value.GetType(), Type.GetTypeFromHandle(new RuntimeTypeHandle(pElementEEType))));
 
                 value = InvokeUtils.CheckArgument(value, pElementEEType, InvokeUtils.CheckArgumentSemantics.ArraySet, binderBundle: null);
-                Debug.Assert(value == null || RuntimeImports.AreTypesAssignable(value.EETypePtr, pElementEEType));
+                Debug.Assert(value == null || RuntimeImports.AreTypesAssignable(value.GetEETypePtr(), pElementEEType));
 
                 RuntimeImports.RhUnbox(value, ref element, pElementEEType);
             }
@@ -1048,7 +1048,7 @@ namespace System
         {
             get
             {
-                return this.EETypePtr.ArrayElementType;
+                return this.GetEETypePtr().ArrayElementType;
             }
         }
 
@@ -1059,7 +1059,7 @@ namespace System
 
         internal bool IsValueOfElementType(object o)
         {
-            return ElementEEType.Equals(o.EETypePtr);
+            return ElementEEType.Equals(o.GetEETypePtr());
         }
 
         //
@@ -1069,7 +1069,7 @@ namespace System
         {
             get
             {
-                return EETypePtr.ComponentSize;
+                return this.GetEETypePtr().ComponentSize;
             }
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Delegate.cs
@@ -125,7 +125,7 @@ namespace System
             else
             {
                 if (m_firstParameter != null)
-                    typeOfFirstParameterIfInstanceDelegate = new RuntimeTypeHandle(m_firstParameter.EETypePtr);
+                    typeOfFirstParameterIfInstanceDelegate = new RuntimeTypeHandle(m_firstParameter.GetEETypePtr());
 
                 // TODO! Implementation issue for generic invokes here ... we need another IntPtr for uniqueness.
 
@@ -373,7 +373,7 @@ namespace System
 
         internal static bool InternalEqualTypes(object a, object b)
         {
-            return a.EETypePtr == b.EETypePtr;
+            return a.GetEETypePtr() == b.GetEETypePtr();
         }
 
         // Returns a new delegate of the specified type whose implementation is provied by the

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Enum.CoreRT.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Enum.CoreRT.cs
@@ -32,7 +32,7 @@ namespace System
 
         private CorElementType InternalGetCorElementType()
         {
-            return this.EETypePtr.CorElementType;
+            return this.GetEETypePtr().CorElementType;
         }
 
         //
@@ -46,7 +46,7 @@ namespace System
         //
         internal static bool TryGetUnboxedValueOfEnumOrInteger(object value, out ulong result)
         {
-            EETypePtr eeType = value.EETypePtr;
+            EETypePtr eeType = value.GetEETypePtr();
             // For now, this check is required to flush out pointers.
             if (!eeType.IsDefType)
             {
@@ -129,7 +129,7 @@ namespace System
             EETypePtr enumEEType;
             if (!enumType.TryGetEEType(out enumEEType))
                 return false;
-            if (!(enumEEType == value.EETypePtr))
+            if (!(enumEEType == value.GetEETypePtr()))
                 return false;
             return true;
         }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Exception.CoreRT.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Exception.CoreRT.cs
@@ -5,7 +5,7 @@ using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime;
-using System.Runtime.Serialization;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 using MethodBase = System.Reflection.MethodBase;
@@ -250,7 +250,7 @@ namespace System
                 {
                     SERIALIZED_EXCEPTION_HEADER* pHeader = (SERIALIZED_EXCEPTION_HEADER*)pBuffer;
                     pHeader->HResult = _HResult;
-                    pHeader->ExceptionEEType = (IntPtr)MethodTable;
+                    pHeader->ExceptionEEType = (IntPtr)this.GetMethodTable();
                     pHeader->StackTraceElementCount = nStackTraceElements;
                     IntPtr* pStackTraceElements = (IntPtr*)(pBuffer + sizeof(SERIALIZED_EXCEPTION_HEADER));
                     for (int i = 0; i < nStackTraceElements; i++)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
@@ -84,7 +84,7 @@ namespace System
             }
             else
             {
-                EETypePtr srcEEType = srcObject.EETypePtr;
+                EETypePtr srcEEType = srcObject.GetEETypePtr();
 
                 if (RuntimeImports.AreTypesAssignable(srcEEType, dstEEType))
                     return srcObject;
@@ -240,7 +240,7 @@ namespace System
                     return CreateChangeTypeException(srcEEType, dstEEType, semantics);
             }
 
-            Debug.Assert(dstObject.EETypePtr == dstEEType);
+            Debug.Assert(dstObject.GetEETypePtr() == dstEEType);
             return null;
         }
 
@@ -371,7 +371,7 @@ namespace System
             {
                 // If the passed in array is not an actual object[] instance, we need to copy it over to an actual object[]
                 // instance so that the rest of the code can safely create managed object references to individual elements.
-                if (parameters != null && EETypePtr.EETypePtrOf<object[]>() != parameters.EETypePtr)
+                if (parameters != null && EETypePtr.EETypePtrOf<object[]>() != parameters.GetEETypePtr())
                 {
                     argSetupState.parameters = new object[parameters.Length];
                     Array.Copy(parameters, argSetupState.parameters, parameters.Length);
@@ -462,7 +462,7 @@ namespace System
         private static object DynamicInvokeBoxIntoNonNullable(object actualBoxedNullable)
         {
             // grab the pointer to data, box using the MethodTable of the actualBoxedNullable, and then return the boxed object
-            return RuntimeImports.RhBox(actualBoxedNullable.EETypePtr, ref actualBoxedNullable.GetRawData());
+            return RuntimeImports.RhBox(actualBoxedNullable.GetEETypePtr(), ref actualBoxedNullable.GetRawData());
         }
 
         [DebuggerStepThrough]
@@ -596,19 +596,19 @@ namespace System
                 {
                     if (nullable || paramType == DynamicInvokeParamType.Ref)
                     {
-                        if (widenAndCompareType.ToEETypePtr() != incomingParam.EETypePtr)
+                        if (widenAndCompareType.ToEETypePtr() != incomingParam.GetEETypePtr())
                         {
                             if (argSetupState.binderBundle == null)
-                                throw CreateChangeTypeArgumentException(incomingParam.EETypePtr, type.ToEETypePtr());
+                                throw CreateChangeTypeArgumentException(incomingParam.GetEETypePtr(), type.ToEETypePtr());
                             Type exactDstType = GetExactTypeForCustomBinder(argSetupState);
                             incomingParam = argSetupState.binderBundle.ChangeType(incomingParam, exactDstType);
-                            if (incomingParam != null && widenAndCompareType.ToEETypePtr() != incomingParam.EETypePtr)
-                                throw CreateChangeTypeArgumentException(incomingParam.EETypePtr, type.ToEETypePtr());
+                            if (incomingParam != null && widenAndCompareType.ToEETypePtr() != incomingParam.GetEETypePtr())
+                                throw CreateChangeTypeArgumentException(incomingParam.GetEETypePtr(), type.ToEETypePtr());
                         }
                     }
                     else
                     {
-                        if (widenAndCompareType.ToEETypePtr().ElementType != incomingParam.EETypePtr.ElementType)
+                        if (widenAndCompareType.ToEETypePtr().ElementType != incomingParam.GetEETypePtr().ElementType)
                         {
                             System.Diagnostics.Debug.Assert(paramType == DynamicInvokeParamType.In);
                             incomingParam = InvokeUtils.CheckArgument(incomingParam, widenAndCompareType.ToEETypePtr(), InvokeUtils.CheckArgumentSemantics.DynamicInvoke, argSetupState.binderBundle, ref argSetupState);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/MulticastDelegate.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/MulticastDelegate.cs
@@ -144,7 +144,7 @@ namespace System
         private MulticastDelegate NewMulticastDelegate(Delegate[] invocationList, int invocationCount, bool thisIsMultiCastAlready = false)
         {
             // First, allocate a new multicast delegate just like this one, i.e. same type as the this object
-            MulticastDelegate result = (MulticastDelegate)RuntimeImports.RhNewObject(this.EETypePtr);
+            MulticastDelegate result = (MulticastDelegate)RuntimeImports.RhNewObject(this.GetEETypePtr());
 
             // Performance optimization - if this already points to a true multicast delegate,
             // copy _methodPtr and _methodPtrAux fields rather than calling into the EE to get them

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Object.CoreRT.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Object.CoreRT.cs
@@ -3,76 +3,32 @@
 
 using System.Runtime;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-
-using Internal.Reflection.Core.NonPortable;
 
 using Internal.Runtime;
-using Internal.Runtime.CompilerServices;
 
 namespace System
 {
     // CONTRACT with Runtime
     // The Object type is one of the primitives understood by the compilers and runtime
-    // Data Contract: Single field of type EEType_ptr (or void * till a tool bug can be fixed)
-    // VTable Contract: The first vtable slot should be the finalizer for object => The first virtual method in the object class should be the Finalizer
-
+    // Data Contract: Single field of type MethodTable*
     public unsafe partial class Object
     {
         // CS0649: Field '{blah}' is never assigned to, and will always have its default value
 #pragma warning disable 649
-        // Marked as internal for now so that some classes (System.Buffer, System.Enum) can use C#'s fixed
-        // statement on partially typed objects. Wouldn't have to do this if we could directly declared pinned
-        // locals.
         [NonSerialized]
-        private MethodTable* m_pEEType;
+        internal MethodTable* m_pEEType;
 #pragma warning restore
-
-#if INPLACE_RUNTIME
-        internal unsafe MethodTable* MethodTable
-        {
-            get
-            {
-                return m_pEEType;
-            }
-        }
-#endif
-
-        [Runtime.CompilerServices.Intrinsic]
-        internal static extern MethodTable* MethodTableOf<T>();
 
         [Intrinsic]
         public Type GetType()
         {
-            return Type.GetTypeFromEETypePtr(EETypePtr);
-        }
-
-        internal EETypePtr EETypePtr
-        {
-            get
-            {
-                return new EETypePtr(m_pEEType);
-            }
+            return Type.GetTypeFromEETypePtr(this.GetEETypePtr());
         }
 
         [Intrinsic]
         protected object MemberwiseClone()
         {
             return RuntimeImports.RhMemberwiseClone(this);
-        }
-
-        internal ref byte GetRawData()
-        {
-            return ref Unsafe.As<RawData>(this).Data;
-        }
-
-        /// <summary>
-        /// Return size of all data (excluding ObjHeader and MethodTable*).
-        /// Note that for strings/arrays this would include the Length as well.
-        /// </summary>
-        internal unsafe uint GetRawDataSize()
-        {
-            return EETypePtr.BaseSize - (uint)sizeof(ObjHeader) - (uint)sizeof(MethodTable*);
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs
@@ -22,11 +22,6 @@ namespace System.Runtime.InteropServices
     [ReflectionBlocked]
     public static class InteropExtensions
     {
-        public static int GetElementSize(this Array array)
-        {
-            return array.EETypePtr.ComponentSize;
-        }
-
         internal static bool MightBeBlittable(this EETypePtr eeType)
         {
             //
@@ -43,7 +38,7 @@ namespace System.Runtime.InteropServices
 
         public static bool IsBlittable(this object obj)
         {
-            return obj.EETypePtr.MightBeBlittable();
+            return obj.GetEETypePtr().MightBeBlittable();
         }
 
         public static bool IsGenericType(this RuntimeTypeHandle handle)
@@ -100,7 +95,7 @@ namespace System.Runtime.InteropServices
 
         public static RuntimeTypeHandle GetTypeHandle(this object target)
         {
-            return new RuntimeTypeHandle(target.EETypePtr);
+            return new RuntimeTypeHandle(target.GetEETypePtr());
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreRT.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreRT.cs
@@ -43,7 +43,7 @@ namespace System.Runtime.InteropServices
             if (structure == null)
                 throw new ArgumentNullException(nameof(structure));
 
-            if (!allowValueClasses && structure.EETypePtr.IsValueType)
+            if (!allowValueClasses && structure.GetEETypePtr().IsValueType)
             {
                 throw new ArgumentException(nameof(structure), SR.Argument_StructMustNotBeValueClass);
             }
@@ -207,7 +207,7 @@ namespace System.Runtime.InteropServices
 
         internal static bool IsPinnable(object o)
         {
-            return (o == null) || o.EETypePtr.MightBeBlittable();
+            return (o == null) || o.GetEETypePtr().MightBeBlittable();
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -270,7 +270,7 @@ namespace System.Runtime.InteropServices
                 throw new AccessViolationException();
             }
 
-            if (ptr.EETypePtr.IsArray ||
+            if (ptr.GetEETypePtr().IsArray ||
                 ptr is string ||
                 ptr is StringBuilder)
             {
@@ -349,7 +349,7 @@ namespace System.Runtime.InteropServices
                 throw new AccessViolationException();
             }
 
-            if (ptr.EETypePtr.IsArray ||
+            if (ptr.GetEETypePtr().IsArray ||
                 ptr is string ||
                 ptr is StringBuilder)
             {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.CoreRT.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.CoreRT.cs
@@ -42,7 +42,7 @@ namespace System.Runtime.InteropServices
             // to special-case arrays of known type and dimension.
 
             // See comment on RawArrayData (in RuntimeHelpers.CoreCLR.cs) for details
-            return ref Unsafe.AddByteOffset(ref Unsafe.As<RawData>(array).Data, (nuint)array.EETypePtr.BaseSize - (nuint)(2 * sizeof(IntPtr)));
+            return ref Unsafe.AddByteOffset(ref Unsafe.As<RawData>(array).Data, (nuint)array.GetEETypePtr().BaseSize - (nuint)(2 * sizeof(IntPtr)));
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
@@ -160,10 +160,10 @@ namespace System.Runtime
 
         public static unsafe IntPtr GetDelegateThunk(object delegateObj, int whichThunk)
         {
-            Entry entry = LookupInCache(s_cache, (IntPtr)delegateObj.MethodTable, new IntPtr(whichThunk));
+            Entry entry = LookupInCache(s_cache, (IntPtr)delegateObj.GetMethodTable(), new IntPtr(whichThunk));
             if (entry == null)
             {
-                entry = CacheMiss((IntPtr)delegateObj.MethodTable, new IntPtr(whichThunk),
+                entry = CacheMiss((IntPtr)delegateObj.GetMethodTable(), new IntPtr(whichThunk),
                     (IntPtr context, IntPtr signature, object contextObject, ref IntPtr auxResult)
                         => RuntimeAugments.TypeLoaderCallbacks.GetDelegateThunk((Delegate)contextObject, (int)signature),
                     delegateObj);
@@ -173,10 +173,10 @@ namespace System.Runtime
 
         public static unsafe IntPtr GVMLookupForSlot(object obj, RuntimeMethodHandle slot)
         {
-            Entry entry = LookupInCache(s_cache, (IntPtr)obj.MethodTable, *(IntPtr*)&slot);
+            Entry entry = LookupInCache(s_cache, (IntPtr)obj.GetMethodTable(), *(IntPtr*)&slot);
             if (entry == null)
             {
-                entry = CacheMiss((IntPtr)obj.MethodTable, *(IntPtr*)&slot,
+                entry = CacheMiss((IntPtr)obj.GetMethodTable(), *(IntPtr*)&slot,
                     (IntPtr context, IntPtr signature, object contextObject, ref IntPtr auxResult)
                         => Internal.Runtime.CompilerServices.GenericVirtualMethodSupport.GVMLookupForSlot(new RuntimeTypeHandle(new EETypePtr(context)), *(RuntimeMethodHandle*)&signature));
             }
@@ -186,10 +186,10 @@ namespace System.Runtime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe IntPtr OpenInstanceMethodLookup(IntPtr openResolver, object obj)
         {
-            Entry entry = LookupInCache(s_cache, (IntPtr)obj.MethodTable, openResolver);
+            Entry entry = LookupInCache(s_cache, (IntPtr)obj.GetMethodTable(), openResolver);
             if (entry == null)
             {
-                entry = CacheMiss((IntPtr)obj.MethodTable, openResolver,
+                entry = CacheMiss((IntPtr)obj.GetMethodTable(), openResolver,
                     (IntPtr context, IntPtr signature, object contextObject, ref IntPtr auxResult)
                         => Internal.Runtime.CompilerServices.OpenMethodResolver.ResolveMethodWorker(signature, contextObject),
                     obj);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
@@ -268,7 +268,7 @@ namespace System
             if (exception != null)
             {
                 if (reason == RhFailFastReason.PN_UnhandledException)
-                    errorCode = (uint)(exception.EETypePtr.GetHashCode());
+                    errorCode = (uint)(exception.GetEETypePtr().GetHashCode());
                 else if (exception.HResult != 0)
                     errorCode = (uint)exception.HResult;
             }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System
@@ -82,7 +83,7 @@ namespace System
                 else
                 {
                     Type underlyingType = Enum.InternalGetUnderlyingType(this);
-                    if (!(underlyingType.TypeHandle.ToEETypePtr() == value.EETypePtr))
+                    if (!(underlyingType.TypeHandle.ToEETypePtr() == value.GetEETypePtr()))
                         throw new ArgumentException(SR.Format(SR.Arg_EnumUnderlyingTypeAndObjectMustBeSameType, value.GetType(), underlyingType));
                 }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ValueType.cs
@@ -49,7 +49,7 @@ namespace System
 
         public override bool Equals([NotNullWhen(true)] object? obj)
         {
-            if (obj == null || obj.EETypePtr != this.EETypePtr)
+            if (obj == null || obj.GetEETypePtr() != this.GetEETypePtr())
                 return false;
 
             int numFields = __GetFieldHelper(GetNumFields, out _);
@@ -60,10 +60,10 @@ namespace System
             if (numFields == UseFastHelper)
             {
                 // Sanity check - if there are GC references, we should not be comparing bytes
-                Debug.Assert(!this.EETypePtr.HasPointers);
+                Debug.Assert(!this.GetEETypePtr().HasPointers);
 
                 // Compare the memory
-                int valueTypeSize = (int)this.EETypePtr.ValueTypeSize;
+                int valueTypeSize = (int)this.GetEETypePtr().ValueTypeSize;
                 for (int i = 0; i < valueTypeSize; i++)
                 {
                     if (Unsafe.Add(ref thisRawData, i) != Unsafe.Add(ref thatRawData, i))
@@ -99,7 +99,7 @@ namespace System
 
         public override int GetHashCode()
         {
-            int hashCode = this.EETypePtr.GetHashCode();
+            int hashCode = this.GetEETypePtr().GetHashCode();
 
             hashCode ^= GetHashCodeImpl();
 
@@ -111,9 +111,9 @@ namespace System
             int numFields = __GetFieldHelper(GetNumFields, out _);
 
             if (numFields == UseFastHelper)
-                return FastGetValueTypeHashCodeHelper(this.EETypePtr, ref this.GetRawData());
+                return FastGetValueTypeHashCodeHelper(this.GetEETypePtr(), ref this.GetRawData());
 
-            return RegularGetValueTypeHashCode(this.EETypePtr, ref this.GetRawData(), numFields);
+            return RegularGetValueTypeHashCode(this.GetEETypePtr(), ref this.GetRawData(), numFields);
         }
 
         private static int FastGetValueTypeHashCodeHelper(EETypePtr type, ref byte data)

--- a/src/coreclr/nativeaot/Test.CoreLib/src/System/Object.cs
+++ b/src/coreclr/nativeaot/Test.CoreLib/src/System/Object.cs
@@ -11,7 +11,6 @@ namespace System
     // CONTRACT with Runtime
     // The Object type is one of the primitives understood by the compilers and runtime
     // Data Contract: Single field of type MethodTable*
-    // VTable Contract: The first vtable slot should be the finalizer for object => The first virtual method in the object class should be the Finalizer
 
     public unsafe class Object
     {
@@ -25,10 +24,6 @@ namespace System
         {
         }
 
-        // Allow an object to free resources before the object is reclaimed by the GC.
-        // CONTRACT with runtime: This method's virtual slot number is hardcoded in the binder. It is an
-        // implementation detail where it winds up at runtime.
-        // **** Do not add any virtual methods in this class ahead of this ****
 #pragma warning disable CA1821 // Remove empty Finalizers
         ~Object()
         {
@@ -45,19 +40,7 @@ namespace System
             return 0;
         }
 
-        internal MethodTable* MethodTable
-        {
-            get
-            {
-                // NOTE:  if managed code can be run when the GC has objects marked, then this method is
-                //        unsafe.  But, generically, we don't expect managed code such as this to be allowed
-                //        to run while the GC is running.
-                return m_pEEType;
-            }
-        }
-
-        [Runtime.CompilerServices.Intrinsic]
-        internal static extern MethodTable* MethodTableOf<T>();
+        internal MethodTable* GetMethodTable() => m_pEEType;
 
         [StructLayout(LayoutKind.Sequential)]
         private class RawData
@@ -74,9 +57,9 @@ namespace System
         /// Return size of all data (excluding ObjHeader and MethodTable*).
         /// Note that for strings/arrays this would include the Length as well.
         /// </summary>
-        internal uint GetRawDataSize()
+        internal uint GetRawObjectDataSize()
         {
-            return MethodTable->BaseSize - (uint)sizeof(ObjHeader) - (uint)sizeof(MethodTable*);
+            return GetMethodTable()->BaseSize - (uint)sizeof(ObjHeader) - (uint)sizeof(MethodTable*);
         }
     }
 }

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
@@ -115,9 +115,9 @@ namespace Internal.IL.Stubs
                     codeStream.EmitLdArg(1);
                     codeStream.Emit(ILOpcode.brfalse, typeCheckPassedLabel);
 
-                    // MethodTable* actualElementType = this.MethodTable.RelatedParameterType; // ArrayElementType
+                    // MethodTable* actualElementType = this.m_pEEType->RelatedParameterType; // ArrayElementType
                     codeStream.EmitLdArg(0);
-                    codeStream.Emit(ILOpcode.call, _emitter.NewToken(objectType.GetKnownMethod("get_MethodTable", null)));
+                    codeStream.Emit(ILOpcode.ldfld, _emitter.NewToken(objectType.GetKnownField("m_pEEType")));
                     codeStream.Emit(ILOpcode.call,
                         _emitter.NewToken(eetypeType.GetKnownMethod("get_RelatedParameterType", null)));
 
@@ -146,7 +146,7 @@ namespace Internal.IL.Stubs
                 TypeDesc eetypeType = context.SystemModule.GetKnownType("Internal.Runtime", "MethodTable");
 
                 codeStream.EmitLdArg(0);
-                codeStream.Emit(ILOpcode.call, _emitter.NewToken(objectType.GetKnownMethod("get_MethodTable", null)));
+                codeStream.Emit(ILOpcode.ldfld, _emitter.NewToken(objectType.GetKnownField("m_pEEType")));
                 codeStream.Emit(ILOpcode.call,
                     _emitter.NewToken(eetypeType.GetKnownMethod("get_IsSzArray", null)));
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/NoMetadataBlockingPolicy.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/NoMetadataBlockingPolicy.cs
@@ -44,21 +44,12 @@ namespace ILCompiler
         {
             if (method is EcmaMethod ecmaMethod)
             {
-                TypeDesc owningType = ecmaMethod.OwningType;
-
                 // Methods on Array`1<T> are implementation details that implement the generic interfaces on
                 // arrays. They should not generate metadata or be reflection invokable.
                 // We can get rid of this special casing if we make these methods stop being regular EcmaMethods
                 // with Array<T> as their owning type
-                if (owningType == GetArrayOfTType(ecmaMethod))
+                if (ecmaMethod.OwningType == GetArrayOfTType(ecmaMethod))
                     return true;
-
-                // Do not expose any of our internal details
-                if (owningType.IsObject)
-                {
-                    return method.Name is not ".ctor" and not "Equals" and not "Finalize" and not "GetHashCode"
-                        and not "GetType" and not "MemberwiseClone" and not "ReferenceEquals" and not "ToString";
-                }
 
                 return false;
             }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -1292,13 +1292,13 @@ namespace Internal.IL
 
         private bool IsEETypePtrOf(MethodDesc method)
         {
-            if (method.IsIntrinsic && (method.Name == "EETypePtrOf" || method.Name == "MethodTableOf") && method.Instantiation.Length == 1)
+            if (method.IsIntrinsic && (method.Name == "EETypePtrOf" || method.Name == "Of") && method.Instantiation.Length == 1)
             {
                 MetadataType owningType = method.OwningType as MetadataType;
                 if (owningType != null)
                 {
                     return (owningType.Name == "EETypePtr" && owningType.Namespace == "System")
-                        || (owningType.Name == "Object" && owningType.Namespace == "System");
+                        || (owningType.Name == "MethodTable" && owningType.Namespace == "Internal.Runtime");
                 }
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1795,7 +1795,7 @@ namespace Internal.JitInterface
             switch (method.Name)
             {
                 case "EETypePtrOf":
-                case "MethodTableOf":
+                case "Of":
                     ComputeLookup(ref pResolvedToken, method.Instantiation[0], ReadyToRunHelperId.TypeHandle, ref pResult.lookup);
                     break;
                 case "DefaultConstructorOf":


### PR DESCRIPTION
When reflection blocking is disabled (like we do for libraries tests), still block implementation details on System.Object because tests (or anyone else for that matter) don't like to see them.