### PR TITLE
[runtime] copy updated byref nullables after invoke

### DIFF
--- a/src/libraries/System.Reflection/tests/MethodInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/MethodInfoTests.cs
@@ -620,7 +620,6 @@ namespace System.Reflection.Tests
             Assert.Equal(expected, methodInfo.ToString());
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/67269", TestRuntimes.Mono)]
         [Fact]
         public void InvokeNullableRefs()
         {
@@ -656,7 +655,6 @@ namespace System.Reflection.Tests
                 name, BindingFlags.Public | BindingFlags.Static)!;
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/67269", TestRuntimes.Mono)]
         [Fact]
         public void InvokeBoxedNullableRefs()
         {

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -4841,6 +4841,20 @@ mono_runtime_try_invoke_span (MonoMethod *method, void *obj, MonoSpanOfObjects *
 			g_assert (box_exc == NULL);
 			mono_error_assert_ok (error);
 		}
+
+		if (has_byref_nullables) {
+			/*
+			 * The runtime invoke wrapper already converted byref nullables back,
+			 * and stored them in pa, we just need to copy them back to the
+			 * managed array.
+			 */
+			for (i = 0; i < params_length; i++) {
+				MonoType *t = sig->params [i];
+
+				if (m_type_is_byref (t) && t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type_internal (t)))
+					mono_span_setref (params_span, i, pa [i]);
+			}
+		}
 	}
 	goto exit;
 exit_null:


### PR DESCRIPTION
Bring back some code lost in https://github.com/dotnet/runtime/pull/60270

When a `null` is passed for a `ref Nullable<S>` argument to a runtime invoke, the invoke wrapper creates a default `Nullable` that should be copied back into the original arguments array of the invoke.

There is code in the managed `Invoke` method to do some of the copying from the temporary array that is created for the Invoke (we pass a `Span<object>` over that array from managed to native), but in `mono_runtime_try_invoke_span` we create a C array `pa` that has the arguments (this takes care of by-value semantics for value types, for example).  We need to copy the byref nullables back from `pa` to the span, so that managed code can then copy it back from the span to the original input array of the Invoke.

Fixes https://github.com/dotnet/runtime/issues/67269