### PR TITLE
Check MultiCoreJit code cache before trying to jit method in mcj thread

### DIFF
--- a/src/coreclr/vm/multicorejit.h
+++ b/src/coreclr/vm/multicorejit.h
@@ -165,6 +165,8 @@ public:
 
     void StoreMethodCode(MethodDesc * pMethod, MulticoreJitCodeInfo codeInfo);
 
+    bool LookupMethodCode(MethodDesc * pMethod);
+
     MulticoreJitCodeInfo QueryAndRemoveMethodCode(MethodDesc * pMethod);
 
     inline unsigned GetRemainingMethodCount() const

--- a/src/coreclr/vm/multicorejitplayer.cpp
+++ b/src/coreclr/vm/multicorejitplayer.cpp
@@ -104,6 +104,20 @@ void MulticoreJitCodeStorage::StoreMethodCode(MethodDesc * pMD, MulticoreJitCode
 }
 
 
+// Check if method is already compiled and stored
+bool MulticoreJitCodeStorage::LookupMethodCode(MethodDesc * pMethod)
+{
+    STANDARD_VM_CONTRACT;
+
+    MulticoreJitCodeInfo codeInfo;
+
+    {
+        CrstHolder holder(& m_crstCodeMap);
+        return m_nativeCodeMap.Lookup(pMethod, &codeInfo);
+    }
+}
+
+
 // Query from MakeJitWorker: Lookup stored JITted methods
 MulticoreJitCodeInfo MulticoreJitCodeStorage::QueryAndRemoveMethodCode(MethodDesc * pMethod)
 {
@@ -958,7 +972,7 @@ void MulticoreJitProfilePlayer::CompileMethodInfoRecord(Module *pModule, MethodD
             }
         }
 
-        if (pMethod->GetNativeCode() == NULL)
+        if (pMethod->GetNativeCode() == NULL && !GetAppDomain()->GetMulticoreJitManager().GetMulticoreJitCodeStorage().LookupMethodCode(pMethod))
         {
             if (CompileMethodDesc(pModule, pMethod))
             {


### PR DESCRIPTION
This is needed when multiple profiles are played and same methods exist in them. Without this change, if method was not yet requested in main thread, it will be jitted as many times in mcj thread as it appears in all profiles.

cc @alpencolt 