### PR TITLE
Use logical and for boolean operation in bstr

### DIFF
--- a/src/coreclr/palrt/bstr.cpp
+++ b/src/coreclr/palrt/bstr.cpp
@@ -47,7 +47,7 @@ inline HRESULT CbSysStringSize(ULONG cchSize, BOOL isByteLen, ULONG *result)
     else
     {
         ULONG temp = 0; // should not use in-place addition in ULongAdd
-        if (SUCCEEDED(ULongMult(cchSize, sizeof(WCHAR), &temp)) &
+        if (SUCCEEDED(ULongMult(cchSize, sizeof(WCHAR), &temp)) &&
             SUCCEEDED(ULongAdd(temp, constant, result)))
         {
             *result = *result & ~WIN32_ALLOC_ALIGN;


### PR DESCRIPTION
This seems like a mistake and recent versions of clang even complain
about it:

    /runtime/src/coreclr/palrt/bstr.cpp:50:13: error: use of bitwise '&' with boolean operands [-Werror,-Wbitwise-instead-of-logical]
            if (SUCCEEDED(ULongMult(cchSize, sizeof(WCHAR), &temp)) &
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                    &&
    /runtime/src/coreclr/pal/inc/pal.h:5144:27: note: expanded from macro 'SUCCEEDED'
    #define SUCCEEDED(Status) ((HRESULT)(Status) >= 0)
                              ^
    /runtime/src/coreclr/palrt/bstr.cpp:50:13: note: cast one or both operands to int to silence this warning
    /runtime/src/coreclr/pal/inc/pal.h:5144:27: note: expanded from macro 'SUCCEEDED'
    #define SUCCEEDED(Status) ((HRESULT)(Status) >= 0)
                              ^
    1 error generated.


Seen with Clang 14:

```
# clang -v
clang version 14.0.0 (Fedora 14.0.0-1.fc37)
Target: x86_64-redhat-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-redhat-linux/12
Selected GCC installation: /usr/bin/../lib/gcc/x86_64-redhat-linux/12
Candidate multilib: .;@m64
Candidate multilib: 32;@m32
Selected multilib: .;@m64
```