### PR TITLE
Support default timeouts in RegexGenerator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
@@ -205,7 +205,7 @@ namespace System.Text.RegularExpressions.Generator
                 methodSyntax.Modifiers.ToString(),
                 pattern,
                 regexOptions,
-                matchTimeout ?? Timeout.Infinite,
+                matchTimeout,
                 regexTree);
 
             RegexType current = regexType;
@@ -233,7 +233,7 @@ namespace System.Text.RegularExpressions.Generator
         }
 
         /// <summary>A regex method.</summary>
-        internal sealed record RegexMethod(RegexType DeclaringType, MethodDeclarationSyntax MethodSyntax, string MethodName, string Modifiers, string Pattern, RegexOptions Options, int MatchTimeout, RegexTree Tree)
+        internal sealed record RegexMethod(RegexType DeclaringType, MethodDeclarationSyntax MethodSyntax, string MethodName, string Modifiers, string Pattern, RegexOptions Options, int? MatchTimeout, RegexTree Tree)
         {
             public string GeneratedName { get; set; }
             public bool IsDuplicate { get; set; }

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
@@ -138,7 +138,7 @@ namespace System.Text.RegularExpressions.Generator
                 // To minimize generated code in the event of duplicated regexes, we only emit one derived Regex type per unique
                 // expression/options/timeout.  A Dictionary<(expression, options, timeout), RegexMethod> is used to deduplicate, where the value of the
                 // pair is the implementation used for the key.
-                var emittedExpressions = new Dictionary<(string Pattern, RegexOptions Options, int Timeout), RegexMethod>();
+                var emittedExpressions = new Dictionary<(string Pattern, RegexOptions Options, int? Timeout), RegexMethod>();
 
                 // If we have any (RegexMethod regexMethod, string generatedName, string reason, Diagnostic diagnostic), these are regexes for which we have
                 // limited support and need to simply output boilerplate.  We need to emit their diagnostics.
@@ -244,16 +244,23 @@ namespace System.Text.RegularExpressions.Generator
                 if (requiredHelpers.Count != 0)
                 {
                     writer.Indent += 2;
+                    writer.WriteLine($"/// <summary>Helper methods used by generated <see cref=\"Regex\"/>-derived implementations.</summary>");
                     writer.WriteLine($"private static class {HelpersTypeName}");
                     writer.WriteLine($"{{");
                     writer.Indent++;
+                    bool sawFirst = false;
                     foreach (KeyValuePair<string, string[]> helper in requiredHelpers)
                     {
+                        if (sawFirst)
+                        {
+                            writer.WriteLine();
+                        }
+                        sawFirst = true;
+
                         foreach (string value in helper.Value)
                         {
                             writer.WriteLine(value);
                         }
-                        writer.WriteLine();
                     }
                     writer.Indent--;
                     writer.WriteLine($"}}");

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Timeout.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Timeout.cs
@@ -38,28 +38,23 @@ namespace System.Text.RegularExpressions
         /// </summary>
         public TimeSpan MatchTimeout => internalMatchTimeout;
 
-        /// <summary>
-        /// Specifies the default RegEx matching timeout value (i.e. the timeout that will be used if no
-        /// explicit timeout is specified).
-        /// The default is queried from the current <code>AppDomain</code>.
-        /// If the AddDomain's data value for that key is not a <code>TimeSpan</code> value or if it is outside the
-        /// valid range, an exception is thrown.
-        /// If the AddDomain's data value for that key is <code>null</code>, a fallback value is returned.
-        /// </summary>
-        /// <returns>The default RegEx matching timeout for this AppDomain</returns>
+        /// <summary>Gets the default matching timeout value.</summary>
+        /// <remarks>
+        /// The default is queried from <code>AppContext</code>. If the AppContext's data value for that key is
+        /// not a <code>TimeSpan</code> value or if it is outside the valid range, an exception is thrown.
+        /// If the AppContext's data value for that key is <code>null</code>, an infinite timeout is returned.
+        /// </remarks>
         private static TimeSpan InitDefaultMatchTimeout()
         {
-            // Query AppDomain
-            AppDomain ad = AppDomain.CurrentDomain;
-            object? defaultMatchTimeoutObj = ad.GetData(DefaultMatchTimeout_ConfigKeyName);
+            object? defaultTimeout = AppContext.GetData(DefaultMatchTimeout_ConfigKeyName);
 
             // If no default is specified, use fallback
-            if (defaultMatchTimeoutObj is null)
+            if (defaultTimeout is null)
             {
                 return InfiniteMatchTimeout;
             }
 
-            if (defaultMatchTimeoutObj is TimeSpan defaultMatchTimeOut)
+            if (defaultTimeout is TimeSpan defaultMatchTimeOut)
             {
                 // If default timeout is outside the valid range, throw. It will result in a TypeInitializationException:
                 try
@@ -74,7 +69,7 @@ namespace System.Text.RegularExpressions
                 return defaultMatchTimeOut;
             }
 
-            throw new InvalidCastException(SR.Format(SR.IllegalDefaultRegexMatchTimeoutInAppDomain, DefaultMatchTimeout_ConfigKeyName, defaultMatchTimeoutObj));
+            throw new InvalidCastException(SR.Format(SR.IllegalDefaultRegexMatchTimeoutInAppDomain, DefaultMatchTimeout_ConfigKeyName, defaultTimeout));
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorHelper.netcoreapp.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorHelper.netcoreapp.cs
@@ -23,7 +23,7 @@ namespace System.Text.RegularExpressions.Tests
 {
     public static class RegexGeneratorHelper
     {
-        private static readonly CSharpParseOptions s_previewParseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview);
+        private static readonly CSharpParseOptions s_previewParseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview).WithDocumentationMode(DocumentationMode.Diagnose);
         private static readonly EmitOptions s_emitOptions = new EmitOptions(debugInformationFormat: DebugInformationFormat.Embedded);
         private static readonly CSharpGeneratorDriver s_generatorDriver = CSharpGeneratorDriver.Create(new[] { new RegexGenerator().AsSourceGenerator() }, parseOptions: s_previewParseOptions);
         private static Compilation? s_compilation;
@@ -135,6 +135,7 @@ namespace System.Text.RegularExpressions.Tests
 
             var code = new StringBuilder();
             code.AppendLine("using System.Text.RegularExpressions;");
+            code.AppendLine("/// <summary>Container for generated regex method.</summary>");
             code.AppendLine("public partial class C {");
 
             // Build up the code for all of the regexes
@@ -142,6 +143,7 @@ namespace System.Text.RegularExpressions.Tests
             foreach (var regex in regexes)
             {
                 Assert.True(regex.options is not null || regex.matchTimeout is null);
+                code.AppendLine("    /// <summary>RegexGenerator method</summary>");
                 code.Append($"    [RegexGenerator({SymbolDisplay.FormatLiteral(regex.pattern, quote: true)}");
                 if (regex.options is not null)
                 {
@@ -174,7 +176,7 @@ namespace System.Text.RegularExpressions.Tests
                             warningLevel: 9999, // docs recommend using "9999" to catch all warnings now and in the future
                             specificDiagnosticOptions: ImmutableDictionary<string, ReportDiagnostic>.Empty.Add("SYSLIB1045", ReportDiagnostic.Hidden)) // regex with limited support
                             .WithNullableContextOptions(NullableContextOptions.Enable))
-                            .WithParseOptions(new CSharpParseOptions(LanguageVersion.Preview, DocumentationMode.Diagnose))
+                            .WithParseOptions(s_previewParseOptions)
                     .AddDocument("RegexGenerator.g.cs", SourceText.From("// Empty", Encoding.UTF8)).Project;
                 Assert.True(proj.Solution.Workspace.TryApplyChanges(proj.Solution));
 


### PR DESCRIPTION
If you pass a timeout to Regex's constructor, that's the timeout that's used, and if it's infinite, no timeout is applied.  However, if you don't specify a timeout, then while it defaults to infinite, it's also overridable by a process-wide AppContext switch.  An AppContext value can be set before any Regex usage, and then any regexes that don't specify a timeout will default to that process-wide timeout value rather than to infinite.

With RegexGenerator, the code is all generated ahead of time, before there's even a process in which to check for a setting, as such, up until now not specifying a timeout has been the same as explicitly specifying infinite.  With this PR, we fix that.  If you explicitly specify a timeout, infinite or otherwise, nothing changes.  But if you don't specify a timeout, we now still emit the timeout related checks, but guarded by a read of a static readonly bool that's initialized with a read for that same AppContext switch.  This allows for the generated code to still participate in the global default while allowing the JIT to remove the guarded blocks when the code is tiered up and it observes that the readonly static highlights there's no default set (in the vast majority case).  And if someone really doesn't want that code emitted at all, they can simplify specify an infinite timeout in the RegexGenerator attribute.

Fixes https://github.com/dotnet/runtime/issues/59491
cc: @joperezr, @GrabYourPitchforks 