### PR TITLE
hostpolicy: As a fallback, try to resolve mangled stdcall symbols on win-x86.

### DIFF
--- a/src/native/corehost/hostpolicy/standalone/coreclr_resolver.cpp
+++ b/src/native/corehost/hostpolicy/standalone/coreclr_resolver.cpp
@@ -23,6 +23,33 @@ bool coreclr_resolver_t::resolve_coreclr(const pal::string_t& libcoreclr_path, c
     coreclr_resolver_contract.coreclr_execute_assembly = reinterpret_cast<coreclr_execute_assembly_fn>(pal::get_symbol(coreclr_resolver_contract.coreclr, "coreclr_execute_assembly"));
     coreclr_resolver_contract.coreclr_create_delegate = reinterpret_cast<coreclr_create_delegate_fn>(pal::get_symbol(coreclr_resolver_contract.coreclr, "coreclr_create_delegate"));
 
+#if defined(_WIN32) && defined(_M_IX86)
+    // Some languages/toolchains (e.g. Zig) have trouble with the notion of
+    // exporting a function as stdcall but *without* the _<name>@<bytes> name
+    // mangling that normally comes with that. So, to accommodate them, if
+    // looking up the unmangled names fails, try the mangled ones as well.
+
+    if (!coreclr_resolver_contract.coreclr_initialize)
+    {
+        coreclr_resolver_contract.coreclr_initialize = reinterpret_cast<coreclr_initialize_fn>(pal::get_symbol(coreclr_resolver_contract.coreclr, "_coreclr_initialize@28"));
+    }
+
+    if (!coreclr_resolver_contract.coreclr_shutdown)
+    {
+        coreclr_resolver_contract.coreclr_shutdown = reinterpret_cast<coreclr_shutdown_fn>(pal::get_symbol(coreclr_resolver_contract.coreclr, "_coreclr_shutdown_2@12"));
+    }
+
+    if (!coreclr_resolver_contract.coreclr_execute_assembly)
+    {
+        coreclr_resolver_contract.coreclr_execute_assembly = reinterpret_cast<coreclr_execute_assembly_fn>(pal::get_symbol(coreclr_resolver_contract.coreclr, "_coreclr_execute_assembly@24"));
+    }
+
+    if (!coreclr_resolver_contract.coreclr_create_delegate)
+    {
+        coreclr_resolver_contract.coreclr_create_delegate = reinterpret_cast<coreclr_create_delegate_fn>(pal::get_symbol(coreclr_resolver_contract.coreclr, "_coreclr_create_delegate@24"));
+    }
+#endif
+
     assert(coreclr_resolver_contract.coreclr_initialize != nullptr
         && coreclr_resolver_contract.coreclr_shutdown != nullptr
         && coreclr_resolver_contract.coreclr_execute_assembly != nullptr


### PR DESCRIPTION
Fixes #57586.