### PR TITLE
Faster IndexOf for arm64

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -615,9 +615,6 @@ namespace System
                 {
                     lengthToExamine = GetByteVector128SpanLength(offset, length);
 
-                    // Mask to help find the first lane in compareResult that is set.
-                    // MSB 0x10 corresponds to 1st lane, 0x01 corresponds to 0th lane and so forth.
-                    Vector128<byte> mask = Vector128.Create((ushort)0x1001).AsByte();
                     Vector128<byte> values = Vector128.Create(value);
                     while (lengthToExamine > offset)
                     {
@@ -630,7 +627,7 @@ namespace System
                             continue;
                         }
 
-                        return (int)(offset + FindFirstMatchedLane(mask, compareResult));
+                        return (int)(offset + FindFirstMatchedLane(compareResult));
                     }
 
                     if (offset < (nuint)(uint)length)
@@ -1022,10 +1019,6 @@ namespace System
             }
             else if (AdvSimd.Arm64.IsSupported)
             {
-                // Mask to help find the first lane in compareResult that is set.
-                // LSB 0x01 corresponds to lane 0, 0x10 - to lane 1, and so on.
-                Vector128<byte> mask = Vector128.Create((ushort)0x1001).AsByte();
-
                 Vector128<byte> search;
                 Vector128<byte> matches;
                 Vector128<byte> values0 = Vector128.Create(value0);
@@ -1046,7 +1039,7 @@ namespace System
                     }
 
                     // Find bitflag offset of first match and add to current offset
-                    offset += FindFirstMatchedLane(mask, matches);
+                    offset += FindFirstMatchedLane(matches);
 
                     goto Found;
                 }
@@ -1066,7 +1059,7 @@ namespace System
                 }
 
                 // Find bitflag offset of first match and add to current offset
-                offset += FindFirstMatchedLane(mask, matches);
+                offset += FindFirstMatchedLane(matches);
 
                 goto Found;
             }
@@ -1353,10 +1346,6 @@ namespace System
             }
             else if (AdvSimd.Arm64.IsSupported)
             {
-                // Mask to help find the first lane in compareResult that is set.
-                // LSB 0x01 corresponds to lane 0, 0x10 - to lane 1, and so on.
-                Vector128<byte> mask = Vector128.Create((ushort)0x1001).AsByte();
-
                 Vector128<byte> search;
                 Vector128<byte> matches;
                 Vector128<byte> values0 = Vector128.Create(value0);
@@ -1380,7 +1369,7 @@ namespace System
                     }
 
                     // Find bitflag offset of first match and add to current offset
-                    offset += FindFirstMatchedLane(mask, matches);
+                    offset += FindFirstMatchedLane(matches);
 
                     goto Found;
                 }
@@ -1402,7 +1391,7 @@ namespace System
                 }
 
                 // Find bitflag offset of first match and add to current offset
-                offset += FindFirstMatchedLane(mask, matches);
+                offset += FindFirstMatchedLane(matches);
 
                 goto Found;
             }
@@ -2221,9 +2210,13 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static uint FindFirstMatchedLane(Vector128<byte> mask, Vector128<byte> compareResult)
+        private static uint FindFirstMatchedLane(Vector128<byte> compareResult)
         {
             Debug.Assert(AdvSimd.Arm64.IsSupported);
+
+            // Mask to help find the first lane in compareResult that is set.
+            // MSB 0x10 corresponds to 1st lane, 0x01 corresponds to 0th lane and so forth.
+            Vector128<byte> mask = Vector128.Create((ushort)0x1001).AsByte();
 
             // Find the first lane that is set inside compareResult.
             Vector128<byte> maskedSelectedLanes = AdvSimd.And(compareResult, mask);

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -618,22 +618,19 @@ namespace System
                     // Mask to help find the first lane in compareResult that is set.
                     // MSB 0x10 corresponds to 1st lane, 0x01 corresponds to 0th lane and so forth.
                     Vector128<byte> mask = Vector128.Create((ushort)0x1001).AsByte();
-                    int matchedLane = 0;
-
                     Vector128<byte> values = Vector128.Create(value);
                     while (lengthToExamine > offset)
                     {
                         Vector128<byte> search = LoadVector128(ref searchSpace, offset);
                         Vector128<byte> compareResult = AdvSimd.CompareEqual(values, search);
 
-                        if (!TryFindFirstMatchedLane(mask, compareResult, ref matchedLane))
+                        if (compareResult == Vector128<byte>.Zero)
                         {
-                            // Zero flags set so no matches
                             offset += (nuint)Vector128<byte>.Count;
                             continue;
                         }
 
-                        return (int)(offset + (uint)matchedLane);
+                        return (int)(offset + FindFirstMatchedLane(mask, compareResult));
                     }
 
                     if (offset < (nuint)(uint)length)
@@ -1028,7 +1025,6 @@ namespace System
                 // Mask to help find the first lane in compareResult that is set.
                 // LSB 0x01 corresponds to lane 0, 0x10 - to lane 1, and so on.
                 Vector128<byte> mask = Vector128.Create((ushort)0x1001).AsByte();
-                int matchedLane = 0;
 
                 Vector128<byte> search;
                 Vector128<byte> matches;
@@ -1043,15 +1039,14 @@ namespace System
                             AdvSimd.CompareEqual(values0, search),
                             AdvSimd.CompareEqual(values1, search));
 
-                    if (!TryFindFirstMatchedLane(mask, matches, ref matchedLane))
+                    if (matches == Vector128<byte>.Zero)
                     {
-                        // Zero flags set so no matches
                         offset += (nuint)Vector128<byte>.Count;
                         continue;
                     }
 
                     // Find bitflag offset of first match and add to current offset
-                    offset += (uint)matchedLane;
+                    offset += FindFirstMatchedLane(mask, matches);
 
                     goto Found;
                 }
@@ -1064,14 +1059,14 @@ namespace System
                         AdvSimd.CompareEqual(values0, search),
                         AdvSimd.CompareEqual(values1, search));
 
-                if (!TryFindFirstMatchedLane(mask, matches, ref matchedLane))
+                if (matches == Vector128<byte>.Zero)
                 {
                     // None matched
                     goto NotFound;
                 }
 
                 // Find bitflag offset of first match and add to current offset
-                offset += (nuint)(uint)matchedLane;
+                offset += FindFirstMatchedLane(mask, matches);
 
                 goto Found;
             }
@@ -1361,7 +1356,6 @@ namespace System
                 // Mask to help find the first lane in compareResult that is set.
                 // LSB 0x01 corresponds to lane 0, 0x10 - to lane 1, and so on.
                 Vector128<byte> mask = Vector128.Create((ushort)0x1001).AsByte();
-                int matchedLane = 0;
 
                 Vector128<byte> search;
                 Vector128<byte> matches;
@@ -1379,15 +1373,14 @@ namespace System
                                     AdvSimd.CompareEqual(values1, search)),
                                 AdvSimd.CompareEqual(values2, search));
 
-                    if (!TryFindFirstMatchedLane(mask, matches, ref matchedLane))
+                    if (matches == Vector128<byte>.Zero)
                     {
-                        // Zero flags set so no matches
                         offset += (nuint)Vector128<byte>.Count;
                         continue;
                     }
 
                     // Find bitflag offset of first match and add to current offset
-                    offset += (uint)matchedLane;
+                    offset += FindFirstMatchedLane(mask, matches);
 
                     goto Found;
                 }
@@ -1402,14 +1395,14 @@ namespace System
                                 AdvSimd.CompareEqual(values1, search)),
                             AdvSimd.CompareEqual(values2, search));
 
-                if (!TryFindFirstMatchedLane(mask, matches, ref matchedLane))
+                if (matches == Vector128<byte>.Zero)
                 {
                     // None matched
                     goto NotFound;
                 }
 
                 // Find bitflag offset of first match and add to current offset
-                offset += (nuint)(uint)matchedLane;
+                offset += FindFirstMatchedLane(mask, matches);
 
                 goto Found;
             }
@@ -2228,7 +2221,7 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryFindFirstMatchedLane(Vector128<byte> mask, Vector128<byte> compareResult, ref int matchedLane)
+        private static uint FindFirstMatchedLane(Vector128<byte> mask, Vector128<byte> compareResult)
         {
             Debug.Assert(AdvSimd.Arm64.IsSupported);
 
@@ -2236,15 +2229,12 @@ namespace System
             Vector128<byte> maskedSelectedLanes = AdvSimd.And(compareResult, mask);
             Vector128<byte> pairwiseSelectedLane = AdvSimd.Arm64.AddPairwise(maskedSelectedLanes, maskedSelectedLanes);
             ulong selectedLanes = pairwiseSelectedLane.AsUInt64().ToScalar();
-            if (selectedLanes == 0)
-            {
-                // all lanes are zero, so nothing matched.
-                return false;
-            }
+
+            // It should be handled by compareResult != Vector.Zero
+            Debug.Assert(selectedLanes != 0);
 
             // Find the first lane that is set inside compareResult.
-            matchedLane = BitOperations.TrailingZeroCount(selectedLanes) >> 2;
-            return true;
+            return (uint)BitOperations.TrailingZeroCount(selectedLanes) >> 2;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -717,7 +717,6 @@ namespace System
                     if (lengthToExamine > 0)
                     {
                         Vector128<ushort> values = Vector128.Create((ushort)value);
-
                         do
                         {
                             Debug.Assert(lengthToExamine >= Vector128<ushort>.Count);
@@ -725,7 +724,7 @@ namespace System
                             Vector128<ushort> search = LoadVector128(ref searchSpace, offset);
                             Vector128<ushort> compareResult = AdvSimd.CompareEqual(values, search);
 
-                            if (compareResult != Vector128<ushort>.Zero)
+                            if (compareResult == Vector128<ushort>.Zero)
                             {
                                 offset += Vector128<ushort>.Count;
                                 lengthToExamine -= Vector128<ushort>.Count;

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -717,7 +717,6 @@ namespace System
                     if (lengthToExamine > 0)
                     {
                         Vector128<ushort> values = Vector128.Create((ushort)value);
-                        int matchedLane = 0;
 
                         do
                         {
@@ -726,15 +725,14 @@ namespace System
                             Vector128<ushort> search = LoadVector128(ref searchSpace, offset);
                             Vector128<ushort> compareResult = AdvSimd.CompareEqual(values, search);
 
-                            if (!TryFindFirstMatchedLane(compareResult, ref matchedLane))
+                            if (compareResult != Vector128<ushort>.Zero)
                             {
-                                // Zero flags set so no matches
                                 offset += Vector128<ushort>.Count;
                                 lengthToExamine -= Vector128<ushort>.Count;
                                 continue;
                             }
 
-                            return (int)(offset + matchedLane);
+                            return (int)(offset + FindFirstMatchedLane(compareResult));
                         } while (lengthToExamine > 0);
                     }
 
@@ -2001,21 +1999,17 @@ namespace System
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryFindFirstMatchedLane(Vector128<ushort> compareResult, ref int matchedLane)
+        private static int FindFirstMatchedLane(Vector128<ushort> compareResult)
         {
             Debug.Assert(AdvSimd.Arm64.IsSupported);
 
             Vector128<byte> pairwiseSelectedLane = AdvSimd.Arm64.AddPairwise(compareResult.AsByte(), compareResult.AsByte());
             ulong selectedLanes = pairwiseSelectedLane.AsUInt64().ToScalar();
-            if (selectedLanes == 0)
-            {
-                // all lanes are zero, so nothing matched.
-                return false;
-            }
 
-            // Find the first lane that is set inside compareResult.
-            matchedLane = BitOperations.TrailingZeroCount(selectedLanes) >> 3;
-            return true;
+            // It should be handled by compareResult != Vector.Zero
+            Debug.Assert(selectedLanes != 0);
+
+            return BitOperations.TrailingZeroCount(selectedLanes) >> 3;
         }
     }
 }


### PR DESCRIPTION
Use a slightly faster "no matches" check in `IndexOf` and `IndexOfAny`.

Benchmark:
```csharp
public class Benchmarks
{
    public IEnumerable<object[]> TestData()
    {
        // Small inputs which are handled via SIMD 
        yield return new object[] { "12345678", '1' };
        yield return new object[] { "123456789", '9' };
        yield return new object[] { "1234567812345678", '1' };
        yield return new object[] { "1234567812345678", '0' };
        yield return new object[] { "Console WriteLine Hello World", 'o' };
        yield return new object[] { "Console WriteLine Hello World", 'd' };

        // Large inputs 
        yield return new object[] { new string('x', 64), 'y' };
        yield return new object[] { new string('x', 200), 'y' };
        yield return new object[] { new string('x', 1000), 'y' };
        yield return new object[] { new string('x', 1000000), 'y' };
    }

    [Benchmark]
    [ArgumentsSource(nameof(TestData))]
    public int IndexOf_byte(string str, char c)
    {
        return MemoryMarshal.Cast<char,byte>(str.AsSpan()).IndexOf((byte)c);
    }

    [Benchmark]
    [ArgumentsSource(nameof(TestData))]
    public int IndexOf_char(string str, char c)
    {
        return str.AsSpan().IndexOf(c);
    }
}
```

### IndexOf_byte
```
|  Method |               Toolchain |                  str | c |          Mean |      Error |     StdDev | Ratio |
|-------- |------------------------ |--------------------- |-- |--------------:|-----------:|-----------:|------:|
| IndexOf |      /Core_Root/corerun |             12345678 | 1 |      1.692 ns |  0.0022 ns |  0.0020 ns |  1.00 |
| IndexOf | /Core_Root_base/corerun |             12345678 | 1 |      1.686 ns |  0.0017 ns |  0.0013 ns |  1.00 |
|         |                         |                      |   |               |            |            |       |
| IndexOf |      /Core_Root/corerun |     1234567812345678 | 0 |     10.262 ns |  0.0127 ns |  0.0119 ns |  1.78 |
| IndexOf | /Core_Root_base/corerun |     1234567812345678 | 0 |      5.763 ns |  0.0030 ns |  0.0025 ns |  1.00 |
|         |                         |                      |   |               |            |            |       |
| IndexOf |      /Core_Root/corerun |     1234567812345678 | 1 |      1.676 ns |  0.0032 ns |  0.0030 ns |  1.01 |
| IndexOf | /Core_Root_base/corerun |     1234567812345678 | 1 |      1.665 ns |  0.0022 ns |  0.0020 ns |  1.00 |
|         |                         |                      |   |               |            |            |       |
| IndexOf |      /Core_Root/corerun |            123456789 | 9 |      4.197 ns |  0.0089 ns |  0.0083 ns |  1.00 |
| IndexOf | /Core_Root_base/corerun |            123456789 | 9 |      4.193 ns |  0.0032 ns |  0.0029 ns |  1.00 |
|         |                         |                      |   |               |            |            |       |
| IndexOf |      /Core_Root/corerun | Conso(...)World [29] | d |      7.010 ns |  0.0049 ns |  0.0043 ns |  1.00 |
| IndexOf | /Core_Root_base/corerun | Conso(...)World [29] | d |      7.014 ns |  0.0018 ns |  0.0017 ns |  1.00 |
|         |                         |                      |   |               |            |            |       |
| IndexOf |      /Core_Root/corerun | Conso(...)World [29] | o |      1.679 ns |  0.0006 ns |  0.0006 ns |  1.00 |
| IndexOf | /Core_Root_base/corerun | Conso(...)World [29] | o |      1.678 ns |  0.0008 ns |  0.0007 ns |  1.00 |
|         |                         |                      |   |               |            |            |       |
| IndexOf |      /Core_Root/corerun | xxxxx(...)xxxxx [64] | y |      7.322 ns |  0.0028 ns |  0.0024 ns |  0.80 |
| IndexOf | /Core_Root_base/corerun | xxxxx(...)xxxxx [64] | y |      9.204 ns |  0.0032 ns |  0.0029 ns |  1.00 |
|         |                         |                      |   |               |            |            |       |
| IndexOf |      /Core_Root/corerun |  xxxx(...)xxxx [200] | y |     13.269 ns |  0.0024 ns |  0.0022 ns |  0.62 |
| IndexOf | /Core_Root_base/corerun |  xxxx(...)xxxx [200] | y |     21.317 ns |  0.2285 ns |  0.2138 ns |  1.00 |
|         |                         |                      |   |               |            |            |       |
| IndexOf |      /Core_Root/corerun | xxxx(...)xxxx [1000] | y |     58.107 ns |  0.0458 ns |  0.0429 ns |  0.65 |
| IndexOf | /Core_Root_base/corerun | xxxx(...)xxxx [1000] | y |     89.510 ns |  0.0272 ns |  0.0241 ns |  1.00 |
|         |                         |                      |   |               |            |            |       |
| IndexOf |      /Core_Root/corerun |  xx(...)xx [1000000] | y | 44,056.624 ns |  9.0990 ns |  8.5112 ns |  0.56 |
| IndexOf | /Core_Root_base/corerun |  xx(...)xx [1000000] | y | 78,269.573 ns | 26.4061 ns | 22.0503 ns |  1.00 |
```
### IndexOf_char
```
|  Method |               Toolchain |                  str | c |          Mean |      Error |     StdDev | Ratio |
|-------- |------------------------ |--------------------- |-- |--------------:|-----------:|-----------:|------:|
| IndexOf |      /Core_Root/corerun |             12345678 | 1 |      1.382 ns |  0.0020 ns |  0.0018 ns |  1.00 |
| IndexOf | /Core_Root_base/corerun |             12345678 | 1 |      1.382 ns |  0.0023 ns |  0.0021 ns |  1.00 |
|         |                         |                      |   |               |            |            |       |
| IndexOf |      /Core_Root/corerun |     1234567812345678 | 0 |     11.378 ns |  0.0141 ns |  0.0132 ns |  1.07 |
| IndexOf | /Core_Root_base/corerun |     1234567812345678 | 0 |     10.634 ns |  0.0240 ns |  0.0187 ns |  1.00 |
|         |                         |                      |   |               |            |            |       |
| IndexOf |      /Core_Root/corerun |     1234567812345678 | 1 |      1.375 ns |  0.0016 ns |  0.0014 ns |  1.01 |
| IndexOf | /Core_Root_base/corerun |     1234567812345678 | 1 |      1.366 ns |  0.0034 ns |  0.0030 ns |  1.00 |
|         |                         |                      |   |               |            |            |       |
| IndexOf |      /Core_Root/corerun |            123456789 | 9 |      2.612 ns |  0.0014 ns |  0.0011 ns |  1.00 |
| IndexOf | /Core_Root_base/corerun |            123456789 | 9 |      2.615 ns |  0.0029 ns |  0.0027 ns |  1.00 |
|         |                         |                      |   |               |            |            |       |
| IndexOf |      /Core_Root/corerun | Conso(...)World [29] | d |      5.784 ns |  0.0043 ns |  0.0038 ns |  0.91 |
| IndexOf | /Core_Root_base/corerun | Conso(...)World [29] | d |      6.389 ns |  0.0059 ns |  0.0052 ns |  1.00 |
|         |                         |                      |   |               |            |            |       |
| IndexOf |      /Core_Root/corerun | Conso(...)World [29] | o |      1.689 ns |  0.0016 ns |  0.0014 ns |  1.00 |
| IndexOf | /Core_Root_base/corerun | Conso(...)World [29] | o |      1.694 ns |  0.0007 ns |  0.0007 ns |  1.00 |
|         |                         |                      |   |               |            |            |       |
| IndexOf |      /Core_Root/corerun | xxxxx(...)xxxxx [64] | y |      7.009 ns |  0.0025 ns |  0.0023 ns |  0.76 |
| IndexOf | /Core_Root_base/corerun | xxxxx(...)xxxxx [64] | y |      9.204 ns |  0.0025 ns |  0.0023 ns |  1.00 |
|         |                         |                      |   |               |            |            |       |
| IndexOf |      /Core_Root/corerun |  xxxx(...)xxxx [200] | y |     14.192 ns |  0.0070 ns |  0.0062 ns |  0.67 |
| IndexOf | /Core_Root_base/corerun |  xxxx(...)xxxx [200] | y |     21.267 ns |  0.2695 ns |  0.2521 ns |  1.00 |
|         |                         |                      |   |               |            |            |       |
| IndexOf |      /Core_Root/corerun | xxxx(...)xxxx [1000] | y |     64.790 ns |  0.2031 ns |  0.1800 ns |  0.72 |
| IndexOf | /Core_Root_base/corerun | xxxx(...)xxxx [1000] | y |     89.485 ns |  0.0196 ns |  0.0174 ns |  1.00 |
|         |                         |                      |   |               |            |            |       |
| IndexOf |      /Core_Root/corerun |  xx(...)xx [1000000] | y | 60,098.282 ns |  3.1361 ns |  2.7801 ns |  0.77 |
| IndexOf | /Core_Root_base/corerun |  xx(...)xx [1000000] | y | 78,264.715 ns | 20.9694 ns | 19.6148 ns |  1.00 |
```
up to +40% faster for large inputs can 0.5-1ns regress in the worst case - if input is found in the very first vector.

There are weird regressions
```
| IndexOf |      /Core_Root/corerun |     1234567812345678 | 0 |     10.262 ns |  0.0127 ns |  0.0119 ns |  1.78 |
| IndexOf | /Core_Root_base/corerun |     1234567812345678 | 0 |      5.763 ns |  0.0030 ns |  0.0025 ns |  1.00 |

| IndexOf |      /Core_Root/corerun |     1234567812345678 | 0 |     11.378 ns |  0.0141 ns |  0.0132 ns |  1.07 |
| IndexOf | /Core_Root_base/corerun |     1234567812345678 | 0 |     10.634 ns |  0.0240 ns |  0.0187 ns |  1.00 |
```
but it goes away in FullPGO mode (and the PR becomes faster than the base as expected in this case) - it means the loop is not properly aligned by default. So the regression will be fixed once we update *.mibc for corelib (IndexOf definitely participates in the trainings)
