### PR TITLE
Enable MSVC standard conformance for JIT sources

### DIFF
--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -11,6 +11,10 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_
   add_compile_options(-Wno-error)
 endif()
 
+if (MSVC)
+  add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/permissive->)
+endif()
+
 function(create_standalone_jit)
 
   set(oneValueArgs TARGET OS ARCH)

--- a/src/coreclr/jit/unwind.h
+++ b/src/coreclr/jit/unwind.h
@@ -79,32 +79,6 @@ protected:
     {
     }
 
-// TODO: How do we get the ability to access uwiComp without error on Clang?
-#if defined(DEBUG) && !defined(__GNUC__)
-
-    template <typename T>
-    T dspPtr(T p)
-    {
-        return uwiComp->dspPtr(p);
-    }
-
-    template <typename T>
-    T dspOffset(T o)
-    {
-        return uwiComp->dspOffset(o);
-    }
-
-    static const char* dspBool(bool b)
-    {
-        return (b) ? "true" : "false";
-    }
-
-#endif // DEBUG
-
-    //
-    // Data
-    //
-
     Compiler* uwiComp;
 };
 


### PR DESCRIPTION
The JIT sources pretty much already compiled under this mode except for
one thing that could just be fixed by removing the code. This will catch
some obvious bugs, like passing 'false' as a pointer.

Unfortunately it seems this cannot be enabled for coreclr in general without more work.