### PR TITLE
[release/6.0] Add single-file debugging fix to DBI

### DIFF
--- a/src/coreclr/debug/di/cordb.cpp
+++ b/src/coreclr/debug/di/cordb.cpp
@@ -102,29 +102,29 @@ STDAPI CreateCordbObject(int iDebuggerVersion, IUnknown ** ppCordb)
     {
         return E_INVALIDARG;
     }
-
     return Cordb::CreateObject(
-        (CorDebugInterfaceVersion)iDebuggerVersion, ProcessDescriptor::UNINITIALIZED_PID, /*lpApplicationGroupId*/ NULL, IID_ICorDebug, (void **) ppCordb);
+        (CorDebugInterfaceVersion)iDebuggerVersion, ProcessDescriptor::UNINITIALIZED_PID, /*lpApplicationGroupId*/ NULL,  /*dacModulePath*/ NULL, IID_ICorDebug, (void **) ppCordb);
 }
 
 //
 // Public API.
-// Telesto Creation path with Mac sandbox support - only way to debug a sandboxed application on Mac.
-// This supercedes code:CoreCLRCreateCordbObject
+// Creation path with Mac sandbox support and explicit DAC module path for single-file apps
+// This supercedes code:CoreCLRCreateCordbObjectEx
 //
 // Arguments:
 //    iDebuggerVersion - version of ICorDebug interfaces that the debugger is requesting
 //    pid - pid of debuggee that we're attaching to.
-//    lpApplicationGroupId - A string representing the application group ID of a sandboxed
+//    lpApplicationGroupId - a string representing the application group ID of a sandboxed
 //                           process running in Mac. Pass NULL if the process is not
 //                           running in a sandbox and other platforms.
+//    dacModulePath - the full module path of the DAC module or NULL.
 //    hmodTargetCLR - module handle to clr in target pid that we're attaching to.
 //    ppCordb - (out) the resulting ICorDebug object.
 //
 // Notes:
 //    It's inconsistent that this takes a (handle, pid) but hands back an ICorDebug instead of an ICorDebugProcess.
 //    Callers will need to call *ppCordb->DebugActiveProcess(pid).
-STDAPI DLLEXPORT CoreCLRCreateCordbObjectEx(int iDebuggerVersion, DWORD pid, LPCWSTR lpApplicationGroupId, HMODULE hmodTargetCLR, IUnknown ** ppCordb)
+STDAPI DLLEXPORT CoreCLRCreateCordbObject3(int iDebuggerVersion, DWORD pid, LPCWSTR lpApplicationGroupId, LPCWSTR dacModulePath, HMODULE hmodTargetCLR, IUnknown** ppCordb)
 {
     if (ppCordb == NULL)
     {
@@ -140,7 +140,7 @@ STDAPI DLLEXPORT CoreCLRCreateCordbObjectEx(int iDebuggerVersion, DWORD pid, LPC
     // Create the ICorDebug object
     //
     RSExtSmartPtr<ICorDebug> pCordb;
-    Cordb::CreateObject((CorDebugInterfaceVersion)iDebuggerVersion, pid, lpApplicationGroupId, IID_ICorDebug, (void **) &pCordb);
+    Cordb::CreateObject((CorDebugInterfaceVersion)iDebuggerVersion, pid, lpApplicationGroupId, dacModulePath, IID_ICorDebug, (void **) &pCordb);
 
     //
     // Associate it with the target instance
@@ -162,7 +162,29 @@ STDAPI DLLEXPORT CoreCLRCreateCordbObjectEx(int iDebuggerVersion, DWORD pid, LPC
 
 //
 // Public API.
-// Telesto Creation path - only way to debug multi-instance.
+// Creation path with Mac sandbox support - only way to debug a sandboxed application on Mac.
+// This supercedes code:CoreCLRCreateCordbObject
+//
+// Arguments:
+//    iDebuggerVersion - version of ICorDebug interfaces that the debugger is requesting
+//    pid - pid of debuggee that we're attaching to.
+//    lpApplicationGroupId - a string representing the application group ID of a sandboxed
+//                           process running in Mac. Pass NULL if the process is not
+//                           running in a sandbox and other platforms.
+//    hmodTargetCLR - module handle to clr in target pid that we're attaching to.
+//    ppCordb - (out) the resulting ICorDebug object.
+//
+// Notes:
+//    It's inconsistent that this takes a (handle, pid) but hands back an ICorDebug instead of an ICorDebugProcess.
+//    Callers will need to call *ppCordb->DebugActiveProcess(pid).
+STDAPI DLLEXPORT CoreCLRCreateCordbObjectEx(int iDebuggerVersion, DWORD pid, LPCWSTR lpApplicationGroupId, HMODULE hmodTargetCLR, IUnknown ** ppCordb)
+{
+    return CoreCLRCreateCordbObject3(iDebuggerVersion, pid, lpApplicationGroupId, NULL, hmodTargetCLR, ppCordb);
+}
+
+//
+// Public API.
+// Creation path - only way to debug multi-instance.
 // This supercedes code:CreateCordbObject
 //
 // Arguments:
@@ -178,9 +200,6 @@ STDAPI DLLEXPORT CoreCLRCreateCordbObject(int iDebuggerVersion, DWORD pid, HMODU
 {
     return CoreCLRCreateCordbObjectEx(iDebuggerVersion, pid, NULL, hmodTargetCLR, ppCordb);
 }
-
-
-
 
 
 //*****************************************************************************

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -686,9 +686,9 @@ CordbProcess::CreateDacDbiInterface()
     // in the new arch we can get the module from OpenVirtualProcess2 but in the shim case
     // and the deprecated OpenVirtualProcess case we must assume it comes from DAC in the
     // same directory as DBI
-    if(m_hDacModule == NULL)
+    if (m_hDacModule == NULL)
     {
-        m_hDacModule.Assign(ShimProcess::GetDacModule());
+        m_hDacModule.Assign(ShimProcess::GetDacModule(m_cordb->GetDacModulePath()));
     }
 
     //

--- a/src/coreclr/debug/di/rspriv.h
+++ b/src/coreclr/debug/di/rspriv.h
@@ -2226,7 +2226,7 @@ public:
 #if defined(FEATURE_DBGIPC_TRANSPORT_DI)
     static COM_METHOD CreateObjectTelesto(REFIID id, void ** pObject);
 #endif // FEATURE_DBGIPC_TRANSPORT_DI
-    static COM_METHOD CreateObject(CorDebugInterfaceVersion iDebuggerVersion, DWORD pid, LPCWSTR lpApplicationGroupId, REFIID id, void **object);
+    static COM_METHOD CreateObject(CorDebugInterfaceVersion iDebuggerVersion, DWORD pid, LPCWSTR lpApplicationGroupId, LPCWSTR lpwstrDacModulePath, REFIID id, void** object);
 
     //-----------------------------------------------------------
     // ICorDebugRemote
@@ -2299,6 +2299,7 @@ public:
 
 private:
     Cordb(CorDebugInterfaceVersion iDebuggerVersion, const ProcessDescriptor& pd);
+    Cordb(CorDebugInterfaceVersion iDebuggerVersion, const ProcessDescriptor& pd, LPCWSTR dacModulePath);
 
     //-----------------------------------------------------------
     // Data members
@@ -2314,6 +2315,8 @@ public:
     CordbRCEventThread*         m_rcEventThread;
 
     CorDebugInterfaceVersion    GetDebuggerVersion() const;
+
+    PathString& GetDacModulePath() { return m_dacModulePath; }
 
 #ifdef FEATURE_CORESYSTEM
     HMODULE GetTargetCLR() { return m_targetCLR; }
@@ -2337,6 +2340,8 @@ private:
 
     // Store information about the process to be debugged
     ProcessDescriptor m_pd;
+
+    PathString m_dacModulePath;
 
 //Note - this code could be useful outside coresystem, but keeping the change localized
 // because we are late in the win8 release

--- a/src/coreclr/debug/di/shimpriv.h
+++ b/src/coreclr/debug/di/shimpriv.h
@@ -389,7 +389,7 @@ public:
     );
 
     // Locates the DAC module adjacent to DBI
-    static HMODULE GetDacModule();
+    static HMODULE GetDacModule(PathString& dacModulePath);
 
     //
     // Functions used by CordbProcess

--- a/src/coreclr/dlls/mscordbi/mscordbi.src
+++ b/src/coreclr/dlls/mscordbi/mscordbi.src
@@ -20,6 +20,7 @@ EXPORTS
 
     CoreCLRCreateCordbObject private
     CoreCLRCreateCordbObjectEx private
+    CoreCLRCreateCordbObject3 private
 
 #if defined(FEATURE_DBGIPC_TRANSPORT_DI)
     DllGetClassObject private

--- a/src/coreclr/dlls/mscordbi/mscordbi_unixexports.src
+++ b/src/coreclr/dlls/mscordbi/mscordbi_unixexports.src
@@ -8,6 +8,7 @@ DllGetClassObject
 ; CoreClr API
 CoreCLRCreateCordbObject
 CoreCLRCreateCordbObjectEx
+CoreCLRCreateCordbObject3
 
 ; Out-of-proc creation path from the shim - ICLRDebugging
 OpenVirtualProcessImpl


### PR DESCRIPTION
# Customer Impact

Visual Studio doesn't support live debugging of single-file applications.  The 6.0.x DBI module assumes the DAC is in the same directory as itself which not true for single-file apps.  This change with the new OOB dbgshim from the diagnostics repo allows VS to support live debugging of single-file apps end to end.

# Details

Adds new CoreCLRCreateCordbObjectEx2 API that takes the DAC module path instead of assuming the DAC module is in the same directory as DBI.

# Testing

Local testing.  The VS team has verified these runtime changes with the new dbgshim.

# Risk

Low. Just affects the DBI module.

