### PR TITLE
Move EventPipe thread buffer allocation outside of lock

### DIFF
--- a/src/native/eventpipe/ep-buffer-manager.c
+++ b/src/native/eventpipe/ep-buffer-manager.c
@@ -501,6 +501,11 @@ buffer_manager_allocate_buffer_for_thread (
 	EP_ASSERT(buffer_size > 0);
 	ep_return_null_if_nok(buffer_manager_try_reserve_buffer(buffer_manager, buffer_size));
 
+	// The sequence counter is exclusively mutated on this thread so this is a thread-local read.
+	sequence_number = ep_thread_session_state_get_volatile_sequence_number (thread_session_state);
+	new_buffer = ep_buffer_alloc (buffer_size, ep_thread_session_state_get_thread (thread_session_state), sequence_number);
+	ep_raise_error_if_nok (new_buffer != NULL);
+
 	// Allocating a buffer requires us to take the lock.
 	EP_SPIN_LOCK_ENTER (&buffer_manager->rt_lock, section1)
 		thread_buffer_list = ep_thread_session_state_get_buffer_list (thread_session_state);
@@ -512,11 +517,6 @@ buffer_manager_allocate_buffer_for_thread (
 			ep_thread_session_state_set_buffer_list (thread_session_state, thread_buffer_list);
 			thread_buffer_list = NULL;
 		}
-
-		// The sequence counter is exclusively mutated on this thread so this is a thread-local read.
-		sequence_number = ep_thread_session_state_get_volatile_sequence_number (thread_session_state);
-		new_buffer = ep_buffer_alloc (buffer_size, ep_thread_session_state_get_thread (thread_session_state), sequence_number);
-		ep_raise_error_if_nok_holding_spin_lock (new_buffer != NULL, section1);
 
 		if (buffer_manager->sequence_point_alloc_budget != 0) {
 			// sequence point bookkeeping

--- a/src/native/eventpipe/ep-buffer-manager.c
+++ b/src/native/eventpipe/ep-buffer-manager.c
@@ -506,7 +506,7 @@ buffer_manager_allocate_buffer_for_thread (
 	new_buffer = ep_buffer_alloc (buffer_size, ep_thread_session_state_get_thread (thread_session_state), sequence_number);
 	ep_raise_error_if_nok (new_buffer != NULL);
 
-	// Allocating a buffer requires us to take the lock.
+	// Adding a buffer to the buffer list requires us to take the lock.
 	EP_SPIN_LOCK_ENTER (&buffer_manager->rt_lock, section1)
 		thread_buffer_list = ep_thread_session_state_get_buffer_list (thread_session_state);
 		if (thread_buffer_list == NULL) {


### PR DESCRIPTION
## Summary

fixes https://github.com/dotnet/runtime/issues/65247

Because GC threads are CPU affinitized, losing a CPU quantum can cause GC delays. Writing an event to EventPipe can incur the need to allocate a new buffer. Currently, that happens behind a lock. When GC related events are turned on, it is possible for GC threads to get blocked waiting on lock long enough to lose their quantum. The extra wait is typically waiting on the allocation and zeroing of the buffer. These buffers are thread local, but need to be added to the global buffer manager behind a lock. To rectify this, this patch moves the allocation of the buffer outside the lock, so there is minimal work inside the lock.

Local testing showed improvement in total throughput (written+dropped) with a higher written count, but not a high enough improvement that I would consider this a performance win beyond the specific GC scenario.

## baseline
```
**** Summary ****
iteration 1: 11,848,091.00 events collected, 28,785,734.00 events dropped in 45.554975 seconds - (29.16% throughput)
	(260,083.36 events/s) (52,016,672.73 bytes/s)


|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| stat                              | Min                | Max                | Average            | Standard Deviation |
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| Events Read                       |       11,848,091.00|       11,848,091.00|       11,848,091.00|                0.00|
| Events Dropped                    |       28,785,734.00|       28,785,734.00|       28,785,734.00|                0.00|
| Throughput Efficiency (%)         |               29.16|               29.16|               29.16|                0.00|
| Event Throughput (events/sec)     |          260,083.36|          260,083.36|          260,083.36|                0.00|
| Data Throughput (Bytes/sec)       |       52,016,672.73|       52,016,672.73|       52,016,672.73|                0.00|
| Duration (seconds)                |           45.554975|           45.554975|           45.554975|            0.000000|
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
```

## patch
```
**** Summary ****
iteration 1: 12,474,621.00 events collected, 31,134,446.00 events dropped in 45.769763 seconds - (28.61% throughput)
	(272,551.58 events/s) (54,510,315.51 bytes/s)


|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| stat                              | Min                | Max                | Average            | Standard Deviation |
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| Events Read                       |       12,474,621.00|       12,474,621.00|       12,474,621.00|                0.00|
| Events Dropped                    |       31,134,446.00|       31,134,446.00|       31,134,446.00|                0.00|
| Throughput Efficiency (%)         |               28.61|               28.61|               28.61|                0.00|
| Event Throughput (events/sec)     |          272,551.58|          272,551.58|          272,551.58|                0.00|
| Data Throughput (Bytes/sec)       |       54,510,315.51|       54,510,315.51|       54,510,315.51|                0.00|
| Duration (seconds)                |           45.769763|           45.769763|           45.769763|            0.000000|
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
```