### PR TITLE
[release/6.0] Handle parameterless ctors in structs in STJ's ReflectionEmitMemberAccessor

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -9,7 +9,8 @@
     <Nullable>enable</Nullable>
     <IncludeInternalObsoleteAttribute>true</IncludeInternalObsoleteAttribute>
     <IsPackable>true</IsPackable>
-    <ServicingVersion>4</ServicingVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>5</ServicingVersion>
     <PackageDescription>Provides high-performance and low-allocating types that serialize objects to JavaScript Object Notation (JSON) text and deserialize JSON text to objects, with UTF-8 support built-in. Also provides types to read and write JSON text encoded as UTF-8, and to create an in-memory document object model (DOM), that is read-only, for random access of the JSON elements within a structured view of the data.
 
 Commonly Used Types:

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitMemberAccessor.cs
@@ -49,6 +49,11 @@ namespace System.Text.Json.Serialization.Metadata
             else
             {
                 generator.Emit(OpCodes.Newobj, realMethod);
+                if (type.IsValueType)
+                {
+                    // Since C# 10 it's now possible to have parameterless constructors in structs
+                    generator.Emit(OpCodes.Box, type);
+                }
             }
 
             generator.Emit(OpCodes.Ret);

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
@@ -1354,6 +1354,7 @@ namespace System.Text.Json.Serialization.Tests
 
         public struct StructWithPropertyInit
         {
+            public StructWithPropertyInit() {}
             public long A { get; set; } = 42;
             public long B { get; set; }
         }
@@ -1369,6 +1370,7 @@ namespace System.Text.Json.Serialization.Tests
 
         public struct StructWithFieldInit
         {
+            public StructWithFieldInit() {}
             public long A;
             public long B = 42;
         }

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
@@ -1356,7 +1356,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             public StructWithPropertyInit() {}
             public long A { get; set; } = 42;
-            public long B { get; set; }
+            public long B { get; set; } = 0;
         }
 
         [Fact]
@@ -1371,7 +1371,7 @@ namespace System.Text.Json.Serialization.Tests
         public struct StructWithFieldInit
         {
             public StructWithFieldInit() {}
-            public long A;
+            public long A = 0;
             public long B = 42;
         }
 

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
@@ -1324,6 +1324,69 @@ namespace System.Text.Json.Serialization.Tests
             public ClassWithIgnoredSameType(ClassWithIgnoredSameType prop) { }
         }
 
+        [Fact]
+        public void StructWithPropertyInit_DeseralizeEmptyObject()
+        {
+            string json = @"{}";
+            var obj = JsonSerializer.Deserialize<StructWithPropertyInit>(json);
+            Assert.Equal(42, obj.A);
+            Assert.Equal(0, obj.B);
+        }
+
+        [Fact]
+        public void StructWithPropertyInit_OverrideInitedProperty()
+        {
+            string json = @"{""A"":43}";
+            var obj = JsonSerializer.Deserialize<StructWithPropertyInit>(json);
+            Assert.Equal(43, obj.A);
+            Assert.Equal(0, obj.B);
+            
+            json = @"{""A"":0,""B"":44}";
+            obj = JsonSerializer.Deserialize<StructWithPropertyInit>(json);
+            Assert.Equal(0, obj.A);
+            Assert.Equal(44, obj.B);
+            
+            json = @"{""B"":45}";
+            obj = JsonSerializer.Deserialize<StructWithPropertyInit>(json);
+            Assert.Equal(42, obj.A); // JSON doesn't set A property so it's expected to be 42
+            Assert.Equal(45, obj.B);
+        }
+
+        public struct StructWithPropertyInit
+        {
+            public long A { get; set; } = 42;
+            public long B { get; set; }
+        }
+
+        [Fact]
+        public void StructWithFieldInit_DeseralizeEmptyObject()
+        {
+            string json = @"{}";
+            var obj = JsonSerializer.Deserialize<StructWithFieldInit>(json);
+            Assert.Equal(0, obj.A);
+            Assert.Equal(42, obj.B);
+        }
+
+        public struct StructWithFieldInit
+        {
+            public long A;
+            public long B = 42;
+        }
+
+        [Fact]
+        public void StructWithExplicitParameterlessCtor_DeseralizeEmptyObject()
+        {
+            string json = @"{}";
+            var obj = JsonSerializer.Deserialize<StructWithExplicitParameterlessCtor>(json);
+            Assert.Equal(42, obj.A);
+        }
+
+        public struct StructWithExplicitParameterlessCtor
+        {
+            public long A;
+            public StructWithExplicitParameterlessCtor() => A = 42;
+        }
+
         public async Task TestClassWithDefaultCtorParams()
         {
             ClassWithDefaultCtorParams obj = new ClassWithDefaultCtorParams(


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/62989

## Customer Impact
Structs with field initializations ([C#10 feature](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/parameterless-struct-constructors)) can cause NRE or AVE exceptions(crashes), minimal repro:
```csharp
JsonSerializer.Deserialize<Foo>("{}");

public struct Foo
{
    public Foo() {}
    public float A = 1;
}
```
causes `AccessViolationException`. There are two bug reports by users against 6.0: https://github.com/dotnet/runtime/issues/62983 and https://github.com/dotnet/runtime/issues/67781
This PR fixes this behaviour.


## Testing
This PR adds tests

## Risk

low

cc @eiriktsarpalis @danmoseley 
