### PR TITLE
Add RegexFindOptimization for embedded strings

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -490,29 +490,25 @@ namespace System.Text.RegularExpressions.Generator
                     // Emit the code for whatever find mode has been determined.
                     switch (regexTree.FindOptimizations.FindMode)
                     {
-                        case FindNextStartingPositionMode.LeadingPrefix_LeftToRight:
-                            Debug.Assert(!string.IsNullOrEmpty(regexTree.FindOptimizations.LeadingPrefix));
-                            EmitIndexOf_LeftToRight(regexTree.FindOptimizations.LeadingPrefix);
+                        case FindNextStartingPositionMode.LeadingString_LeftToRight:
+                        case FindNextStartingPositionMode.FixedDistanceString_LeftToRight:
+                            EmitIndexOf_LeftToRight();
                             break;
 
-                        case FindNextStartingPositionMode.LeadingPrefix_RightToLeft:
-                            Debug.Assert(!string.IsNullOrEmpty(regexTree.FindOptimizations.LeadingPrefix));
-                            EmitIndexOf_RightToLeft(regexTree.FindOptimizations.LeadingPrefix);
+                        case FindNextStartingPositionMode.LeadingString_RightToLeft:
+                            EmitIndexOf_RightToLeft();
                             break;
 
                         case FindNextStartingPositionMode.LeadingSet_LeftToRight:
-                        case FindNextStartingPositionMode.FixedSets_LeftToRight:
-                            Debug.Assert(regexTree.FindOptimizations.FixedDistanceSets is { Count: > 0 });
+                        case FindNextStartingPositionMode.FixedDistanceSets_LeftToRight:
                             EmitFixedSet_LeftToRight();
                             break;
 
                         case FindNextStartingPositionMode.LeadingSet_RightToLeft:
-                            Debug.Assert(regexTree.FindOptimizations.FixedDistanceSets is { Count: > 0 });
                             EmitFixedSet_RightToLeft();
                             break;
 
                         case FindNextStartingPositionMode.LiteralAfterLoop_LeftToRight:
-                            Debug.Assert(regexTree.FindOptimizations.LiteralAfterLoop is not null);
                             EmitLiteralAfterAtomicLoop();
                             break;
 
@@ -712,12 +708,40 @@ namespace System.Text.RegularExpressions.Generator
                 return false;
             }
 
-            // Emits a case-sensitive prefix search for a string at the beginning of the pattern.
-            void EmitIndexOf_LeftToRight(string prefix)
+            // Emits a case-sensitive left-to-right search for a substring.
+            void EmitIndexOf_LeftToRight()
             {
-                writer.WriteLine($"// The pattern begins with a literal {Literal(prefix)}. Find the next occurrence.");
+                RegexFindOptimizations opts = regexTree.FindOptimizations;
+
+                string substring = "";
+                string offset = "";
+                string offsetDescription = "at the beginning of the pattern";
+
+                switch (opts.FindMode)
+                {
+                    case FindNextStartingPositionMode.LeadingString_LeftToRight:
+                        substring = regexTree.FindOptimizations.LeadingPrefix;
+                        Debug.Assert(!string.IsNullOrEmpty(substring));
+                        break;
+
+                    case FindNextStartingPositionMode.FixedDistanceString_LeftToRight:
+                        Debug.Assert(!string.IsNullOrEmpty(regexTree.FindOptimizations.FixedDistanceLiteral.String));
+                        substring = regexTree.FindOptimizations.FixedDistanceLiteral.String;
+                        if (regexTree.FindOptimizations.FixedDistanceLiteral is { Distance: > 0 } literal)
+                        {
+                            offset = $" + {literal.Distance}";
+                            offsetDescription = $" at index {literal.Distance} in the pattern";
+                        }
+                        break;
+
+                    default:
+                        Debug.Fail($"Unexpected mode: {opts.FindMode}");
+                        break;
+                }
+
+                writer.WriteLine($"// The pattern has the literal {Literal(substring)} {offsetDescription}. Find the next occurrence.");
                 writer.WriteLine($"// If it can't be found, there's no match.");
-                writer.WriteLine($"int i = inputSpan.Slice(pos).IndexOf({Literal(prefix)});");
+                writer.WriteLine($"int i = inputSpan.Slice(pos{offset}).IndexOf({Literal(substring)});");
                 using (EmitBlock(writer, "if (i >= 0)"))
                 {
                     writer.WriteLine("base.runtextpos = pos + i;");
@@ -725,9 +749,11 @@ namespace System.Text.RegularExpressions.Generator
                 }
             }
 
-            // Emits a case-sensitive right-to-left prefix search for a string at the beginning of the pattern.
-            void EmitIndexOf_RightToLeft(string prefix)
+            // Emits a case-sensitive right-to-left search for a substring.
+            void EmitIndexOf_RightToLeft()
             {
+                string prefix = regexTree.FindOptimizations.LeadingPrefix;
+
                 writer.WriteLine($"// The pattern begins with a literal {Literal(prefix)}. Find the next occurrence right-to-left.");
                 writer.WriteLine($"// If it can't be found, there's no match.");
                 writer.WriteLine($"pos = inputSpan.Slice(0, pos).LastIndexOf({Literal(prefix)});");
@@ -742,6 +768,8 @@ namespace System.Text.RegularExpressions.Generator
             // and potentially other sets at other fixed positions in the pattern.
             void EmitFixedSet_LeftToRight()
             {
+                Debug.Assert(regexTree.FindOptimizations.FixedDistanceSets is { Count: > 0 });
+
                 List<(char[]? Chars, string Set, int Distance)>? sets = regexTree.FindOptimizations.FixedDistanceSets;
                 (char[]? Chars, string Set, int Distance) primarySet = sets![0];
                 const int MaxSets = 4;
@@ -865,6 +893,8 @@ namespace System.Text.RegularExpressions.Generator
             // (Currently that position will always be a distance of 0, meaning the start of the pattern itself.)
             void EmitFixedSet_RightToLeft()
             {
+                Debug.Assert(regexTree.FindOptimizations.FixedDistanceSets is { Count: > 0 });
+
                 (char[]? Chars, string Set, int Distance) set = regexTree.FindOptimizations.FixedDistanceSets![0];
                 Debug.Assert(set.Distance == 0);
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -417,29 +417,25 @@ namespace System.Text.RegularExpressions
             // Either anchors weren't specified, or they don't completely root all matches to a specific location.
             switch (_regexTree.FindOptimizations.FindMode)
             {
-                case FindNextStartingPositionMode.LeadingPrefix_LeftToRight:
-                    Debug.Assert(!string.IsNullOrEmpty(_regexTree.FindOptimizations.LeadingPrefix));
-                    EmitIndexOf_LeftToRight(_regexTree.FindOptimizations.LeadingPrefix);
+                case FindNextStartingPositionMode.LeadingString_LeftToRight:
+                case FindNextStartingPositionMode.FixedDistanceString_LeftToRight:
+                    EmitIndexOf_LeftToRight();
                     break;
 
-                case FindNextStartingPositionMode.LeadingPrefix_RightToLeft:
-                    Debug.Assert(!string.IsNullOrEmpty(_regexTree.FindOptimizations.LeadingPrefix));
-                    EmitIndexOf_RightToLeft(_regexTree.FindOptimizations.LeadingPrefix);
+                case FindNextStartingPositionMode.LeadingString_RightToLeft:
+                    EmitIndexOf_RightToLeft();
                     break;
 
                 case FindNextStartingPositionMode.LeadingSet_LeftToRight:
-                case FindNextStartingPositionMode.FixedSets_LeftToRight:
-                    Debug.Assert(_regexTree.FindOptimizations.FixedDistanceSets is { Count: > 0 });
+                case FindNextStartingPositionMode.FixedDistanceSets_LeftToRight:
                     EmitFixedSet_LeftToRight();
                     break;
 
                 case FindNextStartingPositionMode.LeadingSet_RightToLeft:
-                    Debug.Assert(_regexTree.FindOptimizations.FixedDistanceSets is { Count: > 0 });
                     EmitFixedSet_RightToLeft();
                     break;
 
                 case FindNextStartingPositionMode.LiteralAfterLoop_LeftToRight:
-                    Debug.Assert(_regexTree.FindOptimizations.LiteralAfterLoop is not null);
                     EmitLiteralAfterAtomicLoop();
                     break;
 
@@ -707,16 +703,27 @@ namespace System.Text.RegularExpressions
                 return false;
             }
 
-            // Emits a case-sensitive prefix search for a string at the beginning of the pattern.
-            void EmitIndexOf_LeftToRight(string prefix)
+            // Emits a case-sensitive left-to-right search for a substring.
+            void EmitIndexOf_LeftToRight()
             {
+                RegexFindOptimizations opts = _regexTree.FindOptimizations;
+                Debug.Assert(opts.FindMode is FindNextStartingPositionMode.LeadingString_LeftToRight or FindNextStartingPositionMode.FixedDistanceString_LeftToRight);
+
                 using RentedLocalBuilder i = RentInt32Local();
 
                 // int i = inputSpan.Slice(pos).IndexOf(prefix);
                 Ldloca(inputSpan);
                 Ldloc(pos);
+                if (opts.FindMode == FindNextStartingPositionMode.FixedDistanceString_LeftToRight &&
+                    opts.FixedDistanceLiteral is { Distance: > 0 } literal)
+                {
+                    Ldc(literal.Distance);
+                    Add();
+                }
                 Call(s_spanSliceIntMethod);
-                Ldstr(prefix);
+                Ldstr(opts.FindMode == FindNextStartingPositionMode.LeadingString_LeftToRight ?
+                    opts.LeadingPrefix :
+                    opts.FixedDistanceLiteral.String!);
                 Call(s_stringAsSpanMethod);
                 Call(s_spanIndexOfSpan);
                 Stloc(i);
@@ -737,9 +744,12 @@ namespace System.Text.RegularExpressions
                 Ret();
             }
 
-            // Emits a case-sensitive right-to-left prefix search for a string at the beginning of the pattern.
-            void EmitIndexOf_RightToLeft(string prefix)
+            // Emits a case-sensitive right-to-left search for a substring.
+            void EmitIndexOf_RightToLeft()
             {
+                string prefix = _regexTree.FindOptimizations.LeadingPrefix;
+                Debug.Assert(!string.IsNullOrEmpty(prefix));
+
                 // pos = inputSpan.Slice(0, pos).LastIndexOf(prefix);
                 Ldloca(inputSpan);
                 Ldc(0);
@@ -770,6 +780,8 @@ namespace System.Text.RegularExpressions
             // and potentially other sets at other fixed positions in the pattern.
             void EmitFixedSet_LeftToRight()
             {
+                Debug.Assert(_regexTree.FindOptimizations.FixedDistanceSets is { Count: > 0 });
+
                 List<(char[]? Chars, string Set, int Distance)>? sets = _regexTree.FindOptimizations.FixedDistanceSets;
                 (char[]? Chars, string Set, int Distance) primarySet = sets![0];
                 const int MaxSets = 4;
@@ -967,6 +979,8 @@ namespace System.Text.RegularExpressions
             // (Currently that position will always be a distance of 0, meaning the start of the pattern itself.)
             void EmitFixedSet_RightToLeft()
             {
+                Debug.Assert(_regexTree.FindOptimizations.FixedDistanceSets is { Count: > 0 });
+
                 (char[]? Chars, string Set, int Distance) set = _regexTree.FindOptimizations.FixedDistanceSets![0];
                 Debug.Assert(set.Distance == 0);
 

--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexFindOptimizationsTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexFindOptimizationsTests.cs
@@ -58,7 +58,7 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData(@"abc\z", RegexOptions.None, (int)FindNextStartingPositionMode.TrailingAnchor_FixedLength_LeftToRight_End, 3, (int)RegexNodeKind.End)]
         [InlineData(@"abc\Z", RegexOptions.None, (int)FindNextStartingPositionMode.TrailingAnchor_FixedLength_LeftToRight_EndZ, 3, (int)RegexNodeKind.EndZ)]
         [InlineData(@"abc$", RegexOptions.None, (int)FindNextStartingPositionMode.TrailingAnchor_FixedLength_LeftToRight_EndZ, 3, (int)RegexNodeKind.EndZ)]
-        [InlineData(@"a{4,10}$", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingPrefix_LeftToRight, 10, (int)RegexNodeKind.EndZ)]
+        [InlineData(@"a{4,10}$", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, 10, (int)RegexNodeKind.EndZ)]
         [InlineData(@"(abc|defg){1,2}\z", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingSet_LeftToRight, 8, (int)RegexNodeKind.End)]
         public void TrailingAnchor(string pattern, RegexOptions options, int expectedMode, int expectedLength, int trailingAnchor)
         {
@@ -69,28 +69,28 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Theory]
-        [InlineData(@"ab", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingPrefix_LeftToRight, "ab")]
-        [InlineData(@"ab", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingPrefix_RightToLeft, "ab")]
-        [InlineData(@"(a)(bc)", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingPrefix_LeftToRight, "abc")]
-        [InlineData(@"(a)(bc)", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingPrefix_RightToLeft, "bc")]
-        [InlineData(@"a{10}", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingPrefix_LeftToRight, "aaaaaaaaaa")]
-        [InlineData(@"a{10}", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingPrefix_RightToLeft, "aaaaaaaaaa")]
-        [InlineData(@"(?>a{10,20})", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingPrefix_LeftToRight, "aaaaaaaaaa")]
-        [InlineData(@"(?>a{10,20})", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingPrefix_RightToLeft, "aaaaaaaaaa")]
-        [InlineData(@"a{3,5}?", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingPrefix_LeftToRight, "aaa")]
-        [InlineData(@"a{3,5}?", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingPrefix_RightToLeft, "aaa")]
-        [InlineData(@"ab{5}", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingPrefix_LeftToRight, "abbbbb")]
-        [InlineData(@"ab{5}", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingPrefix_RightToLeft, "abbbbb")]
-        [InlineData(@"ab\w", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingPrefix_LeftToRight, "ab")]
-        [InlineData(@"\wab", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingPrefix_RightToLeft, "ab")]
-        [InlineData(@"(ab){3}", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingPrefix_LeftToRight, "ababab")]
-        [InlineData(@"(ab){3}", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingPrefix_RightToLeft, "ab")]
-        [InlineData(@"(ab){2,4}(de){4,}", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingPrefix_LeftToRight, "abab")]
-        [InlineData(@"(ab){2,4}(de){4,}", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingPrefix_RightToLeft, "de")]
-        [InlineData(@"ab|(abc)|(abcd)", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingPrefix_LeftToRight, "ab")]
-        [InlineData(@"ab|(abc)|(abcd)", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingPrefix_RightToLeft, "ab")]
-        [InlineData(@"ab(?=cd)", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingPrefix_LeftToRight, "ab")]
-        [InlineData(@"ab(?=cd)", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingPrefix_RightToLeft, "ab")]
+        [InlineData(@"ab", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "ab")]
+        [InlineData(@"ab", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingString_RightToLeft, "ab")]
+        [InlineData(@"(a)(bc)", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "abc")]
+        [InlineData(@"(a)(bc)", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingString_RightToLeft, "bc")]
+        [InlineData(@"a{10}", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "aaaaaaaaaa")]
+        [InlineData(@"a{10}", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingString_RightToLeft, "aaaaaaaaaa")]
+        [InlineData(@"(?>a{10,20})", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "aaaaaaaaaa")]
+        [InlineData(@"(?>a{10,20})", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingString_RightToLeft, "aaaaaaaaaa")]
+        [InlineData(@"a{3,5}?", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "aaa")]
+        [InlineData(@"a{3,5}?", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingString_RightToLeft, "aaa")]
+        [InlineData(@"ab{5}", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "abbbbb")]
+        [InlineData(@"ab{5}", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingString_RightToLeft, "abbbbb")]
+        [InlineData(@"ab\w", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "ab")]
+        [InlineData(@"\wab", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingString_RightToLeft, "ab")]
+        [InlineData(@"(ab){3}", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "ababab")]
+        [InlineData(@"(ab){3}", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingString_RightToLeft, "ab")]
+        [InlineData(@"(ab){2,4}(de){4,}", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "abab")]
+        [InlineData(@"(ab){2,4}(de){4,}", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingString_RightToLeft, "de")]
+        [InlineData(@"ab|(abc)|(abcd)", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "ab")]
+        [InlineData(@"ab|(abc)|(abcd)", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingString_RightToLeft, "ab")]
+        [InlineData(@"ab(?=cd)", RegexOptions.None, (int)FindNextStartingPositionMode.LeadingString_LeftToRight, "ab")]
+        [InlineData(@"ab(?=cd)", RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingString_RightToLeft, "ab")]
         public void LeadingPrefix(string pattern, RegexOptions options, int expectedMode, string expectedPrefix)
         {
             RegexFindOptimizations opts = ComputeOptimizations(pattern, options);
@@ -126,6 +126,19 @@ namespace System.Text.RegularExpressions.Tests
             Assert.NotNull(opts.LiteralAfterLoop);
             Assert.Equal(expectedString, opts.LiteralAfterLoop.Value.Literal.String);
             Assert.Equal(expectedChar, opts.LiteralAfterLoop.Value.Literal.Char);
+        }
+
+        [Theory]
+        [InlineData(@".ab", RegexOptions.None, (int)FindNextStartingPositionMode.FixedDistanceString_LeftToRight, "ab", 1)]
+        [InlineData(@".ab\w\w\wcdef\w\w\w\w\wghijklmnopq\w\w\w", RegexOptions.None, (int)FindNextStartingPositionMode.FixedDistanceString_LeftToRight, "ghijklmnopq", 15)]
+        [InlineData(@"a[Bb]c[Dd]ef", RegexOptions.None, (int)FindNextStartingPositionMode.FixedDistanceString_LeftToRight, "ef", 4)]
+        [InlineData(@"a[Bb]cd[Ee]fgh[Ii]", RegexOptions.None, (int)FindNextStartingPositionMode.FixedDistanceString_LeftToRight, "fgh", 5)]
+        public void FixedDistanceString(string pattern, RegexOptions options, int expectedMode, string expectedString, int distance)
+        {
+            RegexFindOptimizations opts = ComputeOptimizations(pattern, options);
+            Assert.Equal((FindNextStartingPositionMode)expectedMode, opts.FindMode);
+            Assert.Equal(expectedString, opts.FixedDistanceLiteral.String);
+            Assert.Equal(distance, opts.FixedDistanceLiteral.Distance);
         }
 
         private static RegexFindOptimizations ComputeOptimizations(string pattern, RegexOptions options)


### PR DESCRIPTION
Currently if a pattern begins with a multi-character string, we'll use IndexOf with that substring to find the next possible match location.  But if that multi-character string is a non-zero fixed distance into the pattern, we won't see it.  This changes that, letting us find such strings based on the fixed-distance sets we're already gathering, and using IndexOf for it.

From dotnet/performance:

| Method |         Toolchain |    Pattern |         Options |         Mean | Ratio |
|------- |------------------ |----------- |---------------- |-------------:|------:|
|  Count | \main\corerun.exe | [a-z]shing |            None |     9.699 ms |  1.00 |
|  Count |   \pr\corerun.exe | [a-z]shing |            None |     2.206 ms |  0.23 |
|        |                   |            |                 |              |       |
|  Count | \main\corerun.exe | [a-z]shing |        Compiled |     7.210 ms |  1.00 |
|  Count |   \pr\corerun.exe | [a-z]shing |        Compiled |     2.155 ms |  0.30 |
|        |                   |            |                 |              |       |
|  Count | \main\corerun.exe | [a-z]shing | NonBacktracking |     9.946 ms |  1.00 |
|  Count |   \pr\corerun.exe | [a-z]shing | NonBacktracking |     2.352 ms |  0.24 |

There are ~170 patterns in our corpus that benefit from this.