### PR TITLE
[release/6.0] Disable test Runtime_56953

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -649,6 +649,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_19601/Github_19601/*">
             <Issue>Needs Triage</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_56953/Runtime_56953/*">
+            <Issue>https://github.com/dotnet/runtime/issues/67603</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Unix arm64 specific -->
@@ -683,6 +686,9 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/regress/vsw/373472/**">
             <Issue>Allocates large contiguous array that is not consistently available on 32-bit platforms</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_56953/Runtime_56953/*">
+            <Issue>https://github.com/dotnet/runtime/issues/67603</Issue>
         </ExcludeList>
     </ItemGroup>
 


### PR DESCRIPTION
This avoids a JIT assert in jitstress test runs.

We don't intend to fix the underlying issues in release/6.0 branch.

Tracking: https://github.com/dotnet/runtime/issues/67603