### PR TITLE
GC: Correctly align `exclusive_sync.alloc_objects`

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -1107,7 +1107,7 @@ class exclusive_sync
 
     int spin_count;
 
-    uint8_t cache_separator[HS_CACHE_LINE_SIZE - sizeof (int) - sizeof (int32_t)];
+    uint8_t cache_separator[HS_CACHE_LINE_SIZE - (sizeof (spin_count) + sizeof (needs_checking) + sizeof (rwp_object))];
 
     // TODO - perhaps each object should be on its own cache line...
     VOLATILE(uint8_t*) alloc_objects[max_pending_allocs];


### PR DESCRIPTION
Previously, the calculation of the `cache_separator` size of the array failed to take
the first member `rwp_object` into account. Therefore, `alloc_objects` was not properly aligned
to `HS_CACHE_LINE_SIZE`.