### PR TITLE
Add NoWASM to category filter

### DIFF
--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -252,7 +252,7 @@ fi
 
 if [[ "$monoaot" == "true" ]]; then
     configurations="$configurations LLVM=$llvm MonoInterpreter=$monointerpreter MonoAOT=$monoaot"
-    extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --category-exclusion-filter NoAOT"
+    extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --category-exclusion-filter NoAOT NoWASM"
 fi
 
 cleaned_branch_name="main"


### PR DESCRIPTION
We are currently seeing hangs in the Arm64 AOT Mono performance runs in tests using the async pattern. The NoWASM category is already applied to all tests with async, so reusing this for now to unblock the lab while we investigate the hangs.