### PR TITLE
[iOS] Disable OptionsMonitorTest.TestCurrentValueDoesNotAllocateOnceValueIsCached

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsMonitorTest.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsMonitorTest.cs
@@ -471,6 +471,7 @@ namespace Microsoft.Extensions.Options.Tests
         /// Tests the fix for https://github.com/dotnet/runtime/issues/61086
         /// </summary>
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/67611", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public void TestCurrentValueDoesNotAllocateOnceValueIsCached()
         {
             var monitor = new OptionsMonitor<FakeOptions>(


### PR DESCRIPTION
Created a tracking issue so that it can be fixed at a later date and not block the extra-platforms rolling build.

https://github.com/dotnet/runtime/issues/67611