### PR TITLE
Simplify JsonTypeInfo construction

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -59,7 +59,7 @@ namespace System.Text.Json
                     // Some of the validation is done during construction (i.e. validity of JsonConverter, inner types etc.)
                     // therefore we need to unwrap TargetInvocationException for better user experience
                     ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                    throw ex.InnerException;
+                    throw null!;
                 }
 #endif
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.cs
@@ -81,19 +81,7 @@ namespace System.Text.Json.Serialization.Metadata
         public static JsonTypeInfo<T> CreateValueInfo<T>(JsonSerializerOptions options, JsonConverter converter)
         {
             JsonTypeInfo<T> info = new SourceGenJsonTypeInfo<T>(converter, options);
-            info.PropertyInfoForTypeInfo = CreateJsonPropertyInfoForClassInfo(typeof(T), info, converter, options);
             return info;
-        }
-
-        internal static JsonPropertyInfo CreateJsonPropertyInfoForClassInfo(
-            Type type,
-            JsonTypeInfo typeInfo,
-            JsonConverter converter,
-            JsonSerializerOptions options)
-        {
-            JsonPropertyInfo propertyInfo = converter.CreateJsonPropertyInfo();
-            propertyInfo.InitializeForTypeInfo(type, typeInfo, converter, options);
-            return propertyInfo;
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
@@ -58,8 +58,8 @@ namespace System.Text.Json.Serialization.Metadata
             bool isVirtual,
             JsonConverter converter,
             JsonSerializerOptions options,
-            JsonNumberHandling? parentTypeNumberHandling = null,
-            JsonIgnoreCondition? ignoreCondition = null)
+            JsonIgnoreCondition? ignoreCondition = null,
+            JsonTypeInfo? jsonTypeInfo = null)
         {
             // Create the JsonPropertyInfo instance.
             JsonPropertyInfo jsonPropertyInfo = converter.CreateJsonPropertyInfo();
@@ -72,8 +72,8 @@ namespace System.Text.Json.Serialization.Metadata
                 isVirtual,
                 converter,
                 ignoreCondition,
-                parentTypeNumberHandling,
-                options);
+                options,
+                jsonTypeInfo);
 
             return jsonPropertyInfo;
         }
@@ -85,17 +85,17 @@ namespace System.Text.Json.Serialization.Metadata
         private static JsonPropertyInfo CreatePropertyInfoForTypeInfo(
             Type declaredPropertyType,
             JsonConverter converter,
-            JsonNumberHandling? numberHandling,
-            JsonSerializerOptions options)
+            JsonSerializerOptions options,
+            JsonTypeInfo? jsonTypeInfo = null)
         {
             JsonPropertyInfo jsonPropertyInfo = CreateProperty(
                 declaredPropertyType: declaredPropertyType,
                 memberInfo: null, // Not a real property so this is null.
                 parentClassType: ObjectType, // a dummy value (not used)
                 isVirtual: false,
-                converter,
-                options,
-                parentTypeNumberHandling: numberHandling);
+                converter: converter,
+                options: options,
+                jsonTypeInfo: jsonTypeInfo);
 
             Debug.Assert(jsonPropertyInfo.IsForTypeInfo);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -152,7 +152,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// TypeInfo (for the cases mentioned above). In addition, methods that have a JsonPropertyInfo argument would also likely
         /// need to add an argument for JsonTypeInfo.
         /// </remarks>
-        internal JsonPropertyInfo PropertyInfoForTypeInfo { get; set; }
+        internal JsonPropertyInfo PropertyInfoForTypeInfo { get; private set; }
 
         /// <summary>
         /// Returns a helper class used for computing the default value.
@@ -162,24 +162,11 @@ namespace System.Text.Json.Serialization.Metadata
 
         internal JsonNumberHandling? NumberHandling { get; set; }
 
-        internal JsonTypeInfo()
-        {
-            Debug.Assert(false, "This constructor should not be called.");
-        }
-
-        internal JsonTypeInfo(Type type, JsonSerializerOptions options!!)
-        {
-            Type = type;
-            Options = options;
-            // Setting this option is deferred to the initialization methods of the various metadada info types.
-            PropertyInfoForTypeInfo = null!;
-        }
-
         internal JsonTypeInfo(Type type, JsonConverter converter, JsonSerializerOptions options)
         {
             Type = type;
             Options = options;
-            PropertyInfoForTypeInfo = CreatePropertyInfoForTypeInfo(Type, converter, NumberHandling, Options);
+            PropertyInfoForTypeInfo = CreatePropertyInfoForTypeInfo(Type, converter, Options, this);
             ElementType = converter.ElementType;
 
             switch (PropertyInfoForTypeInfo.ConverterStrategy)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
@@ -15,18 +15,9 @@ namespace System.Text.Json.Serialization.Metadata
     {
         private Action<Utf8JsonWriter, T>? _serialize;
 
-        internal JsonTypeInfo(Type type, JsonSerializerOptions options) :
-            base(type, options)
-        { }
-
         internal JsonTypeInfo(JsonConverter converter, JsonSerializerOptions options)
             : base(typeof(T), converter, options)
         { }
-
-        internal JsonTypeInfo()
-        {
-            Debug.Assert(false, "This constructor should not be called.");
-        }
 
         /// <summary>
         /// Serializes an instance of <typeparamref name="T"/> using

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
@@ -176,7 +176,7 @@ namespace System.Text.Json.Serialization.Metadata
                 ThrowHelper.ThrowInvalidOperationException_SerializationDuplicateTypeAttribute(Type, typeof(JsonExtensionDataAttribute));
             }
 
-            JsonPropertyInfo jsonPropertyInfo = AddProperty(memberInfo, memberType, declaringType, isVirtual, typeNumberHandling, Options);
+            JsonPropertyInfo jsonPropertyInfo = AddProperty(memberInfo, memberType, declaringType, isVirtual, Options);
             Debug.Assert(jsonPropertyInfo.NameAsString != null);
 
             if (hasExtensionAttribute)
@@ -197,7 +197,6 @@ namespace System.Text.Json.Serialization.Metadata
             Type memberType,
             Type parentClassType,
             bool isVirtual,
-            JsonNumberHandling? parentTypeNumberHandling,
             JsonSerializerOptions options)
         {
             JsonIgnoreCondition? ignoreCondition = JsonPropertyInfo.GetAttribute<JsonIgnoreAttribute>(memberInfo)?.Condition;
@@ -221,7 +220,6 @@ namespace System.Text.Json.Serialization.Metadata
                 isVirtual,
                 converter,
                 options,
-                parentTypeNumberHandling,
                 ignoreCondition);
         }
 


### PR DESCRIPTION
Follow up on https://github.com/dotnet/runtime/pull/67526

Removed duplicate code and redundant constructors between source gen and reflection JsonTypeInfo

cc: @dotnet/area-system-text-json