### PR TITLE
Asynchronous opening of QuicStreams

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
@@ -59,9 +59,9 @@ namespace System.Net.Test.Common
                 stream.Dispose();
             }
 
-// We don't dispose the connection currently, because this causes races when the server connection is closed before
-// the client has received and handled all response data.
-// See discussion in https://github.com/dotnet/runtime/pull/57223#discussion_r687447832
+            // We don't dispose the connection currently, because this causes races when the server connection is closed before
+            // the client has received and handled all response data.
+            // See discussion in https://github.com/dotnet/runtime/pull/57223#discussion_r687447832
 #if false
             // Dispose the connection
             // If we already waited for graceful shutdown from the client, then the connection is already closed and this will simply release the handle.
@@ -79,14 +79,14 @@ namespace System.Net.Test.Common
             await _connection.CloseAsync(errorCode).ConfigureAwait(false);
         }
 
-        public Http3LoopbackStream OpenUnidirectionalStream()
+        public async ValueTask<Http3LoopbackStream> OpenUnidirectionalStreamAsync()
         {
-            return new Http3LoopbackStream(_connection.OpenUnidirectionalStream());
+            return new Http3LoopbackStream(await _connection.OpenUnidirectionalStreamAsync());
         }
 
-        public Http3LoopbackStream OpenBidirectionalStream()
+        public async ValueTask<Http3LoopbackStream> OpenBidirectionalStreamAsync()
         {
-            return new Http3LoopbackStream(_connection.OpenBidirectionalStream());
+            return new Http3LoopbackStream(await _connection.OpenBidirectionalStreamAsync());
         }
 
         public static int GetRequestId(QuicStream stream)
@@ -185,10 +185,10 @@ namespace System.Net.Test.Common
 
         public async Task EstablishControlStreamAsync()
         {
-            _outboundControlStream = OpenUnidirectionalStream();
+            _outboundControlStream = await OpenUnidirectionalStreamAsync();
             await _outboundControlStream.SendUnidirectionalStreamTypeAsync(Http3LoopbackStream.ControlStream);
             await _outboundControlStream.SendSettingsFrameAsync();
-       }
+        }
 
         public override async Task<byte[]> ReadRequestBodyAsync()
         {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -184,7 +184,6 @@ namespace System.Net.Http
                     {
                         if (HttpTelemetry.Log.IsEnabled() && queueStartingTimestamp == 0)
                         {
-                            // the call below will almost certainly block, measure waiting time for telemetry purposes
                             queueStartingTimestamp = Stopwatch.GetTimestamp();
                         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -182,7 +182,7 @@ namespace System.Net.Http
                     QuicConnection? conn = _connection;
                     if (conn != null)
                     {
-                        if (HttpTelemetry.Log.IsEnabled() && queueStartingTimestamp == 0 && conn.GetRemoteAvailableBidirectionalStreamCount() == 0)
+                        if (HttpTelemetry.Log.IsEnabled() && queueStartingTimestamp == 0)
                         {
                             // the call below will almost certainly block, measure waiting time for telemetry purposes
                             queueStartingTimestamp = Stopwatch.GetTimestamp();

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -187,12 +187,15 @@ namespace System.Net.Http
                             queueStartingTimestamp = Stopwatch.GetTimestamp();
                         }
 
-                        quicStream = await _connection.OpenBidirectionalStreamAsync(cancellationToken).ConfigureAwait(false);
-                        requestStream = new Http3RequestStream(request, this, quicStream);
-
-                        lock (SyncObj)
+                        quicStream = await _connection?.OpenBidirectionalStreamAsync(cancellationToken).ConfigureAwait(false);
+                        if (quicStream != null)
                         {
-                            _activeRequests.Add(quicStream, requestStream);
+                            requestStream = new Http3RequestStream(request, this, quicStream);
+
+                            lock (SyncObj)
+                            {
+                                _activeRequests.Add(quicStream, requestStream);
+                            }
                         }
                     }
                 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -197,6 +197,10 @@ namespace System.Net.Http
                         }
                     }
                 }
+                // Swallow any exceptions caused by the connection being closed locally or even disposed due to a race.
+                // Since quicStream will stay `null`, the code below will throw appropriate exception to retry the request.
+                catch (ObjectDisposedException) { }
+                catch (QuicException e) when (!(e is QuicConnectionAbortedException)) { }
                 finally
                 {
                     if (HttpTelemetry.Log.IsEnabled() && queueStartingTimestamp != 0)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -179,23 +179,21 @@ namespace System.Net.Http
             {
                 try
                 {
-                    if (_connection != null)
+                    QuicConnection? conn = _connection;
+                    if (conn != null)
                     {
-                        if (HttpTelemetry.Log.IsEnabled() && queueStartingTimestamp == 0 && _connection.GetRemoteAvailableBidirectionalStreamCount() == 0)
+                        if (HttpTelemetry.Log.IsEnabled() && queueStartingTimestamp == 0 && conn.GetRemoteAvailableBidirectionalStreamCount() == 0)
                         {
                             // the call below will almost certainly block, measure waiting time for telemetry purposes
                             queueStartingTimestamp = Stopwatch.GetTimestamp();
                         }
 
-                        quicStream = await _connection?.OpenBidirectionalStreamAsync(cancellationToken).ConfigureAwait(false);
-                        if (quicStream != null)
-                        {
-                            requestStream = new Http3RequestStream(request, this, quicStream);
+                        quicStream = await conn.OpenBidirectionalStreamAsync(cancellationToken).ConfigureAwait(false);
 
-                            lock (SyncObj)
-                            {
-                                _activeRequests.Add(quicStream, requestStream);
-                            }
+                        requestStream = new Http3RequestStream(request, this, quicStream);
+                        lock (SyncObj)
+                        {
+                            _activeRequests.Add(quicStream, requestStream);
                         }
                     }
                 }

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -32,8 +32,6 @@ namespace System.Net.Quic
         public System.Threading.Tasks.ValueTask<System.Net.Quic.QuicStream> OpenBidirectionalStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Threading.Tasks.ValueTask<System.Net.Quic.QuicStream> OpenUnidirectionalStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Security.Cryptography.X509Certificates.X509Certificate? RemoteCertificate { get { throw null; } }
-        public System.Threading.Tasks.ValueTask WaitForAvailableBidirectionalStreamsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public System.Threading.Tasks.ValueTask WaitForAvailableUnidirectionalStreamsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class QuicConnectionAbortedException : System.Net.Quic.QuicException
     {

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -22,6 +22,7 @@ namespace System.Net.Quic
         public bool Connected { get { throw null; } }
         public System.Net.IPEndPoint? LocalEndPoint { get { throw null; } }
         public System.Net.Security.SslApplicationProtocol NegotiatedApplicationProtocol { get { throw null; } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate? RemoteCertificate { get { throw null; } }
         public System.Net.EndPoint RemoteEndPoint { get { throw null; } }
         public System.Threading.Tasks.ValueTask<System.Net.Quic.QuicStream> AcceptStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Threading.Tasks.ValueTask CloseAsync(long errorCode, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -31,11 +32,10 @@ namespace System.Net.Quic
         public int GetRemoteAvailableUnidirectionalStreamCount() { throw null; }
         public System.Threading.Tasks.ValueTask<System.Net.Quic.QuicStream> OpenBidirectionalStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Threading.Tasks.ValueTask<System.Net.Quic.QuicStream> OpenUnidirectionalStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public System.Security.Cryptography.X509Certificates.X509Certificate? RemoteCertificate { get { throw null; } }
     }
     public partial class QuicConnectionAbortedException : System.Net.Quic.QuicException
     {
-        public QuicConnectionAbortedException(string message, long errorCode) : base(default(string)) { }
+        public QuicConnectionAbortedException(string message, long errorCode) : base (default(string)) { }
         public long ErrorCode { get { throw null; } }
     }
     public partial class QuicException : System.Exception
@@ -69,7 +69,7 @@ namespace System.Net.Quic
     }
     public partial class QuicOperationAbortedException : System.Net.Quic.QuicException
     {
-        public QuicOperationAbortedException(string message) : base(default(string)) { }
+        public QuicOperationAbortedException(string message) : base (default(string)) { }
     }
     public partial class QuicOptions
     {
@@ -83,12 +83,14 @@ namespace System.Net.Quic
         internal QuicStream() { }
         public override bool CanRead { get { throw null; } }
         public override bool CanSeek { get { throw null; } }
-        public override bool CanWrite { get { throw null; } }
         public override bool CanTimeout { get { throw null; } }
+        public override bool CanWrite { get { throw null; } }
         public override long Length { get { throw null; } }
         public override long Position { get { throw null; } set { } }
         public bool ReadsCompleted { get { throw null; } }
+        public override int ReadTimeout { get { throw null; } set { } }
         public long StreamId { get { throw null; } }
+        public override int WriteTimeout { get { throw null; } set { } }
         public void AbortRead(long errorCode) { }
         public void AbortWrite(long errorCode) { }
         public override System.IAsyncResult BeginRead(byte[] buffer, int offset, int count, System.AsyncCallback? callback, object? state) { throw null; }
@@ -100,10 +102,9 @@ namespace System.Net.Quic
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
         public override int Read(System.Span<byte> buffer) { throw null; }
-        public override int ReadByte() { throw null; }
         public override System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
         public override System.Threading.Tasks.ValueTask<int> ReadAsync(System.Memory<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public override int ReadTimeout { get { throw null; } set { } }
+        public override int ReadByte() { throw null; }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
         public override void SetLength(long value) { }
         public void Shutdown() { }
@@ -111,7 +112,6 @@ namespace System.Net.Quic
         public System.Threading.Tasks.ValueTask WaitForWriteCompletionAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override void Write(byte[] buffer, int offset, int count) { }
         public override void Write(System.ReadOnlySpan<byte> buffer) { }
-        public override void WriteByte(byte value) { }
         public System.Threading.Tasks.ValueTask WriteAsync(System.Buffers.ReadOnlySequence<byte> buffers, bool endStream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Threading.Tasks.ValueTask WriteAsync(System.Buffers.ReadOnlySequence<byte> buffers, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
@@ -119,11 +119,11 @@ namespace System.Net.Quic
         public override System.Threading.Tasks.ValueTask WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Threading.Tasks.ValueTask WriteAsync(System.ReadOnlyMemory<System.ReadOnlyMemory<byte>> buffers, bool endStream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Threading.Tasks.ValueTask WriteAsync(System.ReadOnlyMemory<System.ReadOnlyMemory<byte>> buffers, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public override int WriteTimeout { get { throw null; } set { } }
+        public override void WriteByte(byte value) { }
     }
     public partial class QuicStreamAbortedException : System.Net.Quic.QuicException
     {
-        public QuicStreamAbortedException(string message, long errorCode) : base(default(string)) { }
+        public QuicStreamAbortedException(string message, long errorCode) : base (default(string)) { }
         public long ErrorCode { get { throw null; } }
     }
 }

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -31,13 +31,15 @@ namespace System.Net.Quic
         public int GetRemoteAvailableUnidirectionalStreamCount() { throw null; }
         public System.Net.Quic.QuicStream OpenBidirectionalStream() { throw null; }
         public System.Net.Quic.QuicStream OpenUnidirectionalStream() { throw null; }
+        public System.Threading.Tasks.ValueTask<System.Net.Quic.QuicStream> OpenBidirectionalStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public System.Threading.Tasks.ValueTask<System.Net.Quic.QuicStream> OpenUnidirectionalStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Security.Cryptography.X509Certificates.X509Certificate? RemoteCertificate { get { throw null; } }
         public System.Threading.Tasks.ValueTask WaitForAvailableBidirectionalStreamsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Threading.Tasks.ValueTask WaitForAvailableUnidirectionalStreamsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class QuicConnectionAbortedException : System.Net.Quic.QuicException
     {
-        public QuicConnectionAbortedException(string message, long errorCode) : base (default(string)) { }
+        public QuicConnectionAbortedException(string message, long errorCode) : base(default(string)) { }
         public long ErrorCode { get { throw null; } }
     }
     public partial class QuicException : System.Exception
@@ -71,7 +73,7 @@ namespace System.Net.Quic
     }
     public partial class QuicOperationAbortedException : System.Net.Quic.QuicException
     {
-        public QuicOperationAbortedException(string message) : base (default(string)) { }
+        public QuicOperationAbortedException(string message) : base(default(string)) { }
     }
     public partial class QuicOptions
     {
@@ -125,7 +127,7 @@ namespace System.Net.Quic
     }
     public partial class QuicStreamAbortedException : System.Net.Quic.QuicException
     {
-        public QuicStreamAbortedException(string message, long errorCode) : base (default(string)) { }
+        public QuicStreamAbortedException(string message, long errorCode) : base(default(string)) { }
         public long ErrorCode { get { throw null; } }
     }
 }

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -29,8 +29,6 @@ namespace System.Net.Quic
         public void Dispose() { }
         public int GetRemoteAvailableBidirectionalStreamCount() { throw null; }
         public int GetRemoteAvailableUnidirectionalStreamCount() { throw null; }
-        public System.Net.Quic.QuicStream OpenBidirectionalStream() { throw null; }
-        public System.Net.Quic.QuicStream OpenUnidirectionalStream() { throw null; }
         public System.Threading.Tasks.ValueTask<System.Net.Quic.QuicStream> OpenBidirectionalStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Threading.Tasks.ValueTask<System.Net.Quic.QuicStream> OpenUnidirectionalStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Security.Cryptography.X509Certificates.X509Certificate? RemoteCertificate { get { throw null; } }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/Mock/MockConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/Mock/MockConnection.cs
@@ -162,28 +162,6 @@ namespace System.Net.Quic.Implementations.Mock
             return ValueTask.CompletedTask;
         }
 
-        internal override ValueTask WaitForAvailableUnidirectionalStreamsAsync(CancellationToken cancellationToken = default)
-        {
-            PeerStreamLimit? streamLimit = RemoteStreamLimit;
-            if (streamLimit is null)
-            {
-                throw new InvalidOperationException("Not connected");
-            }
-
-            return streamLimit.Unidirectional.WaitForAvailableStreams(cancellationToken);
-        }
-
-        internal override ValueTask WaitForAvailableBidirectionalStreamsAsync(CancellationToken cancellationToken = default)
-        {
-            PeerStreamLimit? streamLimit = RemoteStreamLimit;
-            if (streamLimit is null)
-            {
-                throw new InvalidOperationException("Not connected");
-            }
-
-            return streamLimit.Bidirectional.WaitForAvailableStreams(cancellationToken);
-        }
-
         internal async override ValueTask<QuicStreamProvider> OpenUnidirectionalStreamAsync(CancellationToken cancellationToken)
         {
             PeerStreamLimit? streamLimit = RemoteStreamLimit;
@@ -194,7 +172,7 @@ namespace System.Net.Quic.Implementations.Mock
 
             while (!streamLimit.Unidirectional.TryIncrement())
             {
-                await WaitForAvailableUnidirectionalStreamsAsync(cancellationToken).ConfigureAwait(false);
+                await streamLimit.Unidirectional.WaitForAvailableStreams(cancellationToken).ConfigureAwait(false);
             }
 
             long streamId;
@@ -217,7 +195,7 @@ namespace System.Net.Quic.Implementations.Mock
 
             while (!streamLimit.Bidirectional.TryIncrement())
             {
-                await WaitForAvailableBidirectionalStreamsAsync(cancellationToken).ConfigureAwait(false);
+                await streamLimit.Bidirectional.WaitForAvailableStreams(cancellationToken).ConfigureAwait(false);
             }
 
             long streamId;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/Mock/MockConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/Mock/MockConnection.cs
@@ -184,52 +184,6 @@ namespace System.Net.Quic.Implementations.Mock
             return streamLimit.Bidirectional.WaitForAvailableStreams(cancellationToken);
         }
 
-        internal override QuicStreamProvider OpenUnidirectionalStream()
-        {
-            PeerStreamLimit? streamLimit = RemoteStreamLimit;
-            if (streamLimit is null)
-            {
-                throw new InvalidOperationException("Not connected");
-            }
-
-            if (!streamLimit.Unidirectional.TryIncrement())
-            {
-                throw new QuicException("No available unidirectional stream");
-            }
-
-            long streamId;
-            lock (_syncObject)
-            {
-                streamId = _nextOutboundUnidirectionalStream;
-                _nextOutboundUnidirectionalStream += 4;
-            }
-
-            return OpenStream(streamId, false);
-        }
-
-        internal override QuicStreamProvider OpenBidirectionalStream()
-        {
-            PeerStreamLimit? streamLimit = RemoteStreamLimit;
-            if (streamLimit is null)
-            {
-                throw new InvalidOperationException("Not connected");
-            }
-
-            if (!streamLimit.Bidirectional.TryIncrement())
-            {
-                throw new QuicException("No available bidirectional stream");
-            }
-
-            long streamId;
-            lock (_syncObject)
-            {
-                streamId = _nextOutboundBidirectionalStream;
-                _nextOutboundBidirectionalStream += 4;
-            }
-
-            return OpenStream(streamId, true);
-        }
-
         internal async override ValueTask<QuicStreamProvider> OpenUnidirectionalStreamAsync(CancellationToken cancellationToken)
         {
             PeerStreamLimit? streamLimit = RemoteStreamLimit;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicEnums.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicEnums.cs
@@ -213,6 +213,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         SEND_SHUTDOWN_COMPLETE = 6,
         SHUTDOWN_COMPLETE = 7,
         IDEAL_SEND_BUFFER_SIZE = 8,
+        PEER_ACCEPTED = 9
     }
 
 #if SOCKADDR_HAS_LENGTH

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -582,7 +582,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             return new ValueTask(tcs.Task.WaitAsync(cancellationToken));
         }
 
-        private async ValueTask<QuicStreamProvider> OpenStreamAsync(QUIC_STREAM_OPEN_FLAGS flags, CancellationToken cancellationToken)
+        private ValueTask<QuicStreamProvider> OpenStreamAsync(QUIC_STREAM_OPEN_FLAGS flags, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
             if (!Connected)
@@ -590,7 +590,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                 throw new InvalidOperationException(SR.net_quic_not_connected);
             }
 
-            return await MsQuicStream.CreateOutbound(_state, flags, cancellationToken).ConfigureAwait(false);
+            return MsQuicStream.CreateOutbound(_state, flags, cancellationToken);
         }
 
         internal override ValueTask<QuicStreamProvider> OpenUnidirectionalStreamAsync(CancellationToken cancellationToken = default) => OpenStreamAsync(QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL, cancellationToken);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -592,10 +592,15 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             var stream = new MsQuicStream(_state, flags);
 
-            // should complete synchronously
-            ValueTask startTask = stream.StartAsync(QUIC_STREAM_START_FLAGS.FAIL_BLOCKED | QUIC_STREAM_START_FLAGS.SHUTDOWN_ON_FAIL | QUIC_STREAM_START_FLAGS.INDICATE_PEER_ACCEPT, default);
-            startTask.AsTask().GetAwaiter().GetResult();
-            Debug.Assert(startTask.IsCompleted);
+            try
+            {
+                stream.StartAsync(QUIC_STREAM_START_FLAGS.FAIL_BLOCKED | QUIC_STREAM_START_FLAGS.SHUTDOWN_ON_FAIL | QUIC_STREAM_START_FLAGS.INDICATE_PEER_ACCEPT, default).AsTask().GetAwaiter().GetResult();
+            }
+            catch
+            {
+                stream.Dispose();
+                throw;
+            }
 
             return stream;
         }
@@ -613,7 +618,15 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             var stream = new MsQuicStream(_state, flags);
 
-            await stream.StartAsync(QUIC_STREAM_START_FLAGS.SHUTDOWN_ON_FAIL | QUIC_STREAM_START_FLAGS.INDICATE_PEER_ACCEPT, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await stream.StartAsync(QUIC_STREAM_START_FLAGS.SHUTDOWN_ON_FAIL | QUIC_STREAM_START_FLAGS.INDICATE_PEER_ACCEPT, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                stream.Dispose();
+                throw;
+            }
 
             return stream;
         }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -590,7 +590,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                 throw new InvalidOperationException(SR.net_quic_not_connected);
             }
 
-            return await MsQuicStream.CreateOutbound(_state, cancellationToken).ConfigureAwait(false);
+            return await MsQuicStream.CreateOutbound(_state, flags, cancellationToken).ConfigureAwait(false);
         }
 
         internal override ValueTask<QuicStreamProvider> OpenUnidirectionalStreamAsync(CancellationToken cancellationToken = default) => OpenStreamAsync(QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL, cancellationToken);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -590,6 +590,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                 throw new InvalidOperationException(SR.net_quic_not_connected);
             }
 
+            cancellationToken.ThrowIfCancellationRequested();
             var stream = new MsQuicStream(_state, flags);
 
             try

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -590,20 +590,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                 throw new InvalidOperationException(SR.net_quic_not_connected);
             }
 
-            cancellationToken.ThrowIfCancellationRequested();
-            var stream = new MsQuicStream(_state, flags);
-
-            try
-            {
-                await stream.StartAsync(QUIC_STREAM_START_FLAGS.SHUTDOWN_ON_FAIL | QUIC_STREAM_START_FLAGS.INDICATE_PEER_ACCEPT, cancellationToken).ConfigureAwait(false);
-            }
-            catch
-            {
-                stream.Dispose();
-                throw;
-            }
-
-            return stream;
+            return await MsQuicStream.CreateOutbound(_state, cancellationToken).ConfigureAwait(false);
         }
 
         internal override ValueTask<QuicStreamProvider> OpenUnidirectionalStreamAsync(CancellationToken cancellationToken = default) => OpenStreamAsync(QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL, cancellationToken);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -52,12 +52,6 @@ namespace System.Net.Quic.Implementations.MsQuic
             // TODO: only allocate these when there is an outstanding shutdown.
             public readonly TaskCompletionSource<uint> ShutdownTcs = new TaskCompletionSource<uint>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            // Note that there's no such thing as resetable TCS, so we cannot reuse the same instance after we've set the result.
-            // We also cannot use solutions like ManualResetValueTaskSourceCore, since we can have multiple waiters on the same TCS.
-            // As a result, we allocate a new TCS when needed, which is when someone explicitely asks for them in WaitForAvailableStreamsAsync.
-            public TaskCompletionSource? NewUnidirectionalStreamsAvailable;
-            public TaskCompletionSource? NewBidirectionalStreamsAvailable;
-
             public bool Connected;
             public long AbortErrorCode = -1;
             public int StreamCount;
@@ -320,26 +314,6 @@ namespace System.Net.Quic.Implementations.MsQuic
             // Stop accepting new streams.
             state.AcceptQueue.Writer.TryComplete();
 
-            // Stop notifying about available streams.
-            TaskCompletionSource? unidirectionalTcs = null;
-            TaskCompletionSource? bidirectionalTcs = null;
-            lock (state)
-            {
-                unidirectionalTcs = state.NewUnidirectionalStreamsAvailable;
-                bidirectionalTcs = state.NewBidirectionalStreamsAvailable;
-                state.NewUnidirectionalStreamsAvailable = null;
-                state.NewBidirectionalStreamsAvailable = null;
-            }
-
-            if (unidirectionalTcs is not null)
-            {
-                unidirectionalTcs.SetException(ExceptionDispatchInfo.SetCurrentStackTrace(new QuicOperationAbortedException()));
-            }
-            if (bidirectionalTcs is not null)
-            {
-                bidirectionalTcs.SetException(ExceptionDispatchInfo.SetCurrentStackTrace(new QuicOperationAbortedException()));
-            }
-
             return MsQuicStatusCodes.Success;
         }
 
@@ -358,32 +332,6 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         private static uint HandleEventStreamsAvailable(State state, ref ConnectionEvent connectionEvent)
         {
-            TaskCompletionSource? unidirectionalTcs = null;
-            TaskCompletionSource? bidirectionalTcs = null;
-            lock (state)
-            {
-                if (connectionEvent.Data.StreamsAvailable.UniDirectionalCount > 0)
-                {
-                    unidirectionalTcs = state.NewUnidirectionalStreamsAvailable;
-                    state.NewUnidirectionalStreamsAvailable = null;
-                }
-
-                if (connectionEvent.Data.StreamsAvailable.BiDirectionalCount > 0)
-                {
-                    bidirectionalTcs = state.NewBidirectionalStreamsAvailable;
-                    state.NewBidirectionalStreamsAvailable = null;
-                }
-            }
-
-            if (unidirectionalTcs is not null)
-            {
-                unidirectionalTcs.SetResult();
-            }
-            if (bidirectionalTcs is not null)
-            {
-                bidirectionalTcs.SetResult();
-            }
-
             return MsQuicStatusCodes.Success;
         }
 
@@ -515,71 +463,6 @@ namespace System.Net.Quic.Implementations.MsQuic
             }
 
             return stream;
-        }
-
-        internal override ValueTask WaitForAvailableUnidirectionalStreamsAsync(CancellationToken cancellationToken = default)
-        {
-            TaskCompletionSource? tcs = _state.NewUnidirectionalStreamsAvailable;
-            if (tcs is null)
-            {
-                // We need to avoid calling MsQuic under lock.
-                // This is not atomic but it won't be anyway as counts can change between when task is completed
-                // and before somebody may try to allocate new stream.
-                int count = GetRemoteAvailableUnidirectionalStreamCount();
-                lock (_state)
-                {
-                    if (_state.NewUnidirectionalStreamsAvailable is null)
-                    {
-                        if (_state.ShutdownTcs.Task.IsCompleted)
-                        {
-                            throw new QuicOperationAbortedException();
-                        }
-
-                        if (count > 0)
-                        {
-                            return ValueTask.CompletedTask;
-                        }
-
-                        _state.NewUnidirectionalStreamsAvailable = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                    }
-
-                    tcs = _state.NewUnidirectionalStreamsAvailable;
-                }
-            }
-
-            return new ValueTask(tcs.Task.WaitAsync(cancellationToken));
-        }
-
-        internal override ValueTask WaitForAvailableBidirectionalStreamsAsync(CancellationToken cancellationToken = default)
-        {
-            TaskCompletionSource? tcs = _state.NewBidirectionalStreamsAvailable;
-            if (tcs is null)
-            {
-                // We need to avoid calling MsQuic under lock.
-                // This is not atomic but it won't be anyway as counts can change between when task is completed
-                // and before somebody may try to allocate new stream.
-                int count = GetRemoteAvailableBidirectionalStreamCount();
-                lock (_state)
-                {
-                    if (_state.NewBidirectionalStreamsAvailable is null)
-                    {
-                        if (_state.ShutdownTcs.Task.IsCompleted)
-                        {
-                            throw new QuicOperationAbortedException();
-                        }
-
-                        if (count > 0)
-                        {
-                            return ValueTask.CompletedTask;
-                        }
-
-                        _state.NewBidirectionalStreamsAvailable = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                    }
-                    tcs = _state.NewBidirectionalStreamsAvailable;
-                }
-            }
-
-            return new ValueTask(tcs.Task.WaitAsync(cancellationToken));
         }
 
         private ValueTask<QuicStreamProvider> OpenStreamAsync(QUIC_STREAM_OPEN_FLAGS flags, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -582,32 +582,6 @@ namespace System.Net.Quic.Implementations.MsQuic
             return new ValueTask(tcs.Task.WaitAsync(cancellationToken));
         }
 
-        private QuicStreamProvider OpenStream(QUIC_STREAM_OPEN_FLAGS flags)
-        {
-            ThrowIfDisposed();
-            if (!Connected)
-            {
-                throw new InvalidOperationException(SR.net_quic_not_connected);
-            }
-
-            var stream = new MsQuicStream(_state, flags);
-
-            try
-            {
-                stream.StartAsync(QUIC_STREAM_START_FLAGS.FAIL_BLOCKED | QUIC_STREAM_START_FLAGS.SHUTDOWN_ON_FAIL | QUIC_STREAM_START_FLAGS.INDICATE_PEER_ACCEPT, default).AsTask().GetAwaiter().GetResult();
-            }
-            catch
-            {
-                stream.Dispose();
-                throw;
-            }
-
-            return stream;
-        }
-
-        internal override QuicStreamProvider OpenUnidirectionalStream() => OpenStream(QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL);
-        internal override QuicStreamProvider OpenBidirectionalStream() => OpenStream(QUIC_STREAM_OPEN_FLAGS.NONE);
-
         private async ValueTask<QuicStreamProvider> OpenStreamAsync(QUIC_STREAM_OPEN_FLAGS flags, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -473,7 +473,6 @@ namespace System.Net.Quic.Implementations.MsQuic
                 throw new InvalidOperationException(SR.net_quic_not_connected);
             }
 
-            cancellationToken.ThrowIfCancellationRequested();
             var stream = new MsQuicStream(_state, flags);
 
             try

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -894,7 +894,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             cancellationToken.ThrowIfCancellationRequested();
             using CancellationTokenRegistration registration = cancellationToken.UnsafeRegister(static (s, token) =>
             {
-                ((State)s!).StartCompletionSource.TrySetCanceled(token);
+                ((State)s!).StartCompletionSource.TrySetException(new OperationCanceledException(token));
             }, _state);
 
             uint status = MsQuicApi.Api.StreamStartDelegate(_state.Handle, flags);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -150,7 +150,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             }
         }
 
-        internal static async ValueTask<MsQuicStream> CreateOutbound(MsQuicConnection.State connectionState, CancellationToken cancellationToken)
+        internal static async ValueTask<MsQuicStream> CreateOutbound(MsQuicConnection.State connectionState, QUIC_STREAM_OPEN_FLAGS flags, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var stream = new MsQuicStream(connectionState, flags);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -150,7 +150,8 @@ namespace System.Net.Quic.Implementations.MsQuic
             }
         }
 
-        internal static async ValueTask<MsQuicStream> CreateOutbound(MsQuicConnection.State connectionState, QUIC_STREAM_OPEN_FLAGS flags, CancellationToken cancellationToken)
+        // return QuicStreamProvider to avoid async/await state machine on the caller's side just to perform the cast
+        internal static async ValueTask<QuicStreamProvider> CreateOutbound(MsQuicConnection.State connectionState, QUIC_STREAM_OPEN_FLAGS flags, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var stream = new MsQuicStream(connectionState, flags);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -1124,9 +1124,17 @@ namespace System.Net.Quic.Implementations.MsQuic
                 //   - StreamLimitReached - only if QUIC_STREAM_START_FLAG_FAIL_BLOCKED was specified (not in our case).
                 //
                 // We disregard duplicate StreamStart calls
+                if (status == MsQuicStatusCodes.Aborted)
+                {
+                    state.StartCompletionSource.SetException(
+                        ExceptionDispatchInfo.SetCurrentStackTrace(GetConnectionAbortedException(state)));
+                }
+                else
+                {
+                    state.StartCompletionSource.SetException(
+                        ExceptionDispatchInfo.SetCurrentStackTrace(new QuicException($"StreamStart finished with status{MsQuicStatusCodes.GetError(status)}")));
+                }
                 Debug.Assert(status == MsQuicStatusCodes.Aborted || status == MsQuicStatusCodes.InvalidState);
-                state.StartCompletionSource.SetException(
-                    ExceptionDispatchInfo.SetCurrentStackTrace(GetConnectionAbortedException(state)));
             }
             else if ((evt.Data.StartComplete.PeerAccepted & 1) != 0)
             {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/QuicConnectionProvider.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/QuicConnectionProvider.cs
@@ -20,10 +20,6 @@ namespace System.Net.Quic.Implementations
 
         internal abstract ValueTask WaitForAvailableBidirectionalStreamsAsync(CancellationToken cancellationToken = default);
 
-        internal abstract QuicStreamProvider OpenUnidirectionalStream();
-
-        internal abstract QuicStreamProvider OpenBidirectionalStream();
-
         internal abstract ValueTask<QuicStreamProvider> OpenUnidirectionalStreamAsync(CancellationToken cancellationToken = default);
         internal abstract ValueTask<QuicStreamProvider> OpenBidirectionalStreamAsync(CancellationToken cancellationToken = default);
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/QuicConnectionProvider.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/QuicConnectionProvider.cs
@@ -16,11 +16,8 @@ namespace System.Net.Quic.Implementations
 
         internal abstract ValueTask ConnectAsync(CancellationToken cancellationToken = default);
 
-        internal abstract ValueTask WaitForAvailableUnidirectionalStreamsAsync(CancellationToken cancellationToken = default);
-
-        internal abstract ValueTask WaitForAvailableBidirectionalStreamsAsync(CancellationToken cancellationToken = default);
-
         internal abstract ValueTask<QuicStreamProvider> OpenUnidirectionalStreamAsync(CancellationToken cancellationToken = default);
+
         internal abstract ValueTask<QuicStreamProvider> OpenBidirectionalStreamAsync(CancellationToken cancellationToken = default);
 
         internal abstract int GetRemoteAvailableUnidirectionalStreamCount();

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/QuicConnectionProvider.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/QuicConnectionProvider.cs
@@ -24,6 +24,9 @@ namespace System.Net.Quic.Implementations
 
         internal abstract QuicStreamProvider OpenBidirectionalStream();
 
+        internal abstract ValueTask<QuicStreamProvider> OpenUnidirectionalStreamAsync(CancellationToken cancellationToken = default);
+        internal abstract ValueTask<QuicStreamProvider> OpenBidirectionalStreamAsync(CancellationToken cancellationToken = default);
+
         internal abstract int GetRemoteAvailableUnidirectionalStreamCount();
 
         internal abstract int GetRemoteAvailableBidirectionalStreamCount();
@@ -32,7 +35,7 @@ namespace System.Net.Quic.Implementations
 
         internal abstract System.Net.Security.SslApplicationProtocol NegotiatedApplicationProtocol { get; }
 
-        internal abstract System.Security.Cryptography.X509Certificates.X509Certificate? RemoteCertificate { get ; }
+        internal abstract System.Security.Cryptography.X509Certificates.X509Certificate? RemoteCertificate { get; }
 
         internal abstract ValueTask CloseAsync(long errorCode, CancellationToken cancellationToken = default);
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -71,18 +71,6 @@ namespace System.Net.Quic
         public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => _provider.ConnectAsync(cancellationToken);
 
         /// <summary>
-        /// Waits for available unidirectional stream capacity to be announced by the peer. If any capacity is available, returns immediately.
-        /// </summary>
-        /// <returns></returns>
-        public ValueTask WaitForAvailableUnidirectionalStreamsAsync(CancellationToken cancellationToken = default) => _provider.WaitForAvailableUnidirectionalStreamsAsync(cancellationToken);
-
-        /// <summary>
-        /// Waits for available bidirectional stream capacity to be announced by the peer. If any capacity is available, returns immediately.
-        /// </summary>
-        /// <returns></returns>
-        public ValueTask WaitForAvailableBidirectionalStreamsAsync(CancellationToken cancellationToken = default) => _provider.WaitForAvailableBidirectionalStreamsAsync(cancellationToken);
-
-        /// <summary>
         /// Create an outbound unidirectional stream.
         /// </summary>
         /// <returns></returns>

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -86,18 +86,6 @@ namespace System.Net.Quic
         /// Create an outbound unidirectional stream.
         /// </summary>
         /// <returns></returns>
-        public QuicStream OpenUnidirectionalStream() => new QuicStream(_provider.OpenUnidirectionalStream());
-
-        /// <summary>
-        /// Create an outbound bidirectional stream.
-        /// </summary>
-        /// <returns></returns>
-        public QuicStream OpenBidirectionalStream() => new QuicStream(_provider.OpenBidirectionalStream());
-
-        /// <summary>
-        /// Create an outbound unidirectional stream.
-        /// </summary>
-        /// <returns></returns>
         public async ValueTask<QuicStream> OpenUnidirectionalStreamAsync(CancellationToken cancellationToken = default) => new QuicStream(await _provider.OpenUnidirectionalStreamAsync(cancellationToken).ConfigureAwait(false));
 
         /// <summary>

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -95,6 +95,19 @@ namespace System.Net.Quic
         public QuicStream OpenBidirectionalStream() => new QuicStream(_provider.OpenBidirectionalStream());
 
         /// <summary>
+        /// Create an outbound unidirectional stream.
+        /// </summary>
+        /// <returns></returns>
+        public async ValueTask<QuicStream> OpenUnidirectionalStreamAsync(CancellationToken cancellationToken = default) => new QuicStream(await _provider.OpenUnidirectionalStreamAsync(cancellationToken).ConfigureAwait(false));
+
+        /// <summary>
+        /// Create an outbound bidirectional stream.
+        /// </summary>
+        /// <returns></returns>
+        public async ValueTask<QuicStream> OpenBidirectionalStreamAsync(CancellationToken cancellationToken = default) => new QuicStream(await _provider.OpenBidirectionalStreamAsync(cancellationToken).ConfigureAwait(false));
+
+
+        /// <summary>
         /// Accept an incoming stream.
         /// </summary>
         /// <returns></returns>

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -502,7 +502,11 @@ namespace System.Net.Quic.Tests
             if (localAbort)
             {
                 await clientConnection.CloseAsync(0);
-                await Assert.ThrowsAsync<QuicOperationAbortedException>(() => waitTask.AsTask().WaitAsync(TimeSpan.FromSeconds(3)));
+                // TODO: This may not always throw QuicOperationAbortedException due to a data race with MsQuic worker threads
+                // (CloseAsync may be processed before OpenStreamAsync as it is scheduled to the front of the operation queue)
+                // To be revisited once we standartize on exceptions.
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/55619")]
+                await Assert.ThrowsAnyAsync<QuicException>(() => waitTask.AsTask().WaitAsync(TimeSpan.FromSeconds(3)));
             }
             else
             {

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -415,7 +415,6 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/67302")]
         public async Task WaitForAvailableBidirectionStreamsAsyncWorks()
         {
             QuicListenerOptions listenerOptions = CreateQuicListenerOptions();

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -443,7 +443,7 @@ namespace System.Net.Quic.Tests
             cts.Cancel();
 
             // awaiting the task should throw
-            var ex = await Assert.ThrowsAsync<OperationCanceledException>(() => waitTask.AsTask().WaitAsync(TimeSpan.FromSeconds(3)));
+            var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waitTask.AsTask().WaitAsync(TimeSpan.FromSeconds(3)));
             Assert.Equal(cts.Token, ex.CancellationToken);
 
             // Close the streams, the waitTask should finish as a result.
@@ -473,7 +473,7 @@ namespace System.Net.Quic.Tests
             CancellationTokenSource cts = new CancellationTokenSource();
             cts.Cancel();
 
-            var ex = await Assert.ThrowsAsync<OperationCanceledException>(() => OpenStreamAsync(clientConnection, cts.Token).AsTask().WaitAsync(TimeSpan.FromSeconds(3)));
+            var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => OpenStreamAsync(clientConnection, cts.Token).AsTask().WaitAsync(TimeSpan.FromSeconds(3)));
             Assert.Equal(cts.Token, ex.CancellationToken);
 
             clientConnection.Dispose();
@@ -482,7 +482,7 @@ namespace System.Net.Quic.Tests
 
         [Theory]
         [InlineData(false, false)]
-        [InlineData(true, true)]
+        [InlineData(true, true)] // the code path for uni/bidirectional streams differs only in a flag passed to MsQuic, so there is no need to test all possible combinations.
         public async Task OpenStreamAsync_ConnectionAbort_Throws(bool unidirectional, bool localAbort)
         {
             ValueTask<QuicStream> OpenStreamAsync(QuicConnection connection, CancellationToken token = default) => unidirectional

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -393,19 +393,13 @@ namespace System.Net.Quic.Tests
         [InlineData(true)]
         public async Task WaitForAvailableStreamsAsyncWorks(bool unidirectional)
         {
-            ValueTask WaitForAvailableStreamsAsync(QuicConnection connection)
-            {
-                return unidirectional
-                    ? connection.WaitForAvailableUnidirectionalStreamsAsync()
-                    : connection.WaitForAvailableBidirectionalStreamsAsync();
-            }
+            ValueTask WaitForAvailableStreamsAsync(QuicConnection connection) => unidirectional
+                ? connection.WaitForAvailableUnidirectionalStreamsAsync()
+                : connection.WaitForAvailableBidirectionalStreamsAsync();
 
-            ValueTask<QuicStream> OpenStreamAsync(QuicConnection connection)
-            {
-                return unidirectional
-                    ? connection.OpenUnidirectionalStreamAsync()
-                    : connection.OpenBidirectionalStreamAsync();
-            }
+            ValueTask<QuicStream> OpenStreamAsync(QuicConnection connection) => unidirectional
+                ? connection.OpenUnidirectionalStreamAsync()
+                : connection.OpenBidirectionalStreamAsync();
 
             QuicListenerOptions listenerOptions = CreateQuicListenerOptions();
             listenerOptions.MaxUnidirectionalStreams = 1;
@@ -435,12 +429,9 @@ namespace System.Net.Quic.Tests
         [InlineData(true)]
         public async Task OpenStreamAsync_BlocksUntilAvailable(bool unidirectional)
         {
-            ValueTask<QuicStream> OpenStreamAsync(QuicConnection connection)
-            {
-                return unidirectional
-                    ? connection.OpenUnidirectionalStreamAsync()
-                    : connection.OpenBidirectionalStreamAsync();
-            }
+            ValueTask<QuicStream> OpenStreamAsync(QuicConnection connection) => unidirectional
+                ? connection.OpenUnidirectionalStreamAsync()
+                : connection.OpenBidirectionalStreamAsync();
 
             QuicListenerOptions listenerOptions = CreateQuicListenerOptions();
             listenerOptions.MaxUnidirectionalStreams = 1;
@@ -469,12 +460,9 @@ namespace System.Net.Quic.Tests
         [InlineData(true)]
         public async Task OpenStreamAsync_Canceled_Throws_OperationCanceledException(bool unidirectional)
         {
-            ValueTask<QuicStream> OpenStreamAsync(QuicConnection connection, CancellationToken token = default)
-            {
-                return unidirectional
-                    ? connection.OpenUnidirectionalStreamAsync(token)
-                    : connection.OpenBidirectionalStreamAsync(token);
-            }
+            ValueTask<QuicStream> OpenStreamAsync(QuicConnection connection, CancellationToken token = default) => unidirectional
+                ? connection.OpenUnidirectionalStreamAsync(token)
+                : connection.OpenBidirectionalStreamAsync(token);
 
             QuicListenerOptions listenerOptions = CreateQuicListenerOptions();
             listenerOptions.MaxUnidirectionalStreams = 1;
@@ -512,12 +500,9 @@ namespace System.Net.Quic.Tests
         [InlineData(true)]
         public async Task OpenStreamAsync_PreCanceled_Throws_OperationCanceledException(bool unidirectional)
         {
-            ValueTask<QuicStream> OpenStreamAsync(QuicConnection connection, CancellationToken token = default)
-            {
-                return unidirectional
-                    ? connection.OpenUnidirectionalStreamAsync(token)
-                    : connection.OpenBidirectionalStreamAsync(token);
-            }
+            ValueTask<QuicStream> OpenStreamAsync(QuicConnection connection, CancellationToken token = default) => unidirectional
+                ? connection.OpenUnidirectionalStreamAsync(token)
+                : connection.OpenBidirectionalStreamAsync(token);
 
             (QuicConnection clientConnection, QuicConnection serverConnection) = await CreateConnectedQuicConnection(null, CreateQuicListenerOptions());
 
@@ -536,12 +521,9 @@ namespace System.Net.Quic.Tests
         [InlineData(true, true)]
         public async Task OpenStreamAsync_ConnectionAbort_Throws(bool unidirectional, bool localAbort)
         {
-            ValueTask<QuicStream> OpenStreamAsync(QuicConnection connection, CancellationToken token = default)
-            {
-                return unidirectional
-                    ? connection.OpenUnidirectionalStreamAsync(token)
-                    : connection.OpenBidirectionalStreamAsync(token);
-            }
+            ValueTask<QuicStream> OpenStreamAsync(QuicConnection connection, CancellationToken token = default) => unidirectional
+                ? connection.OpenUnidirectionalStreamAsync(token)
+                : connection.OpenBidirectionalStreamAsync(token);
 
             QuicListenerOptions listenerOptions = CreateQuicListenerOptions();
             listenerOptions.MaxUnidirectionalStreams = 1;

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -120,7 +120,7 @@ namespace System.Net.Quic.Tests
                     // (CloseAsync may be processed before OpenStreamAsync as it is scheduled to the front of the operation queue)
                     // To be revisited once we standartize on exceptions.
                     // [ActiveIssue("https://github.com/dotnet/runtime/issues/55619")]
-                    await Assert.ThrowsAsync<QuicOperationAbortedException>(() => connectTask);
+                    await Assert.ThrowsAnyAsync<QuicException>(() => connectTask);
 
                     // Subsequent attempts should fail
                     // TODO: Should these be QuicOperationAbortedException, to match above? Or vice-versa?

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -115,6 +115,11 @@ namespace System.Net.Quic.Tests
 
                     // Pending ops should fail
                     await Assert.ThrowsAsync<QuicOperationAbortedException>(() => acceptTask);
+
+                    // TODO: This may not always throw QuicOperationAbortedException due to a data race with MsQuic worker threads
+                    // (CloseAsync may be processed before OpenStreamAsync as it is scheduled to the front of the operation queue)
+                    // To be revisited once we standartize on exceptions.
+                    // [ActiveIssue("https://github.com/dotnet/runtime/issues/55619")]
                     await Assert.ThrowsAsync<QuicOperationAbortedException>(() => connectTask);
 
                     // Subsequent attempts should fail

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -42,7 +42,7 @@ namespace System.Net.Quic.Tests
 
         private static async Task<QuicStream> OpenAndUseStreamAsync(QuicConnection c)
         {
-            QuicStream s = c.OpenBidirectionalStream();
+            QuicStream s = await c.OpenBidirectionalStreamAsync();
 
             // This will pend
             await s.ReadAsync(new byte[1]);
@@ -199,7 +199,7 @@ namespace System.Net.Quic.Tests
             await RunClientServer(
                 async clientConnection =>
                 {
-                    using QuicStream clientStream = clientConnection.OpenBidirectionalStream();
+                    using QuicStream clientStream = await clientConnection.OpenBidirectionalStreamAsync();
                     await DoWrites(clientStream, writesBeforeClose);
 
                     // Wait for peer to receive data
@@ -246,7 +246,7 @@ namespace System.Net.Quic.Tests
             await RunClientServer(
                 async clientConnection =>
                 {
-                    using QuicStream clientStream = clientConnection.OpenBidirectionalStream();
+                    using QuicStream clientStream = await clientConnection.OpenBidirectionalStreamAsync();
                     await DoWrites(clientStream, writesBeforeClose);
 
                     // Wait for peer to receive data

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -74,7 +74,11 @@ namespace System.Net.Quic.Tests
 
                     // Pending ops should fail
                     await Assert.ThrowsAsync<QuicOperationAbortedException>(() => acceptTask);
-                    await Assert.ThrowsAsync<QuicOperationAbortedException>(() => connectTask);
+                    // TODO: This may not always throw QuicOperationAbortedException due to a data race with MsQuic worker threads
+                    // (CloseAsync may be processed before OpenStreamAsync as it is scheduled to the front of the operation queue)
+                    // To be revisited once we standartize on exceptions.
+                    // [ActiveIssue("https://github.com/dotnet/runtime/issues/55619")]
+                    await Assert.ThrowsAnyAsync<QuicException>(() => connectTask);
 
                     // Subsequent attempts should fail
                     // TODO: Which exception is correct?

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
@@ -95,7 +95,7 @@ namespace System.Net.Quic.Tests
                             listener.ListenEndPoint,
                             GetSslClientAuthenticationOptions());
                         await connection2.ConnectAsync();
-                        stream2 = connection2.OpenBidirectionalStream();
+                        stream2 = await connection2.OpenBidirectionalStreamAsync();
                         // OpenBidirectionalStream only allocates ID. We will force stream opening
                         // by Writing there and receiving data on the other side.
                         await stream2.WriteAsync(buffer);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -38,7 +38,7 @@ namespace System.Net.Quic.Tests
                 },
                 clientFunction: async connection =>
                 {
-                    await using QuicStream stream = connection.OpenBidirectionalStream();
+                    await using QuicStream stream = await connection.OpenBidirectionalStreamAsync();
 
                     await stream.WriteAsync(s_data, endStream: true);
 
@@ -89,7 +89,7 @@ namespace System.Net.Quic.Tests
                 },
                 clientFunction: async connection =>
                 {
-                    await using QuicStream stream = connection.OpenBidirectionalStream();
+                    await using QuicStream stream = await connection.OpenBidirectionalStreamAsync();
 
                     for (int i = 0; i < sendCount; i++)
                     {
@@ -135,8 +135,8 @@ namespace System.Net.Quic.Tests
                 },
                 clientFunction: async connection =>
                 {
-                    await using QuicStream stream = connection.OpenBidirectionalStream();
-                    await using QuicStream stream2 = connection.OpenBidirectionalStream();
+                    await using QuicStream stream = await connection.OpenBidirectionalStreamAsync();
+                    await using QuicStream stream2 = await connection.OpenBidirectionalStreamAsync();
 
                     await stream.WriteAsync(s_data, endStream: true);
                     await stream2.WriteAsync(s_data, endStream: true);
@@ -178,7 +178,7 @@ namespace System.Net.Quic.Tests
             static async Task MakeStreams(QuicConnection clientConnection, QuicConnection serverConnection)
             {
                 byte[] buffer = new byte[64];
-                QuicStream clientStream = clientConnection.OpenBidirectionalStream();
+                QuicStream clientStream = await clientConnection.OpenBidirectionalStreamAsync();
                 ValueTask writeTask = clientStream.WriteAsync(Encoding.UTF8.GetBytes("PING"), endStream: true);
                 ValueTask<QuicStream> acceptTask = serverConnection.AcceptStreamAsync();
                 await new Task[] { writeTask.AsTask(), acceptTask.AsTask() }.WhenAllOrAnyFailed(PassingTestTimeoutMilliseconds);
@@ -195,7 +195,7 @@ namespace System.Net.Quic.Tests
             using (clientConnection)
             using (serverConnection)
             {
-                using QuicStream clientStream = clientConnection.OpenBidirectionalStream();
+                using QuicStream clientStream = await clientConnection.OpenBidirectionalStreamAsync();
                 Assert.Equal(0, clientStream.StreamId);
 
                 // TODO: stream that is opened by client but left unaccepted by server may cause AccessViolationException in its Finalizer
@@ -233,7 +233,7 @@ namespace System.Net.Quic.Tests
                 },
                 clientFunction: async connection =>
                 {
-                    await using QuicStream stream = connection.OpenBidirectionalStream();
+                    await using QuicStream stream = await connection.OpenBidirectionalStreamAsync();
 
                     for (int pos = 0; pos < data.Length; pos += writeSize)
                     {
@@ -275,7 +275,7 @@ namespace System.Net.Quic.Tests
 
         private static async Task CreateAndTestBidirectionalStream(QuicConnection c1, QuicConnection c2)
         {
-            using QuicStream s1 = c1.OpenBidirectionalStream();
+            using QuicStream s1 = await c1.OpenBidirectionalStreamAsync();
             Assert.True(s1.CanRead);
             Assert.True(s1.CanWrite);
 
@@ -289,7 +289,7 @@ namespace System.Net.Quic.Tests
 
         private static async Task CreateAndTestUnidirectionalStream(QuicConnection c1, QuicConnection c2)
         {
-            using QuicStream s1 = c1.OpenUnidirectionalStream();
+            using QuicStream s1 = await c1.OpenUnidirectionalStreamAsync();
 
             Assert.False(s1.CanRead);
             Assert.True(s1.CanWrite);
@@ -383,7 +383,7 @@ namespace System.Net.Quic.Tests
             await RunClientServer(
                 async clientConnection =>
                 {
-                    await using QuicStream clientStream = clientConnection.OpenUnidirectionalStream();
+                    await using QuicStream clientStream = await clientConnection.OpenUnidirectionalStreamAsync();
 
                     ReadOnlyMemory<byte> sendBuffer = testBuffer;
                     while (sendBuffer.Length != 0)
@@ -511,7 +511,7 @@ namespace System.Net.Quic.Tests
                 byte[] buffer = new byte[1] { 42 };
                 const int ExpectedErrorCode = 0xfffffff;
 
-                QuicStream clientStream = clientConnection.OpenBidirectionalStream();
+                QuicStream clientStream = await clientConnection.OpenBidirectionalStreamAsync();
                 Task<QuicStream> t = serverConnection.AcceptStreamAsync().AsTask();
                 await TaskTimeoutExtensions.WhenAllOrAnyFailed(clientStream.WriteAsync(buffer).AsTask(), t, PassingTestTimeoutMilliseconds);
                 QuicStream serverStream = t.Result;
@@ -563,7 +563,7 @@ namespace System.Net.Quic.Tests
             await RunClientServer(
                 clientFunction: async connection =>
                 {
-                    await using QuicStream stream = connection.OpenUnidirectionalStream();
+                    await using QuicStream stream = await connection.OpenUnidirectionalStreamAsync();
                     stream.AbortWrite(expectedErrorCode);
                 },
                 serverFunction: async connection =>
@@ -589,7 +589,7 @@ namespace System.Net.Quic.Tests
             await RunClientServer(
                 clientFunction: async connection =>
                 {
-                    await using QuicStream stream = connection.OpenBidirectionalStream();
+                    await using QuicStream stream = await connection.OpenBidirectionalStreamAsync();
                     stream.AbortRead(expectedErrorCode);
                 },
                 serverFunction: async connection =>
@@ -613,7 +613,7 @@ namespace System.Net.Quic.Tests
             await RunClientServer(
                 clientFunction: async connection =>
                 {
-                    await using QuicStream stream = connection.OpenUnidirectionalStream();
+                    await using QuicStream stream = await connection.OpenUnidirectionalStreamAsync();
 
                     CancellationTokenSource cts = new CancellationTokenSource();
                     cts.Cancel();
@@ -655,7 +655,7 @@ namespace System.Net.Quic.Tests
             await RunClientServer(
                 clientFunction: async connection =>
                 {
-                    await using QuicStream stream = connection.OpenUnidirectionalStream();
+                    await using QuicStream stream = await connection.OpenUnidirectionalStreamAsync();
 
                     CancellationTokenSource cts = new CancellationTokenSource(500);
 
@@ -712,7 +712,7 @@ namespace System.Net.Quic.Tests
             await RunClientServer(
                 clientFunction: async connection =>
                 {
-                    QuicStream stream = connection.OpenBidirectionalStream();
+                    QuicStream stream = await connection.OpenBidirectionalStreamAsync();
                     // Force stream to open on the wire
                     await stream.WriteAsync(buffer);
                     await sem.WaitAsync();
@@ -739,9 +739,9 @@ namespace System.Net.Quic.Tests
         public async Task AbortAfterDispose_StreamCreationFlushedByDispose_Success()
         {
             await RunClientServer(
-                clientFunction: connection =>
+                clientFunction: async connection =>
                 {
-                    QuicStream stream = connection.OpenBidirectionalStream();
+                    QuicStream stream = await connection.OpenBidirectionalStreamAsync();
 
                     // dispose will flush stream creation on the wire
                     stream.Dispose();
@@ -749,8 +749,6 @@ namespace System.Net.Quic.Tests
                     // should not throw ODE on aborting
                     stream.AbortRead(1234);
                     stream.AbortWrite(5675);
-
-                    return Task.CompletedTask;
                 },
                 serverFunction: async connection =>
                 {
@@ -1005,7 +1003,7 @@ namespace System.Net.Quic.Tests
                 },
                 clientFunction: async connection =>
                 {
-                    await using QuicStream stream = connection.OpenBidirectionalStream();
+                    await using QuicStream stream = await connection.OpenBidirectionalStreamAsync();
 
                     await stream.WriteAsync(new byte[1], endStream: true);
 

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
@@ -187,7 +187,7 @@ namespace System.Net.Quic.Tests
 
         internal async Task PingPong(QuicConnection client, QuicConnection server)
         {
-            using QuicStream clientStream = client.OpenBidirectionalStream();
+            using QuicStream clientStream = await client.OpenBidirectionalStreamAsync();
             ValueTask t = clientStream.WriteAsync(s_ping);
             using QuicStream serverStream = await server.AcceptStreamAsync();
 
@@ -259,7 +259,7 @@ namespace System.Net.Quic.Tests
             await RunClientServer(
                 clientFunction: async connection =>
                 {
-                    await using QuicStream stream = bidi ? connection.OpenBidirectionalStream() : connection.OpenUnidirectionalStream();
+                    await using QuicStream stream = bidi ? await connection.OpenBidirectionalStreamAsync() : await connection.OpenUnidirectionalStreamAsync();
                     // Open(Bi|Uni)directionalStream only allocates ID. We will force stream opening
                     // by Writing there and receiving data on the other side.
                     await stream.WriteAsync(buffer);


### PR DESCRIPTION
This PR removes `Open(Uni|Bi)directionalStream` methods on `QuicConnection` and replaces them with asynchronous variants. If no stream is available, the methods block until the peer's stream limit is increased.

Most of the changes outside `MsQuicStream` and `MsQuicConnection` are just updating usages.

Fixes #67302.