### PR TITLE
Added the `hard_limit_exceeded_p` back as without it, we won't be retrying another heap to fit the new allocation.

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -16173,6 +16173,7 @@ BOOL gc_heap::a_fit_segment_end_p (int gen_number,
         {
             goto found_fit;
         }
+
         else
         {
 #ifndef USE_REGIONS
@@ -16182,19 +16183,12 @@ BOOL gc_heap::a_fit_segment_end_p (int gen_number,
                 *commit_failed_p = TRUE;
             }
             else
-#endif // !USE_REGIONS
             {
-#ifdef USE_REGIONS
-                if (heap_hard_limit)
-                {
-                    *commit_failed_p = TRUE;
-                }
-                else
-#endif // USE_REGIONS
-                {
-                    assert (heap_hard_limit);
-                }
+                assert (heap_hard_limit);
             }
+#else 
+            *commit_failed_p = TRUE;
+#endif // USE_REGIONS
         }
     }
 

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -16185,9 +16185,15 @@ BOOL gc_heap::a_fit_segment_end_p (int gen_number,
 #endif // !USE_REGIONS
             {
 #ifdef USE_REGIONS
-                *commit_failed_p = TRUE;
+                if (heap_hard_limit)
+                {
+                    *commit_failed_p = TRUE;
+                }
+                else
 #endif // USE_REGIONS
-                assert (heap_hard_limit);
+                {
+                    assert (heap_hard_limit);
+                }
             }
         }
     }

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -16184,7 +16184,9 @@ BOOL gc_heap::a_fit_segment_end_p (int gen_number,
             else
 #endif // !USE_REGIONS
             {
+#ifdef USE_REGIONS
                 *commit_failed_p = TRUE;
+#endif // USE_REGIONS
                 assert (heap_hard_limit);
             }
         }

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -16176,7 +16176,9 @@ BOOL gc_heap::a_fit_segment_end_p (int gen_number,
 
         else
         {
-#ifndef USE_REGIONS
+#ifdef USE_REGIONS
+            *commit_failed_p = TRUE;
+#else 
             if (!hard_limit_short_seg_end_p)
             {
                 dprintf (2, ("can't grow segment, doing a full gc"));
@@ -16186,8 +16188,6 @@ BOOL gc_heap::a_fit_segment_end_p (int gen_number,
             {
                 assert (heap_hard_limit);
             }
-#else 
-            *commit_failed_p = TRUE;
 #endif // USE_REGIONS
         }
     }

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -6803,7 +6803,7 @@ bool gc_heap::virtual_alloc_commit_for_heap (void* addr, size_t size, int h_numb
     return GCToOSInterface::VirtualCommit(addr, size);
 }
 
-bool gc_heap::virtual_commit (void* address, size_t size, gc_oh_num oh, int h_number)
+bool gc_heap::virtual_commit (void* address, size_t size, gc_oh_num oh, int h_number, bool* hard_limit_exceeded_p)
 {
 #ifndef HOST_64BIT
     assert (heap_hard_limit == 0);
@@ -6840,6 +6840,9 @@ bool gc_heap::virtual_commit (void* address, size_t size, gc_oh_num oh, int h_nu
         }
 
         check_commit_cs.Leave();
+
+        if (hard_limit_exceeded_p)
+            *hard_limit_exceeded_p = exceeded_p;
 
         if (exceeded_p)
         {
@@ -14217,9 +14220,12 @@ BOOL gc_heap::a_size_fit_p (size_t size, uint8_t* alloc_pointer, uint8_t* alloc_
 }
 
 // Grow by committing more pages
-BOOL gc_heap::grow_heap_segment (heap_segment* seg, uint8_t* high_address)
+BOOL gc_heap::grow_heap_segment (heap_segment* seg, uint8_t* high_address, bool* hard_limit_exceeded_p)
 {
     assert (high_address <= heap_segment_reserved (seg));
+
+    if (hard_limit_exceeded_p)
+        *hard_limit_exceeded_p = false;
 
     //return 0 if we are at the end of the segment.
     if (align_on_page (high_address) > heap_segment_reserved (seg))
@@ -14239,7 +14245,7 @@ BOOL gc_heap::grow_heap_segment (heap_segment* seg, uint8_t* high_address)
                 "Growing heap_segment: %Ix high address: %Ix\n",
                 (size_t)seg, (size_t)high_address);
 
-    bool ret = virtual_commit (heap_segment_committed (seg), c_size, heap_segment_oh (seg), heap_number);
+    bool ret = virtual_commit (heap_segment_committed (seg), c_size, heap_segment_oh (seg), heap_number, hard_limit_exceeded_p);
     if (ret)
     {
         heap_segment_committed (seg) += c_size;
@@ -16124,6 +16130,7 @@ BOOL gc_heap::a_fit_segment_end_p (int gen_number,
 {
     *commit_failed_p = FALSE;
     size_t limit = 0;
+    bool hard_limit_short_seg_end_p = false;
 #ifdef BACKGROUND_GC
     int cookie = -1;
 #endif //BACKGROUND_GC
@@ -16162,13 +16169,24 @@ BOOL gc_heap::a_fit_segment_end_p (int gen_number,
                                  (end - allocated),
                                  gen_number, align_const);
 
-        if (grow_heap_segment (seg, (allocated + limit)))
+        if (grow_heap_segment (seg, (allocated + limit), &hard_limit_short_seg_end_p))
         {
             goto found_fit;
         }
         else
         {
-            *commit_failed_p = TRUE;
+#ifndef USE_REGIONS
+            if (!hard_limit_short_seg_end_p)
+            {
+                dprintf (2, ("can't grow segment, doing a full gc"));
+                *commit_failed_p = TRUE;
+            }
+            else
+#endif // !USE_REGIONS
+            {
+                *commit_failed_p = TRUE;
+                assert (heap_hard_limit);
+            }
         }
     }
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -2027,7 +2027,7 @@ protected:
     PER_HEAP_ISOLATED
     bool virtual_alloc_commit_for_heap (void* addr, size_t size, int h_number);
     PER_HEAP_ISOLATED
-    bool virtual_commit (void* address, size_t size, gc_oh_num oh, int h_number=-1); 
+    bool virtual_commit (void* address, size_t size, gc_oh_num oh, int h_number=-1, bool* hard_limit_exceeded_p=NULL); 
     PER_HEAP_ISOLATED
     bool virtual_decommit (void* address, size_t size, gc_oh_num oh, int h_number=-1);
     PER_HEAP_ISOLATED
@@ -2128,7 +2128,7 @@ protected:
     BOOL find_card (uint32_t* card_table, size_t& card,
                     size_t card_word_end, size_t& end_card);
     PER_HEAP
-    BOOL grow_heap_segment (heap_segment* seg, uint8_t* high_address);
+    BOOL grow_heap_segment (heap_segment* seg, uint8_t* high_address, bool* hard_limit_exceeded_p=NULL);
     PER_HEAP
     int grow_heap_segment (heap_segment* seg, uint8_t* high_address, uint8_t* old_loc, size_t size, BOOL pad_front_p REQD_ALIGN_AND_OFFSET_DCL);
     PER_HEAP


### PR DESCRIPTION
## Summary

We previously removed ``hard_limit_exceeded_p`` but doing so causes us to not retry fitting the new allocation in other heaps and as a result, we exit early without even trying. 

The fix here is to simply add the removed logic back in. The logic for regions will still remain the same where if we can't grow the heap segment and fit, we will be setting ``commit_failed_p`` = TRUE regardless if ``hard_limit_short_seg_end_p`` is valid or not. 