### PR TITLE
S.S.C.Cose: Remove ECDsa and RSA overloads in favor of AsymmetricAlgorithm

### DIFF
--- a/src/libraries/System.Security.Cryptography.Cose/ref/System.Security.Cryptography.Cose.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/ref/System.Security.Cryptography.Cose.cs
@@ -66,18 +66,12 @@ namespace System.Security.Cryptography.Cose
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static byte[] Sign(byte[] content, System.Security.Cryptography.AsymmetricAlgorithm key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Cose.CoseHeaderMap? protectedHeaders = null, System.Security.Cryptography.Cose.CoseHeaderMap? unprotectedHeaders = null, bool isDetached = false) { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
-        public static byte[] Sign(byte[] content, System.Security.Cryptography.ECDsa key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, bool isDetached = false) { throw null; }
+        public static bool TrySign(ReadOnlySpan<byte> content, Span<byte> destination, System.Security.Cryptography.AsymmetricAlgorithm key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, out int bytesWritten, System.Security.Cryptography.Cose.CoseHeaderMap? protectedHeaders = null, System.Security.Cryptography.Cose.CoseHeaderMap? unprotectedHeaders = null, bool isDetached = false) { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
-        public static byte[] Sign(byte[] content, System.Security.Cryptography.RSA key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, bool isDetached = false) { throw null; }
+        public bool Verify(System.Security.Cryptography.AsymmetricAlgorithm key) { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
-        public static bool TrySign(ReadOnlySpan<byte> content, Span<byte> destination, System.Security.Cryptography.AsymmetricAlgorithm key!!, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, out int bytesWritten, System.Security.Cryptography.Cose.CoseHeaderMap? protectedHeaders = null, System.Security.Cryptography.Cose.CoseHeaderMap? unprotectedHeaders = null, bool isDetached = false) { throw null; }
+        public bool Verify(System.Security.Cryptography.AsymmetricAlgorithm key, System.ReadOnlySpan<byte> content) { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
-        public bool Verify(System.Security.Cryptography.ECDsa key) { throw null; }
-        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
-        public bool Verify(System.Security.Cryptography.ECDsa key, System.ReadOnlySpan<byte> content) { throw null; }
-        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
-        public bool Verify(System.Security.Cryptography.RSA key) { throw null; }
-        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
-        public bool Verify(System.Security.Cryptography.RSA key, System.ReadOnlySpan<byte> content) { throw null; }
+        public bool Verify(System.Security.Cryptography.AsymmetricAlgorithm key, byte[] content) { throw null; }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Cose/ref/System.Security.Cryptography.Cose.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/ref/System.Security.Cryptography.Cose.cs
@@ -56,22 +56,22 @@ namespace System.Security.Cryptography.Cose
         public System.Security.Cryptography.Cose.CoseHeaderMap ProtectedHeaders { get { throw null; } }
         public System.Security.Cryptography.Cose.CoseHeaderMap UnprotectedHeaders { get { throw null; } }
         public static System.Security.Cryptography.Cose.CoseSign1Message DecodeSign1(byte[] cborPayload) { throw null; }
-        public static System.Security.Cryptography.Cose.CoseSign1Message DecodeSign1(ReadOnlySpan<byte> cborPayload) { throw null; }
+        public static System.Security.Cryptography.Cose.CoseSign1Message DecodeSign1(System.ReadOnlySpan<byte> cborPayload) { throw null; }
     }
     public sealed partial class CoseSign1Message : System.Security.Cryptography.Cose.CoseMessage
     {
         internal CoseSign1Message() { }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
-        public static byte[] Sign(ReadOnlySpan<byte> content, System.Security.Cryptography.AsymmetricAlgorithm key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Cose.CoseHeaderMap? protectedHeaders = null, System.Security.Cryptography.Cose.CoseHeaderMap? unprotectedHeaders = null, bool isDetached = false) { throw null; }
-        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static byte[] Sign(byte[] content, System.Security.Cryptography.AsymmetricAlgorithm key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Cose.CoseHeaderMap? protectedHeaders = null, System.Security.Cryptography.Cose.CoseHeaderMap? unprotectedHeaders = null, bool isDetached = false) { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
-        public static bool TrySign(ReadOnlySpan<byte> content, Span<byte> destination, System.Security.Cryptography.AsymmetricAlgorithm key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, out int bytesWritten, System.Security.Cryptography.Cose.CoseHeaderMap? protectedHeaders = null, System.Security.Cryptography.Cose.CoseHeaderMap? unprotectedHeaders = null, bool isDetached = false) { throw null; }
+        public static byte[] Sign(System.ReadOnlySpan<byte> content, System.Security.Cryptography.AsymmetricAlgorithm key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Cose.CoseHeaderMap? protectedHeaders = null, System.Security.Cryptography.Cose.CoseHeaderMap? unprotectedHeaders = null, bool isDetached = false) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
+        public static bool TrySign(System.ReadOnlySpan<byte> content, System.Span<byte> destination, System.Security.Cryptography.AsymmetricAlgorithm key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, out int bytesWritten, System.Security.Cryptography.Cose.CoseHeaderMap? protectedHeaders = null, System.Security.Cryptography.Cose.CoseHeaderMap? unprotectedHeaders = null, bool isDetached = false) { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public bool Verify(System.Security.Cryptography.AsymmetricAlgorithm key) { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
-        public bool Verify(System.Security.Cryptography.AsymmetricAlgorithm key, System.ReadOnlySpan<byte> content) { throw null; }
-        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public bool Verify(System.Security.Cryptography.AsymmetricAlgorithm key, byte[] content) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
+        public bool Verify(System.Security.Cryptography.AsymmetricAlgorithm key, System.ReadOnlySpan<byte> content) { throw null; }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Cose/ref/System.Security.Cryptography.Cose.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/ref/System.Security.Cryptography.Cose.cs
@@ -8,6 +8,8 @@ namespace System.Security.Cryptography.Cose
 {
     public readonly partial struct CoseHeaderLabel : System.IEquatable<System.Security.Cryptography.Cose.CoseHeaderLabel>
     {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
         public CoseHeaderLabel(int label) { throw null; }
         public CoseHeaderLabel(string label) { throw null; }
         public static System.Security.Cryptography.Cose.CoseHeaderLabel Algorithm { get { throw null; } }
@@ -42,6 +44,8 @@ namespace System.Security.Cryptography.Cose
         public bool TryGetEncodedValue(System.Security.Cryptography.Cose.CoseHeaderLabel label, out System.ReadOnlyMemory<byte> encodedValue) { throw null; }
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<(System.Security.Cryptography.Cose.CoseHeaderLabel Label, System.ReadOnlyMemory<byte> EncodedValue)>, System.Collections.IEnumerator, System.IDisposable
         {
+            private object _dummy;
+            private int _dummyPrimitive;
             public readonly (System.Security.Cryptography.Cose.CoseHeaderLabel Label, System.ReadOnlyMemory<byte> EncodedValue) Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public void Dispose() { }

--- a/src/libraries/System.Security.Cryptography.Cose/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Cose/src/Resources/Strings.resx
@@ -168,11 +168,11 @@
   <data name="Sign1SignUnsupportedHashAlgorithm" xml:space="preserve">
     <value>Unsuppoerted hash algorithm '{0}'.</value>
   </data>
-  <data name="Sign1SignUnsupportedKey" xml:space="preserve">
-    <value>Unsupported key '{0}'.</value>
-  </data>
   <data name="Sign1UnknownCoseAlgorithm" xml:space="preserve">
     <value>COSE algorithm '{0}' is unknown.</value>
+  </data>
+  <data name="Sign1UnsupportedKey" xml:space="preserve">
+    <value>Unsupported key '{0}'.</value>
   </data>
   <data name="Sign1VerifyAlgHeaderWasIncorrect" xml:space="preserve">
     <value>Algorithm header CBOR type was incorrect, expected int or tstr.</value>

--- a/src/libraries/System.Security.Cryptography.Cose/tests/CoseSign1MessageTests.Sign.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/tests/CoseSign1MessageTests.Sign.cs
@@ -101,7 +101,7 @@ namespace System.Security.Cryptography.Cose.Tests
         internal override List<CoseAlgorithm> CoseAlgorithms => new() { CoseAlgorithm.ES256, CoseAlgorithm.ES384, CoseAlgorithm.ES512 };
 
         internal override byte[] Sign(byte[] content, ECDsa key, HashAlgorithmName hashAlgorithm, bool isDetached = false)
-            => CoseSign1Message.Sign(content, key, hashAlgorithm, isDetached);
+            => CoseSign1Message.Sign(content, key, hashAlgorithm, isDetached: isDetached);
         internal override bool Verify(CoseSign1Message msg, ECDsa key)
             => msg.Verify(key);
         internal override bool Verify(CoseSign1Message msg, ECDsa key, ReadOnlySpan<byte> content)
@@ -113,7 +113,7 @@ namespace System.Security.Cryptography.Cose.Tests
         internal override List<CoseAlgorithm> CoseAlgorithms => new() { CoseAlgorithm.PS256, CoseAlgorithm.PS384, CoseAlgorithm.PS512 };
 
         internal override byte[] Sign(byte[] content, RSA key, HashAlgorithmName hashAlgorithm, bool isDetached = false)
-            => CoseSign1Message.Sign(content, key, hashAlgorithm, isDetached);
+            => CoseSign1Message.Sign(content, key, hashAlgorithm, isDetached: isDetached);
         internal override bool Verify(CoseSign1Message msg, RSA key)
             => msg.Verify(key);
         internal override bool Verify(CoseSign1Message msg, RSA key, ReadOnlySpan<byte> content)

--- a/src/libraries/System.Security.Cryptography.Cose/tests/CoseSign1MessageTests.Sign.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/tests/CoseSign1MessageTests.Sign.cs
@@ -46,7 +46,7 @@ namespace System.Security.Cryptography.Cose.Tests
         [Fact]
         public void SignWithNullContent()
         {
-            Assert.Throws<ArgumentNullException>(() => Sign(null!, DefaultKey, DefaultHash));
+            Assert.Throws<ArgumentNullException>("content", () => Sign(null!, DefaultKey, DefaultHash));
         }
 
         [Theory]
@@ -63,7 +63,7 @@ namespace System.Security.Cryptography.Cose.Tests
         [Fact]
         public void SignWithNullKey()
         {
-            Assert.Throws<ArgumentNullException>(() => Sign(s_sampleContent, null!, DefaultHash));
+            Assert.Throws<ArgumentNullException>("key", () => Sign(s_sampleContent, null!, DefaultHash));
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Cose/tests/CoseSign1MessageTests.Verify.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/tests/CoseSign1MessageTests.Verify.cs
@@ -116,6 +116,35 @@ namespace System.Security.Cryptography.Cose.Tests
             Assert.False(msg.Verify(DefaultKey, wrongContent), "Calling Verify with the wrong content");
         }
 
+        [Fact]
+        public void VerifyThrowsIfContentIsNull()
+        {
+            byte[] encodedMsg = CoseSign1Message.Sign(s_sampleContent, DefaultKey, DefaultHash);
+            CoseSign1Message msg = CoseMessage.DecodeSign1(encodedMsg);
+
+            Assert.Throws<ArgumentNullException>(() => msg.Verify(DefaultKey, null!));
+        }
+
+        [Fact]
+        public void VerifyThrowsIfKeyIsNull()
+        {
+            byte[] encodedMsg = CoseSign1Message.Sign(s_sampleContent, DefaultKey, DefaultHash);
+            CoseSign1Message msg = CoseMessage.DecodeSign1(encodedMsg);
+
+            Assert.Throws<ArgumentNullException>(() => msg.Verify(null!));
+            Assert.Throws<ArgumentNullException>(() => msg.Verify(null!, s_sampleContent));
+        }
+
+        [Fact]
+        public void VerifyThrowsIfKeyIsNotSupported()
+        {
+            byte[] encodedMsg = CoseSign1Message.Sign(s_sampleContent, DefaultKey, DefaultHash);
+            CoseSign1Message msg = CoseMessage.DecodeSign1(encodedMsg);
+
+            AsymmetricAlgorithm key = ECDiffieHellman.Create();
+            Assert.Throws<CryptographicException>(() => msg.Verify(key));
+        }
+
         [Theory]
         // https://github.com/cose-wg/Examples/blob/master/sign1-tests/sign-fail-03.json
         [InlineData("D28445A1013903E6A10442313154546869732069732074686520636F6E74656E742E58408EB33E4CA31D1C465AB05AAC34CC6B23D58FEF5C083106C4D25A91AEF0B0117E2AF9A291AA32E14AB834DC56ED2A223444547E01F11D3B0916E5A4C345CACB36")]

--- a/src/libraries/System.Security.Cryptography.Cose/tests/CoseSign1MessageTests.Verify.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/tests/CoseSign1MessageTests.Verify.cs
@@ -122,7 +122,7 @@ namespace System.Security.Cryptography.Cose.Tests
             byte[] encodedMsg = CoseSign1Message.Sign(s_sampleContent, DefaultKey, DefaultHash);
             CoseSign1Message msg = CoseMessage.DecodeSign1(encodedMsg);
 
-            Assert.Throws<ArgumentNullException>(() => msg.Verify(DefaultKey, null!));
+            Assert.Throws<ArgumentNullException>("content", () => msg.Verify(DefaultKey, null!));
         }
 
         [Fact]
@@ -131,8 +131,8 @@ namespace System.Security.Cryptography.Cose.Tests
             byte[] encodedMsg = CoseSign1Message.Sign(s_sampleContent, DefaultKey, DefaultHash);
             CoseSign1Message msg = CoseMessage.DecodeSign1(encodedMsg);
 
-            Assert.Throws<ArgumentNullException>(() => msg.Verify(null!));
-            Assert.Throws<ArgumentNullException>(() => msg.Verify(null!, s_sampleContent));
+            Assert.Throws<ArgumentNullException>("key", () => msg.Verify(null!));
+            Assert.Throws<ArgumentNullException>("key", () => msg.Verify(null!, s_sampleContent));
         }
 
         [Fact]


### PR DESCRIPTION
Small clean-up on API surface to avoid creating too much signatures every time a new one is added. 
This benefit will be immediately reflected when we add the new `SignAsync(Stream detachedContent, ...)` and `VerifyAsync(AsymmetricAlgorithm key, Stream detachedContent, ...)` overloads. 