### PR TITLE
Fix exception thrown from MsQuicStream writes when connection is aborted by peer.

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -1264,9 +1264,9 @@ namespace System.Net.Quic.Implementations.MsQuic
         private static uint HandleEventSendComplete(State state, ref StreamEvent evt)
         {
             StreamEventDataSendComplete sendCompleteEvent = evt.Data.SendComplete;
+            bool canceled = sendCompleteEvent.Canceled != 0;
 
             bool complete = false;
-            Exception? abortException = null;
 
             lock (state)
             {
@@ -1276,18 +1276,9 @@ namespace System.Net.Quic.Implementations.MsQuic
                     complete = true;
                 }
 
-                if (sendCompleteEvent.Canceled != 0)
+                if (canceled)
                 {
                     state.SendState = SendState.Aborted;
-
-                    //
-                    // There are multiple reasons the send could have been cancelled:
-                    //   - Connection was aborted (either by transport or peer) => error-code already provided on the connection-level event
-                    //   - Stream's receive side was aborted by peer => already handled by HandleEventPeerRecvAborted
-                    //     and we will not set the exception due to complete == false
-                    //   - Stream's send side was aborted locally => no connection-level abort code and we return QuicOperationAbortException
-                    //
-                    abortException = ThrowHelper.GetConnectionAbortedException(state.ConnectionState.AbortErrorCode);
                 }
             }
 
@@ -1295,14 +1286,22 @@ namespace System.Net.Quic.Implementations.MsQuic
             {
                 CleanupSendState(state);
 
-                if (abortException == null)
+                if (!canceled)
                 {
                     state.SendResettableCompletionSource.Complete(MsQuicStatusCodes.Success);
                 }
                 else
                 {
+                    //
+                    // There are multiple reasons the send could have been cancelled:
+                    //   - Connection was aborted (either by transport or peer) => error-code already provided on the connection-level event
+                    //   - Stream's receive side was aborted by peer => already handled by HandleEventPeerRecvAborted
+                    //     and we will not set the exception due to complete == false
+                    //   - Stream's send side was aborted locally => no connection-level abort code and we return QuicOperationAbortException
+                    //
                     state.SendResettableCompletionSource.CompleteException(
-                        ExceptionDispatchInfo.SetCurrentStackTrace(abortException));
+                        ExceptionDispatchInfo.SetCurrentStackTrace(
+                            ThrowHelper.GetConnectionAbortedException(state.ConnectionState.AbortErrorCode)));
                 }
             }
 


### PR DESCRIPTION
Fixes #53090, closes #58078.

As of recent MsQuic versions, when we receive `SEND_COMPLETE` event in `MsQuicStream` with Cancelled = 1, we already have all the information provided by previous MsQuic events needed to determine the cause of the cancellation and can throw an appropriate exception. There is no data race on the order of events as they are indicated by the same thread (I checked MsQuic source code for that).