### PR TITLE
Check if pointer is null to prevent AV

### DIFF
--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -491,9 +491,9 @@ BOOL MethodTable::ValidateWithPossibleAV()
     // for that. We need to do more sanity checking to
     // make sure that our pointer here is in fact a valid object.
     PTR_EEClass pEEClass = this->GetClassWithPossibleAV();
-    return ((this == pEEClass->GetMethodTableWithPossibleAV()) ||
+    return ((pEEClass && (this == pEEClass->GetMethodTableWithPossibleAV())) ||
         ((HasInstantiation() || IsArray()) &&
-        (pEEClass->GetMethodTableWithPossibleAV()->GetClassWithPossibleAV() == pEEClass)));
+        (pEEClass && (pEEClass->GetMethodTableWithPossibleAV()->GetClassWithPossibleAV() == pEEClass))));
 }
 
 #ifndef DACCESS_COMPILE


### PR DESCRIPTION
The logic of the code has not been altered. The changes to the code are to check if the pointer is null before using it to prevent access violation. fixes [dotnet/diagnostics/2923](https://github.com/dotnet/diagnostics/issues/2923)