### PR TITLE
[wasm][debugger] Fix a randomly failing JS test

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/ExceptionTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/ExceptionTests.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.WebAssembly.Diagnostics;
 using Newtonsoft.Json.Linq;
 using System.Threading;
 using Xunit;
+using Xunit.Sdk;
 
 namespace DebuggerTests
 {
@@ -68,7 +67,7 @@ namespace DebuggerTests
 
             var eval_expr = "window.setTimeout(function () { exceptions_test (); }, 1)";
             var pause_location = await EvaluateAndCheck(eval_expr, null, 0, 0, null);
-            pause_location = await WaitForJSAndNotManagedException(pause_location, "exception_caught_test");
+            pause_location = await WaitForJSException(pause_location, "exception_caught_test");
 
             await CheckValue(pause_location["data"], JObject.FromObject(new
             {
@@ -82,7 +81,7 @@ namespace DebuggerTests
             await CheckString(exception_members, "message", "exception caught");
 
             pause_location = await SendCommandAndCheck(null, "Debugger.resume", null, 0, 0, null);
-            pause_location = await WaitForJSAndNotManagedException(pause_location, "exception_uncaught_test");
+            pause_location = await WaitForJSException(pause_location, "exception_uncaught_test");
 
             await CheckValue(pause_location["data"], JObject.FromObject(new
             {
@@ -95,7 +94,7 @@ namespace DebuggerTests
             exception_members = await GetProperties(pause_location["data"]["objectId"]?.Value<string>());
             await CheckString(exception_members, "message", "exception uncaught");
 
-            async Task<JObject> WaitForJSAndNotManagedException(JObject pause_location, string exp_fn_name)
+            async Task<JObject> WaitForJSException(JObject pause_location, string exp_fn_name)
             {
                 while (true)
                 {
@@ -103,15 +102,19 @@ namespace DebuggerTests
                     {
                         AssertEqual("exception", pause_location["reason"]?.Value<string>(), $"Expected to only pause because of an exception. {pause_location}");
 
+                        string actual_fn_name = pause_location["callFrames"]?[0]?["functionName"]?.Value<string>();
+
                         // return if we hit a managed exception, or an uncaught one
-                        if (pause_location["data"]?["objectId"]?.Value<string>()?.StartsWith("dotnet:object:", StringComparison.Ordinal) == true ||
-                            pause_location["data"]?["uncaught"]?.Value<bool>() == true)
+                        if (pause_location["data"]?["objectId"]?.Value<string>()?.StartsWith("dotnet:object:", StringComparison.Ordinal) == true)
                         {
-                            break;
+                            Console.WriteLine($"Hit an unexpected managed exception, with function name: {actual_fn_name}. {pause_location}");
+                            throw new XunitException($"Hit an unexpected managed exception, with function name: {actual_fn_name}");
                         }
 
-                        string actual_exp_fn_name = pause_location["callFrames"]?[0]?["functionName"]?.Value<string>();
-                        if (actual_exp_fn_name == exp_fn_name)
+                        if (pause_location["data"]?["uncaught"]?.Value<bool>() == true)
+                            break;
+
+                        if (actual_fn_name == exp_fn_name)
                             break;
                     }
 


### PR DESCRIPTION
`DebuggerTests.ExceptionTests.JSExceptionTestAll` can some times fail
with:

```
[xUnit.net 00:01:08.51]     DebuggerTests.ExceptionTests.JSExceptionTestAll [FAIL]
  Failed DebuggerTests.ExceptionTests.JSExceptionTestAll [105 ms]
  Error Message:
   [{
  "callFrameId": "-2618252572970282349.1.0",
  "functionName": "lookup",

...

Expected: exception_caught_test
Actual:   lookup
  Stack Trace:
     at DebuggerTests.DebuggerTestBase.AssertEqual(Object expected, Object actual, String label) in /_/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs:line 1119
   at DebuggerTests.DebuggerTestBase.SendCommandAndCheck(JObject args, String method, String script_loc, Int32 line, Int32 column, String function_name, Func`2 wait_for_event_fn, Func`2 locals_fn, String waitForEvent) in /_/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs:line 562
   at DebuggerTests.DebuggerTestBase.EvaluateAndCheck(String expression, String script_loc, Int32 line, Int32 column, String function_name, Func`2 wait_for_event_fn, Func`2 locals_fn) in /_/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs:line 542
   at DebuggerTests.ExceptionTests.JSExceptionTestAll() in /_/src/mono/wasm/debugger/DebuggerTestSuite/ExceptionTests.cs:line 70
```

This test is set to pause on every exception thrown, but the test
assumes that the first exception that it gets will be the expected one.
But we can get other JS exceptions before that. So, wait for the correct
one, while ignoring any other *js* ones.