### PR TITLE
Fix placeholder files in packages

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -223,7 +223,7 @@
             Pack="true" />
       <!-- Add the placeholder file to the supported target framework buildTransitive folder, if it's empty. -->
       <None Include="$(PlaceholderFile)"
-            PackagePath="$(_NETStandardCompatErrorPlaceholderFilePackagePath)\$(PackageId).targets"
+            PackagePath="$(_NETStandardCompatErrorPlaceholderFilePackagePath)\"
             Pack="true"
             Condition="'@(_PackageBuildFile)' == '' or
                        !@(_PackageBuildFile->AnyHaveMetadataValue('PackagePathWithoutFilename', '$(_NETStandardCompatErrorPlaceholderFilePackagePath)'))" />


### PR DESCRIPTION
Reported in https://github.com/dotnet/runtime/pull/67647#issuecomment-1098044653. Accidentally got the package path wrong for placeholder files and didn't notice it locally.