### PR TITLE
Fix error message for invalid assembly name

### DIFF
--- a/src/coreclr/dlls/mscorrc/mscorrc.rc
+++ b/src/coreclr/dlls/mscorrc/mscorrc.rc
@@ -120,7 +120,7 @@ BEGIN
     FUSION_E_SIGNATURE_CHECK_FAILED         "Strong name signature verification failed for assembly '%1'.  The assembly may have been tampered with, or it was delay signed but not fully signed with the correct private key."
     COR_E_MODULE_HASH_CHECK_FAILED          "The check of the module's hash failed for file '%1'."
     FUSION_E_PRIVATE_ASM_DISALLOWED         "Assembly '%1' is required to be strongly named."
-    FUSION_E_INVALID_NAME                   "The given assembly name or codebase, '%1', was invalid."
+    FUSION_E_INVALID_NAME                   "The given assembly name, '%1', was invalid."
     FUSION_E_ASM_MODULE_MISSING             "A module specified in the manifest of assembly '%1' could not be found."
     FUSION_E_CODE_DOWNLOAD_DISABLED         "HTTP download of assemblies has been disabled for this appdomain."
     FUSION_E_HOST_GAC_ASM_MISMATCH          "The assembly returned from the host store has a different strong name signature than the corresponding one in GAC. Assembly: '%1'"

--- a/src/coreclr/inc/corerror.xml
+++ b/src/coreclr/inc/corerror.xml
@@ -246,8 +246,8 @@
 
 <HRESULT NumericValue="0x80131047">
 	<SymbolicName>FUSION_E_INVALID_NAME</SymbolicName>
-	<Message>"The given assembly name or codebase was invalid."</Message>
-	<Comment> The given assembly name or codebase was invalid. </Comment>
+	<Message>"The given assembly name was invalid."</Message>
+	<Comment> The given assembly name was invalid. </Comment>
 </HRESULT>
 
 <HRESULT NumericValue="0x80131048">

--- a/src/coreclr/pal/prebuilt/corerror/mscorurt.rc
+++ b/src/coreclr/pal/prebuilt/corerror/mscorurt.rc
@@ -26,7 +26,7 @@ BEGIN
 	MSG_FOR_URT_HR(FUSION_E_ASM_MODULE_MISSING) "A module specified in the manifest was not found."
 	MSG_FOR_URT_HR(FUSION_E_PRIVATE_ASM_DISALLOWED) "A strongly-named assembly is required."
 	MSG_FOR_URT_HR(FUSION_E_SIGNATURE_CHECK_FAILED) "Strong name signature could not be verified.  The assembly may have been tampered with, or it was delay signed but not fully signed with the correct private key."
-	MSG_FOR_URT_HR(FUSION_E_INVALID_NAME) "The given assembly name or codebase was invalid."
+	MSG_FOR_URT_HR(FUSION_E_INVALID_NAME) "The given assembly name was invalid."
 	MSG_FOR_URT_HR(FUSION_E_CODE_DOWNLOAD_DISABLED) "HTTP download of assemblies has been disabled for this appdomain."
 	MSG_FOR_URT_HR(FUSION_E_HOST_GAC_ASM_MISMATCH) "Assembly in host store has a different signature than assembly in GAC."
 	MSG_FOR_URT_HR(FUSION_E_LOADFROM_BLOCKED) "LoadFrom(), LoadFile(), Load(byte[]) and LoadModule() have been disabled by the host."

--- a/src/installer/tests/HostActivation.Tests/StartupHooks.cs
+++ b/src/installer/tests/HostActivation.Tests/StartupHooks.cs
@@ -341,7 +341,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute(fExpectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining(string.Format(expectedError, startupHookVar))
-                .And.HaveStdErrContaining("---> System.IO.FileLoadException: The given assembly name or codebase was invalid.");
+                .And.HaveStdErrContaining("---> System.IO.FileLoadException: The given assembly name was invalid.");
 
             // Relative path error is caught before any hooks run
             startupHookVar = startupHookDll + Path.PathSeparator + relativeAssemblyPath;

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1102,7 +1102,7 @@
     <value>Target array type is not compatible with the type of items in the collection.</value>
   </data>
   <data name="InvalidAssemblyName" xml:space="preserve">
-    <value>The given assembly name or codebase was invalid.</value>
+    <value>The given assembly name was invalid.</value>
   </data>
   <data name="Argument_InvalidCalendar" xml:space="preserve">
     <value>Not a valid calendar for the given culture.</value>


### PR DESCRIPTION
The error message is always used for invalid assembly name. Delete mention of codebase to avoid confusion.