### PR TITLE
Enable installation on Ubuntu 22.04 - add libssl3 dependency

### DIFF
--- a/src/installer/pkg/packaging/deb/package.targets
+++ b/src/installer/pkg/packaging/deb/package.targets
@@ -323,7 +323,7 @@
       -->
       <SharedFrameworkTokenValue
         Include="%SSL_DEPENDENCY_LIST%"
-        ReplacementString="libssl1.0.0 | libssl1.0.2 | libssl1.1" />
+        ReplacementString="libssl1.0.0 | libssl1.0.2 | libssl1.1 | libssl3" />
 
       <KnownLibIcuVersion Include="72;71;70;69;68;67;66;65;63;60;57;55;52" />
       <SharedFrameworkTokenValue


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/67658 to release/5.0.