### PR TITLE
Adding Regex.EnumerateMatches

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
+++ b/src/libraries/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
@@ -171,6 +171,10 @@ namespace System.Text.RegularExpressions
         public static int Count(System.ReadOnlySpan<char> input, [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex, "options")] string pattern, System.Text.RegularExpressions.RegexOptions options) { throw null; }
         public static int Count(System.ReadOnlySpan<char> input, [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex, "options")] string pattern, System.Text.RegularExpressions.RegexOptions options, System.TimeSpan matchTimeout) { throw null; }
         public static string Escape(string str) { throw null; }
+        public System.Text.RegularExpressions.Regex.ValueMatchEnumerator EnumerateMatches(System.ReadOnlySpan<char> input) { throw null; }
+        public static System.Text.RegularExpressions.Regex.ValueMatchEnumerator EnumerateMatches(System.ReadOnlySpan<char> input, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("Regex")] string pattern) { throw null; }
+        public static System.Text.RegularExpressions.Regex.ValueMatchEnumerator EnumerateMatches(System.ReadOnlySpan<char> input, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("Regex", new object[]{ "options"})] string pattern, System.Text.RegularExpressions.RegexOptions options) { throw null; }
+        public static System.Text.RegularExpressions.Regex.ValueMatchEnumerator EnumerateMatches(System.ReadOnlySpan<char> input, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("Regex", new object[]{ "options"})] string pattern, System.Text.RegularExpressions.RegexOptions options, System.TimeSpan matchTimeout) { throw null; }
         public string[] GetGroupNames() { throw null; }
         public int[] GetGroupNumbers() { throw null; }
         public string GroupNameFromNumber(int i) { throw null; }
@@ -220,6 +224,14 @@ namespace System.Text.RegularExpressions
         protected bool UseOptionC() { throw null; }
         protected internal bool UseOptionR() { throw null; }
         protected internal static void ValidateMatchTimeout(System.TimeSpan matchTimeout) { }
+        public ref partial struct ValueMatchEnumerator
+        {
+            private object _dummy;
+            private int _dummyPrimitive;
+            public readonly System.Text.RegularExpressions.ValueMatch Current { get { throw null; } }
+            public readonly System.Text.RegularExpressions.Regex.ValueMatchEnumerator GetEnumerator() { throw null; }
+            public bool MoveNext() { throw null; }
+        }
     }
     [System.ObsoleteAttribute("Regex.CompileToAssembly is obsolete and not supported. Use the RegexGeneratorAttribute with the regular expression source generator instead.", DiagnosticId = "SYSLIB0036", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
     public partial class RegexCompilationInfo
@@ -358,5 +370,11 @@ namespace System.Text.RegularExpressions
     {
         protected RegexRunnerFactory() { }
         protected internal abstract System.Text.RegularExpressions.RegexRunner CreateInstance();
+    }
+    public readonly ref partial struct ValueMatch
+    {
+        private readonly int _dummyPrimitive;
+        public int Index { get { throw null; } }
+        public int Length { get { throw null; } }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Compile Include="System\Collections\HashtableExtensions.cs" />
     <Compile Include="System\Collections\Generic\ValueListBuilder.Pop.cs" />
+    <Compile Include="System\Text\RegularExpressions\ValueMatch.cs" />
     <Compile Include="System\Threading\StackHelper.cs" />
     <Compile Include="System\Text\SegmentStringBuilder.cs" />
     <Compile Include="System\Text\RegularExpressions\Capture.cs" />
@@ -23,6 +24,7 @@
     <Compile Include="System\Text\RegularExpressions\Regex.Match.cs" />
     <Compile Include="System\Text\RegularExpressions\Regex.Replace.cs" />
     <Compile Include="System\Text\RegularExpressions\Regex.Split.cs" />
+    <Compile Include="System\Text\RegularExpressions\Regex.EnumerateMatches.cs" />
     <Compile Include="System\Text\RegularExpressions\Regex.Timeout.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexCaseBehavior.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexCaseEquivalences.Data.cs" />

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Count.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Count.cs
@@ -38,10 +38,11 @@ namespace System.Text.RegularExpressions
         {
             int count = 0;
 
-            foreach (ValueMatch _ in EnumerateMatches(input))
+            RunAllMatchesWithCallback(input, 0, ref count, static (ref int count, Match match) =>
             {
                 count++;
-            }
+                return true;
+            }, reuseMatchObject: true);
 
             return count;
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Count.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Count.cs
@@ -38,11 +38,10 @@ namespace System.Text.RegularExpressions
         {
             int count = 0;
 
-            RunAllMatchesWithCallback(input, 0, ref count, static (ref int count, Match match) =>
+            foreach (ValueMatch _ in EnumerateMatches(input))
             {
                 count++;
-                return true;
-            }, reuseMatchObject: true);
+            }
 
             return count;
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.EnumerateMatches.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.EnumerateMatches.cs
@@ -12,6 +12,8 @@ namespace System.Text.RegularExpressions
         /// Searches an input span for all occurrences of a regular expression and returns a <see cref="ValueMatchEnumerator"/> to iterate over the matches.
         /// </summary>
         /// <remarks>
+        /// Each match won't actually happen until <see cref="ValueMatchEnumerator.MoveNext"/> is invoked on the enumerator, with one match being performed per <see cref="ValueMatchEnumerator.MoveNext"/> call.
+        /// Since the evaluation of the match happens lazily, any changes to the passed in input in between calls to <see cref="ValueMatchEnumerator.MoveNext"/> will affect the match results.
         /// The enumerator returned by this method, as well as the structs returned by the enumerator that wrap each match found in the input are ref structs which
         /// make this method be amortized allocation free.
         /// </remarks>
@@ -27,6 +29,8 @@ namespace System.Text.RegularExpressions
         /// Searches an input span for all occurrences of a regular expression and returns a <see cref="ValueMatchEnumerator"/> to iterate over the matches.
         /// </summary>
         /// <remarks>
+        /// Each match won't actually happen until <see cref="ValueMatchEnumerator.MoveNext"/> is invoked on the enumerator, with one match being performed per <see cref="ValueMatchEnumerator.MoveNext"/> call.
+        /// Since the evaluation of the match happens lazily, any changes to the passed in input in between calls to <see cref="ValueMatchEnumerator.MoveNext"/> will affect the match results.
         /// The enumerator returned by this method, as well as the structs returned by the enumerator that wrap each match found in the input are ref structs which
         /// make this method be amortized allocation free.
         /// </remarks>
@@ -44,6 +48,8 @@ namespace System.Text.RegularExpressions
         /// Searches an input span for all occurrences of a regular expression and returns a <see cref="ValueMatchEnumerator"/> to iterate over the matches.
         /// </summary>
         /// <remarks>
+        /// Each match won't actually happen until <see cref="ValueMatchEnumerator.MoveNext"/> is invoked on the enumerator, with one match being performed per <see cref="ValueMatchEnumerator.MoveNext"/> call.
+        /// Since the evaluation of the match happens lazily, any changes to the passed in input in between calls to <see cref="ValueMatchEnumerator.MoveNext"/> will affect the match results.
         /// The enumerator returned by this method, as well as the structs returned by the enumerator that wrap each match found in the input are ref structs which
         /// make this method be amortized allocation free.
         /// </remarks>
@@ -62,6 +68,8 @@ namespace System.Text.RegularExpressions
         /// Searches an input span for all occurrences of a regular expression and returns a <see cref="ValueMatchEnumerator"/> to iterate over the matches.
         /// </summary>
         /// <remarks>
+        /// Each match won't actually happen until <see cref="ValueMatchEnumerator.MoveNext"/> is invoked on the enumerator, with one match being performed per <see cref="ValueMatchEnumerator.MoveNext"/> call.
+        /// Since the evaluation of the match happens lazily, any changes to the passed in input in between calls to <see cref="ValueMatchEnumerator.MoveNext"/> will affect the match results.
         /// The enumerator returned by this method, as well as the structs returned by the enumerator that wrap each match found in the input are ref structs which
         /// make this method be amortized allocation free.
         /// </remarks>
@@ -71,12 +79,11 @@ namespace System.Text.RegularExpressions
             new ValueMatchEnumerator(this, input, RightToLeft ? input.Length : 0);
 
         /// <summary>
-        /// Represents an enumerator containing the set of successful matches found by iteratively applying a regular expression pattern to the input span. The
-        /// enumerator has no public constructor. The <see cref="Regex.EnumerateMatches(ReadOnlySpan{char})"/> method returns a <see cref="Regex.ValueMatchEnumerator"/>
-        /// object.
+        /// Represents an enumerator containing the set of successful matches found by iteratively applying a regular expression pattern to the input span.
         /// </summary>
         /// <remarks>
-        /// The enumerator will lazily iterate over zero or more <see cref="ValueMatch"/> objects. If there is at least one successful match in the span, then
+        /// The enumerator has no public constructor. The <see cref="Regex.EnumerateMatches(ReadOnlySpan{char})"/> method returns a <see cref="Regex.ValueMatchEnumerator"/>
+        /// object.The enumerator will lazily iterate over zero or more <see cref="ValueMatch"/> objects. If there is at least one successful match in the span, then
         /// <see cref="MoveNext"/> returns <see langword="true"/> and <see cref="Current"/> will contain the first <see cref="ValueMatch"/>. If there are no successful matches,
         /// then <see cref="MoveNext"/> returns <see langword="false"/> and <see cref="Current"/> throws an <see cref="InvalidOperationException"/>.
         ///

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.EnumerateMatches.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.EnumerateMatches.cs
@@ -1,0 +1,144 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Text.RegularExpressions
+{
+    public partial class Regex
+    {
+        /// <summary>
+        /// Searches an input span for all occurrences of a regular expression and returns a <see cref="ValueMatchEnumerator"/> to iterate over the matches.
+        /// </summary>
+        /// <remarks>
+        /// The enumerator returned by this method, as well as the structs returned by the enumerator that wrap each match found in the input are ref structs which
+        /// make this method be amortized allocation free.
+        /// </remarks>
+        /// <param name="input">The span to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <returns>A <see cref="ValueMatchEnumerator"/> to iterate over the matches.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is null.</exception>
+        /// <exception cref="RegexParseException">A regular expression parsing error occurred.</exception>
+        public static ValueMatchEnumerator EnumerateMatches(ReadOnlySpan<char> input, [StringSyntax(StringSyntaxAttribute.Regex)] string pattern) =>
+            RegexCache.GetOrAdd(pattern).EnumerateMatches(input);
+
+        /// <summary>
+        /// Searches an input span for all occurrences of a regular expression and returns a <see cref="ValueMatchEnumerator"/> to iterate over the matches.
+        /// </summary>
+        /// <remarks>
+        /// The enumerator returned by this method, as well as the structs returned by the enumerator that wrap each match found in the input are ref structs which
+        /// make this method be amortized allocation free.
+        /// </remarks>
+        /// <param name="input">The span to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that specify options for matching.</param>
+        /// <returns>A <see cref="ValueMatchEnumerator"/> to iterate over the matches.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="options"/> is not a valid bitwise combination of RegexOptions values.</exception>
+        /// <exception cref="RegexParseException">A regular expression parsing error occurred.</exception>
+        public static ValueMatchEnumerator EnumerateMatches(ReadOnlySpan<char> input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options) =>
+            RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).EnumerateMatches(input);
+
+        /// <summary>
+        /// Searches an input span for all occurrences of a regular expression and returns a <see cref="ValueMatchEnumerator"/> to iterate over the matches.
+        /// </summary>
+        /// <remarks>
+        /// The enumerator returned by this method, as well as the structs returned by the enumerator that wrap each match found in the input are ref structs which
+        /// make this method be amortized allocation free.
+        /// </remarks>
+        /// <param name="input">The span to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that specify options for matching.</param>
+        /// <param name="matchTimeout">A time-out interval, or <see cref="InfiniteMatchTimeout"/> to indicate that the method should not time out.</param>
+        /// <returns>A <see cref="ValueMatchEnumerator"/> to iterate over the matches.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="options"/> is not a valid bitwise combination of RegexOptions values, or <paramref name="matchTimeout"/> is negative, zero, or greater than approximately 24 days.</exception>
+        /// <exception cref="RegexParseException">A regular expression parsing error occurred.</exception>
+        public static ValueMatchEnumerator EnumerateMatches(ReadOnlySpan<char> input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
+            RegexCache.GetOrAdd(pattern, options, matchTimeout).EnumerateMatches(input);
+
+        /// <summary>
+        /// Searches an input span for all occurrences of a regular expression and returns a <see cref="ValueMatchEnumerator"/> to iterate over the matches.
+        /// </summary>
+        /// <remarks>
+        /// The enumerator returned by this method, as well as the structs returned by the enumerator that wrap each match found in the input are ref structs which
+        /// make this method be amortized allocation free.
+        /// </remarks>
+        /// <param name="input">The span to search for a match.</param>
+        /// <returns>A <see cref="ValueMatchEnumerator"/> to iterate over the matches.</returns>
+        public ValueMatchEnumerator EnumerateMatches(ReadOnlySpan<char> input) =>
+            new ValueMatchEnumerator(this, input, RightToLeft ? input.Length : 0);
+
+        /// <summary>
+        /// Represents an enumerator containing the set of successful matches found by iteratively applying a regular expression pattern to the input span. The
+        /// enumerator has no public constructor. The <see cref="Regex.EnumerateMatches(ReadOnlySpan{char})"/> method returns a <see cref="Regex.ValueMatchEnumerator"/>
+        /// object.
+        /// </summary>
+        /// <remarks>
+        /// The enumerator will lazily iterate over zero or more <see cref="ValueMatch"/> objects. If there is at least one successful match in the span, then
+        /// <see cref="MoveNext"/> returns <see langword="true"/> and <see cref="Current"/> will contain the first <see cref="ValueMatch"/>. If there are no successful matches,
+        /// then <see cref="MoveNext"/> returns <see langword="false"/> and <see cref="Current"/> throws an <see cref="InvalidOperationException"/>.
+        ///
+        /// This type is a ref struct since it stores the input span as a field in order to be able to lazily iterate over it.
+        /// </remarks>
+        public ref struct ValueMatchEnumerator
+        {
+            private readonly Regex _regex;
+            private readonly ReadOnlySpan<char> _input;
+            private ValueMatch _matchReference;
+            private int _startAt;
+            private int _prevLen;
+            private bool _hasValidValue;
+
+            /// <summary>
+            /// Creates an instance of the <see cref="ValueMatchEnumerator"/> for the passed in <paramref name="regex"/> which iterates over <paramref name="input"/>.
+            /// </summary>
+            /// <param name="regex">The <see cref="Regex"/> to use for finding matches.</param>
+            /// <param name="input">The input span to iterate over.</param>
+            /// <param name="startAt">The position where the engine should start looking for matches from.</param>
+            internal ValueMatchEnumerator(Regex regex, ReadOnlySpan<char> input, int startAt)
+            {
+                _regex = regex;
+                _input = input;
+                _matchReference = default;
+                _startAt = startAt;
+                _prevLen = -1;
+                _hasValidValue = false;
+            }
+
+            /// <summary>
+            /// Provides an enumerator that iterates through the matches in the input span.
+            /// </summary>
+            /// <returns>A copy of this enumerator.</returns>
+            public readonly ValueMatchEnumerator GetEnumerator() => this;
+
+            /// <summary>
+            /// Advances the enumerator to the next match in the span.
+            /// </summary>
+            /// <returns>
+            /// <see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator cannot find additional matches.
+            /// </returns>
+            public bool MoveNext()
+            {
+                Match? match = _regex.RunSingleMatch(quick: false, _prevLen, _input, _startAt);
+                if (match is not null && match != RegularExpressions.Match.Empty)
+                {
+                    _matchReference = new ValueMatch(match);
+                    _hasValidValue = true;
+                    _startAt = match._textpos;
+                    _prevLen = match.Length;
+                    return true;
+                }
+                _hasValidValue = false;
+                _matchReference = default;
+                return false;
+            }
+
+            /// <summary>
+            /// Gets the <see cref="ValueMatch"/> element at the current position of the enumerator.
+            /// </summary>
+            /// <exception cref="InvalidOperationException">Enumeration has either not started or has already finished.</exception>
+            public readonly ValueMatch Current => _hasValidValue ? _matchReference : throw new InvalidOperationException(SR.EnumNotStarted);
+        }
+    }
+}

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.cs
@@ -87,7 +87,7 @@ namespace System.Text.RegularExpressions
         /// <returns><see langword="true"/> if the regular expression finds a match; otherwise, <see langword="false"/>.</returns>
         /// <exception cref="RegexMatchTimeoutException">A time-out ocurred.</exception>
         public bool IsMatch(ReadOnlySpan<char> input) =>
-            RunSingleMatch(input, RightToLeft ? input.Length : 0) is null;
+            RunSingleMatch(quick: true, -1, input, RightToLeft ? input.Length : 0) is null;
 
         /// <summary>
         /// Searches the input string for one or more matches using the previous pattern and options,

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -458,87 +458,115 @@ namespace System.Text.RegularExpressions
             RegexRunner runner = Interlocked.Exchange(ref _runner, null) ?? CreateRunner();
             try
             {
-                // We need to set runtext before starting the match attempts.
+                // For the string overload, we need to set runtext before starting the match attempts.
                 runner.runtext = input;
-                runner.InitializeTimeout(internalMatchTimeout);
-                int runtextpos = startat;
-                while (true)
-                {
-                    runner.InitializeForScan(this, input, startat, false);
-                    runner.runtextpos = runtextpos;
-
-                    int stoppos = RightToLeft ? 0 : input.Length;
-
-                    // We get the Match by calling Scan. 'input' parameter is used to set the Match text.
-                    Match? match = ScanInternal(reuseMatchObject, runner.runtext, 0, runner, input, returnNullIfQuick: false);
-                    Debug.Assert(match is not null);
-
-                    // if we got a match, then call the callback function with the match and prepare for next iteration.
-                    if (match.Success)
-                    {
-                        if (!reuseMatchObject)
-                        {
-                            // We're not reusing match objects, so null out our field reference to the instance.
-                            // It'll be recreated the next time one is needed.
-                            runner.runmatch = null;
-                        }
-
-                        if (!callback(ref state, match))
-                        {
-                            // If the callback returns false, we're done.
-
-                            if (reuseMatchObject)
-                            {
-                                // We're reusing the single match instance so we clear out match.Text which was set above.
-                                // We don't do this if we're not reusing instances, as in that case we're
-                                // dropping the whole reference to the match, and we no longer own the instance
-                                // having handed it out to the callback.
-                                match.Text = null;
-                            }
-                            return;
-                        }
-
-                        // Now that we've matched successfully, update the starting position to reflect
-                        // the current position, just as Match.NextMatch() would pass in _textpos as textstart.
-                        runtextpos = startat = runner.runtextpos;
-
-                        // Reset state for another iteration.
-                        runner.runtrackpos = runner.runtrack!.Length;
-                        runner.runstackpos = runner.runstack!.Length;
-                        runner.runcrawlpos = runner.runcrawl!.Length;
-
-                        if (match.Length == 0)
-                        {
-                            if (runner.runtextpos == stoppos)
-                            {
-                                if (reuseMatchObject)
-                                {
-                                    // See above comment.
-                                    match.Text = null;
-                                }
-                                return;
-                            }
-
-                            runtextpos += RightToLeft ? -1 : 1;
-                        }
-
-                        // Loop around to perform next match from where we left off.
-                        continue;
-                    }
-                    else
-                    {
-                        // We failed to match at this position.  If we're at the stopping point, we're done.
-                        if (runner.runtextpos == stoppos)
-                        {
-                            return;
-                        }
-                    }
-                }
+                RunAllMatchesWithCallbackHelper(input, startat, ref state, callback, runner, usingStringOverload: true, reuseMatchObject);
             }
             finally
             {
                 runner.runtext = null; // drop reference to text to avoid keeping it alive in a cache.
                 _runner = runner;
+            }
+        }
+
+        /// <summary>Internal worker which will scan the passed in string <paramref name="input"/> for all matches, and will call <paramref name="callback"/> for each match found.</summary>
+        internal void RunAllMatchesWithCallback<TState>(ReadOnlySpan<char> input, int startat, ref TState state, MatchCallback<TState> callback, bool reuseMatchObject)
+        {
+            Debug.Assert((uint)startat <= (uint)input.Length);
+
+            RegexRunner runner = Interlocked.Exchange(ref _runner, null) ?? CreateRunner();
+            try
+            {
+                RunAllMatchesWithCallbackHelper(input, startat, ref state, callback, runner, usingStringOverload: false, reuseMatchObject);
+            }
+            finally
+            {
+                _runner = runner;
+            }
+        }
+
+        /// <summary>
+        /// Helper method used by <see cref="RunAllMatchesWithCallback{TState}(string, int, ref TState, MatchCallback{TState}, bool)"/> and
+        /// <see cref="RunAllMatchesWithCallback{TState}(ReadOnlySpan{char}, int, ref TState, MatchCallback{TState}, bool)"/> which loops to find
+        /// all matches on the passed in <paramref name="input"/> and calls <paramref name="callback"/> for each match found.
+        /// </summary>
+        private void RunAllMatchesWithCallbackHelper<TState>(ReadOnlySpan<char> input, int startat, ref TState state, MatchCallback<TState> callback, RegexRunner runner, bool usingStringOverload, bool reuseMatchObject)
+        {
+            runner.InitializeTimeout(internalMatchTimeout);
+            int runtextpos = startat;
+            while (true)
+            {
+                runner.InitializeForScan(this, input, startat, false);
+                runner.runtextpos = runtextpos;
+
+                int stoppos = RightToLeft ? 0 : input.Length;
+
+                // We get the Match by calling Scan. 'input' parameter is used to set the Match text which is only relevante if we are using the Run<TState> string
+                // overload, as APIs that call the span overload (like Count) don't require match.Text to be set, so we pass null in that case.
+                Match? match = ScanInternal(reuseMatchObject, input: usingStringOverload ? runner.runtext : null, 0, runner, input, returnNullIfQuick: false);
+                Debug.Assert(match is not null);
+
+                // if we got a match, then call the callback function with the match and prepare for next iteration.
+                if (match.Success)
+                {
+                    if (!reuseMatchObject)
+                    {
+                        // We're not reusing match objects, so null out our field reference to the instance.
+                        // It'll be recreated the next time one is needed.
+                        runner.runmatch = null;
+                    }
+
+                    if (!callback(ref state, match))
+                    {
+                        // If the callback returns false, we're done.
+
+                        if (usingStringOverload && reuseMatchObject)
+                        {
+                            // We're reusing the single match instance and we were called via the string overload
+                            // which would have set the match's text, so clear it out as well.
+                            // We don't do this if we're not reusing instances, as in that case we're
+                            // dropping the whole reference to the match, and we no longer own the instance
+                            // having handed it out to the callback.
+                            match.Text = null;
+                        }
+                        return;
+                    }
+
+                    // Now that we've matched successfully, update the starting position to reflect
+                    // the current position, just as Match.NextMatch() would pass in _textpos as textstart.
+                    runtextpos = startat = runner.runtextpos;
+
+                    // Reset state for another iteration.
+                    runner.runtrackpos = runner.runtrack!.Length;
+                    runner.runstackpos = runner.runstack!.Length;
+                    runner.runcrawlpos = runner.runcrawl!.Length;
+
+                    if (match.Length == 0)
+                    {
+                        if (runner.runtextpos == stoppos)
+                        {
+                            if (usingStringOverload && reuseMatchObject)
+                            {
+                                // See above comment.
+                                match.Text = null;
+                            }
+                            return;
+                        }
+
+                        runtextpos += RightToLeft ? -1 : 1;
+                    }
+
+                    // Loop around to perform next match from where we left off.
+                    continue;
+                }
+                else
+                {
+                    // We failed to match at this position.  If we're at the stopping point, we're done.
+                    if (runner.runtextpos == stoppos)
+                    {
+                        return;
+                    }
+                }
             }
         }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -415,31 +415,40 @@ namespace System.Text.RegularExpressions
                 runner.InitializeTimeout(internalMatchTimeout);
                 runner.InitializeForScan(this, input, startat, quick);
 
-                int stoppos = RightToLeft ? 0 : input.Length;
-
                 // If previous match was empty or failed, advance by one before matching.
                 if (prevlen == 0)
                 {
-                    if (runner.runtextstart == stoppos)
+                    if (RightToLeft)
                     {
-                        return RegularExpressions.Match.Empty;
+                        if (runner.runtextstart == 0)
+                        {
+                            return RegularExpressions.Match.Empty;
+                        }
+                        runner.runtextpos--;
                     }
-
-                    runner.runtextpos += RightToLeft ? -1 : 1;
+                    else
+                    {
+                        if (runner.runtextstart == input.Length)
+                        {
+                            return RegularExpressions.Match.Empty;
+                        }
+                        runner.runtextpos++;
+                    }
                 }
 
                 runner.Scan(input);
 
                 // If runmatch is null it means that an override of Scan didn't implement it correctly, so we will
                 // let this null ref since there are lots of ways where you can end up in a erroneous state.
-                if (runner.runmatch!.FoundMatch)
+                Match match = runner.runmatch!;
+                if (match!.FoundMatch)
                 {
                     if (quick)
                     {
                         return null;
                     }
-                    runner.runmatch.Tidy(runner.runtextpos, 0);
-                    return runner.runmatch;
+                    match.Tidy(runner.runtextpos, 0);
+                    return match;
                 }
 
                 return RegularExpressions.Match.Empty;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/ValueMatch.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/ValueMatch.cs
@@ -16,13 +16,14 @@ namespace System.Text.RegularExpressions
         private readonly int _length;
 
         /// <summary>
-        /// Crates an instance of the <see cref="ValueMatch"/> type based on the passed in <paramref name="match"/>.
+        /// Crates an instance of the <see cref="ValueMatch"/> type based on the passed in <paramref name="index"/> and <paramref name="length"/>.
         /// </summary>
-        /// <param name="match">The <see cref="Match"/> object represented by this ValueMatch.</param>
-        internal ValueMatch(Match match)
+        /// <param name="index">The position in the original span where the first character of the captured sliced span is found.</param>
+        /// <param name="length">The length of the captured sliced span.</param>
+        internal ValueMatch(int index, int length)
         {
-            _index = match.Index;
-            _length = match.Length;
+            _index = index;
+            _length = length;
         }
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/ValueMatch.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/ValueMatch.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Text.RegularExpressions
+{
+    /// <summary>
+    /// Represents the results from a single regular expression match.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="ValueMatch"/> type is immutable and has no public constructor. An instance of the <see cref="ValueMatch"/> struct is returned by the
+    /// <see cref="Regex.ValueMatchEnumerator.Current"/> method when iterating over the results from calling <see cref="Regex.EnumerateMatches(ReadOnlySpan{char})"/>.
+    /// </remarks>
+    public readonly ref struct ValueMatch
+    {
+        private readonly int _index;
+        private readonly int _length;
+
+        /// <summary>
+        /// Crates an instance of the <see cref="ValueMatch"/> type based on the passed in <paramref name="match"/>.
+        /// </summary>
+        /// <param name="match">The <see cref="Match"/> object represented by this ValueMatch.</param>
+        internal ValueMatch(Match match)
+        {
+            _index = match.Index;
+            _length = match.Length;
+        }
+
+        /// <summary>
+        /// Gets the position in the original span where the first character of the captured sliced span is found.
+        /// </summary>
+        public int Index => _index;
+
+        /// <summary>
+        /// Gets the length of the captured sliced span.
+        /// </summary>
+        public int Length => _length;
+    }
+}

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Count.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Count.Tests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Text.RegularExpressions.Tests
 {
-    public class RegexCountTests
+    public partial class RegexCountTests
     {
         [Theory]
         [MemberData(nameof(Count_ReturnsExpectedCount_TestData))]

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.EnumerateMatches.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.EnumerateMatches.Tests.cs
@@ -45,20 +45,6 @@ namespace System.Text.RegularExpressions.Tests
 
         [Theory]
         [MemberData(nameof(RegexHelpers.AvailableEngines_MemberData), MemberType = typeof(RegexHelpers))]
-        public void Enumerate_No_Match(RegexEngine engine)
-        {
-            Regex r = RegexHelpers.GetRegexAsync(engine, @"\da").GetAwaiter().GetResult();
-            int count = 0;
-            foreach(var match in r.EnumerateMatches("1A2b3c4d5e"))
-            {
-                count++;
-            }
-            Assert.Equal(0, count);
-
-        }
-
-        [Theory]
-        [MemberData(nameof(RegexHelpers.AvailableEngines_MemberData), MemberType = typeof(RegexHelpers))]
         public void EnumerateMatches_Lookahead(RegexEngine engine)
         {
             if (RegexHelpers.IsNonBacktracking(engine))
@@ -133,8 +119,8 @@ namespace System.Text.RegularExpressions.Tests
         {
             Regex regexAdvanced = RegexHelpers.GetRegexAsync(engine, pattern, options).GetAwaiter().GetResult();
             int count = 0;
-            var span = input.AsSpan();
-            foreach (var match in regexAdvanced.EnumerateMatches(span))
+            ReadOnlySpan<char> span = input.AsSpan();
+            foreach (ValueMatch match in regexAdvanced.EnumerateMatches(span))
             {
                 Assert.Equal(expected[count].Index, match.Index);
                 Assert.Equal(expected[count].Length, match.Length);

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.EnumerateMatches.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.EnumerateMatches.Tests.cs
@@ -1,0 +1,237 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Text.RegularExpressions.Tests
+{
+    public class RegexEnumerateMatchesTests
+    {
+        public static IEnumerable<object[]> NoneCompiledBacktracking()
+        {
+            yield return new object[] { RegexOptions.None };
+            yield return new object[] { RegexOptions.Compiled };
+            if (PlatformDetection.IsNetCore)
+            {
+                yield return new object[] { RegexHelpers.RegexOptionNonBacktracking };
+            }
+        }
+
+        [Fact]
+        public void EnumerateMatches_Ctor_Invalid()
+        {
+            // Pattern is null
+            AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.EnumerateMatches("input", null));
+            AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.EnumerateMatches("input", null, RegexOptions.None));
+            AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.EnumerateMatches("input", null, RegexOptions.None, TimeSpan.FromSeconds(1)));
+
+            // Options are invalid
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.EnumerateMatches("input", "pattern", (RegexOptions)(-1)));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.EnumerateMatches("input", "pattern", (RegexOptions)(-1), TimeSpan.FromSeconds(1)));
+
+            // 0x400 is new NonBacktracking mode that is now valid, 0x800 is still invalid
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.EnumerateMatches("input", "pattern", (RegexOptions)0x800));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.EnumerateMatches("input", "pattern", (RegexOptions)0x800, TimeSpan.FromSeconds(1)));
+
+            // MatchTimeout is invalid
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("matchTimeout", () => Regex.EnumerateMatches("input", "pattern", RegexOptions.None, TimeSpan.Zero));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("matchTimeout", () => Regex.EnumerateMatches("input", "pattern", RegexOptions.None, TimeSpan.Zero));
+        }
+
+        [Theory]
+        [MemberData(nameof(RegexHelpers.AvailableEngines_MemberData), MemberType = typeof(RegexHelpers))]
+        public void Enumerate_No_Match(RegexEngine engine)
+        {
+            Regex r = RegexHelpers.GetRegexAsync(engine, @"\da").GetAwaiter().GetResult();
+            int count = 0;
+            foreach(var match in r.EnumerateMatches("1A2b3c4d5e"))
+            {
+                count++;
+            }
+            Assert.Equal(0, count);
+
+        }
+
+        [Theory]
+        [MemberData(nameof(NoneCompiledBacktracking))]
+        public static void EnumerateMatches_Invalid(RegexOptions options)
+        {
+            Regex regex = new Regex("e", options);
+            Regex.ValueMatchEnumerator enumerator = regex.EnumerateMatches("dotnet");
+
+            Assert.True(ThrowsInvalidOperationException(ref enumerator));
+
+            while (enumerator.MoveNext()) ;
+            Assert.True(ThrowsInvalidOperationException(ref enumerator));
+
+            bool ThrowsInvalidOperationException(ref Regex.ValueMatchEnumerator enumerator)
+            {
+                try
+                {
+                    _ = enumerator.Current;
+                }
+                catch (InvalidOperationException)
+                {
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(RegexHelpers.AvailableEngines_MemberData), MemberType = typeof(RegexHelpers))]
+        public void EnumerateMatches_Lookahead(RegexEngine engine)
+        {
+            if (RegexHelpers.IsNonBacktracking(engine))
+            {
+                // lookaheads not supported
+                return;
+            }
+
+            const string Pattern = @"\b(?!un)\w+\b";
+            const string Input = "unite one unethical ethics use untie ultimate";
+
+            Regex r = RegexHelpers.GetRegexAsync(engine, Pattern, RegexOptions.IgnoreCase).GetAwaiter().GetResult();
+            int count = 0;
+            string[] expectedMatches = new[] { "one", "ethics", "use", "ultimate" };
+            ReadOnlySpan<char> span = Input.AsSpan();
+            foreach (ValueMatch match in r.EnumerateMatches(span))
+            {
+                Assert.Equal(expectedMatches[count++], span.Slice(match.Index, match.Length).ToString());
+            }
+            Assert.Equal(4, count);
+        }
+
+        [Theory]
+        [MemberData(nameof(RegexHelpers.AvailableEngines_MemberData), MemberType = typeof(RegexHelpers))]
+        public void EnumerateMatches_Lookbehind(RegexEngine engine)
+        {
+            if (RegexHelpers.IsNonBacktracking(engine))
+            {
+                // lookbehinds not supported
+                return;
+            }
+
+            const string Pattern = @"(?<=\b20)\d{2}\b";
+            const string Input = "2010 1999 1861 2140 2009";
+
+            Regex r = RegexHelpers.GetRegexAsync(engine, Pattern, RegexOptions.IgnoreCase).GetAwaiter().GetResult();
+            int count = 0;
+            string[] expectedMatches = new[] { "10", "09" };
+            ReadOnlySpan<char> span = Input.AsSpan();
+            foreach (ValueMatch match in r.EnumerateMatches(span))
+            {
+                Assert.Equal(expectedMatches[count++], span.Slice(match.Index, match.Length).ToString());
+            }
+            Assert.Equal(2, count);
+        }
+
+        [Theory]
+        [MemberData(nameof(RegexHelpers.AvailableEngines_MemberData), MemberType = typeof(RegexHelpers))]
+        public void EnumerateMatches_CheckIndex(RegexEngine engine)
+        {
+            const string Pattern = @"e{2}\w\b";
+            const string Input = "needing a reed";
+
+            Regex r = RegexHelpers.GetRegexAsync(engine, Pattern).GetAwaiter().GetResult();
+            int count = 0;
+            string[] expectedMatches = new[] { "eed" };
+            int[] expectedIndex = new[] { 11 };
+            ReadOnlySpan<char> span = Input.AsSpan();
+            foreach (ValueMatch match in r.EnumerateMatches(span))
+            {
+                Assert.Equal(expectedMatches[count], span.Slice(match.Index, match.Length).ToString());
+                Assert.Equal(expectedIndex[count++], match.Index);
+            }
+        }
+    }
+
+    public partial class RegexMultipleMatchTests
+    {
+        [Theory]
+        [MemberData(nameof(Matches_TestData))]
+        public void EnumerateMatches(RegexEngine engine, string pattern, string input, RegexOptions options, CaptureData[] expected)
+        {
+            Regex regexAdvanced = RegexHelpers.GetRegexAsync(engine, pattern, options).GetAwaiter().GetResult();
+            int count = 0;
+            var span = input.AsSpan();
+            foreach (var match in regexAdvanced.EnumerateMatches(span))
+            {
+                Assert.Equal(expected[count].Index, match.Index);
+                Assert.Equal(expected[count].Length, match.Length);
+                Assert.Equal(expected[count].Value, span.Slice(match.Index, match.Length).ToString());
+                count++;
+            }
+            Assert.Equal(expected.Length, count);
+        }
+    }
+
+    public partial class RegexMatchTests
+    {
+        [Theory]
+        [MemberData(nameof(Match_Count_TestData))]
+        public void EnumerateMatches_Count(RegexEngine engine, string pattern, string input, int expectedCount)
+        {
+            Regex r = RegexHelpers.GetRegexAsync(engine, pattern).GetAwaiter().GetResult();
+            int count = 0;
+            foreach (ValueMatch _ in r.EnumerateMatches(input))
+            {
+                count++;
+            }
+            Assert.Equal(expectedCount, count);
+        }
+    }
+
+    public partial class RegexCountTests
+    {
+        [Theory]
+        [MemberData(nameof(Count_ReturnsExpectedCount_TestData))]
+        public void EnumerateMatches_ReturnsExpectedCount(RegexEngine engine, string pattern, string input, RegexOptions options, int expectedCount)
+        {
+            Regex r = RegexHelpers.GetRegexAsync(engine, pattern, options).GetAwaiter().GetResult();
+            int count = 0;
+            foreach (ValueMatch _ in r.EnumerateMatches(input))
+            {
+                count++;
+            }
+            Assert.Equal(expectedCount, count);
+
+            if (options == RegexOptions.None && engine == RegexEngine.Interpreter)
+            {
+                count = 0;
+                foreach (ValueMatch _ in Regex.EnumerateMatches(input, pattern))
+                {
+                    count++;
+                }
+                Assert.Equal(expectedCount, count);
+            }
+
+            switch (engine)
+            {
+                case RegexEngine.Interpreter:
+                case RegexEngine.Compiled:
+                case RegexEngine.NonBacktracking:
+                    RegexOptions engineOptions = RegexHelpers.OptionsFromEngine(engine);
+                    count = 0;
+                    foreach (ValueMatch _ in Regex.EnumerateMatches(input, pattern, options | engineOptions))
+                    {
+                        count++;
+                    }
+                    Assert.Equal(expectedCount, count);
+
+                    count = 0;
+                    foreach (ValueMatch _ in Regex.EnumerateMatches(input, pattern, options | engineOptions, Regex.InfiniteMatchTimeout))
+                    {
+                        count++;
+                    }
+                    Assert.Equal(expectedCount, count);
+                    break;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.EnumerateMatches.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.EnumerateMatches.Tests.cs
@@ -58,32 +58,6 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Theory]
-        [MemberData(nameof(NoneCompiledBacktracking))]
-        public static void EnumerateMatches_Invalid(RegexOptions options)
-        {
-            Regex regex = new Regex("e", options);
-            Regex.ValueMatchEnumerator enumerator = regex.EnumerateMatches("dotnet");
-
-            Assert.True(ThrowsInvalidOperationException(ref enumerator));
-
-            while (enumerator.MoveNext()) ;
-            Assert.True(ThrowsInvalidOperationException(ref enumerator));
-
-            bool ThrowsInvalidOperationException(ref Regex.ValueMatchEnumerator enumerator)
-            {
-                try
-                {
-                    _ = enumerator.Current;
-                }
-                catch (InvalidOperationException)
-                {
-                    return true;
-                }
-                return false;
-            }
-        }
-
-        [Theory]
         [MemberData(nameof(RegexHelpers.AvailableEngines_MemberData), MemberType = typeof(RegexHelpers))]
         public void EnumerateMatches_Lookahead(RegexEngine engine)
         {

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace System.Text.RegularExpressions.Tests
 {
-    public class RegexMatchTests
+    public partial class RegexMatchTests
     {
         public static IEnumerable<object[]> Match_MemberData()
         {

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.MultipleMatches.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.MultipleMatches.Tests.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 
 namespace System.Text.RegularExpressions.Tests
 {
-    public class RegexMultipleMatchTests
+    public partial class RegexMultipleMatchTests
     {
         [Theory]
         [MemberData(nameof(RegexHelpers.AvailableEngines_MemberData), MemberType = typeof(RegexHelpers))]

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Regex.Count.Tests.cs" />
     <Compile Include="RegexAssert.netcoreapp.cs" />
     <Compile Include="RegexParserTests.netcoreapp.cs" />
+    <Compile Include="Regex.EnumerateMatches.Tests.cs" />
     <Compile Include="RegexIgnoreCaseTests.cs" />
     <Compile Include="GroupCollectionReadOnlyDictionaryTests.cs" />
     <Compile Include="CaptureCollectionTests2.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/65011
Fixes https://github.com/dotnet/runtime/issues/23602

Adding EnumerateMatches method which returns an enumerator that can iterate over the matches in a passed-in span. The operation is performed amortized allocation free.