### PR TITLE
Make loop consistent and avoid CodeQL warning

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -3301,7 +3301,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
         }
         C_ASSERT((char)MAX_REG_ARG == MAX_REG_ARG);
         assert(slots < INT8_MAX);
-        for (char i = 1; i < slots; i++)
+        for (int i = 1; i < slots; i++)
         {
             regArgTab[regArgNum + i].varNum = varNum;
             regArgTab[regArgNum + i].slot   = i + 1;

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -3304,7 +3304,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
         for (int i = 1; i < slots; i++)
         {
             regArgTab[regArgNum + i].varNum = varNum;
-            regArgTab[regArgNum + i].slot   = i + 1;
+            regArgTab[regArgNum + i].slot   = static_cast<char>(i + 1);
         }
 #endif // TARGET_ARM
 


### PR DESCRIPTION
This is a false positive given the assert, but I guess the easiest is to just change the type here, which also makes the loop consistent with other similar loops around here.

cc @dotnet/jit-contrib