### PR TITLE
Fix slow JSON assert

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -25,8 +25,10 @@ namespace System.Text.Json
             bool createExtensionProperty = true)
         {
 #if DEBUG
-            Debug.Assert(state.Current.JsonTypeInfo.PropertyInfoForTypeInfo.ConverterStrategy == ConverterStrategy.Object,
-                GetLookupPropertyDebugInfo(obj, unescapedPropertyName, ref state));
+            if (state.Current.JsonTypeInfo.PropertyInfoForTypeInfo.ConverterStrategy != ConverterStrategy.Object)
+            {
+                Debug.Fail(GetLookupPropertyDebugInfo(obj, unescapedPropertyName, ref state));
+            }
 #endif
 
             useExtensionProperty = false;


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/67878

The string being constructed by this assert substantially slows down the JSON tests, so much that on slow machines they time out.

Before (on my machine) System.Text.Json tests --  34sec .NET 7 tests/208sec .NET Framework tests. Helix only allows 2700 seconds; I guess 32 bit Arm machines are about 10x slower than mine.
After 39/107