### PR TITLE
Add JitDump output for calls to recordRelocation

### DIFF
--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -2383,15 +2383,40 @@ public:
 
     COMP_HANDLE emitCmpHandle;
 
-    /************************************************************************/
-    /*               Helpers for interface to EE                            */
-    /************************************************************************/
+/************************************************************************/
+/*               Helpers for interface to EE                            */
+/************************************************************************/
 
-    void emitRecordRelocation(void* location,       /* IN */
-                              void* target,         /* IN */
-                              WORD  fRelocType,     /* IN */
-                              WORD  slotNum   = 0,  /* IN */
-                              INT32 addlDelta = 0); /* IN */
+#ifdef DEBUG
+
+#define emitRecordRelocation(location, target, fRelocType)                                                             \
+    emitRecordRelocationHelp(location, target, fRelocType, #fRelocType)
+
+#define emitRecordRelocationWithAddlDelta(location, target, fRelocType, addlDelta)                                     \
+    emitRecordRelocationHelp(location, target, fRelocType, #fRelocType, addlDelta)
+
+    void emitRecordRelocationHelp(void*       location,       /* IN */
+                                  void*       target,         /* IN */
+                                  uint16_t    fRelocType,     /* IN */
+                                  const char* relocTypeName,  /* IN */
+                                  int32_t     addlDelta = 0); /* IN */
+
+#else // !DEBUG
+
+    void emitRecordRelocationWithAddlDelta(void*    location,   /* IN */
+                                           void*    target,     /* IN */
+                                           uint16_t fRelocType, /* IN */
+                                           int32_t  addlDelta)  /* IN */
+    {
+        emitRecordRelocation(location, target, fRelocType, addlDelta);
+    }
+
+    void emitRecordRelocation(void*    location,       /* IN */
+                              void*    target,         /* IN */
+                              uint16_t fRelocType,     /* IN */
+                              int32_t  addlDelta = 0); /* IN */
+
+#endif // !DEBUG
 
 #ifdef TARGET_ARM
     void emitHandlePCRelativeMov32(void* location, /* IN */

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -10607,8 +10607,8 @@ GOT_DSP:
 #else
                     dst += emitOutputLong(dst, dsp);
 #endif
-                    emitRecordRelocation((void*)(dst - sizeof(INT32)), (void*)dsp, IMAGE_REL_BASED_DISP32, 0,
-                                         addlDelta);
+                    emitRecordRelocationWithAddlDelta((void*)(dst - sizeof(INT32)), (void*)dsp, IMAGE_REL_BASED_DISP32,
+                                                      addlDelta);
                 }
                 else
                 {
@@ -11847,7 +11847,7 @@ BYTE* emitter::emitOutputCV(BYTE* dst, instrDesc* id, code_t code, CnsVal* addc)
 
         if (id->idIsDspReloc())
         {
-            emitRecordRelocation((void*)(dst - sizeof(int)), target, IMAGE_REL_BASED_DISP32, 0, addlDelta);
+            emitRecordRelocationWithAddlDelta((void*)(dst - sizeof(int)), target, IMAGE_REL_BASED_DISP32, addlDelta);
         }
     }
     else


### PR DESCRIPTION
E.g.,

```
recordRelocation: 000001ECBD3AE28C (rw: 000001ECBD3AE28C) => 000001ECBD38BC04, type 16 (IMAGE_REL_BASED_DISP32), delta 0
```