### PR TITLE
Start expiry timer using a factory passed to the Lazy

### DIFF
--- a/src/libraries/Microsoft.Extensions.Http/src/ActiveHandlerTrackingEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/ActiveHandlerTrackingEntry.cs
@@ -56,6 +56,15 @@ namespace Microsoft.Extensions.Http
             StartExpiryTimerSlow(callback);
         }
 
+        internal void UnsafeStartExpiryTimer(TimerCallback callback)
+        {
+            if (Lifetime == Timeout.InfiniteTimeSpan) return;
+            Debug.Assert(Volatile.Read(ref _timerInitialized) == false);
+            _callback = callback;
+            _timer = NonCapturingTimer.Create(_timerCallback, this, Lifetime, Timeout.InfiniteTimeSpan);
+            _timerInitialized = true;
+        }
+
         private void StartExpiryTimerSlow(TimerCallback callback)
         {
             Debug.Assert(Lifetime != Timeout.InfiniteTimeSpan);

--- a/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
@@ -78,7 +78,9 @@ namespace Microsoft.Extensions.Http
             {
                 return new Lazy<ActiveHandlerTrackingEntry>(() =>
                 {
-                    return CreateHandlerEntry(name);
+                    ActiveHandlerTrackingEntry entry = CreateHandlerEntry(name);
+                    StartHandlerEntryTimer(entry);
+                    return entry;
                 }, LazyThreadSafetyMode.ExecutionAndPublication);
             };
 
@@ -106,9 +108,6 @@ namespace Microsoft.Extensions.Http
         public HttpMessageHandler CreateHandler(string name!!)
         {
             ActiveHandlerTrackingEntry entry = _activeHandlers.GetOrAdd(name, _entryFactory).Value;
-
-            StartHandlerEntryTimer(entry);
-
             return entry.Handler;
         }
 
@@ -196,7 +195,7 @@ namespace Microsoft.Extensions.Http
         // Internal so it can be overridden in tests
         internal virtual void StartHandlerEntryTimer(ActiveHandlerTrackingEntry entry)
         {
-            entry.StartExpiryTimer(_expiryCallback);
+            entry.UnsafeStartExpiryTimer(_expiryCallback);
         }
 
         // Internal so it can be overridden in tests


### PR DESCRIPTION
Suppose N threads are simultaneously trying to create a HttpMessageHandler instance with some name. During this process, we encounter two locks that help create the instance mentioned above and start its expiration.
- [Lazy.Value](https://github.com/dotnet/runtime/blob/45cc9d5954ecc3bccbff0ac87ad80a1862e71eb8/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs#L81) 
- [StartExpiryTimer](https://github.com/dotnet/runtime/blob/45cc9d5954ecc3bccbff0ac87ad80a1862e71eb8/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs#L110) Uses a lock to initialize and start an expiry timer

This PIR removes the second lock and uses the Lazy class to start expiration.
