### PR TITLE
[wasm][debugger] Debugger Proxy: add property accessibility info.

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -8014,6 +8014,13 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 			buffer_add_methodid (buf, domain, p->get);
 			buffer_add_methodid (buf, domain, p->set);
 			buffer_add_int (buf, p->attrs & ~MONO_PROPERTY_META_FLAG_MASK);
+			if (CHECK_PROTOCOL_VERSION(2, 62)) {
+				// hack: check property accesibility level
+				// one of: getter or setter has to be at least the accessibility of the property,
+            	// so we choose higher value (wider scope)
+				int p_access = p->get->flags > p->set->flags ? p->get->flags : p->set->flags;
+				buffer_add_int (buf, p_access);
+			}
 			i ++;
 		}
 		g_assert (i == nprops);

--- a/src/mono/mono/component/debugger-protocol.h
+++ b/src/mono/mono/component/debugger-protocol.h
@@ -11,7 +11,7 @@
  */
 
 #define MAJOR_VERSION 2
-#define MINOR_VERSION 60
+#define MINOR_VERSION 62
 
 typedef enum {
 	MDBGPROT_CMD_COMPOSITE = 100

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -749,6 +749,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 var getMethodId = retDebuggerCmdReader.ReadInt32();
                 retDebuggerCmdReader.ReadInt32(); //setmethod
                 retDebuggerCmdReader.ReadInt32(); //attrs
+                retDebuggerCmdReader.ReadInt32(); //property accessibility
                 if (await sdbAgent.MethodIsStatic(getMethodId, token))
                     continue;
                 using var command_params_writer_to_proxy = new MonoBinaryWriter();
@@ -1700,6 +1701,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 var getMethodId = retDebuggerCmdReader.ReadInt32();
                 retDebuggerCmdReader.ReadInt32(); //setmethod
                 var attrs = retDebuggerCmdReader.ReadInt32(); //attrs
+                var accessibility = retDebuggerCmdReader.ReadInt32(); //property accessibility
                 if (propertyNameStr == propertyName)
                 {
                     return getMethodId;
@@ -1724,6 +1726,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 var getMethodId = retDebuggerCmdReader.ReadInt32();
                 retDebuggerCmdReader.ReadInt32(); //setmethod
                 var attrs = retDebuggerCmdReader.ReadInt32(); //attrs
+                var accessibility = (MethodAttributes)(retDebuggerCmdReader.ReadInt32() & (int)MethodAttributes.MemberAccessMask);
                 if (getMethodId == 0 || await GetParamCount(getMethodId, token) != 0 || await MethodIsStatic(getMethodId, token))
                     continue;
                 JObject propRet = null;
@@ -2693,6 +2696,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     var getMethodId = retDebuggerCmdReader.ReadInt32();
                     var setMethodId = retDebuggerCmdReader.ReadInt32(); //setmethod
                     var attrValue = retDebuggerCmdReader.ReadInt32(); //attrs
+                    var accessibility = retDebuggerCmdReader.ReadInt32(); //accessibility
                     //Console.WriteLine($"{propertyNameStr} - {attrValue}");
                     if (ret.Where(attribute => attribute["name"].Value<string>().Equals(propertyNameStr)).Any())
                     {

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -821,7 +821,7 @@ namespace Microsoft.WebAssembly.Diagnostics
     {
         private static int debuggerObjectId;
         private static int cmdId = 1; //cmdId == 0 is used by events which come from runtime
-        private static int MINOR_VERSION = 61;
+        private static int MINOR_VERSION = 62;
         private static int MAJOR_VERSION = 2;
 
         private Dictionary<int, MethodInfoWithDebugInformation> methods;


### PR DESCRIPTION
This PR adds a property accessibility level information to the buffer of command: `CMD_TYPE_GET_PROPERTIES` (`CmdType.GetProperties`).

This information is needed to properly sort properties by protection level when sending them to debugger as public/private/other object members should be displayed differently and be sent separately. 

Connected PRs where it will be used:
https://github.com/dotnet/runtime/pull/63339