### PR TITLE
Fix PGO trace data collection in the presence of collectible assemblies

### DIFF
--- a/src/coreclr/inc/pgo_formatprocessing.h
+++ b/src/coreclr/inc/pgo_formatprocessing.h
@@ -568,7 +568,7 @@ public:
                     logicalDataToWrite = *(volatile intptr_t*)pData;
 
                     // As there could be tearing otherwise, inform the caller of exactly what value was written.
-                    logicalDataToWrite = thProcessor(logicalDataToWrite);
+                    thProcessor(logicalDataToWrite);
 
                     bool returnValue = WriteCompressedIntToBytes(logicalDataToWrite - lastTypeDataWritten, byteWriter);
                     lastTypeDataWritten = logicalDataToWrite;

--- a/src/coreclr/inc/pgo_formatprocessing.h
+++ b/src/coreclr/inc/pgo_formatprocessing.h
@@ -568,7 +568,7 @@ public:
                     logicalDataToWrite = *(volatile intptr_t*)pData;
 
                     // As there could be tearing otherwise, inform the caller of exactly what value was written.
-                    thProcessor(logicalDataToWrite);
+                    logicalDataToWrite = thProcessor(logicalDataToWrite);
 
                     bool returnValue = WriteCompressedIntToBytes(logicalDataToWrite - lastTypeDataWritten, byteWriter);
                     lastTypeDataWritten = logicalDataToWrite;

--- a/src/coreclr/vm/pgo.cpp
+++ b/src/coreclr/vm/pgo.cpp
@@ -121,7 +121,8 @@ public:
 
         auto lambda = [&](int64_t thWritten)
         {
-            if (ICorJitInfo::IsUnknownTypeHandle(thWritten)) return (intptr_t)0;
+            if (ICorJitInfo::IsUnknownTypeHandle(thWritten)) return;
+
             if (thWritten != 0)
             {
                 TypeHandle th = *(TypeHandle*)&thWritten;
@@ -130,7 +131,7 @@ public:
                     typeHandlesEncountered.Append(th);
                 }
             }
-            return thWritten;
+            return;
         };
 
         if (!writer.AppendDataFromLastSchema(lambda))

--- a/src/coreclr/vm/pgo.cpp
+++ b/src/coreclr/vm/pgo.cpp
@@ -6,8 +6,8 @@
 #include "pgo.h"
 #include "versionresilienthashcode.h"
 #include "typestring.h"
-#pragma optimize("", off)
 #include "pgo_formatprocessing.h"
+
 #ifdef FEATURE_PGO
 
 // Data structure for holding pgo data


### PR DESCRIPTION
We didn't handle unknown type handles in the data. Currently this can only happen for collectible assemblies.

Fixes #67877 