### PR TITLE
Mark GCStressIncompatible and similar tests as out-of-proc

### DIFF
--- a/src/tests/JIT/Methodical/Arrays/lcs/lcs2_d.csproj
+++ b/src/tests/JIT/Methodical/Arrays/lcs/lcs2_d.csproj
@@ -6,6 +6,7 @@
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="lcs2.cs" />

--- a/src/tests/JIT/Methodical/Arrays/lcs/lcs2_do.csproj
+++ b/src/tests/JIT/Methodical/Arrays/lcs/lcs2_do.csproj
@@ -6,6 +6,7 @@
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="lcs2.cs" />

--- a/src/tests/JIT/Methodical/Arrays/lcs/lcs2_r.csproj
+++ b/src/tests/JIT/Methodical/Arrays/lcs/lcs2_r.csproj
@@ -6,6 +6,7 @@
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="lcs2.cs" />

--- a/src/tests/JIT/Methodical/Arrays/lcs/lcs2_ro.csproj
+++ b/src/tests/JIT/Methodical/Arrays/lcs/lcs2_ro.csproj
@@ -6,6 +6,7 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="lcs2.cs" />

--- a/src/tests/JIT/Methodical/Arrays/lcs/lcsvalbox_d.csproj
+++ b/src/tests/JIT/Methodical/Arrays/lcs/lcsvalbox_d.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/Arrays/lcs/lcsvalbox_do.csproj
+++ b/src/tests/JIT/Methodical/Arrays/lcs/lcsvalbox_do.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/Arrays/lcs/lcsvalbox_r.csproj
+++ b/src/tests/JIT/Methodical/Arrays/lcs/lcsvalbox_r.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/Arrays/lcs/lcsvalbox_ro.csproj
+++ b/src/tests/JIT/Methodical/Arrays/lcs/lcsvalbox_ro.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/Boxing/misc/concurgc_il_d.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/misc/concurgc_il_d.ilproj
@@ -4,6 +4,7 @@
     <RestorePackages>true</RestorePackages>
     <!-- The test leaves a secondary thread running -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Boxing/misc/concurgc_il_r.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/misc/concurgc_il_r.ilproj
@@ -4,6 +4,7 @@
     <RestorePackages>true</RestorePackages>
     <!-- The test leaves a secondary thread running -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_conv_il_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_conv_il_r.ilproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <MonoAotIncompatible>true</MonoAotIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/VT/port/lcs_gcref_d.csproj
+++ b/src/tests/JIT/Methodical/VT/port/lcs_gcref_d.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/VT/port/lcs_gcref_do.csproj
+++ b/src/tests/JIT/Methodical/VT/port/lcs_gcref_do.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/VT/port/lcs_gcref_r.csproj
+++ b/src/tests/JIT/Methodical/VT/port/lcs_gcref_r.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/VT/port/lcs_gcref_ro.csproj
+++ b/src/tests/JIT/Methodical/VT/port/lcs_gcref_ro.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/doublearray/dblarray1_cs_d.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray1_cs_d.csproj
@@ -7,6 +7,7 @@
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray1.cs" />

--- a/src/tests/JIT/Methodical/doublearray/dblarray1_cs_do.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray1_cs_do.csproj
@@ -7,6 +7,7 @@
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray1.cs" />

--- a/src/tests/JIT/Methodical/doublearray/dblarray1_cs_r.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray1_cs_r.csproj
@@ -7,6 +7,7 @@
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray1.cs" />

--- a/src/tests/JIT/Methodical/doublearray/dblarray1_cs_ro.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray1_cs_ro.csproj
@@ -7,6 +7,7 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray1.cs" />

--- a/src/tests/JIT/Methodical/doublearray/dblarray2_cs_d.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray2_cs_d.csproj
@@ -6,6 +6,7 @@
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray2.cs" />

--- a/src/tests/JIT/Methodical/doublearray/dblarray2_cs_do.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray2_cs_do.csproj
@@ -6,6 +6,7 @@
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray2.cs" />

--- a/src/tests/JIT/Methodical/doublearray/dblarray2_cs_r.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray2_cs_r.csproj
@@ -6,6 +6,7 @@
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray2.cs" />

--- a/src/tests/JIT/Methodical/doublearray/dblarray2_cs_ro.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray2_cs_ro.csproj
@@ -6,6 +6,7 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray2.cs" />

--- a/src/tests/JIT/Methodical/doublearray/dblarray3_cs_d.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray3_cs_d.csproj
@@ -7,6 +7,7 @@
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray3.cs" />

--- a/src/tests/JIT/Methodical/doublearray/dblarray3_cs_do.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray3_cs_do.csproj
@@ -6,6 +6,7 @@
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray3.cs" />

--- a/src/tests/JIT/Methodical/doublearray/dblarray3_cs_r.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray3_cs_r.csproj
@@ -7,6 +7,7 @@
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray3.cs" />

--- a/src/tests/JIT/Methodical/doublearray/dblarray3_cs_ro.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray3_cs_ro.csproj
@@ -7,6 +7,7 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray3.cs" />

--- a/src/tests/JIT/Methodical/doublearray/dblarray4_cs_d.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray4_cs_d.csproj
@@ -7,6 +7,7 @@
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray4.cs" />

--- a/src/tests/JIT/Methodical/doublearray/dblarray4_cs_do.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray4_cs_do.csproj
@@ -7,6 +7,7 @@
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray4.cs" />

--- a/src/tests/JIT/Methodical/doublearray/dblarray4_cs_r.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray4_cs_r.csproj
@@ -7,6 +7,7 @@
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray4.cs" />

--- a/src/tests/JIT/Methodical/doublearray/dblarray4_cs_ro.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray4_cs_ro.csproj
@@ -7,6 +7,7 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray4.cs" />

--- a/src/tests/JIT/Methodical/eh/deadcode/deadoponerrorinfunclet_il_d.ilproj
+++ b/src/tests/JIT/Methodical/eh/deadcode/deadoponerrorinfunclet_il_d.ilproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <MonoAotIncompatible>true</MonoAotIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/eh/deadcode/deadoponerrorinfunclet_il_r.ilproj
+++ b/src/tests/JIT/Methodical/eh/deadcode/deadoponerrorinfunclet_il_r.ilproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <MonoAotIncompatible>true</MonoAotIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i1_d.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <!-- TestAssemblyLoadContext.Load called from the finalizer -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i1_r.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <!-- TestAssemblyLoadContext.Load called from the finalizer -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/fp/exgen/10w5d_cs_d.csproj
+++ b/src/tests/JIT/Methodical/fp/exgen/10w5d_cs_d.csproj
@@ -4,6 +4,7 @@
     <!-- NOTE: this test simply takes too long to complete under GC stress/heap verify; it is not fundamentally incompatible -->
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'x86'">true</GCStressIncompatible>
     <HeapVerifyIncompatible>true</HeapVerifyIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/fp/exgen/10w5d_cs_r.csproj
+++ b/src/tests/JIT/Methodical/fp/exgen/10w5d_cs_r.csproj
@@ -4,6 +4,7 @@
     <!-- NOTE: this test simply takes too long to complete under GC stress/heap verify; it is not fundamentally incompatible -->
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'x86'">true</GCStressIncompatible>
     <HeapVerifyIncompatible>true</HeapVerifyIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/refany/stress1_d.csproj
+++ b/src/tests/JIT/Methodical/refany/stress1_d.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/refany/stress1_r.csproj
+++ b/src/tests/JIT/Methodical/refany/stress1_r.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/refany/stress1_ro.csproj
+++ b/src/tests/JIT/Methodical/refany/stress1_ro.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/refany/virtcall_d.csproj
+++ b/src/tests/JIT/Methodical/refany/virtcall_d.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/refany/virtcall_do.csproj
+++ b/src/tests/JIT/Methodical/refany/virtcall_do.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/refany/virtcall_r.csproj
+++ b/src/tests/JIT/Methodical/refany/virtcall_r.csproj
@@ -2,11 +2,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="virtcall.cs" />

--- a/src/tests/JIT/Methodical/refany/virtcall_ro.csproj
+++ b/src/tests/JIT/Methodical/refany/virtcall_ro.csproj
@@ -6,6 +6,7 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="virtcall.cs" />

--- a/src/tests/JIT/Methodical/tailcall/Desktop/thread-race_r.csproj
+++ b/src/tests/JIT/Methodical/tailcall/Desktop/thread-race_r.csproj
@@ -3,6 +3,7 @@
     <!-- NOTE: this test simply takes too long to complete under heap verify or GCStress. It is not fundamentally incompatible. -->
     <HeapVerifyIncompatible>true</HeapVerifyIncompatible>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <IsLongRunningGCTest>true</IsLongRunningGCTest>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/tailcall_v4/hijacking.ilproj
+++ b/src/tests/JIT/Methodical/tailcall_v4/hijacking.ilproj
@@ -6,6 +6,7 @@
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'OSX'">true</GCStressIncompatible>
     <!-- NOTE: this test simply takes too long to complete under heap verify. It is not fundamentally incompatible. -->
     <HeapVerifyIncompatible Condition="'$(TargetArchitecture)' == 'x86'">true</HeapVerifyIncompatible>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>


### PR DESCRIPTION
According to current architecture we must mark conditionally
enabled tests as out of process because the special conditions
are tested in their individual execution scripts that are skipped
for ordinary merged tests.

Thanks

Tomas