### PR TITLE
[LibraryImportGenerator] Fix pointer array marshalling

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ArrayMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ArrayMarshaller.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Interop
         {
             (string managedIdentifer, string nativeIdentifier) = context.GetIdentifiers(info);
             string byRefIdentifier = $"__byref_{managedIdentifer}";
-            TypeSyntax arrayElementType = _elementType;
+            TypeSyntax arrayElementType = _elementType is PointerTypeSyntax ? PredefinedType(Token(SyntaxKind.ByteKeyword)) : _elementType;
             if (context.CurrentStage == StubCodeContext.Stage.Marshal)
             {
                 // [COMPAT] We use explicit byref calculations here instead of just using a fixed statement

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ArrayMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ArrayMarshaller.cs
@@ -82,7 +82,11 @@ namespace Microsoft.Interop
         {
             (string managedIdentifer, string nativeIdentifier) = context.GetIdentifiers(info);
             string byRefIdentifier = $"__byref_{managedIdentifer}";
-            TypeSyntax arrayElementType = _elementType is PointerTypeSyntax ? PredefinedType(Token(SyntaxKind.ByteKeyword)) : _elementType;
+
+            // The element type here is used only for refs/pointers. In the pointer array case, we use byte as the basic placeholder type,
+            // since we can't use pointer types in generic type parameters.
+            bool isPointerArray = info.ManagedType is SzArrayType arrayType && arrayType.ElementTypeInfo is PointerTypeInfo;
+            TypeSyntax arrayElementType = isPointerArray ? PredefinedType(Token(SyntaxKind.ByteKeyword)) : _elementType;
             if (context.CurrentStage == StubCodeContext.Stage.Marshal)
             {
                 // [COMPAT] We use explicit byref calculations here instead of just using a fixed statement

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
@@ -712,7 +712,7 @@ namespace Microsoft.Interop
                                             new[]
                                             {
                                                 PredefinedType(Token(SyntaxKind.ByteKeyword)),
-                                                _elementType is PointerTypeSyntax ? MarshallerHelpers.SystemIntPtrType : _elementType
+                                                _elementType
                                             })))))
                         .AddArgumentListArguments(
                             Argument(
@@ -760,7 +760,7 @@ namespace Microsoft.Interop
                                                 new[]
                                                 {
                                                     PredefinedType(Token(SyntaxKind.ByteKeyword)),
-                                                    _elementType is PointerTypeSyntax ? MarshallerHelpers.SystemIntPtrType : _elementType
+                                                    _elementType
                                                 })))))
                             .AddArgumentListArguments(
                                 Argument(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
@@ -712,7 +712,7 @@ namespace Microsoft.Interop
                                             new[]
                                             {
                                                 PredefinedType(Token(SyntaxKind.ByteKeyword)),
-                                                _elementType
+                                                _elementType is PointerTypeSyntax ? MarshallerHelpers.SystemIntPtrType : _elementType
                                             })))))
                         .AddArgumentListArguments(
                             Argument(
@@ -760,7 +760,7 @@ namespace Microsoft.Interop
                                                 new[]
                                                 {
                                                     PredefinedType(Token(SyntaxKind.ByteKeyword)),
-                                                    _elementType
+                                                    _elementType is PointerTypeSyntax ? MarshallerHelpers.SystemIntPtrType : _elementType
                                                 })))))
                             .AddArgumentListArguments(
                                 Argument(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
@@ -816,6 +816,13 @@ namespace Microsoft.Interop
 
             ITypeSymbol? nativeValueType = ManualTypeMarshallingHelper.FindToNativeValueMethod(arrayMarshaller)?.ReturnType;
 
+            INamedTypeSymbol readOnlySpanOfT = _compilation.GetTypeByMetadataName(TypeNames.System_ReadOnlySpan_Metadata)!;
+            if (!ManualTypeMarshallingHelper.TryGetElementTypeFromLinearCollectionMarshaller(arrayMarshaller, readOnlySpanOfT, out elementType))
+            {
+                Debug.Fail("Runtime-provided array marshallers should have a valid shape");
+                return NoMarshallingInfo.Instance;
+            }
+
             return new NativeLinearCollectionMarshallingInfo(
                 NativeMarshallingType: ManagedTypeInfo.CreateTypeInfoForTypeSymbol(arrayMarshaller),
                 NativeValueType: nativeValueType is not null ? ManagedTypeInfo.CreateTypeInfoForTypeSymbol(nativeValueType) : null,

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
@@ -55,6 +55,18 @@ namespace LibraryImportGenerator.UnitTests
             yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers<double>() };
             yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers<IntPtr>() };
             yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers<UIntPtr>() };
+            yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers("byte*", "unsafe") };
+            yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers("sbyte*", "unsafe") };
+            yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers("short*", "unsafe") };
+            yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers("ushort*", "unsafe") };
+            yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers("int*", "unsafe") };
+            yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers("uint*", "unsafe") };
+            yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers("long*", "unsafe") };
+            yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers("ulong*", "unsafe") };
+            yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers("float*", "unsafe") };
+            yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers("double*", "unsafe") };
+            yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers("System.IntPtr*", "unsafe") };
+            yield return new[] { CodeSnippets.MarshalAsArrayParametersAndModifiers("System.UIntPtr*", "unsafe") };
             yield return new[] { CodeSnippets.MarshalAsArrayParameterWithSizeParam<byte>(isByRef: false) };
             yield return new[] { CodeSnippets.MarshalAsArrayParameterWithSizeParam<sbyte>(isByRef: false) };
             yield return new[] { CodeSnippets.MarshalAsArrayParameterWithSizeParam<short>(isByRef: false) };

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/Arrays.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/Arrays.cs
@@ -63,6 +63,53 @@ namespace NativeExports
             *res = CreateRangeImpl(start, end, numValues);
         }
 
+        [UnmanagedCallersOnly(EntryPoint = "sum_int_ptr_array")]
+        public static int SumPointers(int** values, int numValues)
+        {
+            if (values == null)
+                return -1;
+
+            int sum = 0;
+            for (int i = 0; i < numValues; i++)
+            {
+                sum += *values[i];
+            }
+            return sum;
+        }
+
+        [UnmanagedCallersOnly(EntryPoint = "sum_int_ptr_array_ref")]
+        public static int SumInPointers(int*** values, int numValues)
+        {
+            if (*values == null)
+                return -1;
+
+            int sum = 0;
+            for (int i = 0; i < numValues; i++)
+            {
+                sum += *(*values)[i];
+            }
+            return sum;
+        }
+
+        [UnmanagedCallersOnly(EntryPoint = "duplicate_int_ptr_array")]
+        public static void DuplicatePointers(int*** values, int numValues)
+        {
+            int sizeInBytes = sizeof(int*) * numValues;
+            int** newArray = (int**)Marshal.AllocCoTaskMem(sizeInBytes);
+            new Span<byte>(*values, sizeInBytes).CopyTo(new Span<byte>(newArray, sizeInBytes));
+            Marshal.FreeCoTaskMem((IntPtr)(*values));
+            *values = newArray;
+        }
+
+        [UnmanagedCallersOnly(EntryPoint = "return_duplicate_int_ptr_array")]
+        public static int** ReturnDuplicatePointers(int** values, int numValues)
+        {
+            int sizeInBytes = sizeof(int*) * numValues;
+            int** newArray = (int**)Marshal.AllocCoTaskMem(sizeInBytes);
+            new Span<byte>(values, sizeInBytes).CopyTo(new Span<byte>(newArray, sizeInBytes));
+            return newArray;
+        }
+
         [UnmanagedCallersOnly(EntryPoint = "fill_range_array")]
         [DNNE.C99DeclCode("struct int_struct_wrapper;")]
         public static byte FillRange([DNNE.C99Type("struct int_struct_wrapper*")] IntStructWrapperNative* numValues, int length, int start)


### PR DESCRIPTION
We were generating code that wouldn't compile due to trying to use a pointer type as a generic type param. This makes the generated code use byte for the pinning path and IntPtr for the linear collection marshalling path.

Example difference in generated code:

Pinning:
```diff
public static partial void Test(int*[] arr)
{
-   ref int* __byref_arr = ref (arr == null ? ref *(int**)0 : ref System.Runtime.InteropServices.MemoryMarshal.GetArrayDataReference(arr));
-   fixed (byte* __arr_gen_native = &System.Runtime.CompilerServices.Unsafe.As<int*, byte>(ref __byref_arr))
+   ref byte __byref_arr = ref (arr == null ? ref *(byte*)0 : ref System.Runtime.InteropServices.MemoryMarshal.GetArrayDataReference(arr));
+   fixed (byte* __arr_gen_native = &__byref_arr)
    ...
}
```
Non-pinning:
```diff
public static partial void Test(ref int*[] values)
{
    byte* __values_gen_native = default;
    global::System.Runtime.InteropServices.GeneratedMarshalling.PtrArrayMarshaller<int> __values_gen_native__marshaller = default;
    try
    {
-       __values_gen_native__marshaller = new(values, sizeof(int*));
-       __values_gen_native__marshaller.GetManagedValuesSource().CopyTo(System.Runtime.InteropServices.MemoryMarshal.Cast<byte, int*>(__values_gen_native__marshaller.GetNativeValuesDestination()));
+       __values_gen_native__marshaller = new(values, sizeof(global::System.IntPtr)); 
+       __values_gen_native__marshaller.GetManagedValuesSource().CopyTo(System.Runtime.InteropServices.MemoryMarshal.Cast<byte, global::System.IntPtr>(__values_gen_native__marshaller.GetNativeValuesDestination()));
        __values_gen_native = __values_gen_native__marshaller.ToNativeValue();
        __PInvoke__(&__values_gen_native);

        __values_gen_native__marshaller.FromNativeValue(__values_gen_native);
        int __values_gen_native__marshaller__numElements = 1;
-       System.Runtime.InteropServices.MemoryMarshal.Cast<byte, int*>(__values_gen_native__marshaller.GetNativeValuesSource(__values_gen_native__marshaller__numElements)).CopyTo(__values_gen_native__marshaller.GetManagedValuesDestination(__values_gen_native__marshaller__numElements));
+       System.Runtime.InteropServices.MemoryMarshal.Cast<byte, global::System.IntPtr>(__values_gen_native__marshaller.GetNativeValuesSource(__values_gen_native__marshaller__numElements)).CopyTo(__values_gen_native__marshaller.GetManagedValuesDestination(__values_gen_native__marshaller__numElements));
        values = __values_gen_native__marshaller.ToManaged();
    }
    ...
}
```