### PR TITLE
[mono][llvm] Refactor code to make it easier to support LLVM 13.x in …

### DIFF
--- a/src/mono/mono/mini/mini-llvm-cpp.cpp
+++ b/src/mono/mono/mini/mini-llvm-cpp.cpp
@@ -104,15 +104,6 @@ mono_llvm_build_alloca (LLVMBuilderRef builder, LLVMTypeRef Ty, LLVMValueRef Arr
 	return wrap (ins);
 }
 
-LLVMValueRef 
-mono_llvm_build_load (LLVMBuilderRef builder, LLVMValueRef PointerVal,
-					  const char *Name, gboolean is_volatile)
-{
-	LoadInst *ins = unwrap(builder)->CreateLoad(unwrap(PointerVal), is_volatile, Name);
-
-	return wrap(ins);
-}
-
 LLVMValueRef
 mono_llvm_build_atomic_load (LLVMBuilderRef builder, LLVMValueRef PointerVal,
 							 const char *Name, gboolean is_volatile, int alignment, BarrierKind barrier)
@@ -150,10 +141,25 @@ mono_llvm_build_aligned_load (LLVMBuilderRef builder, LLVMValueRef PointerVal,
 }
 
 LLVMValueRef 
-mono_llvm_build_store (LLVMBuilderRef builder, LLVMValueRef Val, LLVMValueRef PointerVal,
-					  gboolean is_volatile, BarrierKind barrier)
+mono_llvm_build_aligned_store (LLVMBuilderRef builder, LLVMValueRef Val, LLVMValueRef PointerVal,
+							   gboolean is_volatile, int alignment)
 {
-	StoreInst *ins = unwrap(builder)->CreateStore(unwrap(Val), unwrap(PointerVal), is_volatile);
+	StoreInst *ins;
+
+	ins = unwrap(builder)->CreateStore(unwrap(Val), unwrap(PointerVal), is_volatile);
+	ins->setAlignment (to_align (alignment));
+
+	return wrap (ins);
+}
+
+LLVMValueRef
+mono_llvm_build_atomic_store (LLVMBuilderRef builder, LLVMValueRef Val, LLVMValueRef PointerVal,
+							  BarrierKind barrier, int alignment)
+{
+	StoreInst *ins;
+
+	ins = unwrap(builder)->CreateStore(unwrap(Val), unwrap(PointerVal), false);
+	ins->setAlignment (to_align (alignment));
 
 	switch (barrier) {
 	case LLVM_BARRIER_NONE:
@@ -168,18 +174,6 @@ mono_llvm_build_store (LLVMBuilderRef builder, LLVMValueRef Val, LLVMValueRef Po
 		g_assert_not_reached ();
 		break;
 	}
-
-	return wrap(ins);
-}
-
-LLVMValueRef 
-mono_llvm_build_aligned_store (LLVMBuilderRef builder, LLVMValueRef Val, LLVMValueRef PointerVal,
-							   gboolean is_volatile, int alignment)
-{
-	StoreInst *ins;
-
-	ins = unwrap(builder)->CreateStore(unwrap(Val), unwrap(PointerVal), is_volatile);
-	ins->setAlignment (to_align (alignment));
 
 	return wrap (ins);
 }

--- a/src/mono/mono/mini/mini-llvm-cpp.h
+++ b/src/mono/mono/mini/mini-llvm-cpp.h
@@ -68,10 +68,6 @@ mono_llvm_build_alloca (LLVMBuilderRef builder, LLVMTypeRef Ty,
 						int alignment, const char *Name);
 
 LLVMValueRef
-mono_llvm_build_load (LLVMBuilderRef builder, LLVMValueRef PointerVal,
-					  const char *Name, gboolean is_volatile);
-
-LLVMValueRef
 mono_llvm_build_atomic_load (LLVMBuilderRef builder, LLVMValueRef PointerVal,
 							 const char *Name, gboolean is_volatile, int alignment, BarrierKind barrier);
 
@@ -80,12 +76,12 @@ mono_llvm_build_aligned_load (LLVMBuilderRef builder, LLVMValueRef PointerVal,
 							  const char *Name, gboolean is_volatile, int alignment);
 
 LLVMValueRef
-mono_llvm_build_store (LLVMBuilderRef builder, LLVMValueRef Val, LLVMValueRef PointerVal,
-					   gboolean is_volatile, BarrierKind kind);
-
-LLVMValueRef
 mono_llvm_build_aligned_store (LLVMBuilderRef builder, LLVMValueRef Val, LLVMValueRef PointerVal,
 							   gboolean is_volatile, int alignment);
+
+LLVMValueRef
+mono_llvm_build_atomic_store (LLVMBuilderRef builder, LLVMValueRef Val, LLVMValueRef PointerVal,
+							  BarrierKind barrier, int alignment);
 
 LLVMValueRef
 mono_llvm_build_atomic_rmw (LLVMBuilderRef builder, AtomicRMWOp op, LLVMValueRef ptr, LLVMValueRef val);

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -528,7 +528,7 @@ const_int64 (int64_t v)
 static LLVMValueRef
 md_string (const char *s)
 {
-	return LLVMMDString (s, strlen (s));
+	return LLVMMDString (s, (unsigned int)strlen (s));
 }
 
 /*
@@ -2014,7 +2014,7 @@ get_aotconst_module (MonoLLVMModule *module, LLVMBuilderRef builder, MonoJumpInf
 		// FIXME:
 		LLVMSetAlignment (v, 8);
 
-		addr = create_address (module, v, type);
+		addr = create_address (module, v, const_var_type);
 		g_hash_table_insert (module->aotconst_vars, GINT_TO_POINTER (got_offset), addr);
 	}
 
@@ -2335,12 +2335,6 @@ get_most_deep_clause (MonoCompile *cfg, EmitContext *ctx, MonoBasicBlock *bb)
 	}
 
 	return NULL;
-}
-
-static LLVMValueRef
-md_string (const char *s)
-{
-	return LLVMMDString (s, (unsigned int)strlen (s));
 }
 
 static void
@@ -12115,7 +12109,7 @@ after_codegen_1:
 			missing_method_sig = LLVMFunctionType1 (LLVMVoidType (), ctx->module->ptr_type, FALSE);
 		LLVMValueRef callee = get_callee (ctx, missing_method_sig, MONO_PATCH_INFO_JIT_ICALL_ADDR, GUINT_TO_POINTER (MONO_JIT_ICALL_mini_llvmonly_throw_aot_failed_exception));
 		LLVMValueRef args [] = { convert (ctx, name_var, ctx->module->ptr_type) };
-		LLVMBuildCall2 (ctx->builder, sig, callee, args, 1, "");
+		LLVMBuildCall2 (ctx->builder, missing_method_sig, callee, args, 1, "");
 		LLVMBuildUnreachable (ctx->builder);
 	}
 


### PR DESCRIPTION
…the future

* Remove some c++ functions which can be implemented using the C API.
* Use call_intrins in more places.