### PR TITLE
Fix sos.eeheap's LoaderCodeHeap sizes

### DIFF
--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -3447,7 +3447,7 @@ ClrDataAccess::TraverseLoaderHeap(CLRDATA_ADDRESS loaderHeapAddr, VISITHEAP pFun
 
     SOSDacEnter();
 
-    LoaderHeap *pLoaderHeap = PTR_LoaderHeap(TO_TADDR(loaderHeapAddr));
+    ExplicitControlLoaderHeap *pLoaderHeap = PTR_ExplicitControlLoaderHeap(TO_TADDR(loaderHeapAddr));
     PTR_LoaderHeapBlock block = pLoaderHeap->m_pFirstBlock;
     while (block.IsValid())
     {


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/58067