### PR TITLE
Fix off-by-1000 error reported in issue#67807

### DIFF
--- a/src/libraries/Common/src/Interop/FreeBSD/Interop.Process.cs
+++ b/src/libraries/Common/src/Interop/FreeBSD/Interop.Process.cs
@@ -14,6 +14,7 @@ internal static partial class Interop
     internal static partial class Process
     {
         private const ulong SecondsToNanoseconds = 1000000000;
+        private const ulong MicroSecondsToNanoSeconds = 1000;
 
         // Constants from sys/sysctl.h
         private const int KERN_PROC_PATHNAME = 12;
@@ -171,8 +172,8 @@ internal static partial class Interop
                     {
                         ret.startTime = (int)info->ki_start.tv_sec;
                         ret.nice = info->ki_nice;
-                        ret.userTime = (ulong)info->ki_rusage.ru_utime.tv_sec * SecondsToNanoseconds + (ulong)info->ki_rusage.ru_utime.tv_usec;
-                        ret.systemTime = (ulong)info->ki_rusage.ru_stime.tv_sec * SecondsToNanoseconds + (ulong)info->ki_rusage.ru_stime.tv_usec;
+                        ret.userTime = (ulong)info->ki_rusage.ru_utime.tv_sec * SecondsToNanoseconds + (ulong)info->ki_rusage.ru_utime.tv_usec * MicroSecondsToNanoSeconds;
+                        ret.systemTime = (ulong)info->ki_rusage.ru_stime.tv_sec * SecondsToNanoseconds + (ulong)info->ki_rusage.ru_stime.tv_usec * MicroSecondsToNanoSeconds;
                     }
                     else
                     {
@@ -183,8 +184,8 @@ internal static partial class Interop
                             {
                                 ret.startTime = (int)list[i].ki_start.tv_sec;
                                 ret.nice = list[i].ki_nice;
-                                ret.userTime = (ulong)list[i].ki_rusage.ru_utime.tv_sec * SecondsToNanoseconds + (ulong)list[i].ki_rusage.ru_utime.tv_usec;
-                                ret.systemTime = (ulong)list[i].ki_rusage.ru_stime.tv_sec * SecondsToNanoseconds + (ulong)list[i].ki_rusage.ru_stime.tv_usec;
+                                ret.userTime = (ulong)list[i].ki_rusage.ru_utime.tv_sec * SecondsToNanoseconds + (ulong)list[i].ki_rusage.ru_utime.tv_usec * MicroSecondsToNanoSeconds;
+                                ret.systemTime = (ulong)list[i].ki_rusage.ru_stime.tv_sec * SecondsToNanoseconds + (ulong)list[i].ki_rusage.ru_stime.tv_usec * MicroSecondsToNanoSeconds;
                                 break;
                             }
                         }


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/67807
@coypoop Original issue reporter

For the reason I used MicroSecondsToNanoSeconds rather than tv_nsec as seen in other files, see 

https://github.com/dotnet/runtime/blob/3ae87395f638a533f37b8e3385f6d3f199a72f4f/src/libraries/Common/src/Interop/FreeBSD/Interop.Process.GetProcInfo.cs#L70

Appears that it does not have a nsec, only sec and usec.