### PR TITLE
Allow IReadOnlyDictionary GetValueOrDefault parameter key to be nulll…

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
@@ -8,17 +8,29 @@ namespace System.Collections.Generic
 {
     public static class CollectionExtensions
     {
-        public static TValue? GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey? key)
+        public static TValue? GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary!!, TKey key)
         {
             if (key == null) return default!;
             return dictionary.GetValueOrDefault(key, default!);
         }
 
-        public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary!!, TKey? key, TValue defaultValue)
+        public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary!!, TKey key, TValue defaultValue)
         {
             if (key == null) return defaultValue;
             TValue? value;
             return dictionary.TryGetValue(key, out value) ? value : defaultValue;
+        }
+
+        public static TValue? GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary!!, TKey? key) where TKey : struct
+        {
+            if (!key.HasValue) return default!;
+            return dictionary.GetValueOrDefault(key, default!);
+        }
+        public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary!!, TKey? key, TValue defaultValue) where TKey : struct
+        {
+            if (!key.HasValue) return defaultValue;
+            TValue? value;
+            return dictionary.TryGetValue(key.Value, out value) ? value : defaultValue;
         }
 
         public static bool TryAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary!!, TKey key, TValue value)

--- a/src/libraries/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
@@ -8,13 +8,15 @@ namespace System.Collections.Generic
 {
     public static class CollectionExtensions
     {
-        public static TValue? GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key)
+        public static TValue? GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey? key)
         {
+            if (key == null) return default!;
             return dictionary.GetValueOrDefault(key, default!);
         }
 
-        public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary!!, TKey key, TValue defaultValue)
+        public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary!!, TKey? key, TValue defaultValue)
         {
+            if (key == null) return defaultValue;
             TValue? value;
             return dictionary.TryGetValue(key, out value) ? value : defaultValue;
         }


### PR DESCRIPTION
…able, and if it is null, returns default

Dictionaries do not allow keys to be null. Because of that, it can be assured that calling GetValueOrDefault with a null key would not return a value, therefore, it is safe that if a null value for key is passed in, that returning the default is acceptable.

This code change allows code like:
   var nullableInt = (int?)null;
   var dict = new Dictionary<int, string>();
   var foo = nullableInt.HasValue ? dict.TryGetValueOrDefault(nullableInt.Value) : null;

to be like:
   var nullableInt = (int?)null;
   var dict = new Dictionary<int, string>();
   var foo = dict.TryGetValueOrDefault(nullableInt);