### PR TITLE
disable NTLM tests on systems with OpenSSL 3

### DIFF
--- a/src/libraries/Common/tests/System/Net/Capability.Security.Unix.cs
+++ b/src/libraries/Common/tests/System/Net/Capability.Security.Unix.cs
@@ -7,7 +7,9 @@ namespace System.Net.Test.Common
     {
         public static bool IsNtlmInstalled()
         {
-            return Interop.NetSecurityNative.IsNtlmInstalled();
+            // GSS on Linux does not work with OpenSSL 3.0. Fix was submitted to gss-ntlm but it will take a while to make to
+            // all supported distributions. The second part of the check should be removed when it does.
+            return Interop.NetSecurityNative.IsNtlmInstalled() && (!PlatformDetection.IsOpenSslSupported || PlatformDetection.OpenSslVersion.Major < 3);
         }
     }
 }


### PR DESCRIPTION
contributes to #67353. While the underlying issue is in `gss-ntlm` (and was fixed upstream) it will take while to make it to all supported distributions. 
This change effectively disables NTLM tests on Linux with OpenSSL 3.0.
This should allow us to move forward with #67345 and add test queue (like Ubuntu 22) with OpenSSL 3.

cc: @omajid 