### PR TITLE
avoid using TcpClient in FtpWebRequest

### DIFF
--- a/src/libraries/System.Net.Requests/src/System/Net/CommandStream.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/CommandStream.cs
@@ -36,7 +36,7 @@ namespace System.Net
         private ResponseDescription? _currentResponseDescription;
         protected string? _abortReason;
 
-        internal CommandStream(TcpClient client)
+        internal CommandStream(NetworkStream client)
             : base(client)
         {
             _decoder = _encoding.GetDecoder();

--- a/src/libraries/System.Net.Requests/src/System/Net/FtpControlStream.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FtpControlStream.cs
@@ -76,7 +76,7 @@ namespace System.Net
         private static readonly AsyncCallback s_connectCallbackDelegate = new AsyncCallback(ConnectCallback);
         private static readonly AsyncCallback s_SSLHandshakeCallback = new AsyncCallback(SSLHandshakeCallback);
 
-        internal FtpControlStream(TcpClient client)
+        internal FtpControlStream(NetworkStream client)
             : base(client)
         {
         }

--- a/src/libraries/System.Net.Requests/src/System/Net/FtpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FtpWebRequest.cs
@@ -958,9 +958,9 @@ namespace System.Net
             object result;
             try
             {
-                var client = new TcpClient();
+                var client = new Socket(SocketType.Stream, ProtocolType.Tcp);
                 await client.ConnectAsync(_uri.Host, _uri.Port).ConfigureAwait(false);
-                result = new FtpControlStream(client);
+                result = new FtpControlStream(new NetworkStream(client, true));
             }
             catch (Exception e)
             {
@@ -975,7 +975,7 @@ namespace System.Net
             string hostname = _uri.Host;
             int port = _uri.Port;
 
-            TcpClient client = new TcpClient();
+            var client = new Socket(SocketType.Stream, ProtocolType.Tcp); ;
 
             try
             {
@@ -986,7 +986,7 @@ namespace System.Net
                 throw TranslateConnectException(e);
             }
 
-            return new FtpControlStream(client);
+            return new FtpControlStream(new NetworkStream(client, true));
         }
 
         private Stream? TimedSubmitRequestHelper(bool isAsync)

--- a/src/libraries/System.Net.Requests/src/System/Net/FtpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FtpWebRequest.cs
@@ -960,7 +960,7 @@ namespace System.Net
             {
                 var client = new Socket(SocketType.Stream, ProtocolType.Tcp);
                 await client.ConnectAsync(_uri.Host, _uri.Port).ConfigureAwait(false);
-                result = new FtpControlStream(new NetworkStream(client, true));
+                result = new FtpControlStream(new NetworkStream(client, ownsSocket: true));
             }
             catch (Exception e)
             {
@@ -975,7 +975,7 @@ namespace System.Net
             string hostname = _uri.Host;
             int port = _uri.Port;
 
-            var client = new Socket(SocketType.Stream, ProtocolType.Tcp); ;
+            var client = new Socket(SocketType.Stream, ProtocolType.Tcp);
 
             try
             {
@@ -986,7 +986,7 @@ namespace System.Net
                 throw TranslateConnectException(e);
             }
 
-            return new FtpControlStream(new NetworkStream(client, true));
+            return new FtpControlStream(new NetworkStream(client, ownsSocket: true));
         }
 
         private Stream? TimedSubmitRequestHelper(bool isAsync)

--- a/src/libraries/System.Net.Requests/src/System/Net/NetworkStreamWrapper.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/NetworkStreamWrapper.cs
@@ -10,13 +10,11 @@ namespace System.Net
 {
     internal class NetworkStreamWrapper : Stream
     {
-        private readonly TcpClient _client;
         private NetworkStream _networkStream;
 
-        internal NetworkStreamWrapper(TcpClient client)
+        internal NetworkStreamWrapper(NetworkStream stream)
         {
-            _client = client;
-            _networkStream = client.GetStream();
+            _networkStream = stream;
         }
 
         protected bool UsingSecureStream
@@ -39,7 +37,7 @@ namespace System.Net
         {
             get
             {
-                return _client.Client;
+                return _networkStream.Socket;
             }
         }
 
@@ -165,13 +163,11 @@ namespace System.Net
         internal void CloseSocket()
         {
             _networkStream.Close();
-            _client.Dispose();
         }
 
         public void Close(int timeout)
         {
             _networkStream.Close(timeout);
-            _client.Dispose();
         }
 
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int size, AsyncCallback? callback, object? state)


### PR DESCRIPTION
To point made in  #63162 - TcpClient is really useless in most cases. In this case it really does not provide anything beyond `GetStream()` and it costs extra object to be allocated. 