### PR TITLE
Fix exception thrown when MsQuicStream write direction is locally aborted or canceled

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/Mock/MockStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/Mock/MockStream.cs
@@ -133,7 +133,7 @@ namespace System.Net.Quic.Implementations.Mock
             if (Volatile.Read(ref _writesCanceled))
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                throw new OperationCanceledException();
+                throw new QuicOperationAbortedException();
             }
 
             StreamBuffer? streamBuffer = WriteStreamBuffer;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -324,10 +324,13 @@ namespace System.Net.Quic.Implementations.MsQuic
             {
                 if (_state.SendErrorCode != -1)
                 {
+                    // aborted by peer
                     throw new QuicStreamAbortedException(_state.SendErrorCode);
                 }
 
-                throw new OperationCanceledException(cancellationToken);
+                // aborted locally
+                throw new QuicOperationAbortedException(SR.net_quic_sending_aborted);
+
             }
 
             if (cancellationToken.IsCancellationRequested)
@@ -376,7 +379,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                         throw new QuicStreamAbortedException(_state.SendErrorCode);
                     }
 
-                    throw new OperationCanceledException(SR.net_quic_sending_aborted);
+                    throw new QuicOperationAbortedException();
                 }
                 if (_state.SendState == SendState.ConnectionClosed)
                 {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -330,7 +330,6 @@ namespace System.Net.Quic.Implementations.MsQuic
 
                 // aborted locally
                 throw new QuicOperationAbortedException(SR.net_quic_sending_aborted);
-
             }
 
             if (cancellationToken.IsCancellationRequested)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -375,10 +375,12 @@ namespace System.Net.Quic.Implementations.MsQuic
 
                     if (_state.SendErrorCode != -1)
                     {
+                        // aborted by peer
                         throw new QuicStreamAbortedException(_state.SendErrorCode);
                     }
 
-                    throw new QuicOperationAbortedException();
+                    // aborted locally
+                    throw new QuicOperationAbortedException(SR.net_quic_sending_aborted);
                 }
                 if (_state.SendState == SendState.ConnectionClosed)
                 {

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -620,8 +620,8 @@ namespace System.Net.Quic.Tests
 
                     await Assert.ThrowsAsync<OperationCanceledException>(() => stream.WriteAsync(new byte[1], cts.Token).AsTask());
 
-                    // next write would also throw
-                    await Assert.ThrowsAsync<OperationCanceledException>(() => stream.WriteAsync(new byte[1]).AsTask());
+                    // aborting write causes the write direction to throw on subsequent operations
+                    await Assert.ThrowsAsync<QuicOperationAbortedException>(() => stream.WriteAsync(new byte[1]).AsTask());
 
                     // manual write abort is still required
                     stream.AbortWrite(expectedErrorCode);
@@ -672,7 +672,7 @@ namespace System.Net.Quic.Tests
                     await Assert.ThrowsAsync<OperationCanceledException>(() => WriteUntilCanceled().WaitAsync(TimeSpan.FromSeconds(3)));
 
                     // next write would also throw
-                    await Assert.ThrowsAsync<OperationCanceledException>(() => stream.WriteAsync(new byte[1]).AsTask());
+                    await Assert.ThrowsAsync<QuicOperationAbortedException>(() => stream.WriteAsync(new byte[1]).AsTask());
 
                     // manual write abort is still required
                     stream.AbortWrite(expectedErrorCode);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -829,7 +829,6 @@ namespace System.Net.Quic.Tests
             }
 
             const int ExpectedErrorCode = 0xfffffff;
-
             SemaphoreSlim sem = new SemaphoreSlim(0);
 
             await RunBidirectionalClientServer(
@@ -849,7 +848,6 @@ namespace System.Net.Quic.Tests
                     await Assert.ThrowsAsync<QuicOperationAbortedException>(() => writeTask.WaitAsync(TimeSpan.FromSeconds(3)));
                     sem.Release();
                 });
-
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #67612.

The issue with the original code was that when `MsQuicStream` s write direction was locally aborted, subsequent `WriteAsync` calls threw `OperationCanceledException` which does not make sense since the associated `CancellationToken` was not expired (or wasn't even cancellable for that matter).

This PR changes that behavior to throw `QuicOperationAbortedException` instead, which is in line with #55619.

Also, when a `WriteAsync` call si canceled (either during actual write or pre-canceled), subsequent (non-pre-canceled) operations now throw `QuicOperationAbortedException` like we do on the reading side of the stream.