### PR TITLE
[wasm] Update line numbers to track recent changes in JSConditionalBr…

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -213,19 +213,19 @@ namespace DebuggerTests
         }
 
         [Theory]
-        [InlineData("c == 15", 78, 3, 78, 11)]
-        [InlineData("c == 17", 78, 3, 79, 11)]
-        [InlineData("g == 17", 78, 3, 79, 11)]
-        [InlineData("true", 78, 3, 78, 11)]
-        [InlineData("\"false\"", 78, 3, 78, 11)]
-        [InlineData("\"true\"", 78, 3, 78, 11)]
-        [InlineData("5", 78, 3, 78, 11)]
-        [InlineData("p", 78, 3, 79, 11)]
-        [InlineData("0.0", 78, 3, 79, 11)]
+        [InlineData("c == 15", 79, 3, 79, 11)]
+        [InlineData("c == 17", 79, 3, 80, 11)]
+        [InlineData("g == 17", 79, 3, 80, 11)]
+        [InlineData("true", 79, 3, 79, 11)]
+        [InlineData("\"false\"", 79, 3, 79, 11)]
+        [InlineData("\"true\"", 79, 3, 79, 11)]
+        [InlineData("5", 79, 3, 79, 11)]
+        [InlineData("p", 79, 3, 80, 11)]
+        [InlineData("0.0", 79, 3, 80, 11)]
         public async Task JSConditionalBreakpoint(string condition, int line_bp, int column_bp, int line_expected, int column_expected)
         {
             await SetBreakpoint("/debugger-driver.html", line_bp, column_bp, condition: condition);
-            await SetBreakpoint("/debugger-driver.html", 79, 11);
+            await SetBreakpoint("/debugger-driver.html", 80, 11);
 
             await EvaluateAndCheck(
                 "window.setTimeout(function() { conditional_breakpoint_test(5, 10, null); }, 1);",


### PR DESCRIPTION
…eakpoint test

`debugger-driver.html` was changed in
ae5d422e873016d558db236d15c135453b8d603d, but not all the line numbers in
JSConditionalBreakpoint were updated.

This can cause the breakpoint to not be hit, and the test to timeout
instead.