### PR TITLE
Fix cross dac packaging

### DIFF
--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -293,20 +293,15 @@ jobs:
           displayName: 'product build'
 
     - ${{ if and(in(parameters.osGroup, 'windows', 'Linux'), ne(parameters.archType, 'x86'), ne(parameters.compilerName, 'gcc'), ne(parameters.testGroup, 'clrTools'), eq(parameters.pgoType, '')) }}:
-      - ${{ if ne(parameters.archType, 'arm') }}:
         - template: /eng/pipelines/coreclr/templates/crossdac-build.yml
           parameters:
             archType: ${{ parameters.archType }}
             osGroup: ${{ parameters.osGroup }}
             osSubgroup: ${{ parameters.osSubgroup }}
-            hostArchType: x64
-      - ${{ if eq(parameters.archType, 'arm') }}:
-        - template: /eng/pipelines/coreclr/templates/crossdac-build.yml
-          parameters:
-            archType: ${{ parameters.archType }}
-            osGroup: ${{ parameters.osGroup }}
-            osSubgroup: ${{ parameters.osSubgroup }}
-            hostArchType: x86
+            ${{ if eq(parameters.archType, 'arm') }}:
+              hostArchType: x86
+            ${{ else }}:
+              hostArchType: x64
 
     - ${{ if and(ne(parameters.compilerName, 'gcc'), ne(parameters.testGroup, ''), ne(parameters.testGroup, 'clrTools'), ne(parameters.disableClrTest, true)) }}:
       # Publish test native components for consumption by test execution.

--- a/eng/pipelines/coreclr/templates/crossdac-build.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-build.yml
@@ -39,7 +39,7 @@ steps:
             Write-Error "Couldn't find one of the expected crossdac files."
           }
 
-          New-Item $targetDir -ea 0
+          New-Item $targetDir -Force -ea 0
           $availableFiles | %{ cp $_.FullName $targetDir -v }
         }
 

--- a/eng/pipelines/coreclr/templates/crossdac-build.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-build.yml
@@ -13,23 +13,40 @@ steps:
     - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -hostarch ${{ parameters.hostArchType }} -ci -os alpine -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg) -component crosscomponents
       displayName: Build Cross OS Linux-musl DAC for Windows
 
-    - task: CopyFiles@2
-      displayName: Gather CrossDac Artifacts (Linux)
-      inputs:
-        SourceFolder: $(buildLinuxDacRootFolderPath)
-        Contents: |
-          **/*
-          !**/sharedFramework/**/*
-        TargetFolder: $(buildLinuxDacStagingPath)
+    - powershell: |
+        function CopyAndVerifyCrossOsAssets {
+          [CmdletBinding()]
+          param (
+            [Parameter(Mandatory)][string]$crossDacDir,
+            [Parameter(Mandatory)][string]$targetDir
+          )
 
-    - task: CopyFiles@2
-      displayName: Gather CrossDac Artifacts (Linux_musl)
-      inputs:
-        SourceFolder: $(buildMuslDacRootFolderPath)
-        Contents: |
-          **/*
-          !**/sharedFramework/**/*
-        TargetFolder: '$(buildMuslDacStagingPath)'
+          if ('$(archType)' -ne '${{ parameters.hostArchType }}')
+          {
+            $crossDacDir = Join-Path $crossDacDir -ChildPath '${{ parameters.hostArchType }}'
+          }
+
+          $availableFiles = ls -File $crossDacDir
+
+          Write-Host "Probed for files in ""$crossDacDir"", found [$availableFiles]"
+
+          if (-not ("mscordaccore.dll" -in $availableFiles.Name `
+                   -and "mscordaccore.pdb" -in $availableFiles.Name `
+                   -and "mscordbi.dll" -in $availableFiles.Name `
+                   -and "mscordbi.pdb" -in $availableFiles.Name`
+                   ))
+          {
+            Write-Error "Couldn't find one of the expected crossdac files."
+          }
+
+          New-Item $targetDir -ea 0
+          $availableFiles | %{ cp $_.FullName $targetDir -v }
+        }
+
+        CopyAndVerifyCrossOsAssets -CrossDacDir $(buildMuslDacRootFolderPath) -TargetDir '$(buildMuslDacStagingPath)/${{ parameters.hostArchType }}'
+        CopyAndVerifyCrossOsAssets -CrossDacDir $(buildLinuxDacRootFolderPath) -TargetDir '$(buildLinuxDacStagingPath)/${{ parameters.hostArchType }}'
+
+      displayName: Gather CrossDac Artifacts
 
   - ${{ if eq(parameters.osGroup, 'Linux') }}:
     - task: CopyFiles@2
@@ -37,7 +54,7 @@ steps:
       inputs:
         SourceFolder: $(coreClrProductRootFolderPath)
         Contents: libcoreclr.so
-        TargetFolder: '$(crossDacArtifactPath)/${{ parameters.osGroup }}${{ parameters.osSubgroup }}.$(archType).$(buildConfigUpper)/$(crossDacHostArch)'
+        TargetFolder: '$(crossDacArtifactPath)/${{ parameters.osGroup }}${{ parameters.osSubgroup }}.$(archType).$(buildConfigUpper)/${{ parameters.hostArchType }}'
 
   # Make the assets available in a single container for the packaging job.
   - task: PublishBuildArtifacts@1

--- a/eng/pipelines/coreclr/templates/crossdac-build.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-build.yml
@@ -28,7 +28,8 @@ steps:
 
           $availableFiles = ls -File $crossDacDir
 
-          Write-Host "Probed for files in ""$crossDacDir"", found [$availableFiles]"
+          Write-Host "Probed for files in ""$crossDacDir"", found:"
+          $availableFiles | fl
 
           if (-not ("mscordaccore.dll" -in $availableFiles.Name `
                    -and "mscordaccore.pdb" -in $availableFiles.Name `
@@ -39,12 +40,15 @@ steps:
             Write-Error "Couldn't find one of the expected crossdac files."
           }
 
-          New-Item $targetDir -Force -ea 0
+          New-Item $targetDir -ItemType 'Directory' -Force -ea 0
           $availableFiles | %{ cp $_.FullName $targetDir -v }
         }
 
         CopyAndVerifyCrossOsAssets -CrossDacDir $(buildMuslDacRootFolderPath) -TargetDir '$(buildMuslDacStagingPath)/${{ parameters.hostArchType }}'
         CopyAndVerifyCrossOsAssets -CrossDacDir $(buildLinuxDacRootFolderPath) -TargetDir '$(buildLinuxDacStagingPath)/${{ parameters.hostArchType }}'
+
+        Write-Host "Final directory contents:"
+        ls -R $(crossDacArtifactPath)
 
       displayName: Gather CrossDac Artifacts
 

--- a/eng/pipelines/coreclr/templates/crossdac-build.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-build.yml
@@ -7,10 +7,10 @@ parameters:
 steps:
   # Always build the crossdac, that way we know in CI/PR if things break to build.
   - ${{ if and(eq(parameters.osGroup, 'windows'), notin(parameters.archType, 'x86')) }}:
-    - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -hostarch ${{ parameters.hostArchType }} -ci -os Linux -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg) -component crosscomponents
+    - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) ${{ parameters.archType }} -hostarch ${{ parameters.hostArchType }} -ci -os Linux -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg) -component crosscomponents
       displayName: Build Cross OS Linux DAC for Windows
 
-    - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -hostarch ${{ parameters.hostArchType }} -ci -os alpine -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg) -component crosscomponents
+    - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) ${{ parameters.archType }} -hostarch ${{ parameters.hostArchType }} -ci -os alpine -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" -ninja $(officialBuildIdArg) -component crosscomponents
       displayName: Build Cross OS Linux-musl DAC for Windows
 
     - powershell: |
@@ -21,7 +21,7 @@ steps:
             [Parameter(Mandatory)][string]$targetDir
           )
 
-          if ('$(archType)' -ne '${{ parameters.hostArchType }}')
+          if ('${{ parameters.archType }}' -ne '${{ parameters.hostArchType }}')
           {
             $crossDacDir = Join-Path $crossDacDir -ChildPath '${{ parameters.hostArchType }}'
           }

--- a/eng/pipelines/coreclr/templates/xplat-pipeline-job.yml
+++ b/eng/pipelines/coreclr/templates/xplat-pipeline-job.yml
@@ -90,13 +90,6 @@ jobs:
     - name: buildLinuxDacStagingPath
       value: '$(crossDacArtifactPath)/Linux.$(archType).$(buildConfigUpper)'
 
-    - name: crossDacHostArch
-      value: x64
-
-    - ${{ if eq(parameters.archType, 'arm') }}:
-      - name: crossDacHostArch
-        value: x86
-
     # We need this because both mono and coreclr build currently depends on CoreClr
     - name: coreClrProductArtifactName
       value: 'CoreCLRProduct_${{ parameters.pgoType }}_${{ parameters.runtimeVariant }}_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
@@ -129,7 +122,7 @@ jobs:
       value: ''
 
     # 'innerloop' and 'clrinterpreter' jobs run the Priority 0 tests; everything else runs the Priority 1 tests.
-    # 'gc-standalone' is forced to run pri0 as well to start with. 
+    # 'gc-standalone' is forced to run pri0 as well to start with.
     - ${{ if and(ne(parameters.testGroup, 'innerloop'), ne(parameters.testGroup, 'clrinterpreter'), ne(parameters.testGroup, 'gc-standalone'), ne(parameters.testGroup, 'gc-standalone-server') ) }}:
       - ${{ if ne(parameters.osGroup, 'windows') }}:
         - name: priorityArg


### PR DESCRIPTION
Fixes #67632

Now that crossbuilds are not a particularly special invocation of the build scripts, the binary layout is a bit different. Adjusting this in the cmake logic is possible to match prior behavior, but I prefer this as crossbuilds are now consistent across platforms. Instead have the upload match what the packaging job expects to get in the downloaded assets.