### PR TITLE
[PERF][MAUI] Add iOS Startup Scenario (Runtime side)

### DIFF
--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -257,7 +257,7 @@ jobs:
       buildConfig: release
       runtimeFlavor: mono
       platforms:
-        - Windows_x64
+        - OSX_x64
       variables:
         - name: mauiVersion
           value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMaui.outputs['getMauiVersion.mauiVersion'] ]
@@ -267,9 +267,9 @@ jobs:
         projectFile: ios_scenarios.proj
         runKind: ios_scenarios
         runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
-        iosLlvmBuild: False
-        additionalSetupParameters: "-MauiVersion $env:mauiVersion"
+        logicalmachine: 'perfiphone12mini'
+        iOSLlvmBuild: False
+        additionalSetupParameters: "--mauiversion $(mauiVersion)"
 
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
@@ -277,15 +277,19 @@ jobs:
       buildConfig: release
       runtimeFlavor: mono
       platforms:
-        - Windows_x64
+        - OSX_x64
+      variables:
+        - name: mauiVersion
+          value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMaui.outputs['getMauiVersion.mauiVersion'] ]
       jobParameters:
         testGroup: perf
         runtimeType: iOSMono
         projectFile: ios_scenarios.proj
         runKind: ios_scenarios
         runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
-        iosLlvmBuild: True
+        logicalmachine: 'perfiphone12mini'
+        iOSLlvmBuild: True
+        additionalSetupParameters: "--mauiversion $(mauiVersion)"
 
   # run mono microbenchmarks perf job
   - template: /eng/pipelines/common/platform-matrix.yml

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -178,11 +178,11 @@ steps:
       cp MauiTesting.csproj MauiTesting.csproj.bak
       sed -i'' -e 's/net6.0-ios;net6.0-maccatalyst/net6.0-ios/g' MauiTesting.csproj
 
-      ../dotnet publish -bl:MauiiOS.binlog -f net6.0-ios --self-contained -r ios-arm64 -c Release /p:_RequireCodeSigning=false
+      ../dotnet publish -bl:MauiiOS.binlog -f net6.0-ios --self-contained -r ios-arm64 -c Release /p:_RequireCodeSigning=false /p:ApplicationId=net.dot.mauitesting
       mv ./bin/Release/net6.0-ios/ios-arm64/publish/MauiTesting.ipa ./MauiiOSDefault.ipa
 
       cp MauiTesting.csproj.bak MauiTesting.csproj
-    displayName: Build MAUI iOS
+    displayName: Build MAUI Default iOS
     workingDirectory: $(Build.SourcesDirectory)/MauiTesting
 
   - script: |
@@ -192,7 +192,7 @@ steps:
       sed -i'' -e 's/net6.0-ios;net6.0-maccatalyst/net6.0-ios/g' Microsoft.NetConf2021.Maui.csproj
 
       ../../../dotnet build ../Web/Components/Podcast.Components.Maui.csproj
-      ../../../dotnet publish Microsoft.NetConf2021.Maui.csproj -bl:MauiiOSPodcast.binlog -f net6.0-ios --self-contained -r ios-arm64 -c Release /p:_RequireCodeSigning=false
+      ../../../dotnet publish Microsoft.NetConf2021.Maui.csproj -bl:MauiiOSPodcast.binlog -f net6.0-ios --self-contained -r ios-arm64 -c Release /p:_RequireCodeSigning=false /p:ApplicationId=net.dot.netconf2021.maui
       mv ./bin/Release/net6.0-ios/ios-arm64/publish/Microsoft.NetConf2021.Maui.ipa ./MauiiOSPodcast.ipa
 
       cp Microsoft.NetConf2021.Maui.csproj.bak Microsoft.NetConf2021.Maui.csproj

--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -98,7 +98,7 @@ jobs:
     ${{ if eq(parameters.runtimeType, 'AndroidMono') }}:
       extraSetupParameters: -Architecture ${{ parameters.archType }} -AndroidMono
     ${{ if eq(parameters.runtimeType, 'iosMono') }}:
-      extraSetupParameters: -Architecture ${{ parameters.archType }} -iOSMono -iOSLlvmBuild:$${{ parameters.iOSLlvmBuild }}
+      extraSetupParameters: --architecture ${{ parameters.archType }} --iosmono --iosllvmbuild ${{ parameters.iOSLlvmBuild }}
 
     variables: ${{ parameters.variables }}
 

--- a/eng/pipelines/coreclr/templates/run-scenarios-job.yml
+++ b/eng/pipelines/coreclr/templates/run-scenarios-job.yml
@@ -100,9 +100,12 @@ jobs:
       - ${{ if eq(parameters.osGroup, 'windows') }}:
         - AdditionalHelixPreCommands: $(HelixPreCommandWindows)
         - AdditionalHelixPostCommands: $(HelixPostCommandsWindows)
-      - ${{ if ne(parameters.osGroup, 'windows') }}:
+      - ${{ if and(ne(parameters.osGroup, 'windows'), ne(parameters.osGroup, 'OSX')) }}:
         - AdditionalHelixPreCommands: $(HelixPreCommandLinux)
         - AdditionalHelixPostCommands: $(HelixPostCommandsLinux)
+      - ${{ if eq(parameters.osGroup, 'OSX') }}:
+        - AdditionalHelixPreCommands: $(HelixPreCommandOSX)
+        - AdditionalHelixPostCommands: $(HelixPostCommandOSX)
 
     - ${{ if ne(parameters.runtimeType, 'wasm') }}:
       - ExtraSetupArguments: --install-dir $(PayloadDirectory)/dotnet

--- a/eng/pipelines/coreclr/templates/run-scenarios-job.yml
+++ b/eng/pipelines/coreclr/templates/run-scenarios-job.yml
@@ -65,12 +65,15 @@ jobs:
     - ${{ if eq(parameters.osGroup, 'windows') }}:
       - HelixPreCommandWindows: 'set ORIGPYPATH=%PYTHONPATH%;py -3 -m venv %HELIX_WORKITEM_PAYLOAD%\.venv;call %HELIX_WORKITEM_PAYLOAD%\.venv\Scripts\activate.bat;set PYTHONPATH=;py -3 -m pip install -U pip;py -3 -m pip install --user azure.storage.blob==12.0.0 --force-reinstall;py -3 -m pip install --user azure.storage.queue==12.0.0 --force-reinstall;set "PERFLAB_UPLOAD_TOKEN=$(PerfCommandUploadToken)"'
       - HelixPostCommandsWindows: 'set PYTHONPATH=%ORIGPYPATH%'
-    - ${{ if and(ne(parameters.osGroup, 'windows'), ne(parameters.osSubGroup, '_musl')) }}:
+    - ${{ if and(ne(parameters.osGroup, 'windows'), ne(parameters.osGroup, 'OSX'), ne(parameters.osSubGroup, '_musl')) }}:
       - HelixPreCommandLinux: 'export ORIGPYPATH=$PYTHONPATH;export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true;sudo apt-get -y install python3-venv;python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv;source $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;python3 -m pip install -U pip;pip3 install --user azure.storage.blob==12.0.0 --force-reinstall;pip3 install --user azure.storage.queue==12.0.0 --force-reinstall;export PERFLAB_UPLOAD_TOKEN="$(PerfCommandUploadTokenLinux)"'
       - HelixPostCommandsLinux: 'export PYTHONPATH=$ORIGPYPATH'
-    - ${{ if and(ne(parameters.osGroup, 'windows'), eq(parameters.osSubGroup, '_musl')) }}:
+    - ${{ if and(ne(parameters.osGroup, 'windows'), ne(parameters.osGroup, 'OSX'), eq(parameters.osSubGroup, '_musl')) }}:
       - HelixPreCommandMusl: 'export ORIGPYPATH=$PYTHONPATH;sudo apk add py3-virtualenv;python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv;source $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;python3 -m pip install -U pip;pip3 install --user azure.storage.blob==12.0.0 --force-reinstall;pip3 install --user azure.storage.queue==12.0.0 --force-reinstall;export PERFLAB_UPLOAD_TOKEN="$(PerfCommandUploadTokenLinux)"'
       - HelixPostCommandsMusl: 'export PYTHONPATH=$ORIGPYPATH'
+    - ${{ if eq(parameters.osGroup, 'OSX') }}:
+      - HelixPreCommandOSX: 'export ORIGPYPATH=$PYTHONPATH;export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true;python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv;source $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;python3 -m pip install -U pip;pip3 install azure.storage.blob==12.0.0 --force-reinstall;pip3 install azure.storage.queue==12.0.0 --force-reinstall;export PERFLAB_UPLOAD_TOKEN="$(PerfCommandUploadTokenLinux)"'
+      - HelixPreCommandOSX: 'export PYTHONPATH=$ORIGPYPATH'
 
     # extra private job settings
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -78,13 +81,17 @@ jobs:
         - AdditionalHelixPreCommands: $(HelixPreCommandWindows)
         - AdditionalHelixPostCommands: $(HelixPostCommandsWindows)
         - IsInternal: -Internal
-      - ${{ if and(ne(parameters.osGroup, 'windows'), ne(parameters.osSubGroup, '_musl')) }}:
+      - ${{ if and(ne(parameters.osGroup, 'windows'), ne(parameters.osGroup, 'OSX'), ne(parameters.osSubGroup, '_musl')) }}:
         - AdditionalHelixPreCommands: $(HelixPreCommandLinux)
         - AdditionalHelixPostCommands: $(HelixPostCommandsLinux)
         - IsInternal: --internal
-      - ${{ if and(ne(parameters.osGroup, 'windows'), eq(parameters.osSubGroup, '_musl')) }}:
+      - ${{ if and(ne(parameters.osGroup, 'windows'), ne(parameters.osGroup, 'OSX'), eq(parameters.osSubGroup, '_musl')) }}:
         - AdditionalHelixPreCommands: $(HelixPreCommandMusl)
         - AdditionalHelixPostCommands: $(HelixPostCommandsMusl)
+        - IsInternal: --internal
+      - ${{ if eq(parameters.osGroup, 'OSX') }}:
+        - AdditionalHelixPreCommands: $(HelixPreCommandOSX)
+        - AdditionalHelixPostCommands: $(HelixPreCommandOSX)
         - IsInternal: --internal
       - group: DotNet-HelixApi-Access
       - group: dotnet-benchview
@@ -121,7 +128,7 @@ jobs:
       condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'))
       continueOnError: ${{ parameters.continueOnError }}
     - script: $(Build.SourcesDirectory)/eng/testing/performance/performance-setup.sh $(IsInternal) --framework $(_Framework) --kind ${{ parameters.runKind }} --logicalmachine ${{ parameters.logicalMachine }} ${{ parameters.extraSetupParameters }} ${{ parameters.additionalSetupParameters }}
-      displayName: Performance Setup (Linux)
+      displayName: Performance Setup (Linux/MAC)
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
       continueOnError: ${{ parameters.continueOnError }}
     # run ci-setup
@@ -129,7 +136,7 @@ jobs:
       displayName: Run ci setup script (Windows)
       condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'))
     - script: $(Python) $(PerformanceDirectory)/scripts/ci_setup.py $(SetupArguments) $(ExtraSetupArguments) --output-file $(WorkItemDirectory)/machine-setup.sh
-      displayName: Run ci setup script (Linux)
+      displayName: Run ci setup script (Linux/MAC)
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
     # copy wasm packs if running on wasm
     - script: >-
@@ -144,7 +151,7 @@ jobs:
       displayName: Copy scenario support files (Windows)
       condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'))
     - script: cp -r $(PerformanceDirectory)/scripts $(WorkItemDirectory)/scripts/ && cp -r $(PerformanceDirectory)/src/scenarios/shared $(WorkItemDirectory)/shared/ && cp -r $(PerformanceDirectory)/src/scenarios/staticdeps/ $(WorkItemDirectory)/staticdeps/
-      displayName: Copy scenario support files (Linux)
+      displayName: Copy scenario support files (Linux/MAC)
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
     # build Startup
     - script: $(PayloadDirectory)\dotnet\dotnet.exe publish -c Release -o $(WorkItemDirectory)\Startup -f net6.0 -r win-$(Architecture) $(PerformanceDirectory)\src\tools\ScenarioMeasurement\Startup\Startup.csproj
@@ -156,7 +163,12 @@ jobs:
       displayName: Build Startup tool (Linux)
       env:
         PERFLAB_TARGET_FRAMEWORKS: net6.0
-      condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
+      condition: and(succeeded(), eq(variables['Agent.Os'], 'Linux'))
+    - script: $(PayloadDirectory)/dotnet/dotnet publish -c Release -o $(WorkItemDirectory)/startup -f net6.0 -r osx-$(Architecture) $(PerformanceDirectory)/src/tools/ScenarioMeasurement/Startup/Startup.csproj
+      displayName: Build Startup tool (MAC)
+      env:
+        PERFLAB_TARGET_FRAMEWORKS: net6.0
+      condition: and(succeeded(), eq(variables['Agent.Os'], 'Darwin'))
     # build SizeOnDisk
     - script: $(PayloadDirectory)\dotnet\dotnet.exe publish -c Release -o $(WorkItemDirectory)\SOD -f net6.0 -r win-$(Architecture) $(PerformanceDirectory)\src\tools\ScenarioMeasurement\SizeOnDisk\SizeOnDisk.csproj
       displayName: Build SizeOnDisk tool (Windows)
@@ -167,7 +179,20 @@ jobs:
       displayName: Build SizeOnDisk tool (Linux)
       env:
         PERFLAB_TARGET_FRAMEWORKS: net6.0
-      condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
+      condition: and(succeeded(), eq(variables['Agent.Os'], 'Linux'))
+    - script: $(PayloadDirectory)/dotnet/dotnet publish -c Release -o $(WorkItemDirectory)/SOD -f net6.0 -r osx-$(Architecture) $(PerformanceDirectory)/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.csproj
+      displayName: Build SizeOnDisk tool (MAC)
+      env:
+        PERFLAB_TARGET_FRAMEWORKS: net6.0
+      condition: and(succeeded(), eq(variables['Agent.Os'], 'Darwin'))
+
+    # Zip the workitem directory (for xharness based workitems)
+    - task: ArchiveFiles@2
+      inputs:
+        rootFolderOrFile: '$(WorkItemDirectory)'
+        includeRootFolder: false
+        archiveFile: '$(WorkItemDirectory).zip'
+        verbose: True
       
     # run perf testing in helix
     - template: /eng/pipelines/coreclr/templates/perf-send-to-helix.yml

--- a/eng/pipelines/coreclr/templates/run-scenarios-job.yml
+++ b/eng/pipelines/coreclr/templates/run-scenarios-job.yml
@@ -73,7 +73,7 @@ jobs:
       - HelixPostCommandsMusl: 'export PYTHONPATH=$ORIGPYPATH'
     - ${{ if eq(parameters.osGroup, 'OSX') }}:
       - HelixPreCommandOSX: 'export ORIGPYPATH=$PYTHONPATH;export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true;python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv;source $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;python3 -m pip install -U pip;pip3 install azure.storage.blob==12.0.0 --force-reinstall;pip3 install azure.storage.queue==12.0.0 --force-reinstall;export PERFLAB_UPLOAD_TOKEN="$(PerfCommandUploadTokenLinux)"'
-      - HelixPreCommandOSX: 'export PYTHONPATH=$ORIGPYPATH'
+      - HelixPostCommandOSX: 'export PYTHONPATH=$ORIGPYPATH'
 
     # extra private job settings
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -91,7 +91,7 @@ jobs:
         - IsInternal: --internal
       - ${{ if eq(parameters.osGroup, 'OSX') }}:
         - AdditionalHelixPreCommands: $(HelixPreCommandOSX)
-        - AdditionalHelixPostCommands: $(HelixPreCommandOSX)
+        - AdditionalHelixPostCommands: $(HelixPostCommandOSX)
         - IsInternal: --internal
       - group: DotNet-HelixApi-Access
       - group: dotnet-benchview

--- a/eng/testing/performance/ios_scenarios.proj
+++ b/eng/testing/performance/ios_scenarios.proj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test">
+  <PropertyGroup>
+    <IncludeXHarnessCli>true</IncludeXHarnessCli>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT'">
     <Python>python3</Python>
     <HelixPreCommands>$(HelixPreCommands);chmod +x $HELIX_WORKITEM_PAYLOAD/SOD/SizeOnDisk</HelixPreCommands>
+    <HelixPreCommands>$(HelixPreCommands);chmod +x $HELIX_WORKITEM_PAYLOAD/startup/Startup</HelixPreCommands>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,39 +30,87 @@
   <ItemGroup>
     <HelixWorkItem Include="SOD - iOS HelloWorld .app Size">
         <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
-        <PreCommands>cd $(ScenarioDirectory)helloios;xcopy %HELIX_CORRELATION_PAYLOAD%\iosHelloWorld\$(LlvmPath) .\app/e/i;$(Python) pre.py --name app</PreCommands>
+        <PreCommands>cd $(ScenarioDirectory)helloios;cp -rf $HELIX_CORRELATION_PAYLOAD/iosHelloWorld/$(LlvmPath) ./app;$(Python) pre.py --name app</PreCommands>
         <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
         <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
+    <HelixWorkItem Include="SOD - Maui MacCatalyst .app Size" Condition="'$(iOSLlvmBuild)' == 'False'">
+      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+      <PreCommands>cd $(ScenarioDirectory)mauiios;cp -rf $HELIX_CORRELATION_PAYLOAD/MauiMacCatalystDefault ./app;$(Python) pre.py --name app</PreCommands>
+      <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+      <PostCommands>$(Python) post.py</PostCommands>
+    </HelixWorkItem>
     <HelixWorkItem Include="SOD - Maui iOS IPA Size" Condition="'$(iOSLlvmBuild)' == 'False'">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
-      <PreCommands>cd $(ScenarioDirectory)mauiios;copy %HELIX_CORRELATION_PAYLOAD%\MauiiOSDefaultIPA\MauiiOSDefault.ipa .;$(Python) pre.py --name MauiiOSDefault.ipa</PreCommands>
+      <PreCommands>cd $(ScenarioDirectory)mauiios;cp $HELIX_CORRELATION_PAYLOAD/MauiiOSDefault.ipa .;$(Python) pre.py --name MauiiOSDefault.ipa</PreCommands>
       <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
       <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
     <HelixWorkItem Include="SOD - Maui iOS IPA Size Unzipped" Condition="'$(iOSLlvmBuild)' == 'False'">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
-      <PreCommands>cd $(ScenarioDirectory)mauiios;copy %HELIX_CORRELATION_PAYLOAD%\MauiiOSDefaultIPA\MauiiOSDefault.ipa .;$(Python) pre.py --unzip --name MauiiOSDefault.ipa</PreCommands>
-      <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
-      <PostCommands>$(Python) post.py</PostCommands>
-    </HelixWorkItem>
-    <HelixWorkItem Include="SOD - Maui MacCatalyst .app Size" Condition="'$(iOSLlvmBuild)' == 'False'">
-      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
-      <PreCommands>cd $(ScenarioDirectory)mauiios;xcopy %HELIX_CORRELATION_PAYLOAD%\MauiMacCatalystDefault .\app/e/i;$(Python) pre.py --name app</PreCommands>
+      <PreCommands>cd $(ScenarioDirectory)mauiios;cp $HELIX_CORRELATION_PAYLOAD/MauiiOSDefault.ipa .;$(Python) pre.py --unzip --name MauiiOSDefault.ipa</PreCommands>
       <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
       <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
     <HelixWorkItem Include="SOD - Maui iOS Podcast IPA Size" Condition="'$(iOSLlvmBuild)' == 'False'">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
-      <PreCommands>cd $(ScenarioDirectory)mauiios;copy %HELIX_CORRELATION_PAYLOAD%\MauiiOSPodcastIPA\MauiiOSPodcast.ipa .;$(Python) pre.py --name MauiiOSPodcast.ipa</PreCommands>
+      <PreCommands>cd $(ScenarioDirectory)mauiios;cp $HELIX_CORRELATION_PAYLOAD/MauiiOSPodcast.ipa .;$(Python) pre.py --name MauiiOSPodcast.ipa</PreCommands>
       <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
       <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
     <HelixWorkItem Include="SOD - Maui iOS Podcast IPA Size Unzipped" Condition="'$(iOSLlvmBuild)' == 'False'">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
-      <PreCommands>cd $(ScenarioDirectory)mauiios;copy %HELIX_CORRELATION_PAYLOAD%\MauiiOSPodcastIPA\MauiiOSPodcast.ipa .;$(Python) pre.py --unzip --name MauiiOSPodcast.ipa</PreCommands>
+      <PreCommands>cd $(ScenarioDirectory)mauiios;cp $HELIX_CORRELATION_PAYLOAD/MauiiOSPodcast.ipa .;$(Python) pre.py --unzip --name MauiiOSPodcast.ipa</PreCommands>
       <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
       <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
+	<XHarnessAppBundleToTest Include="Device Startup - iOS Maui Default" Condition="'$(iOSLlvmBuild)' == 'False'">
+    <AppBundlePath>$(WorkItemDirectory).zip</AppBundlePath>
+    <WorkItemTimeout>00:05:00</WorkItemTimeout>
+	  <TestTarget>ios-device</TestTarget>
+	  <CustomCommands>
+	   	<![CDATA[
+          # PreCommands
+          export XHARNESSPATH=$XHARNESS_CLI_PATH
+
+          cp -r $HELIX_CORRELATION_PAYLOAD/MauiTesting.app $(ScenarioDirectory)mauiios/MauiTesting.app
+          cp -f embedded.mobileprovision $(ScenarioDirectory)mauiios/MauiTesting.app
+          cd $(ScenarioDirectory)mauiios
+          sign MauiTesting.app
+
+          $(Python) pre.py --name MauiTesting.app
+
+          # Testing commands
+          $(Python) test.py devicestartup --device-type ios --package-path MauiTesting.app --package-name net.dot.mauitesting --scenario-name "%(Identity)"
+
+          # Post commands
+          $(Python) post.py   
+        ]]>
+	  </CustomCommands>
+	</XHarnessAppBundleToTest>
+    <XHarnessAppBundleToTest Include="Device Startup - iOS Maui Podcast" Condition="'$(iOSLlvmBuild)' == 'False'">
+    <AppBundlePath>$(WorkItemDirectory).zip</AppBundlePath>
+    <WorkItemTimeout>00:05:00</WorkItemTimeout>
+	  <TestTarget>ios-device</TestTarget>
+	  <CustomCommands>
+	   	<![CDATA[
+          # PreCommands
+          export XHARNESSPATH=$XHARNESS_CLI_PATH
+
+          cp -r $HELIX_CORRELATION_PAYLOAD/Microsoft.NetConf2021.Maui.app $(ScenarioDirectory)mauiios/Microsoft.NetConf2021.Maui.app
+          cp -f embedded.mobileprovision $(ScenarioDirectory)mauiios/Microsoft.NetConf2021.Maui.app
+          cd $(ScenarioDirectory)mauiios
+          sign Microsoft.NetConf2021.Maui.app
+
+          $(Python) pre.py --name Microsoft.NetConf2021.Maui.app
+
+          # Testing commands
+          $(Python) test.py devicestartup --device-type ios --package-path Microsoft.NetConf2021.Maui.app --package-name net.dot.netconf2021.maui --scenario-name "%(Identity)"
+
+          # Post commands
+          $(Python) post.py   
+        ]]>
+	  </CustomCommands>
+	</XHarnessAppBundleToTest>
   </ItemGroup>
 </Project>

--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -299,7 +299,7 @@ if [[ "$run_from_perf_repo" == true ]]; then
     performance_directory=$workitem_directory
     setup_arguments="--perf-hash $commit_sha $common_setup_arguments"
 else
-    git clone --branch iosstartup --depth 1 https://github.com/akoeplinger/performance.git $performance_directory
+    git clone --branch main --depth 1 --quiet https://github.com/dotnet/performance.git $performance_directory
     # uncomment to use BenchmarkDotNet sources instead of nuget packages
     # git clone https://github.com/dotnet/BenchmarkDotNet.git $benchmark_directory
 

--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -32,6 +32,9 @@ using_wasm=false
 use_latest_dotnet=false
 logical_machine=
 javascript_engine="v8"
+iosmono=false
+iosllvmbuild=""
+maui_version=""
 
 while (($# > 0)); do
   lowerI="$(echo $1 | tr "[:upper:]" "[:lower:]")"
@@ -142,6 +145,18 @@ while (($# > 0)); do
       use_latest_dotnet=true
       shift 1
       ;;
+    --iosmono)
+      iosmono=true
+      shift 1
+      ;;
+    --iosllvmbuild)
+      iosllvmbuild=$2
+      shift 2
+      ;;
+    --mauiversion)
+      maui_version=$2
+      shift 2
+      ;;
     *)
       echo "Common settings:"
       echo "  --corerootdirectory <value>    Directory where Core_Root exists, if running perf testing with --corerun"
@@ -167,6 +182,9 @@ while (($# > 0)); do
       echo "  --wasmaot                      Indicate wasm aot"
       echo "  --latestdotnet                 --dotnet-versions will not be specified. --dotnet-versions defaults to LKG version in global.json "
       echo "  --alpine                       Set for runs on Alpine"
+      echo "  --iosmono                      Set for ios Mono/Maui runs"
+      echo "  --iosllvmbuild                 Set LLVM for iOS Mono/Maui runs"
+      echo "  --mauiversion                  Set the maui version for Mono/Maui runs"
       echo ""
       exit 0
       ;;
@@ -205,7 +223,9 @@ if [[ "$internal" == true ]]; then
     creator=
     extra_benchmark_dotnet_arguments=
 
-    if [[ "$architecture" == "arm64" ]]; then
+    if [[ "$logical_machine" == "perfiphone12mini" ]]; then
+        queue=OSX.1015.Amd64.Iphone.Perf
+    elif [[ "$architecture" == "arm64" ]]; then
         queue=Ubuntu.1804.Arm64.Perf
     else
         if [[ "$logical_machine" == "perfowl" ]]; then
@@ -261,6 +281,11 @@ if [[ "$monoaot" == "true" ]]; then
     extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --category-exclusion-filter NoAOT NoWASM"
 fi
 
+if [[ "$iosmono" == "true" ]]; then
+    configurations="$configurations iOSLlvmBuild=$iosllvmbuild"
+    extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments"
+fi
+
 cleaned_branch_name="main"
 if [[ $branch == *"refs/heads/release"* ]]; then
     cleaned_branch_name=${branch/refs\/heads\//}
@@ -274,12 +299,16 @@ if [[ "$run_from_perf_repo" == true ]]; then
     performance_directory=$workitem_directory
     setup_arguments="--perf-hash $commit_sha $common_setup_arguments"
 else
-    git clone --branch main --depth 1 --quiet https://github.com/dotnet/performance.git $performance_directory
+    git clone --branch iosstartup --depth 1 https://github.com/akoeplinger/performance.git $performance_directory
     # uncomment to use BenchmarkDotNet sources instead of nuget packages
     # git clone https://github.com/dotnet/BenchmarkDotNet.git $benchmark_directory
 
     docs_directory=$performance_directory/docs
     mv $docs_directory $workitem_directory
+fi
+
+if [[ -n "$maui_version" ]]; then
+    setup_arguments="$setup_arguments --maui-version $maui_version"
 fi
 
 if [[ -n "$wasm_bundle_directory" ]]; then
@@ -318,6 +347,28 @@ if [[ "$use_baseline_core_run" == true ]]; then
   mv $baseline_core_root_directory $new_baseline_core_root
 fi
 
+if [[ "$iosmono" == "true" ]]; then
+    if [[ "$iosllvmbuild" == "True" ]]; then
+        # LLVM Mono .app
+        mkdir -p $payload_directory/iosHelloWorld/llvm && cp -rv $source_directory/iosHelloWorld/llvm $payload_directory/iosHelloWorld/llvm
+    else
+        # NoLLVM Mono .app, Maui iOS IPA, Maui Maccatalyst, Maui iOS Podcast IPA
+        mkdir -p $payload_directory/iosHelloWorld/nollvm && cp -rv $source_directory/iosHelloWorld/nollvm $payload_directory/iosHelloWorld/nollvm
+        mkdir -p $payload_directory/MauiMacCatalystDefault && cp -rv $source_directory/MauiMacCatalystDefault/MauiMacCatalystDefault.app $payload_directory/MauiMacCatalystDefault
+        cp -v $source_directory/MauiiOSDefaultIPA/MauiiOSDefault.ipa $payload_directory/MauiiOSDefault.ipa
+        cp -v $source_directory/MauiiOSPodcastIPA/MauiiOSPodcast.ipa $payload_directory/MauiiOSPodcast.ipa
+        # Get the .app so we can resign in the xharness item
+        cp -v $source_directory/MauiiOSDefaultIPA/MauiiOSDefault.ipa $source_directory/MauiiOSDefaultIPA/MauiiOSDefault.zip
+        unzip -d $source_directory/MauiiOSDefaultIPA $source_directory/MauiiOSDefaultIPA/MauiiOSDefault.zip
+        mv $source_directory/MauiiOSDefaultIPA/Payload/MauiTesting.app $payload_directory/
+        # Get the .app so we can resign in the xharness item for podcast
+        cp -v $source_directory/MauiiOSPodcastIPA/MauiiOSPodcast.ipa $source_directory/MauiiOSPodcastIPA/MauiiOSPodcast.zip
+        unzip -d $source_directory/MauiiOSPodcastIPA $source_directory/MauiiOSPodcastIPA/MauiiOSPodcast.zip
+        ls -aR $source_directory/MauiiOSPodcastIPA/
+        mv $source_directory/MauiiOSPodcastIPA/Payload/Microsoft.NetConf2021.Maui.app $payload_directory/
+    fi
+fi
+
 ci=true
 
 _script_dir=$(pwd)/eng/common
@@ -345,3 +396,4 @@ Write-PipelineSetVariable -name "_BuildConfig" -value "$_BuildConfig" -is_multi_
 Write-PipelineSetVariable -name "Compare" -value "$compare" -is_multi_job_variable false
 Write-PipelineSetVariable -name "MonoDotnet" -value "$using_mono" -is_multi_job_variable false
 Write-PipelineSetVariable -name "WasmDotnet" -value "$using_wasm" -is_multi_job_variable false
+Write-PipelineSetVariable -Name 'iOSLlvmBuild' -Value "$iosllvmbuild" -is_multi_job_variable false


### PR DESCRIPTION
This adds tests and flows to run the iOS Startup scenario for Maui. The majority of the work completed revolves around moving the Maui iOS flow from running on Windows (we only had Size on Disk) to running on a MacOS device connected to an iPhone. It also included shifting the app run test to use the xHarnessAppBundleToTest Task. More specifically, the changes included:

- Updating the Maui app id to use net.dot.* so it could be signed on the Mac device
- Changed iOS Helix Workitems to use OSX supported commands instead of Windows ones (ex. xcopy -> cp)
- Added XHarness test task with custom commands usage, and the zipping of the workitem directory to support it
- Copy the iOS scenario flow from the powershell performance-setup to the bash one.
- Added building of scenario tools (SOD and startup) for MAC
- Added MAC specific HelixPrecommands and PostCommands.


TODO:

- [x] Change the testing performance repository back to main
- [x] Reset Perf.yml to running all tasks
- [x] Double check for testing changes

This is a paired PR with https://github.com/dotnet/performance/pull/2355