### PR TITLE
Add more diagnostics info for LookupProperty assert failure

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -17,7 +17,7 @@ namespace System.Text.Json
         /// Also sets state.Current.JsonPropertyInfo to a non-null value.
         /// </summary>
         internal static JsonPropertyInfo LookupProperty(
-            object obj,
+            object? obj,
             ReadOnlySpan<byte> unescapedPropertyName,
             ref ReadStack state,
             JsonSerializerOptions options,
@@ -27,7 +27,7 @@ namespace System.Text.Json
 #if DEBUG
             ConverterStrategy strat = state.Current.JsonTypeInfo.PropertyInfoForTypeInfo.ConverterStrategy;
             string propName = JsonHelpers.Utf8GetString(unescapedPropertyName);
-            string objTypeName = obj.GetType().FullName!;
+            string objTypeName = obj?.GetType().FullName ?? "<null>";
             string jtiTypeName = state.Current.JsonTypeInfo.GetType().Name;
             string typeName = state.Current.JsonTypeInfo.Type.GetType().FullName!;
             bool isConfigured = state.Current.JsonTypeInfo.IsConfigured;
@@ -60,7 +60,7 @@ namespace System.Text.Json
 
                     if (createExtensionProperty)
                     {
-                        CreateDataExtensionProperty(obj, dataExtProperty, options);
+                        CreateDataExtensionProperty(obj!, dataExtProperty, options);
                     }
 
                     jsonPropertyInfo = dataExtProperty;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -31,10 +31,10 @@ namespace System.Text.Json
             string jtiTypeName = state.Current.JsonTypeInfo.GetType().Name;
             string typeName = state.Current.JsonTypeInfo.Type.GetType().FullName!;
             bool isConfigured = state.Current.JsonTypeInfo.IsConfigured;
-            bool propCacacheInitialized = state.Current.JsonTypeInfo.PropertyCache != null;
+            bool propCacheInitialized = state.Current.JsonTypeInfo.PropertyCache != null;
 
             Debug.Assert(strat == ConverterStrategy.Object,
-                $"ConverterStrategy is {strat}. propertyName = {propName}; obj.GetType() => {objTypeName}; JsonTypeInfo[{jtiTypeName}].Type = {typeName}; IsConfigured = {isConfigured}; HasPropertyCache = {propCacacheInitialized}");
+                $"ConverterStrategy is {strat}. propertyName = {propName}; obj.GetType() => {objTypeName}; JsonTypeInfo[{jtiTypeName}].Type = {typeName}; IsConfigured = {isConfigured}; HasPropertyCache = {propCacheInitialized}");
 #endif
 
             useExtensionProperty = false;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -24,8 +24,10 @@ namespace System.Text.Json
             out bool useExtensionProperty,
             bool createExtensionProperty = true)
         {
+#if DEBUG
             Debug.Assert(state.Current.JsonTypeInfo.PropertyInfoForTypeInfo.ConverterStrategy == ConverterStrategy.Object,
                 GetLookupPropertyDebugInfo(obj, unescapedPropertyName, ref state));
+#endif
 
             useExtensionProperty = false;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -24,7 +24,18 @@ namespace System.Text.Json
             out bool useExtensionProperty,
             bool createExtensionProperty = true)
         {
-            Debug.Assert(state.Current.JsonTypeInfo.PropertyInfoForTypeInfo.ConverterStrategy == ConverterStrategy.Object);
+#if DEBUG
+            ConverterStrategy strat = state.Current.JsonTypeInfo.PropertyInfoForTypeInfo.ConverterStrategy;
+            string propName = JsonHelpers.Utf8GetString(unescapedPropertyName);
+            string objTypeName = obj.GetType().FullName!;
+            string jtiTypeName = state.Current.JsonTypeInfo.GetType().Name;
+            string typeName = state.Current.JsonTypeInfo.Type.GetType().FullName!;
+            bool isConfigured = state.Current.JsonTypeInfo.IsConfigured;
+            bool propCacacheInitialized = state.Current.JsonTypeInfo.PropertyCache != null;
+
+            Debug.Assert(strat == ConverterStrategy.Object,
+                $"ConverterStrategy is {strat}. propertyName = {propName}; obj.GetType() => {objTypeName}; JsonTypeInfo[{jtiTypeName}].Type = {typeName}; IsConfigured = {isConfigured}; HasPropertyCache = {propCacacheInitialized}");
+#endif
 
             useExtensionProperty = false;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -501,7 +501,8 @@ namespace System.Text.Json.Serialization.Metadata
             set
             {
                 // Used by JsonMetadataServices.
-                Debug.Assert(_jsonTypeInfo == null);
+                // This could potentially be double initialized
+                Debug.Assert(_jsonTypeInfo == null || _jsonTypeInfo == value);
                 _jsonTypeInfo = value;
             }
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
@@ -461,7 +461,8 @@ namespace System.Text.Json.Serialization.Metadata
                     (name.Length < 7 || name[6] == ((key & ((ulong)0xFF << BitsInByte * 6)) >> BitsInByte * 6)) &&
                     // Verify embedded length.
                     (name.Length >= 0xFF || (key & ((ulong)0xFF << BitsInByte * 7)) >> BitsInByte * 7 == (ulong)name.Length) &&
-                    (name.Length < 0xFF || (key & ((ulong)0xFF << BitsInByte * 7)) >> BitsInByte * 7 == 0xFF));
+                    (name.Length < 0xFF || (key & ((ulong)0xFF << BitsInByte * 7)) >> BitsInByte * 7 == 0xFF),
+                    "Embedded bytes not as expected");
             }
 #endif
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -191,21 +191,24 @@ namespace System.Text.Json.Serialization.Metadata
             }
         }
 
-        private bool _isConfigured;
+        internal bool IsConfigured { get; private set; }
 
         internal void EnsureConfigured()
         {
-            if (_isConfigured)
+            if (IsConfigured)
                 return;
 
             Configure();
 
-            _isConfigured = true;
+            IsConfigured = true;
         }
 
         internal virtual void Configure()
         {
             JsonConverter converter = PropertyInfoForTypeInfo.ConverterBase;
+            Debug.Assert(PropertyInfoForTypeInfo.ConverterStrategy == PropertyInfoForTypeInfo.ConverterBase.ConverterStrategy,
+                $"ConverterStrategy from PropertyInfoForTypeInfo.ConverterStrategy ({PropertyInfoForTypeInfo.ConverterStrategy}) does not match converter's ({PropertyInfoForTypeInfo.ConverterBase.ConverterStrategy})");
+
             converter.ConfigureJsonTypeInfo(this, Options);
             PropertyInfoForTypeInfo.DeclaringTypeNumberHandling = NumberHandling;
             PropertyInfoForTypeInfo.EnsureConfigured();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -191,16 +191,16 @@ namespace System.Text.Json.Serialization.Metadata
             }
         }
 
-        internal bool IsConfigured { get; private set; }
+        private bool _isConfigured;
 
         internal void EnsureConfigured()
         {
-            if (IsConfigured)
+            if (_isConfigured)
                 return;
 
             Configure();
 
-            IsConfigured = true;
+            _isConfigured = true;
         }
 
         internal virtual void Configure()
@@ -236,6 +236,43 @@ namespace System.Text.Json.Serialization.Metadata
                 }
             }
         }
+
+#if DEBUG
+        internal string GetDebugInfo()
+        {
+            ConverterStrategy strat = PropertyInfoForTypeInfo.ConverterStrategy;
+            string jtiTypeName = GetType().Name;
+            string typeName = Type.FullName!;
+            bool propCacheInitialized = PropertyCache != null;
+
+            StringBuilder sb = new();
+            sb.AppendLine($"{jtiTypeName} {{");
+            sb.AppendLine($"  GetType: {jtiTypeName},");
+            sb.AppendLine($"  Type: {typeName},");
+            sb.AppendLine($"  ConverterStrategy: {strat},");
+            sb.AppendLine($"  IsConfigured: {_isConfigured},");
+            sb.AppendLine($"  HasPropertyCache: {propCacheInitialized},");
+
+            if (propCacheInitialized)
+            {
+                sb.AppendLine("  Properties: {");
+                foreach (var property in PropertyCache!.List)
+                {
+                    JsonPropertyInfo pi = property.Value!;
+                    sb.AppendLine($"    {property.Key}: {{");
+                    sb.AppendLine($"      Ignored: {pi.IsIgnored},");
+                    sb.AppendLine($"      ShouldSerialize: {pi.ShouldSerialize},");
+                    sb.AppendLine($"      ShouldDeserialize: {pi.ShouldDeserialize},");
+                    sb.AppendLine("    },");
+                }
+
+                sb.AppendLine("  },");
+            }
+
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+#endif
 
         internal virtual void LateAddProperties() { }
 


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/runtime/issues/67816

Add more diagnostics info for the frequently failing assert.