### PR TITLE
Sets tracking enabled on `AddMemoryCache` extension methods

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCacheServiceCollectionExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCacheServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.AddOptions();
             services.TryAdd(ServiceDescriptor.Singleton<IMemoryCache, MemoryCache>());
+            services.Configure((MemoryCacheOptions o) => o.TrackStatistics = true);
 
             return services;
         }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CacheServiceExtensionsTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CacheServiceExtensionsTests.cs
@@ -30,6 +30,34 @@ namespace Microsoft.Extensions.Caching.Distributed
             Assert.Equal(ServiceLifetime.Singleton, memoryCache.Lifetime);
         }
 
+#if NET6_0_OR_GREATER
+        [Fact]
+        public void AddMemoryCache_RegistersMemoryCacheAsWithTrackingEnabled()
+        {
+            var memoryCache = new ServiceCollection()
+                .AddMemoryCache()
+                .BuildServiceProvider()
+                .GetRequiredService<IMemoryCache>();
+
+            Assert.IsType<MemoryCache>(memoryCache);
+            Assert.NotNull(memoryCache);
+            Assert.NotNull(memoryCache.GetCurrentStatistics());
+        }
+
+        [Fact]
+        public void AddMemoryCache_OtherOverloadNotSettingFlag_RegistersMemoryCacheAsWithTrackingEnabled()
+        {
+            var memoryCache = new ServiceCollection()
+                .AddMemoryCache(o => o.SizeLimit = 10)
+                .BuildServiceProvider()
+                .GetRequiredService<IMemoryCache>();
+
+            Assert.IsType<MemoryCache>(memoryCache);
+            Assert.NotNull(memoryCache);
+            Assert.NotNull(memoryCache.GetCurrentStatistics());
+        }
+#endif
+
         [Fact]
         public void AddDistributedMemoryCache_DoesntConflictWithMemoryCache()
         {


### PR DESCRIPTION
Fixes #67769 

Alternative solution needing API review: https://github.com/dotnet/runtime/commit/3d4f4d084181c58bf0b861603a4b67812f77f740

cc @noahfalk @eerhardt @tarekgh @davidfowl 