### PR TITLE
Improve List performance in IEnumerable.SequenceEqual

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Enumerable.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -14,12 +15,13 @@ namespace System.Linq
         /// <summary>Validates that source is not null and then tries to extract a span from the source.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // fast type checks that don't add a lot of overhead
         private static bool TryGetSpan<TSource>(this IEnumerable<TSource> source, out ReadOnlySpan<TSource> span)
+        {
             // This constraint isn't required, but the overheads involved here can be more substantial when TSource
-            // is a reference type and generic implementations are shared.  So for now we're protecting ourselves
+            // is a reference type and generic implementations are shared. So for now we're protecting ourselves
             // and forcing a conscious choice to remove this in the future, at which point it should be paired with
             // sufficient performance testing.
-            where TSource : struct
-        {
+            Debug.Assert(typeof(TSource).IsValueType);
+
             if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);

--- a/src/libraries/System.Linq/src/System/Linq/SequenceEqual.cs
+++ b/src/libraries/System.Linq/src/System/Linq/SequenceEqual.cs
@@ -24,9 +24,9 @@ namespace System.Linq
 
             if (first is ICollection<TSource> firstCol && second is ICollection<TSource> secondCol)
             {
-                if (first is TSource[] firstArray && second is TSource[] secondArray)
+                if (typeof(TSource).IsValueType && first.TryGetSpan(out ReadOnlySpan<TSource> firstSpan) && second.TryGetSpan(out ReadOnlySpan<TSource> secondSpan))
                 {
-                    return ((ReadOnlySpan<TSource>)firstArray).SequenceEqual(secondArray, comparer);
+                    return firstSpan.SequenceEqual(secondSpan, comparer);
                 }
 
                 if (firstCol.Count != secondCol.Count)


### PR DESCRIPTION
Currently IEnumerable.SequenceEqual is only vectorized when both the source and comparison enumerable are arrays. This change allows them to be either an array or a List.

To be able to use the already existing `TryGetSpan` I had to remove the struct constraint. I still wanted to keep the original intent as the comment suggests, so I replaced it with a `Type.IsValueType` condition. The method was introduced in #64624
@stephentoub Please let me know what you think of this.

The fast path of [MemoryExtensions.SequenceEqual](https://github.com/dotnet/runtime/blob/b11a22f9681863d6bf3193a7ab4c2c2041e0eeaf/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs#L1069) is restricted to `RuntimeHelpers.IsBitwiseEquatable`, and it seem a bit too low-level and implementation coupled to use here, so I chose to keep the restriction to IsValueType for that reason.

For benchmark numbers it's pretty much as expected, it scales really well with large ranges. For this example I mixed comparing an array with a List
```csharp
public class SequenceEqualsListArrayBenchmark
{
    [Params(1, 4, 32, 256, 1024)]
    public int Length { get; set; }

    private IEnumerable<int> _first;
    private IEnumerable<int> _second;

    [GlobalSetup]
    public void Setup()
    {
        _first = Enumerable.Range(1, Length).ToList();
        _second = Enumerable.Range(1, Length).ToArray();
    }

    [Benchmark]
    public bool SequenceEquals() => _first.SequenceEqual(_second);
}
```

|         Method |        Job |                                                                                                          Toolchain | Length |        Mean |    Error |   StdDev | Ratio |
|--------------- |----------- |------------------------------------------------------------------------------------------------------------------- |------- |------------:|---------:|---------:|------:|
| **SequenceEquals** | **Job-OIGBKS** | **main** |      **1** |    **26.86 ns** | **0.018 ns** | **0.016 ns** |  **1.00** |
| SequenceEquals | Job-NXVCHG |   sequenceequals |      1 |    16.82 ns | 0.163 ns | 0.152 ns |  0.63 |
|                |            |                                                                                                                    |        |             |          |          |       |
| **SequenceEquals** | **Job-OIGBKS** | **main** |      **4** |    **42.17 ns** | **0.053 ns** | **0.047 ns** |  **1.00** |
| SequenceEquals | Job-NXVCHG |   sequenceequals |      4 |    17.61 ns | 0.192 ns | 0.180 ns |  0.42 |
|                |            |                                                                                                                    |        |             |          |          |       |
| **SequenceEquals** | **Job-OIGBKS** | **main** |     **32** |   **187.94 ns** | **0.134 ns** | **0.119 ns** |  **1.00** |
| SequenceEquals | Job-NXVCHG |   sequenceequals |     32 |    18.18 ns | 0.211 ns | 0.197 ns |  0.10 |
|                |            |                                                                                                                    |        |             |          |          |       |
| **SequenceEquals** | **Job-OIGBKS** | **main** |    **256** | **1,342.10 ns** | **2.395 ns** | **1.870 ns** |  **1.00** |
| SequenceEquals | Job-NXVCHG |   sequenceequals |    256 |    26.63 ns | 0.238 ns | 0.223 ns |  0.02 |
|                |            |                                                                                                                    |        |             |          |          |       |
| **SequenceEquals** | **Job-OIGBKS** | **main** |   **1024** | **5,228.43 ns** | **6.054 ns** | **4.726 ns** |  **1.00** |
| SequenceEquals | Job-NXVCHG |   sequenceequals |   1024 |    79.60 ns | 0.266 ns | 0.249 ns |  0.02 |
