### PR TITLE
Revert "Enable MSVC standard conformance for JIT sources (#67608)"

### DIFF
--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -11,10 +11,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_
   add_compile_options(-Wno-error)
 endif()
 
-if (MSVC)
-  add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/permissive->)
-endif()
-
 function(create_standalone_jit)
 
   set(oneValueArgs TARGET OS ARCH)

--- a/src/coreclr/jit/unwind.h
+++ b/src/coreclr/jit/unwind.h
@@ -79,6 +79,32 @@ protected:
     {
     }
 
+// TODO: How do we get the ability to access uwiComp without error on Clang?
+#if defined(DEBUG) && !defined(__GNUC__)
+
+    template <typename T>
+    T dspPtr(T p)
+    {
+        return uwiComp->dspPtr(p);
+    }
+
+    template <typename T>
+    T dspOffset(T o)
+    {
+        return uwiComp->dspOffset(o);
+    }
+
+    static const char* dspBool(bool b)
+    {
+        return (b) ? "true" : "false";
+    }
+
+#endif // DEBUG
+
+    //
+    // Data
+    //
+
     Compiler* uwiComp;
 };
 


### PR DESCRIPTION
This reverts commit 548bb581b632b40c8caf1aa39514590b7b183926.
Strangely this builds fine in CI and also built fine locally for me, but seems to cause build failures for some people. I'll investigate more tomorrow.

Fix #67672 