### PR TITLE
Use RegexCaseEquivalence table for case-insensitive backreferences

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -73,8 +73,6 @@ namespace System.Text.RegularExpressions.Generator
         private static void EmitRegexLimitedBoilerplate(
             IndentedTextWriter writer, RegexMethod rm, string reason)
         {
-            // If code generation is not supported but compilation is, then we fall back to use the compiled engine.
-            RegexOptions options = rm.Tree.Root.SupportsCompilation(out string? _) ? rm.Options | RegexOptions.Compiled : rm.Options; 
             writer.WriteLine($"/// <summary>Caches a <see cref=\"Regex\"/> instance for the {rm.MethodName} method.</summary>");
             writer.WriteLine($"/// <remarks>A custom Regex-derived type could not be generated because {reason}.</remarks>");
             writer.WriteLine($"internal sealed class {rm.GeneratedName} : Regex");
@@ -82,8 +80,8 @@ namespace System.Text.RegularExpressions.Generator
             writer.WriteLine($"    /// <summary>Cached, thread-safe singleton instance.</summary>");
             writer.Write($"    internal static readonly Regex Instance = ");
             writer.WriteLine(
-                rm.MatchTimeout is not null ? $"new({Literal(rm.Pattern)}, {Literal(options)}, {GetTimeoutExpression(rm.MatchTimeout.Value)});" :
-                options != 0 ? $"new({Literal(rm.Pattern)}, {Literal(options)});" :
+                rm.MatchTimeout is not null ? $"new({Literal(rm.Pattern)}, {Literal(rm.Options)}, {GetTimeoutExpression(rm.MatchTimeout.Value)});" :
+                rm.Options != 0 ? $"new({Literal(rm.Pattern)}, {Literal(rm.Options)});" :
                 $"new({Literal(rm.Pattern)});");
             writer.WriteLine($"}}");
         }

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
@@ -65,7 +65,7 @@ namespace System.Text.RegularExpressions.Generator
 
                     // If we're unable to generate a full implementation for this regex, report a diagnostic.
                     // We'll still output a limited implementation that just caches a new Regex(...).
-                    if (!regexMethod.Tree.Root.SupportsCompilation(out string? reason))
+                    if (!regexMethod.Tree.Root.SupportsCodeGeneration(out string? reason))
                     {
                         return (regexMethod, reason, Diagnostic.Create(DiagnosticDescriptors.LimitedSourceGeneration, regexMethod.MethodSyntax.GetLocation()));
                     }

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
@@ -65,7 +65,7 @@ namespace System.Text.RegularExpressions.Generator
 
                     // If we're unable to generate a full implementation for this regex, report a diagnostic.
                     // We'll still output a limited implementation that just caches a new Regex(...).
-                    if (!regexMethod.Tree.Root.SupportsCodeGeneration(out string? reason))
+                    if (!SupportsCodeGeneration(regexMethod.Tree.Root, out string? reason))
                     {
                         return (regexMethod, reason, Diagnostic.Create(DiagnosticDescriptors.LimitedSourceGeneration, regexMethod.MethodSyntax.GetLocation()));
                     }
@@ -273,6 +273,55 @@ namespace System.Text.RegularExpressions.Generator
                 // Save out the source
                 context.AddSource("RegexGenerator.g.cs", sw.ToString());
             });
+        }
+
+        // Determines whether the passed in node supports code generation strategy based on walking the tree.
+        // Also returns a human-readable string to explain the reason (it will be emitted by the source generator, hence
+        // there's no need to localize).
+        private static bool SupportsCodeGeneration(RegexNode node, [NotNullWhen(false)] out string? reason)
+        {
+            if (!node.SupportsCompilation(out reason))
+            {
+                // If the pattern doesn't support Compilation, then code generation won't be supported either.
+                return false;
+            }
+
+            if (HasCaseInsensitiveBackReferences(node))
+            {
+                // For case-insensitive patterns, we use our internal Regex case equivalence table when doing character comparisons.
+                // Most of the use of this table is done at Regex construction time by substituting all characters that are involved in
+                // case conversions into sets that contain all possible characters that could match. That said, there is still one case
+                // where you may need to do case-insensitive comparisons at match time which is the case for backreferences. For that reason,
+                // and given the Regex case equivalence table is internal and can't be called by the source generated emitted type, if
+                // the pattern contains case-insensitive backreferences, we won't try to create a source generated Regex-derived type.
+                reason = "the expression contains case-insensitive backreferences which are not supported by the source generator";
+                return false;
+            }
+
+            // If Compilation is supported and pattern doesn't have case insensitive backreferences, then code generation is supported.
+            reason = null;
+            return true;
+
+            static bool HasCaseInsensitiveBackReferences(RegexNode node)
+            {
+                if (node.Kind is RegexNodeKind.Backreference && (node.Options & RegexOptions.IgnoreCase) != 0)
+                {
+                    return true;
+                }
+
+                int childCount = node.ChildCount();
+                for (int i = 0; i < childCount; i++)
+                {
+                    // This recursion shouldn't hit issues with stack depth since this gets checked after
+                    // SupportCompilation has ensured that the max depth is not greater than 40.
+                    if (HasCaseInsensitiveBackReferences(node.Child(i)))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
         }
 
         /// <summary>Computes a hash of the string.</summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CompiledRegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CompiledRegexRunner.cs
@@ -11,6 +11,12 @@ namespace System.Text.RegularExpressions
         /// <summary>This field will only be set if the pattern contains backreferences and has RegexOptions.IgnoreCase</summary>
         private readonly CultureInfo? _culture;
 
+#pragma warning disable CA1823 // Avoid unused private fields. Justification: Used via reflection to cache the Case behavior if needed.
+#pragma warning disable CS0169
+        private RegexCaseBehavior _caseBehavior;
+#pragma warning restore CS0169
+#pragma warning restore CA1823
+
         internal delegate void ScanDelegate(RegexRunner runner, ReadOnlySpan<char> text);
 
         public CompiledRegexRunner(ScanDelegate scan, CultureInfo? culture)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CompiledRegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CompiledRegexRunner.cs
@@ -9,14 +9,14 @@ namespace System.Text.RegularExpressions
     {
         private readonly ScanDelegate _scanMethod;
         /// <summary>This field will only be set if the pattern contains backreferences and has RegexOptions.IgnoreCase</summary>
-        private readonly TextInfo? _textInfo;
+        private readonly CultureInfo? _culture;
 
         internal delegate void ScanDelegate(RegexRunner runner, ReadOnlySpan<char> text);
 
         public CompiledRegexRunner(ScanDelegate scan, CultureInfo? culture)
         {
             _scanMethod = scan;
-            _textInfo = culture?.TextInfo;
+            _culture = culture;
         }
 
         protected internal override void Scan(ReadOnlySpan<char> text)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaseBehavior.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaseBehavior.cs
@@ -12,9 +12,7 @@ namespace System.Text.RegularExpressions
     /// same character. Note that we don't consider a mapping when the only relationship between 'A' and 'B' is that one is the ToUpper() representation of the other. This
     /// is for backwards compatibility since, in Regex, we have only consider ToLower() for case insensitive comparisons. Given the case mappings vary depending on the culture,
     /// Regex supports 3 main different behaviors or mappings: Invariant, NonTurkish, and Turkish. This is in order to match the behavior of all .NET supported cultures
-    /// current behavior for ToLower(). As a side note, there should be no cases where 'A'.ToLower() == 'B' but 'A'.ToLower() != 'B'.ToLower(). This aspect is important since
-    /// for backreferences we make use a.ToLower() == b.ToLower() for comparisons so if there was such a case then it would lead to inconsistencies between how we handle
-    /// backreferences vs how we handle other case insensitive comparisons.
+    /// current behavior for ToLower(). As a side note, there should be no cases where 'A'.ToLower() == 'B' but 'A'.ToLower() != 'B'.ToLower().
     /// </summary>
     internal enum RegexCaseBehavior
     {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaseBehavior.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaseBehavior.cs
@@ -17,6 +17,12 @@ namespace System.Text.RegularExpressions
     internal enum RegexCaseBehavior
     {
         /// <summary>
+        /// This means that the RegexCaseBehavior hasn't been calculated based on a passed in culture yet, so it will need to be calculated before the first
+        /// equivalence check by calling <see cref="RegexCaseEquivalences.GetRegexBehavior(CultureInfo)"/>
+        /// </summary>
+        NotSet,
+
+        /// <summary>
         /// Invariant case-mappings are used. This includes all of the common mappings across cultures. This behavior is used when either the  user
         /// specified <see cref="RegexOptions.CultureInvariant"/> or when the CurrentCulture is <see cref="CultureInfo.InvariantCulture"/>.
         /// </summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaseEquivalences.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaseEquivalences.cs
@@ -28,15 +28,20 @@ namespace System.Text.RegularExpressions
         /// culture and will also factor in the current culture in order to handle the special cases which are different between cultures.
         /// </summary>
         /// <param name="c">The character being analyzed</param>
-        /// <param name="culture">The <see cref="CultureInfo"/> to be used to determine the equivalences.</param>
+        /// <param name="culture">The <see cref="CultureInfo"/> to be used to calculate <paramref name="mappingBehavior"/> in case it hasn't been cached.</param>
+        /// <param name="mappingBehavior">The behavior to be used for case comparisons. If the value hasn't been set yet, it will get initialized in the first lookup.</param>
         /// <param name="equivalences">If <paramref name="c"/> is involved in case conversion, then equivalences will contain the
         /// span of character which should be considered equal to <paramref name="c"/> in a case-insensitive comparison.</param>
         /// <returns><see langword="true"/> if <paramref name="c"/> is involved in case conversion; otherwise, <see langword="false"/></returns>
-        public static bool TryFindCaseEquivalencesForCharWithIBehavior(char c, CultureInfo culture, out ReadOnlySpan<char> equivalences)
+        public static bool TryFindCaseEquivalencesForCharWithIBehavior(char c, CultureInfo culture, ref RegexCaseBehavior mappingBehavior, out ReadOnlySpan<char> equivalences)
         {
             if ((c | 0x20) == 'i' || (c | 0x01) == '\u0131')
             {
-                RegexCaseBehavior mappingBehavior = GetRegexBehavior(culture);
+                // If this is the first time that this method is being called then mappingBehavior will be set to default, so we calculate
+                // the behavior to use and cache the value for future lookups.
+                if (mappingBehavior == default)
+                    mappingBehavior = GetRegexBehavior(culture);
+
                 equivalences = c switch
                 {
                     // Invariant mappings

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaseEquivalences.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCaseEquivalences.cs
@@ -39,7 +39,7 @@ namespace System.Text.RegularExpressions
             {
                 // If this is the first time that this method is being called then mappingBehavior will be set to default, so we calculate
                 // the behavior to use and cache the value for future lookups.
-                if (mappingBehavior == default)
+                if (mappingBehavior == RegexCaseBehavior.NotSet)
                     mappingBehavior = GetRegexBehavior(culture);
 
                 equivalences = c switch

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -276,6 +276,7 @@ namespace System.Text.RegularExpressions
         private StringBuilder? _categories;
         private RegexCharClass? _subtractor;
         private bool _negate;
+        private RegexCaseBehavior _caseBehavior;
 
 #if DEBUG
         static RegexCharClass()
@@ -440,7 +441,7 @@ namespace System.Text.RegularExpressions
                     (char First, char Last) range = rangeList[i];
                     if (range.First == range.Last)
                     {
-                        if (RegexCaseEquivalences.TryFindCaseEquivalencesForCharWithIBehavior(range.First, culture, out ReadOnlySpan<char> equivalences))
+                        if (RegexCaseEquivalences.TryFindCaseEquivalencesForCharWithIBehavior(range.First, culture, ref _caseBehavior, out ReadOnlySpan<char> equivalences))
                         {
                             foreach (char equivalence in equivalences)
                             {
@@ -464,7 +465,7 @@ namespace System.Text.RegularExpressions
         {
             for (int i = chMin; i <= chMax; i++)
             {
-                if (RegexCaseEquivalences.TryFindCaseEquivalencesForCharWithIBehavior((char)i, culture, out ReadOnlySpan<char> equivalences))
+                if (RegexCaseEquivalences.TryFindCaseEquivalencesForCharWithIBehavior((char)i, culture, ref _caseBehavior, out ReadOnlySpan<char> equivalences))
                 {
                     foreach (char equivalence in equivalences)
                     {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -12,20 +12,20 @@ namespace System.Text.RegularExpressions
     internal sealed class RegexInterpreterFactory : RegexRunnerFactory
     {
         private readonly RegexInterpreterCode _code;
-        private readonly TextInfo? _textInfo;
+        private readonly CultureInfo? _culture;
 
         public RegexInterpreterFactory(RegexTree tree)
         {
-            // We use the TextInfo field from the tree's culture which will only be set to an actual culture if the
-            // tree contains IgnoreCase backreferences. If the tree doesn't have IgnoreCase backreferences, then we keep _textInfo as null.
-            _textInfo = tree.Culture?.TextInfo;
+            // We use the CultureInfo field from the tree's culture which will only be set to an actual culture if the
+            // tree contains IgnoreCase backreferences. If the tree doesn't have IgnoreCase backreferences, then we keep _culture as null.
+            _culture = tree.Culture;
             // Generate and store the RegexInterpretedCode for the RegexTree and the specified culture
             _code = RegexWriter.Write(tree);
         }
 
         protected internal override RegexRunner CreateInstance() =>
             // Create a new interpreter instance.
-            new RegexInterpreter(_code, _textInfo);
+            new RegexInterpreter(_code, _culture);
     }
 
     /// <summary>Executes a block of regular expression codes while consuming input.</summary>
@@ -34,18 +34,18 @@ namespace System.Text.RegularExpressions
         private const int LoopTimeoutCheckCount = 2048; // conservative value to provide reasonably-accurate timeout handling.
 
         private readonly RegexInterpreterCode _code;
-        private readonly TextInfo? _textInfo;
+        private readonly CultureInfo? _culture;
 
         private RegexOpcode _operator;
         private int _codepos;
         private bool _rightToLeft;
 
-        public RegexInterpreter(RegexInterpreterCode code, TextInfo? textInfo)
+        public RegexInterpreter(RegexInterpreterCode code, CultureInfo? culture)
         {
             Debug.Assert(code != null, "code must not be null.");
 
             _code = code;
-            _textInfo = textInfo;
+            _culture = culture;
         }
 
         protected override void InitTrackCount() => runtrackcount = _code.TrackCount;
@@ -300,13 +300,29 @@ namespace System.Text.RegularExpressions
             }
             else
             {
-                Debug.Assert(_textInfo != null, "If the pattern has backreferences and is IgnoreCase, then _textInfo must not be null.");
-                TextInfo ti = _textInfo;
                 while (c-- != 0)
                 {
-                    if (ti.ToLower(inputSpan[--cmpos]) != ti.ToLower(inputSpan[--pos]))
+                    char backreferenceChar = inputSpan[--cmpos];
+                    char currentChar = inputSpan[--pos];
+                    // If we are evaluating a backreference case-insensitive match, we first check if the characters at the position
+                    // are the same character.
+                    if (backreferenceChar != currentChar)
                     {
-                        return false;
+                        // If they are not the same character, then we need to check if the backreference character participates in case conversion
+                        // and if so, we need to fetch the case equivalences from our casing tables.
+                        Debug.Assert(_culture != null, "If the pattern has backreferences and is IgnoreCase, then _culture must not be null.");
+                        if (RegexCaseEquivalences.TryFindCaseEquivalencesForCharWithIBehavior(backreferenceChar, _culture, out ReadOnlySpan<char> equivalences))
+                        {
+                            // If the backreference character participates in case conversion, we use IndexOfAny to see if currentChar matches one of the
+                            // equivalences from our casing table.
+                            if (inputSpan.Slice(pos, 1).IndexOfAny(equivalences) == -1)
+                                return false;
+                        }
+                        else
+                        {
+                            // If the backreference character does not participate in case conversions we fail to match.
+                            return false;
+                        }
                     }
                 }
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -29,6 +29,7 @@ namespace System.Text.RegularExpressions
         private readonly string _pattern;
         private int _currentPos;
         private readonly CultureInfo _culture;
+        private RegexCaseBehavior _caseBehavior;
         private bool _hasIgnoreCaseBackreferenceNodes;
 
         private int _autocap;
@@ -58,6 +59,7 @@ namespace System.Text.RegularExpressions
             _pattern = pattern;
             _options = options;
             _culture = culture;
+            _caseBehavior = default;
             _hasIgnoreCaseBackreferenceNodes = false;
             _caps = caps;
             _capsize = capsize;
@@ -1358,7 +1360,7 @@ namespace System.Text.RegularExpressions
             ch = ScanCharEscape();
 
             return !scanOnly ?
-                RegexNode.CreateOneWithCaseConversion(ch, _options, _culture) :
+                RegexNode.CreateOneWithCaseConversion(ch, _options, _culture, ref _caseBehavior) :
                 null;
         }
 
@@ -1369,7 +1371,7 @@ namespace System.Text.RegularExpressions
         {
             if (CharsRight() == 0)
             {
-                return RegexNode.CreateOneWithCaseConversion('$', _options, _culture);
+                return RegexNode.CreateOneWithCaseConversion('$', _options, _culture, ref _caseBehavior);
             }
 
             char ch = RightChar();
@@ -1459,7 +1461,7 @@ namespace System.Text.RegularExpressions
                 {
                     case '$':
                         MoveRight();
-                        return RegexNode.CreateOneWithCaseConversion('$', _options, _culture);
+                        return RegexNode.CreateOneWithCaseConversion('$', _options, _culture, ref _caseBehavior);
 
                     case '&':
                         capnum = 0;
@@ -1492,7 +1494,7 @@ namespace System.Text.RegularExpressions
             // unrecognized $: literalize
 
             Textto(backpos);
-            return RegexNode.CreateOneWithCaseConversion('$', _options, _culture);
+            return RegexNode.CreateOneWithCaseConversion('$', _options, _culture, ref _caseBehavior);
         }
 
         /*
@@ -2135,7 +2137,7 @@ namespace System.Text.RegularExpressions
                     return;
 
                 case 1:
-                    _concatenation!.AddChild(RegexNode.CreateOneWithCaseConversion(_pattern[pos], isReplacement ? _options & ~RegexOptions.IgnoreCase : _options, _culture));
+                    _concatenation!.AddChild(RegexNode.CreateOneWithCaseConversion(_pattern[pos], isReplacement ? _options & ~RegexOptions.IgnoreCase : _options, _culture, ref _caseBehavior));
                     break;
 
                 case > 1 when !UseOptionI() || isReplacement || !RegexCharClass.ParticipatesInCaseConversion(_pattern.AsSpan(pos, cch)):
@@ -2145,7 +2147,7 @@ namespace System.Text.RegularExpressions
                 default:
                     foreach (char c in _pattern.AsSpan(pos, cch))
                     {
-                        _concatenation!.AddChild(RegexNode.CreateOneWithCaseConversion(c, _options, _culture));
+                        _concatenation!.AddChild(RegexNode.CreateOneWithCaseConversion(c, _options, _culture, ref _caseBehavior));
                     }
                     break;
             }
@@ -2229,7 +2231,7 @@ namespace System.Text.RegularExpressions
         private RegexNode? Unit() => _unit;
 
         /// <summary>Sets the current unit to a single char node</summary>
-        private void AddUnitOne(char ch) => _unit = RegexNode.CreateOneWithCaseConversion(ch, _options, _culture);
+        private void AddUnitOne(char ch) => _unit = RegexNode.CreateOneWithCaseConversion(ch, _options, _culture, ref _caseBehavior);
 
         /// <summary>Sets the current unit to a subtree</summary>
         private void AddUnitNode(RegexNode node) => _unit = node;

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexIgnoreCaseTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexIgnoreCaseTests.cs
@@ -13,8 +13,6 @@ namespace System.Text.RegularExpressions.Tests
 {
     public class RegexIgnoreCaseTests
     {
-        public static bool IsIcuGlobalization = PlatformDetection.IsIcuGlobalization;
-
         public static IEnumerable<(string, string)> CharactersWithSameLowercase()
         {
             return new (string, string)[]
@@ -57,11 +55,6 @@ namespace System.Text.RegularExpressions.Tests
             {
                 // Browser runs in Invariant mode, so only test Invariant in that case.
                 if (PlatformDetection.IsBrowser && culture != "")
-                    continue;
-
-                // NLS globalization uses different mappings for invariant culture for some characters so we skip that for now.
-                // https://github.com/dotnet/runtime/issues/67624
-                if (PlatformDetection.IsNlsGlobalization && culture == "")
                     continue;
 
                 foreach ((string firstChar, string secondChar) in CharactersWithSameLowercase())
@@ -160,8 +153,7 @@ namespace System.Text.RegularExpressions.Tests
         // This test takes a long time to run since it needs to compute all possible lowercase mappings across
         // 3 different cultures and then creates Regex matches for all of our engines for each mapping.
         [OuterLoop]
-        // Disabling test in NLS-globalization systems due to https://github.com/dotnet/runtime/issues/67624
-        [ConditionalTheory(nameof(IsIcuGlobalization))]
+        [Theory]
         [MemberData(nameof(Unicode_IgnoreCase_TestData))]
         public async Task Unicode_IgnoreCase_Tests(RegexEngine engine, string culture, RegexOptions options)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/67624

This change will now make it so we no longer have a potential inconsistency between how we evaluate case comparisons with regular characters vs how we do it for backreferences by making sure the latter also use the same RegexCaseEquivalence table. This change will also make it so that the SourceGenerator won't be able to create a custom regex-derived type if a pattern is case-insensitive and contains backreferences, given the Regex Case equivalence table is internal.