### PR TITLE
Fix documentation issues in recent DateTime API additions

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -897,7 +897,7 @@ namespace System
         /// whose value is the result of this operation.
         ///
         /// The fractional part of value is the fractional part of a microsecond.
-        /// For example, 4.5 is equivalent to 4 microseconds and 50 ticks, where one microseconds = 10 ticks.
+        /// For example, 4.5 is equivalent to 4 microseconds and 50 ticks, where one microsecond = 10 ticks.
         ///
         /// The value parameter is rounded to the nearest integer.
         /// </remarks>

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -511,7 +511,7 @@ namespace System
         /// <param name="minute">The minutes (0 through 59).</param>
         /// <param name="second">The seconds (0 through 59).</param>
         /// <param name="millisecond">The milliseconds (0 through 999).</param>
-        /// <param name="microsecond">The milliseconds (0 through 900).</param>
+        /// <param name="microsecond">The microseconds (0 through 999).</param>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="year"/> is less than 1 or greater than 9999.
         ///
@@ -541,7 +541,7 @@ namespace System
         ///
         /// -or-
         ///
-        /// <paramref name="microsecond"/> is less than 0 or greater than 900.
+        /// <paramref name="microsecond"/> is less than 0 or greater than 999.
         /// </exception>
         /// <remarks>
         /// This constructor interprets <paramref name="year"/>, <paramref name="month"/> and <paramref name="day"/> as a year, month and day
@@ -569,7 +569,7 @@ namespace System
         /// <param name="minute">The minutes (0 through 59).</param>
         /// <param name="second">The seconds (0 through 59).</param>
         /// <param name="millisecond">The milliseconds (0 through 999).</param>
-        /// <param name="microsecond">The milliseconds (0 through 900).</param>
+        /// <param name="microsecond">The microseconds (0 through 999).</param>
         /// <param name="kind">
         /// One of the enumeration values that indicates whether <paramref name="year"/>, <paramref name="month"/>, <paramref name="day"/>,
         /// <paramref name="hour"/>, <paramref name="minute"/>, <paramref name="second"/>, and <paramref name="millisecond"/>
@@ -603,7 +603,7 @@ namespace System
         ///
         /// -or-
         ///
-        /// <paramref name="microsecond"/> is less than 0 or greater than 900.
+        /// <paramref name="microsecond"/> is less than 0 or greater than 999.
         /// </exception>
         /// <exception cref="ArgumentException">
         /// <paramref name="kind"/> is not one of the <see cref="DateTimeKind"/> values.
@@ -638,7 +638,7 @@ namespace System
         /// <param name="minute">The minutes (0 through 59).</param>
         /// <param name="second">The seconds (0 through 59).</param>
         /// <param name="millisecond">The milliseconds (0 through 999).</param>
-        /// <param name="microsecond">The milliseconds (0 through 900).</param>
+        /// <param name="microsecond">The microseconds (0 through 999).</param>
         /// <param name="calendar">The calendar that is used to interpret <paramref name="year"/>, <paramref name="month"/>, and <paramref name="day"/>.</param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="calendar"/> is <see langword="null"/>
@@ -672,7 +672,7 @@ namespace System
         ///
         /// -or-
         ///
-        /// <paramref name="microsecond"/> is less than 0 or greater than 900.
+        /// <paramref name="microsecond"/> is less than 0 or greater than 999.
         /// </exception>
         /// <remarks>
         /// The allowable values for <paramref name="year"/>, <paramref name="month"/>, and <paramref name="day"/> parameters
@@ -698,7 +698,7 @@ namespace System
         /// <param name="minute">The minutes (0 through 59).</param>
         /// <param name="second">The seconds (0 through 59).</param>
         /// <param name="millisecond">The milliseconds (0 through 999).</param>
-        /// <param name="microsecond">The milliseconds (0 through 900).</param>
+        /// <param name="microsecond">The microseconds (0 through 999).</param>
         /// <param name="calendar">The calendar that is used to interpret <paramref name="year"/>, <paramref name="month"/>, and <paramref name="day"/>.</param>
         /// <param name="kind">
         /// One of the enumeration values that indicates whether <paramref name="year"/>, <paramref name="month"/>, <paramref name="day"/>,
@@ -736,7 +736,7 @@ namespace System
         ///
         /// -or-
         ///
-        /// <paramref name="microsecond"/> is less than 0 or greater than 900.
+        /// <paramref name="microsecond"/> is less than 0 or greater than 999.
         /// </exception>
         /// <exception cref="ArgumentException">
         /// <paramref name="kind"/> is not one of the <see cref="DateTimeKind"/> values.
@@ -1531,7 +1531,7 @@ namespace System
         public int Microsecond => (int)((UTicks / TicksPerMicrosecond) % 1000);
 
         /// <summary>
-        /// The nanoseconds component, expressed as a value between 0 and 900.
+        /// The nanoseconds component, expressed as a value between 0 and 900 (in increments of 100 nanoseconds).
         /// </summary>
         public int Nanosecond => (int)(UTicks % TicksPerMicrosecond) * 100;
 

--- a/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
@@ -238,7 +238,7 @@ namespace System
         /// <paramref name="millisecond"/> is less than 0 or greater than 999.
         /// -or-
         ///
-        /// <paramref name="microsecond"/> is less than 0 or greater than 900.
+        /// <paramref name="microsecond"/> is less than 0 or greater than 999.
         /// </exception>
         public DateTimeOffset(int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond, TimeSpan offset)
             : this(year, month, day, hour, minute, second, millisecond, offset)
@@ -302,7 +302,7 @@ namespace System
         ///
         /// -or-
         ///
-        /// <paramref name="microsecond"/> is less than 0 or greater than 900.
+        /// <paramref name="microsecond"/> is less than 0 or greater than 999.
         ///
         /// -or-
         ///


### PR DESCRIPTION
The microseconds parameter accepts 0-999, not 0-900. This was likely a copy/paste mistake from nanoseconds in #67666

/cc @tarekgh @deeprobin 