### PR TITLE
Add libssl3 dependency to Debian DEPS package

### DIFF
--- a/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-debian.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-debian.proj
@@ -5,7 +5,7 @@
 
   <ItemGroup>
     <LinuxPackageDependency Include="libc6;libgcc1;libgssapi-krb5-2;libstdc++6;zlib1g"/>
-    <LinuxPackageDependency Include="libssl1.0.0 | libssl1.0.2 | libssl1.1" />
+    <LinuxPackageDependency Include="libssl1.0.0 | libssl1.0.2 | libssl1.1 | libssl3" />
     <KnownLibIcuVersion Include="72;71;70;69;68;67;66;65;63;60;57;55;52" />
     <LibIcuPackageDependency Include="libicu" Dependencies="libicu | @(KnownLibIcuVersion -> 'libicu%(Identity)', ' | ')" />
     <LinuxPackageDependency


### PR DESCRIPTION
Ubuntu 22.04 requires libssl3, it does not have libssl1.1 or previous versions. See: https://github.com/dotnet/core/issues/7038#issuecomment-1090452213