### PR TITLE
JIT: Fix OSR local detection for implicit byref promotion

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9741,7 +9741,20 @@ bool Compiler::lvaIsOSRLocal(unsigned varNum)
     LclVarDsc* const varDsc = lvaGetDesc(varNum);
 
 #ifdef DEBUG
-    if (!opts.IsOSR())
+    if (opts.IsOSR())
+    {
+        if (varDsc->lvIsOSRLocal)
+        {
+            // Sanity check for promoted fields of OSR locals.
+            //
+            if (varNum >= info.compLocalsCount)
+            {
+                assert(varDsc->lvIsStructField);
+                assert(varDsc->lvParentLcl < info.compLocalsCount);
+            }
+        }
+    }
+    else
     {
         assert(!varDsc->lvIsOSRLocal);
     }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -17691,6 +17691,13 @@ void Compiler::fgRetypeImplicitByRefArgs()
 #if FEATURE_MULTIREG_ARGS
                     fieldVarDsc->SetOtherArgReg(REG_NA);
 #endif
+                    // Promoted fields of implicit byrefs can't be OSR locals.
+                    //
+                    if (fieldVarDsc->lvIsOSRLocal)
+                    {
+                        assert(opts.IsOSR());
+                        fieldVarDsc->lvIsOSRLocal = false;
+                    }
                 }
 
                 // Hijack lvFieldLclStart to record the new temp number.


### PR DESCRIPTION
In #67247 I revised how the JIT determines if a local requires special
handling for OSR, but for implicit byrefs we may move locals for promoted
fields back and forth between parents and this messes with the new logic.
The fix is to reset the `lvIsOSRLocal` bit explicitly when creating the
fields for an implicit byref promotion.

Also added a bit of sanity checking to `lvaIsOSRLocal`.

Fixes #67488.