### PR TITLE
Move tests that touch the network to outerloop only for infra-stability reasons

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
@@ -129,6 +129,7 @@ partial class C
 
         [Theory]
         [MemberData(nameof(GetDownlevelTargetFrameworks))]
+        [OuterLoop]
         public async Task SkipLocalsInitOnDownlevelTargetFrameworks(TestTargetFramework targetFramework, bool expectSkipLocalsInit)
         {
             string source = $@"

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
@@ -129,7 +129,7 @@ partial class C
 
         [Theory]
         [MemberData(nameof(GetDownlevelTargetFrameworks))]
-        [OuterLoop]
+        [OuterLoop("Uses the network for downlevel ref packs")]
         public async Task SkipLocalsInitOnDownlevelTargetFrameworks(TestTargetFramework targetFramework, bool expectSkipLocalsInit)
         {
             string source = $@"

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AttributeForwarding.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AttributeForwarding.cs
@@ -297,7 +297,7 @@ struct Native
         }
 
         [Fact]
-        [OuterLoop]
+        [OuterLoop("Uses the network for downlevel ref packs")]
         public async Task InOutAttributes_Forwarded_To_ForwardedParameter()
         {
             string source = @"
@@ -341,7 +341,7 @@ partial class C
         }
 
         [Fact]
-        [OuterLoop]
+        [OuterLoop("Uses the network for downlevel ref packs")]
         public async Task MarshalAsAttribute_Forwarded_To_ForwardedParameter()
         {
             string source = @"
@@ -371,7 +371,7 @@ partial class C
         }
 
         [Fact]
-        [OuterLoop]
+        [OuterLoop("Uses the network for downlevel ref packs")]
         public async Task MarshalAsAttribute_Forwarded_To_ForwardedParameter_Array()
         {
             string source = @"

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AttributeForwarding.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AttributeForwarding.cs
@@ -297,6 +297,7 @@ struct Native
         }
 
         [Fact]
+        [OuterLoop]
         public async Task InOutAttributes_Forwarded_To_ForwardedParameter()
         {
             string source = @"
@@ -340,6 +341,7 @@ partial class C
         }
 
         [Fact]
+        [OuterLoop]
         public async Task MarshalAsAttribute_Forwarded_To_ForwardedParameter()
         {
             string source = @"
@@ -369,6 +371,7 @@ partial class C
         }
 
         [Fact]
+        [OuterLoop]
         public async Task MarshalAsAttribute_Forwarded_To_ForwardedParameter_Array()
         {
             string source = @"

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
@@ -305,7 +305,7 @@ namespace LibraryImportGenerator.UnitTests
 
         [Theory]
         [MemberData(nameof(CodeSnippetsToValidateFallbackForwarder))]
-        [OuterLoop]
+        [OuterLoop("Uses the network for downlevel ref packs")]
         public async Task ValidateSnippetsFallbackForwarder(string source, TestTargetFramework targetFramework, bool expectFallbackForwarder)
         {
             Compilation comp = await TestUtils.CreateCompilation(source, targetFramework);

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
@@ -305,6 +305,7 @@ namespace LibraryImportGenerator.UnitTests
 
         [Theory]
         [MemberData(nameof(CodeSnippetsToValidateFallbackForwarder))]
+        [OuterLoop]
         public async Task ValidateSnippetsFallbackForwarder(string source, TestTargetFramework targetFramework, bool expectFallbackForwarder)
         {
             Compilation comp = await TestUtils.CreateCompilation(source, targetFramework);

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Diagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Diagnostics.cs
@@ -16,57 +16,6 @@ namespace LibraryImportGenerator.UnitTests
 {
     public class Diagnostics
     {
-        [Theory]
-        [InlineData(TestTargetFramework.Framework)]
-        [InlineData(TestTargetFramework.Core)]
-        [InlineData(TestTargetFramework.Standard)]
-        [InlineData(TestTargetFramework.Net5)]
-        public async Task TargetFrameworkNotSupported_NoDiagnostic(TestTargetFramework targetFramework)
-        {
-            string source = $@"
-using System.Runtime.InteropServices;
-{CodeSnippets.LibraryImportAttributeDeclaration}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method();
-}}
-";
-            Compilation comp = await TestUtils.CreateCompilation(source, targetFramework);
-            TestUtils.AssertPreSourceGeneratorCompilation(comp);
-
-            var newComp = TestUtils.RunGenerators(comp, out var generatorDiags, new Microsoft.Interop.LibraryImportGenerator());
-            Assert.Empty(generatorDiags);
-
-            var newCompDiags = newComp.GetDiagnostics();
-            Assert.Empty(newCompDiags);
-        }
-
-        [Theory]
-        [InlineData(TestTargetFramework.Framework)]
-        [InlineData(TestTargetFramework.Core)]
-        [InlineData(TestTargetFramework.Standard)]
-        [InlineData(TestTargetFramework.Net5)]
-        public async Task TargetFrameworkNotSupported_NoLibraryImport_NoDiagnostic(TestTargetFramework targetFramework)
-        {
-            string source = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [DllImport(""DoesNotExist"")]
-    public static extern void Method();
-}
-";
-            Compilation comp = await TestUtils.CreateCompilation(source, targetFramework);
-            TestUtils.AssertPreSourceGeneratorCompilation(comp);
-
-            var newComp = TestUtils.RunGenerators(comp, out var generatorDiags, new Microsoft.Interop.LibraryImportGenerator());
-            Assert.Empty(generatorDiags);
-
-            var newCompDiags = newComp.GetDiagnostics();
-            Assert.Empty(newCompDiags);
-        }
-
         [Fact]
         public async Task ParameterTypeNotSupported_ReportsDiagnostic()
         {


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/67508

cc: @dotnet/interop-contrib, @danmoseley