### PR TITLE
Handle more scenarios for loop cloning

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6130,6 +6130,10 @@ public:
         GenTree*   lpTestTree;         // pointer to the node containing the loop test
         genTreeOps lpTestOper() const; // the type of the comparison between the iterator and the limit (GT_LE, GT_GE,
                                        // etc.)
+
+        bool lpIsIncreasingLoop() const; // if the loop iterator increases from low to high value.
+        bool lpIsDecreasingLoop() const; // if the loop iterator decreases from high to low value.
+
         void VERIFY_lpTestTree() const;
 
         bool     lpIsReversed() const; // true if the iterator node is the second operand in the loop condition

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -3520,6 +3520,27 @@ inline genTreeOps Compiler::LoopDsc::lpTestOper() const
 
 //-----------------------------------------------------------------------------
 
+inline bool Compiler::LoopDsc::lpIsIncreasingLoop() const
+{
+    // Increasing loop is the one that has "+=" increament operation and "< or <=" limit check.
+    bool isLessThanLimitCheck = GenTree::StaticOperIs(lpTestOper(), GT_LT, GT_LE);
+    return (isLessThanLimitCheck &&
+            (((lpIterOper() == GT_ADD) && (lpIterConst() > 0)) || ((lpIterOper() == GT_SUB) && (lpIterConst() < 0))));
+}
+
+//-----------------------------------------------------------------------------
+
+inline bool Compiler::LoopDsc::lpIsDecreasingLoop() const
+{
+    // Decreasing loop is the one that has "-=" decrement operation and "> or >=" limit check. If the operation is
+    // "+=", make sure the constant is negative to give an effect of decrementing the iterator.
+    bool isGreaterThanLimitCheck = GenTree::StaticOperIs(lpTestOper(), GT_GT, GT_GE);
+    return (isGreaterThanLimitCheck &&
+            (((lpIterOper() == GT_ADD) && (lpIterConst() < 0)) || ((lpIterOper() == GT_SUB) && (lpIterConst() > 0))));
+}
+
+//-----------------------------------------------------------------------------
+
 inline GenTree* Compiler::LoopDsc::lpIterator() const
 {
     VERIFY_lpTestTree();

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -3522,7 +3522,7 @@ inline genTreeOps Compiler::LoopDsc::lpTestOper() const
 
 inline bool Compiler::LoopDsc::lpIsIncreasingLoop() const
 {
-    // Increasing loop is the one that has "+=" increament operation and "< or <=" limit check.
+    // Increasing loop is the one that has "+=" increment operation and "< or <=" limit check.
     bool isLessThanLimitCheck = GenTree::StaticOperIs(lpTestOper(), GT_LT, GT_LE);
     return (isLessThanLimitCheck &&
             (((lpIterOper() == GT_ADD) && (lpIterConst() > 0)) || ((lpIterOper() == GT_SUB) && (lpIterConst() < 0))));

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -1022,15 +1022,15 @@ bool Compiler::optDeriveLoopCloningConditions(unsigned loopNum, LoopCloneContext
     JITDUMP("------------------------------------------------------------\n");
     JITDUMP("Deriving cloning conditions for " FMT_LP "\n", loopNum);
 
-    LoopDsc*                         loop     = &optLoopTable[loopNum];
-    JitExpandArrayStack<LcOptInfo*>* optInfos = context->GetLoopOptInfo(loopNum);
+    LoopDsc*                         loop             = &optLoopTable[loopNum];
+    JitExpandArrayStack<LcOptInfo*>* optInfos         = context->GetLoopOptInfo(loopNum);
     bool                             isIncreasingLoop = GenTree::StaticOperIs(loop->lpTestOper(), GT_LT, GT_LE);
 
     if (GenTree::StaticOperIs(loop->lpTestOper(), GT_LT, GT_LE, GT_GT, GT_GE))
     {
         LC_Ident ident;
 
-       // Init conditions
+        // Init conditions
         if (loop->lpFlags & LPFLG_CONST_INIT)
         {
             // Only allowing non-negative const init at this time.
@@ -1067,7 +1067,7 @@ bool Compiler::optDeriveLoopCloningConditions(unsigned loopNum, LoopCloneContext
             else
             {
                 // For decreasing loop, the init value needs to be checked against the array length
-                ident = LC_Ident(initLcl, LC_Ident::Var);
+                ident  = LC_Ident(initLcl, LC_Ident::Var);
                 geZero = LC_Condition(GT_GE, LC_Expr(ident), LC_Expr(LC_Ident(0, LC_Ident::Const)));
             }
             context->EnsureConditions(loopNum)->Push(geZero);
@@ -1644,7 +1644,7 @@ bool Compiler::optIsLoopClonable(unsigned loopInd)
         return false;
     }
 
-    bool isLessThanLimitCheck = GenTree::StaticOperIs(loop.lpTestOper(), GT_LT, GT_LE);
+    bool isLessThanLimitCheck    = GenTree::StaticOperIs(loop.lpTestOper(), GT_LT, GT_LE);
     bool isGreaterThanLimitCheck = GenTree::StaticOperIs(loop.lpTestOper(), GT_GT, GT_GE);
 
     // Increasing loop is the one that has "+=" increament operation and "< or <=" limit check.
@@ -1655,12 +1655,12 @@ bool Compiler::optIsLoopClonable(unsigned loopInd)
     bool isDecreasingLoop = (isGreaterThanLimitCheck && ((loop.lpIterOper() == GT_SUB) ||
                                                          ((loop.lpIterOper() == GT_ADD) && (loop.lpIterConst() < 0))));
 
-    //TODO-CQ: Handle other loops like:
+    // TODO-CQ: Handle other loops like:
     // - The ones whose limit operator is "==" or "!="
     // - The incrementing operator is multiple and divide
     // - The ones that are inverted are not handled here for cases like "i *= 2" because
     //   they are converted to "i + i".
-    //bool isOtherLoop = (loop.lpIterOper() == GT_DIV) || (loop.lpIterOper() == GT_MUL);
+    // bool isOtherLoop = (loop.lpIterOper() == GT_DIV) || (loop.lpIterOper() == GT_MUL);
     if (!(isIncreasingLoop || isDecreasingLoop))
     {
         JITDUMP("Loop cloning: rejecting loop " FMT_LP

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -1648,12 +1648,13 @@ bool Compiler::optIsLoopClonable(unsigned loopInd)
     bool isGreaterThanLimitCheck = GenTree::StaticOperIs(loop.lpTestOper(), GT_GT, GT_GE);
 
     // Increasing loop is the one that has "+=" increament operation and "< or <=" limit check.
-    bool isIncreasingLoop = (isLessThanLimitCheck && (loop.lpIterOper() == GT_ADD));
+    bool isIncreasingLoop = (isLessThanLimitCheck && (((loop.lpIterOper() == GT_ADD) && (loop.lpIterConst() > 0)) ||
+                                                      ((loop.lpIterOper() == GT_SUB) && (loop.lpIterConst() < 0))));
 
     // Increasing loop is the one that has "-=" decrement operation and "> or >=" limit check. If the operation is "+=",
     // make sure the constant is negative to give an effect of decrementing the iterator.
-    bool isDecreasingLoop = (isGreaterThanLimitCheck && ((loop.lpIterOper() == GT_SUB) ||
-                                                         ((loop.lpIterOper() == GT_ADD) && (loop.lpIterConst() < 0))));
+    bool isDecreasingLoop = (isGreaterThanLimitCheck && (((loop.lpIterOper() == GT_ADD) && (loop.lpIterConst() < 0)) ||
+                                                         ((loop.lpIterOper() == GT_SUB) && (loop.lpIterConst() > 0))));
 
     // TODO-CQ: Handle other loops like:
     // - The ones whose limit operator is "==" or "!="

--- a/src/tests/JIT/Directed/Arrays/LoopCloning.cs
+++ b/src/tests/JIT/Directed/Arrays/LoopCloning.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+public class Program
+{
+    public static unsafe int Main()
+    {
+        int result = 0;
+        try {
+            test_up_big(new int[10], 5, 2);
+        } catch (IndexOutOfRangeException) {
+            result = 100;
+        }
+        
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int test_up_big(int[] a, int s, int x)
+    {
+        int r = 0;
+        int i;
+        for (i = 1; i < s; i += 2147483647)
+        {
+            r += a[i];
+        }
+        return r;
+    }
+}

--- a/src/tests/JIT/Directed/Arrays/LoopCloning.csproj
+++ b/src/tests/JIT/Directed/Arrays/LoopCloning.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="LoopCloning.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- Increasing loops that are incremented by more than 1 like "i += 2"


[TypeHashingAlgorithm.cs](https://github.com/dotnet/runtime/blob/main/src/coreclr/tools/Common/TypeSystem/Common/TypeHashingAlgorithms.cs)



https://github.com/dotnet/runtime/blob/7bac4e8fa611eb02ac1bd27b97a8570cbf321437/src/coreclr/tools/Common/TypeSystem/Common/TypeHashingAlgorithms.cs#L44-L49


- Decreasing loops like "i--", "i -= 2", etc.

https://github.com/dotnet/runtime/blob/7bac4e8fa611eb02ac1bd27b97a8570cbf321437/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/EqualityComparer.cs#L50-L63



PriorityQueue's [Heapify](https://github.com/dotnet/runtime/blob/7bac4e8fa611eb02ac1bd27b97a8570cbf321437/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs#L576) method.

https://github.com/dotnet/runtime/blob/7bac4e8fa611eb02ac1bd27b97a8570cbf321437/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs#L588-L591

Contributes to https://github.com/dotnet/runtime/issues/65342