### PR TITLE
Allow getting code coverage for the unit test project itself

### DIFF
--- a/eng/testing/coverage.targets
+++ b/eng/testing/coverage.targets
@@ -19,6 +19,7 @@
       <CoverageInclude Include="System.Private.CoreLib" Condition="'$(TestRuntime)' == 'true'" />
       <CoverageInclude Include="@(AssembliesBeingTested)" />
       <CoverageInclude Include="$(CoverageAssemblies)" Condition="'$(CoverageAssemblies)' != ''" />
+      <CoverageInclude Include="$(AssemblyName)" Condition="'$(CoverageIncludeTests)' == 'true'" />
       <!-- Include analyzer assemblies which are referenced via the P2P protocol. -->
       <CoverageInclude Include="@(ReferencePath->WithMetadataValue('OutputItemType', 'Analyzer')->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->Metadata('Filename'))" />
     </ItemGroup>
@@ -49,6 +50,7 @@
       <RunScriptCommand>"$(DotNetTool)" coverlet "$(TargetFileName)" --target "$(RunScriptHost)" --targetargs "$(RunScriptCommand.Replace('&quot;$(RunScriptHost)&quot;', ''))" --format "opencover" --output "$(CoverageOutputPath)" --verbosity "normal" --use-source-link</RunScriptCommand>
       <RunScriptCommand Condition="'@(CoverageExcludeByFile)' != ''">$(RunScriptCommand) --exclude-by-file @(CoverageExcludeByFile -> '"%(Identity)"', ' --exclude-by-file ')</RunScriptCommand>
       <RunScriptCommand Condition="'@(CoverageIncludeDirectory)' != ''">$(RunScriptCommand) --include-directory @(CoverageIncludeDirectory -> '"$(RunScriptHostDir)%(Identity)"', ' --include-directory ')</RunScriptCommand>
+      <RunScriptCommand Condition="'$(CoverageIncludeTests)' == 'true'">$(RunScriptCommand) --include-test-assembly</RunScriptCommand>
       <RunScriptCommand>$(RunScriptCommand) --include @(CoverageInclude -> '"[%(Identity)]*"', ' --include ')</RunScriptCommand>
       <CoverageReportCommandLine>"$(DotNetTool)" reportgenerator "-reports:$(CoverageReportInputPath)" "-targetdir:$(CoverageReportDir.TrimEnd('\/'))" "-reporttypes:Html" "-verbosity:Info"</CoverageReportCommandLine>
     </PropertyGroup>


### PR DESCRIPTION
This is helpful for our test projects that include source directly into them.  You can now do `dotnet build /t:test /p:Coverage=true /p:CoverageIncludeTests=true` to include the test project in the analysis.