### PR TITLE
re-enable TLS 13 tests on Windows

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -146,9 +146,9 @@
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
       <Sha>971b917c6c2061ea6a747f0345ac86882c02c466</Sha>
     </Dependency>
-    <Dependency Name="System.Net.TestData" Version="7.0.0-beta.22179.2">
+    <Dependency Name="System.Net.TestData" Version="7.0.0-beta.22213.1">
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
-      <Sha>971b917c6c2061ea6a747f0345ac86882c02c466</Sha>
+      <Sha>2e12dc95e1c286961eaea774cf26c1f29098fb43</Sha>
     </Dependency>
     <Dependency Name="System.Private.Runtime.UnicodeData" Version="7.0.0-beta.22179.2">
       <Uri>https://github.com/dotnet/runtime-assets</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -132,7 +132,7 @@
     <SystemDrawingCommonTestDataVersion>7.0.0-beta.22179.2</SystemDrawingCommonTestDataVersion>
     <SystemIOCompressionTestDataVersion>7.0.0-beta.22179.2</SystemIOCompressionTestDataVersion>
     <SystemIOPackagingTestDataVersion>7.0.0-beta.22179.2</SystemIOPackagingTestDataVersion>
-    <SystemNetTestDataVersion>7.0.0-beta.22179.2</SystemNetTestDataVersion>
+    <SystemNetTestDataVersion>7.0.0-beta.22213.1</SystemNetTestDataVersion>
     <SystemPrivateRuntimeUnicodeDataVersion>7.0.0-beta.22179.2</SystemPrivateRuntimeUnicodeDataVersion>
     <SystemRuntimeTimeZoneDataVersion>7.0.0-beta.22179.2</SystemRuntimeTimeZoneDataVersion>
     <SystemSecurityCryptographyX509CertificatesTestDataVersion>7.0.0-beta.22179.2</SystemSecurityCryptographyX509CertificatesTestDataVersion>

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -492,17 +492,10 @@ namespace System.Net.Security.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.SupportsTls13))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/58927", TestPlatforms.Windows)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task SslStream_NegotiateClientCertificateAsyncTls13_Succeeds(bool sendClientCertificate)
         {
-            if (PlatformDetection.IsWindows10Version22000OrGreater)
-            {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/58927")]
-                throw new SkipTestException("Unstable on Windows 11");
-            }
-
             bool negotiateClientCertificateCalled = false;
             using CancellationTokenSource cts = new CancellationTokenSource();
             cts.CancelAfter(TestConfiguration.PassingTestTimeout);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -72,12 +72,6 @@ namespace System.Net.Security.Tests
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "X509 certificate store is not supported on iOS or tvOS.")]
         public async Task SslStream_StreamToStream_Authentication_Success(X509Certificate serverCert = null, X509Certificate clientCert = null)
         {
-            if (PlatformDetection.IsWindows10Version20348OrGreater)
-            {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/58927")]
-                throw new SkipTestException("Unstable on Windows 11");
-            }
-
             (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new SslStream(stream1, false, AllowAnyServerCertificate))
             using (var server = new SslStream(stream2, false, delegate { return true; }))

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
@@ -78,12 +78,6 @@ namespace System.Net.Security.Tests
         [MemberData(nameof(OneOrBothUseDefaulData))]
         public async Task ClientAndServer_OneOrBothUseDefault_Ok(SslProtocols? clientProtocols, SslProtocols? serverProtocols)
         {
-            if (PlatformDetection.IsWindows10Version20348OrGreater)
-            {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/58927")]
-                throw new SkipTestException("Unstable on Windows 11");
-            }
-
             using (X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate())
             using (X509Certificate2 clientCertificate = Configuration.Certificates.GetClientCertificate())
             {


### PR DESCRIPTION
While the underlying issue lives in Schannel and it is being fixed in Windows the root analyses points to certificates with CAPI provider. That works fine for previous TLS versions but it fails for TLS 1.3 as that is somehow different. 

This change brings new pfx files from https://github.com/dotnet/runtime-assets/pull/234
With updated data (essentially still same certificate) everything seems to be stable. 

This is only fix for the 
```
---- System.ComponentModel.Win32Exception : The Local Security Authority cannot be contacted
```

other (recent server 2022) failures are unrelated to this.

fixes #58927