### PR TITLE
[wasm] Bundle net472 dependencies for MonoAOTCompiler task

### DIFF
--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.csproj
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.csproj
@@ -9,6 +9,7 @@
 
     <!-- Ignore nullable warnings on net4* -->
     <NoWarn Condition="$(TargetFramework.StartsWith('net4'))">$(NoWarn),CS8604,CS8602</NoWarn>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
@@ -35,6 +36,10 @@
 
       <FilesToPackage Include="$(OutputPath)%(_PublishFramework.Identity)\$(AssemblyName).dll" TargetPath="tasks\%(_PublishFramework.Identity)" />
       <FilesToPackage Include="$(OutputPath)%(_PublishFramework.Identity)\$(AssemblyName).pdb" TargetPath="tasks\%(_PublishFramework.Identity)" />
+
+      <!-- for net472 we need all the dependent assemblies too, so copy from the publish folder -->
+      <FilesToPackage Include="$(OutputPath)$(TargetFrameworkForNETFrameworkTasks)\*.dll*"
+                      TargetPath="tasks\$(TargetFrameworkForNETFrameworkTasks)" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
.. same as what we do for WasmAppBuilder, and MonoTargets.

Without this, it would work if msbuild/VS happened to load the expected
System.Reflection.Metadata assembly before loading the task. But break
when it didn't. And that breakage happens with 7.0*p3 with VS 17.2 .

msbuild, and VS break with:
```
The "MonoAOTCompiler" task failed unexpectedly.System.IO.FileNotFoundException: Could not load file or assembly 'System.Reflection.Metadata, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies.
    The system cannot find the file specified.File name: 'System.Reflection.Metadata, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
        at MonoAOTCompiler.FilterAssemblies(IEnumerable`1 assemblies)
        at MonoAOTCompiler.ExecuteInternal()
        at MonoAOTCompiler.Execute()
        at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
        at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext()

    WRN: Assembly binding logging is turned OFF.To enable assembly bind failure logging, set the registry value [HKLM\Software\Microsoft\Fusion!EnableLog] (DWORD) to 1.Note: There is some performance penalty associ ated with assembly bind failure logging.To turn this feature off, remove the registry value [HKLM\Software\Microsoft\Fusion!EnableLog].
```

These are the files bundled for net472 now:

```
tasks/net472/Microsoft.Bcl.AsyncInterfaces.dll
tasks/net472/Microsoft.Build.dll
tasks/net472/Microsoft.Build.Framework.dll
tasks/net472/Microsoft.Build.Tasks.Core.dll
tasks/net472/Microsoft.Build.Utilities.Core.dll
tasks/net472/Microsoft.NET.StringTools.dll
tasks/net472/Microsoft.VisualStudio.Setup.Configuration.Interop.dll
tasks/net472/MonoAOTCompiler.dll
tasks/net472/MonoAOTCompiler.dll.config
tasks/net472/System.Buffers.dll
tasks/net472/System.Collections.Immutable.dll
tasks/net472/System.Configuration.ConfigurationManager.dll
tasks/net472/System.Memory.dll
tasks/net472/System.Numerics.Vectors.dll
tasks/net472/System.Reflection.Metadata.dll
tasks/net472/System.Resources.Extensions.dll
tasks/net472/System.Runtime.CompilerServices.Unsafe.dll
tasks/net472/System.Security.AccessControl.dll
tasks/net472/System.Security.Permissions.dll
tasks/net472/System.Security.Principal.Windows.dll
tasks/net472/System.Text.Encodings.Web.dll
tasks/net472/System.Text.Json.dll
tasks/net472/System.Threading.Tasks.Dataflow.dll
tasks/net472/System.Threading.Tasks.Extensions.dll
tasks/net472/System.ValueTuple.dll
```

Issue: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1520454