### PR TITLE
Fix wrong constant folding for bswap16

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -13434,16 +13434,12 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                         i1 = -i1;
                         break;
 
+                    // Note: BSWAP16 is considered to leave upper 16 bits
+                    // undefined as it differs by platform, so we cannot
+                    // constant fold it.
                     case GT_BSWAP:
                         i1 = ((i1 >> 24) & 0xFF) | ((i1 >> 8) & 0xFF00) | ((i1 << 8) & 0xFF0000) |
                              ((i1 << 24) & 0xFF000000);
-                        break;
-
-                    case GT_BSWAP16:
-                        // Semantics of bswap16 is to swap lower 2 bytes, but
-                        // leaver upper 2 bytes alone (with a cast inserted as
-                        // necessary during import).
-                        i1 = (i1 & 0xFFFF0000) | ((i1 >> 8) & 0xFF) | ((i1 << 8) & 0xFF00);
                         break;
 
                     case GT_CAST:

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -13440,7 +13440,10 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                         break;
 
                     case GT_BSWAP16:
-                        i1 = ((i1 >> 8) & 0xFF) | ((i1 << 8) & 0xFF00);
+                        // Semantics of bswap16 is to swap lower 2 bytes, but
+                        // leaver upper 2 bytes alone (with a cast inserted as
+                        // necessary during import).
+                        i1 = (i1 & 0xFFFF0000) | ((i1 >> 8) & 0xFF) | ((i1 << 8) & 0xFF00);
                         break;
 
                     case GT_CAST:

--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -104,7 +104,7 @@ GTNODE(RUNTIMELOOKUP    , GenTreeRuntimeLookup, 0,GTK_UNOP|GTK_EXOP|DBK_NOTLIR) 
 GTNODE(ARR_ADDR         , GenTreeArrAddr     ,0,GTK_UNOP|GTK_EXOP|DBK_NOTLIR)   // Wraps an array address expression
 
 GTNODE(BSWAP            , GenTreeOp          ,0,GTK_UNOP)               // Byte swap (32-bit or 64-bit)
-GTNODE(BSWAP16          , GenTreeOp          ,0,GTK_UNOP)               // Byte swap (16-bit)
+GTNODE(BSWAP16          , GenTreeOp          ,0,GTK_UNOP)               // Byte swap lower 16 bits. The upper 16 bits are undefined.
 
 //-----------------------------------------------------------------------------
 //  Binary operators (2 operands):

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -562,7 +562,8 @@ T ValueNumStore::EvalOpSpecialized(VNFunc vnf, T v0)
                 UINT16 v0_unsigned = UINT16(v0);
 
                 v0_unsigned = ((v0_unsigned >> 8) & 0xFF) | ((v0_unsigned << 8) & 0xFF00);
-                return T(v0_unsigned);
+                // Swap 2 lower bytes, leave rest alone
+                return (v0 & ~T(0xFFFF)) | T(v0_unsigned);
             }
 
             case GT_BSWAP:

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -557,15 +557,9 @@ T ValueNumStore::EvalOpSpecialized(VNFunc vnf, T v0)
             case GT_NOT:
                 return ~v0;
 
-            case GT_BSWAP16:
-            {
-                UINT16 v0_unsigned = UINT16(v0);
-
-                v0_unsigned = ((v0_unsigned >> 8) & 0xFF) | ((v0_unsigned << 8) & 0xFF00);
-                // Swap 2 lower bytes, leave rest alone
-                return (v0 & ~T(0xFFFF)) | T(v0_unsigned);
-            }
-
+            // Note: BSWAP16 is considered to leave upper 16 bits
+            // undefined as it differs by platform, so we cannot
+            // constant fold it.
             case GT_BSWAP:
                 if (sizeof(T) == 4)
                 {
@@ -3356,7 +3350,7 @@ bool ValueNumStore::CanEvalForConstantArgs(VNFunc vnf)
             // Unary Ops
             case GT_NEG:
             case GT_NOT:
-            case GT_BSWAP16:
+            // Cannot constant fold BSWAP16 as upper bits are undefined.
             case GT_BSWAP:
 
             // Binary Ops

--- a/src/tests/JIT/Regression/JitBlue/Runtime_67723/Runtime_67723.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_67723/Runtime_67723.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Binary;
+
+public class Runtime_67223
+{
+    public static int Main()
+    {
+        short[] foo = { short.MinValue };
+        int test = BinaryPrimitives.ReverseEndianness(foo[0]);
+        return test == 0x80 ? 100 : -1;
+    }
+}
+

--- a/src/tests/JIT/Regression/JitBlue/Runtime_67723/Runtime_67723.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_67723/Runtime_67723.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
`bswap16` currently uses `rev16` on ARM architectures and `ror <16 bit reg>, 8` on xarch. The behavior of these are not the same so consider the upper 16 bits to be undefined and disable constant folding of these.

Fix #67723

cc @dotnet/jit-contrib @aromaa