### PR TITLE
JIT: fix OSR handling for pinned locals

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -289,6 +289,14 @@ void Compiler::lvaInitTypeRef()
             {
                 JITDUMP("Setting lvPinned for V%02u\n", varNum);
                 varDsc->lvPinned = 1;
+
+                if (opts.IsOSR())
+                {
+                    // OSR method may not see any references to the pinned local,
+                    // but must still report it in GC info.
+                    //
+                    varDsc->lvImplicitlyReferenced = 1;
+                }
             }
             else
             {

--- a/src/tests/JIT/opt/OSR/pinnedlocal.cs
+++ b/src/tests/JIT/opt/OSR/pinnedlocal.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+// Run under COMPlus_GCStress=3
+
+class PinnedLocal
+{
+    static int F(char c)
+    {
+        return (int) c;
+    }
+
+    public static unsafe int Main()
+    {
+        string ss = "goodbye, world\n";
+        string s = "hello, world\n";
+        int r = 0;
+        fixed(char* p = s)
+        {
+            for (int i = 0; i < 100_000; i++)
+            {
+                r += F(p[i % s.Length]);
+
+                if ((i % 10_000) == 0)
+                {
+                    GC.Collect(2);
+                    ss = new String('a', 100);
+                }
+            }
+
+            Console.WriteLine($"r is {r}");
+            return r - 9000061 + 100;
+        }
+    }
+}

--- a/src/tests/JIT/opt/OSR/pinnedlocal.csproj
+++ b/src/tests/JIT/opt/OSR/pinnedlocal.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType />
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_GCStress=3
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_GCStress=3
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
The OSR method may not see any references to the pinned local, but must
still report it in the GC info. So under OSR, mark (root method) pinned
locals as implicitly referenced.

Fixes #67668.