### PR TITLE
AddUserSecrets fails in environments without generic env var and OS special folders

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/src/PathHelper.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/src/PathHelper.cs
@@ -25,6 +25,22 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
         /// <returns>The full path to the secret file.</returns>
         public static string GetSecretsPathFromSecretsId(string userSecretsId)
         {
+            return InternalGetSecretsPathFromSecretsId(userSecretsId, throwIfNoRoot: true);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Returns the path to the JSON file that stores user secrets or throws exception if not found.
+        /// </para>
+        /// <para>
+        /// This uses the current user profile to locate the secrets file on disk in a location outside of source control.
+        /// </para>
+        /// </summary>
+        /// <param name="userSecretsId">The user secret ID.</param>
+        /// <param name="throwIfNoRoot">specifies if an exception should be thrown when no root for user secrets is found</param>
+        /// <returns>The full path to the secret file.</returns>
+        internal static string InternalGetSecretsPathFromSecretsId(string userSecretsId, bool throwIfNoRoot)
+        {
             if (string.IsNullOrEmpty(userSecretsId))
             {
                 throw new ArgumentException(SR.Common_StringNullOrEmpty, nameof(userSecretsId));
@@ -52,7 +68,12 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
 
             if (string.IsNullOrEmpty(root))
             {
-                throw new InvalidOperationException(SR.Format(SR.Error_Missing_UserSecretsLocation, userSecretsFallbackDir));
+                if (throwIfNoRoot)
+                {
+                    throw new InvalidOperationException(SR.Format(SR.Error_Missing_UserSecretsLocation, userSecretsFallbackDir));
+                }
+
+                return string.Empty;
             }
 
             return !string.IsNullOrEmpty(appData)

--- a/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/src/UserSecretsConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/src/UserSecretsConfigurationExtensions.cs
@@ -169,11 +169,16 @@ namespace Microsoft.Extensions.Configuration
             ThrowHelper.ThrowIfNull(configuration);
             ThrowHelper.ThrowIfNull(userSecretsId);
 
-            return AddSecretsFile(configuration, PathHelper.GetSecretsPathFromSecretsId(userSecretsId), optional, reloadOnChange);
+            return AddSecretsFile(configuration, PathHelper.InternalGetSecretsPathFromSecretsId(userSecretsId, throwIfNoRoot: !optional), optional, reloadOnChange);
         }
 
         private static IConfigurationBuilder AddSecretsFile(IConfigurationBuilder configuration, string secretPath, bool optional, bool reloadOnChange)
         {
+            if (string.IsNullOrEmpty(secretPath))
+            {
+                return configuration;
+            }
+
             string? directoryPath = Path.GetDirectoryName(secretPath);
             PhysicalFileProvider? fileProvider = Directory.Exists(directoryPath)
                 ? new PhysicalFileProvider(directoryPath)


### PR DESCRIPTION
Fixes #66219

I could not add unit test : I need to remove special folders (%APPDATA%, %USERPROFILE% in windows) from build machine OS to force using user secrets file