### PR TITLE
[mono][llvm] Add support for llvm 13.x.

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -10212,7 +10212,12 @@ emit_llvm_file (MonoAotCompile *acfg)
 		// FIXME: This doesn't work yet
 		opts = g_strdup ("");
 	} else {
+#if LLVM_API_VERSION >= 1300
+		/* The safepoints pass requires the old pass manager */
+		opts = g_strdup ("-disable-tail-calls -place-safepoints -spp-all-backedges -enable-new-pm=0");
+#else
 		opts = g_strdup ("-disable-tail-calls -place-safepoints -spp-all-backedges");
+#endif
 	}
 
 	if (acfg->aot_opts.llvm_opts) {

--- a/src/mono/mono/mini/llvm-jit.cpp
+++ b/src/mono/mono/mini/llvm-jit.cpp
@@ -16,7 +16,7 @@
 #include "mini-runtime.h"
 #include "llvm-jit.h"
 
-#if defined(MONO_ARCH_LLVM_JIT_SUPPORTED) && !defined(MONO_CROSS_COMPILE)
+#if defined(MONO_ARCH_LLVM_JIT_SUPPORTED) && !defined(MONO_CROSS_COMPILE) && LLVM_API_VERSION < 1300
 
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/Support/raw_ostream.h>
@@ -34,7 +34,11 @@
 #include "llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/Transforms/Scalar.h"
+#if LLVM_API_VERSION >= 1300
+#include "llvm/IR/BuiltinGCs.h"
+#else
 #include "llvm/CodeGen/BuiltinGCs.h"
+#endif
 #include "llvm/InitializePasses.h"
 
 #include <cstdlib>
@@ -478,6 +482,12 @@ mono_llvm_compile_method (MonoEERef mono_ee, MonoCompile *cfg, LLVMValueRef meth
 {
 	g_assert_not_reached ();
 	return NULL;
+}
+
+void
+mono_llvm_optimize_method (LLVMValueRef method)
+{
+	g_assert_not_reached ();
 }
 
 void


### PR DESCRIPTION
LLVM 13.x removed the JIT APIs the llvm jit code was using, so the JIT support
is disabled when 13.x is used for now.