### PR TITLE
Signal event occured based on expected paths, instead of throw

### DIFF
--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
@@ -40,24 +40,15 @@ namespace System.IO.Tests
             FileSystemEventHandler changeHandler = (o, e) =>
             {
                 Assert.Equal(WatcherChangeTypes.Changed, e.ChangeType);
-                VerifyExpectedPaths(expectedPaths, e);
-                eventOccurred.Set();
+
+                if (expectedPaths == null || expectedPaths.Contains(e.FullPath))
+                {
+                    eventOccurred.Set();
+                }
             };
 
             watcher.Changed += changeHandler;
             return (eventOccurred, changeHandler);
-        }
-
-        private static void VerifyExpectedPaths(string[] expectedPaths, FileSystemEventArgs e)
-        {
-            string fullPath = Path.GetFullPath(e.FullPath);
-            if (expectedPaths is not null && !expectedPaths.Contains(fullPath))
-            {
-                // Assert.Contains does not print a full content of collection which makes it hard to diagnose issues like #65601
-                throw new XunitException($"Expected path(s):{Environment.NewLine}"
-                    + string.Join(Environment.NewLine, expectedPaths)
-                    + $"{Environment.NewLine}Actual path: {fullPath}");
-            }
         }
 
         /// <summary>
@@ -77,9 +68,11 @@ namespace System.IO.Tests
                 }
 
                 Assert.Equal(WatcherChangeTypes.Created, e.ChangeType);
-                VerifyExpectedPaths(expectedPaths, e);
 
-                eventOccurred.Set();
+                if (expectedPaths == null || expectedPaths.Contains(e.FullPath))
+                {
+                    eventOccurred.Set();
+                }
             };
 
             watcher.Created += handler;
@@ -101,9 +94,10 @@ namespace System.IO.Tests
                     Assert.Equal(WatcherChangeTypes.Deleted, e.ChangeType);
                 }
 
-                VerifyExpectedPaths(expectedPaths, e);
-
-                eventOccurred.Set();
+                if (expectedPaths == null || expectedPaths.Contains(e.FullPath))
+                {
+                    eventOccurred.Set();
+                }
             };
 
             watcher.Deleted += handler;
@@ -126,9 +120,10 @@ namespace System.IO.Tests
                     Assert.Equal(WatcherChangeTypes.Renamed, e.ChangeType);
                 }
 
-                VerifyExpectedPaths(expectedPaths, e);
-
-                eventOccurred.Set();
+                if (expectedPaths == null || expectedPaths.Contains(e.FullPath))
+                {
+                    eventOccurred.Set();
+                }
             };
 
             watcher.Renamed += handler;

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
@@ -231,7 +231,7 @@ namespace System.IO.Tests
         /// <param name="expectedPath">Optional. Adds path verification to all expected events.</param>
         public static void ExpectNoEvent(FileSystemWatcher watcher, WatcherChangeTypes unExpectedEvents, Action action, Action cleanup = null, string expectedPath = null, int timeout = WaitForExpectedEventTimeout)
         {
-            bool result = ExecuteAndVerifyEvents(watcher, unExpectedEvents, action, false, new string[] { expectedPath }, timeout);
+            bool result = ExecuteAndVerifyEvents(watcher, unExpectedEvents, action, false, expectedPath == null ? null : new string[] { expectedPath }, timeout);
             Assert.False(result, "Expected Event occured");
 
             if (cleanup != null)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/65601 (https://github.com/dotnet/runtime/pull/68010/commits/6ee72bde1fbba3fb9a0bd36b4c21d7bcfb35bf50)
Fixes https://github.com/dotnet/runtime/issues/67071 (https://github.com/dotnet/runtime/pull/68010/commits/8954c261ff53d99027493d2c7dc1ed912e47a329)