### PR TITLE
Enable MSVC standard conformance for JIT sources, try 2

### DIFF
--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -11,6 +11,10 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_
   add_compile_options(-Wno-error)
 endif()
 
+if (MSVC)
+  add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/permissive->)
+endif()
+
 function(create_standalone_jit)
 
   set(oneValueArgs TARGET OS ARCH)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -102,11 +102,8 @@ class Compiler;
 // Declare global operator new overloads that use the compiler's arena allocator
 //
 
-// I wanted to make the second argument optional, with default = CMK_Unknown, but that
-// caused these to be ambiguous with the global placement new operators.
-void* __cdecl operator new(size_t n, Compiler* context, CompMemKind cmk);
-void* __cdecl operator new[](size_t n, Compiler* context, CompMemKind cmk);
-void* __cdecl operator new(size_t n, void* p, const jitstd::placement_t& syntax_difference);
+void* operator new(size_t n, Compiler* context, CompMemKind cmk);
+void* operator new[](size_t n, Compiler* context, CompMemKind cmk);
 
 // Requires the definitions of "operator new" so including "LoopCloning.h" after the definitions.
 #include "loopcloning.h"

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4419,12 +4419,12 @@ void GenTree::VisitBinOpOperands(TVisitor visitor)
  *  not zero-initialized and can contain data from a prior allocation lifetime.
  */
 
-inline void* __cdecl operator new(size_t sz, Compiler* compiler, CompMemKind cmk)
+inline void* operator new(size_t sz, Compiler* compiler, CompMemKind cmk)
 {
     return compiler->getAllocator(cmk).allocate<char>(sz);
 }
 
-inline void* __cdecl operator new[](size_t sz, Compiler* compiler, CompMemKind cmk)
+inline void* operator new[](size_t sz, Compiler* compiler, CompMemKind cmk)
 {
     return compiler->getAllocator(cmk).allocate<char>(sz);
 }

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4429,11 +4429,6 @@ inline void* __cdecl operator new[](size_t sz, Compiler* compiler, CompMemKind c
     return compiler->getAllocator(cmk).allocate<char>(sz);
 }
 
-inline void* __cdecl operator new(size_t sz, void* p, const jitstd::placement_t& /* syntax_difference */)
-{
-    return p;
-}
-
 /*****************************************************************************/
 
 #ifdef DEBUG

--- a/src/coreclr/jit/jitstd/new.h
+++ b/src/coreclr/jit/jitstd/new.h
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
-
 #pragma once
 
 namespace jitstd
@@ -12,4 +10,9 @@ struct placement_t
 {
 };
 
+}
+
+inline void* operator new(size_t sz, void* p, jitstd::placement_t /* syntax_difference */)
+{
+    return p;
 }

--- a/src/coreclr/jit/unwind.h
+++ b/src/coreclr/jit/unwind.h
@@ -79,32 +79,6 @@ protected:
     {
     }
 
-// TODO: How do we get the ability to access uwiComp without error on Clang?
-#if defined(DEBUG) && !defined(__GNUC__)
-
-    template <typename T>
-    T dspPtr(T p)
-    {
-        return uwiComp->dspPtr(p);
-    }
-
-    template <typename T>
-    T dspOffset(T o)
-    {
-        return uwiComp->dspOffset(o);
-    }
-
-    static const char* dspBool(bool b)
-    {
-        return (b) ? "true" : "false";
-    }
-
-#endif // DEBUG
-
-    //
-    // Data
-    //
-
     Compiler* uwiComp;
 };
 


### PR DESCRIPTION
This was reverted in 794a19941a20275d47527dfa7389ae9accf754e1 as a
compiler error had snuck in in the precompiled header. This fixes the
problem by moving the global placement new operator into new.h instead
of defining it in compiler.h where jitstd cannot (should not) access it.

cc @dotnet/jit-contrib 