### PR TITLE
Use new `TimeSpan.TotalMicroseconds` API in `Socket.ToTimeoutMicroseconds`

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -2178,7 +2178,7 @@ namespace System.Net.Sockets
 
         private static int ToTimeoutMicroseconds(TimeSpan timeout)
         {
-            long totalMicroseconds = timeout.Ticks / 10;
+            long totalMicroseconds = (long)timeout.TotalMicroseconds;
             if (totalMicroseconds < -1 || totalMicroseconds > int.MaxValue)
             {
                 throw new ArgumentOutOfRangeException(nameof(timeout));


### PR DESCRIPTION
In #64860 the new API was missing, which was implemented in #67666 (see <https://github.com/dotnet/runtime/pull/64860#discussion_r831729020>).

This PR is a followup for #64860.

/cc @danmoseley 
/cc @GSPP