### PR TITLE
Use ComSmartPtr in tests

### DIFF
--- a/src/tests/Interop/COM/Dynamic/Server/DispatchImpl.cpp
+++ b/src/tests/Interop/COM/Dynamic/Server/DispatchImpl.cpp
@@ -23,15 +23,6 @@ DispatchImpl::DispatchImpl(GUID guid, void *instance, const wchar_t* tlb)
         throw hr;
 }
 
-DispatchImpl::~DispatchImpl()
-{
-    if (_typeLib != nullptr)
-        _typeLib->Release();
-
-    if (_typeInfo != nullptr)
-        _typeInfo->Release();
-};
-
 HRESULT DispatchImpl::DoGetTypeInfoCount(UINT* pctinfo)
 {
     *pctinfo = 1;

--- a/src/tests/Interop/COM/Dynamic/Server/DispatchImpl.h
+++ b/src/tests/Interop/COM/Dynamic/Server/DispatchImpl.h
@@ -11,7 +11,7 @@ class DispatchImpl : public UnknownImpl
 {
 public:
     DispatchImpl(GUID guid, void *instance, const wchar_t* tlb = nullptr);
-    virtual ~DispatchImpl();
+    virtual ~DispatchImpl() = default;
 
     DispatchImpl(const DispatchImpl&) = delete;
     DispatchImpl& operator=(const DispatchImpl&) = delete;
@@ -26,8 +26,8 @@ protected:
     HRESULT DoInvoke(DISPID dispIdMember, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr);
 
 private:
-    ITypeLib *_typeLib;
-    ITypeInfo *_typeInfo;
+    ComSmartPtr<ITypeLib> _typeLib;
+    ComSmartPtr < ITypeInfo> _typeInfo;
     void *_instance;
 };
 

--- a/src/tests/Interop/COM/Dynamic/Server/DispatchImpl.h
+++ b/src/tests/Interop/COM/Dynamic/Server/DispatchImpl.h
@@ -27,7 +27,7 @@ protected:
 
 private:
     ComSmartPtr<ITypeLib> _typeLib;
-    ComSmartPtr < ITypeInfo> _typeInfo;
+    ComSmartPtr<ITypeInfo> _typeInfo;
     void *_instance;
 };
 


### PR DESCRIPTION
> Boo. I didn't realize we missed that in dotnet/runtime. Yes, we should update that as well.

See https://github.com/dotnet/winforms/pull/6743#discussion_r837019661 for discussion