### PR TITLE
Always run CopyAllNativeProjectReferenceBinaries

### DIFF
--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -81,7 +81,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
         __OutputFile=$1
 
         __ResponseFile="$__OutputFile.rsp"
-        rm $__ResponseFile
+        rm $__ResponseFile 2>/dev/null
 
         __Command=$_DebuggerFullPath
         # Tests run locally need __TestDotNetCmd (set by runtest.py) or a compatible 5.0 dotnet runtime in the path
@@ -212,7 +212,7 @@ if defined RunCrossGen2 (
 :CompileOneFileCrossgen2
     echo %time%
     set __ResponseFile=!__OutputFile!.rsp
-    del /Q !__ResponseFile!
+    del /Q !__ResponseFile! 2>null
 
     set __Command=!_DebuggerFullPath!
     REM Tests run locally need __TestDotNetCmd (set by runtest.py) or a compatible 5.0 dotnet runtime in the path

--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -65,7 +65,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
         cp $CORE_ROOT/lib*.so $CORE_ROOT/lib*.dylib $(scriptPath)
       else
         cp *.dll IL-CG2/
-        rm IL-CG2/composite-r2r.dll
+        rm IL-CG2/composite-r2r.dll 2>/dev/null
       fi
 
       ExtraCrossGen2Args+=" $(CrossGen2TestExtraArguments)"
@@ -185,7 +185,7 @@ if defined RunCrossGen2 (
 
     mkdir IL-CG2
     copy *.dll IL-CG2\
-    del IL-CG2\composite-r2r.dll
+    del IL-CG2\composite-r2r.dll 2>null
 
     if defined CompositeBuildMode (
         set ExtraCrossGen2Args=!ExtraCrossGen2Args! --composite

--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -77,6 +77,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
       __cg2ExitCode=0
 
       OneFileCrossgen2() {
+        date +%H:%M:%S
         __OutputFile=$1
 
         __ResponseFile="$__OutputFile.rsp"
@@ -114,6 +115,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
         __cg2ExitCode=$?
 
         export COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun COMPlus_TC_OnStackReplacement COMPlus_TC_PartialCompilation
+        date +%H:%M:%S
       }
 
       if [ ! -z ${CompositeBuildMode+x} ]%3B then
@@ -208,6 +210,7 @@ if defined RunCrossGen2 (
 
     goto :DoneCrossgen2Operations
 :CompileOneFileCrossgen2
+    echo %time%
     set __ResponseFile=!__OutputFile!.rsp
     del /Q !__ResponseFile!
 
@@ -253,6 +256,7 @@ if defined RunCrossGen2 (
     call !__Command!
     endlocal
     set CrossGen2Status=!ERRORLEVEL!
+    echo %time%
     Exit /b 0
 
 :DoneCrossgen2Operations

--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -185,7 +185,7 @@ if defined RunCrossGen2 (
 
     mkdir IL-CG2
     copy *.dll IL-CG2\
-    del IL-CG2\composite-r2r.dll 2>null
+    del IL-CG2\composite-r2r.dll 2>nul
 
     if defined CompositeBuildMode (
         set ExtraCrossGen2Args=!ExtraCrossGen2Args! --composite
@@ -212,7 +212,7 @@ if defined RunCrossGen2 (
 :CompileOneFileCrossgen2
     echo %time%
     set __ResponseFile=!__OutputFile!.rsp
-    del /Q !__ResponseFile! 2>null
+    del /Q !__ResponseFile! 2>nul
 
     set __Command=!_DebuggerFullPath!
     REM Tests run locally need __TestDotNetCmd (set by runtest.py) or a compatible 5.0 dotnet runtime in the path

--- a/src/tests/Common/CoreCLRTestLibrary/OutOfProcessTest.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/OutOfProcessTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -69,6 +69,12 @@ namespace TestLibrary
                 else
                 {
                     testExecutable = Path.Combine(baseDir, Path.ChangeExtension(assemblyPath.Replace("\\", "/"), ".sh"));
+                }
+
+                if (!File.Exists(testExecutable))
+                {
+                    // Skip platform-specific test when running on the excluded platform
+                    return;
                 }
 
                 System.IO.Directory.CreateDirectory(outputDir);

--- a/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
@@ -338,15 +338,15 @@ sealed class WrapperLibraryTestSummaryReporting : ITestReporterWrapper
 
         builder.AppendLine($"System.TimeSpan testStart = stopwatch.Elapsed;");
         builder.AppendLine("try {");
-        builder.AppendLine($"System.Console.WriteLine(\"Running test: {{0}}\", {test.TestNameExpression});");
+        builder.AppendLine($"System.Console.WriteLine(\"{{0:HH:mm:ss.fff}} Running test: {{1}}\", System.DateTime.Now, {test.TestNameExpression});");
         builder.AppendLine($"{_outputRecorderIdentifier}.ResetTestOutput();");
         builder.AppendLine(testExecutionExpression);
         builder.AppendLine($"{_summaryLocalIdentifier}.ReportPassedTest({test.TestNameExpression}, \"{test.ContainingType}\", @\"{test.Method}\", stopwatch.Elapsed - testStart, {_outputRecorderIdentifier}.GetTestOutput());");
-        builder.AppendLine($"System.Console.WriteLine(\"Passed test: {{0}}\", {test.TestNameExpression});");
+        builder.AppendLine($"System.Console.WriteLine(\"{{0:HH:mm:ss.fff}} Passed test: {{1}}\", System.DateTime.Now, {test.TestNameExpression});");
         builder.AppendLine("}");
         builder.AppendLine("catch (System.Exception ex) {");
         builder.AppendLine($"{_summaryLocalIdentifier}.ReportFailedTest({test.TestNameExpression}, \"{test.ContainingType}\", @\"{test.Method}\", stopwatch.Elapsed - testStart, ex, {_outputRecorderIdentifier}.GetTestOutput());");
-        builder.AppendLine($"System.Console.WriteLine(\"Failed test: {{0}}\", {test.TestNameExpression});");
+        builder.AppendLine($"System.Console.WriteLine(\"{{0:HH:mm:ss.fff}} Failed test: {{1}}\", System.DateTime.Now, {test.TestNameExpression});");
         builder.AppendLine("}");
 
         builder.AppendLine("}");

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -217,12 +217,17 @@
   </Target>
 
   <Target Name="CopyAllNativeProjectReferenceBinaries"
-          DependsOnTargets="ResolveCMakeNativeProjectReference;ConsolidateNativeProjectReference">
+          DependsOnTargets="ResolveCMakeNativeProjectReference;ConsolidateNativeProjectReference"
+          BeforeTargets="Build">
 
     <ItemGroup Condition="'$(IsMergedTestRunnerAssembly)' == 'true'">
-      <MergedWrapperReferenceFolders Include="@(ProjectReference->'$([System.IO.Path]::GetFullPath('%(ProjectReference.Identity)/..', '$(OutDir)/..'))/%(ProjectReference.FileName)')" />
+      <OutOfProcessTestMarkers Include="$(OutDir)/../**/*.OutOfProcessTest" />
+      <OutOfProcessTestFolders Include="$([MSBuild]::NormalizePath('$([System.IO.Path]::GetDirectoryName('%(OutOfProcessTestMarkers.FullPath)'))'))" Condition="'@(OutOfProcessTestMarkers)' != ''" />
+      <MergedWrapperReferenceFolders Include="@(ProjectReference->'$([MSBuild]::NormalizePath('$([System.IO.Path]::GetFullPath('%(ProjectReference.Identity)/..', '$(OutDir)/..'))/%(ProjectReference.FileName)'))')" />
+      <!-- Don't copy out-of-process test components to the merged wrapper output folder -->
+      <MergedWrapperReferenceFolders Remove="@(OutOfProcessTestFolders)" />
       <!-- For merged project wrappers, include native libraries in all project references -->
-      <MergedWrapperReferenceFiles Include="%(MergedWrapperReferenceFolders.Identity)/*$(LibSuffix)" />
+      <MergedWrapperReferenceFiles Include="%(MergedWrapperReferenceFolders.Identity)/*$(LibSuffix)" Condition="'@(MergedWrapperReferenceFolders)' != ''" />
     </ItemGroup>
     <Copy SourceFiles="@(MergedWrapperReferenceFiles)"
         DestinationFiles="@(MergedWrapperReferenceFiles->'$(OutDir)/%(FileName)%(Extension)')"

--- a/src/tests/JIT/Methodical/Arrays/misc/arrres_il_r.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/arrres_il_r.ilproj
@@ -7,6 +7,7 @@
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="arrres.il" />

--- a/src/tests/JIT/Methodical/tailcall_v4/hijacking.ilproj
+++ b/src/tests/JIT/Methodical/tailcall_v4/hijacking.ilproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="hijacking.il" />

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3131,6 +3131,12 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b53980/b53980/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/tailcall/compat_i4_u_il_d/**">
+            <Issue>https://github.com/dotnet/runtime/issues/67756</Issue>
+        </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/tailcall/compat_i4_u_il_r/**">
+            <Issue>https://github.com/dotnet/runtime/issues/67756</Issue>
+        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/tailcall/test_mutual_rec_il_r/**">
             <Issue>needs triage</Issue>
         </ExcludeList>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1868,6 +1868,12 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/refany/lcs_il_r/**">
             <Issue>https://github.com/dotnet/runtime/issues/34196</Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/tailcall/compat_i4_u_il_d/**">
+            <Issue>https://github.com/dotnet/runtime/issues/67756</Issue>
+        </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/tailcall/compat_i4_u_il_r/**">
+            <Issue>https://github.com/dotnet/runtime/issues/67756</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)JIT/Methodical/tailcall_v4/hijacking/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
@@ -3130,12 +3136,6 @@
         </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b53980/b53980/**">
             <Issue>needs triage</Issue>
-        </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/tailcall/compat_i4_u_il_d/**">
-            <Issue>https://github.com/dotnet/runtime/issues/67756</Issue>
-        </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/tailcall/compat_i4_u_il_r/**">
-            <Issue>https://github.com/dotnet/runtime/issues/67756</Issue>
         </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/tailcall/test_mutual_rec_il_r/**">
             <Issue>needs triage</Issue>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -4007,6 +4007,8 @@
             <FilteredExcludeList
                 Include="$([System.IO.Path]::GetRelativePath('$(XunitTestBinBase)', '%(ExcludeList.FullPath)'))"
                 Condition="'%(ExcludeList.Extension)' == '.dll'" />
+            <FilteredExcludeList Include="$([System.IO.Path]::ChangeExtension('$([System.IO.Path]::GetRelativePath('$(XunitTestBinBase)', '%(ExcludeList.RootDir)%(ExcludeList.Directory)%(ExcludeList.FileName)'))', '.cmd'))"
+                Condition="'%(ExcludeList.Extension)' == '.OutOfProcessTest'" />
       </ItemGroup>
     </Target>
 </Project>

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -844,8 +844,8 @@ def run_tests(args,
     if args.skip_test_run:
         return
 
-    # Set default per-test timeout to 15 minutes (in milliseconds).
-    per_test_timeout = 15*60*1000
+    # Set default per-test timeout to 30 minutes (in milliseconds).
+    per_test_timeout = 30*60*1000
 
     # Setup the environment
     if args.long_gc:


### PR DESCRIPTION
Previously this target was only called from the recursive traversal
used when globally copying native artifacts for all projects (this
is used in the lab where the native artifacts are produced on
a different machine than the managed test artifacts). In case of
combined (local) test build we weren't running the target, only
its dependencies (ResolveCMakeNativeProjectReference and
ConsolidateNativeProjectReference); this used to be sufficient as
these two targets handle all logic related to copying native
components of a normal project, however I have recently added
special logic for copying merged test wrapper native artifacts
the CopyAllNativeProjectReferenceBinaries target and so we now must
make sure it also always runs.

Mark JIT optimization-sensitive tests as out-of-process and fix
logic around skipping of out-of-process tests on the excluded platforms.

Thanks

Tomas

P.S. Technically this should be the last pre-requisite to the JIT/Methodical
switchover. For the PR itself,

https://github.com/dotnet/runtime/pull/65597

the latest runs (that should be synced past @jkoritzinsky's Mono fixes)
still fail in multiple Mono legs that will need investigation. Outerloop runs
look pretty clean so far except for the known issue

https://github.com/dotnet/runtime/issues/67603

even though they weren't all finished by the time of publishing this PR.
Jeremy, can you please take a look at the Mono failures and use your
expertise to advise which failures are known and which ones are possibly
caused by / related to the switchover? Thanks!