### PR TITLE
Disable System.Net.Quic.Tests.QuicStreamTests.WriteAsync_LocalAbort_Throws

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -820,6 +820,7 @@ namespace System.Net.Quic.Tests
 
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/67612")]
         public async Task WriteAsync_LocalAbort_Throws()
         {
             if (IsMockProvider)


### PR DESCRIPTION
The new test introduced in #67341 seems to fail quite frequently in PRs, This PR disables it to unblock clean CI.

Contributes to #67612