### PR TITLE
Default interface implementations of static virtual methods - ECMA-335 augments

### DIFF
--- a/docs/design/specs/Ecma-335-Augments.md
+++ b/docs/design/specs/Ecma-335-Augments.md
@@ -444,11 +444,14 @@ The algorithm is amended as follows:
 
 **Section** "III.2.1 constrained. prefix" the paragraph starting with "This last case can only occur when method was defined on `System.Object`, `System.ValueType`, or `System.Enum`" is extended to also cover default interface method implementation. In the case the interface method implementation is provided by an interface, the implicit boxing becomes _observable_ to the program.
 
-**Section** "III.3.41 ldftn" is extended to allow throwing `AmbiguousImplementationException` if the implementation of the static virtual interface method resolves at runtime to more than one default interface method. It's also extended to specify throwing `EntryPointNotFoundException` if the default interface implementation is abstract.
+The following sections are extended to allow throwing `AmbiguousImplementationException` if the implementation
+of the static virtual interface method resolves at runtime to more than one default interface method.
+They are also extended to specify throwing `EntryPointNotFoundException` if the default interface implementation is abstract.
 
-**Section** "III.4.2 callvirt" is extended to allow throwing `AmbiguousImplementationException` if the implementation of the interface method resolves at runtime to more than one default interface method. It's also extended to specify throwing `EntryPointNotFoundException` if the default interface implementation is abstract.
-
-**Section** "III.4.18 ldvirtftn" is extended to allow throwing `AmbiguousImplementationException` if the implementation of the interface method resolves at runtime to more than one default interface method. It's also extended to specify throwing `EntryPointNotFoundException` if the default interface implementation is abstract.
+  * III.3.19 - call
+  * III.3.41 - ldftn
+  * III.4.2 - callvirt
+  * III.4.18 - ldvirtftn
 
 ## Static Interface Methods
 

--- a/docs/design/specs/Ecma-335-Augments.md
+++ b/docs/design/specs/Ecma-335-Augments.md
@@ -399,9 +399,9 @@ Default interface methods is a runtime feature designed to support the [default 
 The major changes are:
 
 * Interfaces are now allowed to have instance methods (both virtual and non-virtual). Previously we only allowed abstract virtual methods.
-  * Interfaces obviously still can't have instance fields.
-  * Interfaces may also define static virtual methods (either as abstract or by directly providing the default implementation in the declaration).
-* Interface methods are allowed to MethodImpl other interface methods the interface _requires_ (but we require the `MethodImpl`s to be final to keep things simple) - i.e. an interface is allowed to provide (or override) an implementation of another interface's method
+* Interfaces obviously still can't have instance fields.
+* Interfaces may also define static virtual methods (either as abstract or by directly providing the default implementation in the declaration).
+* Interface methods are allowed to MethodImpl other interface methods the interface _requires_ i.e. an interface is allowed to provide (or override) an implementation of another interface's method
   (instance or static virtual).
 
 This list of changes to the specification doesn't attempt to be an exhaustive list - there are many places within the spec that mention interfaces being just contracts that don't define implementation. This list should be complete enough to list places where interesting _implementation differences_ happen.
@@ -547,11 +547,11 @@ Interfaces may define static virtual methods that get resolved at runtime based 
 ### II.12.2 Implementing virtual methods on interfaces
 
 (Add a new bullet under the second bullet in the bulleted list below the first paragraph by mentioning
-that classes can implement abstract static virtual methods by implementing a derived interface providing
-the default implementation for the abstract static virtual method):
+that classes can implement static virtual methods by implementing a derived interface providing
+the implementation for the static virtual method):
 
 * Inheritance of an existing default implementation from an implemented interface derived from
-  the interface declaring the abstract static virtual method.
+  the interface declaring the static virtual method.
 
 (Edit 8th paragraph at page 158, the first unindented one below the bullet list, by
 basically clarifying that "public virtual methods" only refer to "public virtual instance methods"):


### PR DESCRIPTION
This change proposes a number of additions and changes to the
ECMA-335 augments with regard to default interface implementations
of static virtual methods. For now I have kept the two sections
separate (Default Interface Methods vs. Virtual Static Methods)
to avoid excessive churn even though there's obvious overlap;
after all, both sections basically amount to "suggestions for a
future editor of the actual ECMA-335 spec" so that keeping them
separate is not a big deal.

(*) At this point I didn't attempt to construct a C# example
demonstrating default interface SVM implementations;

(*) Both sections contain suggestions for modifying the method
resolution algorithm described in II.12.2; each version has its
own merits - the Default Interface version is more focused on
describing the gist of the algorithm change whereas the SVM
version is attempting to propose a complete formulation of the
updated algorithm. I'm not sure what is the ideal way to approach
those.

Thanks

Tomas