### PR TITLE
Vectorize IndexOf for OrdinalIgnoreCase

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
@@ -260,9 +260,10 @@ namespace System.Globalization
                     SpanHelpers.IndexOfAny(ref searchSpace, (char)(valueChar & ~0x20), (char)(valueChar | 0x20), searchSpaceLength) :
                     SpanHelpers.IndexOf(ref searchSpace, valueChar, searchSpaceLength);
 
-                if (candidatePos == -1)
+                if ((candidatePos == -1) || (searchSpaceLength - candidatePos) < valueLength)
                 {
-                    // the whole input doesn't contain the first char
+                    // the whole input doesn't contain the first char or it does
+                    // but there is no room left to fit the value
                     goto NOT_FOUND;
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
@@ -248,7 +248,7 @@ namespace System.Globalization
             }
 
             // hoist some expressions from the loop
-            int searchSpaceLength = source.Length - value.Length - 1;
+            int searchSpaceLength = source.Length - (value.Length - 1);
             ref char searchSpace = ref MemoryMarshal.GetReference(source);
             char valueCharU = default;
             char valueCharL = default;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Text.Unicode;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
 
 namespace System.Globalization
 {
@@ -224,6 +223,7 @@ namespace System.Globalization
                 // A non-linguistic search compares chars directly against one another, so large
                 // target strings can never be found inside small search spaces. This check also
                 // handles empty 'source' spans.
+
                 return -1;
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
@@ -248,7 +248,8 @@ namespace System.Globalization
             }
 
             // hoist some expressions from the loop
-            int searchSpaceLength = source.Length - (value.Length - 1);
+            int valueTailLength = value.Length - 1;
+            int searchSpaceLength = source.Length - valueTailLength;
             ref char searchSpace = ref MemoryMarshal.GetReference(source);
             char valueCharU = default;
             char valueCharL = default;
@@ -275,17 +276,17 @@ namespace System.Globalization
                 }
 
                 searchSpaceLength -= relativeIndex;
-                offset += relativeIndex;
-
                 if (searchSpaceLength <= 0)
                 {
                     break;
                 }
+                offset += relativeIndex;
 
                 // Found the first element of "value". See if the tail matches.
-                if (EqualsIgnoreCase(
+                if (valueTailLength == 0 || // for single-char values we already matched first chars
+                    EqualsIgnoreCase(
                         ref Unsafe.Add(ref searchSpace, (nuint)(offset + 1)),
-                        ref Unsafe.Add(ref valueRef, 1), value.Length - 1))
+                        ref Unsafe.Add(ref valueRef, 1), valueTailLength))
                 {
                     return (int)offset;  // The tail matched. Return a successful find.
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
@@ -237,7 +237,7 @@ namespace System.Globalization
                 return CompareInfo.NlsIndexOfOrdinalCore(source, value, ignoreCase: true, fromBeginning: true);
             }
 
-            // if value starts with an ASCII char we can use a vectorized path
+            // If value starts with an ASCII char, we can use a vectorized path
             ref char valueRef = ref MemoryMarshal.GetReference(value);
             char valueChar = valueRef;
 
@@ -247,7 +247,7 @@ namespace System.Globalization
                 return OrdinalCasing.IndexOf(source, value);
             }
 
-            // hoist some expressions from the loop
+            // Hoist some expressions from the loop
             int valueTailLength = value.Length - 1;
             int searchSpaceLength = source.Length - valueTailLength;
             ref char searchSpace = ref MemoryMarshal.GetReference(source);
@@ -265,11 +265,10 @@ namespace System.Globalization
 
             do
             {
+                // Do a quick search for the first element of "value".
                 int relativeIndex = isLetter ?
                     SpanHelpers.IndexOfAny(ref Unsafe.Add(ref searchSpace, offset), valueCharU, valueCharL, searchSpaceLength) :
                     SpanHelpers.IndexOf(ref Unsafe.Add(ref searchSpace, offset), valueChar, searchSpaceLength);
-
-                // Do a quick search for the first element of "value".
                 if (relativeIndex < 0)
                 {
                     break;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
@@ -274,7 +274,7 @@ namespace System.Globalization
                         ref Unsafe.Add(ref valueRef, (nuint)1),
                         valueLength - 1))
                 {
-                    return source.Length - searchSpaceLength;
+                    return source.Length - searchSpaceLength + candidatePos;
                 }
 
                 searchSpace = Unsafe.Add(ref searchSpace, (nuint)(candidatePos + valueLength));

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
@@ -267,7 +267,11 @@ namespace System.Globalization
                 }
 
                 // Do ASCII and non-ASCII friendly compare for the current candidate
-                if (EqualsIgnoreCase(ref searchSpace, ref valueRef, valueLength))
+                // Since we already know first chars match we ignore them and inspect valueLength - 1
+                if (EqualsIgnoreCase(
+                        ref Unsafe.Add(ref searchSpace, (nuint)(candidatePos + 1)),
+                        ref Unsafe.Add(ref valueRef, (nuint)1),
+                        valueLength - 1))
                 {
                     return source.Length - searchSpaceLength;
                 }


### PR DESCRIPTION
.. when the value starts with any ASCII symbol (even if then it contains non-ASCII too). This implementation is based on @stephentoub's trick used in Regex

Benchmark:
```csharp
StringComparison CmpMode = StringComparison.OrdinalIgnoreCase;

////////////////////////////////////////////////////////////////////////////////

string SmallStr = "hello";

[Benchmark]
public int IndexOf_l() => SmallStr.IndexOf("l", CmpMode);

////////////////////////////////////////////////////////////////////////////////

string DotnetHeader =
    ".NET Runtime uses third-party libraries or other resources that may be distributed";

[Benchmark]
public int IndexOf_distr() => DotnetHeader.IndexOf("distr", CmpMode);

////////////////////////////////////////////////////////////////////////////////

string ThirdPartyNotice = File.ReadAllText(@"C:\prj\runtime\THIRD-PARTY-NOTICES.TXT");

[Benchmark]
public int IndexOf_JavaScript() => ThirdPartyNotice.IndexOf("JavaScript", CmpMode);

[Benchmark]
public int IndexOf_Percentage() => ThirdPartyNotice.AsSpan().IndexOf("%", CmpMode);
```

|             Method |                   Toolchain |           Mean |       Error |      StdDev | Ratio |
|------------------- |---------------------------- |---------------:|------------:|------------:|------:|
|          IndexOf_l |      \Core_Root\corerun.exe |     10.942 ns |   0.0905 ns |   0.0847 ns |  1.00 |
|          IndexOf_l | \Core_Root_base\corerun.exe |      12.751 ns |   0.1634 ns |   0.1448 ns |  **1.17** |
|                    |                             |                |             |             |       |
|      IndexOf_distr |      \Core_Root\corerun.exe |      17.964 ns |   0.0624 ns |   0.0521 ns |  1.00 |
|      IndexOf_distr | \Core_Root_base\corerun.exe |     169.188 ns |   1.0764 ns |   1.0069 ns |  **9.43** |
|                    |                             |                |             |             |       |
| IndexOf_JavaScript |      \Core_Root\corerun.exe |   2,635.342 ns |  21.6150 ns |  19.1611 ns |  1.00 |
| IndexOf_JavaScript | \Core_Root_base\corerun.exe |  97,961.531 ns | 359.4873 ns | 280.6641 ns | **37.23** |
|                    |                             |                |             |             |       |
| IndexOf_Percentage |      \Core_Root\corerun.exe |   1,648.208 ns |  12.4174 ns |  11.6152 ns |  1.00 |
| IndexOf_Percentage | \Core_Root_base\corerun.exe | 113,032.308 ns | 289.2747 ns | 225.8467 ns | **68.57** |