### PR TITLE
improve Tls12 detection on Windows7

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -441,14 +441,16 @@ namespace System
 
         private static bool GetTls10Support()
         {
-            // on Windows, macOS, and Android TLS1.0/1.1 are supported.
+            // on macOS and Android TLS 1.0 is supported.
             if (IsOSXLike || IsAndroid)
             {
                 return true;
             }
+
+            // Windows depend on registry, enabled by default on all supported versions.
             if (IsWindows)
             {
-                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls, true);
+                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls, defaultProtocolSupport: true);
             }
 
             return OpenSslGetTlsSupport(SslProtocols.Tls);
@@ -456,17 +458,18 @@ namespace System
 
         private static bool GetTls11Support()
         {
-            // on Windows, macOS, and Android TLS1.0/1.1 are supported.            
             if (IsWindows)
             {
-                // TLS 1.1 and 1.2 can work on Windows7 but it is not enabled by default.
+                // TLS 1.1 can work on Windows 7 but it is disabled by default.
                 if (IsWindows7)
                 {
-                    return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls11, false, true);
+                    return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls11, defaultProtocolSupport: false, disabledByDefault: true);
                 }
 
-                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls11, true);
+                // It is enabled on other versions unless explicitly disabled.
+                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls11, defaultProtocolSupport: true);
             }
+            // on macOS and Android TLS 1.1 is supported.
             else if (IsOSXLike || IsAndroid)
             {
                 return true;
@@ -479,13 +482,14 @@ namespace System
         {
             if (IsWindows)
             {
-                // TLS 1.1 and 1.2 can work on Windows7 but it is not enabled by default.
+                // TLS 1.2 can work on Windows 7 but it is disabled by default.
                 if (IsWindows7)
                 {
-                    return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls12, false, true);
+                    return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls12, defaultProtocolSupport: false, disabledByDefault: true);
                 }
 
-                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls12, true);
+                // It is enabled on other versions unless explicitly disabled.
+                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls12, defaultProtocolSupport: true);
             }
 
             return true;

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -460,8 +460,12 @@ namespace System
             if (IsWindows)
             {
                 // TLS 1.1 and 1.2 can work on Windows7 but it is not enabled by default.
-                bool defaultProtocolSupport = !IsWindows7;
-                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls11, defaultProtocolSupport);
+                if (IsWindows7)
+                {
+                    return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls11, false, true);
+                }
+
+                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls11, true);
             }
             else if (IsOSXLike || IsAndroid)
             {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
@@ -74,7 +74,6 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/67712")]
         [ConditionalTheory]
         [MemberData(nameof(OneOrBothUseDefaulData))]
         public async Task ClientAndServer_OneOrBothUseDefault_Ok(SslProtocols? clientProtocols, SslProtocols? serverProtocols)


### PR DESCRIPTION
Protocol detection is trickier on Window7. The `Enabled` is not sufficient and recent Helix updated confused our platform detection. 

To make Tls12 working [DisabledByDefault](https://support.microsoft.com/en-us/topic/update-to-enable-tls-1-1-and-tls-1-2-as-default-secure-protocols-in-winhttp-in-windows-c4bd73d2-31d7-761e-0178-11268bb10392) also must be set to 0.

We will need another Helix change to get Tls12 truly working. I did private test run with `DisabledByDefault=0` and all tests could pass (including outer loop)

fixes #67687 and replaces  #67904
fixes #67712

