### PR TITLE
Add initial impl of PartitionedRateLimiter.Create

### DIFF
--- a/src/libraries/System.Threading.RateLimiting/ref/System.Threading.RateLimiting.cs
+++ b/src/libraries/System.Threading.RateLimiting/ref/System.Threading.RateLimiting.cs
@@ -40,6 +40,10 @@ namespace System.Threading.RateLimiting
         public static bool operator !=(System.Threading.RateLimiting.MetadataName<T> left, System.Threading.RateLimiting.MetadataName<T> right) { throw null; }
         public override string ToString() { throw null; }
     }
+    public static partial class PartitionedRateLimiter
+    {
+        public static System.Threading.RateLimiting.PartitionedRateLimiter<TResource> Create<TResource, TPartitionKey>(System.Func<TResource, System.Threading.RateLimiting.RateLimitPartition<TPartitionKey>> partitioner, System.Collections.Generic.IEqualityComparer<TPartitionKey>? equalityComparer = null) where TPartitionKey : notnull { throw null; }
+    }
     public abstract partial class PartitionedRateLimiter<TResource> : System.IAsyncDisposable, System.IDisposable
     {
         protected PartitionedRateLimiter() { }
@@ -82,6 +86,21 @@ namespace System.Threading.RateLimiting
         public virtual System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object?>> GetAllMetadata() { throw null; }
         public abstract bool TryGetMetadata(string metadataName, out object? metadata);
         public bool TryGetMetadata<T>(System.Threading.RateLimiting.MetadataName<T> metadataName, [System.Diagnostics.CodeAnalysis.MaybeNullAttribute] out T metadata) { throw null; }
+    }
+    public static partial class RateLimitPartition
+    {
+        public static System.Threading.RateLimiting.RateLimitPartition<TKey> CreateConcurrencyLimiter<TKey>(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.ConcurrencyLimiterOptions> factory) { throw null; }
+        public static System.Threading.RateLimiting.RateLimitPartition<TKey> CreateNoLimiter<TKey>(TKey partitionKey) { throw null; }
+        public static System.Threading.RateLimiting.RateLimitPartition<TKey> CreateTokenBucketLimiter<TKey>(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.TokenBucketRateLimiterOptions> factory) { throw null; }
+        public static System.Threading.RateLimiting.RateLimitPartition<TKey> Create<TKey>(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.RateLimiter> factory) { throw null; }
+    }
+    public partial struct RateLimitPartition<TKey>
+    {
+        private readonly TKey _PartitionKey_k__BackingField;
+        private object _dummy;
+        private int _dummyPrimitive;
+        public RateLimitPartition(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.RateLimiter> factory) { throw null; }
+        public readonly TKey PartitionKey { get { throw null; } }
     }
     public abstract partial class ReplenishingRateLimiter : System.Threading.RateLimiting.RateLimiter
     {

--- a/src/libraries/System.Threading.RateLimiting/ref/System.Threading.RateLimiting.csproj
+++ b/src/libraries/System.Threading.RateLimiting/ref/System.Threading.RateLimiting.csproj
@@ -3,12 +3,11 @@
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="System.Threading.RateLimiting.cs" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Bcl.AsyncInterfaces\ref\Microsoft.Bcl.AsyncInterfaces.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="System.Threading.RateLimiting.cs" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Threading.RateLimiting/src/System.Threading.RateLimiting.csproj
+++ b/src/libraries/System.Threading.RateLimiting/src/System.Threading.RateLimiting.csproj
@@ -31,6 +31,7 @@ System.Threading.RateLimiting.RateLimitLease</PackageDescription>
     <Compile Include="System\Threading\RateLimiting\ReplenishingRateLimiter.cs" />
     <Compile Include="System\Threading\RateLimiting\SlidingWindowRateLimiter.cs" />
     <Compile Include="System\Threading\RateLimiting\SlidingWindowRateLimiterOptions.cs" />
+    <Compile Include="System\Threading\RateLimiting\TimerAwaitable.cs" />
     <Compile Include="System\Threading\RateLimiting\TokenBucketRateLimiter.cs" />
     <Compile Include="System\Threading\RateLimiting\TokenBucketRateLimiterOptions.cs" />
     <Compile Include="$(CommonPath)System\Collections\Generic\Deque.cs" Link="Common\System\Collections\Generic\Deque.cs" />

--- a/src/libraries/System.Threading.RateLimiting/src/System.Threading.RateLimiting.csproj
+++ b/src/libraries/System.Threading.RateLimiting/src/System.Threading.RateLimiting.csproj
@@ -20,10 +20,14 @@ System.Threading.RateLimiting.RateLimitLease</PackageDescription>
     <Compile Include="System\Threading\RateLimiting\FixedWindowRateLimiterOptions.cs" />
     <Compile Include="System\Threading\RateLimiting\MetadataName.cs" />
     <Compile Include="System\Threading\RateLimiting\MetadataName.T.cs" />
+    <Compile Include="System\Threading\RateLimiting\NoopLimiter.cs" />
+    <Compile Include="System\Threading\RateLimiting\PartitionedRateLimiter.cs" />
     <Compile Include="System\Threading\RateLimiting\PartitionedRateLimiter.T.cs" />
     <Compile Include="System\Threading\RateLimiting\QueueProcessingOrder.cs" />
     <Compile Include="System\Threading\RateLimiting\RateLimiter.cs" />
     <Compile Include="System\Threading\RateLimiting\RateLimitLease.cs" />
+    <Compile Include="System\Threading\RateLimiting\RateLimitPartition.cs" />
+    <Compile Include="System\Threading\RateLimiting\RateLimitPartition.T.cs" />
     <Compile Include="System\Threading\RateLimiting\ReplenishingRateLimiter.cs" />
     <Compile Include="System\Threading\RateLimiting\SlidingWindowRateLimiter.cs" />
     <Compile Include="System\Threading\RateLimiting\SlidingWindowRateLimiterOptions.cs" />

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
@@ -128,7 +128,10 @@ namespace System.Threading.RateLimiting
                             RequestRegistration oldestRequest = _queue.DequeueHead();
                             _queueCount -= oldestRequest.Count;
                             Debug.Assert(_queueCount >= 0);
-                            oldestRequest.Tcs.TrySetResult(FailedLease);
+                            if (!oldestRequest.Tcs.TrySetResult(FailedLease))
+                            {
+                                _queueCount += oldestRequest.Count;
+                            }
                         }
                         while (_options.QueueLimit - _queueCount < requestCount);
                     }
@@ -326,7 +329,7 @@ namespace System.Threading.RateLimiting
                         ? _queue.DequeueHead()
                         : _queue.DequeueTail();
                     next.CancellationTokenRegistration.Dispose();
-                    next.Tcs.SetResult(FailedLease);
+                    next.Tcs.TrySetResult(FailedLease);
                 }
             }
         }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/NoopLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/NoopLimiter.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace System.Threading.RateLimiting
+{
+    internal sealed class NoopLimiter : RateLimiter
+    {
+        private static readonly RateLimitLease _lease = new NoopLease();
+
+        private NoopLimiter() { }
+
+        public static NoopLimiter Instance { get; } = new NoopLimiter();
+
+        public override int GetAvailablePermits() => int.MaxValue;
+
+        protected override RateLimitLease AcquireCore(int permitCount) => _lease;
+
+        protected override ValueTask<RateLimitLease> WaitAsyncCore(int permitCount, CancellationToken cancellationToken)
+            => new ValueTask<RateLimitLease>(_lease);
+
+        private sealed class NoopLease : RateLimitLease
+        {
+            public override bool IsAcquired => true;
+
+            public override IEnumerable<string> MetadataNames => Array.Empty<string>();
+
+            public override bool TryGetMetadata(string metadataName, out object? metadata)
+            {
+                metadata = null;
+                return false;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/NoopLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/NoopLimiter.cs
@@ -14,6 +14,8 @@ namespace System.Threading.RateLimiting
 
         public static NoopLimiter Instance { get; } = new NoopLimiter();
 
+        public override TimeSpan? IdleDuration => null;
+
         public override int GetAvailablePermits() => int.MaxValue;
 
         protected override RateLimitLease AcquireCore(int permitCount) => _lease;

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.cs
@@ -148,10 +148,6 @@ namespace System.Threading.RateLimiting
             }
             _disposed = true;
 
-            _cachedLimiters.Clear();
-
-            _timer?.Dispose();
-
             return false;
         }
 
@@ -182,6 +178,8 @@ namespace System.Threading.RateLimiting
             {
                 if (limiter._disposed)
                 {
+                    limiter._timer!.Dispose();
+                    limiter._cachedLimiters.Clear();
                     return;
                 }
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.cs
@@ -62,7 +62,7 @@ namespace System.Threading.RateLimiting
         private async Task RunTimer()
         {
             _timer.Start();
-            while (!_timer.IsCompleted && !_disposed)
+            while (!_disposed)
             {
                 await _timer;
                 Replenish(this);

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.cs
@@ -1,0 +1,170 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace System.Threading.RateLimiting
+{
+    /// <summary>
+    /// Contains methods to assist with creating a <see cref="PartitionedRateLimiter{TResource}"/>.
+    /// </summary>
+    public static class PartitionedRateLimiter
+    {
+        /// <summary>
+        /// Method used to create a default implementation of <see cref="PartitionedRateLimiter{TResource}"/>.
+        /// </summary>
+        /// <typeparam name="TResource">The resource type that is being rate limited.</typeparam>
+        /// <typeparam name="TPartitionKey">The type to distinguish partitions with.</typeparam>
+        /// <param name="partitioner">Method called every time an Acquire or WaitAsync call is made to figure out what rate limiter to apply to the request.
+        /// If the <see cref="RateLimitPartition{TKey}.PartitionKey"/> matches a cached entry then the rate limiter previously used for that key is used. Otherwise, the factory is called to get a new rate limiter.</param>
+        /// <param name="equalityComparer">Optional <see cref="IEqualityComparer{T}"/> to customize the comparison logic for <typeparamref name="TPartitionKey"/>.</param>
+        /// <returns></returns>
+        public static PartitionedRateLimiter<TResource> Create<TResource, TPartitionKey>(
+            Func<TResource, RateLimitPartition<TPartitionKey>> partitioner,
+            IEqualityComparer<TPartitionKey>? equalityComparer = null) where TPartitionKey : notnull
+        {
+            return new DefaultPartitionedRateLimiter<TResource, TPartitionKey>(partitioner, equalityComparer);
+        }
+    }
+
+    internal sealed class DefaultPartitionedRateLimiter<TResource, TKey> : PartitionedRateLimiter<TResource> where TKey : notnull
+    {
+        private readonly Func<TResource, RateLimitPartition<TKey>> _partitioner;
+
+        // TODO: Look at ConcurrentDictionary to try and avoid a global lock
+        private Dictionary<TKey, Lazy<RateLimiter>> _limiters;
+        private Timer? _timer;
+        private bool _disposed;
+
+        // Use the Dictionary as the lock field so we don't need to allocate another object for a lock and have another field in the object
+        private object Lock => _limiters;
+
+        public DefaultPartitionedRateLimiter(Func<TResource, RateLimitPartition<TKey>> partitioner,
+            IEqualityComparer<TKey>? equalityComparer = null)
+        {
+            _limiters = new Dictionary<TKey, Lazy<RateLimiter>>(equalityComparer);
+            _partitioner = partitioner;
+
+            // TODO: Only create timer once there is an active replenishing limiter
+            // TODO: Figure out what interval we should use
+            _timer = new Timer(Replenish, this, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+        }
+
+        public override int GetAvailablePermits(TResource resourceID)
+        {
+            return GetRateLimiter(resourceID).GetAvailablePermits();
+        }
+
+        protected override RateLimitLease AcquireCore(TResource resourceID, int permitCount)
+        {
+            return GetRateLimiter(resourceID).Acquire(permitCount);
+        }
+
+        protected override ValueTask<RateLimitLease> WaitAsyncCore(TResource resourceID, int permitCount, CancellationToken cancellationToken)
+        {
+            return GetRateLimiter(resourceID).WaitAsync(permitCount, cancellationToken);
+        }
+
+        private RateLimiter GetRateLimiter(TResource resourceID)
+        {
+            RateLimitPartition<TKey> partition = _partitioner(resourceID);
+            Lazy<RateLimiter>? limiter;
+            lock (Lock)
+            {
+                ThrowIfDisposed();
+                if (!_limiters.TryGetValue(partition.PartitionKey, out limiter))
+                {
+                    // Using Lazy avoids calling user code (partition.Factory) inside the lock
+                    limiter = new Lazy<RateLimiter>(() => partition.Factory(partition.PartitionKey));
+                    _limiters.Add(partition.PartitionKey, limiter);
+                }
+            }
+            return limiter.Value;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!disposing)
+            {
+                return;
+            }
+
+            lock (Lock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+                _disposed = true;
+
+                _timer?.Dispose();
+
+                foreach (KeyValuePair<TKey, Lazy<RateLimiter>> limiter in _limiters)
+                {
+                    limiter.Value.Value.Dispose();
+                }
+                _limiters.Clear();
+            }
+        }
+
+        protected override async ValueTask DisposeAsyncCore()
+        {
+            Dictionary<TKey, Lazy<RateLimiter>> limiters;
+            lock (Lock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+                _disposed = true;
+
+                _timer?.Dispose();
+
+                limiters = _limiters;
+                _limiters = new();
+            }
+
+            foreach (KeyValuePair<TKey, Lazy<RateLimiter>> limiter in limiters)
+            {
+                await limiter.Value.Value.DisposeAsync().ConfigureAwait(false);
+            }
+
+            limiters.Clear();
+
+            return;
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(PartitionedRateLimiter));
+            }
+        }
+
+        private static void Replenish(object? state)
+        {
+            DefaultPartitionedRateLimiter<TResource, TKey> limiter = (state as DefaultPartitionedRateLimiter<TResource, TKey>)!;
+            Debug.Assert(limiter is not null);
+
+            lock (limiter.Lock)
+            {
+                if (limiter._disposed)
+                {
+                    return;
+                }
+
+                foreach (KeyValuePair<TKey, Lazy<RateLimiter>> kvp in limiter._limiters)
+                {
+                    // Check IsValueCreated to avoid potentially blocking inside the lock if the Lazy hasn't been initialized yet
+                    if (kvp.Value.IsValueCreated && kvp.Value.Value is TokenBucketRateLimiter tokenBucketLimiter)
+                    {
+                        tokenBucketLimiter.TryReplenish();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.cs
@@ -159,9 +159,12 @@ namespace System.Threading.RateLimiting
                 foreach (KeyValuePair<TKey, Lazy<RateLimiter>> kvp in limiter._limiters)
                 {
                     // Check IsValueCreated to avoid potentially blocking inside the lock if the Lazy hasn't been initialized yet
-                    if (kvp.Value.IsValueCreated && kvp.Value.Value is TokenBucketRateLimiter tokenBucketLimiter)
+                    if (kvp.Value.IsValueCreated)
                     {
-                        tokenBucketLimiter.TryReplenish();
+                        if (kvp.Value.Value is ReplenishingRateLimiter replenishingLimiter)
+                        {
+                            replenishingLimiter.TryReplenish();
+                        }
                     }
                 }
             }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimitPartition.T.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimitPartition.T.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Threading.RateLimiting
+{
+    /// <summary>
+    /// Type returned by <see cref="RateLimitPartition.Create"/> methods to be used by <see cref="PartitionedRateLimiter.Create"/> to know what partitions are configured.
+    /// </summary>
+    /// <typeparam name="TKey">The type to distinguish partitions with.</typeparam>
+    public struct RateLimitPartition<TKey>
+    {
+        /// <summary>
+        /// Constructs the <see cref="RateLimitPartition{TKey}"/> for use in <see cref="PartitionedRateLimiter.Create"/>.
+        /// </summary>
+        /// <param name="partitionKey">The specific key for this partition.</param>
+        /// <param name="factory">The function called when a rate limiter for the given <paramref name="partitionKey"/> is needed.</param>
+        public RateLimitPartition(TKey partitionKey, Func<TKey, RateLimiter> factory)
+        {
+            PartitionKey = partitionKey;
+            Factory = factory;
+        }
+
+        /// <summary>
+        /// The specific key for this partition.
+        /// </summary>
+        public TKey PartitionKey { get; }
+
+        internal readonly Func<TKey, RateLimiter> Factory;
+    }
+}

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimitPartition.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimitPartition.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Threading.RateLimiting
+{
+    /// <summary>
+    /// Contains methods used in <see cref="PartitionedRateLimiter.Create"/> to assist in the creation of partitions for your rate limiter.
+    /// </summary>
+    public static class RateLimitPartition
+    {
+        /// <summary>
+        /// Defines a partition with the given rate limiter factory.
+        /// </summary>
+        /// <typeparam name="TKey">The type to distinguish partitions with.</typeparam>
+        /// <param name="partitionKey">The specific key for this partition. This will be used to check for an existing cached limiter before calling the <paramref name="factory"/>.</param>
+        /// <param name="factory">The function called when a rate limiter for the given <paramref name="partitionKey"/> is needed. This should be a new instance of a rate limiter every time it is called.</param>
+        /// <returns></returns>
+        public static RateLimitPartition<TKey> Create<TKey>(
+            TKey partitionKey,
+            Func<TKey, RateLimiter> factory)
+        {
+            return new RateLimitPartition<TKey>(partitionKey, factory);
+        }
+
+        /// <summary>
+        /// Defines a partition with a <see cref="ConcurrencyLimiter"/> with the given <see cref="ConcurrencyLimiterOptions"/>.
+        /// </summary>
+        /// <typeparam name="TKey">The type to distinguish partitions with.</typeparam>
+        /// <param name="partitionKey">The specific key for this partition. This will be used to check for an existing cached limiter before calling the <paramref name="factory"/>.</param>
+        /// <param name="factory">The function called when a rate limiter for the given <paramref name="partitionKey"/> is needed. This can return the same instance of <see cref="ConcurrencyLimiterOptions"/> across different calls.</param>
+        /// <returns></returns>
+        public static RateLimitPartition<TKey> CreateConcurrencyLimiter<TKey>(
+            TKey partitionKey,
+            Func<TKey, ConcurrencyLimiterOptions> factory)
+        {
+            return Create(partitionKey, key => new ConcurrencyLimiter(factory(key)));
+        }
+
+        /// <summary>
+        /// Defines a partition that will not have a rate limiter.
+        /// This means any calls to <see cref="PartitionedRateLimiter{TResource}.Acquire(TResource, int)"/> or <see cref="PartitionedRateLimiter{TResource}.WaitAsync(TResource, int, CancellationToken)"/> will always succeed for the given <paramref name="partitionKey"/>.
+        /// </summary>
+        /// <typeparam name="TKey">The type to distinguish partitions with.</typeparam>
+        /// <param name="partitionKey">The specific key for this partition.</param>
+        /// <returns></returns>
+        public static RateLimitPartition<TKey> CreateNoLimiter<TKey>(TKey partitionKey)
+        {
+            return Create(partitionKey, _ => NoopLimiter.Instance);
+        }
+
+        /// <summary>
+        /// Defines a partition with a <see cref="TokenBucketRateLimiter"/> with the given <see cref="TokenBucketRateLimiterOptions"/>.
+        /// </summary>
+        /// <remarks>
+        /// Set <see cref="TokenBucketRateLimiterOptions.AutoReplenishment"/> to <see langword="false"/> to save an allocation. This method will create a new options type and set <see cref="TokenBucketRateLimiterOptions.AutoReplenishment"/> to <see langword="false"/> otherwise.
+        /// </remarks>
+        /// <typeparam name="TKey">The type to distinguish partitions with.</typeparam>
+        /// <param name="partitionKey">The specific key for this partition.</param>
+        /// <param name="factory">The function called when a rate limiter for the given <paramref name="partitionKey"/> is needed. This can return the same instance of <see cref="TokenBucketRateLimiterOptions"/> across different calls.</param>
+        /// <returns></returns>
+        public static RateLimitPartition<TKey> CreateTokenBucketLimiter<TKey>(
+            TKey partitionKey,
+            Func<TKey, TokenBucketRateLimiterOptions> factory)
+        {
+            return Create(partitionKey, key =>
+            {
+                TokenBucketRateLimiterOptions options = factory(key);
+                // We don't want individual TokenBucketRateLimiters to have timers. We will instead have our own internal Timer handling all of them
+                if (options.AutoReplenishment is true)
+                {
+                    options = new TokenBucketRateLimiterOptions(options.TokenLimit, options.QueueProcessingOrder, options.QueueLimit,
+                        options.ReplenishmentPeriod, options.TokensPerPeriod, autoReplenishment: false);
+                }
+                return new TokenBucketRateLimiter(options);
+            });
+        }
+    }
+}

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
@@ -133,7 +133,10 @@ namespace System.Threading.RateLimiting
                             RequestRegistration oldestRequest = _queue.DequeueHead();
                             _queueCount -= oldestRequest.Count;
                             Debug.Assert(_queueCount >= 0);
-                            oldestRequest.Tcs.TrySetResult(FailedLease);
+                            if (!oldestRequest.Tcs.TrySetResult(FailedLease))
+                            {
+                                _queueCount += oldestRequest.Count;
+                            }
                         }
                         while (_options.QueueLimit - _queueCount < requestCount);
                     }
@@ -325,7 +328,7 @@ namespace System.Threading.RateLimiting
                         ? _queue.DequeueHead()
                         : _queue.DequeueTail();
                     next.CancellationTokenRegistration.Dispose();
-                    next.Tcs.SetResult(FailedLease);
+                    next.Tcs.TrySetResult(FailedLease);
                 }
             }
         }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TimerAwaitable.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TimerAwaitable.cs
@@ -52,18 +52,12 @@ namespace System.Threading.RateLimiting
                                 restoreFlow = true;
                             }
 
-                            // This fixes the cycle by using a WeakReference to the state object. The object graph now looks like this:
-                            // Timer -> TimerHolder -> TimerQueueTimer -> WeakReference<TimerAwaitable> -> Timer -> ...
-                            // If TimerAwaitable falls out of scope, the timer should be released.
-                            _timer = new Timer(state =>
+                            _timer = new Timer(static state =>
                             {
-                                var weakRef = (WeakReference<TimerAwaitable>)state!;
-                                if (weakRef.TryGetTarget(out var thisRef))
-                                {
-                                    thisRef.Tick();
-                                }
+                                var thisRef = (TimerAwaitable)state!;
+                                thisRef.Tick();
                             },
-                            state: new WeakReference<TimerAwaitable>(this),
+                            state: this,
                             dueTime: _dueTime,
                             period: _period);
                         }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TimerAwaitable.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TimerAwaitable.cs
@@ -1,0 +1,143 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Threading.RateLimiting
+{
+    internal sealed class TimerAwaitable : IDisposable, ICriticalNotifyCompletion
+    {
+        private Timer? _timer;
+        private Action? _callback;
+        private static readonly Action _callbackCompleted = () => { };
+
+        private readonly TimeSpan _period;
+
+        private readonly TimeSpan _dueTime;
+        private readonly object _lockObj = new object();
+        private bool _disposed;
+        private bool _running = true;
+
+        public TimerAwaitable(TimeSpan dueTime, TimeSpan period)
+        {
+            _dueTime = dueTime;
+            _period = period;
+        }
+
+        public void Start()
+        {
+            if (_timer == null)
+            {
+                lock (_lockObj)
+                {
+                    if (_disposed)
+                    {
+                        return;
+                    }
+
+                    if (_timer == null)
+                    {
+                        // Don't capture the current ExecutionContext and its AsyncLocals onto the timer
+                        bool restoreFlow = false;
+                        try
+                        {
+                            if (!ExecutionContext.IsFlowSuppressed())
+                            {
+                                ExecutionContext.SuppressFlow();
+                                restoreFlow = true;
+                            }
+
+                            // This fixes the cycle by using a WeakReference to the state object. The object graph now looks like this:
+                            // Timer -> TimerHolder -> TimerQueueTimer -> WeakReference<TimerAwaitable> -> Timer -> ...
+                            // If TimerAwaitable falls out of scope, the timer should be released.
+                            _timer = new Timer(state =>
+                            {
+                                var weakRef = (WeakReference<TimerAwaitable>)state!;
+                                if (weakRef.TryGetTarget(out var thisRef))
+                                {
+                                    thisRef.Tick();
+                                }
+                            },
+                            state: new WeakReference<TimerAwaitable>(this),
+                            dueTime: _dueTime,
+                            period: _period);
+                        }
+                        finally
+                        {
+                            // Restore the current ExecutionContext
+                            if (restoreFlow)
+                            {
+                                ExecutionContext.RestoreFlow();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        public TimerAwaitable GetAwaiter() => this;
+        public bool IsCompleted => ReferenceEquals(_callback, _callbackCompleted);
+
+        public bool GetResult()
+        {
+            _callback = null;
+
+            return _running;
+        }
+
+        private void Tick()
+        {
+            var continuation = Interlocked.Exchange(ref _callback, _callbackCompleted);
+            continuation?.Invoke();
+        }
+
+        public void OnCompleted(Action continuation)
+        {
+            if (ReferenceEquals(_callback, _callbackCompleted) ||
+                ReferenceEquals(Interlocked.CompareExchange(ref _callback, continuation, null), _callbackCompleted))
+            {
+                Task.Run(continuation);
+            }
+        }
+
+        public void UnsafeOnCompleted(Action continuation)
+        {
+            OnCompleted(continuation);
+        }
+
+        public void Stop()
+        {
+            lock (_lockObj)
+            {
+                // Stop should be used to trigger the call to end the loop which disposes
+                if (_disposed)
+                {
+                    throw new ObjectDisposedException(GetType().FullName);
+                }
+
+                _running = false;
+            }
+
+            // Call tick here to make sure that we yield the callback,
+            // if it's currently waiting, we don't need to wait for the next period
+            Tick();
+        }
+
+        public void Dispose()
+        {
+            lock (_lockObj)
+            {
+                _disposed = true;
+
+                _timer?.Dispose();
+
+                _timer = null;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Threading.RateLimiting/tests/BaseRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/BaseRateLimiterTests.cs
@@ -81,6 +81,12 @@ namespace System.Threading.RateLimiting.Test
         public abstract Task CanCancelWaitAsyncBeforeQueuing();
 
         [Fact]
+        public abstract Task CanFillQueueWithNewestFirstAfterCancelingQueuedRequestWithAnotherQueuedRequest();
+
+        [Fact]
+        public abstract Task CanDisposeAfterCancelingQueuedRequest();
+
+        [Fact]
         public abstract Task CancelUpdatesQueueLimit();
 
         [Fact]

--- a/src/libraries/System.Threading.RateLimiting/tests/FixedWindowRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/FixedWindowRateLimiterTests.cs
@@ -690,5 +690,57 @@ namespace System.Threading.RateLimiting.Test
             Assert.False(limiter2.IsAutoReplenishing);
             Assert.Equal(replenishPeriod, limiter2.ReplenishmentPeriod);
         }
+
+        [Fact]
+        public override async Task CanFillQueueWithNewestFirstAfterCancelingQueuedRequestWithAnotherQueuedRequest()
+        {
+            var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions(2, QueueProcessingOrder.NewestFirst, 2,
+                TimeSpan.Zero, autoReplenishment: false));
+            var lease = limiter.Acquire(2);
+            Assert.True(lease.IsAcquired);
+
+            var cts = new CancellationTokenSource();
+            var wait = limiter.WaitAsync(1, cts.Token);
+
+            // Add another item to queue, will be completed as failed later when we queue another item
+            var wait2 = limiter.WaitAsync(1);
+            Assert.False(wait.IsCompleted);
+
+            cts.Cancel();
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
+            Assert.Equal(cts.Token, ex.CancellationToken);
+
+            lease.Dispose();
+
+            var wait3 = limiter.WaitAsync(2);
+            Assert.False(wait3.IsCompleted);
+
+            // will be kicked by wait3 because we're using NewestFirst
+            lease = await wait2;
+            Assert.False(lease.IsAcquired);
+
+            limiter.TryReplenish();
+            lease = await wait3;
+            Assert.True(lease.IsAcquired);
+        }
+
+        [Fact]
+        public override async Task CanDisposeAfterCancelingQueuedRequest()
+        {
+            var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1,
+                TimeSpan.Zero, autoReplenishment: false));
+            var lease = limiter.Acquire(1);
+            Assert.True(lease.IsAcquired);
+
+            var cts = new CancellationTokenSource();
+            var wait = limiter.WaitAsync(1, cts.Token);
+
+            cts.Cancel();
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
+            Assert.Equal(cts.Token, ex.CancellationToken);
+
+            // Make sure dispose doesn't have any side-effects when dealing with a canceled queued item
+            limiter.Dispose();
+        }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/tests/PartitionedRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/PartitionedRateLimiterTests.cs
@@ -153,7 +153,8 @@ namespace System.Threading.RateLimiting.Tests
             Assert.Equal(1, limiterFactory.Limiters[0].Limiter.WaitAsyncCallCount);
         }
 
-        [Fact]
+        // Uses Task.Wait in a Task.Run to purposefully test a blocking scenario, this doesn't work on WASM currently
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task Create_BlockingFactoryDoesNotBlockOtherPartitions()
         {
             var limiterFactory = new TrackingRateLimiterFactory<int>();

--- a/src/libraries/System.Threading.RateLimiting/tests/PartitionedRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/PartitionedRateLimiterTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -30,11 +32,422 @@ namespace System.Threading.RateLimiting.Tests
                 async () => await limiter.WaitAsync(string.Empty, 1, new CancellationToken(true)));
         }
 
-        internal class NotImplementedPartitionedRateLimiter<T> : PartitionedRateLimiter<T>
+        // Create
+
+        [Fact]
+        public void Create_AcquireCallsUnderlyingPartitionsLimiter()
+        {
+            var limiterFactory = new TrackingRateLimiterFactory<int>();
+            using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+            });
+
+            limiter.Acquire("");
+            Assert.Equal(1, limiterFactory.Limiters.Count);
+            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.AcquireCallCount);
+        }
+
+        [Fact]
+        public async Task Create_WaitAsyncCallsUnderlyingPartitionsLimiter()
+        {
+            var limiterFactory = new TrackingRateLimiterFactory<int>();
+            using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+            });
+
+            await limiter.WaitAsync("");
+            Assert.Equal(1, limiterFactory.Limiters.Count);
+            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.WaitAsyncCallCount);
+        }
+
+        [Fact]
+        public void Create_GetAvailablePermitsCallsUnderlyingPartitionsLimiter()
+        {
+            var limiterFactory = new TrackingRateLimiterFactory<int>();
+            using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+            });
+
+            limiter.GetAvailablePermits("");
+            Assert.Equal(1, limiterFactory.Limiters.Count);
+            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.GetAvailablePermitsCallCount);
+        }
+
+        [Fact]
+        public async Task Create_PartitionIsCached()
+        {
+            var limiterFactory = new TrackingRateLimiterFactory<int>();
+            using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+            });
+
+            limiter.Acquire("");
+            await limiter.WaitAsync("");
+            limiter.Acquire("");
+            await limiter.WaitAsync("");
+            Assert.Equal(1, limiterFactory.Limiters.Count);
+            Assert.Equal(2, limiterFactory.Limiters[0].Limiter.AcquireCallCount);
+            Assert.Equal(2, limiterFactory.Limiters[0].Limiter.WaitAsyncCallCount);
+        }
+
+        [Fact]
+        public void Create_MultiplePartitionsWork()
+        {
+            var limiterFactory = new TrackingRateLimiterFactory<int>();
+            using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                if (resource == "1")
+                {
+                    return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+                }
+                else
+                {
+                    return RateLimitPartition.Create(2, key => limiterFactory.GetLimiter(key));
+                }
+            });
+
+            limiter.Acquire("1");
+            limiter.Acquire("2");
+            limiter.Acquire("1");
+            limiter.Acquire("2");
+
+            Assert.Equal(2, limiterFactory.Limiters.Count);
+
+            Assert.Equal(2, limiterFactory.Limiters[0].Limiter.AcquireCallCount);
+            Assert.Equal(1, limiterFactory.Limiters[0].Key);
+
+            Assert.Equal(2, limiterFactory.Limiters[1].Limiter.AcquireCallCount);
+            Assert.Equal(2, limiterFactory.Limiters[1].Key);
+        }
+
+        [Fact]
+        public async Task Create_BlockingWaitDoesNotBlockOtherPartitions()
+        {
+            var limiterFactory = new TrackingRateLimiterFactory<int>();
+            using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                if (resource == "1")
+                {
+                    return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+                }
+                return RateLimitPartition.CreateConcurrencyLimiter(2,
+                    _ => new ConcurrencyLimiterOptions(1, QueueProcessingOrder.OldestFirst, 2));
+            });
+
+            var lease = await limiter.WaitAsync("2");
+            var wait = limiter.WaitAsync("2");
+            Assert.False(wait.IsCompleted);
+
+            // Different partition, should not be blocked by the wait in the other partition
+            await limiter.WaitAsync("1");
+
+            lease.Dispose();
+            await wait;
+
+            Assert.Equal(1, limiterFactory.Limiters.Count);
+            Assert.Equal(0, limiterFactory.Limiters[0].Limiter.AcquireCallCount);
+            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.WaitAsyncCallCount);
+        }
+
+        [Fact]
+        public async Task Create_BlockingFactoryDoesNotBlockOtherPartitions()
+        {
+            var limiterFactory = new TrackingRateLimiterFactory<int>();
+            var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var startedTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                if (resource == "1")
+                {
+                    return RateLimitPartition.Create(1, key =>
+                    {
+                        startedTcs.SetResult(null);
+                        // block the factory method
+                        Assert.True(tcs.Task.Wait(TimeSpan.FromSeconds(10)));
+                        return limiterFactory.GetLimiter(key);
+                    });
+                }
+                return RateLimitPartition.Create(2,
+                    key => limiterFactory.GetLimiter(key));
+            });
+
+            var lease = await limiter.WaitAsync("2");
+
+            var blockedTask = Task.Run(async () =>
+            {
+                await limiter.WaitAsync("1");
+            });
+            await startedTcs.Task;
+
+            // Other partitions aren't blocked
+            await limiter.WaitAsync("2");
+
+            // Try to acquire from the blocking limiter, this should wait until the blocking limiter has been resolved and not create a new one
+            var blockedTask2 = Task.Run(async () =>
+            {
+                await limiter.WaitAsync("1");
+            });
+
+            // unblock limiter factory
+            tcs.SetResult(null);
+            await blockedTask;
+            await blockedTask2;
+
+            // Only 2 limiters should have been created
+            Assert.Equal(2, limiterFactory.Limiters.Count);
+            Assert.Equal(2, limiterFactory.Limiters[0].Limiter.WaitAsyncCallCount);
+            Assert.Equal(2, limiterFactory.Limiters[1].Limiter.WaitAsyncCallCount);
+        }
+
+        [Fact]
+        public void Create_PassedInEqualityComparerIsUsed()
+        {
+            var limiterFactory = new TrackingRateLimiterFactory<int>();
+            var equality = new TestEquality();
+            using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                if (resource == "1")
+                {
+                    return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+                }
+                return RateLimitPartition.Create(2, key => limiterFactory.GetLimiter(key));
+            }, equality);
+
+            limiter.Acquire("1");
+            // GetHashCode to add item to dictionary (skips TryGet for empty dictionary)
+            Assert.Equal(0, equality.EqualsCallCount);
+            Assert.Equal(1, equality.GetHashCodeCallCount);
+            limiter.Acquire("1");
+            // GetHashCode and Equal from TryGet to see if item is in dictionary
+            Assert.Equal(1, equality.EqualsCallCount);
+            Assert.Equal(2, equality.GetHashCodeCallCount);
+            limiter.Acquire("2");
+            // GetHashCode from TryGet (fails check) and second GetHashCode to add item to dictionary
+            Assert.Equal(1, equality.EqualsCallCount);
+            Assert.Equal(4, equality.GetHashCodeCallCount);
+
+            Assert.Equal(2, limiterFactory.Limiters.Count);
+            Assert.Equal(2, limiterFactory.Limiters[0].Limiter.AcquireCallCount);
+            Assert.Equal(1, limiterFactory.Limiters[1].Limiter.AcquireCallCount);
+        }
+
+        [Fact]
+        public void Create_DisposeWithoutLimitersNoops()
+        {
+            var limiterFactory = new TrackingRateLimiterFactory<int>();
+            using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+            });
+
+            limiter.Dispose();
+
+            Assert.Equal(0, limiterFactory.Limiters.Count);
+        }
+
+        [Fact]
+        public void Create_DisposeDisposesAllLimiters()
+        {
+            var limiterFactory = new TrackingRateLimiterFactory<int>();
+            using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                if (resource == "1")
+                {
+                    return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+                }
+                return RateLimitPartition.Create(2, key => limiterFactory.GetLimiter(key));
+            });
+
+            limiter.Acquire("1");
+            limiter.Acquire("2");
+
+            limiter.Dispose();
+
+            Assert.Equal(2, limiterFactory.Limiters.Count);
+            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.AcquireCallCount);
+            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.DisposeCallCount);
+
+            Assert.Equal(1, limiterFactory.Limiters[1].Limiter.AcquireCallCount);
+            Assert.Equal(1, limiterFactory.Limiters[1].Limiter.DisposeCallCount);
+        }
+
+        [Fact]
+        public void Create_DisposeThrowsForFutureMethodCalls()
+        {
+            var limiterFactory = new TrackingRateLimiterFactory<int>();
+            using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+            });
+
+            limiter.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => limiter.Acquire("1"));
+
+            Assert.Equal(0, limiterFactory.Limiters.Count);
+        }
+
+        [Fact]
+        public async Task Create_DisposeAsyncDisposesAllLimiters()
+        {
+            var limiterFactory = new TrackingRateLimiterFactory<int>();
+            using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                if (resource == "1")
+                {
+                    return RateLimitPartition.Create(1, key => limiterFactory.GetLimiter(key));
+                }
+                return RateLimitPartition.Create(2, key => limiterFactory.GetLimiter(key));
+            });
+
+            limiter.Acquire("1");
+            limiter.Acquire("2");
+
+            await limiter.DisposeAsync();
+
+            Assert.Equal(2, limiterFactory.Limiters.Count);
+            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.AcquireCallCount);
+            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.DisposeCallCount);
+            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.DisposeAsyncCallCount);
+
+            Assert.Equal(1, limiterFactory.Limiters[1].Limiter.AcquireCallCount);
+            Assert.Equal(1, limiterFactory.Limiters[1].Limiter.DisposeCallCount);
+            Assert.Equal(1, limiterFactory.Limiters[1].Limiter.DisposeAsyncCallCount);
+        }
+
+        [Fact]
+        public async Task Create_WithTokenBucketReplenishesAutomatically()
+        {
+            using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.CreateTokenBucketLimiter(1,
+                    _ => new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1, TimeSpan.FromMilliseconds(100), 1, false));
+            });
+
+            var lease = limiter.Acquire("");
+            Assert.True(lease.IsAcquired);
+
+            lease = await limiter.WaitAsync("");
+            Assert.True(lease.IsAcquired);
+        }
+
+        [Fact]
+        public async Task Create_CancellationTokenPassedToUnderlyingLimiter()
+        {
+            using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.CreateConcurrencyLimiter(1,
+                    _ => new ConcurrencyLimiterOptions(1, QueueProcessingOrder.NewestFirst, 1));
+            });
+
+            var lease = limiter.Acquire("");
+            Assert.True(lease.IsAcquired);
+
+            var cts = new CancellationTokenSource();
+            var waitTask = limiter.WaitAsync("", 1, cts.Token);
+            Assert.False(waitTask.IsCompleted);
+            cts.Cancel();
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await waitTask);
+        }
+
+        internal sealed class NotImplementedPartitionedRateLimiter<T> : PartitionedRateLimiter<T>
         {
             public override int GetAvailablePermits(T resourceID) => throw new NotImplementedException();
             protected override RateLimitLease AcquireCore(T resourceID, int permitCount) => throw new NotImplementedException();
             protected override ValueTask<RateLimitLease> WaitAsyncCore(T resourceID, int permitCount, CancellationToken cancellationToken) => throw new NotImplementedException();
+        }
+
+        internal sealed class TrackingRateLimiter : RateLimiter
+        {
+            private int _getAvailablePermitsCallCount;
+            private int _acquireCallCount;
+            private int _waitAsyncCallCount;
+            private int _disposeCallCount;
+            private int _disposeAsyncCallCount;
+
+            public int GetAvailablePermitsCallCount => _getAvailablePermitsCallCount;
+            public int AcquireCallCount => _acquireCallCount;
+            public int WaitAsyncCallCount => _waitAsyncCallCount;
+            public int DisposeCallCount => _disposeCallCount;
+            public int DisposeAsyncCallCount => _disposeAsyncCallCount;
+
+            public override int GetAvailablePermits()
+            {
+                Interlocked.Increment(ref _getAvailablePermitsCallCount);
+                return 1;
+            }
+
+            protected override RateLimitLease AcquireCore(int permitCount)
+            {
+                Interlocked.Increment(ref _acquireCallCount);
+                return new Lease();
+            }
+
+            protected override ValueTask<RateLimitLease> WaitAsyncCore(int permitCount, CancellationToken cancellationToken)
+            {
+                Interlocked.Increment(ref _waitAsyncCallCount);
+                return new ValueTask<RateLimitLease>(new Lease());
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                Interlocked.Increment(ref _disposeCallCount);
+            }
+
+            protected override ValueTask DisposeAsyncCore()
+            {
+                Interlocked.Increment(ref _disposeAsyncCallCount);
+                return new ValueTask();
+            }
+
+            private sealed class Lease : RateLimitLease
+            {
+                public override bool IsAcquired => throw new NotImplementedException();
+
+                public override IEnumerable<string> MetadataNames => throw new NotImplementedException();
+
+                public override bool TryGetMetadata(string metadataName, out object? metadata) => throw new NotImplementedException();
+            }
+        }
+
+        internal sealed class TrackingRateLimiterFactory<TKey>
+        {
+            public List<(TKey Key, TrackingRateLimiter Limiter)> Limiters { get; } = new();
+
+            public RateLimiter GetLimiter(TKey key)
+            {
+                TrackingRateLimiter limiter;
+                lock (Limiters)
+                {
+                    limiter = new TrackingRateLimiter();
+                    Limiters.Add((key, limiter));
+                }
+                return limiter;
+            }
+        }
+
+        internal sealed class TestEquality : IEqualityComparer<int>
+        {
+            private int _equalsCallCount;
+            private int _getHashCodeCallCount;
+
+            public int EqualsCallCount => _equalsCallCount;
+            public int GetHashCodeCallCount => _getHashCodeCallCount;
+
+            public bool Equals(int x, int y)
+            {
+                Interlocked.Increment(ref _equalsCallCount);
+                return x == y;
+            }
+            public int GetHashCode([DisallowNull] int obj)
+            {
+                Interlocked.Increment(ref _getHashCodeCallCount);
+                return obj.GetHashCode();
+            }
         }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/tests/PartitionedRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/PartitionedRateLimiterTests.cs
@@ -376,6 +376,8 @@ namespace System.Threading.RateLimiting.Tests
             public int DisposeCallCount => _disposeCallCount;
             public int DisposeAsyncCallCount => _disposeAsyncCallCount;
 
+            public override TimeSpan? IdleDuration => throw new NotImplementedException();
+
             public override int GetAvailablePermits()
             {
                 Interlocked.Increment(ref _getAvailablePermitsCallCount);

--- a/src/libraries/System.Threading.RateLimiting/tests/RateLimiterPartitionTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/RateLimiterPartitionTests.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Threading.RateLimiting.Tests
+{
+    public class RateLimiterPartitionTests
+    {
+        [Fact]
+        public void Create_Concurrency()
+        {
+            var options = new ConcurrencyLimiterOptions(10, QueueProcessingOrder.OldestFirst, 10);
+            var partition = RateLimitPartition.CreateConcurrencyLimiter(1, key => options);
+
+            var factoryProperty = typeof(RateLimitPartition<int>).GetField("Factory", Reflection.BindingFlags.NonPublic | Reflection.BindingFlags.Instance)!;
+            var factory = (Func<int, RateLimiter>)factoryProperty.GetValue(partition);
+            var limiter = factory(1);
+            var concurrencyLimiter = Assert.IsType<ConcurrencyLimiter>(limiter);
+            Assert.Equal(options.PermitLimit, concurrencyLimiter.GetAvailablePermits());
+        }
+
+        [Fact]
+        public void Create_TokenBucket()
+        {
+            var options = new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 10, TimeSpan.FromMinutes(1), 1, true);
+            var partition = RateLimitPartition.CreateTokenBucketLimiter(1, key => options);
+
+            var factoryProperty = typeof(RateLimitPartition<int>).GetField("Factory", Reflection.BindingFlags.NonPublic | Reflection.BindingFlags.Instance)!;
+            var factory = (Func<int, RateLimiter>)factoryProperty.GetValue(partition);
+            var limiter = factory(1);
+            var tokenBucketLimiter = Assert.IsType<TokenBucketRateLimiter>(limiter);
+            Assert.Equal(options.TokenLimit, tokenBucketLimiter.GetAvailablePermits());
+            // TODO: Check other properties when ReplenshingRateLimiter is merged
+            // TODO: Check that autoReplenishment: true got changed to false
+        }
+
+        [Fact]
+        public async Task Create_NoLimiter()
+        {
+            var partition = RateLimitPartition.CreateNoLimiter(1);
+
+            var factoryProperty = typeof(RateLimitPartition<int>).GetField("Factory", Reflection.BindingFlags.NonPublic | Reflection.BindingFlags.Instance)!;
+            var factory = (Func<int, RateLimiter>)factoryProperty.GetValue(partition);
+            var limiter = factory(1);
+
+            // How do we test an internal implementation of a limiter that doesn't limit? Just try some stuff that normal limiters would probably block on and see if it works.
+            var available = limiter.GetAvailablePermits();
+            var lease = limiter.Acquire(int.MaxValue);
+            Assert.True(lease.IsAcquired);
+            Assert.Equal(available, limiter.GetAvailablePermits());
+
+            lease = limiter.Acquire(int.MaxValue);
+            Assert.True(lease.IsAcquired);
+
+            var wait = limiter.WaitAsync(int.MaxValue);
+            Assert.True(wait.IsCompletedSuccessfully);
+            lease = await wait;
+            Assert.True(lease.IsAcquired);
+
+            lease.Dispose();
+        }
+
+        [Fact]
+        public void Create_AnyLimiter()
+        {
+            var partition = RateLimitPartition.Create(1, key => new ConcurrencyLimiter(new ConcurrencyLimiterOptions(1, QueueProcessingOrder.NewestFirst, 10)));
+
+            var factoryProperty = typeof(RateLimitPartition<int>).GetField("Factory", Reflection.BindingFlags.NonPublic | Reflection.BindingFlags.Instance)!;
+            var factory = (Func<int, RateLimiter>)factoryProperty.GetValue(partition);
+            var limiter = factory(1);
+            var concurrencyLimiter = Assert.IsType<ConcurrencyLimiter>(limiter);
+            Assert.Equal(1, concurrencyLimiter.GetAvailablePermits());
+
+            var partition2 = RateLimitPartition.Create(1, key => new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.NewestFirst, 10, TimeSpan.FromMilliseconds(100), 1, autoReplenishment: false)));
+            factory = (Func<int, RateLimiter>)factoryProperty.GetValue(partition2);
+            limiter = factory(1);
+            var tokenBucketLimiter = Assert.IsType<TokenBucketRateLimiter>(limiter);
+            Assert.Equal(1, tokenBucketLimiter.GetAvailablePermits());
+        }
+    }
+}

--- a/src/libraries/System.Threading.RateLimiting/tests/SlidingWindowRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/SlidingWindowRateLimiterTests.cs
@@ -713,5 +713,58 @@ namespace System.Threading.RateLimiting.Test
             Assert.False(limiter2.IsAutoReplenishing);
             Assert.Equal(replenishPeriod, limiter2.ReplenishmentPeriod);
         }
+
+        [Fact]
+        public override async Task CanFillQueueWithNewestFirstAfterCancelingQueuedRequestWithAnotherQueuedRequest()
+        {
+            var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(2, QueueProcessingOrder.NewestFirst, 2,
+                TimeSpan.Zero, 2, autoReplenishment: false));
+            var lease = limiter.Acquire(2);
+            Assert.True(lease.IsAcquired);
+
+            var cts = new CancellationTokenSource();
+            var wait = limiter.WaitAsync(1, cts.Token);
+
+            // Add another item to queue, will be completed as failed later when we queue another item
+            var wait2 = limiter.WaitAsync(1);
+            Assert.False(wait.IsCompleted);
+
+            cts.Cancel();
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
+            Assert.Equal(cts.Token, ex.CancellationToken);
+
+            lease.Dispose();
+            limiter.TryReplenish();
+
+            var wait3 = limiter.WaitAsync(2);
+            Assert.False(wait3.IsCompleted);
+
+            // will be kicked by wait3 because we're using NewestFirst
+            lease = await wait2;
+            Assert.False(lease.IsAcquired);
+
+            limiter.TryReplenish();
+            lease = await wait3;
+            Assert.True(lease.IsAcquired);
+        }
+
+        [Fact]
+        public override async Task CanDisposeAfterCancelingQueuedRequest()
+        {
+            var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1,
+                TimeSpan.Zero, 2, autoReplenishment: false));
+            var lease = limiter.Acquire(1);
+            Assert.True(lease.IsAcquired);
+
+            var cts = new CancellationTokenSource();
+            var wait = limiter.WaitAsync(1, cts.Token);
+
+            cts.Cancel();
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
+            Assert.Equal(cts.Token, ex.CancellationToken);
+
+            // Make sure dispose doesn't have any side-effects when dealing with a canceled queued item
+            limiter.Dispose();
+        }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/tests/System.Threading.RateLimiting.Tests.csproj
+++ b/src/libraries/System.Threading.RateLimiting/tests/System.Threading.RateLimiting.Tests.csproj
@@ -7,10 +7,14 @@
     <Compile Include="ConcurrencyLimiterTests.cs" />
     <Compile Include="PartitionedRateLimiterTests.cs" />
     <Compile Include="FixedWindowRateLimiterTests.cs" />
+    <Compile Include="RateLimiterPartitionTests.cs" />
     <Compile Include="SlidingWindowRateLimiterTests.cs" />
     <Compile Include="TokenBucketRateLimiterTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Threading.RateLimiting.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
@@ -367,6 +367,58 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
+        public override async Task CanFillQueueWithNewestFirstAfterCancelingQueuedRequestWithAnotherQueuedRequest()
+        {
+            var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(2, QueueProcessingOrder.NewestFirst, 2,
+                TimeSpan.Zero, 2, autoReplenishment: false));
+            var lease = limiter.Acquire(2);
+            Assert.True(lease.IsAcquired);
+
+            var cts = new CancellationTokenSource();
+            var wait = limiter.WaitAsync(1, cts.Token);
+
+            // Add another item to queue, will be completed as failed later when we queue another item
+            var wait2 = limiter.WaitAsync(1);
+            Assert.False(wait.IsCompleted);
+
+            cts.Cancel();
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
+            Assert.Equal(cts.Token, ex.CancellationToken);
+
+            lease.Dispose();
+
+            var wait3 = limiter.WaitAsync(2);
+            Assert.False(wait3.IsCompleted);
+
+            // will be kicked by wait3 because we're using NewestFirst
+            lease = await wait2;
+            Assert.False(lease.IsAcquired);
+
+            limiter.TryReplenish();
+            lease = await wait3;
+            Assert.True(lease.IsAcquired);
+        }
+
+        [Fact]
+        public override async Task CanDisposeAfterCancelingQueuedRequest()
+        {
+            var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1,
+                TimeSpan.Zero, 1, autoReplenishment: false));
+            var lease = limiter.Acquire(1);
+            Assert.True(lease.IsAcquired);
+
+            var cts = new CancellationTokenSource();
+            var wait = limiter.WaitAsync(1, cts.Token);
+
+            cts.Cancel();
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
+            Assert.Equal(cts.Token, ex.CancellationToken);
+
+            // Make sure dispose doesn't have any side-effects when dealing with a canceled queued item
+            limiter.Dispose();
+        }
+
+        [Fact]
         public override async Task CanCancelWaitAsyncBeforeQueuing()
         {
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions(1, QueueProcessingOrder.OldestFirst, 1,


### PR DESCRIPTION
Adds the `PartitionedRateLimiter.Create` method and the other types necessary to implement it.
https://github.com/dotnet/runtime/issues/65400

Some more work will need to be done once https://github.com/dotnet/runtime/pull/67020 is merged so we can properly handle replenishing rate limiters.

Additionally, fixed a bug (in concurrency and token bucket) with cancellation when disposing the limiter and when adding new requests to the queue. Found while writing a cancellation test for the `PartitionedRateLimiter`.

`CreateChained` and `TranslateKey` are not included in this change.
