### PR TITLE
log entire content to see which assertion fails

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
@@ -499,6 +499,17 @@ namespace System
                 throw new XunitException($"Expected: {expected1} || {expected2}{Environment.NewLine}Actual: {value}");
         }
 
+        /// <summary>
+        /// Compares two strings, logs entire content if they are not equal.
+        /// </summary>
+        public static void Equal(string expected, string actual)
+        {
+            if (!expected.Equals(actual))
+            {
+                throw new AssertActualExpectedException(expected, actual, "Provided strings were not equal!");
+            }
+        }
+
         public delegate void AssertThrowsActionReadOnly<T>(ReadOnlySpan<T> span);
 
         public delegate void AssertThrowsAction<T>(Span<T> span);

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -82,7 +82,7 @@ namespace System.Diagnostics.Tests
             p.WaitForExit(); // This ensures async event handlers are finished processing.
 
             const string Expected = RemotelyInvokable.TestConsoleApp + " started error stream" + RemotelyInvokable.TestConsoleApp + " closed error stream";
-            Assert.Equal(Expected, sb.ToString());
+            AssertExtensions.Equal(Expected, sb.ToString());
             Assert.Equal(invokeRequired ? 3 : 0, invokeCalled);
         }
 


### PR DESCRIPTION
Let's log entire content to see which assertion fails. Once we have a repro, we are going to report the actual bug.

fixes #67549

I've hacked the test locally to see if it works as expected. It does, as entire content is logged:

![image](https://user-images.githubusercontent.com/6011991/161773306-5ccb50e2-a38b-4f73-b7c6-881b0de5ec80.png)


