### PR TITLE
Add JSON type hierarchies

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -120,6 +120,11 @@ namespace System.Text.Json.SourceGeneration
                         GenerateTypeInfo(typeGenerationSpec);
                     }
 
+                    foreach (TypeGenerationSpec typeGenerationSpec in _currentContext.ImplicitlyRegisteredTypes)
+                    {
+                        GenerateTypeInfo(typeGenerationSpec);
+                    }
+
                     string contextName = _currentContext.ContextType.Name;
 
                     // Add root context implementation.

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -713,7 +713,9 @@ namespace System.Text.Json.SourceGeneration
                 foreach (CustomAttributeData attributeData in attributeDataList)
                 {
                     Type attributeType = attributeData.AttributeType;
-                    if (attributeType.FullName == JsonNumberHandlingAttributeFullName)
+                    string attributeTypeFullName = attributeType.FullName;
+
+                    if (attributeTypeFullName == JsonNumberHandlingAttributeFullName)
                     {
                         IList<CustomAttributeTypedArgument> ctorArgs = attributeData.ConstructorArguments;
                         numberHandling = (JsonNumberHandling)ctorArgs[0].Value;
@@ -729,7 +731,7 @@ namespace System.Text.Json.SourceGeneration
                             ref hasTypeFactoryConverter);
                     }
 
-                    if (attributeType.FullName == JsonDerivedTypeAttributeFullName)
+                    if (attributeTypeFullName == JsonDerivedTypeAttributeFullName)
                     {
                         Debug.Assert(attributeData.ConstructorArguments.Count > 0);
                         ITypeSymbol derivedTypeSymbol = (ITypeSymbol)attributeData.ConstructorArguments[0].Value;

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -41,7 +41,7 @@ namespace System.Text.Json.SourceGeneration
             private const string JsonPropertyNameAttributeFullName = "System.Text.Json.Serialization.JsonPropertyNameAttribute";
             private const string JsonPropertyOrderAttributeFullName = "System.Text.Json.Serialization.JsonPropertyOrderAttribute";
             private const string JsonSerializerContextFullName = "System.Text.Json.Serialization.JsonSerializerContext";
-            private const string JsonSerializerAttributeFullName = "System.Text.Json.Serialization.JsonSerializableAttribute";
+            private const string JsonSerializableAttributeFullName = "System.Text.Json.Serialization.JsonSerializableAttribute";
             private const string JsonSourceGenerationOptionsAttributeFullName = "System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute";
 
             private const string DateOnlyFullName = "System.DateOnly";
@@ -249,7 +249,7 @@ namespace System.Text.Json.SourceGeneration
             {
                 Compilation compilation = _compilation;
                 INamedTypeSymbol jsonSerializerContextSymbol = compilation.GetBestTypeByMetadataName(JsonSerializerContextFullName);
-                INamedTypeSymbol jsonSerializableAttributeSymbol = compilation.GetBestTypeByMetadataName(JsonSerializerAttributeFullName);
+                INamedTypeSymbol jsonSerializableAttributeSymbol = compilation.GetBestTypeByMetadataName(JsonSerializableAttributeFullName);
                 INamedTypeSymbol jsonSourceGenerationOptionsAttributeSymbol = compilation.GetBestTypeByMetadataName(JsonSourceGenerationOptionsAttributeFullName);
                 INamedTypeSymbol jsonConverterOfTAttributeSymbol = compilation.GetBestTypeByMetadataName(JsonConverterOfTFullName);
 
@@ -560,7 +560,7 @@ namespace System.Text.Json.SourceGeneration
                         INamedTypeSymbol attributeContainingTypeSymbol = attributeSymbol.ContainingType;
                         string fullName = attributeContainingTypeSymbol.ToDisplayString();
 
-                        if (fullName == JsonSerializerAttributeFullName)
+                        if (fullName == JsonSerializableAttributeFullName)
                         {
                             return classDeclarationSyntax;
                         }

--- a/src/libraries/System.Text.Json/gen/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/gen/Resources/Strings.resx
@@ -165,4 +165,10 @@
   <data name="InaccessibleJsonIncludePropertiesNotSupportedFormat" xml:space="preserve">
     <value>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</value>
   </data>
+  <data name="FastPathPolymorphismNotSupportedTitle" xml:space="preserve">
+    <value>'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</value>
+  </data>
+  <data name="FastPathPolymorphismNotSupportedMessageFormat" xml:space="preserve">
+    <value>Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</value>
+  </data>
 </root>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.cs.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Duplicitní název typu</target>
         <note />
       </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedMessageFormat">
+        <source>Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedTitle">
+        <source>'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="translated">Člen {0}.{1} má anotaci od JsonIncludeAttribute, ale není pro zdrojový generátor viditelný.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.de.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Doppelter Typname</target>
         <note />
       </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedMessageFormat">
+        <source>Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedTitle">
+        <source>'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="translated">Der Member "{0}. {1}" wurde mit dem JsonIncludeAttribute versehen, ist jedoch für den Quellgenerator nicht sichtbar.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.es.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Nombre de tipo duplicado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedMessageFormat">
+        <source>Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedTitle">
+        <source>'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="translated">El miembro '{0}.{1}' se ha anotado con JsonIncludeAttribute, pero no es visible para el generador de origen.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.fr.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Nom de type dupliqué.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedMessageFormat">
+        <source>Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedTitle">
+        <source>'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="translated">Le membre '{0}.{1}' a été annoté avec JsonIncludeAttribute mais n’est pas visible pour le générateur source.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.it.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Nome di tipo duplicato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedMessageFormat">
+        <source>Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedTitle">
+        <source>'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="translated">Il membro ' {0}.{1}' è stato annotato con JsonIncludeAttribute ma non è visibile al generatore di origine.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ja.xlf
@@ -32,6 +32,16 @@
         <target state="translated">重複した種類名。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedMessageFormat">
+        <source>Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedTitle">
+        <source>'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="translated">メンバー '{0}.{1}' には、JsonIncludeAttribute で注釈が付けられていますが、ソース ジェネレーターには表示されません。</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ko.xlf
@@ -32,6 +32,16 @@
         <target state="translated">중복된 형식 이름입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedMessageFormat">
+        <source>Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedTitle">
+        <source>'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="translated">멤버 '{0}.{1}'이(가) JsonIncludeAttribute로 주석 처리되었지만 원본 생성기에는 표시되지 않습니다.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pl.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Zduplikowana nazwa typu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedMessageFormat">
+        <source>Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedTitle">
+        <source>'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="translated">Składowa "{0}. {1}" jest adnotowana za pomocą atrybutu JsonIncludeAttribute, ale nie jest widoczna dla generatora źródła.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Nome de tipo duplicado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedMessageFormat">
+        <source>Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedTitle">
+        <source>'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="translated">O membro '{0}.{1}' foi anotado com o JsonIncludeAttribute, mas não é visível para o gerador de origem.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ru.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Дублирующееся имя типа.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedMessageFormat">
+        <source>Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedTitle">
+        <source>'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="translated">Элемент "{0}.{1}" аннотирован с использованием класса JsonIncludeAttribute, но генератор исходного кода не обнаруживает этот элемент.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.tr.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Yinelenen tür adı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedMessageFormat">
+        <source>Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedTitle">
+        <source>'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="translated">'{0}.{1}' üyesine JsonIncludeAttribute notu eklendi ancak bu üye kaynak oluşturucu tarafından görülmüyor.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -32,6 +32,16 @@
         <target state="translated">重复的类型名称。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedMessageFormat">
+        <source>Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedTitle">
+        <source>'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="translated">已使用 JsonIncludeAttribute 注释成员“{0}.{1}”，但对源生成器不可见。</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -32,6 +32,16 @@
         <target state="translated">重複類型名稱。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedMessageFormat">
+        <source>Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Type '{0}' is annotated with 'JsonDerivedTypeAttribute' which is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FastPathPolymorphismNotSupportedTitle">
+        <source>'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">'JsonDerivedTypeAttribute' is not supported in 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="translated">成員 '{0}.{1}' 已經以 JsonIncludeAttribute 標註，但對來源產生器是不可見的。</target>

--- a/src/libraries/System.Text.Json/gen/TypeGenerationSpec.cs
+++ b/src/libraries/System.Text.Json/gen/TypeGenerationSpec.cs
@@ -44,6 +44,7 @@ namespace System.Text.Json.SourceGeneration
         public bool ImplementsIJsonOnSerialized { get; private set; }
         public bool ImplementsIJsonOnSerializing { get; private set; }
 
+        public bool IsPolymorphic { get; private set; }
         public bool IsValueType { get; private set; }
 
         public bool CanBeNull { get; private set; }
@@ -126,7 +127,8 @@ namespace System.Text.Json.SourceGeneration
             bool implementsIJsonOnSerializing,
             bool hasTypeFactoryConverter,
             bool canContainNullableReferenceAnnotations,
-            bool hasPropertyFactoryConverters)
+            bool hasPropertyFactoryConverters,
+            bool isPolymorphic)
         {
             GenerationMode = generationMode;
             TypeRef = type.GetCompilableName();
@@ -135,6 +137,7 @@ namespace System.Text.Json.SourceGeneration
             ClassType = classType;
             IsValueType = type.IsValueType;
             CanBeNull = !IsValueType || nullableUnderlyingTypeMetadata != null;
+            IsPolymorphic = isPolymorphic;
             NumberHandling = numberHandling;
             PropertyGenSpecList = propertyGenSpecList;
             CtorParamGenSpecArray = ctorParamGenSpecArray;
@@ -238,6 +241,11 @@ namespace System.Text.Json.SourceGeneration
 
         private bool FastPathIsSupported()
         {
+            if (IsPolymorphic)
+            {
+                return false;
+            }
+
             if (ClassType == ClassType.Object)
             {
                 if (ExtensionDataPropertyTypeSpec != null)

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -320,6 +320,8 @@ namespace System.Text.Json
         public System.Text.Json.JsonNamingPolicy? PropertyNamingPolicy { get { throw null; } set { } }
         public System.Text.Json.JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
         public System.Text.Json.Serialization.ReferenceHandler? ReferenceHandler { get { throw null; } set { } }
+        [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
+        public System.Collections.Generic.IList<System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration> PolymorphicTypeConfigurations { get { throw null; } }
         public System.Text.Json.Serialization.JsonUnknownTypeHandling UnknownTypeHandling { get { throw null; } set { } }
         public bool WriteIndented { get { throw null; } set { } }
         public void AddContext<TContext>() where TContext : System.Text.Json.Serialization.JsonSerializerContext, new() { }
@@ -829,6 +831,15 @@ namespace System.Text.Json.Serialization
             System.Text.Json.JsonSerializerOptions options);
         public virtual void WriteAsPropertyName(System.Text.Json.Utf8JsonWriter writer, T value, System.Text.Json.JsonSerializerOptions options) { }
     }
+    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple = true, Inherited = false)]
+    public partial class JsonDerivedTypeAttribute : System.Text.Json.Serialization.JsonAttribute
+    {
+        public JsonDerivedTypeAttribute(System.Type derivedType) { }
+        public JsonDerivedTypeAttribute(System.Type derivedType, string typeDiscriminatorId) { }
+        public System.Type DerivedType { get { throw null; } }
+        public string? TypeDiscriminatorId { get { throw null; } }
+    }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple=false)]
     public sealed partial class JsonExtensionDataAttribute : System.Text.Json.Serialization.JsonAttribute
     {
@@ -870,6 +881,15 @@ namespace System.Text.Json.Serialization
     {
         public JsonNumberHandlingAttribute(System.Text.Json.Serialization.JsonNumberHandling handling) { }
         public System.Text.Json.Serialization.JsonNumberHandling Handling { get { throw null; } }
+    }
+    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+    public sealed partial class JsonPolymorphicAttribute : System.Text.Json.Serialization.JsonAttribute
+    {
+        public JsonPolymorphicAttribute() { }
+        public string? CustomTypeDiscriminatorPropertyName { get { throw null; } set { } }
+        public bool IgnoreUnrecognizedTypeDiscriminators { get { throw null; } set { } }
+        public System.Text.Json.Serialization.JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get { throw null; } set { } }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple=false)]
     public sealed partial class JsonPropertyNameAttribute : System.Text.Json.Serialization.JsonAttribute
@@ -923,10 +943,42 @@ namespace System.Text.Json.Serialization
         public sealed override bool CanConvert(System.Type typeToConvert) { throw null; }
         public sealed override System.Text.Json.Serialization.JsonConverter CreateConverter(System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) { throw null; }
     }
+    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
+    public enum JsonUnknownDerivedTypeHandling
+    {
+        FailSerialization = 0,
+        FallbackToBaseType = 1,
+        FallbackToNearestAncestor = 2
+    }
     public enum JsonUnknownTypeHandling
     {
         JsonElement = 0,
         JsonNode = 1,
+    }
+    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
+    public partial class JsonPolymorphicTypeConfiguration : System.Collections.Generic.ICollection<(System.Type DerivedType, string? TypeDiscriminatorId)>, System.Collections.Generic.IEnumerable<(System.Type DerivedType, string? TypeDiscriminatorId)>, System.Collections.IEnumerable
+    {
+        public JsonPolymorphicTypeConfiguration(System.Type baseType) { }
+        public System.Type BaseType { get { throw null; } }
+        public string? CustomTypeDiscriminatorPropertyName { get { throw null; } set { } }
+        public bool IgnoreUnrecognizedTypeDiscriminators { get { throw null; } set { } }
+        int System.Collections.Generic.ICollection<(System.Type DerivedType, string? TypeDiscriminatorId)>.Count { get { throw null; } }
+        public System.Text.Json.Serialization.JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get { throw null; } set { } }
+        bool System.Collections.Generic.ICollection<(System.Type DerivedType, string? TypeDiscriminatorId)>.IsReadOnly { get { throw null; } }
+        void System.Collections.Generic.ICollection<(System.Type DerivedType, string? TypeDiscriminatorId)>.Add((System.Type DerivedType, string TypeDiscriminatorId) item) { }
+        void System.Collections.Generic.ICollection<(System.Type DerivedType, string? TypeDiscriminatorId)>.Clear() { }
+        bool System.Collections.Generic.ICollection<(System.Type DerivedType, string? TypeDiscriminatorId)>.Contains((System.Type DerivedType, string TypeDiscriminatorId) item) { throw null; }
+        void System.Collections.Generic.ICollection<(System.Type DerivedType, string? TypeDiscriminatorId)>.CopyTo((System.Type DerivedType, string TypeDiscriminatorId)[] array, int arrayIndex) { }
+        bool System.Collections.Generic.ICollection<(System.Type DerivedType, string? TypeDiscriminatorId)>.Remove((System.Type DerivedType, string TypeDiscriminatorId) item) { throw null; }
+        System.Collections.Generic.IEnumerator<(System.Type DerivedType, string? TypeDiscriminatorId)> System.Collections.Generic.IEnumerable<(System.Type DerivedType, string? TypeDiscriminatorId)>.GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration WithDerivedType(System.Type derivedType, string? typeDiscriminatorId = null) { throw null; }
+    }
+    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
+    public partial class JsonPolymorphicTypeConfiguration<TBaseType> : System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration where TBaseType : class
+    {
+        public JsonPolymorphicTypeConfiguration() : base(default(System.Type)) { }
+        public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>(string? typeDiscriminatorId = null) where TDerivedType : TBaseType { throw null; }
     }
     public abstract partial class ReferenceHandler
     {

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -320,7 +320,6 @@ namespace System.Text.Json
         public System.Text.Json.JsonNamingPolicy? PropertyNamingPolicy { get { throw null; } set { } }
         public System.Text.Json.JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
         public System.Text.Json.Serialization.ReferenceHandler? ReferenceHandler { get { throw null; } set { } }
-        [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
         public System.Collections.Generic.IList<System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration> PolymorphicTypeConfigurations { get { throw null; } }
         public System.Text.Json.Serialization.JsonUnknownTypeHandling UnknownTypeHandling { get { throw null; } set { } }
         public bool WriteIndented { get { throw null; } set { } }
@@ -831,7 +830,6 @@ namespace System.Text.Json.Serialization
             System.Text.Json.JsonSerializerOptions options);
         public virtual void WriteAsPropertyName(System.Text.Json.Utf8JsonWriter writer, T value, System.Text.Json.JsonSerializerOptions options) { }
     }
-    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple = true, Inherited = false)]
     public partial class JsonDerivedTypeAttribute : System.Text.Json.Serialization.JsonAttribute
     {
@@ -882,7 +880,6 @@ namespace System.Text.Json.Serialization
         public JsonNumberHandlingAttribute(System.Text.Json.Serialization.JsonNumberHandling handling) { }
         public System.Text.Json.Serialization.JsonNumberHandling Handling { get { throw null; } }
     }
-    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
     public sealed partial class JsonPolymorphicAttribute : System.Text.Json.Serialization.JsonAttribute
     {
@@ -943,7 +940,6 @@ namespace System.Text.Json.Serialization
         public sealed override bool CanConvert(System.Type typeToConvert) { throw null; }
         public sealed override System.Text.Json.Serialization.JsonConverter CreateConverter(System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) { throw null; }
     }
-    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
     public enum JsonUnknownDerivedTypeHandling
     {
         FailSerialization = 0,
@@ -955,7 +951,6 @@ namespace System.Text.Json.Serialization
         JsonElement = 0,
         JsonNode = 1,
     }
-    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
     public partial class JsonPolymorphicTypeConfiguration : System.Collections.Generic.ICollection<(System.Type DerivedType, string? TypeDiscriminatorId)>, System.Collections.Generic.IEnumerable<(System.Type DerivedType, string? TypeDiscriminatorId)>, System.Collections.IEnumerable
     {
         public JsonPolymorphicTypeConfiguration(System.Type baseType) { }
@@ -974,7 +969,6 @@ namespace System.Text.Json.Serialization
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration WithDerivedType(System.Type derivedType, string? typeDiscriminatorId = null) { throw null; }
     }
-    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
     public partial class JsonPolymorphicTypeConfiguration<TBaseType> : System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration where TBaseType : class
     {
         public JsonPolymorphicTypeConfiguration() : base(default(System.Type)) { }

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.csproj
@@ -3,9 +3,6 @@
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IncludeInternalObsoleteAttribute>true</IncludeInternalObsoleteAttribute>
-    <!-- Remove once polymoprhism is out of preview. -->
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
-    <GenerateRequiresPreviewFeaturesAttribute>false</GenerateRequiresPreviewFeaturesAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.csproj
@@ -5,7 +5,7 @@
     <IncludeInternalObsoleteAttribute>true</IncludeInternalObsoleteAttribute>
     <!-- Remove once polymoprhism is out of preview. -->
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
-    <GenerateRequiresPreviewFeaturesAttribute>true</GenerateRequiresPreviewFeaturesAttribute>
+    <GenerateRequiresPreviewFeaturesAttribute>false</GenerateRequiresPreviewFeaturesAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.csproj
@@ -3,6 +3,9 @@
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IncludeInternalObsoleteAttribute>true</IncludeInternalObsoleteAttribute>
+    <!-- Remove once polymoprhism is out of preview. -->
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <GenerateRequiresPreviewFeaturesAttribute>true</GenerateRequiresPreviewFeaturesAttribute>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,6 +18,7 @@
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\IsExternalInit.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Runtime\Versioning\RequiresPreviewFeaturesAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\RequiresUnreferencedCodeAttribute.cs" />
@@ -42,6 +46,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Bcl.AsyncInterfaces\ref\Microsoft.Bcl.AsyncInterfaces.csproj" />

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -635,6 +635,9 @@
   <data name="Polymorphism_TypeDicriminatorIdIsAlreadySpecified" xml:space="preserve">
     <value>The polymorphic type '{0}' has already specified a type discriminator '{1}'.</value>
   </data>
+  <data name="Polymorphism_InvalidCustomTypeDiscriminatorPropertyName" xml:space="preserve">
+    <value>The metadata property names '$id', '$ref', and '$values' are reserved and cannot be used as custom type discriminator property names.</value>
+  </data>
   <data name="Polymorphism_ConfigurationDoesNotSpecifyDerivedTypes" xml:space="preserve">
     <value>Polymorphic configuration for type '{0}' should specify at least one derived type.</value>
   </data>

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -430,13 +430,13 @@
     <value>Invalid leading zero before '{0}'.</value>
   </data>
   <data name="MetadataCannotParsePreservedObjectToImmutable" xml:space="preserve">
-    <value>Cannot parse a JSON object containing metadata properties like '$id' into an array or immutable collection type. Type '{0}'.</value>
+    <value>Cannot parse a JSON object containing metadata properties like '$id' or '$type' into an array or immutable collection type. Type '{0}'.</value>
   </data>
   <data name="MetadataDuplicateIdFound" xml:space="preserve">
     <value>The value of the '$id' metadata property '{0}' conflicts with an existing identifier.</value>
   </data>
   <data name="MetadataIdIsNotFirstProperty" xml:space="preserve">
-    <value>The metadata property '$id' must be the first property in the JSON object.</value>
+    <value>The metadata property '$id' must be the first reference preservation property in the JSON object.</value>
   </data>
   <data name="MetadataInvalidReferenceToValueType" xml:space="preserve">
     <value>Invalid reference to value type '{0}'.</value>
@@ -449,23 +449,29 @@
 1. {0}
 2. {1}</value>
   </data>
-  <data name="MetadataPreservedArrayInvalidProperty" xml:space="preserve">
-    <value>Invalid property '{0}' found within a JSON object that must only contain metadata properties and the nested JSON array to be preserved.</value>
+  <data name="MetadataInvalidPropertyInArrayMetadata" xml:space="preserve">
+    <value>A JSON object containing metadata for a nested array includes a non-metadata property '{0}'.</value>
   </data>
-  <data name="MetadataPreservedArrayPropertyNotFound" xml:space="preserve">
-    <value>One or more metadata properties, such as '$id' and '$values', were not found within a JSON object that must only contain metadata properties and the nested JSON array to be preserved.</value>
+  <data name="MetadataStandaloneValuesProperty" xml:space="preserve">
+    <value>A '$values' metadata property must always be preceded by other metadata properties, such as '$id' or '$type'.</value>
   </data>
   <data name="MetadataReferenceCannotContainOtherProperties" xml:space="preserve">
     <value>A JSON object that contains a '$ref' metadata property must not contain any other properties.</value>
   </data>
   <data name="MetadataReferenceNotFound" xml:space="preserve">
-    <value>Reference '{0}' not found.</value>
+    <value>Reference '{0}' was not found.</value>
   </data>
   <data name="MetadataValueWasNotString" xml:space="preserve">
-    <value>The '$id' and '$ref' metadata properties must be JSON strings. Current token type is '{0}'.</value>
+    <value>The '$id', '$ref' or '$type' metadata properties must be JSON strings. Current token type is '{0}'.</value>
   </data>
   <data name="MetadataInvalidPropertyWithLeadingDollarSign" xml:space="preserve">
-    <value>Properties that start with '$' are not allowed on preserve mode, either escape the character or turn off preserve references by setting ReferenceHandler to null.</value>
+    <value>Properties that start with '$' are not allowed in types that support metadata. Either escape the character or disable reference preservation and polymorphic deserialization.</value>
+  </data>
+  <data name="MetadataUnexpectedProperty" xml:space="preserve">
+    <value>The metadata property is either not supported by the type or is not the first property in the deserialized JSON object.</value>
+  </data>
+  <data name="MetadataDuplicateTypeProperty" xml:space="preserve">
+    <value>Deserialized object contains a duplicate '$type' metadata property.</value>
   </data>
   <data name="MultipleMembersBindWithConstructorParameter" xml:space="preserve">
     <value>Members '{0}' and '{1}' on type '{2}' cannot both bind with parameter '{3}' in the deserialization constructor.</value>
@@ -610,5 +616,35 @@
   </data>
   <data name="NoMetadataForTypeCtorParams" xml:space="preserve">
     <value>'JsonSerializerContext' '{0}' did not provide constructor parameter metadata for type '{1}'.</value>
+  </data>
+  <data name="Polymorphism_BaseConverterDoesNotSupportMetadata" xml:space="preserve">
+    <value>The converter for polymorphic type '{0}' does not support metadata writes or reads.</value>
+  </data>
+  <data name="Polymorphism_DerivedConverterDoesNotSupportMetadata" xml:space="preserve">
+    <value>The converter for derived type '{0}' does not support metadata writes or reads.</value>
+  </data>
+  <data name="Polymorphism_TypeDoesNotSupportPolymorphism" xml:space="preserve">
+    <value>Specified type '{0}' does not support polymorphism. Polymorphic types cannot be structs, sealed types, generic types or System.Object.</value>
+  </data>
+  <data name="Polymorphism_DerivedTypeIsNotSupported" xml:space="preserve">
+    <value>Specified type '{0}' is not a supported derived type for the polymorphic type '{1}'. Derived types must be assignable to the base type, must not be generic and cannot be abstact classes or interfaces unless 'JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor' is specified.</value>
+  </data>
+  <data name="Polymorphism_DerivedTypeIsAlreadySpecified" xml:space="preserve">
+    <value>The polymorphic type '{0}' has already specified derived type '{1}'.</value>
+  </data>
+  <data name="Polymorphism_TypeDicriminatorIdIsAlreadySpecified" xml:space="preserve">
+    <value>The polymorphic type '{0}' has already specified a type discriminator '{1}'.</value>
+  </data>
+  <data name="Polymorphism_ConfigurationDoesNotSpecifyDerivedTypes" xml:space="preserve">
+    <value>Polymorphic configuration for type '{0}' should specify at least one derived type.</value>
+  </data>
+  <data name="Polymorphism_UnrecognizedTypeDiscriminator" xml:space="preserve">
+    <value>Read unrecognized type discriminator id '{0}'.</value>
+  </data>
+  <data name="Polymorphism_RuntimeTypeNotSupported" xml:space="preserve">
+    <value>Runtime type '{0}' is not supported by polymorphic type '{1}'.</value>
+  </data>
+  <data name="Polymorphism_RuntimeTypeDiamondAmbiguity" xml:space="preserve">
+    <value>Runtime type '{0}' has a diamond ambiguity between derived types '{1}' and '{2}' of polymorphic type '{3}'. Consider either removing one of the derived types or removing the 'JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor' setting.</value>
   </data>
 </root>

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -471,7 +471,7 @@
     <value>The metadata property is either not supported by the type or is not the first property in the deserialized JSON object.</value>
   </data>
   <data name="MetadataDuplicateTypeProperty" xml:space="preserve">
-    <value>Deserialized object contains a duplicate '$type' metadata property.</value>
+    <value>Deserialized object contains a duplicate type discriminator metadata property.</value>
   </data>
   <data name="MultipleMembersBindWithConstructorParameter" xml:space="preserve">
     <value>Members '{0}' and '{1}' on type '{2}' cannot both bind with parameter '{3}' in the deserialization constructor.</value>

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -7,6 +7,9 @@
     <!-- For this project, we want warnings if there are public APIs/types without properly formatted XML comments (particularly CS1591). -->
     <NoWarn>CS8969</NoWarn>
     <Nullable>enable</Nullable>
+    <!-- Remove once polymorphism is out of preview. -->
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <GenerateRequiresPreviewFeaturesAttribute>false</GenerateRequiresPreviewFeaturesAttribute>
     <IncludeInternalObsoleteAttribute>true</IncludeInternalObsoleteAttribute>
     <IsPackable>true</IsPackable>
     <PackageDescription>Provides high-performance and low-allocating types that serialize objects to JavaScript Object Notation (JSON) text and deserialize JSON text to objects, with UTF-8 support built-in. Also provides types to read and write JSON text encoded as UTF-8, and to create an in-memory document object model (DOM), that is read-only, for random access of the JSON elements within a structured view of the data.
@@ -98,10 +101,12 @@ System.Text.Json.Nodes.JsonValue</PackageDescription>
     <Compile Include="System\Text\Json\Serialization\ArgumentState.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonConstructorAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonConverterAttribute.cs" />
+    <Compile Include="System\Text\Json\Serialization\Attributes\JsonDerivedTypeAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonExtensionDataAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonIgnoreAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonIncludeAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonNumberHandlingAttribute.cs" />
+    <Compile Include="System\Text\Json\Serialization\Attributes\JsonPolymorphicAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonPropertyNameAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonPropertyOrderAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ImmutableDictionaryOfTKeyTValueConverterWithReflection.cs" />
@@ -121,12 +126,12 @@ System.Text.Json.Nodes.JsonValue</PackageDescription>
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Write.Element.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Write.Node.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializerContext.cs" />
-    <Compile Include="System\Text\Json\Serialization\JsonSerializerOptions.Caching.cs" />
-    <Compile Include="System\Text\Json\Serialization\Metadata\ReflectionJsonTypeInfoOfT.cs" />
+    <Compile Include="System\Text\Json\Serialization\JsonUnknownDerivedTypeHandling.cs" />
     <Compile Include="System\Text\Json\Serialization\PolymorphicSerializationState.cs" />
+    <Compile Include="System\Text\Json\Serialization\JsonPolymorphicTypeConfiguration.cs" />
     <Compile Include="System\Text\Json\Serialization\ReferenceEqualsWrapper.cs" />
     <Compile Include="System\Text\Json\Serialization\ConverterStrategy.cs" />
-    <Compile Include="System\Text\Json\Serialization\ConverterList.cs" />
+    <Compile Include="System\Text\Json\Serialization\ConfigurationList.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ArrayConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ConcurrentQueueOfTConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ConcurrentStackOfTConverter.cs" />
@@ -205,6 +210,7 @@ System.Text.Json.Nodes.JsonValue</PackageDescription>
     <Compile Include="System\Text\Json\Serialization\Converters\Value\VersionConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\IgnoreReferenceHandler.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\JsonConverter.MetadataHandling.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonConverter.ReadAhead.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonConverterFactory.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonConverterOfT.ReadCore.cs" />
@@ -226,12 +232,15 @@ System.Text.Json.Nodes.JsonValue</PackageDescription>
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Write.String.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Write.Utf8JsonWriter.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializerDefaults.cs" />
+    <Compile Include="System\Text\Json\Serialization\JsonSerializerOptions.Caching.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializerOptions.Converters.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializerOptions.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonStringEnumConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonUnknownTypeHandling.cs" />
+    <Compile Include="System\Text\Json\Serialization\Metadata\AttributePolymorphicTypeConfiguration.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\FSharpCoreReflectionProxy.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\DefaultValueHolder.cs" />
+    <Compile Include="System\Text\Json\Serialization\Metadata\IJsonPolymorphicTypeConfiguration.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\JsonCollectionInfoValuesOfTCollection.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\JsonMetadataServices.Collections.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\JsonMetadataServices.Converters.cs" />
@@ -249,7 +258,9 @@ System.Text.Json.Nodes.JsonValue</PackageDescription>
     <Compile Include="System\Text\Json\Serialization\Metadata\JsonTypeInfo.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\MemberAccessor.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\ParameterRef.cs" />
+    <Compile Include="System\Text\Json\Serialization\Metadata\PolymorphicTypeResolver.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\PropertyRef.cs" />
+    <Compile Include="System\Text\Json\Serialization\Metadata\ReflectionJsonTypeInfoOfT.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\ReflectionEmitCachingMemberAccessor.Cache.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\ReflectionEmitCachingMemberAccessor.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\ReflectionEmitMemberAccessor.cs" />
@@ -312,6 +323,7 @@ System.Text.Json.Nodes.JsonValue</PackageDescription>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <Compile Include="$(CoreLibSharedDir)System\Collections\Generic\ReferenceEqualityComparer.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\IsExternalInit.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Runtime\Versioning\RequiresPreviewFeaturesAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicDependencyAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -7,9 +7,6 @@
     <!-- For this project, we want warnings if there are public APIs/types without properly formatted XML comments (particularly CS1591). -->
     <NoWarn>CS8969</NoWarn>
     <Nullable>enable</Nullable>
-    <!-- Remove once polymorphism is out of preview. -->
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
-    <GenerateRequiresPreviewFeaturesAttribute>false</GenerateRequiresPreviewFeaturesAttribute>
     <IncludeInternalObsoleteAttribute>true</IncludeInternalObsoleteAttribute>
     <IsPackable>true</IsPackable>
     <PackageDescription>Provides high-performance and low-allocating types that serialize objects to JavaScript Object Notation (JSON) text and deserialize JSON text to objects, with UTF-8 support built-in. Also provides types to read and write JSON text encoded as UTF-8, and to create an in-memory document object model (DOM), that is read-only, for random access of the JSON elements within a structured view of the data.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonDerivedTypeAttribute.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonDerivedTypeAttribute.cs
@@ -6,7 +6,6 @@ namespace System.Text.Json.Serialization
     /// <summary>
     /// When placed on a type declaration, indicates that the specified subtype should be opted into polymorphic serialization.
     /// </summary>
-    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true, Inherited = false)]
     public class JsonDerivedTypeAttribute : JsonAttribute
     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonDerivedTypeAttribute.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonDerivedTypeAttribute.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>
+    /// When placed on a type declaration, indicates that the specified subtype should be opted into polymorphic serialization.
+    /// </summary>
+    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true, Inherited = false)]
+    public class JsonDerivedTypeAttribute : JsonAttribute
+    {
+        /// <summary>
+        /// Initializes a new attribute with specified parameters.
+        /// </summary>
+        /// <param name="derivedType">A derived type that should be supported in polymorphic serialization of the declared based type.</param>
+        public JsonDerivedTypeAttribute(Type derivedType)
+        {
+            DerivedType = derivedType;
+        }
+
+        /// <summary>
+        /// Initializes a new attribute with specified parameters.
+        /// </summary>
+        /// <param name="derivedType">A derived type that should be supported in polymorphic serialization of the declared base type.</param>
+        /// <param name="typeDiscriminatorId">The type discriminator identifier to be used for the serialization of the subtype.</param>
+        public JsonDerivedTypeAttribute(Type derivedType, string typeDiscriminatorId)
+        {
+            DerivedType = derivedType;
+            TypeDiscriminatorId = typeDiscriminatorId;
+        }
+
+        /// <summary>
+        /// A derived type that should be supported in polymorphic serialization of the declared base type.
+        /// </summary>
+        public Type DerivedType { get; }
+
+        /// <summary>
+        /// The type discriminator identifier to be used for the serialization of the subtype.
+        /// </summary>
+        public string? TypeDiscriminatorId { get; }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonPolymorphicAttribute.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonPolymorphicAttribute.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>
+    /// When placed on a type, indicates that the type should be serialized polymorphically.
+    /// </summary>
+    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+    public sealed class JsonPolymorphicAttribute : JsonAttribute
+    {
+        /// <summary>
+        /// Gets or sets a custom type discriminator property name for the polymorhic type.
+        /// Uses the default '$type' property name if left unset.
+        /// </summary>
+        public string? CustomTypeDiscriminatorPropertyName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the behavior when serializing an undeclared derived runtime type.
+        /// </summary>
+        public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get; set; }
+
+        /// <summary>
+        /// When set to <see langword="true"/>, instructs the deserializer to ignore any
+        /// unrecognized type discriminator id's and reverts to the contract of the base type.
+        /// Otherwise, it will fail the deserialization.
+        /// </summary>
+        public bool IgnoreUnrecognizedTypeDiscriminators { get; set; }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonPolymorphicAttribute.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonPolymorphicAttribute.cs
@@ -6,7 +6,6 @@ namespace System.Text.Json.Serialization
     /// <summary>
     /// When placed on a type, indicates that the type should be serialized polymorphically.
     /// </summary>
-    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
     public sealed class JsonPolymorphicAttribute : JsonAttribute
     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ConfigurationList.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ConfigurationList.cs
@@ -3,30 +3,33 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace System.Text.Json.Serialization
 {
     /// <summary>
-    /// A list of JsonConverters that respects the options class being immuttable once (de)serialization occurs.
+    /// A list of configuration items that respects the options class being immutable once (de)serialization occurs.
     /// </summary>
-    internal sealed class ConverterList : IList<JsonConverter>
+    internal sealed class ConfigurationList<TItem> : IList<TItem>
     {
-        private readonly List<JsonConverter> _list;
+        private readonly List<TItem> _list;
         private readonly JsonSerializerOptions _options;
 
-        public ConverterList(JsonSerializerOptions options)
+        public Action<TItem>? OnElementAdded { get; set; }
+
+        public ConfigurationList(JsonSerializerOptions options)
         {
             _options = options;
-            _list = new List<JsonConverter>();
+            _list = new List<TItem>();
         }
 
-        public ConverterList(JsonSerializerOptions options, ConverterList source)
+        public ConfigurationList(JsonSerializerOptions options, IList<TItem> source)
         {
             _options = options;
-            _list = new List<JsonConverter>(source._list);
+            _list = new List<TItem>(source is ConfigurationList<TItem> cl ? cl._list : source);
         }
 
-        public JsonConverter this[int index]
+        public TItem this[int index]
         {
             get
             {
@@ -41,6 +44,7 @@ namespace System.Text.Json.Serialization
 
                 _options.VerifyMutable();
                 _list[index] = value;
+                OnElementAdded?.Invoke(value);
             }
         }
 
@@ -48,10 +52,11 @@ namespace System.Text.Json.Serialization
 
         public bool IsReadOnly => false;
 
-        public void Add(JsonConverter item!!)
+        public void Add(TItem item!!)
         {
             _options.VerifyMutable();
             _list.Add(item);
+            OnElementAdded?.Invoke(item);
         }
 
         public void Clear()
@@ -60,33 +65,34 @@ namespace System.Text.Json.Serialization
             _list.Clear();
         }
 
-        public bool Contains(JsonConverter item)
+        public bool Contains(TItem item)
         {
             return _list.Contains(item);
         }
 
-        public void CopyTo(JsonConverter[] array, int arrayIndex)
+        public void CopyTo(TItem[] array, int arrayIndex)
         {
             _list.CopyTo(array, arrayIndex);
         }
 
-        public IEnumerator<JsonConverter> GetEnumerator()
+        public IEnumerator<TItem> GetEnumerator()
         {
             return _list.GetEnumerator();
         }
 
-        public int IndexOf(JsonConverter item)
+        public int IndexOf(TItem item)
         {
             return _list.IndexOf(item);
         }
 
-        public void Insert(int index, JsonConverter item!!)
+        public void Insert(int index, TItem item!!)
         {
             _options.VerifyMutable();
             _list.Insert(index, item);
+            OnElementAdded?.Invoke(item);
         }
 
-        public bool Remove(JsonConverter item)
+        public bool Remove(TItem item)
         {
             _options.VerifyMutable();
             return _list.Remove(item);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ArrayConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ArrayConverter.cs
@@ -53,6 +53,8 @@ namespace System.Text.Json.Serialization.Converters
                         return false;
                     }
 
+                    state.Current.EndCollectionElement();
+
                     if (ShouldFlush(writer, ref state))
                     {
                         state.Current.EnumeratorIndex = ++index;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
@@ -65,7 +65,7 @@ namespace System.Text.Json.Serialization.Converters
                     return false;
                 }
 
-                state.Current.EndDictionaryElement();
+                state.Current.EndDictionaryEntry();
             } while (enumerator.MoveNext());
 
             enumerator.Dispose();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfTKeyTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfTKeyTValueConverter.cs
@@ -80,7 +80,7 @@ namespace System.Text.Json.Serialization.Converters
                         return false;
                     }
 
-                    state.Current.EndDictionaryElement();
+                    state.Current.EndDictionaryEntry();
                 } while (enumerator.MoveNext());
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableOfTConverter.cs
@@ -117,6 +117,7 @@ namespace System.Text.Json.Serialization.Converters
                     return false;
                 }
 
+                state.Current.EndCollectionElement();
                 moveNextTask = enumerator.MoveNextAsync();
             } while (moveNextTask.IsCompleted);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryConverter.cs
@@ -89,7 +89,7 @@ namespace System.Text.Json.Serialization.Converters
                     return false;
                 }
 
-                state.Current.EndDictionaryElement();
+                state.Current.EndDictionaryEntry();
             } while (enumerator.MoveNext());
 
             return true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverter.cs
@@ -70,6 +70,8 @@ namespace System.Text.Json.Serialization.Converters
                     state.Current.CollectionEnumerator = enumerator;
                     return false;
                 }
+
+                state.Current.EndCollectionElement();
             } while (enumerator.MoveNext());
 
             return true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
@@ -49,6 +49,8 @@ namespace System.Text.Json.Serialization.Converters
                     state.Current.CollectionEnumerator = enumerator;
                     return false;
                 }
+
+                state.Current.EndCollectionElement();
             } while (enumerator.MoveNext());
 
             enumerator.Dispose();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListConverter.cs
@@ -61,6 +61,8 @@ namespace System.Text.Json.Serialization.Converters
                         return false;
                     }
 
+                    state.Current.EndCollectionElement();
+
                     if (ShouldFlush(writer, ref state))
                     {
                         state.Current.EnumeratorIndex = ++index;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
@@ -86,7 +86,7 @@ namespace System.Text.Json.Serialization
             JsonTypeInfo keyTypeInfo = state.Current.JsonTypeInfo.KeyTypeInfo!;
             JsonTypeInfo elementTypeInfo = state.Current.JsonTypeInfo.ElementTypeInfo!;
 
-            if (state.UseFastPath)
+            if (!state.SupportContinuation && !state.Current.CanContainMetadata)
             {
                 // Fast path that avoids maintaining state variables and dealing with preserved references.
 
@@ -156,6 +156,7 @@ namespace System.Text.Json.Serialization
             else
             {
                 // Slower path that supports continuation and reading metadata.
+                JsonTypeInfo jsonTypeInfo = state.Current.JsonTypeInfo;
 
                 if (state.Current.ObjectState == StackFrameObjectState.None)
                 {
@@ -168,29 +169,41 @@ namespace System.Text.Json.Serialization
                 }
 
                 // Handle the metadata properties.
-                if (state.CanContainMetadata && state.Current.ObjectState < StackFrameObjectState.ReadMetadata)
+                if (state.Current.CanContainMetadata && state.Current.ObjectState < StackFrameObjectState.ReadMetadata)
                 {
-                    if (!JsonSerializer.TryReadMetadata(this, ref reader, ref state))
+                    if (!JsonSerializer.TryReadMetadata(this, jsonTypeInfo, ref reader, ref state))
                     {
                         value = default;
                         return false;
-                    }
-
-                    state.Current.ObjectState = StackFrameObjectState.ReadMetadata;
-                }
-
-                // Create the dictionary.
-                if (state.Current.ObjectState < StackFrameObjectState.CreatedObject)
-                {
-                    if (state.CanContainMetadata)
-                    {
-                        JsonSerializer.ValidateMetadataForObjectConverter(this, ref reader, ref state);
                     }
 
                     if (state.Current.MetadataPropertyNames == MetadataPropertyName.Ref)
                     {
                         value = JsonSerializer.ResolveReferenceId<TDictionary>(ref state);
                         return true;
+                    }
+
+                    state.Current.ObjectState = StackFrameObjectState.ReadMetadata;
+                }
+
+                // Dispatch to any polymorphic converters: should always be entered regardless of ObjectState progress
+                if (state.Current.MetadataPropertyNames.HasFlag(MetadataPropertyName.Type) &&
+                    state.Current.PolymorphicSerializationState != PolymorphicSerializationState.PolymorphicReEntryStarted &&
+                    ResolvePolymorphicConverter(jsonTypeInfo, options, ref state) is JsonConverter polymorphicConverter)
+                {
+                    Debug.Assert(!IsValueType);
+                    bool success = polymorphicConverter.OnTryReadAsObject(ref reader, options, ref state, out object? objectResult);
+                    value = (TDictionary)objectResult!;
+                    state.ExitPolymorphicConverter(success);
+                    return success;
+                }
+
+                // Create the dictionary.
+                if (state.Current.ObjectState < StackFrameObjectState.CreatedObject)
+                {
+                    if (state.Current.CanContainMetadata)
+                    {
+                        JsonSerializer.ValidateMetadataForObjectConverter(this, ref reader, ref state);
                     }
 
                     CreateCollection(ref reader, ref state);
@@ -238,10 +251,10 @@ namespace System.Text.Json.Serialization
 
                         state.Current.PropertyState = StackFramePropertyState.Name;
 
-                        if (state.CanContainMetadata)
+                        if (state.Current.CanContainMetadata)
                         {
                             ReadOnlySpan<byte> propertyName = reader.GetSpan();
-                            if (propertyName.Length > 0 && propertyName[0] == '$')
+                            if (JsonSerializer.IsMetadataPropertyName(propertyName, state.Current.BaseJsonTypeInfo.PolymorphicTypeResolver))
                             {
                                 ThrowHelper.ThrowUnexpectedMetadataException(propertyName, ref reader, ref state);
                             }
@@ -326,10 +339,10 @@ namespace System.Text.Json.Serialization
             {
                 state.Current.ProcessedStartToken = true;
                 writer.WriteStartObject();
-                if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.Preserve)
+
+                if (state.CurrentContainsMetadata && CanHaveMetadata)
                 {
-                    MetadataPropertyName propertyName = JsonSerializer.WriteReferenceForObject(this, ref state, writer);
-                    Debug.Assert(propertyName != MetadataPropertyName.Ref);
+                    JsonSerializer.WriteMetadataForObject(this, ref state, writer);
                 }
 
                 state.Current.JsonPropertyInfo = state.Current.JsonTypeInfo.ElementTypeInfo!.PropertyInfoForTypeInfo;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ListOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ListOfTConverter.cs
@@ -52,6 +52,8 @@ namespace System.Text.Json.Serialization.Converters
                         return false;
                     }
 
+                    state.Current.EndCollectionElement();
+
                     if (ShouldFlush(writer, ref state))
                     {
                         state.Current.EnumeratorIndex = ++index;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOrQueueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOrQueueConverter.cs
@@ -64,6 +64,8 @@ namespace System.Text.Json.Serialization.Converters
                     state.Current.CollectionEnumerator = enumerator;
                     return false;
                 }
+
+                state.Current.EndCollectionElement();
             } while (enumerator.MoveNext());
 
             return true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
@@ -61,6 +61,7 @@ namespace System.Text.Json.Serialization.Converters
             if (!state.SupportContinuation &&
                 jsonTypeInfo is JsonTypeInfo<T> info &&
                 info.SerializeHandler != null &&
+                !state.CurrentContainsMetadata && // Do not use the fast path if state needs to write metadata.
                 info.Options.JsonSerializerContext?.CanUseSerializationLogic == true)
             {
                 info.SerializeHandler(writer, value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -22,7 +22,7 @@ namespace System.Text.Json.Serialization.Converters
 
             object obj;
 
-            if (state.UseFastPath)
+            if (!state.SupportContinuation && !state.Current.CanContainMetadata)
             {
                 // Fast path that avoids maintaining state variables and dealing with preserved references.
 
@@ -85,20 +85,38 @@ namespace System.Text.Json.Serialization.Converters
                 }
 
                 // Handle the metadata properties.
-                if (state.CanContainMetadata && state.Current.ObjectState < StackFrameObjectState.ReadMetadata)
+                if (state.Current.CanContainMetadata && state.Current.ObjectState < StackFrameObjectState.ReadMetadata)
                 {
-                    if (!JsonSerializer.TryReadMetadata(this, ref reader, ref state))
+                    if (!JsonSerializer.TryReadMetadata(this, jsonTypeInfo, ref reader, ref state))
                     {
                         value = default;
                         return false;
                     }
 
+                    if (state.Current.MetadataPropertyNames == MetadataPropertyName.Ref)
+                    {
+                        value = JsonSerializer.ResolveReferenceId<T>(ref state);
+                        return true;
+                    }
+
                     state.Current.ObjectState = StackFrameObjectState.ReadMetadata;
+                }
+
+                // Dispatch to any polymorphic converters: should always be entered regardless of ObjectState progress
+                if (state.Current.MetadataPropertyNames.HasFlag(MetadataPropertyName.Type) &&
+                    state.Current.PolymorphicSerializationState != PolymorphicSerializationState.PolymorphicReEntryStarted &&
+                    ResolvePolymorphicConverter(jsonTypeInfo, options, ref state) is JsonConverter polymorphicConverter)
+                {
+                    Debug.Assert(!IsValueType);
+                    bool success = polymorphicConverter.OnTryReadAsObject(ref reader, options, ref state, out object? objectResult);
+                    value = (T)objectResult!;
+                    state.ExitPolymorphicConverter(success);
+                    return success;
                 }
 
                 if (state.Current.ObjectState < StackFrameObjectState.CreatedObject)
                 {
-                    if (state.CanContainMetadata)
+                    if (state.Current.CanContainMetadata)
                     {
                         JsonSerializer.ValidateMetadataForObjectConverter(this, ref reader, ref state);
                     }
@@ -268,10 +286,10 @@ namespace System.Text.Json.Serialization.Converters
             if (!state.SupportContinuation)
             {
                 writer.WriteStartObject();
-                if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.Preserve)
+
+                if (state.CurrentContainsMetadata && CanHaveMetadata)
                 {
-                    MetadataPropertyName propertyName = JsonSerializer.WriteReferenceForObject(this, ref state, writer);
-                    Debug.Assert(propertyName != MetadataPropertyName.Ref);
+                    JsonSerializer.WriteMetadataForObject(this, ref state, writer);
                 }
 
                 if (obj is IJsonOnSerializing onSerializing)
@@ -318,10 +336,10 @@ namespace System.Text.Json.Serialization.Converters
                 if (!state.Current.ProcessedStartToken)
                 {
                     writer.WriteStartObject();
-                    if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.Preserve)
+
+                    if (state.CurrentContainsMetadata && CanHaveMetadata)
                     {
-                        MetadataPropertyName propertyName = JsonSerializer.WriteReferenceForObject(this, ref state, writer);
-                        Debug.Assert(propertyName != MetadataPropertyName.Ref);
+                        JsonSerializer.WriteMetadataForObject(this, ref state, writer);
                     }
 
                     if (obj is IJsonOnSerializing onSerializing)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.MetadataHandling.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.MetadataHandling.cs
@@ -1,0 +1,181 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Text.Json.Serialization.Metadata;
+
+namespace System.Text.Json.Serialization
+{
+    public partial class JsonConverter
+    {
+        /// <summary>
+        /// Initializes the state for polymorphic cases and returns the appropriate derived converter.
+        /// </summary>
+        internal JsonConverter? ResolvePolymorphicConverter(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options, ref ReadStack state)
+        {
+            Debug.Assert(!IsValueType);
+            Debug.Assert(CanHaveMetadata);
+            Debug.Assert(state.Current.MetadataPropertyNames.HasFlag(MetadataPropertyName.Type));
+            Debug.Assert(state.Current.PolymorphicSerializationState != PolymorphicSerializationState.PolymorphicReEntryStarted);
+            Debug.Assert(jsonTypeInfo.PolymorphicTypeResolver?.UsesTypeDiscriminators == true);
+
+            JsonConverter? polymorphicConverter = null;
+
+            switch (state.Current.PolymorphicSerializationState)
+            {
+                case PolymorphicSerializationState.None:
+                    Debug.Assert(!state.IsContinuation);
+                    Debug.Assert(state.PolymorphicTypeDiscriminator != null);
+
+                    PolymorphicTypeResolver resolver = jsonTypeInfo.PolymorphicTypeResolver;
+                    if (resolver.TryGetDerivedJsonTypeInfo(state.PolymorphicTypeDiscriminator, out JsonTypeInfo? resolvedType))
+                    {
+                        Debug.Assert(TypeToConvert.IsAssignableFrom(resolvedType.Type));
+
+                        polymorphicConverter = state.InitializePolymorphicReEntry(resolvedType);
+                        if (!polymorphicConverter.CanHaveMetadata)
+                        {
+                            ThrowHelper.ThrowNotSupportedException_DerivedConverterDoesNotSupportMetadata(resolvedType.Type);
+                        }
+                    }
+                    else
+                    {
+                        state.Current.PolymorphicSerializationState = PolymorphicSerializationState.PolymorphicReEntryNotFound;
+                    }
+
+                    state.PolymorphicTypeDiscriminator = null;
+                    break;
+
+                case PolymorphicSerializationState.PolymorphicReEntrySuspended:
+                    polymorphicConverter = state.ResumePolymorphicReEntry();
+                    Debug.Assert(TypeToConvert.IsAssignableFrom(polymorphicConverter.TypeToConvert));
+                    break;
+
+                case PolymorphicSerializationState.PolymorphicReEntryNotFound:
+                    Debug.Assert(state.Current.PolymorphicJsonTypeInfo is null);
+                    break;
+
+                default:
+                    Debug.Fail("Unexpected PolymorphicSerializationState.");
+                    break;
+            }
+
+            return polymorphicConverter;
+        }
+
+        /// <summary>
+        /// Initializes the state for polymorphic cases and returns the appropriate derived converter.
+        /// </summary>
+        internal JsonConverter? ResolvePolymorphicConverter(object value, JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options, ref WriteStack state)
+        {
+            Debug.Assert(!IsValueType);
+            Debug.Assert(value != null && TypeToConvert.IsAssignableFrom(value.GetType()));
+            Debug.Assert(CanBePolymorphic || jsonTypeInfo.PolymorphicTypeResolver != null);
+            Debug.Assert(state.PolymorphicTypeDiscriminator is null);
+
+            JsonConverter? polymorphicConverter = null;
+
+            switch (state.Current.PolymorphicSerializationState)
+            {
+                case PolymorphicSerializationState.None:
+                    Debug.Assert(!state.IsContinuation);
+
+                    Type runtimeType = value.GetType();
+
+                    if (jsonTypeInfo.PolymorphicTypeResolver is PolymorphicTypeResolver resolver)
+                    {
+                        Debug.Assert(CanHaveMetadata);
+
+                        if (resolver.TryGetDerivedJsonTypeInfo(runtimeType, out JsonTypeInfo? derivedJsonTypeInfo, out string? typeDiscriminatorId))
+                        {
+                            polymorphicConverter = state.Current.InitializePolymorphicReEntry(derivedJsonTypeInfo);
+
+                            if (typeDiscriminatorId is not null)
+                            {
+                                if (!polymorphicConverter.CanHaveMetadata)
+                                {
+                                    ThrowHelper.ThrowNotSupportedException_DerivedConverterDoesNotSupportMetadata(derivedJsonTypeInfo.Type);
+                                }
+
+                                state.PolymorphicTypeDiscriminator = typeDiscriminatorId;
+                            }
+                        }
+                        else
+                        {
+                            state.Current.PolymorphicSerializationState = PolymorphicSerializationState.PolymorphicReEntryNotFound;
+                        }
+                    }
+                    else
+                    {
+                        Debug.Assert(CanBePolymorphic);
+
+                        if (runtimeType != TypeToConvert)
+                        {
+                            polymorphicConverter = state.Current.InitializePolymorphicReEntry(runtimeType, options);
+                        }
+                        else
+                        {
+                            state.Current.PolymorphicSerializationState = PolymorphicSerializationState.PolymorphicReEntryNotFound;
+                        }
+                    }
+                    break;
+
+                case PolymorphicSerializationState.PolymorphicReEntrySuspended:
+                    Debug.Assert(state.IsContinuation);
+                    polymorphicConverter = state.Current.ResumePolymorphicReEntry();
+                    Debug.Assert(TypeToConvert.IsAssignableFrom(polymorphicConverter.TypeToConvert));
+                    break;
+
+                case PolymorphicSerializationState.PolymorphicReEntryNotFound:
+                    Debug.Assert(state.IsContinuation);
+                    break;
+
+                default:
+                    Debug.Fail("Unexpected PolymorphicSerializationState.");
+                    break;
+            }
+
+            return polymorphicConverter;
+        }
+
+        internal bool TryHandleSerializedObjectReference(Utf8JsonWriter writer, object value, JsonSerializerOptions options, JsonConverter? polymorphicConverter, ref WriteStack state)
+        {
+            Debug.Assert(!IsValueType);
+            Debug.Assert(!state.IsContinuation);
+            Debug.Assert(value != null);
+
+            switch (options.ReferenceHandlingStrategy)
+            {
+                case ReferenceHandlingStrategy.IgnoreCycles:
+                    ReferenceResolver resolver = state.ReferenceResolver;
+                    if (resolver.ContainsReferenceForCycleDetection(value))
+                    {
+                        writer.WriteNullValue();
+                        return true;
+                    }
+
+                    resolver.PushReferenceForCycleDetection(value);
+                    // WriteStack reuses root-level stackframes for its children as a performance optimization;
+                    // we want to avoid writing any data for the root-level object to avoid corrupting the stack.
+                    // This is fine since popping the root object at the end of serialization is not essential.
+                    state.Current.IsPushedReferenceForCycleDetection = state.CurrentDepth > 0;
+                    break;
+
+                case ReferenceHandlingStrategy.Preserve:
+                    bool canHaveIdMetata = polymorphicConverter?.CanHaveMetadata ?? CanHaveMetadata;
+                    if (canHaveIdMetata && JsonSerializer.TryGetReferenceForValue(value, ref state, writer))
+                    {
+                        // We found a repeating reference and wrote the relevant metadata; serialization complete.
+                        return true;
+                    }
+                    break;
+
+                default:
+                    Debug.Fail("Unexpected ReferenceHandlingStrategy.");
+                    break;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -29,7 +29,7 @@ namespace System.Text.Json.Serialization
         internal bool CanUseDirectReadOrWrite { get; set; }
 
         /// <summary>
-        /// Can the converter have $id metadata.
+        /// The converter supports writing and reading metadata.
         /// </summary>
         internal virtual bool CanHaveMetadata => false;
 
@@ -103,6 +103,7 @@ namespace System.Text.Json.Serialization
         // This is used internally to quickly determine the type being converted for JsonConverter<T>.
         internal abstract Type TypeToConvert { get; }
 
+        internal abstract bool OnTryReadAsObject(ref Utf8JsonReader reader, JsonSerializerOptions options, ref ReadStack state, out object? value);
         internal abstract bool TryReadAsObject(ref Utf8JsonReader reader, JsonSerializerOptions options, ref ReadStack state, out object? value);
 
         internal abstract bool TryWriteAsObject(Utf8JsonWriter writer, object? value, JsonSerializerOptions options, ref WriteStack state);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
@@ -78,6 +78,17 @@ namespace System.Text.Json.Serialization
             throw new InvalidOperationException();
         }
 
+        internal sealed override bool OnTryReadAsObject(
+            ref Utf8JsonReader reader,
+            JsonSerializerOptions options,
+            ref ReadStack state,
+            out object? value)
+        {
+            Debug.Fail("We should never get here.");
+
+            throw new InvalidOperationException();
+        }
+
         internal sealed override bool TryReadAsObject(
             ref Utf8JsonReader reader,
             JsonSerializerOptions options,

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPolymorphicTypeConfiguration.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPolymorphicTypeConfiguration.cs
@@ -1,0 +1,183 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Text.Json.Serialization.Metadata;
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>
+    /// Defines polymorphic configuration for a specified base type.
+    /// </summary>
+    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
+    public class JsonPolymorphicTypeConfiguration : IJsonPolymorphicTypeConfiguration, ICollection<(Type DerivedType, string? TypeDiscriminatorId)>
+    {
+        private readonly List<(Type DerivedType, string? TypeDiscriminatorId)> _derivedTypes = new();
+        private string? _customTypeDiscriminatorPropertyName;
+        private JsonUnknownDerivedTypeHandling _unknownDerivedTypeHandling;
+        private bool _ignoreUnrecognizedTypeDiscriminators;
+
+        /// <summary>
+        /// Creates a new polymorphic configuration instance for a given base type.
+        /// </summary>
+        /// <param name="baseType">The base type for which to configure polymorphic serialization.</param>
+        public JsonPolymorphicTypeConfiguration(Type baseType)
+        {
+            if (!PolymorphicTypeResolver.IsSupportedPolymorphicBaseType(baseType))
+            {
+                throw new ArgumentException(SR.Format(SR.Polymorphism_TypeDoesNotSupportPolymorphism, baseType), nameof(baseType));
+            }
+
+            BaseType = baseType;
+        }
+
+        /// <summary>
+        /// Gets the base type for which polymorphic serialization is being configured.
+        /// </summary>
+        public Type BaseType { get; }
+
+        /// <summary>
+        /// Gets or sets the behavior when serializing an undeclared derived runtime type.
+        /// </summary>
+        public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling
+        {
+            get => _unknownDerivedTypeHandling;
+            set
+            {
+                VerifyMutable();
+                _unknownDerivedTypeHandling = value;
+            }
+        }
+
+        /// <summary>
+        /// When set to <see langword="true"/>, instructs the deserializer to ignore any
+        /// unrecognized type discriminator id's and reverts to the contract of the base type.
+        /// Otherwise, it will fail the deserialization.
+        /// </summary>
+        public bool IgnoreUnrecognizedTypeDiscriminators
+        {
+            get => _ignoreUnrecognizedTypeDiscriminators;
+            set
+            {
+                VerifyMutable();
+                _ignoreUnrecognizedTypeDiscriminators = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a custom type discriminator property name for the polymorhic type.
+        /// Uses the default '$type' property name if left unset.
+        /// </summary>
+        public string? CustomTypeDiscriminatorPropertyName
+        {
+            get => _customTypeDiscriminatorPropertyName;
+            set
+            {
+                VerifyMutable();
+                _customTypeDiscriminatorPropertyName = value;
+            }
+        }
+
+        /// <summary>
+        /// Opts in polymorphic serialization for the specified derived type.
+        /// </summary>
+        /// <param name="derivedType">The derived type for which to enable polymorphism.</param>
+        /// <param name="typeDiscriminatorId">The type discriminator id to use for the specified derived type.</param>
+        /// <returns>The same <see cref="JsonPolymorphicTypeConfiguration"/> instance after it has been updated.</returns>
+        public JsonPolymorphicTypeConfiguration WithDerivedType(Type derivedType, string? typeDiscriminatorId = null)
+        {
+            VerifyMutable();
+
+            if (!PolymorphicTypeResolver.IsSupportedDerivedType(BaseType, derivedType))
+            {
+                throw new ArgumentException(SR.Format(SR.Polymorphism_DerivedTypeIsNotSupported, derivedType, BaseType), nameof(derivedType));
+            }
+
+            // Perform a linear traversal to determine any duplicate derived types or discriminator Id's
+            // The assumption is that each type maintains a small number of subtypes so this is preferable
+            // to maintaing hashtables to existing entries.
+            foreach ((Type DerivedType, string? TypeDiscriminatorId) entry in _derivedTypes)
+            {
+                if (entry.DerivedType == derivedType)
+                {
+                    throw new ArgumentException(SR.Format(SR.Polymorphism_DerivedTypeIsAlreadySpecified, BaseType, derivedType), nameof(derivedType));
+                }
+
+                if (typeDiscriminatorId != null && entry.TypeDiscriminatorId == typeDiscriminatorId)
+                {
+                    throw new ArgumentException(SR.Format(SR.Polymorphism_TypeDicriminatorIdIsAlreadySpecified, BaseType, typeDiscriminatorId), nameof(typeDiscriminatorId));
+                }
+            }
+
+            // Validation complete; update the configuration state.
+            _derivedTypes.Add((derivedType, typeDiscriminatorId));
+            return this;
+        }
+
+        IEnumerable<(Type DerivedType, string? TypeDiscriminatorId)> IJsonPolymorphicTypeConfiguration.GetSupportedDerivedTypes()
+        {
+            foreach ((Type, string?) entry in _derivedTypes)
+            {
+                yield return entry;
+            }
+        }
+
+        internal bool IsAssignedToOptionsInstance { get; set; }
+
+        private void VerifyMutable()
+        {
+            if (IsAssignedToOptionsInstance)
+            {
+                ThrowHelper.ThrowInvalidOperationException_SerializerOptionsImmutable(context: null);
+            }
+        }
+
+        bool ICollection<(Type DerivedType, string? TypeDiscriminatorId)>.Contains((Type DerivedType, string? TypeDiscriminatorId) item) => _derivedTypes.Contains(item);
+        void ICollection<(Type DerivedType, string? TypeDiscriminatorId)>.CopyTo((Type DerivedType, string? TypeDiscriminatorId)[] array, int arrayIndex) => _derivedTypes.CopyTo(array, arrayIndex);
+        bool ICollection<(Type DerivedType, string? TypeDiscriminatorId)>.Remove((Type DerivedType, string? TypeDiscriminatorId) item)
+        {
+            VerifyMutable();
+            return _derivedTypes.Remove(item);
+        }
+
+        bool ICollection<(Type DerivedType, string? TypeDiscriminatorId)>.IsReadOnly => IsAssignedToOptionsInstance;
+        int ICollection<(Type DerivedType, string? TypeDiscriminatorId)>.Count => _derivedTypes.Count;
+        void ICollection<(Type DerivedType, string? TypeDiscriminatorId)>.Add((Type DerivedType, string? TypeDiscriminatorId) item) => WithDerivedType(item.DerivedType, item.TypeDiscriminatorId);
+        void ICollection<(Type DerivedType, string? TypeDiscriminatorId)>.Clear()
+        {
+            VerifyMutable();
+            _derivedTypes.Clear();
+        }
+
+        IEnumerator<(Type DerivedType, string? TypeDiscriminatorId)> IEnumerable<(Type DerivedType, string? TypeDiscriminatorId)>.GetEnumerator() => _derivedTypes.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => _derivedTypes.GetEnumerator();
+    }
+
+    /// <summary>
+    /// Defines polymorphic type configuration for a given type.
+    /// </summary>
+    /// <typeparam name="TBaseType">The type for which polymorphic configuration is provided.</typeparam>
+    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
+    public class JsonPolymorphicTypeConfiguration<TBaseType> : JsonPolymorphicTypeConfiguration where TBaseType : class
+    {
+        /// <summary>
+        /// Creates a new polymorphic configuration instance for a given base type.
+        /// </summary>
+        public JsonPolymorphicTypeConfiguration() : base(typeof(TBaseType))
+        {
+        }
+
+        /// <summary>
+        /// Associates specified derived type with supplied string identifier.
+        /// </summary>
+        /// <typeparam name="TDerivedType">The derived type with which to associate a type identifier.</typeparam>
+        /// <param name="typeDiscriminatorId">The type identifier to use for the specified derived type.</param>
+        /// <returns>The same <see cref="JsonPolymorphicTypeConfiguration"/> instance after it has been updated.</returns>
+        public JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>(string? typeDiscriminatorId = null) where TDerivedType : TBaseType
+        {
+            WithDerivedType(typeof(TDerivedType), typeDiscriminatorId);
+            return this;
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPolymorphicTypeConfiguration.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPolymorphicTypeConfiguration.cs
@@ -24,6 +24,11 @@ namespace System.Text.Json.Serialization
         /// <param name="baseType">The base type for which to configure polymorphic serialization.</param>
         public JsonPolymorphicTypeConfiguration(Type baseType)
         {
+            if (baseType is null)
+            {
+                throw new ArgumentNullException(nameof(baseType));
+            }
+
             if (!PolymorphicTypeResolver.IsSupportedPolymorphicBaseType(baseType))
             {
                 throw new ArgumentException(SR.Format(SR.Polymorphism_TypeDoesNotSupportPolymorphism, baseType), nameof(baseType));
@@ -51,7 +56,7 @@ namespace System.Text.Json.Serialization
         }
 
         /// <summary>
-        /// When set to <see langword="true"/>, instructs the deserializer to ignore any
+        /// When set to <see langword="true"/>, instructs the serializer to ignore any
         /// unrecognized type discriminator id's and reverts to the contract of the base type.
         /// Otherwise, it will fail the deserialization.
         /// </summary>
@@ -88,6 +93,11 @@ namespace System.Text.Json.Serialization
         public JsonPolymorphicTypeConfiguration WithDerivedType(Type derivedType, string? typeDiscriminatorId = null)
         {
             VerifyMutable();
+
+            if (derivedType is null)
+            {
+                throw new ArgumentNullException(nameof(derivedType));
+            }
 
             if (!PolymorphicTypeResolver.IsSupportedDerivedType(BaseType, derivedType))
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPolymorphicTypeConfiguration.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPolymorphicTypeConfiguration.cs
@@ -10,7 +10,6 @@ namespace System.Text.Json.Serialization
     /// <summary>
     /// Defines polymorphic configuration for a specified base type.
     /// </summary>
-    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
     public class JsonPolymorphicTypeConfiguration : IJsonPolymorphicTypeConfiguration, ICollection<(Type DerivedType, string? TypeDiscriminatorId)>
     {
         private readonly List<(Type DerivedType, string? TypeDiscriminatorId)> _derivedTypes = new();
@@ -168,7 +167,6 @@ namespace System.Text.Json.Serialization
     /// Defines polymorphic type configuration for a given type.
     /// </summary>
     /// <typeparam name="TBaseType">The type for which polymorphic configuration is provided.</typeparam>
-    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
     public class JsonPolymorphicTypeConfiguration<TBaseType> : JsonPolymorphicTypeConfiguration where TBaseType : class
     {
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -96,9 +96,9 @@ namespace System.Text.Json
                 unescapedPropertyName = propertyName;
             }
 
-            if (state.CanContainMetadata)
+            if (state.Current.CanContainMetadata)
             {
-                if (propertyName.Length > 0 && propertyName[0] == '$')
+                if (IsMetadataPropertyName(propertyName, state.Current.BaseJsonTypeInfo.PolymorphicTypeResolver))
                 {
                     ThrowHelper.ThrowUnexpectedMetadataException(propertyName, ref reader, ref state);
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleMetadata.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleMetadata.cs
@@ -11,8 +11,8 @@ namespace System.Text.Json
         // Pre-encoded metadata properties.
         internal static readonly JsonEncodedText s_metadataId = JsonEncodedText.Encode("$id", encoder: null);
         internal static readonly JsonEncodedText s_metadataRef = JsonEncodedText.Encode("$ref", encoder: null);
-        internal static readonly JsonEncodedText s_metadataValues = JsonEncodedText.Encode("$values", encoder: null);
         internal static readonly JsonEncodedText s_metadataType = JsonEncodedText.Encode("$type", encoder: null);
+        internal static readonly JsonEncodedText s_metadataValues = JsonEncodedText.Encode("$values", encoder: null);
 
         internal static MetadataPropertyName WriteMetadataForObject(
             JsonConverter jsonConverter,
@@ -37,7 +37,7 @@ namespace System.Text.Json
                 Debug.Assert(state.Parent.JsonPropertyInfo!.JsonTypeInfo.PolymorphicTypeResolver != null);
 
                 JsonEncodedText propertyName =
-                    state.Parent.JsonPropertyInfo.JsonTypeInfo.PolymorphicTypeResolver.CustomTypeDiscriminatorPropertyNameEncoded is JsonEncodedText customPropertyName
+                    state.Parent.JsonPropertyInfo.JsonTypeInfo.PolymorphicTypeResolver.CustomTypeDiscriminatorPropertyNameJsonEncoded is JsonEncodedText customPropertyName
                     ? customPropertyName
                     : s_metadataType;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleMetadata.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleMetadata.cs
@@ -12,41 +12,54 @@ namespace System.Text.Json
         internal static readonly JsonEncodedText s_metadataId = JsonEncodedText.Encode("$id", encoder: null);
         internal static readonly JsonEncodedText s_metadataRef = JsonEncodedText.Encode("$ref", encoder: null);
         internal static readonly JsonEncodedText s_metadataValues = JsonEncodedText.Encode("$values", encoder: null);
+        internal static readonly JsonEncodedText s_metadataType = JsonEncodedText.Encode("$type", encoder: null);
 
-        internal static MetadataPropertyName WriteReferenceForObject(
+        internal static MetadataPropertyName WriteMetadataForObject(
             JsonConverter jsonConverter,
             ref WriteStack state,
             Utf8JsonWriter writer)
         {
+            Debug.Assert(jsonConverter.CanHaveMetadata);
+            Debug.Assert(!state.IsContinuation);
+            Debug.Assert(state.CurrentContainsMetadata);
+
+            MetadataPropertyName writtenMetadata = MetadataPropertyName.None;
+
             if (state.NewReferenceId != null)
             {
-                Debug.Assert(jsonConverter.CanHaveMetadata);
                 writer.WriteString(s_metadataId, state.NewReferenceId);
+                writtenMetadata |= MetadataPropertyName.Id;
                 state.NewReferenceId = null;
-                return MetadataPropertyName.Id;
             }
 
-            return MetadataPropertyName.None;
+            if (state.PolymorphicTypeDiscriminator is string typeDiscriminatorId)
+            {
+                Debug.Assert(state.Parent.JsonPropertyInfo!.JsonTypeInfo.PolymorphicTypeResolver != null);
+
+                JsonEncodedText propertyName =
+                    state.Parent.JsonPropertyInfo.JsonTypeInfo.PolymorphicTypeResolver.CustomTypeDiscriminatorPropertyNameEncoded is JsonEncodedText customPropertyName
+                    ? customPropertyName
+                    : s_metadataType;
+
+                writer.WriteString(propertyName, typeDiscriminatorId);
+                writtenMetadata |= MetadataPropertyName.Type;
+                state.PolymorphicTypeDiscriminator = null;
+            }
+
+            Debug.Assert(writtenMetadata != MetadataPropertyName.None);
+            return writtenMetadata;
         }
 
-        internal static MetadataPropertyName WriteReferenceForCollection(
+        internal static MetadataPropertyName WriteMetadataForCollection(
             JsonConverter jsonConverter,
             ref WriteStack state,
             Utf8JsonWriter writer)
         {
-            if (state.NewReferenceId != null)
-            {
-                Debug.Assert(jsonConverter.CanHaveMetadata);
-                writer.WriteStartObject();
-                writer.WriteString(s_metadataId, state.NewReferenceId);
-                writer.WriteStartArray(s_metadataValues);
-                state.NewReferenceId = null;
-                return MetadataPropertyName.Id;
-            }
-
-            // If the jsonConverter supports immutable enumerables or value type collections, don't write any metadata
-            writer.WriteStartArray();
-            return MetadataPropertyName.None;
+            // For collections with metadata, we nest the array payload within a JSON object.
+            writer.WriteStartObject();
+            MetadataPropertyName writtenMetadata = WriteMetadataForObject(jsonConverter, ref state, writer);
+            writer.WritePropertyName(s_metadataValues); // property name containing nested array values.
+            return writtenMetadata;
         }
 
         /// <summary>
@@ -65,6 +78,8 @@ namespace System.Text.Json
                 writer.WriteStartObject();
                 writer.WriteString(s_metadataRef, referenceId);
                 writer.WriteEndObject();
+
+                state.PolymorphicTypeDiscriminator = null; // clear out any polymorphism state.
             }
             else
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -288,9 +288,12 @@ namespace System.Text.Json
                     left._propertyNameCaseInsensitive == right._propertyNameCaseInsensitive &&
                     left._writeIndented == right._writeIndented &&
                     left._serializerContext == right._serializerContext &&
-                    CompareConverters(left._converters, right._converters);
+                    CompareLists(left._converters, right._converters) &&
+#pragma warning disable CA2252 // This API requires opting into preview features
+                    CompareLists(left._polymorphicTypeConfigurations, right._polymorphicTypeConfigurations);
+#pragma warning restore CA2252 // This API requires opting into preview features
 
-                static bool CompareConverters(ConverterList left, ConverterList right)
+                static bool CompareLists<TValue>(ConfigurationList<TValue> left, ConfigurationList<TValue> right)
                 {
                     int n;
                     if ((n = left.Count) != right.Count)
@@ -300,7 +303,7 @@ namespace System.Text.Json
 
                     for (int i = 0; i < n; i++)
                     {
-                        if (left[i] != right[i])
+                        if (!left[i]!.Equals(right[i]))
                         {
                             return false;
                         }
@@ -332,10 +335,17 @@ namespace System.Text.Json
                 hc.Add(options._propertyNameCaseInsensitive);
                 hc.Add(options._writeIndented);
                 hc.Add(options._serializerContext);
+                GetHashCode(ref hc, options._converters);
+#pragma warning disable CA2252 // This API requires opting into preview features
+                GetHashCode(ref hc, options._polymorphicTypeConfigurations);
+#pragma warning restore CA2252 // This API requires opting into preview features
 
-                for (int i = 0; i < options._converters.Count; i++)
+                static void GetHashCode<TValue>(ref HashCode hc, ConfigurationList<TValue> list)
                 {
-                    hc.Add(options._converters[i]);
+                    for (int i = 0; i < list.Count; i++)
+                    {
+                        hc.Add(list[i]);
+                    }
                 }
 
                 return hc.ToHashCode();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -140,6 +140,15 @@ namespace System.Text.Json
         /// </remarks>
         public IList<JsonConverter> Converters => _converters;
 
+        /// <summary>
+        /// The list of custom polymorphic type configurations.
+        /// </summary>
+        /// <remarks>
+        /// Once serialization or deserialization occurs, the list cannot be modified.
+        /// </remarks>
+        [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
+        public IList<JsonPolymorphicTypeConfiguration> PolymorphicTypeConfigurations => _polymorphicTypeConfigurations;
+
         internal JsonConverter GetConverterFromMember(Type? parentClassType, Type propertyType, MemberInfo? memberInfo)
         {
             JsonConverter converter = null!;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -146,7 +146,6 @@ namespace System.Text.Json
         /// <remarks>
         /// Once serialization or deserialization occurs, the list cannot be modified.
         /// </remarks>
-        [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
         public IList<JsonPolymorphicTypeConfiguration> PolymorphicTypeConfigurations => _polymorphicTypeConfigurations;
 
         internal JsonConverter GetConverterFromMember(Type? parentClassType, Type propertyType, MemberInfo? memberInfo)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonUnknownDerivedTypeHandling.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonUnknownDerivedTypeHandling.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>
+    /// Defines how objects of a derived runtime type that has not been explicitly declared for polymorphic serialization should be handled.
+    /// </summary>
+    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
+    public enum JsonUnknownDerivedTypeHandling
+    {
+        /// <summary>
+        /// An object of undeclared runtime type will fail polymorphic serialization.
+        /// </summary>
+        FailSerialization = 0,
+        /// <summary>
+        /// An object of undeclared runtime type will fall back to the serialization contract of the base type.
+        /// </summary>
+        FallbackToBaseType = 1,
+        /// <summary>
+        /// An object of undeclared runtime type will revert to the serialization contract of the nearest declared ancestor type.
+        /// Certain interface hierarchies are not supported due to diamond ambiguity constraints.
+        /// </summary>
+        FallbackToNearestAncestor = 2
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonUnknownDerivedTypeHandling.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonUnknownDerivedTypeHandling.cs
@@ -6,7 +6,6 @@ namespace System.Text.Json.Serialization
     /// <summary>
     /// Defines how objects of a derived runtime type that has not been explicitly declared for polymorphic serialization should be handled.
     /// </summary>
-    [System.Runtime.Versioning.RequiresPreviewFeatures("Polymorphic serialization is currently in preview.")]
     public enum JsonUnknownDerivedTypeHandling
     {
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/AttributePolymorphicTypeConfiguration.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/AttributePolymorphicTypeConfiguration.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    /// <summary>
+    /// Maps attribute-based polymorphism configuration to IJsonPolymorphicTypeConfiguration
+    /// </summary>
+    internal class AttributePolymorphicTypeConfiguration : IJsonPolymorphicTypeConfiguration
+    {
+#pragma warning disable CA2252 // This API requires opting into preview features
+        private readonly JsonPolymorphicAttribute? _polymorphicTypeAttribute;
+        private readonly IEnumerable<JsonDerivedTypeAttribute> _derivedTypeAttributes;
+
+        private AttributePolymorphicTypeConfiguration(Type baseType, JsonPolymorphicAttribute? polymorphicTypeAttribute, IEnumerable<JsonDerivedTypeAttribute> derivedTypeAttributes)
+        {
+            BaseType = baseType;
+            _polymorphicTypeAttribute = polymorphicTypeAttribute;
+            _derivedTypeAttributes = derivedTypeAttributes;
+        }
+
+        public static AttributePolymorphicTypeConfiguration? Create(Type baseType)
+        {
+            JsonPolymorphicAttribute? polymorphicTypeAttribute = baseType.GetCustomAttribute<JsonPolymorphicAttribute>(inherit: false);
+            IEnumerable<JsonDerivedTypeAttribute> derivedTypeAttributes = baseType.GetCustomAttributes<JsonDerivedTypeAttribute>(inherit: false);
+
+            if (polymorphicTypeAttribute is null && IsEmpty(derivedTypeAttributes))
+            {
+                return null;
+            }
+
+            return new AttributePolymorphicTypeConfiguration(baseType, polymorphicTypeAttribute, derivedTypeAttributes);
+
+            static bool IsEmpty<T>(IEnumerable<T> source)
+            {
+                using IEnumerator<T> enumerator = source.GetEnumerator();
+                return !enumerator.MoveNext();
+            }
+        }
+
+        public Type BaseType { get; }
+
+        public string? CustomTypeDiscriminatorPropertyName => _polymorphicTypeAttribute?.CustomTypeDiscriminatorPropertyName;
+
+        public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling => _polymorphicTypeAttribute?.UnknownDerivedTypeHandling ?? default;
+
+        public bool IgnoreUnrecognizedTypeDiscriminators => _polymorphicTypeAttribute?.IgnoreUnrecognizedTypeDiscriminators ?? false;
+
+        public IEnumerable<(Type DerivedType, string? TypeDiscriminatorId)> GetSupportedDerivedTypes()
+        {
+            foreach (JsonDerivedTypeAttribute attribute in _derivedTypeAttributes)
+            {
+                yield return (attribute.DerivedType, attribute.TypeDiscriminatorId);
+            }
+        }
+#pragma warning restore CA2252 // This API requires opting into preview features
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IJsonPolymorphicTypeConfiguration.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IJsonPolymorphicTypeConfiguration.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    internal interface IJsonPolymorphicTypeConfiguration
+    {
+#pragma warning disable CA2252 // This API requires opting into preview features
+        Type BaseType { get; }
+        string? CustomTypeDiscriminatorPropertyName { get; }
+        JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get; }
+        bool IgnoreUnrecognizedTypeDiscriminators { get; }
+        IEnumerable<(Type DerivedType, string? TypeDiscriminatorId)> GetSupportedDerivedTypes();
+#pragma warning restore CA2252 // This API requires opting into preview features
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
@@ -1,0 +1,243 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    /// <summary>
+    /// Validates and indexes polymorphic type configuration,
+    /// providing derived JsonTypeInfo resolution methods
+    /// in both serialization and deserialization scenaria.
+    /// </summary>
+    internal sealed class PolymorphicTypeResolver
+    {
+#pragma warning disable CA2252 // This API requires opting into preview features
+        private readonly JsonSerializerOptions _options;
+        private readonly ConcurrentDictionary<Type, DerivedJsonTypeInfo?> _typeToDiscriminatorId = new();
+        private readonly Dictionary<string, DerivedJsonTypeInfo>? _discriminatorIdtoType;
+
+        public PolymorphicTypeResolver(JsonConverter baseConverter, IJsonPolymorphicTypeConfiguration configuration, JsonSerializerOptions options)
+        {
+            _options = options;
+            BaseType = configuration.BaseType;
+            UnknownDerivedTypeHandling = configuration.UnknownDerivedTypeHandling;
+            IgnoreUnrecognizedTypeDiscriminators = configuration.IgnoreUnrecognizedTypeDiscriminators;
+
+            if (!IsSupportedPolymorphicBaseType(BaseType))
+            {
+                ThrowHelper.ThrowInvalidOperationException_TypeDoesNotSupportPolymorphism(BaseType);
+            }
+
+            int count = 0;
+            foreach ((Type derivedType, string? typeDiscriminatorId) in configuration.GetSupportedDerivedTypes())
+            {
+                if (!IsSupportedDerivedType(BaseType, derivedType) ||
+                    (derivedType.IsAbstract && UnknownDerivedTypeHandling != JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor))
+                {
+                    ThrowHelper.ThrowInvalidOperationException_DerivedTypeNotSupported(BaseType, derivedType);
+                }
+
+                if (typeDiscriminatorId is not null)
+                {
+                    UsesTypeDiscriminators = true;
+                }
+
+                var derivedJsonTypeInfo = new DerivedJsonTypeInfo(derivedType, typeDiscriminatorId);
+
+                if (!_typeToDiscriminatorId.TryAdd(derivedType, derivedJsonTypeInfo))
+                {
+                    ThrowHelper.ThrowInvalidOperationException_DerivedTypeIsAlreadySpecified(BaseType, derivedType);
+                }
+
+                if (typeDiscriminatorId is not null)
+                {
+                    if (!(_discriminatorIdtoType ??= new()).TryAdd(typeDiscriminatorId, derivedJsonTypeInfo))
+                    {
+                        ThrowHelper.ThrowInvalidOperationException_TypeDicriminatorIdIsAlreadySpecified(BaseType, typeDiscriminatorId);
+                    }
+                }
+
+                count++;
+            }
+
+            if (count == 0)
+            {
+                ThrowHelper.ThrowInvalidOperationException_PolymorphicTypeConfigurationDoesNotSpecifyDerivedTypes(BaseType);
+            }
+
+            if (UsesTypeDiscriminators)
+            {
+                if (!baseConverter.CanHaveMetadata)
+                {
+                    ThrowHelper.ThrowNotSupportedException_BaseConverterDoesNotSupportMetadata(BaseType);
+                }
+
+                if (configuration.CustomTypeDiscriminatorPropertyName is string customPropertyName)
+                {
+                    CustomTypeDiscriminatorPropertyName = customPropertyName;
+                    CustomTypeDiscriminatorPropertyNameUtf8 = Encoding.UTF8.GetBytes(customPropertyName);
+                    CustomTypeDiscriminatorPropertyNameEncoded = JsonEncodedText.Encode(CustomTypeDiscriminatorPropertyNameUtf8, options.Encoder);
+                }
+            }
+        }
+
+        public Type BaseType { get; }
+        public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get; }
+        public bool UsesTypeDiscriminators { get; }
+        public bool IgnoreUnrecognizedTypeDiscriminators { get; }
+        public string? CustomTypeDiscriminatorPropertyName { get; }
+        public byte[]? CustomTypeDiscriminatorPropertyNameUtf8 { get; }
+        public JsonEncodedText? CustomTypeDiscriminatorPropertyNameEncoded { get; }
+
+        public bool TryGetDerivedJsonTypeInfo(Type runtimeType, [NotNullWhen(true)] out JsonTypeInfo? jsonTypeInfo, out string? typeDiscriminatorId)
+        {
+            Debug.Assert(BaseType.IsAssignableFrom(runtimeType));
+
+            if (!_typeToDiscriminatorId.TryGetValue(runtimeType, out DerivedJsonTypeInfo? result))
+            {
+                switch (UnknownDerivedTypeHandling)
+                {
+                    case JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor:
+                        // Calculate (and cache the result) of the nearest ancestor for given runtime type.
+                        // A `null` result denotes no matching ancestor type, we also cache that.
+                        result = CalculateNearestAncestor(runtimeType);
+                        _typeToDiscriminatorId[runtimeType] = result;
+                        break;
+                    case JsonUnknownDerivedTypeHandling.FallbackToBaseType:
+                        // Recover the polymorphic contract (i.e. any type discriminators) for the base type, if it exists.
+                        _typeToDiscriminatorId.TryGetValue(BaseType, out result);
+                        _typeToDiscriminatorId[runtimeType] = result;
+                        break;
+
+                    case JsonUnknownDerivedTypeHandling.FailSerialization:
+                    default:
+                        if (runtimeType != BaseType)
+                        {
+                            ThrowHelper.ThrowNotSupportedException_RuntimeTypeNotSupported(BaseType, runtimeType);
+                        }
+                        break;
+                }
+            }
+
+            if (result is null)
+            {
+                jsonTypeInfo = null;
+                typeDiscriminatorId = null;
+                return false;
+            }
+            else
+            {
+                jsonTypeInfo = result.GetJsonTypeInfo(_options);
+                typeDiscriminatorId = result.TypeDiscriminatorId;
+                return true;
+            }
+        }
+
+        public bool TryGetDerivedJsonTypeInfo(string typeDiscriminatorId, [NotNullWhen(true)] out JsonTypeInfo? jsonTypeInfo)
+        {
+            Debug.Assert(UsesTypeDiscriminators);
+            Debug.Assert(_discriminatorIdtoType != null);
+
+            if (_discriminatorIdtoType.TryGetValue(typeDiscriminatorId, out DerivedJsonTypeInfo? result))
+            {
+                Debug.Assert(result.TypeDiscriminatorId == typeDiscriminatorId);
+                jsonTypeInfo = result.GetJsonTypeInfo(_options);
+                return true;
+            }
+
+            if (!IgnoreUnrecognizedTypeDiscriminators)
+            {
+                ThrowHelper.ThrowJsonException_UnrecognizedTypeDiscriminator(typeDiscriminatorId);
+            }
+
+            jsonTypeInfo = null;
+            return false;
+        }
+
+        public static bool IsSupportedPolymorphicBaseType(Type type) =>
+            (type.IsClass || type.IsInterface) &&
+            !type.IsSealed &&
+            !type.IsGenericTypeDefinition &&
+            !type.IsPointer &&
+            type != JsonTypeInfo.ObjectType;
+
+        public static bool IsSupportedDerivedType(Type baseType, Type derivedType) =>
+            baseType.IsAssignableFrom(derivedType) && !derivedType.IsGenericTypeDefinition;
+
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+            Justification = "The call to GetInterfaces will cross-reference results with interface types " +
+                            "already declared as derived types of the polymorphic base type.")]
+        private DerivedJsonTypeInfo? CalculateNearestAncestor(Type type)
+        {
+            Debug.Assert(!type.IsAbstract);
+            Debug.Assert(BaseType.IsAssignableFrom(type));
+            Debug.Assert(UnknownDerivedTypeHandling == JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor);
+
+            if (type == BaseType)
+            {
+                return null;
+            }
+
+            DerivedJsonTypeInfo? result = null;
+
+            // First, walk up the class hierarchy for any suported types.
+            for (Type? candidate = type.BaseType; BaseType.IsAssignableFrom(candidate); candidate = candidate.BaseType)
+            {
+                Debug.Assert(candidate != null);
+
+                if (_typeToDiscriminatorId.TryGetValue(candidate, out result))
+                {
+                    break;
+                }
+            }
+
+            // Interface hierarchies admit the possibility of diamond ambiguities in type discriminators.
+            // Examine all interface implementations and identify potential conflicts.
+            if (BaseType.IsInterface)
+            {
+                foreach (Type interfaceTy in type.GetInterfaces())
+                {
+                    if (interfaceTy != BaseType && BaseType.IsAssignableFrom(interfaceTy) &&
+                        _typeToDiscriminatorId.TryGetValue(interfaceTy, out DerivedJsonTypeInfo? interfaceResult) &&
+                        interfaceResult is not null)
+                    {
+                        if (result is null)
+                        {
+                            result = interfaceResult;
+                        }
+                        else
+                        {
+                            ThrowHelper.ThrowNotSupportedException_RuntimeTypeDiamondAmbiguity(BaseType, type, result.DerivedType, interfaceResult.DerivedType);
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Lazy JsonTypeInfo result holder for a derived type.
+        /// </summary>
+        private class DerivedJsonTypeInfo
+        {
+            private volatile JsonTypeInfo? _jsonTypeInfo;
+
+            public DerivedJsonTypeInfo(Type type, string? typeDiscriminatorId)
+            {
+                DerivedType = type;
+                TypeDiscriminatorId = typeDiscriminatorId;
+            }
+
+            public Type DerivedType { get; }
+            public string? TypeDiscriminatorId { get; }
+            public JsonTypeInfo GetJsonTypeInfo(JsonSerializerOptions options)
+                => _jsonTypeInfo ??= options.GetOrAddJsonTypeInfo(DerivedType);
+        }
+#pragma warning restore CA2252 // This API requires opting into preview features
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
@@ -32,7 +32,7 @@ namespace System.Text.Json.Serialization.Metadata
                 ThrowHelper.ThrowInvalidOperationException_TypeDoesNotSupportPolymorphism(BaseType);
             }
 
-            int count = 0;
+            bool containsDerivedTypes = false;
             foreach ((Type derivedType, string? typeDiscriminatorId) in configuration.GetSupportedDerivedTypes())
             {
                 if (!IsSupportedDerivedType(BaseType, derivedType) ||
@@ -61,10 +61,10 @@ namespace System.Text.Json.Serialization.Metadata
                     }
                 }
 
-                count++;
+                containsDerivedTypes = true;
             }
 
-            if (count == 0)
+            if (!containsDerivedTypes)
             {
                 ThrowHelper.ThrowInvalidOperationException_PolymorphicTypeConfigurationDoesNotSpecifyDerivedTypes(BaseType);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
@@ -166,14 +166,15 @@ namespace System.Text.Json.Serialization.Metadata
             return false;
         }
 
-        public static bool IsSupportedPolymorphicBaseType(Type type) =>
+        public static bool IsSupportedPolymorphicBaseType(Type? type) =>
+            type != null &&
             (type.IsClass || type.IsInterface) &&
             !type.IsSealed &&
             !type.IsGenericTypeDefinition &&
             !type.IsPointer &&
             type != JsonTypeInfo.ObjectType;
 
-        public static bool IsSupportedDerivedType(Type baseType, Type derivedType) =>
+        public static bool IsSupportedDerivedType(Type baseType, Type? derivedType) =>
             baseType.IsAssignableFrom(derivedType) && !derivedType.IsGenericTypeDefinition;
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
@@ -78,9 +78,17 @@ namespace System.Text.Json.Serialization.Metadata
 
                 if (configuration.CustomTypeDiscriminatorPropertyName is string customPropertyName)
                 {
+                    JsonEncodedText jsonEncodedName = JsonEncodedText.Encode(customPropertyName, options.Encoder);
+
+                    // Check if the property name conflicts with other metadata property names
+                    if ((JsonSerializer.GetMetadataPropertyName(jsonEncodedName.EncodedUtf8Bytes, resolver: null) & ~MetadataPropertyName.Type) != 0)
+                    {
+                        ThrowHelper.ThrowInvalidOperationException_InvalidCustomTypeDiscriminatorPropertyName();
+                    }
+
                     CustomTypeDiscriminatorPropertyName = customPropertyName;
-                    CustomTypeDiscriminatorPropertyNameUtf8 = Encoding.UTF8.GetBytes(customPropertyName);
-                    CustomTypeDiscriminatorPropertyNameEncoded = JsonEncodedText.Encode(CustomTypeDiscriminatorPropertyNameUtf8, options.Encoder);
+                    CustomTypeDiscriminatorPropertyNameUtf8 = jsonEncodedName.EncodedUtf8Bytes.ToArray();
+                    CustomTypeDiscriminatorPropertyNameJsonEncoded = jsonEncodedName;
                 }
             }
         }
@@ -91,7 +99,7 @@ namespace System.Text.Json.Serialization.Metadata
         public bool IgnoreUnrecognizedTypeDiscriminators { get; }
         public string? CustomTypeDiscriminatorPropertyName { get; }
         public byte[]? CustomTypeDiscriminatorPropertyNameUtf8 { get; }
-        public JsonEncodedText? CustomTypeDiscriminatorPropertyNameEncoded { get; }
+        public JsonEncodedText? CustomTypeDiscriminatorPropertyNameJsonEncoded { get; }
 
         public bool TryGetDerivedJsonTypeInfo(Type runtimeType, [NotNullWhen(true)] out JsonTypeInfo? jsonTypeInfo, out string? typeDiscriminatorId)
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/MetadataPropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/MetadataPropertyName.cs
@@ -6,9 +6,10 @@ namespace System.Text.Json
     [Flags]
     internal enum MetadataPropertyName : byte
     {
-        None = 0,
-        Values = 1,
-        Id = 2,
-        Ref = 4,
+        None       = 0,
+        Values     = 1,
+        Id         = 2,
+        Ref        = 4,
+        Type       = 8,
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/PolymorphicSerializationState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/PolymorphicSerializationState.cs
@@ -8,13 +8,19 @@ namespace System.Text.Json
         None,
 
         /// <summary>
-        /// Dispatch to a polymorphic converter has been initiated.
+        /// Dispatch to a derived converter has been initiated.
         /// </summary>
         PolymorphicReEntryStarted,
 
         /// <summary>
-        /// Current frame is a continuation using a suspended polymorphic converter.
+        /// Current frame is a continuation using a suspended derived converter.
         /// </summary>
-        PolymorphicReEntrySuspended
+        PolymorphicReEntrySuspended,
+
+        /// <summary>
+        /// Current frame is a polymorphic converter that couldn't resolve a derived converter.
+        /// (E.g. because the runtime type matches the declared type).
+        /// </summary>
+        PolymorphicReEntryNotFound
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -36,8 +36,22 @@ namespace System.Text.Json
         public JsonTypeInfo JsonTypeInfo;
         public StackFrameObjectState ObjectState; // State tracking the current object.
 
+        // Current object can contain metadata
+        public bool CanContainMetadata;
         public MetadataPropertyName LatestMetadataPropertyName;
         public MetadataPropertyName MetadataPropertyNames;
+
+        // Serialization state for value serialized by the current frame.
+        public PolymorphicSerializationState PolymorphicSerializationState;
+
+        // Holds any entered polymorphic JsonTypeInfo metadata.
+        public JsonTypeInfo? PolymorphicJsonTypeInfo;
+
+        // Gets the initial JsonTypeInfo metadata used when deserializing the current value.
+        public JsonTypeInfo BaseJsonTypeInfo
+            => PolymorphicSerializationState == PolymorphicSerializationState.PolymorphicReEntryStarted
+                ? PolymorphicJsonTypeInfo!
+                : JsonTypeInfo;
 
         // For performance, we order the properties by the first deserialize and PropertyIndex helps find the right slot quicker.
         public int PropertyIndex;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -23,6 +23,19 @@ namespace System.Text.Json
         public WriteStackFrame Current;
 
         /// <summary>
+        /// Gets the parent stackframe, if it exists.
+        /// </summary>
+        public ref WriteStackFrame Parent
+        {
+            get
+            {
+                Debug.Assert(_count - _indexOffset > 0);
+                Debug.Assert(_stack is not null);
+                return ref _stack[_count - _indexOffset - 1];
+            }
+        }
+
+        /// <summary>
         /// Buffer containing all frames in the stack. For performance it is only populated for serialization depths > 1.
         /// </summary>
         private WriteStackFrame[] _stack;
@@ -36,6 +49,14 @@ namespace System.Text.Json
         /// If not zero, indicates that the stack is part of a re-entrant continuation of given depth.
         /// </summary>
         private int _continuationCount;
+
+        /// <summary>
+        /// Offset used to derive the index of the current frame in the stack buffer from the current value of <see cref="_count"/>,
+        /// following the formula currentIndex := _count - _indexOffset.
+        /// Value can vary between 0 or 1 depending on whether we need to allocate a new frame on the first Push() operation,
+        /// which can happen if the root converter is polymorphic.
+        /// </summary>
+        private byte _indexOffset;
 
         /// <summary>
         /// Cancellation token used by converters performing async serialization (e.g. IAsyncEnumerable)
@@ -88,6 +109,16 @@ namespace System.Text.Json
         /// </summary>
         public string? NewReferenceId;
 
+        /// <summary>
+        /// Indicates that the next converter is polymorphic and must serialize a type discriminator.
+        /// </summary>
+        public string? PolymorphicTypeDiscriminator;
+
+        /// <summary>
+        /// Whether the current frame needs to write out any metadata.
+        /// </summary>
+        public bool CurrentContainsMetadata => NewReferenceId != null || PolymorphicTypeDiscriminator != null;
+
         private void EnsurePushCapacity()
         {
             if (_stack is null)
@@ -130,16 +161,27 @@ namespace System.Text.Json
             return jsonTypeInfo.PropertyInfoForTypeInfo.ConverterBase;
         }
 
+        /// <summary>
+        /// Gets the nested JsonTypeInfo before resolving any polymorphic converters
+        /// </summary>
+        public JsonTypeInfo PeekNestedJsonTypeInfo()
+        {
+            Debug.Assert(Current.PolymorphicSerializationState != PolymorphicSerializationState.PolymorphicReEntryStarted);
+            return _count == 0 ? Current.JsonTypeInfo : Current.JsonPropertyInfo!.JsonTypeInfo;
+        }
+
         public void Push()
         {
             if (_continuationCount == 0)
             {
-                if (_count == 0)
+                Debug.Assert(Current.PolymorphicSerializationState != PolymorphicSerializationState.PolymorphicReEntrySuspended);
+
+                if (_count == 0 && Current.PolymorphicSerializationState == PolymorphicSerializationState.None)
                 {
-                    // Performance optimization: reuse the first stackframe on the first push operation.
-                    // NB need to be careful when making writes to Current _before_ the first `Push`
-                    // operation is performed.
+                    // Perf enhancement: do not create a new stackframe on the first push operation
+                    // unless the converter has primed the current frame for polymorphic dispatch.
                     _count = 1;
+                    _indexOffset = 1; // currentIndex := _count - 1;
                 }
                 else
                 {
@@ -147,7 +189,7 @@ namespace System.Text.Json
                     JsonNumberHandling? numberHandling = Current.NumberHandling;
 
                     EnsurePushCapacity();
-                    _stack[_count - 1] = Current;
+                    _stack[_count - _indexOffset] = Current;
                     Current = default;
                     _count++;
 
@@ -160,9 +202,9 @@ namespace System.Text.Json
             else
             {
                 // We are re-entering a continuation, adjust indices accordingly
-                if (_count++ > 0)
+                if (_count++ > 0 || _indexOffset == 0)
                 {
-                    Current = _stack[_count - 1];
+                    Current = _stack[_count - _indexOffset];
                 }
 
                 // check if we are done
@@ -187,7 +229,7 @@ namespace System.Text.Json
                 // Check if we need to initialize the continuation.
                 if (_continuationCount == 0)
                 {
-                    if (_count == 1)
+                    if (_count == 1 && _indexOffset > 0)
                     {
                         // No need to copy any frames here.
                         _continuationCount = 1;
@@ -200,22 +242,23 @@ namespace System.Text.Json
                     EnsurePushCapacity();
                     _continuationCount = _count--;
                 }
-                else if (--_count == 0)
+                else if (--_count == 0 && _indexOffset > 0)
                 {
                     // reached the root, no need to copy frames.
                     return;
                 }
 
-                _stack[_count] = Current;
-                Current = _stack[_count - 1];
+                int currentIndex = _count - _indexOffset;
+                _stack[currentIndex + 1] = Current;
+                Current = _stack[currentIndex];
             }
             else
             {
                 Debug.Assert(_continuationCount == 0);
 
-                if (--_count > 0)
+                if (--_count > 0 || _indexOffset == 0)
                 {
-                    Current = _stack[_count - 1];
+                    Current = _stack[_count - _indexOffset];
                 }
             }
         }
@@ -342,14 +385,14 @@ namespace System.Text.Json
 
             (int frameCount, bool includeCurrentFrame) = _continuationCount switch
             {
-                0 => (_count - 1, true), // Not a countinuation, report previous frames and Current.
+                0 => (_count - 1, true), // Not a continuation, report previous frames and Current.
                 1 => (0, true), // Continuation of depth 1, just report Current frame.
                 int c => (c, false) // Continuation of depth > 1, report the entire stack.
             };
 
-            for (int i = 0; i < frameCount; i++)
+            for (int i = 1; i <= frameCount; i++)
             {
-                AppendStackFrame(sb, ref _stack[i]);
+                AppendStackFrame(sb, ref _stack[i - _indexOffset]);
             }
 
             if (includeCurrentFrame)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -678,6 +678,12 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        public static void ThrowInvalidOperationException_InvalidCustomTypeDiscriminatorPropertyName()
+        {
+            throw new InvalidOperationException(SR.Polymorphism_InvalidCustomTypeDiscriminatorPropertyName);
+        }
+
+        [DoesNotReturn]
         public static void ThrowInvalidOperationException_PolymorphicTypeConfigurationDoesNotSpecifyDerivedTypes(Type baseType)
         {
             throw new InvalidOperationException(SR.Format(SR.Polymorphism_ConfigurationDoesNotSpecifyDerivedTypes, baseType));

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -472,6 +472,13 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        public static void ThrowJsonException_MetadataUnexpectedProperty(ReadOnlySpan<byte> propertyName, ref ReadStack state)
+        {
+            state.Current.JsonPropertyName = propertyName.ToArray();
+            ThrowJsonException(SR.Format(SR.MetadataUnexpectedProperty));
+        }
+
+        [DoesNotReturn]
         public static void ThrowJsonException_MetadataReferenceObjectCannotContainOtherProperties()
         {
             ThrowJsonException(SR.MetadataReferenceCannotContainOtherProperties);
@@ -485,10 +492,10 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowJsonException_MetadataMissingIdBeforeValues(ref ReadStack state, ReadOnlySpan<byte> propertyName)
+        public static void ThrowJsonException_MetadataStandaloneValuesProperty(ref ReadStack state, ReadOnlySpan<byte> propertyName)
         {
             state.Current.JsonPropertyName = propertyName.ToArray();
-            ThrowJsonException(SR.MetadataPreservedArrayPropertyNotFound);
+            ThrowJsonException(SR.MetadataStandaloneValuesProperty);
         }
 
         [DoesNotReturn]
@@ -514,19 +521,25 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        public static void ThrowJsonException_MetadataDuplicateTypeProperty()
+        {
+            ThrowJsonException(SR.Format(SR.MetadataDuplicateTypeProperty));
+        }
+
+        [DoesNotReturn]
         public static void ThrowJsonException_MetadataInvalidReferenceToValueType(Type propertyType)
         {
             ThrowJsonException(SR.Format(SR.MetadataInvalidReferenceToValueType, propertyType));
         }
 
         [DoesNotReturn]
-        public static void ThrowJsonException_MetadataPreservedArrayInvalidProperty(ref ReadStack state, Type propertyType, in Utf8JsonReader reader)
+        public static void ThrowJsonException_MetadataInvalidPropertyInArrayMetadata(ref ReadStack state, Type propertyType, in Utf8JsonReader reader)
         {
             state.Current.JsonPropertyName = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan.ToArray();
             string propertyNameAsString = reader.GetString()!;
 
             ThrowJsonException(SR.Format(SR.MetadataPreservedArrayFailed,
-                SR.Format(SR.MetadataPreservedArrayInvalidProperty, propertyNameAsString),
+                SR.Format(SR.MetadataInvalidPropertyInArrayMetadata, propertyNameAsString),
                 SR.Format(SR.DeserializeUnableToConvertValue, propertyType)));
         }
 
@@ -537,7 +550,7 @@ namespace System.Text.Json
             state.Current.JsonPropertyName = null;
 
             ThrowJsonException(SR.Format(SR.MetadataPreservedArrayFailed,
-                SR.MetadataPreservedArrayPropertyNotFound,
+                SR.MetadataStandaloneValuesProperty,
                 SR.Format(SR.DeserializeUnableToConvertValue, propertyType)));
         }
 
@@ -560,14 +573,10 @@ namespace System.Text.Json
             ref ReadStack state)
         {
 
-            MetadataPropertyName name = JsonSerializer.GetMetadataPropertyName(propertyName);
-            if (name == MetadataPropertyName.Id)
+            MetadataPropertyName name = JsonSerializer.GetMetadataPropertyName(propertyName, state.Current.BaseJsonTypeInfo.PolymorphicTypeResolver);
+            if (name != 0)
             {
-                ThrowJsonException_MetadataIdIsNotFirstProperty(propertyName, ref state);
-            }
-            else if (name == MetadataPropertyName.Ref)
-            {
-                ThrowJsonException_MetadataReferenceObjectCannotContainOtherProperties(propertyName, ref state);
+                ThrowJsonException_MetadataUnexpectedProperty(propertyName, ref state);
             }
             else
             {
@@ -618,6 +627,66 @@ namespace System.Text.Json
         public static void ThrowMissingMemberException_MissingFSharpCoreMember(string missingFsharpCoreMember)
         {
             throw new MissingMemberException(SR.Format(SR.MissingFSharpCoreMember, missingFsharpCoreMember));
+        }
+
+        [DoesNotReturn]
+        public static void ThrowNotSupportedException_BaseConverterDoesNotSupportMetadata(Type derivedType)
+        {
+            throw new NotSupportedException(SR.Format(SR.Polymorphism_DerivedConverterDoesNotSupportMetadata, derivedType));
+        }
+
+        [DoesNotReturn]
+        public static void ThrowNotSupportedException_DerivedConverterDoesNotSupportMetadata(Type derivedType)
+        {
+            throw new NotSupportedException(SR.Format(SR.Polymorphism_DerivedConverterDoesNotSupportMetadata, derivedType));
+        }
+
+        [DoesNotReturn]
+        public static void ThrowNotSupportedException_RuntimeTypeNotSupported(Type baseType, Type runtimeType)
+        {
+            throw new NotSupportedException(SR.Format(SR.Polymorphism_RuntimeTypeNotSupported, runtimeType, baseType));
+        }
+
+        [DoesNotReturn]
+        public static void ThrowNotSupportedException_RuntimeTypeDiamondAmbiguity(Type baseType, Type runtimeType, Type derivedType1, Type derivedType2)
+        {
+            throw new NotSupportedException(SR.Format(SR.Polymorphism_RuntimeTypeDiamondAmbiguity, runtimeType, derivedType1, derivedType2, baseType));
+        }
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException_TypeDoesNotSupportPolymorphism(Type baseType)
+        {
+            throw new InvalidOperationException(SR.Format(SR.Polymorphism_TypeDoesNotSupportPolymorphism, baseType));
+        }
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException_DerivedTypeNotSupported(Type baseType, Type derivedType)
+        {
+            throw new InvalidOperationException(SR.Format(SR.Polymorphism_DerivedTypeIsNotSupported, derivedType, baseType));
+        }
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException_DerivedTypeIsAlreadySpecified(Type baseType, Type derivedType)
+        {
+            throw new InvalidOperationException(SR.Format(SR.Polymorphism_DerivedTypeIsAlreadySpecified, baseType, derivedType));
+        }
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException_TypeDicriminatorIdIsAlreadySpecified(Type baseType, string typeDiscriminatorId)
+        {
+            throw new InvalidOperationException(SR.Format(SR.Polymorphism_TypeDicriminatorIdIsAlreadySpecified, baseType, typeDiscriminatorId));
+        }
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException_PolymorphicTypeConfigurationDoesNotSpecifyDerivedTypes(Type baseType)
+        {
+            throw new InvalidOperationException(SR.Format(SR.Polymorphism_ConfigurationDoesNotSpecifyDerivedTypes, baseType));
+        }
+
+        [DoesNotReturn]
+        public static void ThrowJsonException_UnrecognizedTypeDiscriminator(string typeDiscriminatorId)
+        {
+            ThrowJsonException(SR.Format(SR.Polymorphism_UnrecognizedTypeDiscriminator, typeDiscriminatorId));
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -523,7 +523,7 @@ namespace System.Text.Json
         [DoesNotReturn]
         public static void ThrowJsonException_MetadataDuplicateTypeProperty()
         {
-            ThrowJsonException(SR.Format(SR.MetadataDuplicateTypeProperty));
+            ThrowJsonException(SR.MetadataDuplicateTypeProperty);
         }
 
         [DoesNotReturn]

--- a/src/libraries/System.Text.Json/tests/Common/ReferenceHandlerTests/ReferenceHandlerTests.Deserialize.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ReferenceHandlerTests/ReferenceHandlerTests.Deserialize.cs
@@ -914,7 +914,21 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(@"{""$iz"": ""1""}", "$.$iz")]
         [InlineData(@"{""$rez"": ""1""}", "$.$rez")]
         [InlineData(@"{""$valuez"": []}", "$.$valuez")]
-        public async Task InvalidMetadataPropertyNameWithSameLengthIsNotRecognized(string json, string expectedPath)
+        [InlineData(@"{""$type"": ""derivedType""}", "$.$type")]
+        [InlineData(@"{""$PropertyWithDollarSign"": ""1""}", "$.$PropertyWithDollarSign")]
+        [InlineData(@"{""$id"" : ""1"", ""$iz"": ""1""}", "$.$iz")]
+        [InlineData(@"{""$id"" : ""1"", ""$rez"": ""1""}", "$.$rez")]
+        [InlineData(@"{""$id"" : ""1"", ""$id"" : 1 }", "$.$id")]
+        [InlineData(@"{""$id"" : ""1"", ""$ref"" : 1 }", "$.$ref")]
+        [InlineData(@"{""$id"" : ""1"", ""$valuez"": ""[]""}", "$.$valuez")]
+        [InlineData(@"{""$id"" : ""1"", ""$type"": ""derivedType""}", "$.$type")]
+        [InlineData(@"{""$id"" : ""1"", ""$PropertyWithDollarSign"": ""1""}", "$.$PropertyWithDollarSign")]
+        [InlineData(@"{""$id"" : ""1"", ""NonMetadataProperty"" : 42, ""$iz"": ""1""}", "$.$iz")]
+        [InlineData(@"{""$id"" : ""1"", ""NonMetadataProperty"" : 42, ""$rez"": ""1""}", "$.$rez")]
+        [InlineData(@"{""$id"" : ""1"", ""NonMetadataProperty"" : 42, ""$valuez"": ""[]""}", "$.$valuez")]
+        [InlineData(@"{""$id"" : ""1"", ""NonMetadataProperty"" : 42, ""$type"": ""derivedType""}", "$.$type")]
+        [InlineData(@"{""$id"" : ""1"", ""NonMetadataProperty"" : 42, ""$PropertyWithDollarSign"": ""1""}", "$.$PropertyWithDollarSign")]
+        public async Task InvalidMetadataPropertyNameIsRejected(string json, string expectedPath)
         {
             JsonException ex = await Assert.ThrowsAsync<JsonException>(async () => await Serializer.DeserializeWrapper<Employee>(json, s_deserializerOptionsPreserve));
             Assert.Equal(expectedPath, ex.Path);

--- a/src/libraries/System.Text.Json/tests/Common/SerializerTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/SerializerTests.cs
@@ -1,6 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Xunit;
+
 namespace System.Text.Json.Serialization.Tests
 {
     /// <summary>
@@ -8,6 +15,12 @@ namespace System.Text.Json.Serialization.Tests
     /// </summary>
     public abstract class SerializerTests
     {
+        protected SerializerTests(JsonSerializerWrapper serializerUnderTest)
+        {
+            Serializer = serializerUnderTest;
+            StreamingSerializer = serializerUnderTest as StreamingJsonSerializerWrapper;
+        }
+
         /// <summary>
         /// The serialization System Under Test to be targeted by deriving test suites.
         /// </summary>
@@ -18,10 +31,291 @@ namespace System.Text.Json.Serialization.Tests
         /// </summary>
         protected StreamingJsonSerializerWrapper? StreamingSerializer { get; }
 
-        protected SerializerTests(JsonSerializerWrapper serializerUnderTest)
+        [Flags]
+        protected enum SerializedValueContext
         {
-            Serializer = serializerUnderTest;
-            StreamingSerializer = serializerUnderTest as StreamingJsonSerializerWrapper;
+            None = 0,
+            RootValue = 1,
+            ObjectProperty = 2,
+            CollectionElement = 4,
+            DictionaryValue = 8,
+            JsonNode = 16,
+            All = RootValue | ObjectProperty | CollectionElement | DictionaryValue | JsonNode
+        }
+
+        /// <summary>
+        /// Tests serialization of a given value within the context of multiple types:
+        /// root values, object properties, collection elements, dictionary values, etc.
+        /// </summary>
+        protected async Task TestMultiContextSerialization<TValue>(
+            TValue value,
+            string expectedJson,
+            Type? expectedExceptionType = null,
+            SerializedValueContext contexts = SerializedValueContext.All,
+            JsonSerializerOptions? options = null)
+        {
+            Assert.True((contexts & SerializedValueContext.All) != SerializedValueContext.None);
+
+            string actualJson;
+
+            if (contexts.HasFlag(SerializedValueContext.RootValue))
+            {
+                if (expectedExceptionType != null)
+                {
+                    await Assert.ThrowsAsync(expectedExceptionType, () => Serializer.SerializeWrapper(value, options));
+                }
+                else
+                {
+                    actualJson = await Serializer.SerializeWrapper(value, options);
+                    JsonTestHelper.AssertJsonEqual(expectedJson, actualJson);
+                }
+            }
+
+            if (contexts.HasFlag(SerializedValueContext.ObjectProperty))
+            {
+                var poco = new GenericPoco<TValue> { Property = value };
+
+                if (expectedExceptionType != null)
+                {
+                    await Assert.ThrowsAsync(expectedExceptionType, () => Serializer.SerializeWrapper(poco, options));
+                }
+                else
+                {
+                    string propertyName = options?.PropertyNamingPolicy is JsonNamingPolicy policy
+                        ? policy.ConvertName(nameof(GenericPoco<TValue>.Property))
+                        : nameof(GenericPoco<TValue>.Property);
+
+                    actualJson = await Serializer.SerializeWrapper(poco, options);
+                    JsonTestHelper.AssertJsonEqual($@"{{ ""{propertyName}"" : {expectedJson} }}", actualJson);
+                }
+            }
+
+            if (contexts.HasFlag(SerializedValueContext.CollectionElement))
+            {
+                var list = new List<TValue> { value };
+
+                if (expectedExceptionType != null)
+                {
+                    await Assert.ThrowsAsync(expectedExceptionType, () => Serializer.SerializeWrapper(list, options));
+                }
+                else
+                {
+                    actualJson = await Serializer.SerializeWrapper(list, options);
+                    JsonTestHelper.AssertJsonEqual($"[{expectedJson}]", actualJson);
+                }
+            }
+
+            if (contexts.HasFlag(SerializedValueContext.DictionaryValue))
+            {
+                const string key = "key";
+                var dictionary = new Dictionary<string, TValue> { [key] = value };
+
+                if (expectedExceptionType != null)
+                {
+                    await Assert.ThrowsAsync(expectedExceptionType, () => Serializer.SerializeWrapper(dictionary, options));
+                }
+                else
+                {
+                    string jsonKey = options?.DictionaryKeyPolicy is JsonNamingPolicy policy
+                        ? policy.ConvertName(key)
+                        : key;
+
+                    actualJson = await Serializer.SerializeWrapper(dictionary, options);
+                    JsonTestHelper.AssertJsonEqual($@"{{ ""{jsonKey}"" : {expectedJson} }}", actualJson);
+                }
+            }
+
+            if (contexts.HasFlag(SerializedValueContext.JsonNode))
+            {
+                const string key = "key";
+                var jsonObject = new JsonObject { [key] = JsonValue.Create<TValue>(value) };
+
+                if (expectedExceptionType != null)
+                {
+                    await Assert.ThrowsAsync(expectedExceptionType, () => Serializer.SerializeWrapper(jsonObject, options));
+                }
+                else
+                {
+                    actualJson = await Serializer.SerializeWrapper(jsonObject, options);
+                    JsonTestHelper.AssertJsonEqual($@"{{ ""{key}"" : {expectedJson} }}", actualJson);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tests serialization of a given list of values within the context of multiple types:
+        /// root values, object properties, collection elements, dictionary values, etc.
+        /// </summary>
+        protected async Task TestMultiContextSerialization<TValue>(
+            IEnumerable<(TValue Value, string ExpectedJson)> inputs,
+            SerializedValueContext contexts = SerializedValueContext.All,
+            JsonSerializerOptions? options = null)
+        {
+            inputs = inputs.ToList();
+            string expectedJson = $"[{string.Join(", ", inputs.Select(x => x.ExpectedJson))}]";
+            List<TValue> values = inputs.Select(x => x.Value).ToList();
+            await TestMultiContextSerialization(
+                values,
+                expectedJson,
+                expectedExceptionType: null,
+                contexts,
+                options);
+        }
+
+        /// <summary>
+        /// Tests deserialization of a given value within the context of multiple types:
+        /// root values, object properties, collection elements, dictionary values, etc.
+        /// </summary>
+        protected async Task TestMultiContextDeserialization<TValue>(
+            string json,
+            TValue? expectedValue = default,
+            Type? expectedExceptionType = null,
+            SerializedValueContext contexts = SerializedValueContext.All,
+            JsonSerializerOptions? options = null,
+            IEqualityComparer<TValue>? equalityComparer = null)
+        {
+            Assert.True((contexts & SerializedValueContext.All) != SerializedValueContext.None);
+
+            string wrappedJson;
+            equalityComparer ??= expectedValue is IEquatable<TValue>
+                ? EqualityComparer<TValue>.Default
+                : new JsonEqualityComparer<TValue>();
+
+            if (contexts.HasFlag(SerializedValueContext.RootValue))
+            {
+                if (expectedExceptionType != null)
+                {
+                    await Assert.ThrowsAsync(expectedExceptionType, () => Serializer.DeserializeWrapper<TValue>(json, options));
+                }
+                else
+                {
+                    TValue value = await Serializer.DeserializeWrapper<TValue>(json, options);
+                    Assert.Equal(expectedValue, value, equalityComparer);
+                }
+            }
+
+            if (contexts.HasFlag(SerializedValueContext.ObjectProperty))
+            {
+                string propertyName =
+                    options?.PropertyNamingPolicy is JsonNamingPolicy policy
+                    ? policy.ConvertName(nameof(GenericPoco<TValue>.Property))
+                    : nameof(GenericPoco<TValue>.Property);
+
+                wrappedJson = $@"{{ ""{propertyName}"" : {json} }}";
+
+                if (expectedExceptionType != null)
+                {
+                    await Assert.ThrowsAsync(expectedExceptionType, () => Serializer.DeserializeWrapper<GenericPoco<TValue>>(wrappedJson, options));
+                }
+                else
+                {
+
+                    GenericPoco<TValue> poco = await Serializer.DeserializeWrapper<GenericPoco<TValue>>(wrappedJson, options);
+                    Assert.Equal(expectedValue, poco.Property, equalityComparer);
+                }
+            }
+
+            if (contexts.HasFlag(SerializedValueContext.CollectionElement))
+            {
+                wrappedJson = $@"[{json}]";
+
+                if (expectedExceptionType != null)
+                {
+                    await Assert.ThrowsAsync(expectedExceptionType, () => Serializer.DeserializeWrapper<List<TValue>>(wrappedJson, options));
+                }
+                else
+                {
+                    List<TValue> list = await Serializer.DeserializeWrapper<List<TValue>>(wrappedJson, options);
+                    Assert.Equal(1, list.Count);
+                    Assert.Equal(expectedValue, list[0], equalityComparer);
+                }
+            }
+
+            if (contexts.HasFlag(SerializedValueContext.DictionaryValue))
+            {
+                const string key = "key";
+                wrappedJson = $@"{{ ""{key}"" : {json} }}";
+
+                if (expectedExceptionType != null)
+                {
+                    await Assert.ThrowsAsync(expectedExceptionType, () => Serializer.DeserializeWrapper<Dictionary<string, TValue>>(wrappedJson, options));
+                }
+                else
+                {
+                    Dictionary<string, TValue> dictionary = await Serializer.DeserializeWrapper<Dictionary<string, TValue>>(wrappedJson, options);
+                    Assert.Equal(1, dictionary.Count);
+                    Assert.True(dictionary.ContainsKey(key));
+                    Assert.Equal(expectedValue, dictionary[key], equalityComparer);
+                }
+            }
+
+            if (contexts.HasFlag(SerializedValueContext.JsonNode))
+            {
+                const string key = "key";
+                wrappedJson = $@"{{ ""{key}"" : {json} }}";
+
+                if (expectedExceptionType != null)
+                {
+                    await Assert.ThrowsAsync(expectedExceptionType,
+                        async () =>
+                        {
+                            JsonNode jsonNode = await Serializer.DeserializeWrapper<JsonNode>(wrappedJson, options);
+                            JsonSerializer.Deserialize<TValue>(jsonNode[key], options);
+                        });
+                }
+                else
+                {
+                    JsonNode jsonNode = await Serializer.DeserializeWrapper<JsonNode>(wrappedJson, options);
+                    TValue value = JsonSerializer.Deserialize<TValue>(jsonNode[key], options);
+                    Assert.Equal(expectedValue, value, equalityComparer);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tests deserialization of a given list of values within the context of multiple types:
+        /// root values, object properties, collection elements, dictionary values, etc.
+        /// </summary>
+        protected async Task TestMultiContextDeserialization<TValue>(
+            IEnumerable<(string Json, TValue ExpectedValue)> inputs,
+            SerializedValueContext contexts = SerializedValueContext.All,
+            JsonSerializerOptions? options = null,
+            IEqualityComparer<TValue>? equalityComparer = null)
+        {
+            inputs = inputs.ToList();
+            List<TValue> expectedValues = inputs.Select(x => x.ExpectedValue).ToList();
+            string json = $"[{string.Join(",", inputs.Select(x => x.Json))}]";
+            var listEqualityComparer = new ListAssertionEqualityComparer<TValue>(equalityComparer);
+            await TestMultiContextDeserialization<List<TValue>>(json, expectedValues, expectedExceptionType: null, contexts, options, listEqualityComparer);
+        }
+
+        private class GenericPoco<T>
+        {
+            public T Property { get; set; }
+        }
+
+        private class JsonEqualityComparer<TValue> : IEqualityComparer<TValue>
+        {
+            public bool Equals(TValue? x, TValue? y) => JsonSerializer.Serialize(x) == JsonSerializer.Serialize(y);
+            public int GetHashCode([DisallowNull] TValue obj) => JsonSerializer.Serialize(obj).GetHashCode();
+        }
+
+        private class ListAssertionEqualityComparer<TValue> : IEqualityComparer<IList<TValue>>
+        {
+            private readonly IEqualityComparer<TValue>? _elementComparer;
+
+            public ListAssertionEqualityComparer(IEqualityComparer<TValue>? elementComparer)
+            {
+                _elementComparer = elementComparer ?? EqualityComparer<TValue>.Default;
+            }
+
+            public bool Equals(IList<TValue>? x, IList<TValue>? y)
+            {
+                Assert.Equal(x, y, _elementComparer);
+                return true;
+            }
+
+            public int GetHashCode([DisallowNull] IList<TValue> obj) => throw new NotImplementedException();
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/ContextClasses.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/ContextClasses.cs
@@ -49,6 +49,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         public JsonTypeInfo<PersonStruct?> NullablePersonStruct { get; }
         public JsonTypeInfo<TypeWithValidationAttributes> TypeWithValidationAttributes { get; }
         public JsonTypeInfo<TypeWithDerivedAttribute> TypeWithDerivedAttribute { get; }
+        public JsonTypeInfo<PolymorphicClass> PolymorphicClass { get; }
     }
 
     internal partial class JsonContext : JsonSerializerContext

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MetadataAndSerializationContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MetadataAndSerializationContextTests.cs
@@ -43,6 +43,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(PersonStruct?))]
     [JsonSerializable(typeof(TypeWithValidationAttributes))]
     [JsonSerializable(typeof(TypeWithDerivedAttribute))]
+    [JsonSerializable(typeof(PolymorphicClass))]
     internal partial class MetadataAndSerializationContext : JsonSerializerContext, ITestContext
     {
         public JsonSourceGenerationMode JsonSourceGenerationMode => JsonSourceGenerationMode.Default;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MetadataContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MetadataContextTests.cs
@@ -42,6 +42,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(PersonStruct?), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(TypeWithValidationAttributes), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(TypeWithDerivedAttribute), GenerationMode = JsonSourceGenerationMode.Metadata)]
+    [JsonSerializable(typeof(PolymorphicClass), GenerationMode = JsonSourceGenerationMode.Metadata)]
     internal partial class MetadataWithPerTypeAttributeContext : JsonSerializerContext, ITestContext
     {
         public JsonSourceGenerationMode JsonSourceGenerationMode => JsonSourceGenerationMode.Metadata;
@@ -130,6 +131,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(PersonStruct?))]
     [JsonSerializable(typeof(TypeWithValidationAttributes))]
     [JsonSerializable(typeof(TypeWithDerivedAttribute))]
+    [JsonSerializable(typeof(PolymorphicClass))]
     internal partial class MetadataContext : JsonSerializerContext, ITestContext
     {
         public JsonSourceGenerationMode JsonSourceGenerationMode => JsonSourceGenerationMode.Metadata;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MixedModeContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MixedModeContextTests.cs
@@ -43,6 +43,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(PersonStruct?), GenerationMode = JsonSourceGenerationMode.Metadata | JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(TypeWithValidationAttributes), GenerationMode = JsonSourceGenerationMode.Metadata | JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(TypeWithDerivedAttribute), GenerationMode = JsonSourceGenerationMode.Metadata | JsonSourceGenerationMode.Serialization)]
+    [JsonSerializable(typeof(PolymorphicClass), GenerationMode = JsonSourceGenerationMode.Metadata | JsonSourceGenerationMode.Serialization)]
     internal partial class MixedModeContext : JsonSerializerContext, ITestContext
     {
         public JsonSourceGenerationMode JsonSourceGenerationMode => JsonSourceGenerationMode.Metadata | JsonSourceGenerationMode.Serialization;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
@@ -925,5 +925,40 @@ namespace System.Text.Json.SourceGeneration.Tests
             instance = JsonSerializer.Deserialize(json, DefaultContext.TypeWithDerivedAttribute);
             Assert.NotNull(instance);
         }
+
+        [Fact]
+        public void PolymorphicClass_Serialization()
+        {
+            PolymorphicClass value = new PolymorphicClass.DerivedClass { Number = 42, Boolean = true };
+
+            if (DefaultContext.JsonSourceGenerationMode == JsonSourceGenerationMode.Serialization)
+            {
+                Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(value, DefaultContext.PolymorphicClass));
+            }
+            else
+            {
+                string expectedJson = @"{""$type"" : ""derivedClass"", ""Number"" : 42, ""Boolean"" : true }";
+                string actualJson = JsonSerializer.Serialize(value, DefaultContext.PolymorphicClass);
+                JsonTestHelper.AssertJsonEqual(expectedJson, actualJson);
+            }
+        }
+
+        [Fact]
+        public void PolymorphicClass_Deserialization()
+        {
+            string json = @"{""$type"" : ""derivedClass"", ""Number"" : 42, ""Boolean"" : true }";
+
+            if (DefaultContext.JsonSourceGenerationMode == JsonSourceGenerationMode.Serialization)
+            {
+                Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<PolymorphicClass>(json, DefaultContext.PolymorphicClass));
+            }
+            else
+            {
+                PolymorphicClass result = JsonSerializer.Deserialize<PolymorphicClass>(json, DefaultContext.PolymorphicClass);
+                PolymorphicClass.DerivedClass derivedResult = Assert.IsType<PolymorphicClass.DerivedClass>(result);
+                Assert.Equal(42, derivedResult.Number);
+                Assert.True(derivedResult.Boolean);
+            }
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/SerializationContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/SerializationContextTests.cs
@@ -43,6 +43,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(PersonStruct?))]
     [JsonSerializable(typeof(TypeWithValidationAttributes))]
     [JsonSerializable(typeof(TypeWithDerivedAttribute))]
+    [JsonSerializable(typeof(PolymorphicClass))]
     internal partial class SerializationContext : JsonSerializerContext, ITestContext
     {
         public JsonSourceGenerationMode JsonSourceGenerationMode => JsonSourceGenerationMode.Serialization;
@@ -84,6 +85,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(PersonStruct?), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(TypeWithValidationAttributes), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(TypeWithDerivedAttribute), GenerationMode = JsonSourceGenerationMode.Serialization)]
+    [JsonSerializable(typeof(PolymorphicClass), GenerationMode = JsonSourceGenerationMode.Serialization)]
     internal partial class SerializationWithPerTypeAttributeContext : JsonSerializerContext, ITestContext
     {
         public JsonSourceGenerationMode JsonSourceGenerationMode => JsonSourceGenerationMode.Serialization;
@@ -126,6 +128,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(PersonStruct?), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(TypeWithValidationAttributes), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(TypeWithDerivedAttribute), GenerationMode = JsonSourceGenerationMode.Serialization)]
+    [JsonSerializable(typeof(PolymorphicClass), GenerationMode = JsonSourceGenerationMode.Serialization)]
     internal partial class SerializationContextWithCamelCase : JsonSerializerContext, ITestContext
     {
         public JsonSourceGenerationMode JsonSourceGenerationMode => JsonSourceGenerationMode.Serialization;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Tests.targets
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Tests.targets
@@ -6,12 +6,20 @@
     <!-- SYSLIB0020: JsonSerializerOptions.IgnoreNullValues is obsolete -->
     <!-- SYSLIB1037: Suppress init-only property deserialization warning -->
     <!-- SYSLIB1038: Suppress JsonInclude on inaccessible members warning -->
-    <NoWarn>$(NoWarn);SYSLIB0020;SYSLIB1037;SYSLIB1038</NoWarn>
+    <!-- SYSLIB1039: Suppress Polymorphic types not supported warning -->
+    <NoWarn>$(NoWarn);SYSLIB0020;SYSLIB1037;SYSLIB1038;SYSLIB1039</NoWarn>
+    <!-- Remove once polymorphism is out of preview. -->
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <GenerateRequiresPreviewFeaturesAttribute>true</GenerateRequiresPreviewFeaturesAttribute>
   </PropertyGroup>
 
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);BUILDING_SOURCE_GENERATOR_TESTS</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <Compile Include="$(CoreLibSharedDir)System\Runtime\Versioning\RequiresPreviewFeaturesAttribute.cs" Link="System\Runtime\Versioning\RequiresPreviewFeaturesAttribute.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\DateTimeTestHelpers.cs" Link="CommonTest\System\DateTimeTestHelpers.cs" />

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Tests.targets
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Tests.targets
@@ -8,9 +8,6 @@
     <!-- SYSLIB1038: Suppress JsonInclude on inaccessible members warning -->
     <!-- SYSLIB1039: Suppress Polymorphic types not supported warning -->
     <NoWarn>$(NoWarn);SYSLIB0020;SYSLIB1037;SYSLIB1038;SYSLIB1039</NoWarn>
-    <!-- Remove once polymorphism is out of preview. -->
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
-    <GenerateRequiresPreviewFeaturesAttribute>true</GenerateRequiresPreviewFeaturesAttribute>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/TestClasses.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/TestClasses.cs
@@ -180,4 +180,15 @@ namespace System.Text.Json.SourceGeneration.Tests
     [Derived(TestProperty = "Test")]
     public class TypeWithDerivedAttribute
     { }
+
+    [JsonDerivedType(typeof(DerivedClass), "derivedClass")]
+    public class PolymorphicClass
+    {
+        public int Number { get; set; }
+
+        public class DerivedClass : PolymorphicClass
+        {
+            public bool Boolean { get; set; }
+        }
+    }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/System.Text.Json.SourceGeneration.Unit.Tests.targets
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/System.Text.Json.SourceGeneration.Unit.Tests.targets
@@ -2,18 +2,12 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <!-- Remove once polymorphism is out of preview. -->
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
-    <GenerateRequiresPreviewFeaturesAttribute>true</GenerateRequiresPreviewFeaturesAttribute>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="$(RoslynApiVersion)" />
-    <ProjectReference Include="..\..\src\System.Text.Json.csproj" />
-  </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-    <Compile Include="$(CoreLibSharedDir)System\Runtime\Versioning\RequiresPreviewFeaturesAttribute.cs" Link="System\Runtime\Versioning\RequiresPreviewFeaturesAttribute.cs" />
+    <ProjectReference Include="..\..\src\System.Text.Json.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/System.Text.Json.SourceGeneration.Unit.Tests.targets
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/System.Text.Json.SourceGeneration.Unit.Tests.targets
@@ -2,12 +2,18 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <!-- Remove once polymorphism is out of preview. -->
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <GenerateRequiresPreviewFeaturesAttribute>true</GenerateRequiresPreviewFeaturesAttribute>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="$(RoslynApiVersion)" />
-
     <ProjectReference Include="..\..\src\System.Text.Json.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <Compile Include="$(CoreLibSharedDir)System\Runtime\Versioning\RequiresPreviewFeaturesAttribute.cs" Link="System\Runtime\Versioning\RequiresPreviewFeaturesAttribute.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonPolymorphicTypeConfigurationTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonPolymorphicTypeConfigurationTests.cs
@@ -69,7 +69,6 @@ namespace System.Text.Json.Tests.Serialization
         }
 
         [Theory]
-        [InlineData(null)]
         [InlineData(typeof(int))]
         [InlineData(typeof(int*))]
         [InlineData(typeof(string))]
@@ -84,9 +83,14 @@ namespace System.Text.Json.Tests.Serialization
             Assert.Throws<ArgumentException>(() => new JsonPolymorphicTypeConfiguration(baseType));
         }
 
+        [Fact]
+        public static void NullBaseTypeArgument_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new JsonPolymorphicTypeConfiguration(null));
+        }
+
         [Theory]
         [InlineData(typeof(Interface), typeof(object))]
-        [InlineData(typeof(Class), null)]
         [InlineData(typeof(Class), typeof(Interface))]
         [InlineData(typeof(Class), typeof(GenericClass<>))]
         public static void InvalidDerivedTypeArgument_ThrowsArgumentException(Type baseType, Type derivedType)
@@ -97,6 +101,14 @@ namespace System.Text.Json.Tests.Serialization
             Assert.Empty(configuration);
 
             Assert.Throws<ArgumentException>(() => configuration.WithDerivedType(derivedType, "typeDiscriminator"));
+            Assert.Empty(configuration);
+        }
+
+        [Fact]
+        public static void NullDerivedTypeArgument_ThrowsArgumentNullException()
+        {
+            var configuration = new JsonPolymorphicTypeConfiguration(typeof(Class));
+            Assert.Throws<ArgumentNullException>(() => configuration.WithDerivedType(derivedType: null));
             Assert.Empty(configuration);
         }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonPolymorphicTypeConfigurationTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonPolymorphicTypeConfigurationTests.cs
@@ -1,0 +1,144 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.Json.Serialization;
+using Xunit;
+
+namespace System.Text.Json.Tests.Serialization
+{
+    public static class JsonPolymorphicTypeConfigurationTests
+    {
+        [Theory]
+        [InlineData(typeof(IEnumerable))]
+        [InlineData(typeof(Interface))]
+        [InlineData(typeof(Class))]
+        [InlineData(typeof(GenericClass<int>))]
+        public static void SupportedBaseTypeArgument_ShouldSucced(Type baseType)
+        {
+            var configuration = new JsonPolymorphicTypeConfiguration(baseType);
+            Assert.Equal(baseType, configuration.BaseType);
+            Assert.Empty(configuration);
+        }
+
+        [Theory]
+        [InlineData(typeof(IEnumerable), typeof(IEnumerable<int>))]
+        [InlineData(typeof(IList<string>), typeof(string[]))]
+        [InlineData(typeof(MemberInfo), typeof(Type))]
+        [InlineData(typeof(Interface), typeof(Class))]
+        [InlineData(typeof(Interface), typeof(Struct))]
+        [InlineData(typeof(Class), typeof(GenericClass<int>))]
+        public static void SupportedDerivedTypeArgument_ShouldSucced(Type baseType, Type derivedType)
+        {
+            var configuration = new JsonPolymorphicTypeConfiguration(baseType).WithDerivedType(derivedType);
+            Assert.Equal(new[] { (derivedType, (string)null) }, configuration);
+
+            configuration = new JsonPolymorphicTypeConfiguration(baseType).WithDerivedType(derivedType, "typeDiscriminator");
+            Assert.Equal(new[] { (derivedType, "typeDiscriminator") }, configuration);
+        }
+
+        [Fact]
+        public static void SupportsDeclaringBaseTypeAsDerivedType()
+        {
+            var configuration =
+                new JsonPolymorphicTypeConfiguration(typeof(Class))
+                    .WithDerivedType(typeof(Class));
+
+            Assert.Equal(new[] { (typeof(Class), (string)null) }, configuration);
+
+            configuration =
+                new JsonPolymorphicTypeConfiguration(typeof(Class))
+                    .WithDerivedType(typeof(Class), "typeDiscriminatorId");
+
+            Assert.Equal(new[] { (typeof(Class), "typeDiscriminatorId") }, configuration);
+        }
+
+        [Fact]
+        public static void SupportsMixingAndMatchingTypeDiscriminators()
+        {
+            var configuration =
+                new JsonPolymorphicTypeConfiguration(typeof(Class))
+                    .WithDerivedType(typeof(GenericClass<int>), "typeDiscriminator")
+                    .WithDerivedType(typeof(GenericClass<string>));
+
+            Assert.Equal(
+                new[] { (typeof(GenericClass<int>), "typeDiscriminator"), (typeof(GenericClass<string>), (string)null) },
+                configuration);
+        }
+
+        [Theory]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(int*))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(Guid))]
+        [InlineData(typeof(Struct))]
+        [InlineData(typeof(ReadOnlySpan<int>))]
+        [InlineData(typeof(SealedClass))]
+        [InlineData(typeof(GenericClass<>))]
+        public static void InvalidBaseTypeArgument_ThrowsArgumentException(Type baseType)
+        {
+            Assert.Throws<ArgumentException>(() => new JsonPolymorphicTypeConfiguration(baseType));
+        }
+
+        [Theory]
+        [InlineData(typeof(Interface), typeof(object))]
+        [InlineData(typeof(Class), typeof(Interface))]
+        [InlineData(typeof(Class), typeof(GenericClass<>))]
+        public static void InvalidDerivedTypeArgument_ThrowsArgumentException(Type baseType, Type derivedType)
+        {
+            var configuration = new JsonPolymorphicTypeConfiguration(baseType);
+
+            Assert.Throws<ArgumentException>(() => configuration.WithDerivedType(derivedType));
+            Assert.Empty(configuration);
+
+            Assert.Throws<ArgumentException>(() => configuration.WithDerivedType(derivedType, "typeDiscriminator"));
+            Assert.Empty(configuration);
+        }
+
+        [Fact]
+        public static void DuplicateDerivedType_ThrowsArgumentException()
+        {
+            var configuration = new JsonPolymorphicTypeConfiguration(typeof(Class)).WithDerivedType(typeof(GenericClass<int>));
+            Assert.Throws<ArgumentException>(() => configuration.WithDerivedType(typeof(GenericClass<int>)));
+            Assert.Equal(new[] { (typeof(GenericClass<int>), (string)null) }, configuration);
+        }
+
+        [Fact]
+        public static void DuplicateTypeDiscriminator_ThrowsArgumentException()
+        {
+            var configuration =
+                new JsonPolymorphicTypeConfiguration(typeof(Class))
+                    .WithDerivedType(typeof(GenericClass<int>), "discriminator1")
+                    .WithDerivedType(typeof(GenericClass<string>), "discriminator2");
+
+            Assert.Equal(new[] { (typeof(GenericClass<int>), "discriminator1"), (typeof(GenericClass<string>), "discriminator2") }, configuration);
+
+            Assert.Throws<ArgumentException>(() => configuration.WithDerivedType(typeof(GenericClass<bool>), "discriminator2"));
+
+            Assert.Equal(new[] { (typeof(GenericClass<int>), "discriminator1"), (typeof(GenericClass<string>), "discriminator2") }, configuration);
+        }
+
+        [Fact]
+        public static void ModifyingAfterAssignmentToOptions_ShouldThrowInvalidOperationException()
+        {
+            var config = new JsonPolymorphicTypeConfiguration(typeof(Class))
+                .WithDerivedType(typeof(GenericClass<int>), "derived");
+
+            _ = new JsonSerializerOptions { PolymorphicTypeConfigurations = { config } };
+
+            Assert.Throws<InvalidOperationException>(() => config.WithDerivedType(typeof(GenericClass<string>), "derived2"));
+            Assert.Throws<InvalidOperationException>(() => config.CustomTypeDiscriminatorPropertyName = "_case");
+            Assert.Throws<InvalidOperationException>(() => config.UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToBaseType);
+            Assert.Throws<InvalidOperationException>(() => config.IgnoreUnrecognizedTypeDiscriminators = true);
+        }
+
+        private interface Interface { }
+        private class Class : Interface { }
+        private struct Struct : Interface { }
+        private sealed class SealedClass : Interface { }
+        private class GenericClass<T> : Class { } 
+    }
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonPolymorphicTypeConfigurationTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonPolymorphicTypeConfigurationTests.cs
@@ -69,6 +69,7 @@ namespace System.Text.Json.Tests.Serialization
         }
 
         [Theory]
+        [InlineData(null)]
         [InlineData(typeof(int))]
         [InlineData(typeof(int*))]
         [InlineData(typeof(string))]
@@ -85,6 +86,7 @@ namespace System.Text.Json.Tests.Serialization
 
         [Theory]
         [InlineData(typeof(Interface), typeof(object))]
+        [InlineData(typeof(Class), null)]
         [InlineData(typeof(Class), typeof(Interface))]
         [InlineData(typeof(Class), typeof(GenericClass<>))]
         public static void InvalidDerivedTypeArgument_ThrowsArgumentException(Type baseType, Type derivedType)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
@@ -587,6 +587,13 @@ namespace System.Text.Json.Serialization.Tests
                     options.Converters.Add(new JsonStringEnumConverter());
                     options.Converters.Add(new ConverterForInt32());
                 }
+                else if (propertyType == typeof(IList<JsonPolymorphicTypeConfiguration>))
+                {
+                    options.PolymorphicTypeConfigurations.Add(
+                        new JsonPolymorphicTypeConfiguration<ITestClass>()
+                            .WithDerivedType<Point_With_Array>("point_with_array")
+                            .WithDerivedType<Point_With_Dictionary>("point_with_dictionary"));
+                }
                 else if (propertyType == typeof(JavaScriptEncoder))
                 {
                     options.Encoder = JavaScriptEncoder.Default;
@@ -632,10 +639,21 @@ namespace System.Text.Json.Serialization.Tests
                 {
                     Assert.Equal((int)property.GetValue(options), (int)property.GetValue(newOptions));
                 }
-                else if (typeof(IEnumerable).IsAssignableFrom(propertyType))
+                else if (propertyType == typeof(IList<JsonConverter>))
                 {
                     var list1 = (IList<JsonConverter>)property.GetValue(options);
                     var list2 = (IList<JsonConverter>)property.GetValue(newOptions);
+
+                    Assert.Equal(list1.Count, list2.Count);
+                    for (int i = 0; i < list1.Count; i++)
+                    {
+                        Assert.Same(list1[i], list2[i]);
+                    }
+                }
+                else if (propertyType == typeof(IList<JsonPolymorphicTypeConfiguration>))
+                {
+                    var list1 = (IList<JsonPolymorphicTypeConfiguration>)property.GetValue(options);
+                    var list2 = (IList<JsonPolymorphicTypeConfiguration>)property.GetValue(newOptions);
 
                     Assert.Equal(list1.Count, list2.Count);
                     for (int i = 0; i < list1.Count; i++)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.CustomTypeHierarchies.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.CustomTypeHierarchies.cs
@@ -1,0 +1,2348 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    public abstract partial class PolymorphicTests
+    {
+        #region Polymorphic Class
+        [Theory]
+        [MemberData(nameof(Get_PolymorphicClass_TestData_Serialization))]
+        public Task PolymorphicClass_TestData_Serialization(PolymorphicClass.TestData testData)
+            => TestMultiContextSerialization(testData.Value, testData.ExpectedJson, testData.ExpectedSerializationException);
+
+        public static IEnumerable<object[]> Get_PolymorphicClass_TestData_Serialization()
+            => PolymorphicClass.GetSerializeTestData().Select(entry => new object[] { entry });
+
+        [Theory]
+        [MemberData(nameof(Get_PolymorphicClass_TestData_Deserialization))]
+        public Task PolymorphicClass_TestData_Deserialization(PolymorphicClass.TestData testData)
+            => TestMultiContextDeserialization<PolymorphicClass>(
+                testData.ExpectedJson,
+                testData.ExpectedRoundtripValue,
+                testData.ExpectedDeserializationException,
+                equalityComparer: PolymorphicEqualityComparer<PolymorphicClass>.Instance);
+
+        public static IEnumerable<object[]> Get_PolymorphicClass_TestData_Deserialization()
+            => PolymorphicClass.GetSerializeTestData().Where(entry => entry.ExpectedJson != null).Select(entry => new object[] { entry });
+
+        [Fact]
+        public async Task PolymorphicClass_TestDataArray_Serialization()
+        {
+            IEnumerable<(PolymorphicClass Value, string ExpectedJson)> inputs =
+                PolymorphicClass.GetSerializeTestData()
+                    .Where(entry => entry.ExpectedSerializationException is null)
+                    .Select(entry => (entry.Value, entry.ExpectedJson));
+
+            await TestMultiContextSerialization(inputs);
+        }
+
+        [Fact]
+        public async Task PolymorphicClass_TestDataArray_Deserialization()
+        {
+            IEnumerable<(string ExpectedJson, PolymorphicClass ExpectedRoundtripValue)> inputs =
+                PolymorphicClass.GetSerializeTestData()
+                    .Where(entry => entry.ExpectedRoundtripValue is not null)
+                    .Select(entry => (entry.ExpectedJson, entry.ExpectedRoundtripValue));
+
+            await TestMultiContextDeserialization(inputs, equalityComparer: PolymorphicEqualityComparer<PolymorphicClass>.Instance);
+        }
+
+        [Theory]
+        [InlineData("$.$type", @"{ ""$type"" : ""derivedClass1"", ""$type"" : ""derivedClass1"", ""Number"" : 42 }")]
+        [InlineData("$.$type", @"{ ""$type"" : ""derivedClass1"", ""Number"" : 42, ""$type"" : ""derivedClass1""}")]
+        [InlineData("$.$id", @"{ ""$type"" : ""derivedClass1"", ""Number"" : 42, ""$id"" : ""referenceId""}")]
+        [InlineData("$.$values", @"{ ""Number"" : 42, ""$values"" : [] }")]
+        [InlineData("$.$type", @"{ ""Number"" : 42, ""$type"" : ""derivedClass"" }")]
+        [InlineData("$", @"{ ""$type"" : ""invalidDiscriminator"", ""Number"" : 42 }")]
+        [InlineData("$.$type", @"{ ""$type"" : 0, ""Number"" : 42 }")]
+        [InlineData("$.$type", @"{ ""$type"" : false, ""Number"" : 42 }")]
+        [InlineData("$.$type", @"{ ""$type"" : {}, ""Number"" : 42 }")]
+        [InlineData("$.$type", @"{ ""$type"" : [], ""Number"" : 42 }")]
+        [InlineData("$.$id", @"{ ""$id"" : ""1"", ""Number"" : 42 }")]
+        [InlineData("$.$ref", @"{ ""$ref"" : ""1"" }")]
+        public async Task PolymorphicClass_InvalidTypeDiscriminatorMetadata_ShouldThrowJsonException(string expectedJsonPath, string json)
+        {
+            JsonException exception = await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<PolymorphicClass>(json));
+            Assert.Equal(expectedJsonPath, exception.Path);
+        }
+
+        //--
+
+        [Theory]
+        [MemberData(nameof(Get_PolymorphicClass_CustomConfigWithBaseTypeFallback_TestData_Serialization))]
+        public Task PolymorphicClass_CustomConfigWithBaseTypeFallback_TestData_Serialization(PolymorphicClass.TestData testData)
+            => TestMultiContextSerialization(
+                testData.Value,
+                testData.ExpectedJson,
+                testData.ExpectedSerializationException,
+                options: PolymorphicClass.CustomConfigWithBaseTypeFallback);
+
+        public static IEnumerable<object[]> Get_PolymorphicClass_CustomConfigWithBaseTypeFallback_TestData_Serialization()
+            => PolymorphicClass.GetSerializeTestData_CustomConfigWithBaseTypeFallback().Select(entry => new object[] { entry });
+
+        [Theory]
+        [MemberData(nameof(Get_PolymorphicClass_CustomConfigWithBaseTypeFallback_TestData_Deserialization))]
+        public Task PolymorphicClass_CustomConfigWithBaseTypeFallback_TestData_Deserialization(PolymorphicClass.TestData testData)
+            => TestMultiContextDeserialization<PolymorphicClass>(
+                testData.ExpectedJson,
+                testData.ExpectedRoundtripValue,
+                testData.ExpectedSerializationException,
+                equalityComparer: PolymorphicEqualityComparer<PolymorphicClass>.Instance,
+                options: PolymorphicClass.CustomConfigWithBaseTypeFallback);
+
+        public static IEnumerable<object[]> Get_PolymorphicClass_CustomConfigWithBaseTypeFallback_TestData_Deserialization()
+            => PolymorphicClass.GetSerializeTestData_CustomConfigWithBaseTypeFallback()
+                .Where(entry => entry.ExpectedJson != null)
+                .Select(entry => new object[] { entry });
+
+        [Fact]
+        public async Task PolymorphicClass_CustomConfigWithBaseTypeFallback_TestDataArray_Serialization()
+        {
+            IEnumerable<(PolymorphicClass Value, string ExpectedJson)> inputs =
+                PolymorphicClass.GetSerializeTestData_CustomConfigWithBaseTypeFallback()
+                    .Where(entry => entry.ExpectedSerializationException is null)
+                    .Select(entry => (entry.Value, entry.ExpectedJson));
+
+            await TestMultiContextSerialization(inputs, options: PolymorphicClass.CustomConfigWithBaseTypeFallback);
+        }
+
+        [Fact]
+        public async Task PolymorphicClass_CustomConfigWithBaseTypeFallbacks_TestDataArray_Deserialization()
+        {
+            IEnumerable<(string ExpectedJson, PolymorphicClass ExpectedRoundtripValue)> inputs =
+                PolymorphicClass.GetSerializeTestData_CustomConfigWithBaseTypeFallback()
+                .Where(entry => entry.ExpectedRoundtripValue is not null)
+                .Select(entry => (entry.ExpectedJson, entry.ExpectedRoundtripValue));
+
+            await TestMultiContextDeserialization(
+                inputs,
+                equalityComparer: PolymorphicEqualityComparer<PolymorphicClass>.Instance,
+                options: PolymorphicClass.CustomConfigWithBaseTypeFallback);
+        }
+
+        [Theory]
+        [InlineData("$.$type", @"{ ""$type"" : ""derivedClass1"", ""Number"" : 42 }")]
+        [InlineData("$._case", @"{ ""_case"" : ""derivedClass1"", ""_case"" : ""derivedClass1"", ""Number"" : 42 }")]
+        [InlineData("$._case", @"{ ""_case"" : ""derivedClass1"", ""Number"" : 42, ""_case"" : ""derivedClass1""}")]
+        [InlineData("$.$type", @"{ ""_case"" : ""derivedClass1"", ""Number"" : 42, ""$type"" : ""derivedClass1""}")]
+        [InlineData("$.$id", @"{ ""_case"" : ""derivedClass1"", ""Number"" : 42, ""$id"" : ""referenceId""}")]
+        [InlineData("$.$values", @"{ ""_case"" : ""derivedClass1"", ""Number"" : 42, ""$values"" : [] }")]
+        [InlineData("$._case", @"{ ""Number"" : 42, ""_case"" : ""derivedClass1"" }")]
+        [InlineData("$", @"{ ""_case"" : ""invalidDiscriminator"", ""Number"" : 42 }")]
+        [InlineData("$._case", @"{ ""_case"" : 0, ""Number"" : 42 }")]
+        [InlineData("$._case", @"{ ""_case"" : false, ""Number"" : 42 }")]
+        [InlineData("$._case", @"{ ""_case"" : {}, ""Number"" : 42 }")]
+        [InlineData("$._case", @"{ ""_case"" : [], ""Number"" : 42 }")]
+        [InlineData("$.$id", @"{ ""$id"" : ""1"", ""Number"" : 42 }")]
+        [InlineData("$.$ref", @"{ ""$ref"" : ""1"" }")]
+        public async Task PolymorphicClass_CustomConfigWithBaseTypeFallback_InvalidTypeDiscriminatorMetadata_ShouldThrowJsonException(string expectedJsonPath, string json)
+        {
+            JsonException exception = await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<PolymorphicClass>(json, PolymorphicClass.CustomConfigWithBaseTypeFallback));
+            Assert.Equal(expectedJsonPath, exception.Path);
+        }
+
+        //---
+
+        [Theory]
+        [MemberData(nameof(Get_PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Serialization))]
+        public Task PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Serialization(PolymorphicClass.TestData testData)
+            => TestMultiContextSerialization(
+                testData.Value,
+                testData.ExpectedJson,
+                testData.ExpectedSerializationException,
+                options: PolymorphicClass.CustomConfigWithNearestAncestorFallback);
+
+        public static IEnumerable<object[]> Get_PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Serialization()
+            => PolymorphicClass.GetSerializeTestData_CustomConfigWithNearestAncestorFallback().Select(entry => new object[] { entry });
+
+        [Theory]
+        [MemberData(nameof(Get_PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Deserialization))]
+        public Task PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Deserialization(PolymorphicClass.TestData testData)
+            => TestMultiContextDeserialization<PolymorphicClass>(
+                testData.ExpectedJson,
+                testData.ExpectedRoundtripValue,
+                testData.ExpectedDeserializationException,
+                equalityComparer: PolymorphicEqualityComparer<PolymorphicClass>.Instance,
+                options: PolymorphicClass.CustomConfigWithNearestAncestorFallback);
+
+        public static IEnumerable<object[]> Get_PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestData_Deserialization()
+            => PolymorphicClass.GetSerializeTestData_CustomConfigWithNearestAncestorFallback()
+                    .Where(entry => entry.ExpectedJson != null)
+                    .Select(entry => new object[] { entry });
+
+        [Fact]
+        public async Task PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestDataArray_Serialization()
+        {
+            IEnumerable<(PolymorphicClass Value, string ExpectedJson)> inputs =
+                PolymorphicClass.GetSerializeTestData_CustomConfigWithNearestAncestorFallback()
+                    .Where(entry => entry.ExpectedSerializationException is null)
+                    .Select(entry => (entry.Value, entry.ExpectedJson));
+
+            await TestMultiContextSerialization(inputs, options: PolymorphicClass.CustomConfigWithNearestAncestorFallback);
+        }
+
+        [Fact]
+        public async Task PolymorphicClass_CustomConfigWithNearestAncestorFallback_TestDataArray_Deserialization()
+        {
+            IEnumerable<(string ExpectedJson, PolymorphicClass ExpectedRoundtripValue)> inputs =
+                PolymorphicClass.GetSerializeTestData_CustomConfigWithNearestAncestorFallback()
+                .Where(entry => entry.ExpectedRoundtripValue is not null)
+                .Select(entry => (entry.ExpectedJson, entry.ExpectedRoundtripValue));
+
+            await TestMultiContextDeserialization(
+                inputs,
+                equalityComparer: PolymorphicEqualityComparer<PolymorphicClass>.Instance,
+                options: PolymorphicClass.CustomConfigWithNearestAncestorFallback);
+        }
+
+        [Theory]
+        [InlineData("$.$type", @"{ ""$type"" : ""derivedClass1"", ""Number"" : 42 }")]
+        [InlineData("$._case", @"{ ""_case"" : ""derivedClass1"", ""_case"" : ""derivedClass1"", ""Number"" : 42 }")]
+        [InlineData("$._case", @"{ ""_case"" : ""derivedClass1"", ""Number"" : 42, ""_case"" : ""derivedClass1""}")]
+        [InlineData("$.$type", @"{ ""_case"" : ""derivedClass1"", ""Number"" : 42, ""$type"" : ""derivedClass1""}")]
+        [InlineData("$.$id", @"{ ""_case"" : ""derivedClass1"", ""Number"" : 42, ""$id"" : ""referenceId""}")]
+        [InlineData("$.$values", @"{ ""_case"" : ""derivedClass1"", ""Number"" : 42, ""$values"" : [] }")]
+        [InlineData("$._case", @"{ ""Number"" : 42, ""_case"" : ""derivedClass1"" }")]
+        [InlineData("$", @"{ ""_case"" : ""invalidDiscriminator"", ""Number"" : 42 }")]
+        [InlineData("$._case", @"{ ""_case"" : 0, ""Number"" : 42 }")]
+        [InlineData("$._case", @"{ ""_case"" : false, ""Number"" : 42 }")]
+        [InlineData("$._case", @"{ ""_case"" : {}, ""Number"" : 42 }")]
+        [InlineData("$._case", @"{ ""_case"" : [], ""Number"" : 42 }")]
+        [InlineData("$.$id", @"{ ""$id"" : ""1"", ""Number"" : 42 }")]
+        [InlineData("$.$ref", @"{ ""$ref"" : ""1"" }")]
+        public async Task PolymorphicClass_CustomConfigWithNearestAncestorFallback_InvalidTypeDiscriminatorMetadata_ShouldThrowJsonException(string expectedJsonPath, string json)
+        {
+            JsonException exception = await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<PolymorphicClass>(json, PolymorphicClass.CustomConfigWithBaseTypeFallback));
+            Assert.Equal(expectedJsonPath, exception.Path);
+        }
+
+        [Theory]
+        [InlineData(JsonUnknownDerivedTypeHandling.FailSerialization)]
+        [InlineData(JsonUnknownDerivedTypeHandling.FallbackToBaseType)]
+        public async Task PolymorphicClass_ConfigWithAbstractClass_ShouldThrowNotSupportedException(JsonUnknownDerivedTypeHandling jsonUnknownDerivedTypeHandling)
+        {
+            var options = new JsonSerializerOptions
+            {
+                PolymorphicTypeConfigurations =
+                {
+                    new JsonPolymorphicTypeConfiguration<PolymorphicClass> { UnknownDerivedTypeHandling = jsonUnknownDerivedTypeHandling }
+                        .WithDerivedType<PolymorphicClass.DerivedAbstractClass>()
+                }
+            };
+
+            PolymorphicClass value = new PolymorphicClass.DerivedAbstractClass.DerivedClass();
+            await Assert.ThrowsAsync<NotSupportedException>(() => Serializer.SerializeWrapper(value));
+        }
+
+        [JsonDerivedType(typeof(DerivedClass1_NoTypeDiscriminator))]
+        [JsonDerivedType(typeof(DerivedClass1_NoTypeDiscriminator.DerivedClass))]
+        [JsonDerivedType(typeof(DerivedClass1_TypeDiscriminator), "derivedClass1")]
+        [JsonDerivedType(typeof(DerivedClass1_TypeDiscriminator.DerivedClass), "derivedClassOfDerivedClass1")]
+        [JsonDerivedType(typeof(DerivedClass2_NoTypeDiscriminator))]
+        [JsonDerivedType(typeof(DerivedClass2_TypeDiscriminator), "derivedClass2")]
+        [JsonDerivedType(typeof(DerivedCollection_NoTypeDiscriminator))]
+        [JsonDerivedType(typeof(DerivedCollection_TypeDiscriminator), "derivedCollection")]
+        [JsonDerivedType(typeof(DerivedCollection_TypeDiscriminator.DerivedClass), "derivedCollectionOfDerivedCollection")]
+        [JsonDerivedType(typeof(DerivedDictionary_NoTypeDiscriminator))]
+        [JsonDerivedType(typeof(DerivedDictionary_TypeDiscriminator), "derivedDictionary")]
+        [JsonDerivedType(typeof(DerivedDictionary_TypeDiscriminator.DerivedClass), "derivedDictionaryOfDerivedDictionary")]
+        [JsonDerivedType(typeof(DerivedClassWithConstructor_TypeDiscriminator), "derivedClassWithCtor")]
+        [JsonDerivedType(typeof(DerivedClassWithConstructor_TypeDiscriminator.DerivedClass), "derivedClassOfDerivedClassWithCtor")]
+        [JsonDerivedType(typeof(DerivedClassWithCustomConverter_NoTypeDiscriminator))]
+        [JsonDerivedType(typeof(DerivedClassWithCustomConverter_TypeDiscriminator), "derivedClassWithCustomConverter")]
+        public class PolymorphicClass
+        {
+            public int Number { get; set; }
+
+            public class DerivedClass1_NoTypeDiscriminator : PolymorphicClass
+            {
+                public string String { get; set; }
+
+                public class DerivedClass : DerivedClass1_NoTypeDiscriminator
+                {
+                    public string ExtraProperty { get; set; }
+                }
+            }
+
+            // Ensure derived class polymorphic configuration is not inherited by base class polymorphic configuration
+            [JsonPolymorphic(CustomTypeDiscriminatorPropertyName = "$case")]
+            [JsonDerivedType(typeof(DerivedClass), "derivedClassOfDerivedClass1")]
+            public class DerivedClass1_TypeDiscriminator : PolymorphicClass
+            {
+                public string String { get; set; }
+
+                [JsonExtensionData]
+                public Dictionary<string, object>? ExtensionData { get; set; }
+
+                public class DerivedClass : DerivedClass1_TypeDiscriminator
+                {
+                    public string ExtraProperty { get; set; }
+                }
+            }
+
+            public class DerivedClass2_NoTypeDiscriminator : PolymorphicClass
+            {
+                public bool Boolean { get; set; }
+
+                public class DerivedClass : DerivedClass2_NoTypeDiscriminator
+                {
+                    public string ExtraProperty { get; set; }
+                }
+            }
+
+            public class DerivedClass2_TypeDiscriminator : PolymorphicClass
+            {
+                public bool Boolean { get; set; }
+
+                public class DerivedClass : DerivedClass2_TypeDiscriminator
+                {
+                    public string ExtraProperty { get; set; }
+                }
+            }
+
+            public abstract class DerivedAbstractClass : PolymorphicClass
+            {
+                public abstract bool Boolean { get; set; }
+
+                public class DerivedClass : DerivedAbstractClass
+                {
+                    public override bool Boolean { get; set; }
+                }
+            }
+
+            public class DerivedCollection_NoTypeDiscriminator : PolymorphicClass, ICollection<int>
+            {
+                // Minimal ICollection implementation meant to enable collection deserialization
+                bool ICollection<int>.IsReadOnly => false;
+                void ICollection<int>.Add(int item) => Number = item;
+                public IEnumerator<int> GetEnumerator() => Enumerable.Repeat(Number, 3).GetEnumerator();
+
+                int ICollection<int>.Count => throw new NotImplementedException();
+                void ICollection<int>.Clear() => throw new NotImplementedException();
+                bool ICollection<int>.Contains(int item) => throw new NotImplementedException();
+                void ICollection<int>.CopyTo(int[] array, int arrayIndex) => throw new NotImplementedException();
+                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                bool ICollection<int>.Remove(int item) => throw new NotImplementedException();
+
+                public class DerivedClass : DerivedCollection_NoTypeDiscriminator
+                {
+                    public string ExtraProperty { get; set; }
+                }
+            }
+
+            public class DerivedCollection_TypeDiscriminator : PolymorphicClass, ICollection<int>
+            {
+                // Minimal ICollection implementation meant to enable collection deserialization
+                bool ICollection<int>.IsReadOnly => false;
+                void ICollection<int>.Add(int item) => Number = item;
+                public IEnumerator<int> GetEnumerator() => Enumerable.Repeat(Number, 3).GetEnumerator();
+
+                int ICollection<int>.Count => throw new NotImplementedException();
+                void ICollection<int>.Clear() => throw new NotImplementedException();
+                bool ICollection<int>.Contains(int item) => throw new NotImplementedException();
+                void ICollection<int>.CopyTo(int[] array, int arrayIndex) => throw new NotImplementedException();
+                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                bool ICollection<int>.Remove(int item) => throw new NotImplementedException();
+
+                public class DerivedClass : DerivedCollection_TypeDiscriminator
+                {
+                    public string ExtraProperty { get; set; }
+                }
+            }
+
+            public class DerivedDictionary_NoTypeDiscriminator : PolymorphicClass, IDictionary<string, int>
+            {
+                // Minimal IDictionary implementation meant to enable serialization
+                bool ICollection<KeyValuePair<string, int>>.IsReadOnly => false;
+                public IEnumerator<KeyValuePair<string, int>> GetEnumerator() => Enumerable.Repeat(new KeyValuePair<string, int>("dictionaryKey", Number), 1).GetEnumerator();
+                int IDictionary<string, int>.this[string key] { get => throw new NotImplementedException(); set { if (key == "dictionaryKey") Number = value; } }
+
+                void IDictionary<string, int>.Add(string key, int value) => throw new NotImplementedException();
+                ICollection<string> IDictionary<string, int>.Keys => throw new NotImplementedException();
+                ICollection<int> IDictionary<string, int>.Values => throw new NotImplementedException();
+                int ICollection<KeyValuePair<string, int>>.Count => throw new NotImplementedException();
+                void ICollection<KeyValuePair<string, int>>.Add(KeyValuePair<string, int> item) => throw new NotImplementedException();
+                void ICollection<KeyValuePair<string, int>>.Clear() => throw new NotImplementedException();
+                bool ICollection<KeyValuePair<string, int>>.Contains(KeyValuePair<string, int> item) => throw new NotImplementedException();
+                bool IDictionary<string, int>.ContainsKey(string key) => throw new NotImplementedException();
+                void ICollection<KeyValuePair<string, int>>.CopyTo(KeyValuePair<string, int>[] array, int arrayIndex) => throw new NotImplementedException();
+                IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
+                bool IDictionary<string, int>.Remove(string key) => throw new NotImplementedException();
+                bool ICollection<KeyValuePair<string, int>>.Remove(KeyValuePair<string, int> item) => throw new NotImplementedException();
+                bool IDictionary<string, int>.TryGetValue(string key, out int value) => throw new NotImplementedException();
+
+                public class DerivedClass : DerivedDictionary_NoTypeDiscriminator
+                {
+                    public string ExtraProperty { get; set; }
+                }
+            }
+
+            public class DerivedDictionary_TypeDiscriminator : PolymorphicClass, IDictionary<string, int>
+            {
+                // Minimal IDictionary implementation meant to enable serialization
+                bool ICollection<KeyValuePair<string, int>>.IsReadOnly => false;
+                public IEnumerator<KeyValuePair<string, int>> GetEnumerator() => Enumerable.Repeat(new KeyValuePair<string, int>("dictionaryKey", Number), 1).GetEnumerator();
+                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                int IDictionary<string, int>.this[string key] { get => throw new NotImplementedException(); set { if (key == "dictionaryKey") Number = value; } }
+
+                void IDictionary<string, int>.Add(string key, int value) => throw new NotImplementedException();
+                ICollection<string> IDictionary<string, int>.Keys => throw new NotImplementedException();
+                ICollection<int> IDictionary<string, int>.Values => throw new NotImplementedException();
+                int ICollection<KeyValuePair<string, int>>.Count => throw new NotImplementedException();
+                void ICollection<KeyValuePair<string, int>>.Add(KeyValuePair<string, int> item) => throw new NotImplementedException();
+                void ICollection<KeyValuePair<string, int>>.Clear() => throw new NotImplementedException();
+                bool ICollection<KeyValuePair<string, int>>.Contains(KeyValuePair<string, int> item) => throw new NotImplementedException();
+                bool IDictionary<string, int>.ContainsKey(string key) => throw new NotImplementedException();
+                void ICollection<KeyValuePair<string, int>>.CopyTo(KeyValuePair<string, int>[] array, int arrayIndex) => throw new NotImplementedException();
+                bool IDictionary<string, int>.Remove(string key) => throw new NotImplementedException();
+                bool ICollection<KeyValuePair<string, int>>.Remove(KeyValuePair<string, int> item) => throw new NotImplementedException();
+                bool IDictionary<string, int>.TryGetValue(string key, out int value) => throw new NotImplementedException();
+
+                public class DerivedClass : DerivedDictionary_TypeDiscriminator
+                {
+                    public string ExtraProperty { get; set; }
+                }
+            }
+
+            public class DerivedClassWithConstructor_TypeDiscriminator : PolymorphicClass
+            {
+                [JsonConstructor]
+                public DerivedClassWithConstructor_TypeDiscriminator(int number)
+                {
+                    Number = number;
+                }
+
+                public class DerivedClass : DerivedClassWithConstructor_TypeDiscriminator
+                {
+                    [JsonConstructor]
+                    public DerivedClass(int number, string extraProperty)
+                        : base(number)
+                    {
+                        ExtraProperty = extraProperty;
+                    }
+
+                    public string ExtraProperty { get; set; }
+                }
+            }
+
+            [JsonConverter(typeof(CustomConverter))]
+            public class DerivedClassWithCustomConverter_NoTypeDiscriminator : PolymorphicClass
+            {
+                public class CustomConverter : JsonConverter<DerivedClassWithCustomConverter_NoTypeDiscriminator>
+                {
+                    public override DerivedClassWithCustomConverter_NoTypeDiscriminator Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+                        => throw new NotSupportedException();
+
+                    public override void Write(Utf8JsonWriter writer, DerivedClassWithCustomConverter_NoTypeDiscriminator value, JsonSerializerOptions options)
+                        => writer.WriteNumberValue(value.Number);
+                }
+
+                public class DerivedClass : DerivedClassWithCustomConverter_NoTypeDiscriminator
+                {
+                    public string ExtraProperty { get; set; }
+                }
+            }
+
+            [JsonConverter(typeof(CustomConverter))]
+            public class DerivedClassWithCustomConverter_TypeDiscriminator : PolymorphicClass
+            {
+                public class CustomConverter : JsonConverter<DerivedClassWithCustomConverter_TypeDiscriminator>
+                {
+                    public override DerivedClassWithCustomConverter_TypeDiscriminator Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+                        => throw new NotSupportedException();
+
+                    public override void Write(Utf8JsonWriter writer, DerivedClassWithCustomConverter_TypeDiscriminator value, JsonSerializerOptions options)
+                        => writer.WriteNumberValue(value.Number);
+                }
+
+                public class DerivedClass : DerivedClassWithCustomConverter_TypeDiscriminator
+                {
+                    public string ExtraProperty { get; set; }
+                }
+            }
+
+            public static IEnumerable<TestData> GetSerializeTestData()
+            {
+                yield return new TestData(
+                    Value: new PolymorphicClass { Number = 42 },
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClass1_NoTypeDiscriminator { Number = 42, String = "str" },
+                    ExpectedJson: @"{ ""Number"" : 42, ""String"" : ""str"" }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClass2_NoTypeDiscriminator.DerivedClass(),
+                    ExpectedSerializationException: typeof(NotSupportedException));
+
+                yield return new TestData(
+                    Value: new DerivedClass1_NoTypeDiscriminator.DerivedClass { Number = 42, String = "str", ExtraProperty = "extra" },
+                    ExpectedJson: @"{ ""Number"" : 42, ""String"" : ""str"", ""ExtraProperty"" : ""extra"" }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClass1_TypeDiscriminator { Number = 42, String = "str" },
+                    ExpectedJson: @"{ ""$type"" : ""derivedClass1"", ""Number"" : 42, ""String"" : ""str"" }",
+                    ExpectedRoundtripValue: new DerivedClass1_TypeDiscriminator { Number = 42, String = "str" });
+
+                yield return new TestData(
+                    Value: new DerivedClass1_TypeDiscriminator.DerivedClass { Number = 42, String = "str", ExtraProperty = "extra" },
+                    ExpectedJson: @"{ ""$type"" : ""derivedClassOfDerivedClass1"", ""Number"" : 42, ""String"" : ""str"", ""ExtraProperty"" : ""extra"" }",
+                    ExpectedRoundtripValue: new DerivedClass1_TypeDiscriminator.DerivedClass { Number = 42, String = "str", ExtraProperty = "extra" });
+
+                yield return new TestData(
+                    Value: new DerivedClass2_NoTypeDiscriminator { Number = 42, Boolean = true },
+                    ExpectedJson: @"{ ""Number"" : 42, ""Boolean"" : true }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClass2_TypeDiscriminator.DerivedClass(),
+                    ExpectedSerializationException: typeof(NotSupportedException));
+
+                yield return new TestData(
+                    Value: new DerivedClass2_TypeDiscriminator { Number = 42, Boolean = true },
+                    ExpectedJson: @"{ ""$type"" : ""derivedClass2"", ""Number"" : 42, ""Boolean"" : true }",
+                    ExpectedRoundtripValue: new DerivedClass2_TypeDiscriminator { Number = 42, Boolean = true });
+
+                yield return new TestData(
+                    Value: new DerivedCollection_NoTypeDiscriminator { Number = 42 },
+                    ExpectedJson: @"[42,42,42]",
+                    ExpectedDeserializationException: typeof(JsonException));
+
+                yield return new TestData(
+                    Value: new DerivedCollection_NoTypeDiscriminator.DerivedClass(),
+                    ExpectedSerializationException: typeof(NotSupportedException));
+
+                yield return new TestData(
+                    Value: new DerivedCollection_TypeDiscriminator { Number = 42 },
+                    ExpectedJson: @"{ ""$type"" : ""derivedCollection"", ""$values"" : [42,42,42] }",
+                    ExpectedRoundtripValue: new DerivedCollection_TypeDiscriminator { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedCollection_TypeDiscriminator.DerivedClass { Number = 42, ExtraProperty = "extra" },
+                    ExpectedJson: @"{ ""$type"" : ""derivedCollectionOfDerivedCollection"", ""$values"" : [42,42,42] }",
+                    ExpectedRoundtripValue: new DerivedCollection_TypeDiscriminator.DerivedClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedDictionary_NoTypeDiscriminator { Number = 42 },
+                    ExpectedJson: @"{ ""dictionaryKey"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass());
+
+                yield return new TestData(
+                    Value: new DerivedDictionary_TypeDiscriminator { Number = 42 },
+                    ExpectedJson: @"{ ""$type"":""derivedDictionary"", ""dictionaryKey"" : 42 }",
+                    ExpectedRoundtripValue: new DerivedDictionary_TypeDiscriminator { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedDictionary_TypeDiscriminator.DerivedClass { Number = 42, ExtraProperty = "extra" },
+                    ExpectedJson: @"{ ""$type"" : ""derivedDictionaryOfDerivedDictionary"", ""dictionaryKey"" : 42 }",
+                    ExpectedRoundtripValue: new DerivedDictionary_TypeDiscriminator.DerivedClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClassWithConstructor_TypeDiscriminator(42),
+                    ExpectedJson: @"{ ""$type"" : ""derivedClassWithCtor"", ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new DerivedClassWithConstructor_TypeDiscriminator(42));
+
+                yield return new TestData(
+                    Value: new DerivedClassWithConstructor_TypeDiscriminator.DerivedClass(42, "extra"),
+                    ExpectedJson: @"{ ""$type"" : ""derivedClassOfDerivedClassWithCtor"", ""Number"" : 42, ""ExtraProperty"" : ""extra"" }",
+                    ExpectedRoundtripValue: new DerivedClassWithConstructor_TypeDiscriminator.DerivedClass(42, "extra"));
+
+                yield return new TestData(
+                    Value: new DerivedClassWithCustomConverter_NoTypeDiscriminator { Number = 42 },
+                    ExpectedJson: "42",
+                    ExpectedDeserializationException: typeof(JsonException));
+
+                yield return new TestData(
+                    Value: new DerivedClassWithCustomConverter_NoTypeDiscriminator.DerivedClass(),
+                    ExpectedSerializationException: typeof(NotSupportedException));
+
+                yield return new TestData(
+                    Value: new DerivedClassWithCustomConverter_TypeDiscriminator(), // TODO special unit test for type discriminators with custom converters
+                    ExpectedSerializationException: typeof(NotSupportedException));
+
+                yield return new TestData(
+                    Value: new DerivedClassWithCustomConverter_TypeDiscriminator.DerivedClass(),
+                    ExpectedSerializationException: typeof(NotSupportedException));
+            }
+
+            public static JsonSerializerOptions CustomConfigWithBaseTypeFallback { get; } =
+                new JsonSerializerOptions
+                {
+                    PolymorphicTypeConfigurations =
+                    {
+                        new JsonPolymorphicTypeConfiguration<PolymorphicClass>
+                        {
+                            CustomTypeDiscriminatorPropertyName = "_case",
+                            UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToBaseType
+                        }
+                        .WithDerivedType<DerivedClass1_NoTypeDiscriminator>()
+                        .WithDerivedType<DerivedClass1_TypeDiscriminator>("derivedClass1")
+                        .WithDerivedType<DerivedClass1_TypeDiscriminator.DerivedClass>("derivedClassOfDerivedClass1")
+                        .WithDerivedType<DerivedClass2_TypeDiscriminator>("derivedClass2")
+                        .WithDerivedType<DerivedCollection_TypeDiscriminator>("derivedCollection")
+                        .WithDerivedType<DerivedDictionary_NoTypeDiscriminator>()
+                        .WithDerivedType<DerivedDictionary_TypeDiscriminator.DerivedClass>("derivedDictionaryOfDerivedDictionary")
+                        .WithDerivedType<DerivedClassWithConstructor_TypeDiscriminator.DerivedClass>("derivedClassOfDerivedClassWithCtor")
+                        .WithDerivedType<DerivedClassWithCustomConverter_TypeDiscriminator>("derivedClassWithCustomConverter")
+                    }
+                };
+
+            public static IEnumerable<TestData> GetSerializeTestData_CustomConfigWithBaseTypeFallback()
+            {
+                yield return new TestData(
+                    Value: new PolymorphicClass { Number = 42 },
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClass1_NoTypeDiscriminator { Number = 42, String = "str" },
+                    ExpectedJson: @"{ ""Number"" : 42, ""String"" : ""str"" }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClass1_NoTypeDiscriminator.DerivedClass { Number = 42, String = "str", ExtraProperty = "extra" },
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClass1_TypeDiscriminator { Number = 42, String = "str" },
+                    ExpectedJson: @"{ ""_case"" : ""derivedClass1"", ""Number"" : 42, ""String"" : ""str"" }",
+                    ExpectedRoundtripValue: new DerivedClass1_TypeDiscriminator { Number = 42, String = "str" });
+
+                yield return new TestData(
+                    Value: new DerivedClass1_TypeDiscriminator.DerivedClass { Number = 42, String = "str", ExtraProperty = "extra" },
+                    ExpectedJson: @"{ ""_case"" : ""derivedClassOfDerivedClass1"", ""Number"" : 42, ""String"" : ""str"", ""ExtraProperty"" : ""extra"" }",
+                    ExpectedRoundtripValue: new DerivedClass1_TypeDiscriminator.DerivedClass { Number = 42, String = "str", ExtraProperty = "extra" });
+
+                yield return new TestData(
+                    Value: new DerivedClass2_NoTypeDiscriminator { Number = 42, Boolean = true },
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClass2_NoTypeDiscriminator.DerivedClass { Number = 42, Boolean = true },
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClass2_TypeDiscriminator { Number = 42, Boolean = true },
+                    ExpectedJson: @"{ ""_case"" : ""derivedClass2"", ""Number"" : 42, ""Boolean"" : true }",
+                    ExpectedRoundtripValue: new DerivedClass2_TypeDiscriminator { Number = 42, Boolean = true });
+
+                yield return new TestData(
+                    Value: new DerivedClass2_TypeDiscriminator.DerivedClass { Number = 42, Boolean = true, ExtraProperty = "extra" },
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedCollection_NoTypeDiscriminator { Number = 42 },
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedCollection_TypeDiscriminator { Number = 42 },
+                    ExpectedJson: @"{ ""_case"" : ""derivedCollection"", ""$values"" : [42,42,42] }",
+                    ExpectedRoundtripValue: new DerivedCollection_TypeDiscriminator { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedCollection_TypeDiscriminator.DerivedClass { Number = 42, ExtraProperty = "extra" },
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedDictionary_NoTypeDiscriminator { Number = 42 },
+                    ExpectedJson: @"{ ""dictionaryKey"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass());
+
+                yield return new TestData(
+                    Value: new DerivedDictionary_TypeDiscriminator { Number = 42 },
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedDictionary_TypeDiscriminator.DerivedClass { Number = 42, ExtraProperty = "extra" },
+                    ExpectedJson: @"{ ""_case"" : ""derivedDictionaryOfDerivedDictionary"", ""dictionaryKey"" : 42 }",
+                    ExpectedRoundtripValue: new DerivedDictionary_TypeDiscriminator.DerivedClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClassWithConstructor_TypeDiscriminator(42),
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClassWithConstructor_TypeDiscriminator.DerivedClass(42, "extra"),
+                    ExpectedJson: @"{ ""_case"" : ""derivedClassOfDerivedClassWithCtor"", ""Number"" : 42, ""ExtraProperty"" : ""extra"" }",
+                    ExpectedRoundtripValue: new DerivedClassWithConstructor_TypeDiscriminator.DerivedClass(42, "extra"));
+
+                yield return new TestData(
+                    Value: new DerivedClassWithCustomConverter_NoTypeDiscriminator { Number = 42 },
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClassWithCustomConverter_TypeDiscriminator.DerivedClass { Number = 42, ExtraProperty = "extra" },
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClassWithCustomConverter_TypeDiscriminator(),
+                    ExpectedSerializationException: typeof(NotSupportedException));
+            }
+
+            public static JsonSerializerOptions CustomConfigWithNearestAncestorFallback { get; } =
+                new JsonSerializerOptions
+                {
+                    PolymorphicTypeConfigurations =
+                    {
+                        new JsonPolymorphicTypeConfiguration<PolymorphicClass>
+                        {
+                            CustomTypeDiscriminatorPropertyName = "_case",
+                            UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor
+                        }
+                        .WithDerivedType<DerivedClass1_NoTypeDiscriminator>()
+                        .WithDerivedType<DerivedClass1_TypeDiscriminator>("derivedClass1")
+                        .WithDerivedType<DerivedClass1_TypeDiscriminator.DerivedClass>("derivedClassOfDerivedClass1")
+                        .WithDerivedType<DerivedClass2_TypeDiscriminator>("derivedClass2")
+                        .WithDerivedType<DerivedAbstractClass>("derivedAbstractClass")
+                        .WithDerivedType<DerivedCollection_TypeDiscriminator>("derivedCollection")
+                        .WithDerivedType<DerivedDictionary_NoTypeDiscriminator>()
+                        .WithDerivedType<DerivedDictionary_TypeDiscriminator.DerivedClass>("derivedDictionaryOfDerivedDictionary")
+                        .WithDerivedType<DerivedClassWithConstructor_TypeDiscriminator.DerivedClass>("derivedClassOfDerivedClassWithCtor")
+                        .WithDerivedType<DerivedClassWithCustomConverter_TypeDiscriminator>("derivedClassWithCustomConverter")
+                    }
+                };
+
+            public static IEnumerable<TestData> GetSerializeTestData_CustomConfigWithNearestAncestorFallback()
+            {
+                yield return new TestData(
+                    Value: new PolymorphicClass { Number = 42 },
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClass1_NoTypeDiscriminator { Number = 42, String = "str" },
+                    ExpectedJson: @"{ ""Number"" : 42, ""String"" : ""str"" }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClass1_NoTypeDiscriminator.DerivedClass { Number = 42, String = "str", ExtraProperty = "extra" },
+                    ExpectedJson: @"{ ""Number"" : 42, ""String"" : ""str"" }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClass1_TypeDiscriminator { Number = 42, String = "str" },
+                    ExpectedJson: @"{ ""_case"" : ""derivedClass1"", ""Number"" : 42, ""String"" : ""str"" }",
+                    ExpectedRoundtripValue: new DerivedClass1_TypeDiscriminator { Number = 42, String = "str" });
+
+                yield return new TestData(
+                    Value: new DerivedClass1_TypeDiscriminator.DerivedClass { Number = 42, String = "str", ExtraProperty = "extra" },
+                    ExpectedJson: @"{ ""_case"" : ""derivedClassOfDerivedClass1"", ""Number"" : 42, ""String"" : ""str"", ""ExtraProperty"" : ""extra"" }",
+                    ExpectedRoundtripValue: new DerivedClass1_TypeDiscriminator.DerivedClass { Number = 42, String = "str", ExtraProperty = "extra" });
+
+                yield return new TestData(
+                    Value: new DerivedClass2_NoTypeDiscriminator { Number = 42, Boolean = true },
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClass2_NoTypeDiscriminator.DerivedClass { Number = 42, Boolean = true },
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClass2_TypeDiscriminator { Number = 42, Boolean = true },
+                    ExpectedJson: @"{ ""_case"" : ""derivedClass2"", ""Number"" : 42, ""Boolean"" : true }",
+                    ExpectedRoundtripValue: new DerivedClass2_TypeDiscriminator { Number = 42, Boolean = true });
+
+                yield return new TestData(
+                    Value: new DerivedClass2_TypeDiscriminator.DerivedClass { Number = 42, Boolean = true, ExtraProperty = "extra" },
+                    ExpectedJson: @"{ ""_case"" : ""derivedClass2"", ""Number"" : 42, ""Boolean"" : true }",
+                    ExpectedRoundtripValue: new DerivedClass2_TypeDiscriminator { Number = 42, Boolean = true });
+
+                yield return new TestData(
+                    Value: new DerivedAbstractClass.DerivedClass { Number = 42, Boolean = true },
+                    ExpectedJson: @"{ ""_case"" : ""derivedAbstractClass"", ""Number"" : 42, ""Boolean"" : true }",
+                    ExpectedDeserializationException: typeof(NotSupportedException));
+
+                yield return new TestData(
+                    Value: new DerivedCollection_NoTypeDiscriminator { Number = 42 },
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedCollection_TypeDiscriminator { Number = 42 },
+                    ExpectedJson: @"{ ""_case"" : ""derivedCollection"", ""$values"" : [42,42,42] }",
+                    ExpectedRoundtripValue: new DerivedCollection_TypeDiscriminator { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedCollection_TypeDiscriminator.DerivedClass { Number = 42, ExtraProperty = "extra" },
+                    ExpectedJson: @"{ ""_case"" : ""derivedCollection"", ""$values"" : [42,42,42] }",
+                    ExpectedRoundtripValue: new DerivedCollection_TypeDiscriminator { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedDictionary_NoTypeDiscriminator { Number = 42 },
+                    ExpectedJson: @"{ ""dictionaryKey"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass());
+
+                yield return new TestData(
+                    Value: new DerivedDictionary_TypeDiscriminator { Number = 42 },
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedDictionary_TypeDiscriminator.DerivedClass { Number = 42, ExtraProperty = "extra" },
+                    ExpectedJson: @"{ ""_case"" : ""derivedDictionaryOfDerivedDictionary"", ""dictionaryKey"" : 42 }",
+                    ExpectedRoundtripValue: new DerivedDictionary_TypeDiscriminator.DerivedClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClassWithConstructor_TypeDiscriminator(42),
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClassWithConstructor_TypeDiscriminator.DerivedClass(42, "extra"),
+                    ExpectedJson: @"{ ""_case"" : ""derivedClassOfDerivedClassWithCtor"", ""Number"" : 42, ""ExtraProperty"" : ""extra"" }",
+                    ExpectedRoundtripValue: new DerivedClassWithConstructor_TypeDiscriminator.DerivedClass(42, "extra"));
+
+                yield return new TestData(
+                    Value: new DerivedClassWithCustomConverter_NoTypeDiscriminator { Number = 42 },
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClass { Number = 42 });
+
+                yield return new TestData(
+                    Value: new DerivedClassWithCustomConverter_TypeDiscriminator(),
+                    ExpectedSerializationException: typeof(NotSupportedException));
+
+                yield return new TestData(
+                    Value: new DerivedClassWithCustomConverter_TypeDiscriminator.DerivedClass(),
+                    ExpectedSerializationException: typeof(NotSupportedException));
+            }
+
+            public record TestData(
+                PolymorphicClass Value,
+                string? ExpectedJson = null,
+                Type? ExpectedSerializationException = null,
+                PolymorphicClass? ExpectedRoundtripValue = null,
+                Type? ExpectedDeserializationException = null);
+        }
+
+        [Fact]
+        public async Task PolymorphicClass_NoTypeDiscriminators_Deserialization_IgnoresTypeMetadata()
+        {
+            string json = @"{""$type"" : ""derivedClass""}";
+            PolymorphicClass_NoTypeDiscriminators result = await Serializer.DeserializeWrapper<PolymorphicClass_NoTypeDiscriminators>(json);
+            Assert.IsType<PolymorphicClass_NoTypeDiscriminators>(result);
+            Assert.True(result.ExtensionData?.ContainsKey("$type") == true);
+        }
+
+        [JsonDerivedType(typeof(DerivedClass1))]
+        [JsonDerivedType(typeof(DerivedClass2))]
+        public class PolymorphicClass_NoTypeDiscriminators
+        {
+            [JsonExtensionData]
+            public Dictionary<string, object?>? ExtensionData { get; set; }
+
+            public class DerivedClass1 : PolymorphicClass_NoTypeDiscriminators { }
+            public class DerivedClass2 : PolymorphicClass_NoTypeDiscriminators { }
+        }
+
+        [Fact]
+        public async Task PolymorphicClass_WithDerivedPolymorphicClass_Serialization_ShouldUseBaseTypeContract()
+        {
+            string expectedJson = @"{""$type"":""derivedClass""}";
+            PolymorphicClass_WithDerivedPolymorphicClass value = new PolymorphicClass_WithDerivedPolymorphicClass.DerivedClass();
+            await TestMultiContextSerialization(value, expectedJson);
+        }
+
+        [Fact]
+        public async Task PolymorphicClass_WithDerivedPolymorphicClass_Deserialization_ShouldUseBaseTypeContract()
+        {
+            string json = @"{""$type"":""derivedClass""}";
+
+            var expectedValueUsingBaseContract = new PolymorphicClass_WithDerivedPolymorphicClass.DerivedClass();
+            await TestMultiContextDeserialization<PolymorphicClass_WithDerivedPolymorphicClass>(
+                json,
+                expectedValueUsingBaseContract,
+                equalityComparer: PolymorphicEqualityComparer<PolymorphicClass_WithDerivedPolymorphicClass>.Instance);
+
+            var expectedValueUsingDerivedContract = new PolymorphicClass_WithDerivedPolymorphicClass.DerivedClass.DerivedClass2();
+            await TestMultiContextDeserialization<PolymorphicClass_WithDerivedPolymorphicClass.DerivedClass>(
+                json,
+                expectedValueUsingDerivedContract,
+                equalityComparer: PolymorphicEqualityComparer<PolymorphicClass_WithDerivedPolymorphicClass.DerivedClass>.Instance);
+        }
+
+        [JsonDerivedType(typeof(DerivedClass), "derivedClass")]
+        [JsonDerivedType(typeof(DerivedClass.DerivedClass2), "derivedClass2")]
+        public class PolymorphicClass_WithDerivedPolymorphicClass
+        {
+            // Derived class with conflicting configuration
+            [JsonDerivedType(typeof(DerivedClass), "baseClass")]
+            [JsonDerivedType(typeof(DerivedClass.DerivedClass2), "derivedClass")]
+            public class DerivedClass : PolymorphicClass_WithDerivedPolymorphicClass
+            {
+                public class DerivedClass2 : DerivedClass
+                {
+                }
+            }
+        }
+
+        [Theory]
+        [ActiveIssue("Need to refactor root-level polymorphic JsonTypeInfo handling.")]
+        [MemberData(nameof(PolymorphicClass_WithBaseTypeDiscriminator.GetTestData), MemberType = typeof(PolymorphicClass_WithBaseTypeDiscriminator))]
+        public async Task PolymorphicClass_BoxedSerialization_DoesNotUseTypeDiscriminators(PolymorphicClass_WithBaseTypeDiscriminator value, string expectedJson)
+        {
+            await TestMultiContextSerialization<object>(value, expectedJson);
+        }
+
+        [JsonDerivedType(typeof(PolymorphicClass_WithBaseTypeDiscriminator), "baseType")]
+        [JsonDerivedType(typeof(DerivedClass), "derivedType")]
+        public class PolymorphicClass_WithBaseTypeDiscriminator
+        {
+            public int Number { get; set; }
+
+            public class DerivedClass : PolymorphicClass_WithBaseTypeDiscriminator
+            {
+                public string String { get; set; }
+            }
+
+            public static IEnumerable<object[]> GetTestData()
+            {
+                yield return WrapArgs(new PolymorphicClass_WithBaseTypeDiscriminator { Number = 42 }, @"{""Number"" : 42 }");
+                yield return WrapArgs(new DerivedClass { Number = 42, String = "str" }, @"{""Number"" : 42, ""String"" : str }");
+
+                static object[] WrapArgs(PolymorphicClass_WithBaseTypeDiscriminator value, string expectedJson)
+                    => new object[] { value, expectedJson };
+            }
+        }
+        #endregion
+
+        #region Polymorphic Class with Constructor
+
+        [Theory]
+        [MemberData(nameof(Get_PolymorphicClassWithConstructor_TestData_Serialization))]
+        public Task PolymorphicClassWithConstructor_TestData_Serialization(PolymorphicClassWithConstructor.TestData testData)
+            => TestMultiContextSerialization(testData.Value, testData.ExpectedJson);
+
+        public static IEnumerable<object[]> Get_PolymorphicClassWithConstructor_TestData_Serialization()
+            => PolymorphicClassWithConstructor.GetSerializeTestData().Select(entry => new object[] { entry });
+
+        [Theory]
+        [MemberData(nameof(Get_PolymorphicClassWithConstructor_TestData_Deserialization))]
+        public Task PolymorphicClassWithConstructor_TestData_Deserialization(PolymorphicClassWithConstructor.TestData testData)
+            => TestMultiContextDeserialization<PolymorphicClassWithConstructor>(
+                testData.ExpectedJson,
+                testData.ExpectedRoundtripValue,
+                equalityComparer: PolymorphicEqualityComparer<PolymorphicClassWithConstructor>.Instance);
+
+        public static IEnumerable<object[]> Get_PolymorphicClassWithConstructor_TestData_Deserialization()
+            => PolymorphicClassWithConstructor.GetSerializeTestData()
+                .Where(entry => entry.ExpectedJson != null)
+                .Select(entry => new object[] { entry });
+
+        [Fact]
+        public async Task PolymorphicClassWithConstructor_TestDataArray_Serialization()
+        {
+            IEnumerable<(PolymorphicClassWithConstructor Value, string ExpectedJson)> inputs =
+                PolymorphicClassWithConstructor.GetSerializeTestData().Select(entry => (entry.Value, entry.ExpectedJson));
+
+            await TestMultiContextSerialization(inputs);
+        }
+
+        [Fact]
+        public async Task PolymorphicClassWithConstructor_TestDataArray_Deserialization()
+        {
+            IEnumerable<(string ExpectedJson, PolymorphicClassWithConstructor ExpectedRoundtripValue)> inputs =
+                PolymorphicClassWithConstructor.GetSerializeTestData().Select(entry => (entry.ExpectedJson, entry.ExpectedRoundtripValue));
+
+            await TestMultiContextDeserialization(inputs, equalityComparer: PolymorphicEqualityComparer<PolymorphicClassWithConstructor>.Instance);
+        }
+
+        [JsonPolymorphic]
+        [JsonDerivedType(typeof(DerivedClass), "derivedClass")]
+        [JsonDerivedType(typeof(DerivedClassWithConstructor), "derivedClassWithCtor")]
+        [JsonDerivedType(typeof(DerivedCollection), "derivedCollection")]
+        [JsonDerivedType(typeof(DerivedDictionary), "derivedDictionary")]
+        public class PolymorphicClassWithConstructor
+        {
+            [JsonConstructor]
+            public PolymorphicClassWithConstructor(int number) => Number = number;
+
+            public int Number { get; }
+
+            public class DerivedClass : PolymorphicClassWithConstructor
+            {
+                public DerivedClass() : base(0) { }
+                public string String { get; set; }
+            }
+
+            public class DerivedClassWithConstructor : PolymorphicClassWithConstructor
+            {
+                [JsonConstructor]
+                public DerivedClassWithConstructor(int number, bool boolean)
+                    : base(number)
+                {
+                    Boolean = boolean;
+                }
+
+                public bool Boolean { get; }
+            }
+
+            public class DerivedCollection : PolymorphicClassWithConstructor, ICollection<int>
+            {
+                private List<int> _list = new();
+
+                public DerivedCollection() : base(0)
+                {
+                }
+
+                bool ICollection<int>.IsReadOnly => false;
+                public void Add(int item) => _list.Add(item);
+                IEnumerator<int> IEnumerable<int>.GetEnumerator() => _list.GetEnumerator();
+                IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                int ICollection<int>.Count => _list.Count;
+                void ICollection<int>.Clear() => throw new NotImplementedException();
+                bool ICollection<int>.Contains(int item) => throw new NotImplementedException();
+                void ICollection<int>.CopyTo(int[] array, int arrayIndex) => throw new NotImplementedException();
+                bool ICollection<int>.Remove(int item) => throw new NotImplementedException();
+            }
+
+            public class DerivedDictionary : PolymorphicClassWithConstructor, IDictionary<string, int>
+            {
+                private Dictionary<string, int> _dict = new();
+
+                public DerivedDictionary() : base(0)
+                {
+                }
+
+                public int this[string key] { get => _dict[key]; set => _dict[key] = value; }
+                bool ICollection<KeyValuePair<string, int>>.IsReadOnly => false;
+                IEnumerator<KeyValuePair<string, int>> IEnumerable<KeyValuePair<string, int>>.GetEnumerator() => _dict.GetEnumerator();
+                IEnumerator IEnumerable.GetEnumerator() => _dict.GetEnumerator();
+
+
+                ICollection<string> IDictionary<string, int>.Keys => throw new NotImplementedException();
+                ICollection<int> IDictionary<string, int>.Values => throw new NotImplementedException();
+                int ICollection<KeyValuePair<string, int>>.Count => throw new NotImplementedException();
+                void IDictionary<string, int>.Add(string key, int value) => throw new NotImplementedException();
+                void ICollection<KeyValuePair<string, int>>.Add(KeyValuePair<string, int> item) => throw new NotImplementedException();
+                void ICollection<KeyValuePair<string, int>>.Clear() => throw new NotImplementedException();
+                bool ICollection<KeyValuePair<string, int>>.Contains(KeyValuePair<string, int> item) => throw new NotImplementedException();
+                bool IDictionary<string, int>.ContainsKey(string key) => throw new NotImplementedException();
+                void ICollection<KeyValuePair<string, int>>.CopyTo(KeyValuePair<string, int>[] array, int arrayIndex) => throw new NotImplementedException();
+                bool IDictionary<string, int>.Remove(string key) => throw new NotImplementedException();
+                bool ICollection<KeyValuePair<string, int>>.Remove(KeyValuePair<string, int> item) => throw new NotImplementedException();
+                bool IDictionary<string, int>.TryGetValue(string key, out int value) => throw new NotImplementedException();
+            }
+
+            public static IEnumerable<TestData> GetSerializeTestData()
+            {
+                yield return new TestData(
+                    Value: new PolymorphicClassWithConstructor(42),
+                    ExpectedJson: @"{ ""Number"" : 42 }",
+                    ExpectedRoundtripValue: new PolymorphicClassWithConstructor(42));
+
+                yield return new TestData(
+                    Value: new DerivedClass { String = "str" },
+                    ExpectedJson: @"{ ""$type"" : ""derivedClass"", ""Number"" : 0, ""String"" : ""str"" }",
+                    ExpectedRoundtripValue: new DerivedClass { String = "str" });
+
+                yield return new TestData(
+                    Value: new DerivedClassWithConstructor(42, true),
+                    ExpectedJson: @"{ ""$type"" : ""derivedClassWithCtor"", ""Number"" : 42, ""Boolean"" : true }",
+                    ExpectedRoundtripValue: new DerivedClassWithConstructor(42, true));
+
+                yield return new TestData(
+                    Value: new DerivedCollection { 1, 2, 3 },
+                    ExpectedJson: @"{ ""$type"" : ""derivedCollection"", ""$values"" : [1,2,3]}",
+                    ExpectedRoundtripValue: new DerivedCollection { 1, 2, 3 });
+
+                yield return new TestData(
+                    Value: new DerivedDictionary { ["key1"] = 42, ["key2"] = -1 },
+                    ExpectedJson: @"{ ""$type"" : ""derivedDictionary"", ""key1"" : 42, ""key2"" : -1 }",
+                    ExpectedRoundtripValue: new DerivedDictionary { ["key1"] = 42, ["key2"] = -1 });
+            }
+
+            public record TestData(PolymorphicClassWithConstructor Value, string ExpectedJson, PolymorphicClassWithConstructor ExpectedRoundtripValue);
+        }
+
+        #endregion
+
+        #region Polymorphic Interface
+        [Theory]
+        [MemberData(nameof(Get_PolymorphicInterface_TestData_Serialization))]
+        public Task PolymorphicInterface_TestData_Serialization(PolymorphicInterface.TestData testData)
+            => TestMultiContextSerialization(testData.Value, testData.ExpectedJson, testData.ExpectedSerializationException);
+
+        public static IEnumerable<object[]> Get_PolymorphicInterface_TestData_Serialization()
+            => PolymorphicInterface.Helpers.GetSerializeTestData().Select(entry => new object[] { entry });
+
+        [Theory]
+        [MemberData(nameof(Get_PolymorphicInterface_TestData_Deserialization))]
+        public Task PolymorphicInterface_TestData_Deserialization(PolymorphicInterface.TestData testData)
+            => TestMultiContextDeserialization<PolymorphicInterface>(
+                testData.ExpectedJson,
+                testData.ExpectedRoundtripValue,
+                testData.ExpectedDeserializationException,
+                equalityComparer: PolymorphicEqualityComparer<PolymorphicInterface>.Instance);
+
+        public static IEnumerable<object[]> Get_PolymorphicInterface_TestData_Deserialization()
+            => PolymorphicInterface.Helpers.GetSerializeTestData()
+                .Where(entry => entry.ExpectedJson != null)
+                .Select(entry => new object[] { entry });
+
+        [Fact]
+        public async Task PolymorphicInterface_TestDataArray_Serialization()
+        {
+            IEnumerable<(PolymorphicInterface Value, string ExpectedJson)> inputs =
+                PolymorphicInterface.Helpers.GetSerializeTestData()
+                    .Where(entry => entry.ExpectedSerializationException is null)
+                    .Select(entry => (entry.Value, entry.ExpectedJson));
+
+            await TestMultiContextSerialization(inputs);
+        }
+
+        [Fact]
+        public async Task PolymorphicInterface_TestDataArray_Deserialization()
+        {
+            IEnumerable<(string ExpectedJson, PolymorphicInterface ExpectedRoundtripValue)> inputs =
+                PolymorphicInterface.Helpers.GetSerializeTestData()
+                .Where(entry => entry.ExpectedRoundtripValue is not null)
+                .Select(entry => (entry.ExpectedJson, entry.ExpectedRoundtripValue));
+
+            await TestMultiContextDeserialization(inputs, equalityComparer: PolymorphicEqualityComparer<PolymorphicInterface>.Instance);
+        }
+
+        [Theory]
+        [InlineData("$.$type", @"{ ""$type"" : ""derivedClass"", ""$type"" : ""derivedClass"", ""Number"" : 42 }")]
+        [InlineData("$.$type", @"{ ""$type"" : ""derivedClass"", ""Number"" : 42, ""$type"" : ""derivedClass""}")]
+        [InlineData("$.$id", @"{ ""$type"" : ""derivedClass"", ""Number"" : 42, ""$id"" : ""referenceId""}")]
+        [InlineData("$.$values", @"{ ""$type"" : ""derivedClass"", ""Number"" : 42, ""$values"" : [] }")]
+        [InlineData("$", @"{ ""$type"" : ""invalidDiscriminator"", ""Number"" : 42 }")]
+        [InlineData("$.$type", @"{ ""$type"" : 0, ""Number"" : 42 }")]
+        [InlineData("$.$type", @"{ ""$type"" : false, ""Number"" : 42 }")]
+        [InlineData("$.$type", @"{ ""$type"" : {}, ""Number"" : 42 }")]
+        [InlineData("$.$type", @"{ ""$type"" : [], ""Number"" : 42 }")]
+        [InlineData("$.$id", @"{ ""$id"" : ""1"", ""Number"" : 42 }")]
+        [InlineData("$.$ref", @"{ ""$ref"" : ""1"" }")]
+        public async Task PolymorphicInterface_InvalidTypeDiscriminatorMetadata_ShouldThrowJsonException(string expectedJsonPath, string json)
+        {
+            JsonException exception = await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<PolymorphicInterface>(json, PolymorphicClass.CustomConfigWithBaseTypeFallback));
+            Assert.Equal(expectedJsonPath, exception.Path);
+        }
+
+        // --
+
+        [Theory]
+        [MemberData(nameof(Get_PolymorphicInterface_CustomConfigWithNearestAncestorFallback_TestData_Serialization))]
+        public Task PolymorphicInterface_CustomConfigWithNearestAncestorFallback_TestData_Serialization(PolymorphicInterface.TestData testData)
+            => TestMultiContextSerialization(
+                testData.Value,
+                testData.ExpectedJson,
+                testData.ExpectedSerializationException,
+                options: PolymorphicInterface.Helpers.CustomConfigWithNearestAncestorFallback);
+
+        public static IEnumerable<object[]> Get_PolymorphicInterface_CustomConfigWithNearestAncestorFallback_TestData_Serialization()
+            => PolymorphicInterface.Helpers.GetSerializeTestData_CustomConfigWithNearestAncestorFallback().Select(entry => new object[] { entry });
+
+        [Theory]
+        [MemberData(nameof(Get_PolymorphicInterface_CustomConfigWithNearestAncestorFallback_TestData_Deserialization))]
+        public Task PolymorphicInterface_CustomConfigWithNearestAncestorFallback_TestData_Deserialization(PolymorphicInterface.TestData testData)
+            => TestMultiContextDeserialization<PolymorphicInterface>(
+                testData.ExpectedJson,
+                testData.ExpectedRoundtripValue,
+                testData.ExpectedDeserializationException,
+                options: PolymorphicInterface.Helpers.CustomConfigWithNearestAncestorFallback,
+                equalityComparer: PolymorphicEqualityComparer<PolymorphicInterface>.Instance);
+
+        public static IEnumerable<object[]> Get_PolymorphicInterface_CustomConfigWithNearestAncestorFallback_TestData_Deserialization()
+            => PolymorphicInterface.Helpers.GetSerializeTestData_CustomConfigWithNearestAncestorFallback()
+                .Where(entry => entry.ExpectedJson != null)
+                .Select(entry => new object[] { entry });
+
+        [Fact]
+        public async Task PolymorphicInterface_CustomConfigWithNearestAncestorFallback_TestDataArray_Serialization()
+        {
+            IEnumerable<(PolymorphicInterface Value, string ExpectedJson)> inputs =
+                PolymorphicInterface.Helpers.GetSerializeTestData_CustomConfigWithNearestAncestorFallback()
+                    .Where(entry => entry.ExpectedSerializationException is null)
+                    .Select(entry => (entry.Value, entry.ExpectedJson));
+
+            await TestMultiContextSerialization(inputs, options: PolymorphicInterface.Helpers.CustomConfigWithNearestAncestorFallback);
+        }
+
+        [Fact]
+        public async Task PolymorphicInterface_CustomConfigWithNearestAncestorFallback_TestDataArray_Deserialization()
+        {
+            IEnumerable<(string ExpectedJson, PolymorphicInterface ExpectedRoundtripValue)> inputs =
+                PolymorphicInterface.Helpers.GetSerializeTestData_CustomConfigWithNearestAncestorFallback()
+                .Where(entry => entry.ExpectedRoundtripValue is not null)
+                .Select(entry => (entry.ExpectedJson, entry.ExpectedRoundtripValue));
+
+            await TestMultiContextDeserialization(
+                inputs,
+                options: PolymorphicInterface.Helpers.CustomConfigWithNearestAncestorFallback,
+                equalityComparer: PolymorphicEqualityComparer<PolymorphicInterface>.Instance);
+        }
+
+        // --
+
+        [Theory]
+        [MemberData(nameof(Get_PolymorphicInterface_DiamondInducingConfigurations_ShouldThrowNotSupportedException))]
+        public async Task PolymorphicInterface_DiamondInducingConfigurations_ShouldThrowNotSupportedException(PolymorphicInterface value, JsonPolymorphicTypeConfiguration configuration)
+        {
+            var options = new JsonSerializerOptions { PolymorphicTypeConfigurations = { configuration } };
+            await Assert.ThrowsAsync<NotSupportedException>(() => Serializer.SerializeWrapper(value, options));
+        }
+
+        public static IEnumerable<object[]> Get_PolymorphicInterface_DiamondInducingConfigurations_ShouldThrowNotSupportedException()
+            => PolymorphicInterface.Helpers.GetDiamondInducingConfigurations().Select(entry => new object[] { entry.diamondValue, entry.configuration });
+
+
+        [JsonDerivedType(typeof(DerivedClass_NoTypeDiscriminator))]
+        [JsonDerivedType(typeof(DerivedClass_TypeDiscriminator), "derivedClass")]
+        [JsonDerivedType(typeof(DerivedStruct_NoTypeDiscriminator))]
+        [JsonDerivedType(typeof(DerivedStruct_TypeDiscriminator), "derivedStruct")]
+        [JsonDerivedType(typeof(DerivedInterface1.ImplementingClass), "implementingClassOfDerivedInterface")]
+        public interface PolymorphicInterface
+        {
+            public int Number { get; set; }
+
+            public class DerivedClass_NoTypeDiscriminator : PolymorphicInterface
+            {
+                public int Number { get; set; }
+                public string String { get; set; }
+
+                public class DerivedClass : DerivedClass_NoTypeDiscriminator
+                {
+                    public string ExtraProperty { get; set; }
+                }
+            }
+
+            public class DerivedClass_TypeDiscriminator : PolymorphicInterface
+            {
+                public int Number { get; set; }
+                public string String { get; set; }
+
+                public class DerivedClass : DerivedClass_TypeDiscriminator
+                {
+                    public string ExtraProperty { get; set; }
+                }
+            }
+
+            public struct DerivedStruct_NoTypeDiscriminator : PolymorphicInterface
+            {
+                public int Number { get; set; }
+                public string String { get; set; }
+            }
+
+            public struct DerivedStruct_TypeDiscriminator : PolymorphicInterface
+            {
+                public int Number { get; set; }
+                public string String { get; set; }
+            }
+
+            public interface DerivedInterface1 : PolymorphicInterface
+            {
+                public string String { get; set; }
+
+                public class ImplementingClass : DerivedInterface1
+                {
+                    public int Number { get; set; }
+                    public string String { get; set; }
+                }
+            }
+
+            public interface DerivedInterface2 : PolymorphicInterface
+            {
+                public bool Boolean { get; set; }
+            }
+
+            public class DiamondKind1 : DerivedInterface1, DerivedInterface2
+            {
+                public int Number { get; set; }
+                public string String { get; set; }
+                public bool Boolean { get; set; }
+            }
+
+            public class DiamondKind2 : DerivedClass_TypeDiscriminator, DerivedInterface1
+            {
+                public bool Boolean { get; set; }
+            }
+
+            public static class Helpers
+            {
+                public static IEnumerable<TestData> GetSerializeTestData()
+                {
+                    yield return new TestData(
+                        Value: new DerivedClass_NoTypeDiscriminator { Number = 42, String = "str" },
+                        ExpectedJson: @"{ ""Number"" : 42, ""String"" : ""str"" }",
+                        ExpectedDeserializationException: typeof(NotSupportedException));
+
+                    yield return new TestData(
+                        new DerivedClass_NoTypeDiscriminator.DerivedClass(),
+                        ExpectedSerializationException: typeof(NotSupportedException));
+
+                    yield return new TestData(
+                        Value: new DerivedClass_TypeDiscriminator { Number = 42, String = "str" },
+                        ExpectedJson: @"{ ""$type"" : ""derivedClass"", ""Number"" : 42, ""String"" : ""str"" }",
+                        ExpectedRoundtripValue: new DerivedClass_TypeDiscriminator { Number = 42, String = "str" });
+
+                    yield return new TestData(
+                        new DerivedClass_TypeDiscriminator.DerivedClass(),
+                        ExpectedSerializationException: typeof(NotSupportedException));
+
+                    yield return new TestData(
+                        Value: new DerivedStruct_NoTypeDiscriminator { Number = 42, String = "str" },
+                        ExpectedJson: @"{ ""Number"" : 42, ""String"" : ""str"" }",
+                        ExpectedDeserializationException: typeof(NotSupportedException));
+
+                    yield return new TestData(
+                        Value: new DerivedStruct_TypeDiscriminator { Number = 42, String = "str" },
+                        ExpectedJson: @"{ ""$type"" : ""derivedStruct"", ""Number"" : 42, ""String"" : ""str"" }",
+                        ExpectedRoundtripValue: new DerivedStruct_TypeDiscriminator { Number = 42, String = "str" });
+                }
+
+                public static JsonSerializerOptions CustomConfigWithNearestAncestorFallback { get; } =
+                    new JsonSerializerOptions
+                    {
+                        PolymorphicTypeConfigurations =
+                        {
+                            new JsonPolymorphicTypeConfiguration<PolymorphicInterface>
+                            {
+                                UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor
+                            }
+                            .WithDerivedType<DerivedClass_TypeDiscriminator>("derivedClass")
+                            .WithDerivedType<DerivedStruct_NoTypeDiscriminator>()
+                            .WithDerivedType<DerivedInterface1>()
+                            .WithDerivedType<DerivedInterface2>()
+                        }
+                    };
+
+                public static IEnumerable<TestData> GetSerializeTestData_CustomConfigWithNearestAncestorFallback()
+                {
+                    yield return new TestData(
+                        Value: new DerivedClass_NoTypeDiscriminator { Number = 42, String = "str" },
+                        ExpectedJson: @"{ ""Number"" : 42 }",
+                        ExpectedDeserializationException: typeof(NotSupportedException));
+
+                    yield return new TestData(
+                        new DerivedClass_NoTypeDiscriminator.DerivedClass { Number = 42 },
+                        ExpectedJson: @"{ ""Number"" : 42 }",
+                        ExpectedDeserializationException: typeof(NotSupportedException));
+
+                    yield return new TestData(
+                        Value: new DerivedClass_TypeDiscriminator { Number = 42, String = "str" },
+                        ExpectedJson: @"{ ""$type"" : ""derivedClass"", ""Number"" : 42, ""String"" : ""str"" }",
+                        ExpectedRoundtripValue: new DerivedClass_TypeDiscriminator { Number = 42, String = "str" });
+
+                    yield return new TestData(
+                        new DerivedClass_TypeDiscriminator.DerivedClass { Number = 42, String = "str", ExtraProperty = "extra" },
+                        ExpectedJson: @"{ ""$type"" : ""derivedClass"", ""Number"" : 42, ""String"" : ""str"" }",
+                        ExpectedRoundtripValue: new DerivedClass_TypeDiscriminator { Number = 42, String = "str" });
+
+                    yield return new TestData(
+                        Value: new DerivedStruct_NoTypeDiscriminator { Number = 42, String = "str" },
+                        ExpectedJson: @"{ ""Number"" : 42, ""String"" : ""str"" }",
+                        ExpectedDeserializationException: typeof(NotSupportedException));
+
+                    yield return new TestData(
+                        Value: new DerivedStruct_TypeDiscriminator { Number = 42, String = "str" },
+                        ExpectedJson: @"{ ""Number"" : 42 }",
+                        ExpectedDeserializationException: typeof(NotSupportedException));
+
+                    yield return new TestData(
+                        Value: new DiamondKind1(),
+                        ExpectedSerializationException: typeof(NotSupportedException));
+
+                    yield return new TestData(
+                        Value: new DiamondKind2(),
+                        ExpectedSerializationException: typeof(NotSupportedException));
+
+                }
+
+                public static IEnumerable<(PolymorphicInterface diamondValue, JsonPolymorphicTypeConfiguration configuration)> GetDiamondInducingConfigurations()
+                {
+                    yield return (
+                        new DiamondKind1(),
+                        new JsonPolymorphicTypeConfiguration<PolymorphicInterface> { UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor }
+                            .WithDerivedType<DerivedInterface1>()
+                            .WithDerivedType<DerivedInterface2>());
+
+                    yield return (
+                        new DiamondKind2(),
+                        new JsonPolymorphicTypeConfiguration<PolymorphicInterface> { UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor }
+                            .WithDerivedType<DerivedInterface1>()
+                            .WithDerivedType<DerivedClass_TypeDiscriminator>());
+                }
+            }
+
+            public record TestData(
+                PolymorphicInterface Value = null,
+                string? ExpectedJson = null,
+                PolymorphicInterface? ExpectedRoundtripValue = null,
+                Type? ExpectedSerializationException = null,
+                Type? ExpectedDeserializationException = null);
+        }
+        #endregion
+
+        #region Polymorphic List
+
+        [Theory]
+        [MemberData(nameof(Get_PolymorphicList_TestData_Serialization))]
+        public Task PolymorphicList_TestData_Serialization(PolymorphicList.TestData testData)
+            => TestMultiContextSerialization(testData.Value, testData.ExpectedJson);
+
+        public static IEnumerable<object[]> Get_PolymorphicList_TestData_Serialization()
+            => PolymorphicList.GetSerializeTestData().Select(entry => new object[] { entry });
+
+        [Theory]
+        [MemberData(nameof(Get_PolymorphicList_TestData_Serialization))]
+        public Task PolymorphicList_TestData_Deserialization(PolymorphicList.TestData testData)
+            => TestMultiContextDeserialization(
+                testData.ExpectedJson,
+                testData.ExpectedRoundtripValue,
+                equalityComparer: PolymorphicEqualityComparer<PolymorphicList>.Instance);
+
+        public static IEnumerable<object[]> Get_PolymorphicList_TestData_Deserialization()
+            => PolymorphicList.GetSerializeTestData().Select(entry => new object[] { entry });
+
+        [Fact]
+        public async Task PolymorphicList_TestDataArray_Serialization()
+        {
+            IEnumerable<(PolymorphicList Value, string ExpectedJson)> inputs =
+                PolymorphicList.GetSerializeTestData().Select(entry => (entry.Value, entry.ExpectedJson));
+
+            await TestMultiContextSerialization(inputs);
+        }
+
+        [Fact]
+        public async Task PolymorphicList_TestDataArray_Deserialization()
+        {
+            IEnumerable<(string ExpectedJson, PolymorphicList ExpectedRoundtripValue)> inputs =
+                PolymorphicList.GetSerializeTestData().Select(entry => (entry.ExpectedJson, entry.ExpectedRoundtripValue));
+
+            await TestMultiContextDeserialization(inputs, equalityComparer: PolymorphicEqualityComparer<PolymorphicList>.Instance);
+        }
+
+        [Fact]
+        public async Task PolymorphicList_UnrecognizedTypeDiscriminators_ShouldSucceedDeserialization()
+        {
+            string json = @"{ ""$type"" : ""invalidTypeDiscriminator"", ""$values"" : [42,42,42] }";
+            PolymorphicList result = await Serializer.DeserializeWrapper<PolymorphicList>(json);
+            Assert.IsType<PolymorphicList>(result);
+            Assert.Equal(Enumerable.Repeat(42, 3), result);
+        }
+
+        [Theory]
+        [InlineData("$.UnsupportedProperty", @"{ ""$type"" : ""derivedList"", ""UnsupportedProperty"" : 42 }")]
+        [InlineData("$.UnsupportedProperty", @"{ ""$type"" : ""derivedList"", ""$values"" : [], ""UnsupportedProperty"" : 42 }")]
+        [InlineData("$.$id", @"{ ""$id"" : 42, ""$values"" : [] }")]
+        [InlineData("$.$ref", @"{ ""$ref"" : 42 }")]
+        public async Task PolymorphicList_InvalidTypeDiscriminatorMetadata_ShouldThrowJsonException(string expectedJsonPath, string json)
+        {
+            JsonException exception = await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<PolymorphicList>(json));
+            Assert.Equal(expectedJsonPath, exception.Path);
+        }
+
+        [JsonPolymorphic(UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor, IgnoreUnrecognizedTypeDiscriminators = true)]
+        [JsonDerivedType(typeof(PolymorphicList), "baseList")]
+        [JsonDerivedType(typeof(DerivedList1), "derivedList")]
+        public class PolymorphicList : List<int>
+        {
+            public class DerivedList1 : PolymorphicList
+            {
+            }
+
+            public class DerivedList2 : PolymorphicList
+            {
+            }
+
+            public static IEnumerable<TestData> GetSerializeTestData()
+            {
+                yield return new TestData(
+                    Value: new PolymorphicList { 42 },
+                    ExpectedJson: @"{ ""$type"" : ""baseList"", ""$values"" : [42]}",
+                    ExpectedRoundtripValue:  new PolymorphicList { 42 });
+
+                yield return new TestData(
+                    Value: new DerivedList1 { 42 },
+                    ExpectedJson: @"{ ""$type"" : ""derivedList"", ""$values"" : [42]}",
+                    ExpectedRoundtripValue: new DerivedList1 { 42 });
+
+                yield return new TestData(
+                    Value: new DerivedList2 { 42 },
+                    ExpectedJson: @"{ ""$type"" : ""baseList"", ""$values"" : [42]}",
+                    ExpectedRoundtripValue: new PolymorphicList { 42 });
+            }
+
+            public record TestData(PolymorphicList Value, string ExpectedJson, PolymorphicList ExpectedRoundtripValue);
+        }
+
+        [Fact]
+        public async Task PolymorphicCollectionInterface_Serialization()
+        {
+            var source = new int[] { 1, 2, 3 };
+            var values = new IEnumerable<int>[]
+            {
+                source,
+                new List<int>(source),
+                new Queue<int>(source),
+                new HashSet<int>(source)
+            };
+
+            string expectedJson =
+                @"[ [1,2,3],
+                    { ""$type"":""list"" , ""$values"":[1,2,3] },
+                    { ""$type"":""queue"", ""$values"":[1,2,3] },
+                    { ""$type"":""set""  , ""$values"":[1,2,3] }]";
+
+            string actualJson = await Serializer.SerializeWrapper(values, s_optionsWithPolymorphicCollectionInterface);
+
+            JsonTestHelper.AssertJsonEqual(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public async Task PolymorphicCollectionInterface_Deserialization()
+        {
+            var source = new int[] { 1, 2, 3 };
+            var expectedValues = new IEnumerable<int>[]
+            {
+                new List<int>(source),
+                new List<int>(source),
+                new Queue<int>(source),
+                new HashSet<int>(source)
+            };
+
+            string json =
+                @"[ [1,2,3],
+                    { ""$type"":""list"" , ""$values"":[1,2,3] },
+                    { ""$type"":""queue"", ""$values"":[1,2,3] },
+                    { ""$type"":""set""  , ""$values"":[1,2,3] }]";
+
+            var actualValues = await Serializer.DeserializeWrapper<IEnumerable<int>[]>(json, s_optionsWithPolymorphicCollectionInterface);
+            Assert.Equal(expectedValues.Length, actualValues.Length);
+            for (int i = 0; i < expectedValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], actualValues[i]);
+                Assert.IsType(expectedValues[i].GetType(), actualValues[i]);
+            }
+        }
+
+        private readonly static JsonSerializerOptions s_optionsWithPolymorphicCollectionInterface = new JsonSerializerOptions
+        {
+            PolymorphicTypeConfigurations =
+                {
+                    new JsonPolymorphicTypeConfiguration<IEnumerable<int>>
+                    {
+                        UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor
+                    }
+                    .WithDerivedType<List<int>>("list")
+                    .WithDerivedType<Queue<int>>("queue")
+                    .WithDerivedType<ISet<int>>("set")
+                }
+        };
+        #endregion
+
+        #region Polymorphic Dictionary
+        [Theory]
+        [MemberData(nameof(Get_PolymorphicDictionary_TestData_Serialization))]
+        public Task PolymorphicDictionary_TestData_Serialization(PolymorphicDictionary.TestData testData)
+            => TestMultiContextSerialization(testData.Value, testData.ExpectedJson);
+
+        public static IEnumerable<object[]> Get_PolymorphicDictionary_TestData_Serialization()
+            => PolymorphicDictionary.GetSerializeTestData().Select(entry => new object[] { entry });
+
+        [Theory]
+        [MemberData(nameof(Get_PolymorphicDictionary_TestData_Serialization))]
+        public Task PolymorphicDictionary_TestData_Deserialization(PolymorphicDictionary.TestData testData)
+            => TestMultiContextDeserialization(
+                testData.ExpectedJson,
+                testData.ExpectedRoundtripValue,
+                equalityComparer: PolymorphicEqualityComparer<PolymorphicDictionary>.Instance);
+
+        public static IEnumerable<object[]> Get_PolymorphicDictionary_TestData_Deserialization()
+            => PolymorphicDictionary.GetSerializeTestData().Select(entry => new object[] { entry });
+
+        [Fact]
+        public async Task PolymorphicDictionary_TestDataArray_Serialization()
+        {
+            IEnumerable<(PolymorphicDictionary Value, string ExpectedJson)> inputs =
+                PolymorphicDictionary.GetSerializeTestData().Select(entry => (entry.Value, entry.ExpectedJson));
+
+            await TestMultiContextSerialization(inputs);
+        }
+
+        [Fact]
+        public async Task PolymorphicDictionary_TestDataArray_Deserialization()
+        {
+            IEnumerable<(string ExpectedJson, PolymorphicDictionary ExpectedRoundtripValue)> inputs =
+                PolymorphicDictionary.GetSerializeTestData().Select(entry => (entry.ExpectedJson, entry.ExpectedRoundtripValue));
+
+            await TestMultiContextDeserialization(inputs, equalityComparer: PolymorphicEqualityComparer<PolymorphicDictionary>.Instance);
+        }
+
+        [Fact]
+        public async Task PolymorphicDictionary_UnrecognizedTypeDiscriminators_ShouldSucceedDeserialization()
+        {
+            string json = @"{ ""$type"" : ""invalidTypeDiscriminator"", ""key"" : 42 }";
+            PolymorphicDictionary result = await Serializer.DeserializeWrapper<PolymorphicDictionary>(json);
+            Assert.IsType<PolymorphicDictionary>(result);
+            Assert.Equal(new PolymorphicDictionary { ["key"] = 42 }, result);
+        }
+
+        [Theory]
+        [InlineData("$.$ref", @"{ ""$type"" : ""derivedList"", ""UserProperty"" : 42, ""$ref"" : ""42"" }")]
+        [InlineData("$.$type", @"{ ""$type"" : ""derivedList"", ""UserProperty"" : 42, ""$type"" : ""derivedDictionary"" }")]
+        [InlineData("$.$type", @"{ ""UserProperty"" : 42, ""$type"" : ""derivedDictionary"" }")]
+        [InlineData("$.$values", @"{ ""$type"" : ""derivedDictionary"", ""$values"" : [] }")]
+        [InlineData("$.$id", @"{ ""$id"" : 42, ""UserProperty"" : 42 }")]
+        [InlineData("$.$ref", @"{ ""$ref"" : 42 }")]
+        public async Task PolymorphicDictionary_InvalidTypeDiscriminatorMetadata_ShouldThrowJsonException(string expectedJsonPath, string json)
+        {
+            JsonException exception = await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<PolymorphicDictionary>(json));
+            Assert.Equal(expectedJsonPath, exception.Path);
+        }
+
+        [JsonPolymorphic(UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor, IgnoreUnrecognizedTypeDiscriminators = true)]
+        [JsonDerivedType(typeof(PolymorphicDictionary), "baseDictionary")]
+        [JsonDerivedType(typeof(DerivedDictionary1), "derivedDictionary")]
+        public class PolymorphicDictionary : Dictionary<string, int>
+        {
+            public class DerivedDictionary1 : PolymorphicDictionary
+            {
+            }
+
+            public class DerivedDictionary2 : PolymorphicDictionary
+            {
+            }
+
+            public static IEnumerable<TestData> GetSerializeTestData()
+            {
+                yield return new TestData(
+                    Value: new PolymorphicDictionary { ["key1"] = 42 , ["key2"] = -1 },
+                    ExpectedJson: @"{ ""$type"" : ""baseDictionary"", ""key1"" : 42, ""key2"" : -1 }",
+                    ExpectedRoundtripValue: new PolymorphicDictionary { ["key1"] = 42, ["key2"] = -1 });
+
+                yield return new TestData(
+                    Value: new DerivedDictionary1 { ["key1"] = 42, ["key2"] = -1 },
+                    ExpectedJson: @"{ ""$type"" : ""derivedDictionary"", ""key1"" : 42, ""key2"" : -1 }",
+                    ExpectedRoundtripValue: new DerivedDictionary1 { ["key1"] = 42, ["key2"] = -1 });
+
+                yield return new TestData(
+                    Value: new DerivedDictionary2 { ["key1"] = 42, ["key2"] = -1 },
+                    ExpectedJson: @"{ ""$type"" : ""baseDictionary"", ""key1"" : 42, ""key2"" : -1 }",
+                    ExpectedRoundtripValue: new PolymorphicDictionary { ["key1"] = 42, ["key2"] = -1 });
+            }
+
+            public record TestData(PolymorphicDictionary Value, string ExpectedJson, PolymorphicDictionary ExpectedRoundtripValue);
+        }
+
+        [Fact]
+        public async Task PolymorphicDictionaryInterface_Serialization()
+        {
+            var values = new IEnumerable<KeyValuePair<int, object>>[]
+            {
+                new List<KeyValuePair<int, object>> { new KeyValuePair<int, object>(0, 0) },
+                new Dictionary<int, object> { [42] = false },
+                new SortedDictionary<int, object> { [0] = 1, [1] = 42 },
+                ImmutableDictionary.Create<int, object>()
+            };
+
+            string expectedJson =
+                @"[ [ { ""Key"":0, ""Value"":0 } ],
+                    { ""$type"" : ""dictionary"", ""42"" : false },
+                    { ""$type"" : ""sortedDictionary"", ""0"" : 1, ""1"" : 42 },
+                    { ""$type"" : ""readOnlyDictionary"" } ]";
+
+            string actualJson = await Serializer.SerializeWrapper(values, s_optionsWithPolymorphicDictionaryInterface);
+
+            JsonTestHelper.AssertJsonEqual(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public async Task PolymorphicDictionaryInterface_Deserialization()
+        {
+            string json =
+                @"[ [ { ""Key"":0, ""Value"":0 } ],
+                    { ""$type"" : ""dictionary"", ""42"" : false },
+                    { ""$type"" : ""sortedDictionary"", ""0"" : 1, ""1"" : 42 },
+                    { ""$type"" : ""readOnlyDictionary"" } ]";
+
+            var expectedValues = new IEnumerable<KeyValuePair<int, object>>[]
+            {
+                new List<KeyValuePair<int, object>> { new KeyValuePair<int, object>(0, 0) },
+                new Dictionary<int, object> { [42] = false },
+                new SortedDictionary<int, object> { [0] = 1, [1] = 42 },
+                new Dictionary<int, object>()
+            };
+
+            var actualValues = await Serializer.DeserializeWrapper<IEnumerable<KeyValuePair<int, object>>[]>(json, s_optionsWithPolymorphicDictionaryInterface);
+
+            Assert.Equal(expectedValues.Length, actualValues.Length);
+            for (int i = 0; i < expectedValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i].Select(x => x.Key), actualValues[i].Select(x => x.Key));
+                Assert.Equal(expectedValues[i].Select(x => x.Value.ToString()), actualValues[i].Select(x => x.Value.ToString()));
+                Assert.IsType(expectedValues[i].GetType(), actualValues[i]);
+            }
+        }
+
+        private readonly static JsonSerializerOptions s_optionsWithPolymorphicDictionaryInterface = new JsonSerializerOptions
+        {
+            PolymorphicTypeConfigurations =
+                {
+                    new JsonPolymorphicTypeConfiguration<IEnumerable<KeyValuePair<int, object>>>
+                    {
+                        UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor
+                    }
+                    .WithDerivedType<Dictionary<int, object>>("dictionary")
+                    .WithDerivedType<SortedDictionary<int, object>>("sortedDictionary")
+                    .WithDerivedType<IReadOnlyDictionary<int, object>>("readOnlyDictionary")
+                }
+        };
+        #endregion
+
+        #region Polymorphic Record Types
+        [Theory]
+        [InlineData(0, @"{""$type"":""zero""}")]
+        [InlineData(1, @"{""$type"":""succ"", ""value"":{""$type"":""zero""}}")]
+        [InlineData(3, @"{""$type"":""succ"", ""value"":{""$type"":""succ"",""value"":{""$type"":""succ"",""value"":{""$type"":""zero""}}}}")]
+        public async Task Peano_Serialization(int size, string expectedJson)
+        {
+            Peano peano = Peano.FromInteger(size);
+            await TestMultiContextSerialization(peano, expectedJson);
+        }
+
+        [Theory]
+        [InlineData(0, @"{""$type"":""zero""}")]
+        [InlineData(1, @"{""$type"":""succ"", ""value"":{""$type"":""zero""}}")]
+        [InlineData(3, @"{""$type"":""succ"", ""value"":{""$type"":""succ"",""value"":{""$type"":""succ"",""value"":{""$type"":""zero""}}}}")]
+        public async Task Peano_Deserialization(int expectedSize, string json)
+        {
+            Peano expected = Peano.FromInteger(expectedSize);
+            await TestMultiContextDeserialization<Peano>(json, expected);
+        }
+
+        // A Peano representation for natural numbers
+        [JsonDerivedType(typeof(Zero), "zero")]
+        [JsonDerivedType(typeof(Succ), "succ")]
+        public abstract record Peano
+        {
+            public static Peano FromInteger(int value) => value == 0 ? new Zero() : new Succ(FromInteger(value - 1));
+            public record Zero : Peano;
+            public record Succ(Peano value) : Peano;
+        }
+
+        [Theory]
+        [MemberData(nameof(BinaryTree.GetTestData), MemberType = typeof(BinaryTree))]
+        public async Task BinaryTree_TestData_Serialization(BinaryTree tree, string expectedJson)
+        {
+            string actualJson = await Serializer.SerializeWrapper(tree);
+            JsonTestHelper.AssertJsonEqual(expectedJson, actualJson);
+        }
+
+        [Theory]
+        [MemberData(nameof(BinaryTree.GetTestData), MemberType = typeof(BinaryTree))]
+        public async Task BinaryTree_TestData_Deserialization(BinaryTree expected, string json)
+        {
+            BinaryTree actual = await Serializer.DeserializeWrapper<BinaryTree>(json);
+            Assert.Equal(expected, actual);
+        }
+
+        [JsonDerivedType(typeof(Leaf), "leaf")]
+        [JsonDerivedType(typeof(Node), "node")]
+        public abstract record BinaryTree
+        {
+            public record Leaf : BinaryTree;
+            public record Node(int value, BinaryTree left, BinaryTree right) : BinaryTree;
+
+            public static IEnumerable<object[]> GetTestData()
+            {
+                yield return WrapArgs(new Leaf(), @"{""$type"":""leaf""}");
+                yield return WrapArgs(
+                    new Node(-1,
+                        new Leaf(),
+                        new Leaf()),
+                    @"{""$type"":""node"",""value"":-1,""left"":{""$type"":""leaf""},""right"":{""$type"":""leaf""}}");
+
+                yield return WrapArgs(
+                    new Node(12,
+                        new Leaf(),
+                        new Node(24,
+                            new Leaf(),
+                            new Leaf())),
+                    @"{""$type"":""node"", ""value"":12,
+                            ""left"":{""$type"":""leaf""},
+                            ""right"":{""$type"":""node"", ""value"":24,
+                                      ""left"":{""$type"":""leaf""},
+                                      ""right"":{""$type"":""leaf""}}}");
+
+                static object[] WrapArgs(BinaryTree value, string expectedJson) => new object[] { value, expectedJson };
+            }
+        }
+
+        #endregion
+
+        #region Polymorphism/Reference Preservation
+
+        [Theory]
+        [MemberData(nameof(Get_ReferencePreservation_TestData_Boxed))]
+        public async Task ReferencePreservation_SingleValue_Serialization(PolymorphicClass value, Func<string, string> jsonTemplate)
+        {
+            string expectedJson = jsonTemplate("1"); // root values have reference id "1"
+            string actualJson = await Serializer.SerializeWrapper(value, s_jsonSerializerOptionsPreserveRefs);
+            JsonTestHelper.AssertJsonEqual(expectedJson, actualJson);
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_ReferencePreservation_TestData_Boxed))]
+        public async Task ReferencePreservation_SingleValue_Deserialization(PolymorphicClass expectedValue, Func<string, string> jsonTemplate)
+        {
+            string json = jsonTemplate("1"); // root values have reference id "1"
+            PolymorphicClass actualValue = await Serializer.DeserializeWrapper<PolymorphicClass>(json, s_jsonSerializerOptionsPreserveRefs);
+            Assert.Equal(expectedValue, actualValue, PolymorphicEqualityComparer<PolymorphicClass>.Instance);
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_ReferencePreservation_TestData_Boxed))]
+        public async Task ReferencePreservation_RepeatingValue_Serialization(PolymorphicClass value, Func<string, string> jsonTemplate)
+        {
+            List<PolymorphicClass> input = new() { value, value };
+            string expectedJson =
+                $@"{{""$id"":""1"",
+                     ""$values"":[
+                          {jsonTemplate("2")},
+                          {{""$ref"":""2""}} ]
+                }}";
+
+            string actualJson = await Serializer.SerializeWrapper(input, s_jsonSerializerOptionsPreserveRefs);
+            JsonTestHelper.AssertJsonEqual(expectedJson, actualJson);
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_ReferencePreservation_TestData_Boxed))]
+        public async Task ReferencePreservation_RepeatingValue_Deserialization(PolymorphicClass expectedValue, Func<string, string> jsonTemplate)
+        {
+            string json =
+                $@"{{""$id"":""1"",
+                     ""$values"":[
+                          {jsonTemplate("2")},
+                          {{""$ref"":""2""}} ]
+                }}";
+
+            var result = await Serializer.DeserializeWrapper<List<PolymorphicClass>>(json, s_jsonSerializerOptionsPreserveRefs);
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(expectedValue, result[0], PolymorphicEqualityComparer<PolymorphicClass>.Instance);
+            Assert.Same(result[0], result[1]);
+        }
+
+        [Fact]
+        public async Task ReferencePreservation_MultipleRepeatingValues_Serialization()
+        {
+            (PolymorphicClass Value, Func<string, string> JsonTemplate)[] data = Get_ReferencePreservation_TestData().ToArray();
+            PolymorphicClass[] values = data.Select(entry => entry.Value).Concat(data.Select(entry => entry.Value)).ToArray();
+
+            IEnumerable<string> idValues = data.Select((entry, i) => entry.JsonTemplate((i + 1).ToString()));
+            IEnumerable<string> refValues = Enumerable.Range(1, data.Length).Select(x => $@"{{ ""$ref"" : ""{x}""}}");
+            string expectedJson = "[" + string.Join(", ", idValues.Concat(refValues)) + "]";
+
+            string actualJson = await Serializer.SerializeWrapper(values, s_jsonSerializerOptionsPreserveRefs);
+            JsonTestHelper.AssertJsonEqual(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public async Task ReferencePreservation_MultipleRepeatingValues_Deserialization()
+        {
+            (PolymorphicClass Value, Func<string, string> JsonTemplate)[] data = Get_ReferencePreservation_TestData().ToArray();
+            PolymorphicClass[] expectedValues = data.Select(entry => entry.Value).Concat(data.Select(entry => entry.Value)).ToArray();
+
+            IEnumerable<string> idValues = data.Select((entry, i) => entry.JsonTemplate((i + 1).ToString()));
+            IEnumerable<string> refValues = Enumerable.Range(1, data.Length).Select(x => $@"{{ ""$ref"" : ""{x}""}}");
+            string json = "[" + string.Join(", ", idValues.Concat(refValues)) + "]";
+
+            PolymorphicClass[] result = await Serializer.DeserializeWrapper<PolymorphicClass[]>(json, s_jsonSerializerOptionsPreserveRefs);
+            Assert.Equal(expectedValues, result, PolymorphicEqualityComparer<PolymorphicClass>.Instance);
+        }
+
+        public static IEnumerable<(PolymorphicClass Value, Func<string, string> JsonTemplate)> Get_ReferencePreservation_TestData()
+        {
+            yield return (
+                Value: new PolymorphicClass.DerivedClass1_TypeDiscriminator { Number = 42, String = "str" },
+                JsonTemplate: id => $@"{{""$id"":""{id}"",""$type"":""derivedClass1"",""Number"":42,""String"":""str""}}");
+
+            yield return (
+                Value: new PolymorphicClass.DerivedClassWithConstructor_TypeDiscriminator(42),
+                JsonTemplate: id => $@"{{""$id"":""{id}"",""$type"":""derivedClassWithCtor"",""Number"":42}}");
+
+            yield return (
+                Value: new PolymorphicClass.DerivedCollection_TypeDiscriminator { Number = 42 },
+                JsonTemplate: id => $@"{{""$id"":""{id}"",""$type"":""derivedCollection"",""$values"":[42,42,42]}}");
+
+            yield return (
+                Value: new PolymorphicClass.DerivedDictionary_TypeDiscriminator { Number = 42 },
+                JsonTemplate: id => $@"{{""$id"":""{id}"",""$type"":""derivedDictionary"",""dictionaryKey"":42}}");
+        }
+
+        public static IEnumerable<object[]> Get_ReferencePreservation_TestData_Boxed()
+            => Get_ReferencePreservation_TestData().Select(entry => new object[] { entry.Value, entry.JsonTemplate });
+
+        [Theory]
+        [MemberData(nameof(PolymorphicClassWithCustomTypeDiscriminator.GetTestData_Boxed), MemberType = typeof(PolymorphicClassWithCustomTypeDiscriminator))]
+        public async Task ReferencePreservation_CustomTypeDiscriminator_SingleValue_Serialization(PolymorphicClassWithCustomTypeDiscriminator value, Func<string, string> jsonTemplate)
+        {
+            string expectedJson = jsonTemplate("1"); // root values have reference id "1"
+            string actualJson = await Serializer.SerializeWrapper(value, s_jsonSerializerOptionsPreserveRefs);
+            JsonTestHelper.AssertJsonEqual(expectedJson, actualJson);
+        }
+
+        [Theory]
+        [MemberData(nameof(PolymorphicClassWithCustomTypeDiscriminator.GetTestData_Boxed), MemberType = typeof(PolymorphicClassWithCustomTypeDiscriminator))]
+        public async Task ReferencePreservation_CustomTypeDiscriminator_SingleValue_Deserialization(PolymorphicClassWithCustomTypeDiscriminator expectedValue, Func<string, string> jsonTemplate)
+        {
+            string json = jsonTemplate("1"); // root values have reference id "1"
+            PolymorphicClassWithCustomTypeDiscriminator actualValue = await Serializer.DeserializeWrapper<PolymorphicClassWithCustomTypeDiscriminator>(json, s_jsonSerializerOptionsPreserveRefs);
+            Assert.Equal(expectedValue, actualValue, PolymorphicEqualityComparer<PolymorphicClassWithCustomTypeDiscriminator>.Instance);
+        }
+
+        [Theory]
+        [MemberData(nameof(PolymorphicClassWithCustomTypeDiscriminator.GetTestData_Boxed), MemberType = typeof(PolymorphicClassWithCustomTypeDiscriminator))]
+        public async Task ReferencePreservation_CustomTypeDiscriminator_RepeatingValue_Serialization(PolymorphicClassWithCustomTypeDiscriminator value, Func<string, string> jsonTemplate)
+        {
+            List<PolymorphicClassWithCustomTypeDiscriminator> input = new() { value, value };
+            string expectedJson =
+                $@"{{""$id"":""1"",
+                     ""$values"":[
+                          {jsonTemplate("2")},
+                          {{""$ref"":""2""}} ]
+                }}";
+
+            string actualJson = await Serializer.SerializeWrapper(input, s_jsonSerializerOptionsPreserveRefs);
+            JsonTestHelper.AssertJsonEqual(expectedJson, actualJson);
+        }
+
+        [Theory]
+        [MemberData(nameof(PolymorphicClassWithCustomTypeDiscriminator.GetTestData_Boxed), MemberType = typeof(PolymorphicClassWithCustomTypeDiscriminator))]
+        public async Task ReferencePreservation_CustomTypeDiscriminator_RepeatingValue_Deserialization(PolymorphicClassWithCustomTypeDiscriminator expectedValue, Func<string, string> jsonTemplate)
+        {
+            string json =
+                $@"{{""$id"":""1"",
+                     ""$values"":[
+                          {jsonTemplate("2")},
+                          {{""$ref"":""2""}} ]
+                }}";
+
+            var result = await Serializer.DeserializeWrapper<List<PolymorphicClassWithCustomTypeDiscriminator>>(json, s_jsonSerializerOptionsPreserveRefs);
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(expectedValue, result[0], PolymorphicEqualityComparer<PolymorphicClassWithCustomTypeDiscriminator>.Instance);
+            Assert.Same(result[0], result[1]);
+        }
+
+        [Fact]
+        public async Task ReferencePreservation_CustomTypeDiscriminator_MultipleRepeatingValues_Serialization()
+        {
+            (PolymorphicClassWithCustomTypeDiscriminator Value, Func<string, string> JsonTemplate)[] data = PolymorphicClassWithCustomTypeDiscriminator.GetTestData().ToArray();
+            PolymorphicClassWithCustomTypeDiscriminator[] values = data.Select(entry => entry.Value).Concat(data.Select(entry => entry.Value)).ToArray();
+
+            IEnumerable<string> idValues = data.Select((entry, i) => entry.JsonTemplate((i + 1).ToString()));
+            IEnumerable<string> refValues = Enumerable.Range(1, data.Length).Select(x => $@"{{ ""$ref"" : ""{x}""}}");
+            string expectedJson = "[" + string.Join(", ", idValues.Concat(refValues)) + "]";
+
+            string actualJson = await Serializer.SerializeWrapper(values, s_jsonSerializerOptionsPreserveRefs);
+            JsonTestHelper.AssertJsonEqual(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public async Task ReferencePreservation_CustomTypeDiscriminator_MultipleRepeatingValues_Deserialization()
+        {
+            (PolymorphicClassWithCustomTypeDiscriminator Value, Func<string, string> JsonTemplate)[] data = PolymorphicClassWithCustomTypeDiscriminator.GetTestData().ToArray();
+            PolymorphicClassWithCustomTypeDiscriminator[] expectedValues = data.Select(entry => entry.Value).Concat(data.Select(entry => entry.Value)).ToArray();
+
+            IEnumerable<string> idValues = data.Select((entry, i) => entry.JsonTemplate((i + 1).ToString()));
+            IEnumerable<string> refValues = Enumerable.Range(1, data.Length).Select(x => $@"{{ ""$ref"" : ""{x}""}}");
+            string json = "[" + string.Join(", ", idValues.Concat(refValues)) + "]";
+
+            PolymorphicClassWithCustomTypeDiscriminator[] result = await Serializer.DeserializeWrapper<PolymorphicClassWithCustomTypeDiscriminator[]>(json, s_jsonSerializerOptionsPreserveRefs);
+            Assert.Equal(expectedValues, result, PolymorphicEqualityComparer<PolymorphicClassWithCustomTypeDiscriminator>.Instance);
+        }
+
+        [JsonPolymorphic(CustomTypeDiscriminatorPropertyName = "case")]
+        [JsonDerivedType(typeof(PolymorphicClassWithCustomTypeDiscriminator), "baseClass")]
+        [JsonDerivedType(typeof(DerivedClass), "derivedClass")]
+        [JsonDerivedType(typeof(DerivedCollection), "derivedCollection")]
+        public class PolymorphicClassWithCustomTypeDiscriminator
+        {
+            public int Number { get; set; }
+
+            public class DerivedClass : PolymorphicClassWithCustomTypeDiscriminator
+            {
+                public string String { get; set; }
+            }
+
+            public class DerivedCollection : PolymorphicClassWithCustomTypeDiscriminator, ICollection<int>
+            {
+                public bool IsReadOnly => false;
+                public void Add(int item) => Number = item;
+                public IEnumerator<int> GetEnumerator() => Enumerable.Repeat(Number, 3).GetEnumerator();
+                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+                public int Count => throw new NotImplementedException();
+                public void Clear() => throw new NotImplementedException();
+                public bool Contains(int item) => throw new NotImplementedException();
+                public void CopyTo(int[] array, int arrayIndex) => throw new NotImplementedException();
+                public bool Remove(int item) => throw new NotImplementedException();
+            }
+
+            public static IEnumerable<(PolymorphicClassWithCustomTypeDiscriminator Value, Func<string, string> JsonTemplate)> GetTestData()
+            {
+                yield return (
+                    Value: new PolymorphicClassWithCustomTypeDiscriminator { Number = 42 },
+                    JsonTemplate: id => $@"{{""$id"":""{id}"",""case"":""baseClass"",""Number"":42}}");
+
+                yield return (
+                    Value: new DerivedClass { Number = 42, String = "str" },
+                    JsonTemplate: id => $@"{{""case"":""derivedClass"",""$id"":""{id}"",""Number"":42,""String"":""str""}}");
+
+                yield return (
+                    Value: new DerivedCollection { 42 },
+                    JsonTemplate: id => $@"{{""case"":""derivedCollection"",""$id"":""{id}"",""$values"":[42,42,42]}}");
+            }
+
+            public static IEnumerable<object[]> GetTestData_Boxed()
+                => GetTestData().Select(entry => new object[] { entry.Value, entry.JsonTemplate });
+        }
+
+        private readonly static JsonSerializerOptions s_jsonSerializerOptionsPreserveRefs = new JsonSerializerOptions
+        {
+            ReferenceHandler = ReferenceHandler.Preserve
+        };
+        #endregion
+
+        #region Attribute Negative Tests
+
+        [Fact]
+        public async Task PolymorphicClassWithoutDerivedTypeAttribute_ThrowsInvalidOperationException()
+        {
+            var value = new PolymorphicClassWithoutDerivedTypeAttribute();
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Serializer.SerializeWrapper(value));
+        }
+
+        [JsonPolymorphic]
+        public class PolymorphicClassWithoutDerivedTypeAttribute
+        {
+        }
+
+        [Fact]
+        public async Task PolymorphicClassWithStructDerivedTypeAttribute_ThrowsInvalidOperationException()
+        {
+            var value = new PolymorphicClassWithStructDerivedTypeAttribute();
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Serializer.SerializeWrapper(value));
+        }
+
+        [JsonDerivedType(typeof(Guid))]
+        public class PolymorphicClassWithStructDerivedTypeAttribute
+        {
+        }
+
+        [Fact]
+        public async Task PolymorphicClassWithObjectDerivedTypeAttribute_ThrowsInvalidOperationException()
+        {
+            var value = new PolymorphicClassWithObjectDerivedTypeAttribute();
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Serializer.SerializeWrapper(value));
+        }
+
+        [JsonDerivedType(typeof(object), "object")]
+        public class PolymorphicClassWithObjectDerivedTypeAttribute
+        {
+        }
+
+        [Fact]
+        public async Task PolymorphicClassWithNonAssignableDerivedTypeAttribute_ThrowsInvalidOperationException()
+        {
+            var value = new PolymorphicClassWithNonAssignableDerivedTypeAttribute();
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Serializer.SerializeWrapper(value));
+        }
+
+        [JsonDerivedType(typeof(object))]
+        public class PolymorphicClassWithNonAssignableDerivedTypeAttribute
+        {
+        }
+
+
+        [Fact]
+        public async Task PolymorphicInterfaceWithInterfaceDerivedType_Serialization_ThrowsInvalidOperationException()
+        {
+            PolymorphicInterfaceWithInterfaceDerivedType value = new PolymorphicInterfaceWithInterfaceDerivedType.DerivedClass();
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Serializer.SerializeWrapper(value));
+        }
+
+        [Fact]
+        public async Task PolymorphicInterfaceWithInterfaceDerivedType_Deserialization_ThrowsInvalidOperationException()
+        {
+            string json = @"{""$type"":""derivedInterface""}";
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Serializer.DeserializeWrapper<PolymorphicInterfaceWithInterfaceDerivedType>(json));
+        }
+
+        [Fact]
+        public async Task PolymorphicInterfaceWithInterfaceDerivedType_FallbackToNearestAncestor_Serialization()
+        {
+            PolymorphicInterfaceWithInterfaceDerivedType value = new PolymorphicInterfaceWithInterfaceDerivedType.DerivedInterface.ImplementingClass();
+            string expectedJson = @"{""$type"":""derivedInterface""}";
+            string actualJson = await Serializer.SerializeWrapper(value, PolymorphicInterfaceWithInterfaceDerivedType_OptionsWithFallbackToNearestAncestor);
+            JsonTestHelper.AssertJsonEqual(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public async Task PolymorphicInterfaceWithInterfaceDerivedType_FallbackToNearestAncestor_Deserialization_ThrowsNotSupportedException()
+        {
+            string json = @"{""$type"":""derivedInterface""}";
+            await Assert.ThrowsAsync<NotSupportedException>(() =>
+                Serializer.DeserializeWrapper<PolymorphicInterfaceWithInterfaceDerivedType>(json,
+                    PolymorphicInterfaceWithInterfaceDerivedType_OptionsWithFallbackToNearestAncestor));
+        }
+
+        [JsonDerivedType(typeof(DerivedInterface), "derivedInterface")]
+        [JsonDerivedType(typeof(DerivedClass), "derivedClass")]
+        public interface PolymorphicInterfaceWithInterfaceDerivedType
+        {
+            public interface DerivedInterface : PolymorphicInterfaceWithInterfaceDerivedType
+            {
+                public class ImplementingClass : DerivedInterface
+                {
+                }
+            }
+
+            public class DerivedClass : PolymorphicInterfaceWithInterfaceDerivedType
+            {
+            }
+
+        }
+
+        public static JsonSerializerOptions PolymorphicInterfaceWithInterfaceDerivedType_OptionsWithFallbackToNearestAncestor { get; } =
+            new JsonSerializerOptions
+            {
+                PolymorphicTypeConfigurations =
+                {
+                    new JsonPolymorphicTypeConfiguration<PolymorphicInterfaceWithInterfaceDerivedType>()
+                    {
+                        UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor
+                    }
+                    .WithDerivedType<PolymorphicInterfaceWithInterfaceDerivedType.DerivedInterface>("derivedInterface")
+                    .WithDerivedType<PolymorphicInterfaceWithInterfaceDerivedType.DerivedClass>("derivedClass")
+                }
+            };
+
+        [Fact]
+        public async Task PolymorphicAbstractClassWithAbstractClassDerivedType_ThrowsInvalidOperationException()
+        {
+            PolymorphicAbstractClassWithAbstractClassDerivedType value = new PolymorphicAbstractClassWithAbstractClassDerivedType.DerivedClass();
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Serializer.SerializeWrapper(value));
+        }
+
+        [JsonDerivedType(typeof(DerivedAbstractClass))]
+        [JsonDerivedType(typeof(DerivedClass))]
+        public abstract class PolymorphicAbstractClassWithAbstractClassDerivedType
+        {
+            public abstract class DerivedAbstractClass : PolymorphicAbstractClassWithAbstractClassDerivedType
+            {
+            }
+
+            public class DerivedClass : PolymorphicAbstractClassWithAbstractClassDerivedType
+            {
+            }
+        }
+
+        [Fact]
+        public async Task PolymorphicClassWithDuplicateDerivedTypeRegistrations_ThrowsInvalidOperationException()
+        {
+            PolymorphicClassWithDuplicateDerivedTypeRegistrations value = new PolymorphicClassWithDuplicateDerivedTypeRegistrations.DerivedClass();
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Serializer.SerializeWrapper(value));
+        }
+
+        [JsonDerivedType(typeof(DerivedClass))]
+        [JsonDerivedType(typeof(DerivedClass), "id")]
+        public class PolymorphicClassWithDuplicateDerivedTypeRegistrations
+        {
+            public class DerivedClass : PolymorphicClassWithDuplicateDerivedTypeRegistrations
+            {
+            }
+        }
+
+        [Fact]
+        public async Task PolymorphicClasWithDuplicateTypeDiscriminators_ThrowsInvalidOperationException()
+        {
+            var value = new PolymorphicClasWithDuplicateTypeDiscriminators();
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Serializer.SerializeWrapper(value));
+        }
+
+        [JsonDerivedType(typeof(A), "duplicateId")]
+        [JsonDerivedType(typeof(B), "duplicateId")]
+        public class PolymorphicClasWithDuplicateTypeDiscriminators
+        {
+            public class A : PolymorphicClasWithDuplicateTypeDiscriminators { }
+            public class B : PolymorphicClasWithDuplicateTypeDiscriminators { }
+        }
+
+        [Fact]
+        public async Task PolymorphicGenericClass_ThrowsInvalidOperationException()
+        {
+            PolymorphicGenericClass<int> value = new PolymorphicGenericClass<int>.DerivedClass();
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Serializer.SerializeWrapper(value));
+        }
+
+        [JsonDerivedType(typeof(PolymorphicGenericClass<>.DerivedClass))]
+        public class PolymorphicGenericClass<T>
+        {
+            public class DerivedClass : PolymorphicGenericClass<T>
+            {
+            }
+        }
+
+        [Fact]
+        public async Task PolymorphicDerivedGenericClass_ThrowsInvalidOperationException()
+        {
+            PolymorphicDerivedGenericClass value = new PolymorphicDerivedGenericClass.DerivedClass<int>();
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Serializer.SerializeWrapper(value));
+        }
+
+        [JsonDerivedType(typeof(DerivedClass<>))]
+        public class PolymorphicDerivedGenericClass
+        {
+            public class DerivedClass<T> : PolymorphicDerivedGenericClass
+            {
+            }
+        }
+
+        [Fact]
+        public async Task PolymorphicClass_CustomConverter_TypeDiscriminator_Serialization_ThrowsNotSupportedException()
+        {
+            PolymorphicClass_CustomConverter_TypeDiscriminator value = new PolymorphicClass_CustomConverter_TypeDiscriminator.DerivedClass();
+            await Assert.ThrowsAsync<NotSupportedException>(() => Serializer.SerializeWrapper(value));
+        }
+
+        [Fact]
+        public async Task PolymorphicClass_CustomConverter_TypeDiscriminator_Deserialization_ThrowsNotSupportedException()
+        {
+            string json = @"{ ""$type"" : ""derivedClass"" }";
+            await Assert.ThrowsAsync<NotSupportedException>(() => Serializer.DeserializeWrapper<PolymorphicClass_CustomConverter_TypeDiscriminator>(json));
+        }
+
+        [JsonConverter(typeof(CustomConverter))]
+        [JsonDerivedType(typeof(DerivedClass), "derivedClass")]
+        public class PolymorphicClass_CustomConverter_TypeDiscriminator
+        {
+            public class DerivedClass : PolymorphicClass_CustomConverter_TypeDiscriminator
+            {
+            }
+
+            public class CustomConverter : JsonConverter<PolymorphicClass_CustomConverter_TypeDiscriminator>
+            {
+                public override PolymorphicClass_CustomConverter_TypeDiscriminator? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+                {
+                    reader.TrySkip();
+                    return null;
+                }
+
+                public override void Write(Utf8JsonWriter writer, PolymorphicClass_CustomConverter_TypeDiscriminator value, JsonSerializerOptions options)
+                    => writer.WriteNullValue();
+            }
+        }
+
+        [Fact]
+        public async Task PolymorphicClass_CustomConverter_NoTypeDiscriminator_Serialization()
+        {
+            var value = new PolymorphicClass_CustomConverter_NoTypeDiscriminator.DerivedClass { Number = 42 };
+            string expectedJson = @"{ ""Number"" : 42 }";
+            string actualJson = await Serializer.SerializeWrapper(value);
+            JsonTestHelper.AssertJsonEqual(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public async Task PolymorphicClass_CustomConverter_NoTypeDiscriminator_Deserialization()
+        {
+            string json = @"{ ""Number"" : 42 }";
+            PolymorphicClass_CustomConverter_NoTypeDiscriminator result = await Serializer.DeserializeWrapper<PolymorphicClass_CustomConverter_NoTypeDiscriminator>(json);
+            Assert.Null(result);
+        }
+
+        [JsonConverter(typeof(CustomConverter))]
+        [JsonDerivedType(typeof(DerivedClass))]
+        public class PolymorphicClass_CustomConverter_NoTypeDiscriminator
+        {
+            public class DerivedClass : PolymorphicClass_CustomConverter_NoTypeDiscriminator
+            {
+                public int Number { get; set; }
+            }
+
+            public class CustomConverter : JsonConverter<PolymorphicClass_CustomConverter_NoTypeDiscriminator>
+            {
+                public override PolymorphicClass_CustomConverter_NoTypeDiscriminator? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+                {
+                    reader.TrySkip();
+                    return null;
+                }
+
+                public override void Write(Utf8JsonWriter writer, PolymorphicClass_CustomConverter_NoTypeDiscriminator value, JsonSerializerOptions options)
+                    => writer.WriteNullValue();
+            }
+        }
+        #endregion
+
+        #region Test Helpers
+        public class PolymorphicEqualityComparer<TBaseType> : IEqualityComparer<TBaseType>
+            where TBaseType : class
+        {
+            public static PolymorphicEqualityComparer<TBaseType> Instance { get; } = new();
+
+            public bool Equals(TBaseType? left, TBaseType? right)
+            {
+                if (left is null || right is null)
+                {
+                    return left is null == right is null;
+                }
+
+                Type runtimeType = left.GetType();
+                if (runtimeType != right.GetType())
+                {
+                    return false;
+                }
+
+                EqualityComparer<object> objComparer = EqualityComparer<object>.Default;
+
+                // Runtime type is enumerable; use enumerable sequence comparison
+                if (left is IEnumerable leftColl)
+                {
+                    IEnumerable rightColl = (IEnumerable)right;
+                    return leftColl.Cast<object>().SequenceEqual(rightColl.Cast<object>(), objComparer);
+                }
+
+                // Runtime is regular POCO; use property structural comparison
+                foreach (var propInfo in runtimeType.GetProperties())
+                {
+                    if (!objComparer.Equals(propInfo.GetValue(left), propInfo.GetValue(right)))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            public int GetHashCode(TBaseType _) => throw new NotImplementedException();
+        }
+        #endregion
+    }
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.CustomTypeHierarchies.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.CustomTypeHierarchies.cs
@@ -2046,6 +2046,18 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public async Task PolymorphicClassWithNullDerivedTypeAttribute_ThrowsInvalidOperationException()
+        {
+            var value = new PolymorphicClassWithNullDerivedTypeAttribute();
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Serializer.SerializeWrapper(value));
+        }
+
+        [JsonDerivedType(derivedType: null)]
+        public class PolymorphicClassWithNullDerivedTypeAttribute
+        {
+        }
+
+        [Fact]
         public async Task PolymorphicClassWithStructDerivedTypeAttribute_ThrowsInvalidOperationException()
         {
             var value = new PolymorphicClassWithStructDerivedTypeAttribute();

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.cs
@@ -54,13 +54,10 @@ namespace System.Text.Json.Serialization.Tests
         public PolymorphicTests_Node() : base(JsonSerializerWrapper.NodeSerializer) { }
     }
 
-    public abstract class PolymorphicTests
+    public abstract partial class PolymorphicTests : SerializerTests
     {
-        private JsonSerializerWrapper Serializer { get; }
-
-        public PolymorphicTests(JsonSerializerWrapper serializer)
+        public PolymorphicTests(JsonSerializerWrapper serializer) : base(serializer)
         {
-            Serializer = serializer;
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
@@ -12,6 +12,9 @@
     <MetadataUpdaterSupport Condition="'$(MetadataUpdaterSupport)' == '' and '$(TargetOS)' == 'Browser'">true</MetadataUpdaterSupport>
     <WasmXHarnessArgs>$(WasmXHarnessArgs) --timeout=1800</WasmXHarnessArgs>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
+    <!-- Remove once polymorphism is out of preview. -->
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <GenerateRequiresPreviewFeaturesAttribute>true</GenerateRequiresPreviewFeaturesAttribute>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
@@ -20,6 +23,10 @@
 
   <ItemGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
     <HighAotMemoryUsageAssembly Include="System.Text.Json.Tests.dll" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <Compile Include="$(CoreLibSharedDir)System\Runtime\Versioning\RequiresPreviewFeaturesAttribute.cs" Link="System\Runtime\Versioning\RequiresPreviewFeaturesAttribute.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -178,6 +185,8 @@
     <Compile Include="Serialization\OnSerializeTests.cs" />
     <Compile Include="Serialization\OptionsTests.cs" />
     <Compile Include="Serialization\PolymorphicTests.cs" />
+    <Compile Include="Serialization\PolymorphicTests.CustomTypeHierarchies.cs" />
+    <Compile Include="Serialization\JsonPolymorphicTypeConfigurationTests.cs" />
     <Compile Include="Serialization\PropertyNameTests.cs" />
     <Compile Include="Serialization\PropertyOrderTests.cs" />
     <Compile Include="Serialization\PropertyVisibilityTests.cs" />

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
@@ -12,9 +12,6 @@
     <MetadataUpdaterSupport Condition="'$(MetadataUpdaterSupport)' == '' and '$(TargetOS)' == 'Browser'">true</MetadataUpdaterSupport>
     <WasmXHarnessArgs>$(WasmXHarnessArgs) --timeout=1800</WasmXHarnessArgs>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
-    <!-- Remove once polymorphism is out of preview. -->
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
-    <GenerateRequiresPreviewFeaturesAttribute>true</GenerateRequiresPreviewFeaturesAttribute>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
@@ -170,6 +170,7 @@
     <Compile Include="Serialization\InvalidTypeTests.cs" />
     <Compile Include="Serialization\JsonDocumentTests.cs" />
     <Compile Include="Serialization\JsonElementTests.cs" />
+    <Compile Include="Serialization\JsonPolymorphicTypeConfigurationTests.cs" />
     <Compile Include="Serialization\JsonSerializerApiValidation.cs" />
     <Compile Include="Serialization\JsonSerializerWrapper.Reflection.cs" />
     <Compile Include="Serialization\MetadataTests\MetadataTests.cs" />
@@ -186,7 +187,6 @@
     <Compile Include="Serialization\OptionsTests.cs" />
     <Compile Include="Serialization\PolymorphicTests.cs" />
     <Compile Include="Serialization\PolymorphicTests.CustomTypeHierarchies.cs" />
-    <Compile Include="Serialization\JsonPolymorphicTypeConfigurationTests.cs" />
     <Compile Include="Serialization\PropertyNameTests.cs" />
     <Compile Include="Serialization\PropertyOrderTests.cs" />
     <Compile Include="Serialization\PropertyVisibilityTests.cs" />


### PR DESCRIPTION
This PR implements [polymorphism for System.Text.Json](https://github.com/dotnet/runtime/issues/63747) as a preview feature. 

### Walkthrough of Changes

* Adds the [`JsonDerivedTypeAttribute`](https://github.com/dotnet/runtime/pull/67961/files#diff-4e0e2699c6d264f7260f0eac0003566f82c11647b74daf771ae95f8b8685ce3c) and [`JsonPolymorphicAttribute`](https://github.com/dotnet/runtime/pull/67961/files#diff-390a8d72e84c719752a34b45a8bb8b21e949a8cb1abb1f89ae734b89fde53961) types for configuring polymorphism using attributes.
* Adds the [`JsonPolymorphicTypeConfiguration`](https://github.com/dotnet/runtime/pull/67961/files#diff-f43ffc37119e5a93a2da25c41b438d69531234411459356eacb1de667d182290) class for configuring polymorphism without attributes.
* Adds a provisional [`JsonSerializerOptions.PolymorphicTypeConfiguration`](https://github.com/dotnet/runtime/pull/67961/files#diff-143351693c2cb653ad82e34086cfd8863b0bda66c8b498ed8a400924c4f5224e) property. Used as a temporary configuration entry point until #63686 has been implemented.
* Extends the existing polymorphic serialization infrastructure from `System.Object` types to arbitrary classes and interfaces (cf. [`JsonConverter.MetadataHandling.cs`](https://github.com/dotnet/runtime/pull/67961/files#diff-4cae397f0241cce39eb560119bf2025e68eac1d5d1f1b4c598615f034e17e244), [`WriteStack.cs`](https://github.com/dotnet/runtime/pull/67961/files#diff-fd44619c2d7a1beb99624d996f4f8a45bd086859dbd186cc4d0378a11cadbec7)). 
* Adds infrastructure for polymorphic deserialization. Unlike serialization, dispatch to the derived converter happens in the converter layer (since it can only be determined mid-deserialization). Polymorphic deserialization is implemented in four converters: [`ObjectDefaultConverter`](https://github.com/dotnet/runtime/pull/67961/files#diff-0874d1d450648c0d50d10d46cad93999e052f1e0e4d7ed2f17b6226626d859ab), [`ObjectWithParameterizedConstructorConverter`](https://github.com/dotnet/runtime/pull/67961/files#diff-b57fe2ce353d518a2aab19a636875d7bafe43989a498aec7fd3d13c5b12dbcda), [`JsonCollectionConverter`](https://github.com/dotnet/runtime/pull/67961/files#diff-d74e7556a718fad8f72bd9d50e1135b997c708548bbc21af049e34a9f9ab99de) and [`JsonDictionaryConverter`](https://github.com/dotnet/runtime/pull/67961/files#diff-a37776ecf9d66439f845a0d27f05eb9961d290f16ff591cfe6f18e80e3ebbecf).
* [`PolymorphicTypeResolver.cs`](https://github.com/dotnet/runtime/pull/67961/files#diff-c0c6a6581f2a19df70177a8be2af804b0c09915cde3ab47841281fdf6aeadf77) validates polymorphic type configuration and provides an entrypoint for mapping runtime types/type discriminators to derived `JsonTypeInfo` metadata.
* Updates the source generator [to support polymorphic attributes](https://github.com/dotnet/runtime/pull/67961/files#diff-c0c6a6581f2a19df70177a8be2af804b0c09915cde3ab47841281fdf6aeadf77): derived types are added to the implicitly registered types of a `JsonSerializerContext` and a diagnostic warning is emitted for `JsonSourceGenerationMode.Serialization`.

Contributes to #63747.