### PR TITLE
Adding generic-math tests for decimal and double/single/half to parity the integer tests

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -250,6 +250,7 @@
   <ItemGroup>
     <Compile Include="System\ByteTests.GenericMath.cs" />
     <Compile Include="System\CharTests.GenericMath.cs" />
+    <Compile Include="System\DecimalTests.GenericMath.cs" />
     <Compile Include="System\DoubleTests.GenericMath.cs" />
     <Compile Include="System\GenericMathHelpers.cs" />
     <Compile Include="System\HalfTests.GenericMath.cs" />

--- a/src/libraries/System.Runtime/tests/System/DecimalTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/DecimalTests.GenericMath.cs
@@ -1,0 +1,1142 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Xunit;
+
+namespace System.Tests
+{
+    public class DecimalTests_GenericMath
+    {
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            Assert.Equal(0.0m, AdditiveIdentityHelper<decimal, decimal>.AdditiveIdentity);
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            Assert.Equal(decimal.MinValue, MinMaxValueHelper<decimal>.MinValue);
+        }
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            Assert.Equal(decimal.MaxValue, MinMaxValueHelper<decimal>.MaxValue);
+        }
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            Assert.Equal(1.0m, MultiplicativeIdentityHelper<decimal, decimal>.MultiplicativeIdentity);
+        }
+
+        [Fact]
+        public static void NegativeOneTest()
+        {
+            Assert.Equal(-1.0m, SignedNumberHelper<decimal>.NegativeOne);
+        }
+
+        [Fact]
+        public static void OneTest()
+        {
+            Assert.Equal(1.0m, NumberBaseHelper<decimal>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            Assert.Equal(0.0m, NumberBaseHelper<decimal>.Zero);
+        }
+
+        [Fact]
+        public static void op_AdditionTest()
+        {
+            Assert.Equal(-79228162514264337593543950334.0m, AdditionOperatorsHelper<decimal, decimal, decimal>.op_Addition(decimal.MinValue, 1.0m));
+            Assert.Equal(0.0m, AdditionOperatorsHelper<decimal, decimal, decimal>.op_Addition(-1.0m, 1.0m));
+            Assert.Equal(1.0m, AdditionOperatorsHelper<decimal, decimal, decimal>.op_Addition(-0.0m, 1.0m));
+            Assert.Equal(1.0m, AdditionOperatorsHelper<decimal, decimal, decimal>.op_Addition(0.0m, 1.0m));
+            Assert.Equal(2.0m, AdditionOperatorsHelper<decimal, decimal, decimal>.op_Addition(1.0m, 1.0m));
+
+            Assert.Throws<OverflowException>(() => AdditionOperatorsHelper<decimal, decimal, decimal>.op_Addition(decimal.MaxValue, 1.0m));
+        }
+
+        [Fact]
+        public static void op_CheckedAdditionTest()
+        {
+            Assert.Equal(-79228162514264337593543950334.0m, AdditionOperatorsHelper<decimal, decimal, decimal>.op_CheckedAddition(decimal.MinValue, 1.0m));
+            Assert.Equal(0.0m, AdditionOperatorsHelper<decimal, decimal, decimal>.op_CheckedAddition(-1.0m, 1.0m));
+            Assert.Equal(1.0m, AdditionOperatorsHelper<decimal, decimal, decimal>.op_CheckedAddition(-0.0m, 1.0m));
+            Assert.Equal(1.0m, AdditionOperatorsHelper<decimal, decimal, decimal>.op_CheckedAddition(0.0m, 1.0m));
+            Assert.Equal(2.0m, AdditionOperatorsHelper<decimal, decimal, decimal>.op_CheckedAddition(1.0m, 1.0m));
+
+            Assert.Throws<OverflowException>(() => AdditionOperatorsHelper<decimal, decimal, decimal>.op_CheckedAddition(decimal.MaxValue, 1.0m));
+        }
+
+        [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThan(decimal.MinValue, 1.0m));
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThan(-1.0m, 1.0m));
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThan(-0.0m, 1.0m));
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThan(0.0m, 1.0m));
+            Assert.False(ComparisonOperatorsHelper<decimal, decimal>.op_LessThan(1.0m, 1.0m));
+            Assert.False(ComparisonOperatorsHelper<decimal, decimal>.op_LessThan(decimal.MaxValue, 1.0m));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThanOrEqual(decimal.MinValue, 1.0m));
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThanOrEqual(-1.0m, 1.0m));
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThanOrEqual(-0.0m, 1.0m));
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThanOrEqual(0.0m, 1.0m));
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_LessThanOrEqual(1.0m, 1.0m));
+            Assert.False(ComparisonOperatorsHelper<decimal, decimal>.op_LessThanOrEqual(decimal.MaxValue, 1.0m));
+        }
+
+        [Fact]
+        public static void op_GreaterThanTest()
+        {
+            Assert.False(ComparisonOperatorsHelper<decimal, decimal>.op_GreaterThan(decimal.MinValue, 1.0m));
+            Assert.False(ComparisonOperatorsHelper<decimal, decimal>.op_GreaterThan(-1.0m, 1.0m));
+            Assert.False(ComparisonOperatorsHelper<decimal, decimal>.op_GreaterThan(-0.0m, 1.0m));
+            Assert.False(ComparisonOperatorsHelper<decimal, decimal>.op_GreaterThan(0.0m, 1.0m));
+            Assert.False(ComparisonOperatorsHelper<decimal, decimal>.op_GreaterThan(1.0m, 1.0m));
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_GreaterThan(decimal.MaxValue, 1.0m));
+        }
+
+        [Fact]
+        public static void op_GreaterThanOrEqualTest()
+        {
+            Assert.False(ComparisonOperatorsHelper<decimal, decimal>.op_GreaterThanOrEqual(decimal.MinValue, 1.0m));
+            Assert.False(ComparisonOperatorsHelper<decimal, decimal>.op_GreaterThanOrEqual(-1.0m, 1.0m));
+            Assert.False(ComparisonOperatorsHelper<decimal, decimal>.op_GreaterThanOrEqual(-0.0m, 1.0m));
+            Assert.False(ComparisonOperatorsHelper<decimal, decimal>.op_GreaterThanOrEqual(0.0m, 1.0m));
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_GreaterThanOrEqual(1.0m, 1.0m));
+            Assert.True(ComparisonOperatorsHelper<decimal, decimal>.op_GreaterThanOrEqual(decimal.MaxValue, 1.0m));
+        }
+
+        [Fact]
+        public static void op_DecrementTest()
+        {
+            Assert.Equal(-2.0m, DecrementOperatorsHelper<decimal>.op_Decrement(-1.0m));
+            Assert.Equal(-1.0m, DecrementOperatorsHelper<decimal>.op_Decrement(-0.0m));
+            Assert.Equal(-1.0m, DecrementOperatorsHelper<decimal>.op_Decrement(0.0m));
+            Assert.Equal(0.0m, DecrementOperatorsHelper<decimal>.op_Decrement(1.0m));
+            Assert.Equal(79228162514264337593543950334.0m, DecrementOperatorsHelper<decimal>.op_Decrement(decimal.MaxValue));
+
+            Assert.Throws<OverflowException>(() => DecrementOperatorsHelper<decimal>.op_Decrement(decimal.MinValue));
+        }
+
+        [Fact]
+        public static void op_CheckedDecrementTest()
+        {
+            Assert.Equal(-2.0m, DecrementOperatorsHelper<decimal>.op_CheckedDecrement(-1.0m));
+            Assert.Equal(-1.0m, DecrementOperatorsHelper<decimal>.op_CheckedDecrement(-0.0m));
+            Assert.Equal(-1.0m, DecrementOperatorsHelper<decimal>.op_CheckedDecrement(0.0m));
+            Assert.Equal(0.0m, DecrementOperatorsHelper<decimal>.op_CheckedDecrement(1.0m));
+            Assert.Equal(79228162514264337593543950334.0m, DecrementOperatorsHelper<decimal>.op_CheckedDecrement(decimal.MaxValue));
+
+            Assert.Throws<OverflowException>(() => DecrementOperatorsHelper<decimal>.op_CheckedDecrement(decimal.MinValue));
+        }
+
+        [Fact]
+        public static void op_DivisionTest()
+        {
+            Assert.Equal(-39614081257132168796771975168.0m, DivisionOperatorsHelper<decimal, decimal, decimal>.op_Division(decimal.MinValue, 2.0m));
+            Assert.Equal(-0.5m, DivisionOperatorsHelper<decimal, decimal, decimal>.op_Division(-1.0m, 2.0m));
+            Assert.Equal(-0.0m, DivisionOperatorsHelper<decimal, decimal, decimal>.op_Division(-0.0m, 2.0m));
+            Assert.Equal(0.0m, DivisionOperatorsHelper<decimal, decimal, decimal>.op_Division(0.0m, 2.0m));
+            Assert.Equal(0.5m, DivisionOperatorsHelper<decimal, decimal, decimal>.op_Division(1.0m, 2.0m));
+            Assert.Equal(39614081257132168796771975168.0m, DivisionOperatorsHelper<decimal, decimal, decimal>.op_Division(decimal.MaxValue, 2.0m));
+        }
+
+        [Fact]
+        public static void op_CheckedDivisionTest()
+        {
+            Assert.Equal(-39614081257132168796771975168.0m, DivisionOperatorsHelper<decimal, decimal, decimal>.op_CheckedDivision(decimal.MinValue, 2.0m));
+            Assert.Equal(-0.5m, DivisionOperatorsHelper<decimal, decimal, decimal>.op_CheckedDivision(-1.0m, 2.0m));
+            Assert.Equal(-0.0m, DivisionOperatorsHelper<decimal, decimal, decimal>.op_CheckedDivision(-0.0m, 2.0m));
+            Assert.Equal(0.0m, DivisionOperatorsHelper<decimal, decimal, decimal>.op_CheckedDivision(0.0m, 2.0m));
+            Assert.Equal(0.5m, DivisionOperatorsHelper<decimal, decimal, decimal>.op_CheckedDivision(1.0m, 2.0m));
+            Assert.Equal(39614081257132168796771975168.0m, DivisionOperatorsHelper<decimal, decimal, decimal>.op_CheckedDivision(decimal.MaxValue, 2.0m));
+        }
+
+        [Fact]
+        public static void op_EqualityTest()
+        {
+            Assert.False(EqualityOperatorsHelper<decimal, decimal>.op_Equality(decimal.MinValue, 1.0m));
+            Assert.False(EqualityOperatorsHelper<decimal, decimal>.op_Equality(-1.0m, 1.0m));
+            Assert.False(EqualityOperatorsHelper<decimal, decimal>.op_Equality(-0.0m, 1.0m));
+            Assert.False(EqualityOperatorsHelper<decimal, decimal>.op_Equality(0.0m, 1.0m));
+            Assert.True(EqualityOperatorsHelper<decimal, decimal>.op_Equality(1.0m, 1.0m));
+            Assert.False(EqualityOperatorsHelper<decimal, decimal>.op_Equality(decimal.MaxValue, 1.0m));
+        }
+
+        [Fact]
+        public static void op_InequalityTest()
+        {
+            Assert.True(EqualityOperatorsHelper<decimal, decimal>.op_Inequality(decimal.MinValue, 1.0m));
+            Assert.True(EqualityOperatorsHelper<decimal, decimal>.op_Inequality(-1.0m, 1.0m));
+            Assert.True(EqualityOperatorsHelper<decimal, decimal>.op_Inequality(-0.0m, 1.0m));
+            Assert.True(EqualityOperatorsHelper<decimal, decimal>.op_Inequality(0.0m, 1.0m));
+            Assert.False(EqualityOperatorsHelper<decimal, decimal>.op_Inequality(1.0m, 1.0m));
+            Assert.True(EqualityOperatorsHelper<decimal, decimal>.op_Inequality(decimal.MaxValue, 1.0m));
+        }
+
+        [Fact]
+        public static void op_IncrementTest()
+        {
+            Assert.Equal(-79228162514264337593543950334.0m, IncrementOperatorsHelper<decimal>.op_Increment(decimal.MinValue));
+            Assert.Equal(0.0m, IncrementOperatorsHelper<decimal>.op_Increment(-1.0m));
+            Assert.Equal(1.0m, IncrementOperatorsHelper<decimal>.op_Increment(-0.0m));
+            Assert.Equal(1.0m, IncrementOperatorsHelper<decimal>.op_Increment(0.0m));
+            Assert.Equal(2.0m, IncrementOperatorsHelper<decimal>.op_Increment(1.0m));
+
+            Assert.Throws<OverflowException>(() => IncrementOperatorsHelper<decimal>.op_Increment(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void op_CheckedIncrementTest()
+        {
+            Assert.Equal(-79228162514264337593543950334.0m, IncrementOperatorsHelper<decimal>.op_CheckedIncrement(decimal.MinValue));
+            Assert.Equal(0.0m, IncrementOperatorsHelper<decimal>.op_CheckedIncrement(-1.0m));
+            Assert.Equal(1.0m, IncrementOperatorsHelper<decimal>.op_CheckedIncrement(-0.0m));
+            Assert.Equal(1.0m, IncrementOperatorsHelper<decimal>.op_CheckedIncrement(0.0m));
+            Assert.Equal(2.0m, IncrementOperatorsHelper<decimal>.op_CheckedIncrement(1.0m));
+
+            Assert.Throws<OverflowException>(() => IncrementOperatorsHelper<decimal>.op_CheckedIncrement(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void op_ModulusTest()
+        {
+            Assert.Equal(-1.0m, ModulusOperatorsHelper<decimal, decimal, decimal>.op_Modulus(decimal.MinValue, 2.0m));
+            Assert.Equal(-1.0m, ModulusOperatorsHelper<decimal, decimal, decimal>.op_Modulus(-1.0m, 2.0m));
+            Assert.Equal(-0.0m, ModulusOperatorsHelper<decimal, decimal, decimal>.op_Modulus(-0.0m, 2.0m));
+            Assert.Equal(0.0m, ModulusOperatorsHelper<decimal, decimal, decimal>.op_Modulus(0.0m, 2.0m));
+            Assert.Equal(1.0m, ModulusOperatorsHelper<decimal, decimal, decimal>.op_Modulus(1.0m, 2.0m));
+            Assert.Equal(1.0m, ModulusOperatorsHelper<decimal, decimal, decimal>.op_Modulus(decimal.MaxValue, 2.0m));
+        }
+
+        [Fact]
+        public static void op_MultiplyTest()
+        {
+            Assert.Equal(-2.0m, MultiplyOperatorsHelper<decimal, decimal, decimal>.op_Multiply(-1.0m, 2.0m));
+            Assert.Equal(-0.0m, MultiplyOperatorsHelper<decimal, decimal, decimal>.op_Multiply(-0.0m, 2.0m));
+            Assert.Equal(0.0m, MultiplyOperatorsHelper<decimal, decimal, decimal>.op_Multiply(0.0m, 2.0m));
+            Assert.Equal(2.0m, MultiplyOperatorsHelper<decimal, decimal, decimal>.op_Multiply(1.0m, 2.0m));
+
+            Assert.Throws<OverflowException>(() => MultiplyOperatorsHelper<decimal, decimal, decimal>.op_Multiply(decimal.MinValue, 2.0m));
+            Assert.Throws<OverflowException>(() => MultiplyOperatorsHelper<decimal, decimal, decimal>.op_Multiply(decimal.MaxValue, 2.0m));
+        }
+
+        [Fact]
+        public static void op_CheckedMultiplyTest()
+        {
+            Assert.Equal(-2.0m, MultiplyOperatorsHelper<decimal, decimal, decimal>.op_CheckedMultiply(-1.0m, 2.0m));
+            Assert.Equal(-0.0m, MultiplyOperatorsHelper<decimal, decimal, decimal>.op_CheckedMultiply(-0.0m, 2.0m));
+            Assert.Equal(0.0m, MultiplyOperatorsHelper<decimal, decimal, decimal>.op_CheckedMultiply(0.0m, 2.0m));
+            Assert.Equal(2.0m, MultiplyOperatorsHelper<decimal, decimal, decimal>.op_CheckedMultiply(1.0m, 2.0m));
+
+            Assert.Throws<OverflowException>(() => MultiplyOperatorsHelper<decimal, decimal, decimal>.op_CheckedMultiply(decimal.MinValue, 2.0m));
+            Assert.Throws<OverflowException>(() => MultiplyOperatorsHelper<decimal, decimal, decimal>.op_CheckedMultiply(decimal.MaxValue, 2.0m));
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            Assert.Equal(decimal.MaxValue, NumberHelper<decimal>.Abs(decimal.MinValue));
+            Assert.Equal(1.0m, NumberHelper<decimal>.Abs(-1.0m));
+            Assert.Equal(0.0m, NumberHelper<decimal>.Abs(-0.0m));
+            Assert.Equal(0.0m, NumberHelper<decimal>.Abs(0.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.Abs(1.0m));
+            Assert.Equal(decimal.MaxValue, NumberHelper<decimal>.Abs(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void ClampTest()
+        {
+            Assert.Equal(1.0m, NumberHelper<decimal>.Clamp(decimal.MinValue, 1.0m, 63.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.Clamp(-1.0m, 1.0m, 63.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.Clamp(-0.0m, 1.0m, 63.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.Clamp(0.0m, 1.0m, 63.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.Clamp(1.0m, 1.0m, 63.0m));
+            Assert.Equal(63.0m, NumberHelper<decimal>.Clamp(decimal.MaxValue, 1.0m, 63.0m));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromByteTest()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<byte>(0x00));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<byte>(0x01));
+            Assert.Equal(127.0m, NumberHelper<decimal>.CreateChecked<byte>(0x7F));
+            Assert.Equal(128.0m, NumberHelper<decimal>.CreateChecked<byte>(0x80));
+            Assert.Equal(255.0m, NumberHelper<decimal>.CreateChecked<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromCharTest()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<char>((char)0x0000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<char>((char)0x0001));
+            Assert.Equal(32767.0m, NumberHelper<decimal>.CreateChecked<char>((char)0x7FFF));
+            Assert.Equal(32768.0m, NumberHelper<decimal>.CreateChecked<char>((char)0x8000));
+            Assert.Equal(65535.0m, NumberHelper<decimal>.CreateChecked<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt16Test()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<short>(0x0000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<short>(0x0001));
+            Assert.Equal(32767.0m, NumberHelper<decimal>.CreateChecked<short>(0x7FFF));
+            Assert.Equal(-32768.0m, NumberHelper<decimal>.CreateChecked<short>(unchecked((short)0x8000)));
+            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateChecked<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt32Test()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<int>(0x00000000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<int>(0x00000001));
+            Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateChecked<int>(0x7FFFFFFF));
+            Assert.Equal(-2147483648.0m, NumberHelper<decimal>.CreateChecked<int>(unchecked((int)0x80000000)));
+            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt64Test()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<long>(0x0000000000000000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<long>(0x0000000000000001));
+            Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(-9223372036854775808.0m, NumberHelper<decimal>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
+            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(-9223372036854775808.0m, NumberHelper<decimal>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(-1.0m, NumberHelper<decimal>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<nint>((nint)0x00000000));
+                Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<nint>((nint)0x00000001));
+                Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(-2147483648.0m, NumberHelper<decimal>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(-1.0m, NumberHelper<decimal>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateCheckedFromSByteTest()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<sbyte>(0x00));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<sbyte>(0x01));
+            Assert.Equal(127.0m, NumberHelper<decimal>.CreateChecked<sbyte>(0x7F));
+            Assert.Equal(-128.0m, NumberHelper<decimal>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt16Test()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<ushort>(0x0000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<ushort>(0x0001));
+            Assert.Equal(32767.0m, NumberHelper<decimal>.CreateChecked<ushort>(0x7FFF));
+            Assert.Equal(32768.0m, NumberHelper<decimal>.CreateChecked<ushort>(0x8000));
+            Assert.Equal(65535.0m, NumberHelper<decimal>.CreateChecked<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt32Test()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<uint>(0x00000000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<uint>(0x00000001));
+            Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateChecked<uint>(0x7FFFFFFF));
+            Assert.Equal(2147483648.0m, NumberHelper<decimal>.CreateChecked<uint>(0x80000000));
+            Assert.Equal(4294967295.0m, NumberHelper<decimal>.CreateChecked<uint>(0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt64Test()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<ulong>(0x0000000000000000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<ulong>(0x0000000000000001));
+            Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(9223372036854775808.0m, NumberHelper<decimal>.CreateChecked<ulong>(0x8000000000000000));
+            Assert.Equal(18446744073709551615.0m, NumberHelper<decimal>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(9223372036854775808.0m, NumberHelper<decimal>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(18446744073709551615.0m,NumberHelper<decimal>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.Equal(0.0m, NumberHelper<decimal>.CreateChecked<nuint>((nuint)0x00000000));
+                Assert.Equal(1.0m, NumberHelper<decimal>.CreateChecked<nuint>((nuint)0x00000001));
+                Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal(2147483648.0m, NumberHelper<decimal>.CreateChecked<nuint>((nuint)0x80000000));
+                Assert.Equal(4294967295.0m, NumberHelper<decimal>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromByteTest()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<byte>(0x00));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<byte>(0x01));
+            Assert.Equal(127.0m, NumberHelper<decimal>.CreateSaturating<byte>(0x7F));
+            Assert.Equal(128.0m, NumberHelper<decimal>.CreateSaturating<byte>(0x80));
+            Assert.Equal(255.0m, NumberHelper<decimal>.CreateSaturating<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromCharTest()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<char>((char)0x0000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<char>((char)0x0001));
+            Assert.Equal(32767.0m, NumberHelper<decimal>.CreateSaturating<char>((char)0x7FFF));
+            Assert.Equal(32768.0m, NumberHelper<decimal>.CreateSaturating<char>((char)0x8000));
+            Assert.Equal(65535.0m, NumberHelper<decimal>.CreateSaturating<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt16Test()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<short>(0x0000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<short>(0x0001));
+            Assert.Equal(32767.0m, NumberHelper<decimal>.CreateSaturating<short>(0x7FFF));
+            Assert.Equal(-32768.0m, NumberHelper<decimal>.CreateSaturating<short>(unchecked((short)0x8000)));
+            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt32Test()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<int>(0x00000000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<int>(0x00000001));
+            Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateSaturating<int>(0x7FFFFFFF));
+            Assert.Equal(-2147483648.0m, NumberHelper<decimal>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt64Test()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<long>(0x0000000000000000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<long>(0x0000000000000001));
+            Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(-9223372036854775808.0m, NumberHelper<decimal>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(-9223372036854775808.0m, NumberHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(-1.0m, NumberHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<nint>((nint)0x00000000));
+                Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<nint>((nint)0x00000001));
+                Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(-2147483648.0m, NumberHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(-1.0m, NumberHelper<decimal>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromSByteTest()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<sbyte>(0x00));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<sbyte>(0x01));
+            Assert.Equal(127.0m, NumberHelper<decimal>.CreateSaturating<sbyte>(0x7F));
+            Assert.Equal(-128.0m, NumberHelper<decimal>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt16Test()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<ushort>(0x0000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<ushort>(0x0001));
+            Assert.Equal(32767.0m, NumberHelper<decimal>.CreateSaturating<ushort>(0x7FFF));
+            Assert.Equal(32768.0m, NumberHelper<decimal>.CreateSaturating<ushort>(0x8000));
+            Assert.Equal(65535.0m, NumberHelper<decimal>.CreateSaturating<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt32Test()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<uint>(0x00000000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<uint>(0x00000001));
+            Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateSaturating<uint>(0x7FFFFFFF));
+            Assert.Equal(2147483648.0m, NumberHelper<decimal>.CreateSaturating<uint>(0x80000000));
+            Assert.Equal(4294967295.0m, NumberHelper<decimal>.CreateSaturating<uint>(0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt64Test()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<ulong>(0x0000000000000000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<ulong>(0x0000000000000001));
+            Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(9223372036854775808.0m, NumberHelper<decimal>.CreateSaturating<ulong>(0x8000000000000000));
+            Assert.Equal(18446744073709551615.0m, NumberHelper<decimal>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(9223372036854775808.0m, NumberHelper<decimal>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(18446744073709551615.0m, NumberHelper<decimal>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.Equal(0.0m, NumberHelper<decimal>.CreateSaturating<nuint>((nuint)0x00000000));
+                Assert.Equal(1.0m, NumberHelper<decimal>.CreateSaturating<nuint>((nuint)0x00000001));
+                Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal(2147483648.0m, NumberHelper<decimal>.CreateSaturating<nuint>((nuint)0x80000000));
+                Assert.Equal(4294967295.0m, NumberHelper<decimal>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromByteTest()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<byte>(0x00));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<byte>(0x01));
+            Assert.Equal(127.0m, NumberHelper<decimal>.CreateTruncating<byte>(0x7F));
+            Assert.Equal(128.0m, NumberHelper<decimal>.CreateTruncating<byte>(0x80));
+            Assert.Equal(255.0m, NumberHelper<decimal>.CreateTruncating<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromCharTest()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<char>((char)0x0000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<char>((char)0x0001));
+            Assert.Equal(32767.0m, NumberHelper<decimal>.CreateTruncating<char>((char)0x7FFF));
+            Assert.Equal(32768.0m, NumberHelper<decimal>.CreateTruncating<char>((char)0x8000));
+            Assert.Equal(65535.0m, NumberHelper<decimal>.CreateTruncating<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt16Test()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<short>(0x0000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<short>(0x0001));
+            Assert.Equal(32767.0m, NumberHelper<decimal>.CreateTruncating<short>(0x7FFF));
+            Assert.Equal(-32768.0m, NumberHelper<decimal>.CreateTruncating<short>(unchecked((short)0x8000)));
+            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt32Test()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<int>(0x00000000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<int>(0x00000001));
+            Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateTruncating<int>(0x7FFFFFFF));
+            Assert.Equal(-2147483648.0m, NumberHelper<decimal>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt64Test()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<long>(0x0000000000000000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<long>(0x0000000000000001));
+            Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(-9223372036854775808.0m, NumberHelper<decimal>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(-9223372036854775808.0m, NumberHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                Assert.Equal(-1.0m, NumberHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<nint>((nint)0x00000000));
+                Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<nint>((nint)0x00000001));
+                Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                Assert.Equal(-2147483648.0m, NumberHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                Assert.Equal(-1.0m, NumberHelper<decimal>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromSByteTest()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<sbyte>(0x00));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<sbyte>(0x01));
+            Assert.Equal(127.0m, NumberHelper<decimal>.CreateTruncating<sbyte>(0x7F));
+            Assert.Equal(-128.0m, NumberHelper<decimal>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            Assert.Equal(-1.0m, NumberHelper<decimal>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt16Test()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<ushort>(0x0000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<ushort>(0x0001));
+            Assert.Equal(32767.0m, NumberHelper<decimal>.CreateTruncating<ushort>(0x7FFF));
+            Assert.Equal(32768.0m, NumberHelper<decimal>.CreateTruncating<ushort>(0x8000));
+            Assert.Equal(65535.0m, NumberHelper<decimal>.CreateTruncating<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt32Test()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<uint>(0x00000000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<uint>(0x00000001));
+            Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateTruncating<uint>(0x7FFFFFFF));
+            Assert.Equal(2147483648.0m, NumberHelper<decimal>.CreateTruncating<uint>(0x80000000));
+            Assert.Equal(4294967295.0m, NumberHelper<decimal>.CreateTruncating<uint>(0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt64Test()
+        {
+            Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<ulong>(0x0000000000000000));
+            Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<ulong>(0x0000000000000001));
+            Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            Assert.Equal(9223372036854775808.0m, NumberHelper<decimal>.CreateTruncating<ulong>(0x8000000000000000));
+            Assert.Equal(18446744073709551615.0m, NumberHelper<decimal>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                Assert.Equal(9223372036854775807.0m, NumberHelper<decimal>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+                Assert.Equal(9223372036854775808.0m, NumberHelper<decimal>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                Assert.Equal(18446744073709551615.0m, NumberHelper<decimal>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                Assert.Equal(0.0m, NumberHelper<decimal>.CreateTruncating<nuint>((nuint)0x00000000));
+                Assert.Equal(1.0m, NumberHelper<decimal>.CreateTruncating<nuint>((nuint)0x00000001));
+                Assert.Equal(2147483647.0m, NumberHelper<decimal>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+                Assert.Equal(2147483648.0m, NumberHelper<decimal>.CreateTruncating<nuint>((nuint)0x80000000));
+                Assert.Equal(4294967295.0m, NumberHelper<decimal>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            Assert.Equal(1.0m, NumberHelper<decimal>.Max(decimal.MinValue, 1.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.Max(-1.0m, 1.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.Max(-0.0m, 1.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.Max(0.0m, 1.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.Max(1.0m, 1.0m));
+            Assert.Equal(decimal.MaxValue, NumberHelper<decimal>.Max(decimal.MaxValue, 1.0m));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            Assert.Equal(decimal.MinValue, NumberHelper<decimal>.Min(decimal.MinValue, 1.0m));
+            Assert.Equal(-1.0m, NumberHelper<decimal>.Min(-1.0m, 1.0m));
+            Assert.Equal(-0.0m, NumberHelper<decimal>.Min(-0.0m, 1.0m));
+            Assert.Equal(0.0m, NumberHelper<decimal>.Min(0.0m, 1.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.Min(1.0m, 1.0m));
+            Assert.Equal(1.0m, NumberHelper<decimal>.Min(decimal.MaxValue, 1.0m));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(-1, NumberHelper<decimal>.Sign(decimal.MinValue));
+            Assert.Equal(-1, NumberHelper<decimal>.Sign(-1.0m));
+
+            Assert.Equal(0, NumberHelper<decimal>.Sign(-0.0m));
+            Assert.Equal(0, NumberHelper<decimal>.Sign(0.0m));
+
+            Assert.Equal(1, NumberHelper<decimal>.Sign(1.0m));
+            Assert.Equal(1, NumberHelper<decimal>.Sign(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void TryCreateFromByteTest()
+        {
+            decimal result;
+
+            Assert.True(NumberHelper<decimal>.TryCreate<byte>(0x00, out result));
+            Assert.Equal(0.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<byte>(0x01, out result));
+            Assert.Equal(1.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<byte>(0x7F, out result));
+            Assert.Equal(127.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<byte>(0x80, out result));
+            Assert.Equal(128.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<byte>(0xFF, out result));
+            Assert.Equal(255.0m, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromCharTest()
+        {
+            decimal result;
+
+            Assert.True(NumberHelper<decimal>.TryCreate<char>((char)0x0000, out result));
+            Assert.Equal(0.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<char>((char)0x0001, out result));
+            Assert.Equal(1.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.Equal(32767.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<char>((char)0x8000, out result));
+            Assert.Equal(32768.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.Equal(65535.0m, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt16Test()
+        {
+            decimal result;
+
+            Assert.True(NumberHelper<decimal>.TryCreate<short>(0x0000, out result));
+            Assert.Equal(0.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<short>(0x0001, out result));
+            Assert.Equal(1.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<short>(0x7FFF, out result));
+            Assert.Equal(32767.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.Equal(-32768.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.Equal(-1.0m, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt32Test()
+        {
+            decimal result;
+
+            Assert.True(NumberHelper<decimal>.TryCreate<int>(0x00000000, out result));
+            Assert.Equal(0.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<int>(0x00000001, out result));
+            Assert.Equal(1.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.Equal(2147483647.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.Equal(-2147483648.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.Equal(-1.0m, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt64Test()
+        {
+            decimal result;
+
+            Assert.True(NumberHelper<decimal>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.Equal(0.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.Equal(1.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.Equal(9223372036854775807.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
+            Assert.Equal(-9223372036854775808.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
+            Assert.Equal(-1.0m, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromIntPtrTest()
+        {
+            decimal result;
+
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberHelper<decimal>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.Equal(0.0m, result);
+
+                Assert.True(NumberHelper<decimal>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.Equal(1.0m, result);
+
+                Assert.True(NumberHelper<decimal>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.Equal(9223372036854775807.0m, result);
+
+                Assert.True(NumberHelper<decimal>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.Equal(-9223372036854775808.0m, result);
+
+                Assert.True(NumberHelper<decimal>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.Equal(-1.0m, result);
+            }
+            else
+            {
+                Assert.True(NumberHelper<decimal>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.Equal(0.0m, result);
+
+                Assert.True(NumberHelper<decimal>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.Equal(1.0m, result);
+
+                Assert.True(NumberHelper<decimal>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.Equal(2147483647.0m, result);
+
+                Assert.True(NumberHelper<decimal>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.Equal(-2147483648.0m, result);
+
+                Assert.True(NumberHelper<decimal>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.Equal(-1.0m, result);
+            }
+        }
+
+        [Fact]
+        public static void TryCreateFromSByteTest()
+        {
+            decimal result;
+
+            Assert.True(NumberHelper<decimal>.TryCreate<sbyte>(0x00, out result));
+            Assert.Equal(0.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<sbyte>(0x01, out result));
+            Assert.Equal(1.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<sbyte>(0x7F, out result));
+            Assert.Equal(127.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.Equal(-128.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.Equal(-1.0m, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt16Test()
+        {
+            decimal result;
+
+            Assert.True(NumberHelper<decimal>.TryCreate<ushort>(0x0000, out result));
+            Assert.Equal(0.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<ushort>(0x0001, out result));
+            Assert.Equal(1.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.Equal(32767.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<ushort>(0x8000, out result));
+            Assert.Equal(32768.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.Equal(65535.0m, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt32Test()
+        {
+            decimal result;
+
+            Assert.True(NumberHelper<decimal>.TryCreate<uint>(0x00000000, out result));
+            Assert.Equal(0.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<uint>(0x00000001, out result));
+            Assert.Equal(1.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.Equal(2147483647.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<uint>(0x80000000, out result));
+            Assert.Equal(2147483648.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.Equal(4294967295.0m, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt64Test()
+        {
+            decimal result;
+
+            Assert.True(NumberHelper<decimal>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.Equal(0.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.Equal(1.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.Equal(9223372036854775807.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.Equal(9223372036854775808.0m, result);
+
+            Assert.True(NumberHelper<decimal>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.Equal(18446744073709551615.0m, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUIntPtrTest()
+        {
+            decimal result;
+
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.Equal(0.0m, result);
+
+                Assert.True(NumberHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.Equal(1.0m, result);
+
+                Assert.True(NumberHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.Equal(9223372036854775807.0m, result);
+
+                Assert.True(NumberHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                Assert.Equal(9223372036854775808.0m, result);
+
+                Assert.True(NumberHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.Equal(18446744073709551615.0m, result);
+            }
+            else
+            {
+                Assert.True(NumberHelper<decimal>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.Equal(0.0m, result);
+
+                Assert.True(NumberHelper<decimal>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.Equal(1.0m, result);
+
+                Assert.True(NumberHelper<decimal>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.Equal(2147483647.0m, result);
+
+                Assert.True(NumberHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                Assert.Equal(2147483648.0m, result);
+
+                Assert.True(NumberHelper<decimal>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                Assert.Equal(4294967295.0m, result);
+            }
+        }
+
+        [Fact]
+        public static void op_SubtractionTest()
+        {
+            Assert.Equal(-2.0m, SubtractionOperatorsHelper<decimal, decimal, decimal>.op_Subtraction(-1.0m, 1.0m));
+            Assert.Equal(-1.0m, SubtractionOperatorsHelper<decimal, decimal, decimal>.op_Subtraction(-0.0m, 1.0m));
+            Assert.Equal(-1.0m, SubtractionOperatorsHelper<decimal, decimal, decimal>.op_Subtraction(0.0m, 1.0m));
+            Assert.Equal(0.0m, SubtractionOperatorsHelper<decimal, decimal, decimal>.op_Subtraction(1.0m, 1.0m));
+            Assert.Equal(79228162514264337593543950334.0m, SubtractionOperatorsHelper<decimal, decimal, decimal>.op_Subtraction(decimal.MaxValue, 1.0m));
+
+            Assert.Throws<OverflowException>(() => SubtractionOperatorsHelper<decimal, decimal, decimal>.op_Subtraction(decimal.MinValue, 1.0m));
+        }
+
+        [Fact]
+        public static void op_CheckedSubtractionTest()
+        {
+            Assert.Equal(-2.0m, SubtractionOperatorsHelper<decimal, decimal, decimal>.op_CheckedSubtraction(-1.0m, 1.0m));
+            Assert.Equal(-1.0m, SubtractionOperatorsHelper<decimal, decimal, decimal>.op_CheckedSubtraction(-0.0m, 1.0m));
+            Assert.Equal(-1.0m, SubtractionOperatorsHelper<decimal, decimal, decimal>.op_CheckedSubtraction(0.0m, 1.0m));
+            Assert.Equal(0.0m, SubtractionOperatorsHelper<decimal, decimal, decimal>.op_CheckedSubtraction(1.0m, 1.0m));
+            Assert.Equal(79228162514264337593543950334.0m, SubtractionOperatorsHelper<decimal, decimal, decimal>.op_CheckedSubtraction(decimal.MaxValue, 1.0m));
+
+            Assert.Throws<OverflowException>(() => SubtractionOperatorsHelper<decimal, decimal, decimal>.op_CheckedSubtraction(decimal.MinValue, 1.0m));
+        }
+
+        [Fact]
+        public static void op_UnaryNegationTest()
+        {
+            Assert.Equal(decimal.MaxValue, UnaryNegationOperatorsHelper<decimal, decimal>.op_UnaryNegation(decimal.MinValue));
+            Assert.Equal(1.0m, UnaryNegationOperatorsHelper<decimal, decimal>.op_UnaryNegation(-1.0m));
+            Assert.Equal(0.0m, UnaryNegationOperatorsHelper<decimal, decimal>.op_UnaryNegation(-0.0m));
+            Assert.Equal(-0.0m, UnaryNegationOperatorsHelper<decimal, decimal>.op_UnaryNegation(0.0m));
+            Assert.Equal(-1.0m, UnaryNegationOperatorsHelper<decimal, decimal>.op_UnaryNegation(1.0m));
+            Assert.Equal(decimal.MinValue, UnaryNegationOperatorsHelper<decimal, decimal>.op_UnaryNegation(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void op_CheckedUnaryNegationTest()
+        {
+            Assert.Equal(decimal.MaxValue, UnaryNegationOperatorsHelper<decimal, decimal>.op_CheckedUnaryNegation(decimal.MinValue));
+            Assert.Equal(1.0m, UnaryNegationOperatorsHelper<decimal, decimal>.op_CheckedUnaryNegation(-1.0m));
+            Assert.Equal(0.0m, UnaryNegationOperatorsHelper<decimal, decimal>.op_CheckedUnaryNegation(-0.0m));
+            Assert.Equal(-0.0m, UnaryNegationOperatorsHelper<decimal, decimal>.op_CheckedUnaryNegation(0.0m));
+            Assert.Equal(-1.0m, UnaryNegationOperatorsHelper<decimal, decimal>.op_CheckedUnaryNegation(1.0m));
+            Assert.Equal(decimal.MinValue, UnaryNegationOperatorsHelper<decimal, decimal>.op_CheckedUnaryNegation(decimal.MaxValue));
+        }
+
+        [Fact]
+        public static void op_UnaryPlusTest()
+        {
+            Assert.Equal(decimal.MinValue, UnaryPlusOperatorsHelper<decimal, decimal>.op_UnaryPlus(decimal.MinValue));
+            Assert.Equal(-1.0m, UnaryPlusOperatorsHelper<decimal, decimal>.op_UnaryPlus(-1.0m));
+            Assert.Equal(-0.0m, UnaryPlusOperatorsHelper<decimal, decimal>.op_UnaryPlus(-0.0m));
+            Assert.Equal(0.0m, UnaryPlusOperatorsHelper<decimal, decimal>.op_UnaryPlus(0.0m));
+            Assert.Equal(1.0m, UnaryPlusOperatorsHelper<decimal, decimal>.op_UnaryPlus(1.0m));
+            Assert.Equal(decimal.MaxValue, UnaryPlusOperatorsHelper<decimal, decimal>.op_UnaryPlus(decimal.MaxValue));
+        }
+
+        [Theory]
+        [MemberData(nameof(DecimalTests.Parse_Valid_TestData), MemberType = typeof(DecimalTests))]
+        public static void ParseValidStringTest(string value, NumberStyles style, IFormatProvider provider, decimal expected)
+        {
+            bool isDefaultProvider = provider == null || provider == NumberFormatInfo.CurrentInfo;
+            decimal result;
+            if ((style & ~(NumberStyles.Float | NumberStyles.AllowThousands)) == 0 && style != NumberStyles.None)
+            {
+                // Use Parse(string) or Parse(string, IFormatProvider)
+                if (isDefaultProvider)
+                {
+                    Assert.True(NumberHelper<decimal>.TryParse(value, null, out result));
+                    Assert.Equal(expected, result);
+
+                    Assert.Equal(expected, NumberHelper<decimal>.Parse(value, null));
+                }
+
+                Assert.Equal(expected, NumberHelper<decimal>.Parse(value, provider));
+            }
+
+            // Use Parse(string, NumberStyles, IFormatProvider)
+            Assert.True(NumberHelper<decimal>.TryParse(value, style, provider, out result));
+            Assert.Equal(expected, result);
+
+            Assert.Equal(expected, NumberHelper<decimal>.Parse(value, style, provider));
+
+            if (isDefaultProvider)
+            {
+                // Use Parse(string, NumberStyles) or Parse(string, NumberStyles, IFormatProvider)
+                Assert.True(NumberHelper<decimal>.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
+                Assert.Equal(expected, result);
+
+                Assert.Equal(expected, NumberHelper<decimal>.Parse(value, style, null));
+                Assert.Equal(expected, NumberHelper<decimal>.Parse(value, style, NumberFormatInfo.CurrentInfo));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(DecimalTests.Parse_Invalid_TestData), MemberType = typeof(DecimalTests))]
+        public static void ParseInvalidStringTest(string value, NumberStyles style, IFormatProvider provider, Type exceptionType)
+        {
+            bool isDefaultProvider = provider == null || provider == NumberFormatInfo.CurrentInfo;
+            decimal result;
+            if ((style & ~(NumberStyles.Float | NumberStyles.AllowThousands)) == 0 && style != NumberStyles.None && (style & NumberStyles.AllowLeadingWhite) == (style & NumberStyles.AllowTrailingWhite))
+            {
+                // Use Parse(string) or Parse(string, IFormatProvider)
+                if (isDefaultProvider)
+                {
+                    Assert.False(NumberHelper<decimal>.TryParse(value, null, out result));
+                    Assert.Equal(default(decimal), result);
+
+                    Assert.Throws(exceptionType, () => NumberHelper<decimal>.Parse(value, null));
+                }
+
+                Assert.Throws(exceptionType, () => NumberHelper<decimal>.Parse(value, provider));
+            }
+
+            // Use Parse(string, NumberStyles, IFormatProvider)
+            Assert.False(NumberHelper<decimal>.TryParse(value, style, provider, out result));
+            Assert.Equal(default(decimal), result);
+
+            Assert.Throws(exceptionType, () => NumberHelper<decimal>.Parse(value, style, provider));
+
+            if (isDefaultProvider)
+            {
+                // Use Parse(string, NumberStyles) or Parse(string, NumberStyles, IFormatProvider)
+                Assert.False(NumberHelper<decimal>.TryParse(value, style, NumberFormatInfo.CurrentInfo, out result));
+                Assert.Equal(default(decimal), result);
+
+                Assert.Throws(exceptionType, () => NumberHelper<decimal>.Parse(value, style, null));
+                Assert.Throws(exceptionType, () => NumberHelper<decimal>.Parse(value, style, NumberFormatInfo.CurrentInfo));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(DecimalTests.Parse_ValidWithOffsetCount_TestData), MemberType = typeof(DecimalTests))]
+        public static void ParseValidSpanTest(string value, int offset, int count, NumberStyles style, IFormatProvider provider, decimal expected)
+        {
+            bool isDefaultProvider = provider == null || provider == NumberFormatInfo.CurrentInfo;
+            decimal result;
+            if ((style & ~(NumberStyles.Float | NumberStyles.AllowThousands)) == 0 && style != NumberStyles.None)
+            {
+                // Use Parse(string) or Parse(string, IFormatProvider)
+                if (isDefaultProvider)
+                {
+                    Assert.True(NumberHelper<decimal>.TryParse(value.AsSpan(offset, count), null, out result));
+                    Assert.Equal(expected, result);
+
+                    Assert.Equal(expected, NumberHelper<decimal>.Parse(value.AsSpan(offset, count), null));
+                }
+
+                Assert.Equal(expected, NumberHelper<decimal>.Parse(value.AsSpan(offset, count), provider: provider));
+            }
+
+            Assert.Equal(expected, NumberHelper<decimal>.Parse(value.AsSpan(offset, count), style, provider));
+
+            Assert.True(NumberHelper<decimal>.TryParse(value.AsSpan(offset, count), style, provider, out result));
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(DecimalTests.Parse_Invalid_TestData), MemberType = typeof(DecimalTests))]
+        public static void ParseInvalidSpanTest(string value, NumberStyles style, IFormatProvider provider, Type exceptionType)
+        {
+            if (value != null)
+            {
+                Assert.Throws(exceptionType, () => NumberHelper<decimal>.Parse(value.AsSpan(), style, provider));
+
+                Assert.False(NumberHelper<decimal>.TryParse(value.AsSpan(), style, provider, out decimal result));
+                Assert.Equal(0, result);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.GenericMath.cs
@@ -2,13 +2,1340 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using System.Runtime.Versioning;
 using Xunit;
 
 namespace System.Tests
 {
     public class DoubleTests_GenericMath
     {
+        private const double MinNormal = 2.2250738585072014E-308;
+
+        private const double MaxSubnormal = 2.2250738585072009E-308;
+
+        private static void AssertBitwiseEqual(double expected, double actual)
+        {
+            ulong expectedBits = BitConverter.DoubleToUInt64Bits(expected);
+            ulong actualBits = BitConverter.DoubleToUInt64Bits(actual);
+
+            if (expectedBits == actualBits)
+            {
+                return;
+            }
+
+            if (double.IsNaN(expected) && double.IsNaN(actual))
+            {
+                return;
+            }
+
+            throw new Xunit.Sdk.EqualException(expected, actual);
+        }
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            AssertBitwiseEqual(0.0, AdditiveIdentityHelper<double, double>.AdditiveIdentity);
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            AssertBitwiseEqual(double.MinValue, MinMaxValueHelper<double>.MinValue);
+        }
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            AssertBitwiseEqual(double.MaxValue, MinMaxValueHelper<double>.MaxValue);
+        }
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            AssertBitwiseEqual(1.0, MultiplicativeIdentityHelper<double, double>.MultiplicativeIdentity);
+        }
+
+        [Fact]
+        public static void NegativeOneTest()
+        {
+            Assert.Equal(-1.0, SignedNumberHelper<double>.NegativeOne);
+        }
+
+        [Fact]
+        public static void OneTest()
+        {
+            AssertBitwiseEqual(1.0, NumberBaseHelper<double>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            AssertBitwiseEqual(0.0, NumberBaseHelper<double>.Zero);
+        }
+
+        [Fact]
+        public static void op_AdditionTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, AdditionOperatorsHelper<double, double, double>.op_Addition(double.NegativeInfinity, 1.0));
+            AssertBitwiseEqual(double.MinValue, AdditionOperatorsHelper<double, double, double>.op_Addition(double.MinValue, 1.0));
+            AssertBitwiseEqual(0.0, AdditionOperatorsHelper<double, double, double>.op_Addition(-1.0, 1.0));
+            AssertBitwiseEqual(1.0, AdditionOperatorsHelper<double, double, double>.op_Addition(-MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, AdditionOperatorsHelper<double, double, double>.op_Addition(-MaxSubnormal, 1.0));
+            AssertBitwiseEqual(1.0, AdditionOperatorsHelper<double, double, double>.op_Addition(-double.Epsilon, 1.0));
+            AssertBitwiseEqual(1.0, AdditionOperatorsHelper<double, double, double>.op_Addition(-0.0, 1.0));
+            AssertBitwiseEqual(double.NaN, AdditionOperatorsHelper<double, double, double>.op_Addition(double.NaN, 1.0));
+            AssertBitwiseEqual(1.0, AdditionOperatorsHelper<double, double, double>.op_Addition(0.0, 1.0));
+            AssertBitwiseEqual(1.0, AdditionOperatorsHelper<double, double, double>.op_Addition(double.Epsilon, 1.0));
+            AssertBitwiseEqual(1.0, AdditionOperatorsHelper<double, double, double>.op_Addition(MaxSubnormal, 1.0));
+            AssertBitwiseEqual(1.0, AdditionOperatorsHelper<double, double, double>.op_Addition(MinNormal, 1.0));
+            AssertBitwiseEqual(2.0, AdditionOperatorsHelper<double, double, double>.op_Addition(1.0, 1.0));
+            AssertBitwiseEqual(double.MaxValue, AdditionOperatorsHelper<double, double, double>.op_Addition(double.MaxValue, 1.0));
+            AssertBitwiseEqual(double.PositiveInfinity, AdditionOperatorsHelper<double, double, double>.op_Addition(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void op_CheckedAdditionTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, AdditionOperatorsHelper<double, double, double>.op_CheckedAddition(double.NegativeInfinity, 1.0));
+            AssertBitwiseEqual(double.MinValue, AdditionOperatorsHelper<double, double, double>.op_CheckedAddition(double.MinValue, 1.0));
+            AssertBitwiseEqual(0.0, AdditionOperatorsHelper<double, double, double>.op_CheckedAddition(-1.0, 1.0));
+            AssertBitwiseEqual(1.0, AdditionOperatorsHelper<double, double, double>.op_CheckedAddition(-MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, AdditionOperatorsHelper<double, double, double>.op_CheckedAddition(-MaxSubnormal, 1.0));
+            AssertBitwiseEqual(1.0, AdditionOperatorsHelper<double, double, double>.op_CheckedAddition(-double.Epsilon, 1.0));
+            AssertBitwiseEqual(1.0, AdditionOperatorsHelper<double, double, double>.op_CheckedAddition(-0.0, 1.0));
+            AssertBitwiseEqual(double.NaN, AdditionOperatorsHelper<double, double, double>.op_CheckedAddition(double.NaN, 1.0));
+            AssertBitwiseEqual(1.0, AdditionOperatorsHelper<double, double, double>.op_CheckedAddition(0.0, 1.0));
+            AssertBitwiseEqual(1.0, AdditionOperatorsHelper<double, double, double>.op_CheckedAddition(double.Epsilon, 1.0));
+            AssertBitwiseEqual(1.0, AdditionOperatorsHelper<double, double, double>.op_CheckedAddition(MaxSubnormal, 1.0));
+            AssertBitwiseEqual(1.0, AdditionOperatorsHelper<double, double, double>.op_CheckedAddition(MinNormal, 1.0));
+            AssertBitwiseEqual(2.0, AdditionOperatorsHelper<double, double, double>.op_CheckedAddition(1.0, 1.0));
+            AssertBitwiseEqual(double.MaxValue, AdditionOperatorsHelper<double, double, double>.op_CheckedAddition(double.MaxValue, 1.0));
+            AssertBitwiseEqual(double.PositiveInfinity, AdditionOperatorsHelper<double, double, double>.op_CheckedAddition(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void IsPow2Test()
+        {
+            Assert.False(BinaryNumberHelper<double>.IsPow2(double.NegativeInfinity));
+            Assert.False(BinaryNumberHelper<double>.IsPow2(double.MinValue));
+            Assert.False(BinaryNumberHelper<double>.IsPow2(-1.0));
+            Assert.False(BinaryNumberHelper<double>.IsPow2(-MinNormal));
+            Assert.False(BinaryNumberHelper<double>.IsPow2(-MaxSubnormal));
+            Assert.False(BinaryNumberHelper<double>.IsPow2(-double.Epsilon));
+            Assert.False(BinaryNumberHelper<double>.IsPow2(-0.0));
+            Assert.False(BinaryNumberHelper<double>.IsPow2(double.NaN));
+            Assert.False(BinaryNumberHelper<double>.IsPow2(0.0));
+            Assert.False(BinaryNumberHelper<double>.IsPow2(double.Epsilon));
+            Assert.False(BinaryNumberHelper<double>.IsPow2(MaxSubnormal));
+            Assert.True(BinaryNumberHelper<double>.IsPow2(MinNormal));
+            Assert.True(BinaryNumberHelper<double>.IsPow2(1.0));
+            Assert.False(BinaryNumberHelper<double>.IsPow2(double.MaxValue));
+            Assert.False(BinaryNumberHelper<double>.IsPow2(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void Log2Test()
+        {
+            AssertBitwiseEqual(double.NaN, BinaryNumberHelper<double>.Log2(double.NegativeInfinity));
+            AssertBitwiseEqual(double.NaN, BinaryNumberHelper<double>.Log2(double.MinValue));
+            AssertBitwiseEqual(double.NaN, BinaryNumberHelper<double>.Log2(-1.0));
+            AssertBitwiseEqual(double.NaN, BinaryNumberHelper<double>.Log2(-MinNormal));
+            AssertBitwiseEqual(double.NaN, BinaryNumberHelper<double>.Log2(-MaxSubnormal));
+            AssertBitwiseEqual(double.NaN, BinaryNumberHelper<double>.Log2(-double.Epsilon));
+            AssertBitwiseEqual(double.NegativeInfinity, BinaryNumberHelper<double>.Log2(-0.0));
+            AssertBitwiseEqual(double.NaN, BinaryNumberHelper<double>.Log2(double.NaN));
+            AssertBitwiseEqual(double.NegativeInfinity, BinaryNumberHelper<double>.Log2(0.0));
+            AssertBitwiseEqual(-1074.0, BinaryNumberHelper<double>.Log2(double.Epsilon));
+            AssertBitwiseEqual(-1022.0, BinaryNumberHelper<double>.Log2(MaxSubnormal));
+            AssertBitwiseEqual(-1022.0, BinaryNumberHelper<double>.Log2(MinNormal));
+            AssertBitwiseEqual(0.0, BinaryNumberHelper<double>.Log2(1.0));
+            AssertBitwiseEqual(1024.0, BinaryNumberHelper<double>.Log2(double.MaxValue));
+            AssertBitwiseEqual(double.PositiveInfinity, BinaryNumberHelper<double>.Log2(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(double.NegativeInfinity, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(double.MinValue, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(-1.0, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(-MinNormal, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(-MaxSubnormal, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(-double.Epsilon, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(-0.0, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThan(double.NaN, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(0.0, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(double.Epsilon, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(MaxSubnormal, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThan(MinNormal, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThan(1.0, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThan(double.MaxValue, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThan(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(double.NegativeInfinity, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(double.MinValue, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(-1.0, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(-MinNormal, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(-MaxSubnormal, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(-double.Epsilon, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(-0.0, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(double.NaN, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(0.0, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(double.Epsilon, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(MaxSubnormal, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(MinNormal, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(1.0, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(double.MaxValue, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_LessThanOrEqual(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void op_GreaterThanTest()
+        {
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThan(double.NegativeInfinity, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThan(double.MinValue, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThan(-1.0, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThan(-MinNormal, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThan(-MaxSubnormal, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThan(-double.Epsilon, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThan(-0.0, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThan(double.NaN, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThan(0.0, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThan(double.Epsilon, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThan(MaxSubnormal, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThan(MinNormal, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThan(1.0, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_GreaterThan(double.MaxValue, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_GreaterThan(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void op_GreaterThanOrEqualTest()
+        {
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThanOrEqual(double.NegativeInfinity, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThanOrEqual(double.MinValue, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThanOrEqual(-1.0, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThanOrEqual(-MinNormal, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThanOrEqual(-MaxSubnormal, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThanOrEqual(-double.Epsilon, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThanOrEqual(-0.0, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThanOrEqual(double.NaN, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThanOrEqual(0.0, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThanOrEqual(double.Epsilon, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThanOrEqual(MaxSubnormal, 1.0));
+            Assert.False(ComparisonOperatorsHelper<double, double>.op_GreaterThanOrEqual(MinNormal, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_GreaterThanOrEqual(1.0, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_GreaterThanOrEqual(double.MaxValue, 1.0));
+            Assert.True(ComparisonOperatorsHelper<double, double>.op_GreaterThanOrEqual(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void op_DecrementTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, DecrementOperatorsHelper<double>.op_Decrement(double.NegativeInfinity));
+            AssertBitwiseEqual(double.MinValue, DecrementOperatorsHelper<double>.op_Decrement(double.MinValue));
+            AssertBitwiseEqual(-2.0, DecrementOperatorsHelper<double>.op_Decrement(-1.0));
+            AssertBitwiseEqual(-1.0, DecrementOperatorsHelper<double>.op_Decrement(-MinNormal));
+            AssertBitwiseEqual(-1.0, DecrementOperatorsHelper<double>.op_Decrement(-MaxSubnormal));
+            AssertBitwiseEqual(-1.0, DecrementOperatorsHelper<double>.op_Decrement(-double.Epsilon));
+            AssertBitwiseEqual(-1.0, DecrementOperatorsHelper<double>.op_Decrement(-0.0));
+            AssertBitwiseEqual(double.NaN, DecrementOperatorsHelper<double>.op_Decrement(double.NaN));
+            AssertBitwiseEqual(-1.0, DecrementOperatorsHelper<double>.op_Decrement(0.0));
+            AssertBitwiseEqual(-1.0, DecrementOperatorsHelper<double>.op_Decrement(double.Epsilon));
+            AssertBitwiseEqual(-1.0, DecrementOperatorsHelper<double>.op_Decrement(MaxSubnormal));
+            AssertBitwiseEqual(-1.0, DecrementOperatorsHelper<double>.op_Decrement(MinNormal));
+            AssertBitwiseEqual(0.0, DecrementOperatorsHelper<double>.op_Decrement(1.0));
+            AssertBitwiseEqual(double.MaxValue, DecrementOperatorsHelper<double>.op_Decrement(double.MaxValue));
+            AssertBitwiseEqual(double.PositiveInfinity, DecrementOperatorsHelper<double>.op_Decrement(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_CheckedDecrementTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, DecrementOperatorsHelper<double>.op_CheckedDecrement(double.NegativeInfinity));
+            AssertBitwiseEqual(double.MinValue, DecrementOperatorsHelper<double>.op_CheckedDecrement(double.MinValue));
+            AssertBitwiseEqual(-2.0, DecrementOperatorsHelper<double>.op_CheckedDecrement(-1.0));
+            AssertBitwiseEqual(-1.0, DecrementOperatorsHelper<double>.op_CheckedDecrement(-MinNormal));
+            AssertBitwiseEqual(-1.0, DecrementOperatorsHelper<double>.op_CheckedDecrement(-MaxSubnormal));
+            AssertBitwiseEqual(-1.0, DecrementOperatorsHelper<double>.op_CheckedDecrement(-double.Epsilon));
+            AssertBitwiseEqual(-1.0, DecrementOperatorsHelper<double>.op_CheckedDecrement(-0.0));
+            AssertBitwiseEqual(double.NaN, DecrementOperatorsHelper<double>.op_CheckedDecrement(double.NaN));
+            AssertBitwiseEqual(-1.0, DecrementOperatorsHelper<double>.op_CheckedDecrement(0.0));
+            AssertBitwiseEqual(-1.0, DecrementOperatorsHelper<double>.op_CheckedDecrement(double.Epsilon));
+            AssertBitwiseEqual(-1.0, DecrementOperatorsHelper<double>.op_CheckedDecrement(MaxSubnormal));
+            AssertBitwiseEqual(-1.0, DecrementOperatorsHelper<double>.op_CheckedDecrement(MinNormal));
+            AssertBitwiseEqual(0.0, DecrementOperatorsHelper<double>.op_CheckedDecrement(1.0));
+            AssertBitwiseEqual(double.MaxValue, DecrementOperatorsHelper<double>.op_CheckedDecrement(double.MaxValue));
+            AssertBitwiseEqual(double.PositiveInfinity, DecrementOperatorsHelper<double>.op_CheckedDecrement(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_DivisionTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, DivisionOperatorsHelper<double, double, double>.op_Division(double.NegativeInfinity, 2.0));
+            AssertBitwiseEqual(-8.9884656743115785E+307, DivisionOperatorsHelper<double, double, double>.op_Division(double.MinValue, 2.0));
+            AssertBitwiseEqual(-0.5, DivisionOperatorsHelper<double, double, double>.op_Division(-1.0, 2.0));
+            AssertBitwiseEqual(-1.1125369292536007E-308, DivisionOperatorsHelper<double, double, double>.op_Division(-MinNormal, 2.0));
+            AssertBitwiseEqual(-1.1125369292536007E-308, DivisionOperatorsHelper<double, double, double>.op_Division(-MaxSubnormal, 2.0));
+            AssertBitwiseEqual(-0.0, DivisionOperatorsHelper<double, double, double>.op_Division(-double.Epsilon, 2.0));
+            AssertBitwiseEqual(-0.0, DivisionOperatorsHelper<double, double, double>.op_Division(-0.0, 2.0));
+            AssertBitwiseEqual(double.NaN, DivisionOperatorsHelper<double, double, double>.op_Division(double.NaN, 2.0));
+            AssertBitwiseEqual(0.0, DivisionOperatorsHelper<double, double, double>.op_Division(0.0, 2.0));
+            AssertBitwiseEqual(0.0, DivisionOperatorsHelper<double, double, double>.op_Division(double.Epsilon, 2.0));
+            AssertBitwiseEqual(1.1125369292536007E-308, DivisionOperatorsHelper<double, double, double>.op_Division(MaxSubnormal, 2.0));
+            AssertBitwiseEqual(1.1125369292536007E-308, DivisionOperatorsHelper<double, double, double>.op_Division(MinNormal, 2.0));
+            AssertBitwiseEqual(0.5, DivisionOperatorsHelper<double, double, double>.op_Division(1.0, 2.0));
+            AssertBitwiseEqual(8.9884656743115785E+307, DivisionOperatorsHelper<double, double, double>.op_Division(double.MaxValue, 2.0));
+            AssertBitwiseEqual(double.PositiveInfinity, DivisionOperatorsHelper<double, double, double>.op_Division(double.PositiveInfinity, 2.0));
+        }
+
+        [Fact]
+        public static void op_CheckedDivisionTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, DivisionOperatorsHelper<double, double, double>.op_CheckedDivision(double.NegativeInfinity, 2.0));
+            AssertBitwiseEqual(-8.9884656743115785E+307, DivisionOperatorsHelper<double, double, double>.op_CheckedDivision(double.MinValue, 2.0));
+            AssertBitwiseEqual(-0.5, DivisionOperatorsHelper<double, double, double>.op_CheckedDivision(-1.0, 2.0));
+            AssertBitwiseEqual(-1.1125369292536007E-308, DivisionOperatorsHelper<double, double, double>.op_CheckedDivision(-MinNormal, 2.0));
+            AssertBitwiseEqual(-1.1125369292536007E-308, DivisionOperatorsHelper<double, double, double>.op_CheckedDivision(-MaxSubnormal, 2.0));
+            AssertBitwiseEqual(-0.0, DivisionOperatorsHelper<double, double, double>.op_CheckedDivision(-double.Epsilon, 2.0));
+            AssertBitwiseEqual(-0.0, DivisionOperatorsHelper<double, double, double>.op_CheckedDivision(-0.0, 2.0));
+            AssertBitwiseEqual(double.NaN, DivisionOperatorsHelper<double, double, double>.op_CheckedDivision(double.NaN, 2.0));
+            AssertBitwiseEqual(0.0, DivisionOperatorsHelper<double, double, double>.op_CheckedDivision(0.0, 2.0));
+            AssertBitwiseEqual(0.0, DivisionOperatorsHelper<double, double, double>.op_CheckedDivision(double.Epsilon, 2.0));
+            AssertBitwiseEqual(1.1125369292536007E-308, DivisionOperatorsHelper<double, double, double>.op_CheckedDivision(MaxSubnormal, 2.0));
+            AssertBitwiseEqual(1.1125369292536007E-308, DivisionOperatorsHelper<double, double, double>.op_CheckedDivision(MinNormal, 2.0));
+            AssertBitwiseEqual(0.5, DivisionOperatorsHelper<double, double, double>.op_CheckedDivision(1.0, 2.0));
+            AssertBitwiseEqual(8.9884656743115785E+307, DivisionOperatorsHelper<double, double, double>.op_CheckedDivision(double.MaxValue, 2.0));
+            AssertBitwiseEqual(double.PositiveInfinity, DivisionOperatorsHelper<double, double, double>.op_CheckedDivision(double.PositiveInfinity, 2.0));
+        }
+
+        [Fact]
+        public static void op_EqualityTest()
+        {
+            Assert.False(EqualityOperatorsHelper<double, double>.op_Equality(double.NegativeInfinity, 1.0));
+            Assert.False(EqualityOperatorsHelper<double, double>.op_Equality(double.MinValue, 1.0));
+            Assert.False(EqualityOperatorsHelper<double, double>.op_Equality(-1.0, 1.0));
+            Assert.False(EqualityOperatorsHelper<double, double>.op_Equality(-MinNormal, 1.0));
+            Assert.False(EqualityOperatorsHelper<double, double>.op_Equality(-MaxSubnormal, 1.0));
+            Assert.False(EqualityOperatorsHelper<double, double>.op_Equality(-double.Epsilon, 1.0));
+            Assert.False(EqualityOperatorsHelper<double, double>.op_Equality(-0.0, 1.0));
+            Assert.False(EqualityOperatorsHelper<double, double>.op_Equality(double.NaN, 1.0));
+            Assert.False(EqualityOperatorsHelper<double, double>.op_Equality(0.0, 1.0));
+            Assert.False(EqualityOperatorsHelper<double, double>.op_Equality(double.Epsilon, 1.0));
+            Assert.False(EqualityOperatorsHelper<double, double>.op_Equality(MaxSubnormal, 1.0));
+            Assert.False(EqualityOperatorsHelper<double, double>.op_Equality(MinNormal, 1.0));
+            Assert.True(EqualityOperatorsHelper<double, double>.op_Equality(1.0, 1.0));
+            Assert.False(EqualityOperatorsHelper<double, double>.op_Equality(double.MaxValue, 1.0));
+            Assert.False(EqualityOperatorsHelper<double, double>.op_Equality(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void op_InequalityTest()
+        {
+            Assert.True(EqualityOperatorsHelper<double, double>.op_Inequality(double.NegativeInfinity, 1.0));
+            Assert.True(EqualityOperatorsHelper<double, double>.op_Inequality(double.MinValue, 1.0));
+            Assert.True(EqualityOperatorsHelper<double, double>.op_Inequality(-1.0, 1.0));
+            Assert.True(EqualityOperatorsHelper<double, double>.op_Inequality(-MinNormal, 1.0));
+            Assert.True(EqualityOperatorsHelper<double, double>.op_Inequality(-MaxSubnormal, 1.0));
+            Assert.True(EqualityOperatorsHelper<double, double>.op_Inequality(-double.Epsilon, 1.0));
+            Assert.True(EqualityOperatorsHelper<double, double>.op_Inequality(-0.0, 1.0));
+            Assert.True(EqualityOperatorsHelper<double, double>.op_Inequality(double.NaN, 1.0));
+            Assert.True(EqualityOperatorsHelper<double, double>.op_Inequality(0.0, 1.0));
+            Assert.True(EqualityOperatorsHelper<double, double>.op_Inequality(double.Epsilon, 1.0));
+            Assert.True(EqualityOperatorsHelper<double, double>.op_Inequality(MaxSubnormal, 1.0));
+            Assert.True(EqualityOperatorsHelper<double, double>.op_Inequality(MinNormal, 1.0));
+            Assert.False(EqualityOperatorsHelper<double, double>.op_Inequality(1.0, 1.0));
+            Assert.True(EqualityOperatorsHelper<double, double>.op_Inequality(double.MaxValue, 1.0));
+            Assert.True(EqualityOperatorsHelper<double, double>.op_Inequality(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void op_IncrementTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, IncrementOperatorsHelper<double>.op_Increment(double.NegativeInfinity));
+            AssertBitwiseEqual(double.MinValue, IncrementOperatorsHelper<double>.op_Increment(double.MinValue));
+            AssertBitwiseEqual(0.0, IncrementOperatorsHelper<double>.op_Increment(-1.0));
+            AssertBitwiseEqual(1.0, IncrementOperatorsHelper<double>.op_Increment(-MinNormal));
+            AssertBitwiseEqual(1.0, IncrementOperatorsHelper<double>.op_Increment(-MaxSubnormal));
+            AssertBitwiseEqual(1.0, IncrementOperatorsHelper<double>.op_Increment(-double.Epsilon));
+            AssertBitwiseEqual(1.0, IncrementOperatorsHelper<double>.op_Increment(-0.0));
+            AssertBitwiseEqual(double.NaN, IncrementOperatorsHelper<double>.op_Increment(double.NaN));
+            AssertBitwiseEqual(1.0, IncrementOperatorsHelper<double>.op_Increment(0.0));
+            AssertBitwiseEqual(1.0, IncrementOperatorsHelper<double>.op_Increment(double.Epsilon));
+            AssertBitwiseEqual(1.0, IncrementOperatorsHelper<double>.op_Increment(MaxSubnormal));
+            AssertBitwiseEqual(1.0, IncrementOperatorsHelper<double>.op_Increment(MinNormal));
+            AssertBitwiseEqual(2.0, IncrementOperatorsHelper<double>.op_Increment(1.0));
+            AssertBitwiseEqual(double.MaxValue, IncrementOperatorsHelper<double>.op_Increment(double.MaxValue));
+            AssertBitwiseEqual(double.PositiveInfinity, IncrementOperatorsHelper<double>.op_Increment(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_CheckedIncrementTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, IncrementOperatorsHelper<double>.op_CheckedIncrement(double.NegativeInfinity));
+            AssertBitwiseEqual(double.MinValue, IncrementOperatorsHelper<double>.op_CheckedIncrement(double.MinValue));
+            AssertBitwiseEqual(0.0, IncrementOperatorsHelper<double>.op_CheckedIncrement(-1.0));
+            AssertBitwiseEqual(1.0, IncrementOperatorsHelper<double>.op_CheckedIncrement(-MinNormal));
+            AssertBitwiseEqual(1.0, IncrementOperatorsHelper<double>.op_CheckedIncrement(-MaxSubnormal));
+            AssertBitwiseEqual(1.0, IncrementOperatorsHelper<double>.op_CheckedIncrement(-double.Epsilon));
+            AssertBitwiseEqual(1.0, IncrementOperatorsHelper<double>.op_CheckedIncrement(-0.0));
+            AssertBitwiseEqual(double.NaN, IncrementOperatorsHelper<double>.op_CheckedIncrement(double.NaN));
+            AssertBitwiseEqual(1.0, IncrementOperatorsHelper<double>.op_CheckedIncrement(0.0));
+            AssertBitwiseEqual(1.0, IncrementOperatorsHelper<double>.op_CheckedIncrement(double.Epsilon));
+            AssertBitwiseEqual(1.0, IncrementOperatorsHelper<double>.op_CheckedIncrement(MaxSubnormal));
+            AssertBitwiseEqual(1.0, IncrementOperatorsHelper<double>.op_CheckedIncrement(MinNormal));
+            AssertBitwiseEqual(2.0, IncrementOperatorsHelper<double>.op_CheckedIncrement(1.0));
+            AssertBitwiseEqual(double.MaxValue, IncrementOperatorsHelper<double>.op_CheckedIncrement(double.MaxValue));
+            AssertBitwiseEqual(double.PositiveInfinity, IncrementOperatorsHelper<double>.op_CheckedIncrement(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_ModulusTest()
+        {
+            AssertBitwiseEqual(double.NaN, ModulusOperatorsHelper<double, double, double>.op_Modulus(double.NegativeInfinity, 2.0));
+            AssertBitwiseEqual(-0.0, ModulusOperatorsHelper<double, double, double>.op_Modulus(double.MinValue, 2.0));
+            AssertBitwiseEqual(-1.0, ModulusOperatorsHelper<double, double, double>.op_Modulus(-1.0, 2.0));
+            AssertBitwiseEqual(-MinNormal, ModulusOperatorsHelper<double, double, double>.op_Modulus(-MinNormal, 2.0));
+            AssertBitwiseEqual(-MaxSubnormal, ModulusOperatorsHelper<double, double, double>.op_Modulus(-MaxSubnormal, 2.0));
+            AssertBitwiseEqual(-double.Epsilon, ModulusOperatorsHelper<double, double, double>.op_Modulus(-double.Epsilon, 2.0)); ;
+            AssertBitwiseEqual(-0.0, ModulusOperatorsHelper<double, double, double>.op_Modulus(-0.0, 2.0));
+            AssertBitwiseEqual(double.NaN, ModulusOperatorsHelper<double, double, double>.op_Modulus(double.NaN, 2.0));
+            AssertBitwiseEqual(0.0, ModulusOperatorsHelper<double, double, double>.op_Modulus(0.0, 2.0));
+            AssertBitwiseEqual(double.Epsilon, ModulusOperatorsHelper<double, double, double>.op_Modulus(double.Epsilon, 2.0));
+            AssertBitwiseEqual(MaxSubnormal, ModulusOperatorsHelper<double, double, double>.op_Modulus(MaxSubnormal, 2.0));
+            AssertBitwiseEqual(MinNormal, ModulusOperatorsHelper<double, double, double>.op_Modulus(MinNormal, 2.0));
+            AssertBitwiseEqual(1.0, ModulusOperatorsHelper<double, double, double>.op_Modulus(1.0, 2.0));
+            AssertBitwiseEqual(0.0, ModulusOperatorsHelper<double, double, double>.op_Modulus(double.MaxValue, 2.0));
+            AssertBitwiseEqual(double.NaN, ModulusOperatorsHelper<double, double, double>.op_Modulus(double.PositiveInfinity, 2.0));
+        }
+
+        [Fact]
+        public static void op_MultiplyTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, MultiplyOperatorsHelper<double, double, double>.op_Multiply(double.NegativeInfinity, 2.0));
+            AssertBitwiseEqual(double.NegativeInfinity, MultiplyOperatorsHelper<double, double, double>.op_Multiply(double.MinValue, 2.0));
+            AssertBitwiseEqual(-2.0, MultiplyOperatorsHelper<double, double, double>.op_Multiply(-1.0, 2.0));
+            AssertBitwiseEqual(-4.4501477170144028E-308, MultiplyOperatorsHelper<double, double, double>.op_Multiply(-MinNormal, 2.0));
+            AssertBitwiseEqual(-4.4501477170144018E-308, MultiplyOperatorsHelper<double, double, double>.op_Multiply(-MaxSubnormal, 2.0));
+            AssertBitwiseEqual(-9.8813129168249309E-324, MultiplyOperatorsHelper<double, double, double>.op_Multiply(-double.Epsilon, 2.0));
+            AssertBitwiseEqual(-0.0, MultiplyOperatorsHelper<double, double, double>.op_Multiply(-0.0, 2.0));
+            AssertBitwiseEqual(double.NaN, MultiplyOperatorsHelper<double, double, double>.op_Multiply(double.NaN, 2.0));
+            AssertBitwiseEqual(0.0, MultiplyOperatorsHelper<double, double, double>.op_Multiply(0.0, 2.0));
+            AssertBitwiseEqual(9.8813129168249309E-324, MultiplyOperatorsHelper<double, double, double>.op_Multiply(double.Epsilon, 2.0));
+            AssertBitwiseEqual(4.4501477170144018E-308, MultiplyOperatorsHelper<double, double, double>.op_Multiply(MaxSubnormal, 2.0));
+            AssertBitwiseEqual(4.4501477170144028E-308, MultiplyOperatorsHelper<double, double, double>.op_Multiply(MinNormal, 2.0));
+            AssertBitwiseEqual(2.0, MultiplyOperatorsHelper<double, double, double>.op_Multiply(1.0, 2.0));
+            AssertBitwiseEqual(double.PositiveInfinity, MultiplyOperatorsHelper<double, double, double>.op_Multiply(double.MaxValue, 2.0));
+            AssertBitwiseEqual(double.PositiveInfinity, MultiplyOperatorsHelper<double, double, double>.op_Multiply(double.PositiveInfinity, 2.0));
+        }
+
+        [Fact]
+        public static void op_CheckedMultiplyTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, MultiplyOperatorsHelper<double, double, double>.op_CheckedMultiply(double.NegativeInfinity, 2.0));
+            AssertBitwiseEqual(double.NegativeInfinity, MultiplyOperatorsHelper<double, double, double>.op_CheckedMultiply(double.MinValue, 2.0));
+            AssertBitwiseEqual(-2.0, MultiplyOperatorsHelper<double, double, double>.op_CheckedMultiply(-1.0, 2.0));
+            AssertBitwiseEqual(-4.4501477170144028E-308, MultiplyOperatorsHelper<double, double, double>.op_CheckedMultiply(-MinNormal, 2.0));
+            AssertBitwiseEqual(-4.4501477170144018E-308, MultiplyOperatorsHelper<double, double, double>.op_CheckedMultiply(-MaxSubnormal, 2.0));
+            AssertBitwiseEqual(-9.8813129168249309E-324, MultiplyOperatorsHelper<double, double, double>.op_CheckedMultiply(-double.Epsilon, 2.0));
+            AssertBitwiseEqual(-0.0, MultiplyOperatorsHelper<double, double, double>.op_CheckedMultiply(-0.0, 2.0));
+            AssertBitwiseEqual(double.NaN, MultiplyOperatorsHelper<double, double, double>.op_CheckedMultiply(double.NaN, 2.0));
+            AssertBitwiseEqual(0.0, MultiplyOperatorsHelper<double, double, double>.op_CheckedMultiply(0.0, 2.0));
+            AssertBitwiseEqual(9.8813129168249309E-324, MultiplyOperatorsHelper<double, double, double>.op_CheckedMultiply(double.Epsilon, 2.0));
+            AssertBitwiseEqual(4.4501477170144018E-308, MultiplyOperatorsHelper<double, double, double>.op_CheckedMultiply(MaxSubnormal, 2.0));
+            AssertBitwiseEqual(4.4501477170144028E-308, MultiplyOperatorsHelper<double, double, double>.op_CheckedMultiply(MinNormal, 2.0));
+            AssertBitwiseEqual(2.0, MultiplyOperatorsHelper<double, double, double>.op_CheckedMultiply(1.0, 2.0));
+            AssertBitwiseEqual(double.PositiveInfinity, MultiplyOperatorsHelper<double, double, double>.op_CheckedMultiply(double.MaxValue, 2.0));
+            AssertBitwiseEqual(double.PositiveInfinity, MultiplyOperatorsHelper<double, double, double>.op_CheckedMultiply(double.PositiveInfinity, 2.0));
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            AssertBitwiseEqual(double.PositiveInfinity, NumberHelper<double>.Abs(double.NegativeInfinity));
+            AssertBitwiseEqual(double.MaxValue, NumberHelper<double>.Abs(double.MinValue));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Abs(-1.0));
+            AssertBitwiseEqual(MinNormal, NumberHelper<double>.Abs(-MinNormal));
+            AssertBitwiseEqual(MaxSubnormal, NumberHelper<double>.Abs(-MaxSubnormal));
+            AssertBitwiseEqual(double.Epsilon, NumberHelper<double>.Abs(-double.Epsilon));
+            AssertBitwiseEqual(0.0, NumberHelper<double>.Abs(-0.0));
+            AssertBitwiseEqual(double.NaN, NumberHelper<double>.Abs(double.NaN));
+            AssertBitwiseEqual(0.0, NumberHelper<double>.Abs(0.0));
+            AssertBitwiseEqual(double.Epsilon, NumberHelper<double>.Abs(double.Epsilon));
+            AssertBitwiseEqual(MaxSubnormal, NumberHelper<double>.Abs(MaxSubnormal));
+            AssertBitwiseEqual(MinNormal, NumberHelper<double>.Abs(MinNormal));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Abs(1.0));
+            AssertBitwiseEqual(double.MaxValue, NumberHelper<double>.Abs(double.MaxValue));
+            AssertBitwiseEqual(double.PositiveInfinity, NumberHelper<double>.Abs(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void ClampTest()
+        {
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Clamp(double.NegativeInfinity, 1.0, 63.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Clamp(double.MinValue, 1.0, 63.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Clamp(-1.0, 1.0, 63.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Clamp(-MinNormal, 1.0, 63.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Clamp(-MaxSubnormal, 1.0, 63.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Clamp(-double.Epsilon, 1.0, 63.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Clamp(-0.0, 1.0, 63.0));
+            AssertBitwiseEqual(double.NaN, NumberHelper<double>.Clamp(double.NaN, 1.0, 63.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Clamp(0.0, 1.0, 63.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Clamp(double.Epsilon, 1.0, 63.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Clamp(MaxSubnormal, 1.0, 63.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Clamp(MinNormal, 1.0, 63.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Clamp(1.0, 1.0, 63.0));
+            AssertBitwiseEqual(63.0, NumberHelper<double>.Clamp(double.MaxValue, 1.0, 63.0));
+            AssertBitwiseEqual(63.0, NumberHelper<double>.Clamp(double.PositiveInfinity, 1.0, 63.0));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromByteTest()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<byte>(0x00));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<byte>(0x01));
+            AssertBitwiseEqual(127.0, NumberHelper<double>.CreateChecked<byte>(0x7F));
+            AssertBitwiseEqual(128.0, NumberHelper<double>.CreateChecked<byte>(0x80));
+            AssertBitwiseEqual(255.0, NumberHelper<double>.CreateChecked<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromCharTest()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<char>((char)0x0000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<char>((char)0x0001));
+            AssertBitwiseEqual(32767.0, NumberHelper<double>.CreateChecked<char>((char)0x7FFF));
+            AssertBitwiseEqual(32768.0, NumberHelper<double>.CreateChecked<char>((char)0x8000));
+            AssertBitwiseEqual(65535.0, NumberHelper<double>.CreateChecked<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt16Test()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<short>(0x0000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<short>(0x0001));
+            AssertBitwiseEqual(32767.0, NumberHelper<double>.CreateChecked<short>(0x7FFF));
+            AssertBitwiseEqual(-32768.0, NumberHelper<double>.CreateChecked<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateChecked<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt32Test()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<int>(0x00000000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<int>(0x00000001));
+            AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateChecked<int>(0x7FFFFFFF));
+            AssertBitwiseEqual(-2147483648.0, NumberHelper<double>.CreateChecked<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt64Test()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<long>(0x0000000000000000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<long>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(-9223372036854775808.0, NumberHelper<double>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(-9223372036854775808.0, NumberHelper<double>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<nint>((nint)0x00000000));
+                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<nint>((nint)0x00000001));
+                AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual(-2147483648.0, NumberHelper<double>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateCheckedFromSByteTest()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<sbyte>(0x00));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<sbyte>(0x01));
+            AssertBitwiseEqual(127.0, NumberHelper<double>.CreateChecked<sbyte>(0x7F));
+            AssertBitwiseEqual(-128.0, NumberHelper<double>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt16Test()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<ushort>(0x0000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<ushort>(0x0001));
+            AssertBitwiseEqual(32767.0, NumberHelper<double>.CreateChecked<ushort>(0x7FFF));
+            AssertBitwiseEqual(32768.0, NumberHelper<double>.CreateChecked<ushort>(0x8000));
+            AssertBitwiseEqual(65535.0, NumberHelper<double>.CreateChecked<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt32Test()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<uint>(0x00000000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<uint>(0x00000001));
+            AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateChecked<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual(2147483648.0, NumberHelper<double>.CreateChecked<uint>(0x80000000));
+            AssertBitwiseEqual(4294967295.0, NumberHelper<double>.CreateChecked<uint>(0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt64Test()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(9223372036854775808.0, NumberHelper<double>.CreateChecked<ulong>(0x8000000000000000));
+            AssertBitwiseEqual(18446744073709551615.0, NumberHelper<double>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual(9223372036854775808.0, NumberHelper<double>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual(18446744073709551615.0,NumberHelper<double>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateChecked<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateChecked<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual(2147483648.0, NumberHelper<double>.CreateChecked<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual(4294967295.0, NumberHelper<double>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromByteTest()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<byte>(0x00));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<byte>(0x01));
+            AssertBitwiseEqual(127.0, NumberHelper<double>.CreateSaturating<byte>(0x7F));
+            AssertBitwiseEqual(128.0, NumberHelper<double>.CreateSaturating<byte>(0x80));
+            AssertBitwiseEqual(255.0, NumberHelper<double>.CreateSaturating<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromCharTest()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<char>((char)0x0000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<char>((char)0x0001));
+            AssertBitwiseEqual(32767.0, NumberHelper<double>.CreateSaturating<char>((char)0x7FFF));
+            AssertBitwiseEqual(32768.0, NumberHelper<double>.CreateSaturating<char>((char)0x8000));
+            AssertBitwiseEqual(65535.0, NumberHelper<double>.CreateSaturating<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt16Test()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<short>(0x0000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<short>(0x0001));
+            AssertBitwiseEqual(32767.0, NumberHelper<double>.CreateSaturating<short>(0x7FFF));
+            AssertBitwiseEqual(-32768.0, NumberHelper<double>.CreateSaturating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt32Test()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<int>(0x00000000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<int>(0x00000001));
+            AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateSaturating<int>(0x7FFFFFFF));
+            AssertBitwiseEqual(-2147483648.0, NumberHelper<double>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt64Test()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<long>(0x0000000000000000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<long>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(-9223372036854775808.0, NumberHelper<double>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(-9223372036854775808.0, NumberHelper<double>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<nint>((nint)0x00000001));
+                AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual(-2147483648.0, NumberHelper<double>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromSByteTest()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<sbyte>(0x00));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<sbyte>(0x01));
+            AssertBitwiseEqual(127.0, NumberHelper<double>.CreateSaturating<sbyte>(0x7F));
+            AssertBitwiseEqual(-128.0, NumberHelper<double>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt16Test()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<ushort>(0x0000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<ushort>(0x0001));
+            AssertBitwiseEqual(32767.0, NumberHelper<double>.CreateSaturating<ushort>(0x7FFF));
+            AssertBitwiseEqual(32768.0, NumberHelper<double>.CreateSaturating<ushort>(0x8000));
+            AssertBitwiseEqual(65535.0, NumberHelper<double>.CreateSaturating<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt32Test()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<uint>(0x00000000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<uint>(0x00000001));
+            AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateSaturating<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual(2147483648.0, NumberHelper<double>.CreateSaturating<uint>(0x80000000));
+            AssertBitwiseEqual(4294967295.0, NumberHelper<double>.CreateSaturating<uint>(0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt64Test()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(9223372036854775808.0, NumberHelper<double>.CreateSaturating<ulong>(0x8000000000000000));
+            AssertBitwiseEqual(18446744073709551615.0, NumberHelper<double>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual(9223372036854775808.0, NumberHelper<double>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual(18446744073709551615.0, NumberHelper<double>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateSaturating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateSaturating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual(2147483648.0, NumberHelper<double>.CreateSaturating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual(4294967295.0, NumberHelper<double>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromByteTest()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<byte>(0x00));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<byte>(0x01));
+            AssertBitwiseEqual(127.0, NumberHelper<double>.CreateTruncating<byte>(0x7F));
+            AssertBitwiseEqual(128.0, NumberHelper<double>.CreateTruncating<byte>(0x80));
+            AssertBitwiseEqual(255.0, NumberHelper<double>.CreateTruncating<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromCharTest()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<char>((char)0x0000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<char>((char)0x0001));
+            AssertBitwiseEqual(32767.0, NumberHelper<double>.CreateTruncating<char>((char)0x7FFF));
+            AssertBitwiseEqual(32768.0, NumberHelper<double>.CreateTruncating<char>((char)0x8000));
+            AssertBitwiseEqual(65535.0, NumberHelper<double>.CreateTruncating<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt16Test()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<short>(0x0000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<short>(0x0001));
+            AssertBitwiseEqual(32767.0, NumberHelper<double>.CreateTruncating<short>(0x7FFF));
+            AssertBitwiseEqual(-32768.0, NumberHelper<double>.CreateTruncating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt32Test()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<int>(0x00000000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<int>(0x00000001));
+            AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateTruncating<int>(0x7FFFFFFF));
+            AssertBitwiseEqual(-2147483648.0, NumberHelper<double>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt64Test()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<long>(0x0000000000000000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<long>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(-9223372036854775808.0, NumberHelper<double>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(-9223372036854775808.0, NumberHelper<double>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<nint>((nint)0x00000001));
+                AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual(-2147483648.0, NumberHelper<double>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromSByteTest()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<sbyte>(0x00));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<sbyte>(0x01));
+            AssertBitwiseEqual(127.0, NumberHelper<double>.CreateTruncating<sbyte>(0x7F));
+            AssertBitwiseEqual(-128.0, NumberHelper<double>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(-1.0, NumberHelper<double>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt16Test()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<ushort>(0x0000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<ushort>(0x0001));
+            AssertBitwiseEqual(32767.0, NumberHelper<double>.CreateTruncating<ushort>(0x7FFF));
+            AssertBitwiseEqual(32768.0, NumberHelper<double>.CreateTruncating<ushort>(0x8000));
+            AssertBitwiseEqual(65535.0, NumberHelper<double>.CreateTruncating<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt32Test()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<uint>(0x00000000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<uint>(0x00000001));
+            AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateTruncating<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual(2147483648.0, NumberHelper<double>.CreateTruncating<uint>(0x80000000));
+            AssertBitwiseEqual(4294967295.0, NumberHelper<double>.CreateTruncating<uint>(0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt64Test()
+        {
+            AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(9223372036854775808.0, NumberHelper<double>.CreateTruncating<ulong>(0x8000000000000000));
+            AssertBitwiseEqual(18446744073709551615.0, NumberHelper<double>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0, NumberHelper<double>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual(9223372036854775808.0, NumberHelper<double>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual(18446744073709551615.0, NumberHelper<double>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(0.0, NumberHelper<double>.CreateTruncating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(1.0, NumberHelper<double>.CreateTruncating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual(2147483647.0, NumberHelper<double>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual(2147483648.0, NumberHelper<double>.CreateTruncating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual(4294967295.0, NumberHelper<double>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(double.NegativeInfinity, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(double.MinValue, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(-1.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(-MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(-MaxSubnormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(-double.Epsilon, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(-0.0, 1.0));
+            AssertBitwiseEqual(double.NaN, NumberHelper<double>.Max(double.NaN, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(0.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(double.Epsilon, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(MaxSubnormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Max(1.0, 1.0));
+            AssertBitwiseEqual(double.MaxValue, NumberHelper<double>.Max(double.MaxValue, 1.0));
+            AssertBitwiseEqual(double.PositiveInfinity, NumberHelper<double>.Max(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, NumberHelper<double>.Min(double.NegativeInfinity, 1.0));
+            AssertBitwiseEqual(double.MinValue, NumberHelper<double>.Min(double.MinValue, 1.0));
+            AssertBitwiseEqual(-1.0, NumberHelper<double>.Min(-1.0, 1.0));
+            AssertBitwiseEqual(-MinNormal, NumberHelper<double>.Min(-MinNormal, 1.0));
+            AssertBitwiseEqual(-MaxSubnormal, NumberHelper<double>.Min(-MaxSubnormal, 1.0));
+            AssertBitwiseEqual(-double.Epsilon, NumberHelper<double>.Min(-double.Epsilon, 1.0));
+            AssertBitwiseEqual(-0.0, NumberHelper<double>.Min(-0.0, 1.0));
+            AssertBitwiseEqual(double.NaN, NumberHelper<double>.Min(double.NaN, 1.0));
+            AssertBitwiseEqual(0.0, NumberHelper<double>.Min(0.0, 1.0));
+            AssertBitwiseEqual(double.Epsilon, NumberHelper<double>.Min(double.Epsilon, 1.0));
+            AssertBitwiseEqual(MaxSubnormal, NumberHelper<double>.Min(MaxSubnormal, 1.0));
+            AssertBitwiseEqual(MinNormal, NumberHelper<double>.Min(MinNormal, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Min(1.0, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Min(double.MaxValue, 1.0));
+            AssertBitwiseEqual(1.0, NumberHelper<double>.Min(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(-1, NumberHelper<double>.Sign(double.NegativeInfinity));
+            Assert.Equal(-1, NumberHelper<double>.Sign(double.MinValue));
+            Assert.Equal(-1, NumberHelper<double>.Sign(-1.0));
+            Assert.Equal(-1, NumberHelper<double>.Sign(-MinNormal));
+            Assert.Equal(-1, NumberHelper<double>.Sign(-MaxSubnormal));
+            Assert.Equal(-1, NumberHelper<double>.Sign(-double.Epsilon));
+
+            Assert.Equal(0, NumberHelper<double>.Sign(-0.0));
+            Assert.Equal(0, NumberHelper<double>.Sign(0.0));
+
+            Assert.Equal(1, NumberHelper<double>.Sign(double.Epsilon));
+            Assert.Equal(1, NumberHelper<double>.Sign(MaxSubnormal));
+            Assert.Equal(1, NumberHelper<double>.Sign(MinNormal));
+            Assert.Equal(1, NumberHelper<double>.Sign(1.0));
+            Assert.Equal(1, NumberHelper<double>.Sign(double.MaxValue));
+            Assert.Equal(1, NumberHelper<double>.Sign(double.PositiveInfinity));
+
+            Assert.Throws<ArithmeticException>(() => NumberHelper<double>.Sign(double.NaN));
+        }
+
+        [Fact]
+        public static void TryCreateFromByteTest()
+        {
+            double result;
+
+            Assert.True(NumberHelper<double>.TryCreate<byte>(0x00, out result));
+            Assert.Equal(0.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<byte>(0x01, out result));
+            Assert.Equal(1.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<byte>(0x7F, out result));
+            Assert.Equal(127.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<byte>(0x80, out result));
+            Assert.Equal(128.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<byte>(0xFF, out result));
+            Assert.Equal(255.0, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromCharTest()
+        {
+            double result;
+
+            Assert.True(NumberHelper<double>.TryCreate<char>((char)0x0000, out result));
+            Assert.Equal(0.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<char>((char)0x0001, out result));
+            Assert.Equal(1.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.Equal(32767.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<char>((char)0x8000, out result));
+            Assert.Equal(32768.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.Equal(65535.0, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt16Test()
+        {
+            double result;
+
+            Assert.True(NumberHelper<double>.TryCreate<short>(0x0000, out result));
+            Assert.Equal(0.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<short>(0x0001, out result));
+            Assert.Equal(1.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<short>(0x7FFF, out result));
+            Assert.Equal(32767.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.Equal(-32768.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.Equal(-1.0, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt32Test()
+        {
+            double result;
+
+            Assert.True(NumberHelper<double>.TryCreate<int>(0x00000000, out result));
+            Assert.Equal(0.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<int>(0x00000001, out result));
+            Assert.Equal(1.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.Equal(2147483647.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.Equal(-2147483648.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.Equal(-1.0, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt64Test()
+        {
+            double result;
+
+            Assert.True(NumberHelper<double>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.Equal(0.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.Equal(1.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.Equal(9223372036854775807.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
+            Assert.Equal(-9223372036854775808.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
+            Assert.Equal(-1.0, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromIntPtrTest()
+        {
+            double result;
+
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberHelper<double>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.Equal(0.0, result);
+
+                Assert.True(NumberHelper<double>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.Equal(1.0, result);
+
+                Assert.True(NumberHelper<double>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.Equal(9223372036854775807.0, result);
+
+                Assert.True(NumberHelper<double>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.Equal(-9223372036854775808.0, result);
+
+                Assert.True(NumberHelper<double>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.Equal(-1.0, result);
+            }
+            else
+            {
+                Assert.True(NumberHelper<double>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.Equal(0.0, result);
+
+                Assert.True(NumberHelper<double>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.Equal(1.0, result);
+
+                Assert.True(NumberHelper<double>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.Equal(2147483647.0, result);
+
+                Assert.True(NumberHelper<double>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.Equal(-2147483648.0, result);
+
+                Assert.True(NumberHelper<double>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.Equal(-1.0, result);
+            }
+        }
+
+        [Fact]
+        public static void TryCreateFromSByteTest()
+        {
+            double result;
+
+            Assert.True(NumberHelper<double>.TryCreate<sbyte>(0x00, out result));
+            Assert.Equal(0.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<sbyte>(0x01, out result));
+            Assert.Equal(1.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<sbyte>(0x7F, out result));
+            Assert.Equal(127.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.Equal(-128.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.Equal(-1.0, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt16Test()
+        {
+            double result;
+
+            Assert.True(NumberHelper<double>.TryCreate<ushort>(0x0000, out result));
+            Assert.Equal(0.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<ushort>(0x0001, out result));
+            Assert.Equal(1.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.Equal(32767.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<ushort>(0x8000, out result));
+            Assert.Equal(32768.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.Equal(65535.0, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt32Test()
+        {
+            double result;
+
+            Assert.True(NumberHelper<double>.TryCreate<uint>(0x00000000, out result));
+            Assert.Equal(0.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<uint>(0x00000001, out result));
+            Assert.Equal(1.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.Equal(2147483647.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<uint>(0x80000000, out result));
+            Assert.Equal(2147483648.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.Equal(4294967295.0, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt64Test()
+        {
+            double result;
+
+            Assert.True(NumberHelper<double>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.Equal(0.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.Equal(1.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.Equal(9223372036854775807.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.Equal(9223372036854775808.0, result);
+
+            Assert.True(NumberHelper<double>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.Equal(18446744073709551615.0, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUIntPtrTest()
+        {
+            double result;
+
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberHelper<double>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.Equal(0.0, result);
+
+                Assert.True(NumberHelper<double>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.Equal(1.0, result);
+
+                Assert.True(NumberHelper<double>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.Equal(9223372036854775807.0, result);
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // Assert.True(NumberHelper<double>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                // Assert.Equal(9223372036854775808.0, result);
+                //
+                // Assert.True(NumberHelper<double>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                // Assert.Equal(18446744073709551615.0, result);
+            }
+            else
+            {
+                Assert.True(NumberHelper<double>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.Equal(0.0, result);
+
+                Assert.True(NumberHelper<double>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.Equal(1.0, result);
+
+                Assert.True(NumberHelper<double>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.Equal(2147483647.0, result);
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // Assert.True(NumberHelper<double>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                // Assert.Equal(2147483648.0, result);
+                //
+                // Assert.True(NumberHelper<double>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                // Assert.Equal(4294967295.0, result);
+            }
+        }
+
+        [Fact]
+        public static void op_SubtractionTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, SubtractionOperatorsHelper<double, double, double>.op_Subtraction(double.NegativeInfinity, 1.0));
+            AssertBitwiseEqual(double.MinValue, SubtractionOperatorsHelper<double, double, double>.op_Subtraction(double.MinValue, 1.0));
+            AssertBitwiseEqual(-2.0, SubtractionOperatorsHelper<double, double, double>.op_Subtraction(-1.0, 1.0));
+            AssertBitwiseEqual(-1.0, SubtractionOperatorsHelper<double, double, double>.op_Subtraction(-MinNormal, 1.0));
+            AssertBitwiseEqual(-1.0, SubtractionOperatorsHelper<double, double, double>.op_Subtraction(-MaxSubnormal, 1.0));
+            AssertBitwiseEqual(-1.0, SubtractionOperatorsHelper<double, double, double>.op_Subtraction(-double.Epsilon, 1.0));
+            AssertBitwiseEqual(-1.0, SubtractionOperatorsHelper<double, double, double>.op_Subtraction(-0.0, 1.0));
+            AssertBitwiseEqual(double.NaN, SubtractionOperatorsHelper<double, double, double>.op_Subtraction(double.NaN, 1.0));
+            AssertBitwiseEqual(-1.0, SubtractionOperatorsHelper<double, double, double>.op_Subtraction(0.0, 1.0));
+            AssertBitwiseEqual(-1.0, SubtractionOperatorsHelper<double, double, double>.op_Subtraction(double.Epsilon, 1.0));
+            AssertBitwiseEqual(-1.0, SubtractionOperatorsHelper<double, double, double>.op_Subtraction(MaxSubnormal, 1.0));
+            AssertBitwiseEqual(-1.0, SubtractionOperatorsHelper<double, double, double>.op_Subtraction(MinNormal, 1.0));
+            AssertBitwiseEqual(0.0, SubtractionOperatorsHelper<double, double, double>.op_Subtraction(1.0, 1.0));
+            AssertBitwiseEqual(double.MaxValue, SubtractionOperatorsHelper<double, double, double>.op_Subtraction(double.MaxValue, 1.0));
+            AssertBitwiseEqual(double.PositiveInfinity, SubtractionOperatorsHelper<double, double, double>.op_Subtraction(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void op_CheckedSubtractionTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, SubtractionOperatorsHelper<double, double, double>.op_CheckedSubtraction(double.NegativeInfinity, 1.0));
+            AssertBitwiseEqual(double.MinValue, SubtractionOperatorsHelper<double, double, double>.op_CheckedSubtraction(double.MinValue, 1.0));
+            AssertBitwiseEqual(-2.0, SubtractionOperatorsHelper<double, double, double>.op_CheckedSubtraction(-1.0, 1.0));
+            AssertBitwiseEqual(-1.0, SubtractionOperatorsHelper<double, double, double>.op_CheckedSubtraction(-MinNormal, 1.0));
+            AssertBitwiseEqual(-1.0, SubtractionOperatorsHelper<double, double, double>.op_CheckedSubtraction(-MaxSubnormal, 1.0));
+            AssertBitwiseEqual(-1.0, SubtractionOperatorsHelper<double, double, double>.op_CheckedSubtraction(-double.Epsilon, 1.0));
+            AssertBitwiseEqual(-1.0, SubtractionOperatorsHelper<double, double, double>.op_CheckedSubtraction(-0.0, 1.0));
+            AssertBitwiseEqual(double.NaN, SubtractionOperatorsHelper<double, double, double>.op_CheckedSubtraction(double.NaN, 1.0));
+            AssertBitwiseEqual(-1.0, SubtractionOperatorsHelper<double, double, double>.op_CheckedSubtraction(0.0, 1.0));
+            AssertBitwiseEqual(-1.0, SubtractionOperatorsHelper<double, double, double>.op_CheckedSubtraction(double.Epsilon, 1.0));
+            AssertBitwiseEqual(-1.0, SubtractionOperatorsHelper<double, double, double>.op_CheckedSubtraction(MaxSubnormal, 1.0));
+            AssertBitwiseEqual(-1.0, SubtractionOperatorsHelper<double, double, double>.op_CheckedSubtraction(MinNormal, 1.0));
+            AssertBitwiseEqual(0.0, SubtractionOperatorsHelper<double, double, double>.op_CheckedSubtraction(1.0, 1.0));
+            AssertBitwiseEqual(double.MaxValue, SubtractionOperatorsHelper<double, double, double>.op_CheckedSubtraction(double.MaxValue, 1.0));
+            AssertBitwiseEqual(double.PositiveInfinity, SubtractionOperatorsHelper<double, double, double>.op_CheckedSubtraction(double.PositiveInfinity, 1.0));
+        }
+
+        [Fact]
+        public static void op_UnaryNegationTest()
+        {
+            AssertBitwiseEqual(double.PositiveInfinity, UnaryNegationOperatorsHelper<double, double>.op_UnaryNegation(double.NegativeInfinity));
+            AssertBitwiseEqual(double.MaxValue, UnaryNegationOperatorsHelper<double, double>.op_UnaryNegation(double.MinValue));
+            AssertBitwiseEqual(1.0, UnaryNegationOperatorsHelper<double, double>.op_UnaryNegation(-1.0));
+            AssertBitwiseEqual(MinNormal, UnaryNegationOperatorsHelper<double, double>.op_UnaryNegation(-MinNormal));
+            AssertBitwiseEqual(MaxSubnormal, UnaryNegationOperatorsHelper<double, double>.op_UnaryNegation(-MaxSubnormal));
+            AssertBitwiseEqual(double.Epsilon, UnaryNegationOperatorsHelper<double, double>.op_UnaryNegation(-double.Epsilon));
+            AssertBitwiseEqual(0.0, UnaryNegationOperatorsHelper<double, double>.op_UnaryNegation(-0.0));
+            AssertBitwiseEqual(double.NaN, UnaryNegationOperatorsHelper<double, double>.op_UnaryNegation(double.NaN));
+            AssertBitwiseEqual(-0.0, UnaryNegationOperatorsHelper<double, double>.op_UnaryNegation(0.0));
+            AssertBitwiseEqual(-double.Epsilon, UnaryNegationOperatorsHelper<double, double>.op_UnaryNegation(double.Epsilon));
+            AssertBitwiseEqual(-MaxSubnormal, UnaryNegationOperatorsHelper<double, double>.op_UnaryNegation(MaxSubnormal));
+            AssertBitwiseEqual(-MinNormal, UnaryNegationOperatorsHelper<double, double>.op_UnaryNegation(MinNormal));
+            AssertBitwiseEqual(-1.0, UnaryNegationOperatorsHelper<double, double>.op_UnaryNegation(1.0));
+            AssertBitwiseEqual(double.MinValue, UnaryNegationOperatorsHelper<double, double>.op_UnaryNegation(double.MaxValue));
+            AssertBitwiseEqual(double.NegativeInfinity, UnaryNegationOperatorsHelper<double, double>.op_UnaryNegation(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_CheckedUnaryNegationTest()
+        {
+            AssertBitwiseEqual(double.PositiveInfinity, UnaryNegationOperatorsHelper<double, double>.op_CheckedUnaryNegation(double.NegativeInfinity));
+            AssertBitwiseEqual(double.MaxValue, UnaryNegationOperatorsHelper<double, double>.op_CheckedUnaryNegation(double.MinValue));
+            AssertBitwiseEqual(1.0, UnaryNegationOperatorsHelper<double, double>.op_CheckedUnaryNegation(-1.0));
+            AssertBitwiseEqual(MinNormal, UnaryNegationOperatorsHelper<double, double>.op_CheckedUnaryNegation(-MinNormal));
+            AssertBitwiseEqual(MaxSubnormal, UnaryNegationOperatorsHelper<double, double>.op_CheckedUnaryNegation(-MaxSubnormal));
+            AssertBitwiseEqual(double.Epsilon, UnaryNegationOperatorsHelper<double, double>.op_CheckedUnaryNegation(-double.Epsilon));
+            AssertBitwiseEqual(0.0, UnaryNegationOperatorsHelper<double, double>.op_CheckedUnaryNegation(-0.0));
+            AssertBitwiseEqual(double.NaN, UnaryNegationOperatorsHelper<double, double>.op_CheckedUnaryNegation(double.NaN));
+            AssertBitwiseEqual(-0.0, UnaryNegationOperatorsHelper<double, double>.op_CheckedUnaryNegation(0.0));
+            AssertBitwiseEqual(-double.Epsilon, UnaryNegationOperatorsHelper<double, double>.op_CheckedUnaryNegation(double.Epsilon));
+            AssertBitwiseEqual(-MaxSubnormal, UnaryNegationOperatorsHelper<double, double>.op_CheckedUnaryNegation(MaxSubnormal));
+            AssertBitwiseEqual(-MinNormal, UnaryNegationOperatorsHelper<double, double>.op_CheckedUnaryNegation(MinNormal));
+            AssertBitwiseEqual(-1.0, UnaryNegationOperatorsHelper<double, double>.op_CheckedUnaryNegation(1.0));
+            AssertBitwiseEqual(double.MinValue, UnaryNegationOperatorsHelper<double, double>.op_CheckedUnaryNegation(double.MaxValue));
+            AssertBitwiseEqual(double.NegativeInfinity, UnaryNegationOperatorsHelper<double, double>.op_CheckedUnaryNegation(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_UnaryPlusTest()
+        {
+            AssertBitwiseEqual(double.NegativeInfinity, UnaryPlusOperatorsHelper<double, double>.op_UnaryPlus(double.NegativeInfinity));
+            AssertBitwiseEqual(double.MinValue, UnaryPlusOperatorsHelper<double, double>.op_UnaryPlus(double.MinValue));
+            AssertBitwiseEqual(-1.0, UnaryPlusOperatorsHelper<double, double>.op_UnaryPlus(-1.0));
+            AssertBitwiseEqual(-MinNormal, UnaryPlusOperatorsHelper<double, double>.op_UnaryPlus(-MinNormal));
+            AssertBitwiseEqual(-MaxSubnormal, UnaryPlusOperatorsHelper<double, double>.op_UnaryPlus(-MaxSubnormal));
+            AssertBitwiseEqual(-double.Epsilon, UnaryPlusOperatorsHelper<double, double>.op_UnaryPlus(-double.Epsilon));
+            AssertBitwiseEqual(-0.0, UnaryPlusOperatorsHelper<double, double>.op_UnaryPlus(-0.0));
+            AssertBitwiseEqual(double.NaN, UnaryPlusOperatorsHelper<double, double>.op_UnaryPlus(double.NaN));
+            AssertBitwiseEqual(0.0, UnaryPlusOperatorsHelper<double, double>.op_UnaryPlus(0.0));
+            AssertBitwiseEqual(double.Epsilon, UnaryPlusOperatorsHelper<double, double>.op_UnaryPlus(double.Epsilon));
+            AssertBitwiseEqual(MaxSubnormal, UnaryPlusOperatorsHelper<double, double>.op_UnaryPlus(MaxSubnormal));
+            AssertBitwiseEqual(MinNormal, UnaryPlusOperatorsHelper<double, double>.op_UnaryPlus(MinNormal));
+            AssertBitwiseEqual(1.0, UnaryPlusOperatorsHelper<double, double>.op_UnaryPlus(1.0));
+            AssertBitwiseEqual(double.MaxValue, UnaryPlusOperatorsHelper<double, double>.op_UnaryPlus(double.MaxValue));
+            AssertBitwiseEqual(double.PositiveInfinity, UnaryPlusOperatorsHelper<double, double>.op_UnaryPlus(double.PositiveInfinity));
+        }
+
         [Theory]
         [MemberData(nameof(DoubleTests.Parse_Valid_TestData), MemberType = typeof(DoubleTests))]
         public static void ParseValidStringTest(string value, NumberStyles style, IFormatProvider provider, double expected)

--- a/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
@@ -2,13 +2,1358 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using System.Runtime.Versioning;
 using Xunit;
 
 namespace System.Tests
 {
     public class HalfTests_GenericMath
     {
+        private static Half MinNormal => BitConverter.UInt16BitsToHalf(0x0400);
+
+        private static Half MaxSubnormal => BitConverter.UInt16BitsToHalf(0x03FF);
+
+        private static Half NegativeOne => BitConverter.UInt16BitsToHalf(0xBC00);
+
+        private static Half NegativeTwo => BitConverter.UInt16BitsToHalf(0xC000);
+
+        private static Half NegativeZero => BitConverter.UInt16BitsToHalf(0x8000);
+
+        private static Half PositiveOne => BitConverter.UInt16BitsToHalf(0x3C00);
+
+        private static Half PositiveTwo => BitConverter.UInt16BitsToHalf(0x4000);
+
+        private static Half PositiveZero => BitConverter.UInt16BitsToHalf(0x0000);
+
+        private static void AssertBitwiseEqual(Half expected, Half actual)
+        {
+            ushort expectedBits = BitConverter.HalfToUInt16Bits(expected);
+            ushort actualBits = BitConverter.HalfToUInt16Bits(actual);
+
+            if (expectedBits == actualBits)
+            {
+                return;
+            }
+
+            if (Half.IsNaN(expected) && Half.IsNaN(actual))
+            {
+                return;
+            }
+
+            throw new Xunit.Sdk.EqualException(expected, actual);
+        }
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            AssertBitwiseEqual(PositiveZero, AdditiveIdentityHelper<Half, Half>.AdditiveIdentity);
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            AssertBitwiseEqual(Half.MinValue, MinMaxValueHelper<Half>.MinValue);
+        }
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            AssertBitwiseEqual(Half.MaxValue, MinMaxValueHelper<Half>.MaxValue);
+        }
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            AssertBitwiseEqual(PositiveOne, MultiplicativeIdentityHelper<Half, Half>.MultiplicativeIdentity);
+        }
+
+        [Fact]
+        public static void NegativeOneTest()
+        {
+            Assert.Equal(NegativeOne, SignedNumberHelper<Half>.NegativeOne);
+        }
+
+        [Fact]
+        public static void OneTest()
+        {
+            AssertBitwiseEqual(PositiveOne, NumberBaseHelper<Half>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberBaseHelper<Half>.Zero);
+        }
+
+        [Fact]
+        public static void op_AdditionTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Half.NegativeInfinity, PositiveOne));
+            AssertBitwiseEqual(Half.MinValue, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Half.MinValue, PositiveOne));
+            AssertBitwiseEqual(PositiveZero, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(NegativeOne, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(-MinNormal, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(-MaxSubnormal, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(-Half.Epsilon, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(NegativeZero, PositiveOne));
+            AssertBitwiseEqual(Half.NaN, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Half.NaN, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(PositiveZero, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Half.Epsilon, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(MaxSubnormal, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(MinNormal, PositiveOne));
+            AssertBitwiseEqual(PositiveTwo, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(PositiveOne, PositiveOne));
+            AssertBitwiseEqual(Half.MaxValue, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Half.MaxValue, PositiveOne));
+            AssertBitwiseEqual(Half.PositiveInfinity, AdditionOperatorsHelper<Half, Half, Half>.op_Addition(Half.PositiveInfinity, PositiveOne));
+        }
+
+        [Fact]
+        public static void op_CheckedAdditionTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Half.NegativeInfinity, PositiveOne));
+            AssertBitwiseEqual(Half.MinValue, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Half.MinValue, PositiveOne));
+            AssertBitwiseEqual(PositiveZero, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(NegativeOne, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(-MinNormal, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(-MaxSubnormal, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(-Half.Epsilon, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(NegativeZero, PositiveOne));
+            AssertBitwiseEqual(Half.NaN, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Half.NaN, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(PositiveZero, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Half.Epsilon, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(MaxSubnormal, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(MinNormal, PositiveOne));
+            AssertBitwiseEqual(PositiveTwo, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(PositiveOne, PositiveOne));
+            AssertBitwiseEqual(Half.MaxValue, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Half.MaxValue, PositiveOne));
+            AssertBitwiseEqual(Half.PositiveInfinity, AdditionOperatorsHelper<Half, Half, Half>.op_CheckedAddition(Half.PositiveInfinity, PositiveOne));
+        }
+
+        [Fact]
+        public static void IsPow2Test()
+        {
+            Assert.False(BinaryNumberHelper<Half>.IsPow2(Half.NegativeInfinity));
+            Assert.False(BinaryNumberHelper<Half>.IsPow2(Half.MinValue));
+            Assert.False(BinaryNumberHelper<Half>.IsPow2(NegativeOne));
+            Assert.False(BinaryNumberHelper<Half>.IsPow2(-MinNormal));
+            Assert.False(BinaryNumberHelper<Half>.IsPow2(-MaxSubnormal));
+            Assert.False(BinaryNumberHelper<Half>.IsPow2(-Half.Epsilon));
+            Assert.False(BinaryNumberHelper<Half>.IsPow2(NegativeZero));
+            Assert.False(BinaryNumberHelper<Half>.IsPow2(Half.NaN));
+            Assert.False(BinaryNumberHelper<Half>.IsPow2(PositiveZero));
+            Assert.False(BinaryNumberHelper<Half>.IsPow2(Half.Epsilon));
+            Assert.False(BinaryNumberHelper<Half>.IsPow2(MaxSubnormal));
+            Assert.True(BinaryNumberHelper<Half>.IsPow2(MinNormal));
+            Assert.True(BinaryNumberHelper<Half>.IsPow2(PositiveOne));
+            Assert.False(BinaryNumberHelper<Half>.IsPow2(Half.MaxValue));
+            Assert.False(BinaryNumberHelper<Half>.IsPow2(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void Log2Test()
+        {
+            AssertBitwiseEqual(Half.NaN, BinaryNumberHelper<Half>.Log2(Half.NegativeInfinity));
+            AssertBitwiseEqual(Half.NaN, BinaryNumberHelper<Half>.Log2(Half.MinValue));
+            AssertBitwiseEqual(Half.NaN, BinaryNumberHelper<Half>.Log2(NegativeOne));
+            AssertBitwiseEqual(Half.NaN, BinaryNumberHelper<Half>.Log2(-MinNormal));
+            AssertBitwiseEqual(Half.NaN, BinaryNumberHelper<Half>.Log2(-MaxSubnormal));
+            AssertBitwiseEqual(Half.NaN, BinaryNumberHelper<Half>.Log2(-Half.Epsilon));
+            AssertBitwiseEqual(Half.NegativeInfinity, BinaryNumberHelper<Half>.Log2(NegativeZero));
+            AssertBitwiseEqual(Half.NaN, BinaryNumberHelper<Half>.Log2(Half.NaN));
+            AssertBitwiseEqual(Half.NegativeInfinity, BinaryNumberHelper<Half>.Log2(PositiveZero));
+            AssertBitwiseEqual((Half)(-24.0f), BinaryNumberHelper<Half>.Log2(Half.Epsilon));
+            AssertBitwiseEqual((Half)(-14.0f), BinaryNumberHelper<Half>.Log2(MaxSubnormal));
+            AssertBitwiseEqual((Half)(-14.0f), BinaryNumberHelper<Half>.Log2(MinNormal));
+            AssertBitwiseEqual(PositiveZero, BinaryNumberHelper<Half>.Log2(PositiveOne));
+            AssertBitwiseEqual((Half)16.0f, BinaryNumberHelper<Half>.Log2(Half.MaxValue));
+            AssertBitwiseEqual(Half.PositiveInfinity, BinaryNumberHelper<Half>.Log2(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Half.NegativeInfinity, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Half.MinValue, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(NegativeOne, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(-MinNormal, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(-MaxSubnormal, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(-Half.Epsilon, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(NegativeZero, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Half.NaN, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(PositiveZero, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Half.Epsilon, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(MaxSubnormal, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThan(MinNormal, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThan(PositiveOne, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Half.MaxValue, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThan(Half.PositiveInfinity, PositiveOne));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Half.NegativeInfinity, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Half.MinValue, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(NegativeOne, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(-MinNormal, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(-MaxSubnormal, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(-Half.Epsilon, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(NegativeZero, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Half.NaN, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(PositiveZero, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Half.Epsilon, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(MaxSubnormal, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(MinNormal, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(PositiveOne, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Half.MaxValue, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_LessThanOrEqual(Half.PositiveInfinity, PositiveOne));
+        }
+
+        [Fact]
+        public static void op_GreaterThanTest()
+        {
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Half.NegativeInfinity, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Half.MinValue, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(NegativeOne, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(-MinNormal, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(-MaxSubnormal, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(-Half.Epsilon, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(NegativeZero, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Half.NaN, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(PositiveZero, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Half.Epsilon, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(MaxSubnormal, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(MinNormal, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(PositiveOne, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Half.MaxValue, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_GreaterThan(Half.PositiveInfinity, PositiveOne));
+        }
+
+        [Fact]
+        public static void op_GreaterThanOrEqualTest()
+        {
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Half.NegativeInfinity, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Half.MinValue, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(NegativeOne, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(-MinNormal, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(-MaxSubnormal, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(-Half.Epsilon, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(NegativeZero, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Half.NaN, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(PositiveZero, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Half.Epsilon, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(MaxSubnormal, PositiveOne));
+            Assert.False(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(MinNormal, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(PositiveOne, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Half.MaxValue, PositiveOne));
+            Assert.True(ComparisonOperatorsHelper<Half, Half>.op_GreaterThanOrEqual(Half.PositiveInfinity, PositiveOne));
+        }
+
+        [Fact]
+        public static void op_DecrementTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, DecrementOperatorsHelper<Half>.op_Decrement(Half.NegativeInfinity));
+            AssertBitwiseEqual(Half.MinValue, DecrementOperatorsHelper<Half>.op_Decrement(Half.MinValue));
+            AssertBitwiseEqual(NegativeTwo, DecrementOperatorsHelper<Half>.op_Decrement(NegativeOne));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_Decrement(-MinNormal));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_Decrement(-MaxSubnormal));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_Decrement(-Half.Epsilon));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_Decrement(NegativeZero));
+            AssertBitwiseEqual(Half.NaN, DecrementOperatorsHelper<Half>.op_Decrement(Half.NaN));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_Decrement(PositiveZero));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_Decrement(Half.Epsilon));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_Decrement(MaxSubnormal));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_Decrement(MinNormal));
+            AssertBitwiseEqual(PositiveZero, DecrementOperatorsHelper<Half>.op_Decrement(PositiveOne));
+            AssertBitwiseEqual(Half.MaxValue, DecrementOperatorsHelper<Half>.op_Decrement(Half.MaxValue));
+            AssertBitwiseEqual(Half.PositiveInfinity, DecrementOperatorsHelper<Half>.op_Decrement(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_CheckedDecrementTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, DecrementOperatorsHelper<Half>.op_CheckedDecrement(Half.NegativeInfinity));
+            AssertBitwiseEqual(Half.MinValue, DecrementOperatorsHelper<Half>.op_CheckedDecrement(Half.MinValue));
+            AssertBitwiseEqual(NegativeTwo, DecrementOperatorsHelper<Half>.op_CheckedDecrement(NegativeOne));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_CheckedDecrement(-MinNormal));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_CheckedDecrement(-MaxSubnormal));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_CheckedDecrement(-Half.Epsilon));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_CheckedDecrement(NegativeZero));
+            AssertBitwiseEqual(Half.NaN, DecrementOperatorsHelper<Half>.op_CheckedDecrement(Half.NaN));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_CheckedDecrement(PositiveZero));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_CheckedDecrement(Half.Epsilon));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_CheckedDecrement(MaxSubnormal));
+            AssertBitwiseEqual(NegativeOne, DecrementOperatorsHelper<Half>.op_CheckedDecrement(MinNormal));
+            AssertBitwiseEqual(PositiveZero, DecrementOperatorsHelper<Half>.op_CheckedDecrement(PositiveOne));
+            AssertBitwiseEqual(Half.MaxValue, DecrementOperatorsHelper<Half>.op_CheckedDecrement(Half.MaxValue));
+            AssertBitwiseEqual(Half.PositiveInfinity, DecrementOperatorsHelper<Half>.op_CheckedDecrement(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_DivisionTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, DivisionOperatorsHelper<Half, Half, Half>.op_Division(Half.NegativeInfinity, PositiveTwo));
+            AssertBitwiseEqual((Half)(-32750.0f), DivisionOperatorsHelper<Half, Half, Half>.op_Division(Half.MinValue, PositiveTwo));
+            AssertBitwiseEqual((Half)(-0.5f), DivisionOperatorsHelper<Half, Half, Half>.op_Division(NegativeOne, PositiveTwo));
+            AssertBitwiseEqual((Half)(-3.05E-05f), DivisionOperatorsHelper<Half, Half, Half>.op_Division(-MinNormal, PositiveTwo));
+            AssertBitwiseEqual((Half)(-3.05E-05f), DivisionOperatorsHelper<Half, Half, Half>.op_Division(-MaxSubnormal, PositiveTwo));
+            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<Half, Half, Half>.op_Division(-Half.Epsilon, PositiveTwo));
+            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<Half, Half, Half>.op_Division(NegativeZero, PositiveTwo));
+            AssertBitwiseEqual(Half.NaN, DivisionOperatorsHelper<Half, Half, Half>.op_Division(Half.NaN, PositiveTwo));
+            AssertBitwiseEqual(PositiveZero, DivisionOperatorsHelper<Half, Half, Half>.op_Division(PositiveZero, PositiveTwo));
+            AssertBitwiseEqual(PositiveZero, DivisionOperatorsHelper<Half, Half, Half>.op_Division(Half.Epsilon, PositiveTwo));
+            AssertBitwiseEqual((Half)3.05E-05f, DivisionOperatorsHelper<Half, Half, Half>.op_Division(MaxSubnormal, PositiveTwo));
+            AssertBitwiseEqual((Half)3.05E-05f, DivisionOperatorsHelper<Half, Half, Half>.op_Division(MinNormal, PositiveTwo));
+            AssertBitwiseEqual((Half)0.5f, DivisionOperatorsHelper<Half, Half, Half>.op_Division(PositiveOne, PositiveTwo));
+            AssertBitwiseEqual((Half)32750.0f, DivisionOperatorsHelper<Half, Half, Half>.op_Division(Half.MaxValue, PositiveTwo));
+            AssertBitwiseEqual(Half.PositiveInfinity, DivisionOperatorsHelper<Half, Half, Half>.op_Division(Half.PositiveInfinity, PositiveTwo));
+        }
+
+        [Fact]
+        public static void op_CheckedDivisionTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Half.NegativeInfinity, PositiveTwo));
+            AssertBitwiseEqual((Half)(-32750.0f), DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Half.MinValue, PositiveTwo));
+            AssertBitwiseEqual((Half)(-0.5f), DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(NegativeOne, PositiveTwo));
+            AssertBitwiseEqual((Half)(-3.05E-05f), DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(-MinNormal, PositiveTwo));
+            AssertBitwiseEqual((Half)(-3.05E-05f), DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(-MaxSubnormal, PositiveTwo));
+            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(-Half.Epsilon, PositiveTwo));
+            AssertBitwiseEqual(NegativeZero, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(NegativeZero, PositiveTwo));
+            AssertBitwiseEqual(Half.NaN, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Half.NaN, PositiveTwo));
+            AssertBitwiseEqual(PositiveZero, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(PositiveZero, PositiveTwo));
+            AssertBitwiseEqual(PositiveZero, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Half.Epsilon, PositiveTwo));
+            AssertBitwiseEqual((Half)3.05E-05f, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(MaxSubnormal, PositiveTwo));
+            AssertBitwiseEqual((Half)3.05E-05f, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(MinNormal, PositiveTwo));
+            AssertBitwiseEqual((Half)0.5f, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(PositiveOne, PositiveTwo));
+            AssertBitwiseEqual((Half)32750.0f, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Half.MaxValue, PositiveTwo));
+            AssertBitwiseEqual(Half.PositiveInfinity, DivisionOperatorsHelper<Half, Half, Half>.op_CheckedDivision(Half.PositiveInfinity, PositiveTwo));
+        }
+
+        [Fact]
+        public static void op_EqualityTest()
+        {
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Half.NegativeInfinity, PositiveOne));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Half.MinValue, PositiveOne));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(NegativeOne, PositiveOne));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(-MinNormal, PositiveOne));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(-MaxSubnormal, PositiveOne));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(-Half.Epsilon, PositiveOne));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(NegativeZero, PositiveOne));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Half.NaN, PositiveOne));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(PositiveZero, PositiveOne));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Half.Epsilon, PositiveOne));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(MaxSubnormal, PositiveOne));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(MinNormal, PositiveOne));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Equality(PositiveOne, PositiveOne));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Half.MaxValue, PositiveOne));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Equality(Half.PositiveInfinity, PositiveOne));
+        }
+
+        [Fact]
+        public static void op_InequalityTest()
+        {
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Half.NegativeInfinity, PositiveOne));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Half.MinValue, PositiveOne));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(NegativeOne, PositiveOne));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(-MinNormal, PositiveOne));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(-MaxSubnormal, PositiveOne));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(-Half.Epsilon, PositiveOne));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(NegativeZero, PositiveOne));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Half.NaN, PositiveOne));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(PositiveZero, PositiveOne));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Half.Epsilon, PositiveOne));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(MaxSubnormal, PositiveOne));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(MinNormal, PositiveOne));
+            Assert.False(EqualityOperatorsHelper<Half, Half>.op_Inequality(PositiveOne, PositiveOne));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Half.MaxValue, PositiveOne));
+            Assert.True(EqualityOperatorsHelper<Half, Half>.op_Inequality(Half.PositiveInfinity, PositiveOne));
+        }
+
+        [Fact]
+        public static void op_IncrementTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, IncrementOperatorsHelper<Half>.op_Increment(Half.NegativeInfinity));
+            AssertBitwiseEqual(Half.MinValue, IncrementOperatorsHelper<Half>.op_Increment(Half.MinValue));
+            AssertBitwiseEqual(PositiveZero, IncrementOperatorsHelper<Half>.op_Increment(NegativeOne));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_Increment(-MinNormal));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_Increment(-MaxSubnormal));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_Increment(-Half.Epsilon));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_Increment(NegativeZero));
+            AssertBitwiseEqual(Half.NaN, IncrementOperatorsHelper<Half>.op_Increment(Half.NaN));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_Increment(PositiveZero));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_Increment(Half.Epsilon));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_Increment(MaxSubnormal));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_Increment(MinNormal));
+            AssertBitwiseEqual(PositiveTwo, IncrementOperatorsHelper<Half>.op_Increment(PositiveOne));
+            AssertBitwiseEqual(Half.MaxValue, IncrementOperatorsHelper<Half>.op_Increment(Half.MaxValue));
+            AssertBitwiseEqual(Half.PositiveInfinity, IncrementOperatorsHelper<Half>.op_Increment(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_CheckedIncrementTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Half.NegativeInfinity));
+            AssertBitwiseEqual(Half.MinValue, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Half.MinValue));
+            AssertBitwiseEqual(PositiveZero, IncrementOperatorsHelper<Half>.op_CheckedIncrement(NegativeOne));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_CheckedIncrement(-MinNormal));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_CheckedIncrement(-MaxSubnormal));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_CheckedIncrement(-Half.Epsilon));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_CheckedIncrement(NegativeZero));
+            AssertBitwiseEqual(Half.NaN, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Half.NaN));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_CheckedIncrement(PositiveZero));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Half.Epsilon));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_CheckedIncrement(MaxSubnormal));
+            AssertBitwiseEqual(PositiveOne, IncrementOperatorsHelper<Half>.op_CheckedIncrement(MinNormal));
+            AssertBitwiseEqual(PositiveTwo, IncrementOperatorsHelper<Half>.op_CheckedIncrement(PositiveOne));
+            AssertBitwiseEqual(Half.MaxValue, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Half.MaxValue));
+            AssertBitwiseEqual(Half.PositiveInfinity, IncrementOperatorsHelper<Half>.op_CheckedIncrement(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_ModulusTest()
+        {
+            AssertBitwiseEqual(Half.NaN, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.NegativeInfinity, PositiveTwo));
+
+            // https://github.com/dotnet/runtime/issues/67993
+            // AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.MinValue, PositiveTwo));
+
+            AssertBitwiseEqual(NegativeOne, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(NegativeOne, PositiveTwo));
+            AssertBitwiseEqual(-MinNormal, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(-MinNormal, PositiveTwo));
+            AssertBitwiseEqual(-MaxSubnormal, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(-MaxSubnormal, PositiveTwo));
+            AssertBitwiseEqual(-Half.Epsilon, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(-Half.Epsilon, PositiveTwo)); ;
+
+            // https://github.com/dotnet/runtime/issues/67993
+            // AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(NegativeZero, PositiveTwo));
+
+            AssertBitwiseEqual(Half.NaN, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.NaN, PositiveTwo));
+            AssertBitwiseEqual(PositiveZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(PositiveZero, PositiveTwo));
+            AssertBitwiseEqual(Half.Epsilon, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.Epsilon, PositiveTwo));
+            AssertBitwiseEqual(MaxSubnormal, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(MaxSubnormal, PositiveTwo));
+            AssertBitwiseEqual(MinNormal, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(MinNormal, PositiveTwo));
+            AssertBitwiseEqual(PositiveOne, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(PositiveOne, PositiveTwo));
+            AssertBitwiseEqual(PositiveZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.MaxValue, PositiveTwo));
+            AssertBitwiseEqual(Half.NaN, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.PositiveInfinity, PositiveTwo));
+        }
+
+        [Fact]
+        public static void op_MultiplyTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Half.NegativeInfinity, PositiveTwo));
+            AssertBitwiseEqual(Half.NegativeInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Half.MinValue, PositiveTwo));
+            AssertBitwiseEqual(NegativeTwo, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(NegativeOne, PositiveTwo));
+            AssertBitwiseEqual((Half)(-0.0001221f), MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(-MinNormal, PositiveTwo));
+            AssertBitwiseEqual((Half)(-0.00012195f), MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(-MaxSubnormal, PositiveTwo));
+            AssertBitwiseEqual((Half)(-1E-07f), MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(-Half.Epsilon, PositiveTwo));
+            AssertBitwiseEqual(NegativeZero, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(NegativeZero, PositiveTwo));
+            AssertBitwiseEqual(Half.NaN, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Half.NaN, PositiveTwo));
+            AssertBitwiseEqual(PositiveZero, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(PositiveZero, PositiveTwo));
+            AssertBitwiseEqual((Half)1E-07f, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Half.Epsilon, PositiveTwo));
+            AssertBitwiseEqual((Half)0.00012195f, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(MaxSubnormal, PositiveTwo));
+            AssertBitwiseEqual((Half)0.0001221f, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(MinNormal, PositiveTwo));
+            AssertBitwiseEqual(PositiveTwo, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(PositiveOne, PositiveTwo));
+            AssertBitwiseEqual(Half.PositiveInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Half.MaxValue, PositiveTwo));
+            AssertBitwiseEqual(Half.PositiveInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_Multiply(Half.PositiveInfinity, PositiveTwo));
+        }
+
+        [Fact]
+        public static void op_CheckedMultiplyTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Half.NegativeInfinity, PositiveTwo));
+            AssertBitwiseEqual(Half.NegativeInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Half.MinValue, PositiveTwo));
+            AssertBitwiseEqual(NegativeTwo, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(NegativeOne, PositiveTwo));
+            AssertBitwiseEqual((Half)(-0.0001221f), MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(-MinNormal, PositiveTwo));
+            AssertBitwiseEqual((Half)(-0.00012195f), MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(-MaxSubnormal, PositiveTwo));
+            AssertBitwiseEqual((Half)(-1E-07f), MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(-Half.Epsilon, PositiveTwo));
+            AssertBitwiseEqual(NegativeZero, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(NegativeZero, PositiveTwo));
+            AssertBitwiseEqual(Half.NaN, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Half.NaN, PositiveTwo));
+            AssertBitwiseEqual(PositiveZero, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(PositiveZero, PositiveTwo));
+            AssertBitwiseEqual((Half)1E-07f, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Half.Epsilon, PositiveTwo));
+            AssertBitwiseEqual((Half)0.00012195f, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(MaxSubnormal, PositiveTwo));
+            AssertBitwiseEqual((Half)0.0001221f, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(MinNormal, PositiveTwo));
+            AssertBitwiseEqual(PositiveTwo, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(PositiveOne, PositiveTwo));
+            AssertBitwiseEqual(Half.PositiveInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Half.MaxValue, PositiveTwo));
+            AssertBitwiseEqual(Half.PositiveInfinity, MultiplyOperatorsHelper<Half, Half, Half>.op_CheckedMultiply(Half.PositiveInfinity, PositiveTwo));
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            AssertBitwiseEqual(Half.PositiveInfinity, NumberHelper<Half>.Abs(Half.NegativeInfinity));
+            AssertBitwiseEqual(Half.MaxValue, NumberHelper<Half>.Abs(Half.MinValue));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Abs(NegativeOne));
+            AssertBitwiseEqual(MinNormal, NumberHelper<Half>.Abs(-MinNormal));
+            AssertBitwiseEqual(MaxSubnormal, NumberHelper<Half>.Abs(-MaxSubnormal));
+            AssertBitwiseEqual(Half.Epsilon, NumberHelper<Half>.Abs(-Half.Epsilon));
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.Abs(NegativeZero));
+            AssertBitwiseEqual(Half.NaN, NumberHelper<Half>.Abs(Half.NaN));
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.Abs(PositiveZero));
+            AssertBitwiseEqual(Half.Epsilon, NumberHelper<Half>.Abs(Half.Epsilon));
+            AssertBitwiseEqual(MaxSubnormal, NumberHelper<Half>.Abs(MaxSubnormal));
+            AssertBitwiseEqual(MinNormal, NumberHelper<Half>.Abs(MinNormal));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Abs(PositiveOne));
+            AssertBitwiseEqual(Half.MaxValue, NumberHelper<Half>.Abs(Half.MaxValue));
+            AssertBitwiseEqual(Half.PositiveInfinity, NumberHelper<Half>.Abs(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void ClampTest()
+        {
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(Half.NegativeInfinity, PositiveOne, (Half)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(Half.MinValue, PositiveOne, (Half)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(NegativeOne, PositiveOne, (Half)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(-MinNormal, PositiveOne, (Half)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(-MaxSubnormal, PositiveOne, (Half)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(-Half.Epsilon, PositiveOne, (Half)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(NegativeZero, PositiveOne, (Half)63.0f));
+            AssertBitwiseEqual(Half.NaN, NumberHelper<Half>.Clamp(Half.NaN, PositiveOne, (Half)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(PositiveZero, PositiveOne, (Half)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(Half.Epsilon, PositiveOne, (Half)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(MaxSubnormal, PositiveOne, (Half)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(MinNormal, PositiveOne, (Half)63.0f));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Clamp(PositiveOne, PositiveOne, (Half)63.0f));
+            AssertBitwiseEqual((Half)63.0f, NumberHelper<Half>.Clamp(Half.MaxValue, PositiveOne, (Half)63.0f));
+            AssertBitwiseEqual((Half)63.0f, NumberHelper<Half>.Clamp(Half.PositiveInfinity, PositiveOne, (Half)63.0f));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromByteTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<byte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<byte>(0x01));
+            AssertBitwiseEqual((Half)127.0f, NumberHelper<Half>.CreateChecked<byte>(0x7F));
+            AssertBitwiseEqual((Half)128.0f, NumberHelper<Half>.CreateChecked<byte>(0x80));
+            AssertBitwiseEqual((Half)255.0f, NumberHelper<Half>.CreateChecked<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromCharTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<char>((char)0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<char>((char)0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberHelper<Half>.CreateChecked<char>((char)0x7FFF));
+            AssertBitwiseEqual((Half)32768.0f, NumberHelper<Half>.CreateChecked<char>((char)0x8000));
+            AssertBitwiseEqual((Half)65535.0f, NumberHelper<Half>.CreateChecked<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt16Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<short>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<short>(0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberHelper<Half>.CreateChecked<short>(0x7FFF));
+            AssertBitwiseEqual((Half)(-32768.0f), NumberHelper<Half>.CreateChecked<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateChecked<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt32Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<int>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<int>(0x00000001));
+            AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateChecked<int>(0x7FFFFFFF));
+            AssertBitwiseEqual((Half)(-2147483648.0f), NumberHelper<Half>.CreateChecked<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt64Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<long>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<long>(0x0000000000000001));
+            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberHelper<Half>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberHelper<Half>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<nint>((nint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<nint>((nint)0x00000001));
+                AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual((Half)(-2147483648.0f), NumberHelper<Half>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateCheckedFromSByteTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<sbyte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<sbyte>(0x01));
+            AssertBitwiseEqual((Half)127.0f, NumberHelper<Half>.CreateChecked<sbyte>(0x7F));
+            AssertBitwiseEqual((Half)(-128.0f), NumberHelper<Half>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt16Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<ushort>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<ushort>(0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberHelper<Half>.CreateChecked<ushort>(0x7FFF));
+            AssertBitwiseEqual((Half)32768.0f, NumberHelper<Half>.CreateChecked<ushort>(0x8000));
+            AssertBitwiseEqual((Half)65535.0f, NumberHelper<Half>.CreateChecked<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt32Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<uint>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<uint>(0x00000001));
+            AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateChecked<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual((Half)2147483648.0f, NumberHelper<Half>.CreateChecked<uint>(0x80000000));
+            AssertBitwiseEqual((Half)4294967295.0f, NumberHelper<Half>.CreateChecked<uint>(0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt64Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<ulong>(0x0000000000000001));
+            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual((Half)9223372036854775808.0f, NumberHelper<Half>.CreateChecked<ulong>(0x8000000000000000));
+            AssertBitwiseEqual((Half)18446744073709551615.0f, NumberHelper<Half>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual((Half)9223372036854775808.0f, NumberHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual((Half)18446744073709551615.0f,NumberHelper<Half>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateChecked<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateChecked<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual((Half)2147483648.0f, NumberHelper<Half>.CreateChecked<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual((Half)4294967295.0f, NumberHelper<Half>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromByteTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<byte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<byte>(0x01));
+            AssertBitwiseEqual((Half)127.0f, NumberHelper<Half>.CreateSaturating<byte>(0x7F));
+            AssertBitwiseEqual((Half)128.0f, NumberHelper<Half>.CreateSaturating<byte>(0x80));
+            AssertBitwiseEqual((Half)255.0f, NumberHelper<Half>.CreateSaturating<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromCharTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<char>((char)0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<char>((char)0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberHelper<Half>.CreateSaturating<char>((char)0x7FFF));
+            AssertBitwiseEqual((Half)32768.0f, NumberHelper<Half>.CreateSaturating<char>((char)0x8000));
+            AssertBitwiseEqual((Half)65535.0f, NumberHelper<Half>.CreateSaturating<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt16Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<short>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<short>(0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberHelper<Half>.CreateSaturating<short>(0x7FFF));
+            AssertBitwiseEqual((Half)(-32768.0f), NumberHelper<Half>.CreateSaturating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt32Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<int>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<int>(0x00000001));
+            AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateSaturating<int>(0x7FFFFFFF));
+            AssertBitwiseEqual((Half)(-2147483648.0f), NumberHelper<Half>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt64Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<long>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<long>(0x0000000000000001));
+            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberHelper<Half>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<nint>((nint)0x00000001));
+                AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual((Half)(-2147483648.0f), NumberHelper<Half>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromSByteTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<sbyte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<sbyte>(0x01));
+            AssertBitwiseEqual((Half)127.0f, NumberHelper<Half>.CreateSaturating<sbyte>(0x7F));
+            AssertBitwiseEqual((Half)(-128.0f), NumberHelper<Half>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt16Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<ushort>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<ushort>(0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberHelper<Half>.CreateSaturating<ushort>(0x7FFF));
+            AssertBitwiseEqual((Half)32768.0f, NumberHelper<Half>.CreateSaturating<ushort>(0x8000));
+            AssertBitwiseEqual((Half)65535.0f, NumberHelper<Half>.CreateSaturating<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt32Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<uint>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<uint>(0x00000001));
+            AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateSaturating<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual((Half)2147483648.0f, NumberHelper<Half>.CreateSaturating<uint>(0x80000000));
+            AssertBitwiseEqual((Half)4294967295.0f, NumberHelper<Half>.CreateSaturating<uint>(0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt64Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual((Half)9223372036854775808.0f, NumberHelper<Half>.CreateSaturating<ulong>(0x8000000000000000));
+            AssertBitwiseEqual((Half)18446744073709551615.0f, NumberHelper<Half>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual((Half)9223372036854775808.0f, NumberHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual((Half)18446744073709551615.0f, NumberHelper<Half>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateSaturating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateSaturating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual((Half)2147483648.0f, NumberHelper<Half>.CreateSaturating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual((Half)4294967295.0f, NumberHelper<Half>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromByteTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<byte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<byte>(0x01));
+            AssertBitwiseEqual((Half)127.0f, NumberHelper<Half>.CreateTruncating<byte>(0x7F));
+            AssertBitwiseEqual((Half)128.0f, NumberHelper<Half>.CreateTruncating<byte>(0x80));
+            AssertBitwiseEqual((Half)255.0f, NumberHelper<Half>.CreateTruncating<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromCharTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<char>((char)0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<char>((char)0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberHelper<Half>.CreateTruncating<char>((char)0x7FFF));
+            AssertBitwiseEqual((Half)32768.0f, NumberHelper<Half>.CreateTruncating<char>((char)0x8000));
+            AssertBitwiseEqual((Half)65535.0f, NumberHelper<Half>.CreateTruncating<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt16Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<short>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<short>(0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberHelper<Half>.CreateTruncating<short>(0x7FFF));
+            AssertBitwiseEqual((Half)(-32768.0f), NumberHelper<Half>.CreateTruncating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt32Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<int>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<int>(0x00000001));
+            AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateTruncating<int>(0x7FFFFFFF));
+            AssertBitwiseEqual((Half)(-2147483648.0f), NumberHelper<Half>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt64Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<long>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<long>(0x0000000000000001));
+            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberHelper<Half>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual((Half)(-9223372036854775808.0f), NumberHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<nint>((nint)0x00000001));
+                AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual((Half)(-2147483648.0f), NumberHelper<Half>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromSByteTest()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<sbyte>(0x00));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<sbyte>(0x01));
+            AssertBitwiseEqual((Half)127.0f, NumberHelper<Half>.CreateTruncating<sbyte>(0x7F));
+            AssertBitwiseEqual((Half)(-128.0f), NumberHelper<Half>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt16Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<ushort>(0x0000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<ushort>(0x0001));
+            AssertBitwiseEqual((Half)32767.0f, NumberHelper<Half>.CreateTruncating<ushort>(0x7FFF));
+            AssertBitwiseEqual((Half)32768.0f, NumberHelper<Half>.CreateTruncating<ushort>(0x8000));
+            AssertBitwiseEqual((Half)65535.0f, NumberHelper<Half>.CreateTruncating<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt32Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<uint>(0x00000000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<uint>(0x00000001));
+            AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateTruncating<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual((Half)2147483648.0f, NumberHelper<Half>.CreateTruncating<uint>(0x80000000));
+            AssertBitwiseEqual((Half)4294967295.0f, NumberHelper<Half>.CreateTruncating<uint>(0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt64Test()
+        {
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual((Half)9223372036854775808.0f, NumberHelper<Half>.CreateTruncating<ulong>(0x8000000000000000));
+            AssertBitwiseEqual((Half)18446744073709551615.0f, NumberHelper<Half>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual((Half)9223372036854775807.0f, NumberHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual((Half)9223372036854775808.0f, NumberHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual((Half)18446744073709551615.0f, NumberHelper<Half>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.CreateTruncating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.CreateTruncating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual((Half)2147483647.0f, NumberHelper<Half>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual((Half)2147483648.0f, NumberHelper<Half>.CreateTruncating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual((Half)4294967295.0f, NumberHelper<Half>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(Half.NegativeInfinity, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(Half.MinValue, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(NegativeOne, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(-MinNormal, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(-MaxSubnormal, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(-Half.Epsilon, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(NegativeZero, PositiveOne));
+            AssertBitwiseEqual(Half.NaN, NumberHelper<Half>.Max(Half.NaN, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(PositiveZero, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(Half.Epsilon, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(MaxSubnormal, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(MinNormal, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Max(PositiveOne, PositiveOne));
+            AssertBitwiseEqual(Half.MaxValue, NumberHelper<Half>.Max(Half.MaxValue, PositiveOne));
+            AssertBitwiseEqual(Half.PositiveInfinity, NumberHelper<Half>.Max(Half.PositiveInfinity, PositiveOne));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, NumberHelper<Half>.Min(Half.NegativeInfinity, PositiveOne));
+            AssertBitwiseEqual(Half.MinValue, NumberHelper<Half>.Min(Half.MinValue, PositiveOne));
+            AssertBitwiseEqual(NegativeOne, NumberHelper<Half>.Min(NegativeOne, PositiveOne));
+            AssertBitwiseEqual(-MinNormal, NumberHelper<Half>.Min(-MinNormal, PositiveOne));
+            AssertBitwiseEqual(-MaxSubnormal, NumberHelper<Half>.Min(-MaxSubnormal, PositiveOne));
+            AssertBitwiseEqual(-Half.Epsilon, NumberHelper<Half>.Min(-Half.Epsilon, PositiveOne));
+            AssertBitwiseEqual(NegativeZero, NumberHelper<Half>.Min(NegativeZero, PositiveOne));
+            AssertBitwiseEqual(Half.NaN, NumberHelper<Half>.Min(Half.NaN, PositiveOne));
+            AssertBitwiseEqual(PositiveZero, NumberHelper<Half>.Min(PositiveZero, PositiveOne));
+            AssertBitwiseEqual(Half.Epsilon, NumberHelper<Half>.Min(Half.Epsilon, PositiveOne));
+            AssertBitwiseEqual(MaxSubnormal, NumberHelper<Half>.Min(MaxSubnormal, PositiveOne));
+            AssertBitwiseEqual(MinNormal, NumberHelper<Half>.Min(MinNormal, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Min(PositiveOne, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Min(Half.MaxValue, PositiveOne));
+            AssertBitwiseEqual(PositiveOne, NumberHelper<Half>.Min(Half.PositiveInfinity, PositiveOne));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(-1, NumberHelper<Half>.Sign(Half.NegativeInfinity));
+            Assert.Equal(-1, NumberHelper<Half>.Sign(Half.MinValue));
+            Assert.Equal(-1, NumberHelper<Half>.Sign(NegativeOne));
+            Assert.Equal(-1, NumberHelper<Half>.Sign(-MinNormal));
+            Assert.Equal(-1, NumberHelper<Half>.Sign(-MaxSubnormal));
+            Assert.Equal(-1, NumberHelper<Half>.Sign(-Half.Epsilon));
+
+            Assert.Equal(0, NumberHelper<Half>.Sign(NegativeZero));
+            Assert.Equal(0, NumberHelper<Half>.Sign(PositiveZero));
+
+            Assert.Equal(1, NumberHelper<Half>.Sign(Half.Epsilon));
+            Assert.Equal(1, NumberHelper<Half>.Sign(MaxSubnormal));
+            Assert.Equal(1, NumberHelper<Half>.Sign(MinNormal));
+            Assert.Equal(1, NumberHelper<Half>.Sign(PositiveOne));
+            Assert.Equal(1, NumberHelper<Half>.Sign(Half.MaxValue));
+            Assert.Equal(1, NumberHelper<Half>.Sign(Half.PositiveInfinity));
+
+            Assert.Throws<ArithmeticException>(() => NumberHelper<Half>.Sign(Half.NaN));
+        }
+
+        [Fact]
+        public static void TryCreateFromByteTest()
+        {
+            Half result;
+
+            Assert.True(NumberHelper<Half>.TryCreate<byte>(0x00, out result));
+            Assert.Equal(PositiveZero, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<byte>(0x01, out result));
+            Assert.Equal(PositiveOne, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<byte>(0x7F, out result));
+            Assert.Equal((Half)127.0f, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<byte>(0x80, out result));
+            Assert.Equal((Half)128.0f, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<byte>(0xFF, out result));
+            Assert.Equal((Half)255.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromCharTest()
+        {
+            Half result;
+
+            Assert.True(NumberHelper<Half>.TryCreate<char>((char)0x0000, out result));
+            Assert.Equal(PositiveZero, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<char>((char)0x0001, out result));
+            Assert.Equal(PositiveOne, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.Equal((Half)32767.0f, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<char>((char)0x8000, out result));
+            Assert.Equal((Half)32768.0f, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.Equal((Half)65535.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt16Test()
+        {
+            Half result;
+
+            Assert.True(NumberHelper<Half>.TryCreate<short>(0x0000, out result));
+            Assert.Equal(PositiveZero, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<short>(0x0001, out result));
+            Assert.Equal(PositiveOne, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<short>(0x7FFF, out result));
+            Assert.Equal((Half)32767.0f, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.Equal((Half)(-32768.0f), result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.Equal(NegativeOne, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt32Test()
+        {
+            Half result;
+
+            Assert.True(NumberHelper<Half>.TryCreate<int>(0x00000000, out result));
+            Assert.Equal(PositiveZero, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<int>(0x00000001, out result));
+            Assert.Equal(PositiveOne, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.Equal((Half)2147483647.0f, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.Equal((Half)(-2147483648.0f), result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.Equal(NegativeOne, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt64Test()
+        {
+            Half result;
+
+            Assert.True(NumberHelper<Half>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.Equal(PositiveZero, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.Equal(PositiveOne, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.Equal((Half)9223372036854775807.0f, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
+            Assert.Equal((Half)(-9223372036854775808.0f), result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
+            Assert.Equal(NegativeOne, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromIntPtrTest()
+        {
+            Half result;
+
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberHelper<Half>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.Equal(PositiveZero, result);
+
+                Assert.True(NumberHelper<Half>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.Equal(PositiveOne, result);
+
+                Assert.True(NumberHelper<Half>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.Equal((Half)9223372036854775807.0f, result);
+
+                Assert.True(NumberHelper<Half>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.Equal((Half)(-9223372036854775808.0f), result);
+
+                Assert.True(NumberHelper<Half>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.Equal(NegativeOne, result);
+            }
+            else
+            {
+                Assert.True(NumberHelper<Half>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.Equal(PositiveZero, result);
+
+                Assert.True(NumberHelper<Half>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.Equal(PositiveOne, result);
+
+                Assert.True(NumberHelper<Half>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.Equal((Half)2147483647.0f, result);
+
+                Assert.True(NumberHelper<Half>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.Equal((Half)(-2147483648.0f), result);
+
+                Assert.True(NumberHelper<Half>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.Equal(NegativeOne, result);
+            }
+        }
+
+        [Fact]
+        public static void TryCreateFromSByteTest()
+        {
+            Half result;
+
+            Assert.True(NumberHelper<Half>.TryCreate<sbyte>(0x00, out result));
+            Assert.Equal(PositiveZero, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<sbyte>(0x01, out result));
+            Assert.Equal(PositiveOne, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<sbyte>(0x7F, out result));
+            Assert.Equal((Half)127.0f, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.Equal((Half)(-128.0f), result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.Equal(NegativeOne, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt16Test()
+        {
+            Half result;
+
+            Assert.True(NumberHelper<Half>.TryCreate<ushort>(0x0000, out result));
+            Assert.Equal(PositiveZero, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<ushort>(0x0001, out result));
+            Assert.Equal(PositiveOne, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.Equal((Half)32767.0f, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<ushort>(0x8000, out result));
+            Assert.Equal((Half)32768.0f, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.Equal((Half)65535.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt32Test()
+        {
+            Half result;
+
+            Assert.True(NumberHelper<Half>.TryCreate<uint>(0x00000000, out result));
+            Assert.Equal(PositiveZero, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<uint>(0x00000001, out result));
+            Assert.Equal(PositiveOne, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.Equal((Half)2147483647.0f, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<uint>(0x80000000, out result));
+            Assert.Equal((Half)2147483648.0f, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.Equal((Half)4294967295.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt64Test()
+        {
+            Half result;
+
+            Assert.True(NumberHelper<Half>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.Equal(PositiveZero, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.Equal(PositiveOne, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.Equal((Half)9223372036854775807.0f, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.Equal((Half)9223372036854775808.0f, result);
+
+            Assert.True(NumberHelper<Half>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.Equal((Half)18446744073709551615.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUIntPtrTest()
+        {
+            Half result;
+
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.Equal(PositiveZero, result);
+
+                Assert.True(NumberHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.Equal(PositiveOne, result);
+
+                Assert.True(NumberHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.Equal((Half)9223372036854775807.0f, result);
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // Assert.True(NumberHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                // Assert.Equal((Half)9223372036854775808.0f, result);
+                //
+                // Assert.True(NumberHelper<Half>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                // Assert.Equal((Half)18446744073709551615.0f, result);
+            }
+            else
+            {
+                Assert.True(NumberHelper<Half>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.Equal(PositiveZero, result);
+
+                Assert.True(NumberHelper<Half>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.Equal(PositiveOne, result);
+
+                Assert.True(NumberHelper<Half>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.Equal((Half)2147483647.0f, result);
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // Assert.True(NumberHelper<Half>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                // Assert.Equal((Half)2147483648.0f, result);
+                //
+                // Assert.True(NumberHelper<Half>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                // Assert.Equal((Half)4294967295.0f, result);
+            }
+        }
+
+        [Fact]
+        public static void op_SubtractionTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Half.NegativeInfinity, PositiveOne));
+            AssertBitwiseEqual(Half.MinValue, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Half.MinValue, PositiveOne));
+            AssertBitwiseEqual(NegativeTwo, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(NegativeOne, PositiveOne));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(-MinNormal, PositiveOne));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(-MaxSubnormal, PositiveOne));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(-Half.Epsilon, PositiveOne));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(NegativeZero, PositiveOne));
+            AssertBitwiseEqual(Half.NaN, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Half.NaN, PositiveOne));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(PositiveZero, PositiveOne));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Half.Epsilon, PositiveOne));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(MaxSubnormal, PositiveOne));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(MinNormal, PositiveOne));
+            AssertBitwiseEqual(PositiveZero, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(PositiveOne, PositiveOne));
+            AssertBitwiseEqual(Half.MaxValue, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Half.MaxValue, PositiveOne));
+            AssertBitwiseEqual(Half.PositiveInfinity, SubtractionOperatorsHelper<Half, Half, Half>.op_Subtraction(Half.PositiveInfinity, PositiveOne));
+        }
+
+        [Fact]
+        public static void op_CheckedSubtractionTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Half.NegativeInfinity, PositiveOne));
+            AssertBitwiseEqual(Half.MinValue, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Half.MinValue, PositiveOne));
+            AssertBitwiseEqual(NegativeTwo, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(NegativeOne, PositiveOne));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(-MinNormal, PositiveOne));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(-MaxSubnormal, PositiveOne));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(-Half.Epsilon, PositiveOne));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(NegativeZero, PositiveOne));
+            AssertBitwiseEqual(Half.NaN, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Half.NaN, PositiveOne));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(PositiveZero, PositiveOne));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Half.Epsilon, PositiveOne));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(MaxSubnormal, PositiveOne));
+            AssertBitwiseEqual(NegativeOne, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(MinNormal, PositiveOne));
+            AssertBitwiseEqual(PositiveZero, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(PositiveOne, PositiveOne));
+            AssertBitwiseEqual(Half.MaxValue, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Half.MaxValue, PositiveOne));
+            AssertBitwiseEqual(Half.PositiveInfinity, SubtractionOperatorsHelper<Half, Half, Half>.op_CheckedSubtraction(Half.PositiveInfinity, PositiveOne));
+        }
+
+        [Fact]
+        public static void op_UnaryNegationTest()
+        {
+            AssertBitwiseEqual(Half.PositiveInfinity, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(Half.NegativeInfinity));
+            AssertBitwiseEqual(Half.MaxValue, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(Half.MinValue));
+            AssertBitwiseEqual(PositiveOne, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(NegativeOne));
+            AssertBitwiseEqual(MinNormal, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(-MinNormal));
+            AssertBitwiseEqual(MaxSubnormal, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(-MaxSubnormal));
+            AssertBitwiseEqual(Half.Epsilon, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(-Half.Epsilon));
+            AssertBitwiseEqual(PositiveZero, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(NegativeZero));
+            AssertBitwiseEqual(Half.NaN, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(Half.NaN));
+            AssertBitwiseEqual(NegativeZero, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(PositiveZero));
+            AssertBitwiseEqual(-Half.Epsilon, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(Half.Epsilon));
+            AssertBitwiseEqual(-MaxSubnormal, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(MaxSubnormal));
+            AssertBitwiseEqual(-MinNormal, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(MinNormal));
+            AssertBitwiseEqual(NegativeOne, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(PositiveOne));
+            AssertBitwiseEqual(Half.MinValue, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(Half.MaxValue));
+            AssertBitwiseEqual(Half.NegativeInfinity, UnaryNegationOperatorsHelper<Half, Half>.op_UnaryNegation(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_CheckedUnaryNegationTest()
+        {
+            AssertBitwiseEqual(Half.PositiveInfinity, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(Half.NegativeInfinity));
+            AssertBitwiseEqual(Half.MaxValue, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(Half.MinValue));
+            AssertBitwiseEqual(PositiveOne, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(NegativeOne));
+            AssertBitwiseEqual(MinNormal, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(-MinNormal));
+            AssertBitwiseEqual(MaxSubnormal, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(-MaxSubnormal));
+            AssertBitwiseEqual(Half.Epsilon, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(-Half.Epsilon));
+            AssertBitwiseEqual(PositiveZero, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(NegativeZero));
+            AssertBitwiseEqual(Half.NaN, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(Half.NaN));
+            AssertBitwiseEqual(NegativeZero, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(PositiveZero));
+            AssertBitwiseEqual(-Half.Epsilon, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(Half.Epsilon));
+            AssertBitwiseEqual(-MaxSubnormal, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(MaxSubnormal));
+            AssertBitwiseEqual(-MinNormal, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(MinNormal));
+            AssertBitwiseEqual(NegativeOne, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(PositiveOne));
+            AssertBitwiseEqual(Half.MinValue, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(Half.MaxValue));
+            AssertBitwiseEqual(Half.NegativeInfinity, UnaryNegationOperatorsHelper<Half, Half>.op_CheckedUnaryNegation(Half.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_UnaryPlusTest()
+        {
+            AssertBitwiseEqual(Half.NegativeInfinity, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(Half.NegativeInfinity));
+            AssertBitwiseEqual(Half.MinValue, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(Half.MinValue));
+            AssertBitwiseEqual(NegativeOne, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(NegativeOne));
+            AssertBitwiseEqual(-MinNormal, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(-MinNormal));
+            AssertBitwiseEqual(-MaxSubnormal, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(-MaxSubnormal));
+            AssertBitwiseEqual(-Half.Epsilon, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(-Half.Epsilon));
+            AssertBitwiseEqual(NegativeZero, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(NegativeZero));
+            AssertBitwiseEqual(Half.NaN, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(Half.NaN));
+            AssertBitwiseEqual(PositiveZero, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(PositiveZero));
+            AssertBitwiseEqual(Half.Epsilon, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(Half.Epsilon));
+            AssertBitwiseEqual(MaxSubnormal, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(MaxSubnormal));
+            AssertBitwiseEqual(MinNormal, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(MinNormal));
+            AssertBitwiseEqual(PositiveOne, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(PositiveOne));
+            AssertBitwiseEqual(Half.MaxValue, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(Half.MaxValue));
+            AssertBitwiseEqual(Half.PositiveInfinity, UnaryPlusOperatorsHelper<Half, Half>.op_UnaryPlus(Half.PositiveInfinity));
+        }
+
         [Theory]
         [MemberData(nameof(HalfTests.Parse_Valid_TestData), MemberType = typeof(HalfTests))]
         public static void ParseValidStringTest(string value, NumberStyles style, IFormatProvider provider, Half expected)

--- a/src/libraries/System.Runtime/tests/System/SingleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/SingleTests.GenericMath.cs
@@ -2,13 +2,1340 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using System.Runtime.Versioning;
 using Xunit;
 
 namespace System.Tests
 {
     public class SingleTests_GenericMath
     {
+        private const float MinNormal = 1.17549435E-38f;
+
+        private const float MaxSubnormal = 1.17549421E-38f;
+
+        private static void AssertBitwiseEqual(float expected, float actual)
+        {
+            uint expectedBits = BitConverter.SingleToUInt32Bits(expected);
+            uint actualBits = BitConverter.SingleToUInt32Bits(actual);
+
+            if (expectedBits == actualBits)
+            {
+                return;
+            }
+
+            if (float.IsNaN(expected) && float.IsNaN(actual))
+            {
+                return;
+            }
+
+            throw new Xunit.Sdk.EqualException(expected, actual);
+        }
+
+        [Fact]
+        public static void AdditiveIdentityTest()
+        {
+            AssertBitwiseEqual(0.0f, AdditiveIdentityHelper<float, float>.AdditiveIdentity);
+        }
+
+        [Fact]
+        public static void MinValueTest()
+        {
+            AssertBitwiseEqual(float.MinValue, MinMaxValueHelper<float>.MinValue);
+        }
+
+        [Fact]
+        public static void MaxValueTest()
+        {
+            AssertBitwiseEqual(float.MaxValue, MinMaxValueHelper<float>.MaxValue);
+        }
+
+        [Fact]
+        public static void MultiplicativeIdentityTest()
+        {
+            AssertBitwiseEqual(1.0f, MultiplicativeIdentityHelper<float, float>.MultiplicativeIdentity);
+        }
+
+        [Fact]
+        public static void NegativeOneTest()
+        {
+            Assert.Equal(-1.0f, SignedNumberHelper<float>.NegativeOne);
+        }
+
+        [Fact]
+        public static void OneTest()
+        {
+            AssertBitwiseEqual(1.0f, NumberBaseHelper<float>.One);
+        }
+
+        [Fact]
+        public static void ZeroTest()
+        {
+            AssertBitwiseEqual(0.0f, NumberBaseHelper<float>.Zero);
+        }
+
+        [Fact]
+        public static void op_AdditionTest()
+        {
+            AssertBitwiseEqual(float.NegativeInfinity, AdditionOperatorsHelper<float, float, float>.op_Addition(float.NegativeInfinity, 1.0f));
+            AssertBitwiseEqual(float.MinValue, AdditionOperatorsHelper<float, float, float>.op_Addition(float.MinValue, 1.0f));
+            AssertBitwiseEqual(0.0f, AdditionOperatorsHelper<float, float, float>.op_Addition(-1.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, AdditionOperatorsHelper<float, float, float>.op_Addition(-MinNormal, 1.0f));
+            AssertBitwiseEqual(1.0f, AdditionOperatorsHelper<float, float, float>.op_Addition(-MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(1.0f, AdditionOperatorsHelper<float, float, float>.op_Addition(-float.Epsilon, 1.0f));
+            AssertBitwiseEqual(1.0f, AdditionOperatorsHelper<float, float, float>.op_Addition(-0.0f, 1.0f));
+            AssertBitwiseEqual(float.NaN, AdditionOperatorsHelper<float, float, float>.op_Addition(float.NaN, 1.0f));
+            AssertBitwiseEqual(1.0f, AdditionOperatorsHelper<float, float, float>.op_Addition(0.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, AdditionOperatorsHelper<float, float, float>.op_Addition(float.Epsilon, 1.0f));
+            AssertBitwiseEqual(1.0f, AdditionOperatorsHelper<float, float, float>.op_Addition(MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(1.0f, AdditionOperatorsHelper<float, float, float>.op_Addition(MinNormal, 1.0f));
+            AssertBitwiseEqual(2.0f, AdditionOperatorsHelper<float, float, float>.op_Addition(1.0f, 1.0f));
+            AssertBitwiseEqual(float.MaxValue, AdditionOperatorsHelper<float, float, float>.op_Addition(float.MaxValue, 1.0f));
+            AssertBitwiseEqual(float.PositiveInfinity, AdditionOperatorsHelper<float, float, float>.op_Addition(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void op_CheckedAdditionTest()
+        {
+            AssertBitwiseEqual(float.NegativeInfinity, AdditionOperatorsHelper<float, float, float>.op_CheckedAddition(float.NegativeInfinity, 1.0f));
+            AssertBitwiseEqual(float.MinValue, AdditionOperatorsHelper<float, float, float>.op_CheckedAddition(float.MinValue, 1.0f));
+            AssertBitwiseEqual(0.0f, AdditionOperatorsHelper<float, float, float>.op_CheckedAddition(-1.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, AdditionOperatorsHelper<float, float, float>.op_CheckedAddition(-MinNormal, 1.0f));
+            AssertBitwiseEqual(1.0f, AdditionOperatorsHelper<float, float, float>.op_CheckedAddition(-MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(1.0f, AdditionOperatorsHelper<float, float, float>.op_CheckedAddition(-float.Epsilon, 1.0f));
+            AssertBitwiseEqual(1.0f, AdditionOperatorsHelper<float, float, float>.op_CheckedAddition(-0.0f, 1.0f));
+            AssertBitwiseEqual(float.NaN, AdditionOperatorsHelper<float, float, float>.op_CheckedAddition(float.NaN, 1.0f));
+            AssertBitwiseEqual(1.0f, AdditionOperatorsHelper<float, float, float>.op_CheckedAddition(0.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, AdditionOperatorsHelper<float, float, float>.op_CheckedAddition(float.Epsilon, 1.0f));
+            AssertBitwiseEqual(1.0f, AdditionOperatorsHelper<float, float, float>.op_CheckedAddition(MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(1.0f, AdditionOperatorsHelper<float, float, float>.op_CheckedAddition(MinNormal, 1.0f));
+            AssertBitwiseEqual(2.0f, AdditionOperatorsHelper<float, float, float>.op_CheckedAddition(1.0f, 1.0f));
+            AssertBitwiseEqual(float.MaxValue, AdditionOperatorsHelper<float, float, float>.op_CheckedAddition(float.MaxValue, 1.0f));
+            AssertBitwiseEqual(float.PositiveInfinity, AdditionOperatorsHelper<float, float, float>.op_CheckedAddition(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void IsPow2Test()
+        {
+            Assert.False(BinaryNumberHelper<float>.IsPow2(float.NegativeInfinity));
+            Assert.False(BinaryNumberHelper<float>.IsPow2(float.MinValue));
+            Assert.False(BinaryNumberHelper<float>.IsPow2(-1.0f));
+            Assert.False(BinaryNumberHelper<float>.IsPow2(-MinNormal));
+            Assert.False(BinaryNumberHelper<float>.IsPow2(-MaxSubnormal));
+            Assert.False(BinaryNumberHelper<float>.IsPow2(-float.Epsilon));
+            Assert.False(BinaryNumberHelper<float>.IsPow2(-0.0f));
+            Assert.False(BinaryNumberHelper<float>.IsPow2(float.NaN));
+            Assert.False(BinaryNumberHelper<float>.IsPow2(0.0f));
+            Assert.False(BinaryNumberHelper<float>.IsPow2(float.Epsilon));
+            Assert.False(BinaryNumberHelper<float>.IsPow2(MaxSubnormal));
+            Assert.True(BinaryNumberHelper<float>.IsPow2(MinNormal));
+            Assert.True(BinaryNumberHelper<float>.IsPow2(1.0f));
+            Assert.False(BinaryNumberHelper<float>.IsPow2(float.MaxValue));
+            Assert.False(BinaryNumberHelper<float>.IsPow2(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void Log2Test()
+        {
+            AssertBitwiseEqual(float.NaN, BinaryNumberHelper<float>.Log2(float.NegativeInfinity));
+            AssertBitwiseEqual(float.NaN, BinaryNumberHelper<float>.Log2(float.MinValue));
+            AssertBitwiseEqual(float.NaN, BinaryNumberHelper<float>.Log2(-1.0f));
+            AssertBitwiseEqual(float.NaN, BinaryNumberHelper<float>.Log2(-MinNormal));
+            AssertBitwiseEqual(float.NaN, BinaryNumberHelper<float>.Log2(-MaxSubnormal));
+            AssertBitwiseEqual(float.NaN, BinaryNumberHelper<float>.Log2(-float.Epsilon));
+            AssertBitwiseEqual(float.NegativeInfinity, BinaryNumberHelper<float>.Log2(-0.0f));
+            AssertBitwiseEqual(float.NaN, BinaryNumberHelper<float>.Log2(float.NaN));
+            AssertBitwiseEqual(float.NegativeInfinity, BinaryNumberHelper<float>.Log2(0.0f));
+            AssertBitwiseEqual(-149.0f, BinaryNumberHelper<float>.Log2(float.Epsilon));
+            AssertBitwiseEqual(-126.0f, BinaryNumberHelper<float>.Log2(MaxSubnormal));
+            AssertBitwiseEqual(-126.0f, BinaryNumberHelper<float>.Log2(MinNormal));
+            AssertBitwiseEqual(0.0f, BinaryNumberHelper<float>.Log2(1.0f));
+            AssertBitwiseEqual(128.0f, BinaryNumberHelper<float>.Log2(float.MaxValue));
+            AssertBitwiseEqual(float.PositiveInfinity, BinaryNumberHelper<float>.Log2(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_LessThanTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(float.NegativeInfinity, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(float.MinValue, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(-1.0f, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(-MinNormal, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(-MaxSubnormal, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(-float.Epsilon, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(-0.0f, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThan(float.NaN, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(0.0f, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(float.Epsilon, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(MaxSubnormal, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThan(MinNormal, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThan(1.0f, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThan(float.MaxValue, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThan(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void op_LessThanOrEqualTest()
+        {
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(float.NegativeInfinity, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(float.MinValue, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(-1.0f, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(-MinNormal, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(-MaxSubnormal, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(-float.Epsilon, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(-0.0f, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(float.NaN, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(0.0f, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(float.Epsilon, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(MaxSubnormal, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(MinNormal, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(1.0f, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(float.MaxValue, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_LessThanOrEqual(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void op_GreaterThanTest()
+        {
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThan(float.NegativeInfinity, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThan(float.MinValue, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThan(-1.0f, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThan(-MinNormal, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThan(-MaxSubnormal, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThan(-float.Epsilon, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThan(-0.0f, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThan(float.NaN, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThan(0.0f, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThan(float.Epsilon, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThan(MaxSubnormal, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThan(MinNormal, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThan(1.0f, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_GreaterThan(float.MaxValue, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_GreaterThan(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void op_GreaterThanOrEqualTest()
+        {
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThanOrEqual(float.NegativeInfinity, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThanOrEqual(float.MinValue, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThanOrEqual(-1.0f, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThanOrEqual(-MinNormal, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThanOrEqual(-MaxSubnormal, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThanOrEqual(-float.Epsilon, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThanOrEqual(-0.0f, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThanOrEqual(float.NaN, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThanOrEqual(0.0f, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThanOrEqual(float.Epsilon, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThanOrEqual(MaxSubnormal, 1.0f));
+            Assert.False(ComparisonOperatorsHelper<float, float>.op_GreaterThanOrEqual(MinNormal, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_GreaterThanOrEqual(1.0f, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_GreaterThanOrEqual(float.MaxValue, 1.0f));
+            Assert.True(ComparisonOperatorsHelper<float, float>.op_GreaterThanOrEqual(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void op_DecrementTest()
+        {
+            AssertBitwiseEqual(float.NegativeInfinity, DecrementOperatorsHelper<float>.op_Decrement(float.NegativeInfinity));
+            AssertBitwiseEqual(float.MinValue, DecrementOperatorsHelper<float>.op_Decrement(float.MinValue));
+            AssertBitwiseEqual(-2.0f, DecrementOperatorsHelper<float>.op_Decrement(-1.0f));
+            AssertBitwiseEqual(-1.0f, DecrementOperatorsHelper<float>.op_Decrement(-MinNormal));
+            AssertBitwiseEqual(-1.0f, DecrementOperatorsHelper<float>.op_Decrement(-MaxSubnormal));
+            AssertBitwiseEqual(-1.0f, DecrementOperatorsHelper<float>.op_Decrement(-float.Epsilon));
+            AssertBitwiseEqual(-1.0f, DecrementOperatorsHelper<float>.op_Decrement(-0.0f));
+            AssertBitwiseEqual(float.NaN, DecrementOperatorsHelper<float>.op_Decrement(float.NaN));
+            AssertBitwiseEqual(-1.0f, DecrementOperatorsHelper<float>.op_Decrement(0.0f));
+            AssertBitwiseEqual(-1.0f, DecrementOperatorsHelper<float>.op_Decrement(float.Epsilon));
+            AssertBitwiseEqual(-1.0f, DecrementOperatorsHelper<float>.op_Decrement(MaxSubnormal));
+            AssertBitwiseEqual(-1.0f, DecrementOperatorsHelper<float>.op_Decrement(MinNormal));
+            AssertBitwiseEqual(0.0f, DecrementOperatorsHelper<float>.op_Decrement(1.0f));
+            AssertBitwiseEqual(float.MaxValue, DecrementOperatorsHelper<float>.op_Decrement(float.MaxValue));
+            AssertBitwiseEqual(float.PositiveInfinity, DecrementOperatorsHelper<float>.op_Decrement(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_CheckedDecrementTest()
+        {
+            AssertBitwiseEqual(float.NegativeInfinity, DecrementOperatorsHelper<float>.op_CheckedDecrement(float.NegativeInfinity));
+            AssertBitwiseEqual(float.MinValue, DecrementOperatorsHelper<float>.op_CheckedDecrement(float.MinValue));
+            AssertBitwiseEqual(-2.0f, DecrementOperatorsHelper<float>.op_CheckedDecrement(-1.0f));
+            AssertBitwiseEqual(-1.0f, DecrementOperatorsHelper<float>.op_CheckedDecrement(-MinNormal));
+            AssertBitwiseEqual(-1.0f, DecrementOperatorsHelper<float>.op_CheckedDecrement(-MaxSubnormal));
+            AssertBitwiseEqual(-1.0f, DecrementOperatorsHelper<float>.op_CheckedDecrement(-float.Epsilon));
+            AssertBitwiseEqual(-1.0f, DecrementOperatorsHelper<float>.op_CheckedDecrement(-0.0f));
+            AssertBitwiseEqual(float.NaN, DecrementOperatorsHelper<float>.op_CheckedDecrement(float.NaN));
+            AssertBitwiseEqual(-1.0f, DecrementOperatorsHelper<float>.op_CheckedDecrement(0.0f));
+            AssertBitwiseEqual(-1.0f, DecrementOperatorsHelper<float>.op_CheckedDecrement(float.Epsilon));
+            AssertBitwiseEqual(-1.0f, DecrementOperatorsHelper<float>.op_CheckedDecrement(MaxSubnormal));
+            AssertBitwiseEqual(-1.0f, DecrementOperatorsHelper<float>.op_CheckedDecrement(MinNormal));
+            AssertBitwiseEqual(0.0f, DecrementOperatorsHelper<float>.op_CheckedDecrement(1.0f));
+            AssertBitwiseEqual(float.MaxValue, DecrementOperatorsHelper<float>.op_CheckedDecrement(float.MaxValue));
+            AssertBitwiseEqual(float.PositiveInfinity, DecrementOperatorsHelper<float>.op_CheckedDecrement(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_DivisionTest()
+        {
+            AssertBitwiseEqual(float.NegativeInfinity, DivisionOperatorsHelper<float, float, float>.op_Division(float.NegativeInfinity, 2.0f));
+            AssertBitwiseEqual(-1.70141173E+38f, DivisionOperatorsHelper<float, float, float>.op_Division(float.MinValue, 2.0f));
+            AssertBitwiseEqual(-0.5f, DivisionOperatorsHelper<float, float, float>.op_Division(-1.0f, 2.0f));
+            AssertBitwiseEqual(-5.87747175E-39f, DivisionOperatorsHelper<float, float, float>.op_Division(-MinNormal, 2.0f));
+            AssertBitwiseEqual(-5.87747175E-39f, DivisionOperatorsHelper<float, float, float>.op_Division(-MaxSubnormal, 2.0f));
+            AssertBitwiseEqual(-0.0f, DivisionOperatorsHelper<float, float, float>.op_Division(-float.Epsilon, 2.0f));
+            AssertBitwiseEqual(-0.0f, DivisionOperatorsHelper<float, float, float>.op_Division(-0.0f, 2.0f));
+            AssertBitwiseEqual(float.NaN, DivisionOperatorsHelper<float, float, float>.op_Division(float.NaN, 2.0f));
+            AssertBitwiseEqual(0.0f, DivisionOperatorsHelper<float, float, float>.op_Division(0.0f, 2.0f));
+            AssertBitwiseEqual(0.0f, DivisionOperatorsHelper<float, float, float>.op_Division(float.Epsilon, 2.0f));
+            AssertBitwiseEqual(5.87747175E-39f, DivisionOperatorsHelper<float, float, float>.op_Division(MaxSubnormal, 2.0f));
+            AssertBitwiseEqual(5.87747175E-39f, DivisionOperatorsHelper<float, float, float>.op_Division(MinNormal, 2.0f));
+            AssertBitwiseEqual(0.5f, DivisionOperatorsHelper<float, float, float>.op_Division(1.0f, 2.0f));
+            AssertBitwiseEqual(1.70141173E+38f, DivisionOperatorsHelper<float, float, float>.op_Division(float.MaxValue, 2.0f));
+            AssertBitwiseEqual(float.PositiveInfinity, DivisionOperatorsHelper<float, float, float>.op_Division(float.PositiveInfinity, 2.0f));
+        }
+
+        [Fact]
+        public static void op_CheckedDivisionTest()
+        {
+            AssertBitwiseEqual(float.NegativeInfinity, DivisionOperatorsHelper<float, float, float>.op_CheckedDivision(float.NegativeInfinity, 2.0f));
+            AssertBitwiseEqual(-1.70141173E+38f, DivisionOperatorsHelper<float, float, float>.op_CheckedDivision(float.MinValue, 2.0f));
+            AssertBitwiseEqual(-0.5f, DivisionOperatorsHelper<float, float, float>.op_CheckedDivision(-1.0f, 2.0f));
+            AssertBitwiseEqual(-5.87747175E-39f, DivisionOperatorsHelper<float, float, float>.op_CheckedDivision(-MinNormal, 2.0f));
+            AssertBitwiseEqual(-5.87747175E-39f, DivisionOperatorsHelper<float, float, float>.op_CheckedDivision(-MaxSubnormal, 2.0f));
+            AssertBitwiseEqual(-0.0f, DivisionOperatorsHelper<float, float, float>.op_CheckedDivision(-float.Epsilon, 2.0f));
+            AssertBitwiseEqual(-0.0f, DivisionOperatorsHelper<float, float, float>.op_CheckedDivision(-0.0f, 2.0f));
+            AssertBitwiseEqual(float.NaN, DivisionOperatorsHelper<float, float, float>.op_CheckedDivision(float.NaN, 2.0f));
+            AssertBitwiseEqual(0.0f, DivisionOperatorsHelper<float, float, float>.op_CheckedDivision(0.0f, 2.0f));
+            AssertBitwiseEqual(0.0f, DivisionOperatorsHelper<float, float, float>.op_CheckedDivision(float.Epsilon, 2.0f));
+            AssertBitwiseEqual(5.87747175E-39f, DivisionOperatorsHelper<float, float, float>.op_CheckedDivision(MaxSubnormal, 2.0f));
+            AssertBitwiseEqual(5.87747175E-39f, DivisionOperatorsHelper<float, float, float>.op_CheckedDivision(MinNormal, 2.0f));
+            AssertBitwiseEqual(0.5f, DivisionOperatorsHelper<float, float, float>.op_CheckedDivision(1.0f, 2.0f));
+            AssertBitwiseEqual(1.70141173E+38f, DivisionOperatorsHelper<float, float, float>.op_CheckedDivision(float.MaxValue, 2.0f));
+            AssertBitwiseEqual(float.PositiveInfinity, DivisionOperatorsHelper<float, float, float>.op_CheckedDivision(float.PositiveInfinity, 2.0f));
+        }
+
+        [Fact]
+        public static void op_EqualityTest()
+        {
+            Assert.False(EqualityOperatorsHelper<float, float>.op_Equality(float.NegativeInfinity, 1.0f));
+            Assert.False(EqualityOperatorsHelper<float, float>.op_Equality(float.MinValue, 1.0f));
+            Assert.False(EqualityOperatorsHelper<float, float>.op_Equality(-1.0f, 1.0f));
+            Assert.False(EqualityOperatorsHelper<float, float>.op_Equality(-MinNormal, 1.0f));
+            Assert.False(EqualityOperatorsHelper<float, float>.op_Equality(-MaxSubnormal, 1.0f));
+            Assert.False(EqualityOperatorsHelper<float, float>.op_Equality(-float.Epsilon, 1.0f));
+            Assert.False(EqualityOperatorsHelper<float, float>.op_Equality(-0.0f, 1.0f));
+            Assert.False(EqualityOperatorsHelper<float, float>.op_Equality(float.NaN, 1.0f));
+            Assert.False(EqualityOperatorsHelper<float, float>.op_Equality(0.0f, 1.0f));
+            Assert.False(EqualityOperatorsHelper<float, float>.op_Equality(float.Epsilon, 1.0f));
+            Assert.False(EqualityOperatorsHelper<float, float>.op_Equality(MaxSubnormal, 1.0f));
+            Assert.False(EqualityOperatorsHelper<float, float>.op_Equality(MinNormal, 1.0f));
+            Assert.True(EqualityOperatorsHelper<float, float>.op_Equality(1.0f, 1.0f));
+            Assert.False(EqualityOperatorsHelper<float, float>.op_Equality(float.MaxValue, 1.0f));
+            Assert.False(EqualityOperatorsHelper<float, float>.op_Equality(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void op_InequalityTest()
+        {
+            Assert.True(EqualityOperatorsHelper<float, float>.op_Inequality(float.NegativeInfinity, 1.0f));
+            Assert.True(EqualityOperatorsHelper<float, float>.op_Inequality(float.MinValue, 1.0f));
+            Assert.True(EqualityOperatorsHelper<float, float>.op_Inequality(-1.0f, 1.0f));
+            Assert.True(EqualityOperatorsHelper<float, float>.op_Inequality(-MinNormal, 1.0f));
+            Assert.True(EqualityOperatorsHelper<float, float>.op_Inequality(-MaxSubnormal, 1.0f));
+            Assert.True(EqualityOperatorsHelper<float, float>.op_Inequality(-float.Epsilon, 1.0f));
+            Assert.True(EqualityOperatorsHelper<float, float>.op_Inequality(-0.0f, 1.0f));
+            Assert.True(EqualityOperatorsHelper<float, float>.op_Inequality(float.NaN, 1.0f));
+            Assert.True(EqualityOperatorsHelper<float, float>.op_Inequality(0.0f, 1.0f));
+            Assert.True(EqualityOperatorsHelper<float, float>.op_Inequality(float.Epsilon, 1.0f));
+            Assert.True(EqualityOperatorsHelper<float, float>.op_Inequality(MaxSubnormal, 1.0f));
+            Assert.True(EqualityOperatorsHelper<float, float>.op_Inequality(MinNormal, 1.0f));
+            Assert.False(EqualityOperatorsHelper<float, float>.op_Inequality(1.0f, 1.0f));
+            Assert.True(EqualityOperatorsHelper<float, float>.op_Inequality(float.MaxValue, 1.0f));
+            Assert.True(EqualityOperatorsHelper<float, float>.op_Inequality(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void op_IncrementTest()
+        {
+            AssertBitwiseEqual(float.NegativeInfinity, IncrementOperatorsHelper<float>.op_Increment(float.NegativeInfinity));
+            AssertBitwiseEqual(float.MinValue, IncrementOperatorsHelper<float>.op_Increment(float.MinValue));
+            AssertBitwiseEqual(0.0f, IncrementOperatorsHelper<float>.op_Increment(-1.0f));
+            AssertBitwiseEqual(1.0f, IncrementOperatorsHelper<float>.op_Increment(-MinNormal));
+            AssertBitwiseEqual(1.0f, IncrementOperatorsHelper<float>.op_Increment(-MaxSubnormal));
+            AssertBitwiseEqual(1.0f, IncrementOperatorsHelper<float>.op_Increment(-float.Epsilon));
+            AssertBitwiseEqual(1.0f, IncrementOperatorsHelper<float>.op_Increment(-0.0f));
+            AssertBitwiseEqual(float.NaN, IncrementOperatorsHelper<float>.op_Increment(float.NaN));
+            AssertBitwiseEqual(1.0f, IncrementOperatorsHelper<float>.op_Increment(0.0f));
+            AssertBitwiseEqual(1.0f, IncrementOperatorsHelper<float>.op_Increment(float.Epsilon));
+            AssertBitwiseEqual(1.0f, IncrementOperatorsHelper<float>.op_Increment(MaxSubnormal));
+            AssertBitwiseEqual(1.0f, IncrementOperatorsHelper<float>.op_Increment(MinNormal));
+            AssertBitwiseEqual(2.0f, IncrementOperatorsHelper<float>.op_Increment(1.0f));
+            AssertBitwiseEqual(float.MaxValue, IncrementOperatorsHelper<float>.op_Increment(float.MaxValue));
+            AssertBitwiseEqual(float.PositiveInfinity, IncrementOperatorsHelper<float>.op_Increment(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_CheckedIncrementTest()
+        {
+            AssertBitwiseEqual(float.NegativeInfinity, IncrementOperatorsHelper<float>.op_CheckedIncrement(float.NegativeInfinity));
+            AssertBitwiseEqual(float.MinValue, IncrementOperatorsHelper<float>.op_CheckedIncrement(float.MinValue));
+            AssertBitwiseEqual(0.0f, IncrementOperatorsHelper<float>.op_CheckedIncrement(-1.0f));
+            AssertBitwiseEqual(1.0f, IncrementOperatorsHelper<float>.op_CheckedIncrement(-MinNormal));
+            AssertBitwiseEqual(1.0f, IncrementOperatorsHelper<float>.op_CheckedIncrement(-MaxSubnormal));
+            AssertBitwiseEqual(1.0f, IncrementOperatorsHelper<float>.op_CheckedIncrement(-float.Epsilon));
+            AssertBitwiseEqual(1.0f, IncrementOperatorsHelper<float>.op_CheckedIncrement(-0.0f));
+            AssertBitwiseEqual(float.NaN, IncrementOperatorsHelper<float>.op_CheckedIncrement(float.NaN));
+            AssertBitwiseEqual(1.0f, IncrementOperatorsHelper<float>.op_CheckedIncrement(0.0f));
+            AssertBitwiseEqual(1.0f, IncrementOperatorsHelper<float>.op_CheckedIncrement(float.Epsilon));
+            AssertBitwiseEqual(1.0f, IncrementOperatorsHelper<float>.op_CheckedIncrement(MaxSubnormal));
+            AssertBitwiseEqual(1.0f, IncrementOperatorsHelper<float>.op_CheckedIncrement(MinNormal));
+            AssertBitwiseEqual(2.0f, IncrementOperatorsHelper<float>.op_CheckedIncrement(1.0f));
+            AssertBitwiseEqual(float.MaxValue, IncrementOperatorsHelper<float>.op_CheckedIncrement(float.MaxValue));
+            AssertBitwiseEqual(float.PositiveInfinity, IncrementOperatorsHelper<float>.op_CheckedIncrement(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_ModulusTest()
+        {
+            AssertBitwiseEqual(float.NaN, ModulusOperatorsHelper<float, float, float>.op_Modulus(float.NegativeInfinity, 2.0f));
+            AssertBitwiseEqual(-0.0f, ModulusOperatorsHelper<float, float, float>.op_Modulus(float.MinValue, 2.0f));
+            AssertBitwiseEqual(-1.0f, ModulusOperatorsHelper<float, float, float>.op_Modulus(-1.0f, 2.0f));
+            AssertBitwiseEqual(-MinNormal, ModulusOperatorsHelper<float, float, float>.op_Modulus(-MinNormal, 2.0f));
+            AssertBitwiseEqual(-MaxSubnormal, ModulusOperatorsHelper<float, float, float>.op_Modulus(-MaxSubnormal, 2.0f));
+            AssertBitwiseEqual(-float.Epsilon, ModulusOperatorsHelper<float, float, float>.op_Modulus(-float.Epsilon, 2.0f)); ;
+            AssertBitwiseEqual(-0.0f, ModulusOperatorsHelper<float, float, float>.op_Modulus(-0.0f, 2.0f));
+            AssertBitwiseEqual(float.NaN, ModulusOperatorsHelper<float, float, float>.op_Modulus(float.NaN, 2.0f));
+            AssertBitwiseEqual(0.0f, ModulusOperatorsHelper<float, float, float>.op_Modulus(0.0f, 2.0f));
+            AssertBitwiseEqual(float.Epsilon, ModulusOperatorsHelper<float, float, float>.op_Modulus(float.Epsilon, 2.0f));
+            AssertBitwiseEqual(MaxSubnormal, ModulusOperatorsHelper<float, float, float>.op_Modulus(MaxSubnormal, 2.0f));
+            AssertBitwiseEqual(MinNormal, ModulusOperatorsHelper<float, float, float>.op_Modulus(MinNormal, 2.0f));
+            AssertBitwiseEqual(1.0f, ModulusOperatorsHelper<float, float, float>.op_Modulus(1.0f, 2.0f));
+            AssertBitwiseEqual(0.0f, ModulusOperatorsHelper<float, float, float>.op_Modulus(float.MaxValue, 2.0f));
+            AssertBitwiseEqual(float.NaN, ModulusOperatorsHelper<float, float, float>.op_Modulus(float.PositiveInfinity, 2.0f));
+        }
+
+        [Fact]
+        public static void op_MultiplyTest()
+        {
+            AssertBitwiseEqual(float.NegativeInfinity, MultiplyOperatorsHelper<float, float, float>.op_Multiply(float.NegativeInfinity, 2.0f));
+            AssertBitwiseEqual(float.NegativeInfinity, MultiplyOperatorsHelper<float, float, float>.op_Multiply(float.MinValue, 2.0f));
+            AssertBitwiseEqual(-2.0f, MultiplyOperatorsHelper<float, float, float>.op_Multiply(-1.0f, 2.0f));
+            AssertBitwiseEqual(-2.3509887E-38f, MultiplyOperatorsHelper<float, float, float>.op_Multiply(-MinNormal, 2.0f));
+            AssertBitwiseEqual(-2.35098842E-38f, MultiplyOperatorsHelper<float, float, float>.op_Multiply(-MaxSubnormal, 2.0f));
+            AssertBitwiseEqual(-2.80259693E-45f, MultiplyOperatorsHelper<float, float, float>.op_Multiply(-float.Epsilon, 2.0f));
+            AssertBitwiseEqual(-0.0f, MultiplyOperatorsHelper<float, float, float>.op_Multiply(-0.0f, 2.0f));
+            AssertBitwiseEqual(float.NaN, MultiplyOperatorsHelper<float, float, float>.op_Multiply(float.NaN, 2.0f));
+            AssertBitwiseEqual(0.0f, MultiplyOperatorsHelper<float, float, float>.op_Multiply(0.0f, 2.0f));
+            AssertBitwiseEqual(2.80259693E-45f, MultiplyOperatorsHelper<float, float, float>.op_Multiply(float.Epsilon, 2.0f));
+            AssertBitwiseEqual(2.35098842E-38f, MultiplyOperatorsHelper<float, float, float>.op_Multiply(MaxSubnormal, 2.0f));
+            AssertBitwiseEqual(2.3509887E-38f, MultiplyOperatorsHelper<float, float, float>.op_Multiply(MinNormal, 2.0f));
+            AssertBitwiseEqual(2.0f, MultiplyOperatorsHelper<float, float, float>.op_Multiply(1.0f, 2.0f));
+            AssertBitwiseEqual(float.PositiveInfinity, MultiplyOperatorsHelper<float, float, float>.op_Multiply(float.MaxValue, 2.0f));
+            AssertBitwiseEqual(float.PositiveInfinity, MultiplyOperatorsHelper<float, float, float>.op_Multiply(float.PositiveInfinity, 2.0f));
+        }
+
+        [Fact]
+        public static void op_CheckedMultiplyTest()
+        {
+            AssertBitwiseEqual(float.NegativeInfinity, MultiplyOperatorsHelper<float, float, float>.op_CheckedMultiply(float.NegativeInfinity, 2.0f));
+            AssertBitwiseEqual(float.NegativeInfinity, MultiplyOperatorsHelper<float, float, float>.op_CheckedMultiply(float.MinValue, 2.0f));
+            AssertBitwiseEqual(-2.0f, MultiplyOperatorsHelper<float, float, float>.op_CheckedMultiply(-1.0f, 2.0f));
+            AssertBitwiseEqual(-2.3509887E-38f, MultiplyOperatorsHelper<float, float, float>.op_CheckedMultiply(-MinNormal, 2.0f));
+            AssertBitwiseEqual(-2.35098842E-38f, MultiplyOperatorsHelper<float, float, float>.op_CheckedMultiply(-MaxSubnormal, 2.0f));
+            AssertBitwiseEqual(-2.80259693E-45f, MultiplyOperatorsHelper<float, float, float>.op_CheckedMultiply(-float.Epsilon, 2.0f));
+            AssertBitwiseEqual(-0.0f, MultiplyOperatorsHelper<float, float, float>.op_CheckedMultiply(-0.0f, 2.0f));
+            AssertBitwiseEqual(float.NaN, MultiplyOperatorsHelper<float, float, float>.op_CheckedMultiply(float.NaN, 2.0f));
+            AssertBitwiseEqual(0.0f, MultiplyOperatorsHelper<float, float, float>.op_CheckedMultiply(0.0f, 2.0f));
+            AssertBitwiseEqual(2.80259693E-45f, MultiplyOperatorsHelper<float, float, float>.op_CheckedMultiply(float.Epsilon, 2.0f));
+            AssertBitwiseEqual(2.35098842E-38f, MultiplyOperatorsHelper<float, float, float>.op_CheckedMultiply(MaxSubnormal, 2.0f));
+            AssertBitwiseEqual(2.3509887E-38f, MultiplyOperatorsHelper<float, float, float>.op_CheckedMultiply(MinNormal, 2.0f));
+            AssertBitwiseEqual(2.0f, MultiplyOperatorsHelper<float, float, float>.op_CheckedMultiply(1.0f, 2.0f));
+            AssertBitwiseEqual(float.PositiveInfinity, MultiplyOperatorsHelper<float, float, float>.op_CheckedMultiply(float.MaxValue, 2.0f));
+            AssertBitwiseEqual(float.PositiveInfinity, MultiplyOperatorsHelper<float, float, float>.op_CheckedMultiply(float.PositiveInfinity, 2.0f));
+        }
+
+        [Fact]
+        public static void AbsTest()
+        {
+            AssertBitwiseEqual(float.PositiveInfinity, NumberHelper<float>.Abs(float.NegativeInfinity));
+            AssertBitwiseEqual(float.MaxValue, NumberHelper<float>.Abs(float.MinValue));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Abs(-1.0f));
+            AssertBitwiseEqual(MinNormal, NumberHelper<float>.Abs(-MinNormal));
+            AssertBitwiseEqual(MaxSubnormal, NumberHelper<float>.Abs(-MaxSubnormal));
+            AssertBitwiseEqual(float.Epsilon, NumberHelper<float>.Abs(-float.Epsilon));
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.Abs(-0.0f));
+            AssertBitwiseEqual(float.NaN, NumberHelper<float>.Abs(float.NaN));
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.Abs(0.0f));
+            AssertBitwiseEqual(float.Epsilon, NumberHelper<float>.Abs(float.Epsilon));
+            AssertBitwiseEqual(MaxSubnormal, NumberHelper<float>.Abs(MaxSubnormal));
+            AssertBitwiseEqual(MinNormal, NumberHelper<float>.Abs(MinNormal));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Abs(1.0f));
+            AssertBitwiseEqual(float.MaxValue, NumberHelper<float>.Abs(float.MaxValue));
+            AssertBitwiseEqual(float.PositiveInfinity, NumberHelper<float>.Abs(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void ClampTest()
+        {
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Clamp(float.NegativeInfinity, 1.0f, 63.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Clamp(float.MinValue, 1.0f, 63.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Clamp(-1.0f, 1.0f, 63.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Clamp(-MinNormal, 1.0f, 63.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Clamp(-MaxSubnormal, 1.0f, 63.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Clamp(-float.Epsilon, 1.0f, 63.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Clamp(-0.0f, 1.0f, 63.0f));
+            AssertBitwiseEqual(float.NaN, NumberHelper<float>.Clamp(float.NaN, 1.0f, 63.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Clamp(0.0f, 1.0f, 63.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Clamp(float.Epsilon, 1.0f, 63.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Clamp(MaxSubnormal, 1.0f, 63.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Clamp(MinNormal, 1.0f, 63.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Clamp(1.0f, 1.0f, 63.0f));
+            AssertBitwiseEqual(63.0f, NumberHelper<float>.Clamp(float.MaxValue, 1.0f, 63.0f));
+            AssertBitwiseEqual(63.0f, NumberHelper<float>.Clamp(float.PositiveInfinity, 1.0f, 63.0f));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromByteTest()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<byte>(0x00));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<byte>(0x01));
+            AssertBitwiseEqual(127.0f, NumberHelper<float>.CreateChecked<byte>(0x7F));
+            AssertBitwiseEqual(128.0f, NumberHelper<float>.CreateChecked<byte>(0x80));
+            AssertBitwiseEqual(255.0f, NumberHelper<float>.CreateChecked<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromCharTest()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<char>((char)0x0000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<char>((char)0x0001));
+            AssertBitwiseEqual(32767.0f, NumberHelper<float>.CreateChecked<char>((char)0x7FFF));
+            AssertBitwiseEqual(32768.0f, NumberHelper<float>.CreateChecked<char>((char)0x8000));
+            AssertBitwiseEqual(65535.0f, NumberHelper<float>.CreateChecked<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt16Test()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<short>(0x0000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<short>(0x0001));
+            AssertBitwiseEqual(32767.0f, NumberHelper<float>.CreateChecked<short>(0x7FFF));
+            AssertBitwiseEqual(-32768.0f, NumberHelper<float>.CreateChecked<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateChecked<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt32Test()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<int>(0x00000000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<int>(0x00000001));
+            AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateChecked<int>(0x7FFFFFFF));
+            AssertBitwiseEqual(-2147483648.0f, NumberHelper<float>.CreateChecked<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateChecked<int>(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromInt64Test()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<long>(0x0000000000000000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<long>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateChecked<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(-9223372036854775808.0f, NumberHelper<float>.CreateChecked<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateChecked<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateChecked<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(-9223372036854775808.0f, NumberHelper<float>.CreateChecked<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<nint>((nint)0x00000000));
+                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<nint>((nint)0x00000001));
+                AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateChecked<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual(-2147483648.0f, NumberHelper<float>.CreateChecked<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateChecked<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateCheckedFromSByteTest()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<sbyte>(0x00));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<sbyte>(0x01));
+            AssertBitwiseEqual(127.0f, NumberHelper<float>.CreateChecked<sbyte>(0x7F));
+            AssertBitwiseEqual(-128.0f, NumberHelper<float>.CreateChecked<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateChecked<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt16Test()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<ushort>(0x0000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<ushort>(0x0001));
+            AssertBitwiseEqual(32767.0f, NumberHelper<float>.CreateChecked<ushort>(0x7FFF));
+            AssertBitwiseEqual(32768.0f, NumberHelper<float>.CreateChecked<ushort>(0x8000));
+            AssertBitwiseEqual(65535.0f, NumberHelper<float>.CreateChecked<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt32Test()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<uint>(0x00000000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<uint>(0x00000001));
+            AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateChecked<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual(2147483648.0f, NumberHelper<float>.CreateChecked<uint>(0x80000000));
+            AssertBitwiseEqual(4294967295.0f, NumberHelper<float>.CreateChecked<uint>(0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUInt64Test()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateChecked<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(9223372036854775808.0f, NumberHelper<float>.CreateChecked<ulong>(0x8000000000000000));
+            AssertBitwiseEqual(18446744073709551615.0f, NumberHelper<float>.CreateChecked<ulong>(0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateCheckedFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateChecked<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual(9223372036854775808.0f, NumberHelper<float>.CreateChecked<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual(18446744073709551615.0f,NumberHelper<float>.CreateChecked<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateChecked<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateChecked<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateChecked<nuint>((nuint)0x7FFFFFFF));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual(2147483648.0f, NumberHelper<float>.CreateChecked<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual(4294967295.0f, NumberHelper<float>.CreateChecked<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromByteTest()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<byte>(0x00));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<byte>(0x01));
+            AssertBitwiseEqual(127.0f, NumberHelper<float>.CreateSaturating<byte>(0x7F));
+            AssertBitwiseEqual(128.0f, NumberHelper<float>.CreateSaturating<byte>(0x80));
+            AssertBitwiseEqual(255.0f, NumberHelper<float>.CreateSaturating<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromCharTest()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<char>((char)0x0000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<char>((char)0x0001));
+            AssertBitwiseEqual(32767.0f, NumberHelper<float>.CreateSaturating<char>((char)0x7FFF));
+            AssertBitwiseEqual(32768.0f, NumberHelper<float>.CreateSaturating<char>((char)0x8000));
+            AssertBitwiseEqual(65535.0f, NumberHelper<float>.CreateSaturating<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt16Test()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<short>(0x0000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<short>(0x0001));
+            AssertBitwiseEqual(32767.0f, NumberHelper<float>.CreateSaturating<short>(0x7FFF));
+            AssertBitwiseEqual(-32768.0f, NumberHelper<float>.CreateSaturating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateSaturating<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt32Test()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<int>(0x00000000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<int>(0x00000001));
+            AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateSaturating<int>(0x7FFFFFFF));
+            AssertBitwiseEqual(-2147483648.0f, NumberHelper<float>.CreateSaturating<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateSaturating<int>(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromInt64Test()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<long>(0x0000000000000000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<long>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateSaturating<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(-9223372036854775808.0f, NumberHelper<float>.CreateSaturating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateSaturating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateSaturating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(-9223372036854775808.0f, NumberHelper<float>.CreateSaturating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<nint>((nint)0x00000001));
+                AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateSaturating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual(-2147483648.0f, NumberHelper<float>.CreateSaturating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateSaturating<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromSByteTest()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<sbyte>(0x00));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<sbyte>(0x01));
+            AssertBitwiseEqual(127.0f, NumberHelper<float>.CreateSaturating<sbyte>(0x7F));
+            AssertBitwiseEqual(-128.0f, NumberHelper<float>.CreateSaturating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateSaturating<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt16Test()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<ushort>(0x0000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<ushort>(0x0001));
+            AssertBitwiseEqual(32767.0f, NumberHelper<float>.CreateSaturating<ushort>(0x7FFF));
+            AssertBitwiseEqual(32768.0f, NumberHelper<float>.CreateSaturating<ushort>(0x8000));
+            AssertBitwiseEqual(65535.0f, NumberHelper<float>.CreateSaturating<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt32Test()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<uint>(0x00000000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<uint>(0x00000001));
+            AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateSaturating<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual(2147483648.0f, NumberHelper<float>.CreateSaturating<uint>(0x80000000));
+            AssertBitwiseEqual(4294967295.0f, NumberHelper<float>.CreateSaturating<uint>(0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUInt64Test()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateSaturating<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(9223372036854775808.0f, NumberHelper<float>.CreateSaturating<ulong>(0x8000000000000000));
+            AssertBitwiseEqual(18446744073709551615.0f, NumberHelper<float>.CreateSaturating<ulong>(0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateSaturatingFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateSaturating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual(9223372036854775808.0f, NumberHelper<float>.CreateSaturating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual(18446744073709551615.0f, NumberHelper<float>.CreateSaturating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateSaturating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateSaturating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateSaturating<nuint>((nuint)0x7FFFFFFF));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual(2147483648.0f, NumberHelper<float>.CreateSaturating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual(4294967295.0f, NumberHelper<float>.CreateSaturating<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromByteTest()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<byte>(0x00));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<byte>(0x01));
+            AssertBitwiseEqual(127.0f, NumberHelper<float>.CreateTruncating<byte>(0x7F));
+            AssertBitwiseEqual(128.0f, NumberHelper<float>.CreateTruncating<byte>(0x80));
+            AssertBitwiseEqual(255.0f, NumberHelper<float>.CreateTruncating<byte>(0xFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromCharTest()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<char>((char)0x0000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<char>((char)0x0001));
+            AssertBitwiseEqual(32767.0f, NumberHelper<float>.CreateTruncating<char>((char)0x7FFF));
+            AssertBitwiseEqual(32768.0f, NumberHelper<float>.CreateTruncating<char>((char)0x8000));
+            AssertBitwiseEqual(65535.0f, NumberHelper<float>.CreateTruncating<char>((char)0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt16Test()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<short>(0x0000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<short>(0x0001));
+            AssertBitwiseEqual(32767.0f, NumberHelper<float>.CreateTruncating<short>(0x7FFF));
+            AssertBitwiseEqual(-32768.0f, NumberHelper<float>.CreateTruncating<short>(unchecked((short)0x8000)));
+            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateTruncating<short>(unchecked((short)0xFFFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt32Test()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<int>(0x00000000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<int>(0x00000001));
+            AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateTruncating<int>(0x7FFFFFFF));
+            AssertBitwiseEqual(-2147483648.0f, NumberHelper<float>.CreateTruncating<int>(unchecked((int)0x80000000)));
+            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateTruncating<int>(unchecked((int)0xFFFFFFFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromInt64Test()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<long>(0x0000000000000000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<long>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateTruncating<long>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(-9223372036854775808.0f, NumberHelper<float>.CreateTruncating<long>(unchecked(unchecked((long)0x8000000000000000))));
+            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateTruncating<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF))));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<nint>(unchecked((nint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<nint>(unchecked((nint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateTruncating<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF)));
+                AssertBitwiseEqual(-9223372036854775808.0f, NumberHelper<float>.CreateTruncating<nint>(unchecked((nint)0x8000000000000000)));
+                AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<nint>((nint)0x00000000));
+                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<nint>((nint)0x00000001));
+                AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateTruncating<nint>((nint)0x7FFFFFFF));
+                AssertBitwiseEqual(-2147483648.0f, NumberHelper<float>.CreateTruncating<nint>(unchecked((nint)0x80000000)));
+                AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateTruncating<nint>(unchecked((nint)0xFFFFFFFF)));
+            }
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromSByteTest()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<sbyte>(0x00));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<sbyte>(0x01));
+            AssertBitwiseEqual(127.0f, NumberHelper<float>.CreateTruncating<sbyte>(0x7F));
+            AssertBitwiseEqual(-128.0f, NumberHelper<float>.CreateTruncating<sbyte>(unchecked((sbyte)0x80)));
+            AssertBitwiseEqual(-1.0f, NumberHelper<float>.CreateTruncating<sbyte>(unchecked((sbyte)0xFF)));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt16Test()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<ushort>(0x0000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<ushort>(0x0001));
+            AssertBitwiseEqual(32767.0f, NumberHelper<float>.CreateTruncating<ushort>(0x7FFF));
+            AssertBitwiseEqual(32768.0f, NumberHelper<float>.CreateTruncating<ushort>(0x8000));
+            AssertBitwiseEqual(65535.0f, NumberHelper<float>.CreateTruncating<ushort>(0xFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt32Test()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<uint>(0x00000000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<uint>(0x00000001));
+            AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateTruncating<uint>(0x7FFFFFFF));
+            AssertBitwiseEqual(2147483648.0f, NumberHelper<float>.CreateTruncating<uint>(0x80000000));
+            AssertBitwiseEqual(4294967295.0f, NumberHelper<float>.CreateTruncating<uint>(0xFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUInt64Test()
+        {
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<ulong>(0x0000000000000000));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<ulong>(0x0000000000000001));
+            AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateTruncating<ulong>(0x7FFFFFFFFFFFFFFF));
+            AssertBitwiseEqual(9223372036854775808.0f, NumberHelper<float>.CreateTruncating<ulong>(0x8000000000000000));
+            AssertBitwiseEqual(18446744073709551615.0f, NumberHelper<float>.CreateTruncating<ulong>(0xFFFFFFFFFFFFFFFF));
+        }
+
+        [Fact]
+        public static void CreateTruncatingFromUIntPtrTest()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000000)));
+                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<nuint>(unchecked((nuint)0x0000000000000001)));
+                AssertBitwiseEqual(9223372036854775807.0f, NumberHelper<float>.CreateTruncating<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF)));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual(9223372036854775808.0f, NumberHelper<float>.CreateTruncating<nuint>(unchecked((nuint)0x8000000000000000)));
+                // AssertBitwiseEqual(18446744073709551615.0f, NumberHelper<float>.CreateTruncating<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF)));
+            }
+            else
+            {
+                AssertBitwiseEqual(0.0f, NumberHelper<float>.CreateTruncating<nuint>((nuint)0x00000000));
+                AssertBitwiseEqual(1.0f, NumberHelper<float>.CreateTruncating<nuint>((nuint)0x00000001));
+                AssertBitwiseEqual(2147483647.0f, NumberHelper<float>.CreateTruncating<nuint>((nuint)0x7FFFFFFF));
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // AssertBitwiseEqual(2147483648.0f, NumberHelper<float>.CreateTruncating<nuint>((nuint)0x80000000));
+                // AssertBitwiseEqual(4294967295.0f, NumberHelper<float>.CreateTruncating<nuint>((nuint)0xFFFFFFFF));
+            }
+        }
+
+        [Fact]
+        public static void MaxTest()
+        {
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(float.NegativeInfinity, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(float.MinValue, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(-1.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(-MinNormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(-MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(-float.Epsilon, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(-0.0f, 1.0f));
+            AssertBitwiseEqual(float.NaN, NumberHelper<float>.Max(float.NaN, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(0.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(float.Epsilon, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(MinNormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Max(1.0f, 1.0f));
+            AssertBitwiseEqual(float.MaxValue, NumberHelper<float>.Max(float.MaxValue, 1.0f));
+            AssertBitwiseEqual(float.PositiveInfinity, NumberHelper<float>.Max(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void MinTest()
+        {
+            AssertBitwiseEqual(float.NegativeInfinity, NumberHelper<float>.Min(float.NegativeInfinity, 1.0f));
+            AssertBitwiseEqual(float.MinValue, NumberHelper<float>.Min(float.MinValue, 1.0f));
+            AssertBitwiseEqual(-1.0f, NumberHelper<float>.Min(-1.0f, 1.0f));
+            AssertBitwiseEqual(-MinNormal, NumberHelper<float>.Min(-MinNormal, 1.0f));
+            AssertBitwiseEqual(-MaxSubnormal, NumberHelper<float>.Min(-MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(-float.Epsilon, NumberHelper<float>.Min(-float.Epsilon, 1.0f));
+            AssertBitwiseEqual(-0.0f, NumberHelper<float>.Min(-0.0f, 1.0f));
+            AssertBitwiseEqual(float.NaN, NumberHelper<float>.Min(float.NaN, 1.0f));
+            AssertBitwiseEqual(0.0f, NumberHelper<float>.Min(0.0f, 1.0f));
+            AssertBitwiseEqual(float.Epsilon, NumberHelper<float>.Min(float.Epsilon, 1.0f));
+            AssertBitwiseEqual(MaxSubnormal, NumberHelper<float>.Min(MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(MinNormal, NumberHelper<float>.Min(MinNormal, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Min(1.0f, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Min(float.MaxValue, 1.0f));
+            AssertBitwiseEqual(1.0f, NumberHelper<float>.Min(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void SignTest()
+        {
+            Assert.Equal(-1, NumberHelper<float>.Sign(float.NegativeInfinity));
+            Assert.Equal(-1, NumberHelper<float>.Sign(float.MinValue));
+            Assert.Equal(-1, NumberHelper<float>.Sign(-1.0f));
+            Assert.Equal(-1, NumberHelper<float>.Sign(-MinNormal));
+            Assert.Equal(-1, NumberHelper<float>.Sign(-MaxSubnormal));
+            Assert.Equal(-1, NumberHelper<float>.Sign(-float.Epsilon));
+
+            Assert.Equal(0, NumberHelper<float>.Sign(-0.0f));
+            Assert.Equal(0, NumberHelper<float>.Sign(0.0f));
+
+            Assert.Equal(1, NumberHelper<float>.Sign(float.Epsilon));
+            Assert.Equal(1, NumberHelper<float>.Sign(MaxSubnormal));
+            Assert.Equal(1, NumberHelper<float>.Sign(MinNormal));
+            Assert.Equal(1, NumberHelper<float>.Sign(1.0f));
+            Assert.Equal(1, NumberHelper<float>.Sign(float.MaxValue));
+            Assert.Equal(1, NumberHelper<float>.Sign(float.PositiveInfinity));
+
+            Assert.Throws<ArithmeticException>(() => NumberHelper<float>.Sign(float.NaN));
+        }
+
+        [Fact]
+        public static void TryCreateFromByteTest()
+        {
+            float result;
+
+            Assert.True(NumberHelper<float>.TryCreate<byte>(0x00, out result));
+            Assert.Equal(0.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<byte>(0x01, out result));
+            Assert.Equal(1.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<byte>(0x7F, out result));
+            Assert.Equal(127.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<byte>(0x80, out result));
+            Assert.Equal(128.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<byte>(0xFF, out result));
+            Assert.Equal(255.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromCharTest()
+        {
+            float result;
+
+            Assert.True(NumberHelper<float>.TryCreate<char>((char)0x0000, out result));
+            Assert.Equal(0.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<char>((char)0x0001, out result));
+            Assert.Equal(1.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<char>((char)0x7FFF, out result));
+            Assert.Equal(32767.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<char>((char)0x8000, out result));
+            Assert.Equal(32768.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<char>((char)0xFFFF, out result));
+            Assert.Equal(65535.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt16Test()
+        {
+            float result;
+
+            Assert.True(NumberHelper<float>.TryCreate<short>(0x0000, out result));
+            Assert.Equal(0.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<short>(0x0001, out result));
+            Assert.Equal(1.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<short>(0x7FFF, out result));
+            Assert.Equal(32767.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<short>(unchecked((short)0x8000), out result));
+            Assert.Equal(-32768.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<short>(unchecked((short)0xFFFF), out result));
+            Assert.Equal(-1.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt32Test()
+        {
+            float result;
+
+            Assert.True(NumberHelper<float>.TryCreate<int>(0x00000000, out result));
+            Assert.Equal(0.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<int>(0x00000001, out result));
+            Assert.Equal(1.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<int>(0x7FFFFFFF, out result));
+            Assert.Equal(2147483647.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<int>(unchecked((int)0x80000000), out result));
+            Assert.Equal(-2147483648.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<int>(unchecked((int)0xFFFFFFFF), out result));
+            Assert.Equal(-1.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromInt64Test()
+        {
+            float result;
+
+            Assert.True(NumberHelper<float>.TryCreate<long>(0x0000000000000000, out result));
+            Assert.Equal(0.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<long>(0x0000000000000001, out result));
+            Assert.Equal(1.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<long>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.Equal(9223372036854775807.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<long>(unchecked(unchecked((long)0x8000000000000000)), out result));
+            Assert.Equal(-9223372036854775808.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<long>(unchecked(unchecked((long)0xFFFFFFFFFFFFFFFF)), out result));
+            Assert.Equal(-1.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromIntPtrTest()
+        {
+            float result;
+
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberHelper<float>.TryCreate<nint>(unchecked((nint)0x0000000000000000), out result));
+                Assert.Equal(0.0f, result);
+
+                Assert.True(NumberHelper<float>.TryCreate<nint>(unchecked((nint)0x0000000000000001), out result));
+                Assert.Equal(1.0f, result);
+
+                Assert.True(NumberHelper<float>.TryCreate<nint>(unchecked((nint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.Equal(9223372036854775807.0f, result);
+
+                Assert.True(NumberHelper<float>.TryCreate<nint>(unchecked((nint)0x8000000000000000), out result));
+                Assert.Equal(-9223372036854775808.0f, result);
+
+                Assert.True(NumberHelper<float>.TryCreate<nint>(unchecked((nint)0xFFFFFFFFFFFFFFFF), out result));
+                Assert.Equal(-1.0f, result);
+            }
+            else
+            {
+                Assert.True(NumberHelper<float>.TryCreate<nint>((nint)0x00000000, out result));
+                Assert.Equal(0.0f, result);
+
+                Assert.True(NumberHelper<float>.TryCreate<nint>((nint)0x00000001, out result));
+                Assert.Equal(1.0f, result);
+
+                Assert.True(NumberHelper<float>.TryCreate<nint>((nint)0x7FFFFFFF, out result));
+                Assert.Equal(2147483647.0f, result);
+
+                Assert.True(NumberHelper<float>.TryCreate<nint>(unchecked((nint)0x80000000), out result));
+                Assert.Equal(-2147483648.0f, result);
+
+                Assert.True(NumberHelper<float>.TryCreate<nint>(unchecked((nint)0xFFFFFFFF), out result));
+                Assert.Equal(-1.0f, result);
+            }
+        }
+
+        [Fact]
+        public static void TryCreateFromSByteTest()
+        {
+            float result;
+
+            Assert.True(NumberHelper<float>.TryCreate<sbyte>(0x00, out result));
+            Assert.Equal(0.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<sbyte>(0x01, out result));
+            Assert.Equal(1.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<sbyte>(0x7F, out result));
+            Assert.Equal(127.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<sbyte>(unchecked((sbyte)0x80), out result));
+            Assert.Equal(-128.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<sbyte>(unchecked((sbyte)0xFF), out result));
+            Assert.Equal(-1.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt16Test()
+        {
+            float result;
+
+            Assert.True(NumberHelper<float>.TryCreate<ushort>(0x0000, out result));
+            Assert.Equal(0.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<ushort>(0x0001, out result));
+            Assert.Equal(1.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<ushort>(0x7FFF, out result));
+            Assert.Equal(32767.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<ushort>(0x8000, out result));
+            Assert.Equal(32768.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<ushort>(0xFFFF, out result));
+            Assert.Equal(65535.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt32Test()
+        {
+            float result;
+
+            Assert.True(NumberHelper<float>.TryCreate<uint>(0x00000000, out result));
+            Assert.Equal(0.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<uint>(0x00000001, out result));
+            Assert.Equal(1.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<uint>(0x7FFFFFFF, out result));
+            Assert.Equal(2147483647.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<uint>(0x80000000, out result));
+            Assert.Equal(2147483648.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<uint>(0xFFFFFFFF, out result));
+            Assert.Equal(4294967295.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUInt64Test()
+        {
+            float result;
+
+            Assert.True(NumberHelper<float>.TryCreate<ulong>(0x0000000000000000, out result));
+            Assert.Equal(0.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<ulong>(0x0000000000000001, out result));
+            Assert.Equal(1.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<ulong>(0x7FFFFFFFFFFFFFFF, out result));
+            Assert.Equal(9223372036854775807.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<ulong>(0x8000000000000000, out result));
+            Assert.Equal(9223372036854775808.0f, result);
+
+            Assert.True(NumberHelper<float>.TryCreate<ulong>(0xFFFFFFFFFFFFFFFF, out result));
+            Assert.Equal(18446744073709551615.0f, result);
+        }
+
+        [Fact]
+        public static void TryCreateFromUIntPtrTest()
+        {
+            float result;
+
+            if (Environment.Is64BitProcess)
+            {
+                Assert.True(NumberHelper<float>.TryCreate<nuint>(unchecked((nuint)0x0000000000000000), out result));
+                Assert.Equal(0.0f, result);
+
+                Assert.True(NumberHelper<float>.TryCreate<nuint>(unchecked((nuint)0x0000000000000001), out result));
+                Assert.Equal(1.0f, result);
+
+                Assert.True(NumberHelper<float>.TryCreate<nuint>(unchecked((nuint)0x7FFFFFFFFFFFFFFF), out result));
+                Assert.Equal(9223372036854775807.0f, result);
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // Assert.True(NumberHelper<float>.TryCreate<nuint>(unchecked((nuint)0x8000000000000000), out result));
+                // Assert.Equal(9223372036854775808.0f, result);
+                //
+                // Assert.True(NumberHelper<float>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFFFFFFFFFF), out result));
+                // Assert.Equal(18446744073709551615.0f, result);
+            }
+            else
+            {
+                Assert.True(NumberHelper<float>.TryCreate<nuint>((nuint)0x00000000, out result));
+                Assert.Equal(0.0f, result);
+
+                Assert.True(NumberHelper<float>.TryCreate<nuint>((nuint)0x00000001, out result));
+                Assert.Equal(1.0f, result);
+
+                Assert.True(NumberHelper<float>.TryCreate<nuint>((nuint)0x7FFFFFFF, out result));
+                Assert.Equal(2147483647.0f, result);
+
+                // https://github.com/dotnet/roslyn/issues/60714
+                // Assert.True(NumberHelper<float>.TryCreate<nuint>(unchecked((nuint)0x80000000), out result));
+                // Assert.Equal(2147483648.0f, result);
+                //
+                // Assert.True(NumberHelper<float>.TryCreate<nuint>(unchecked((nuint)0xFFFFFFFF), out result));
+                // Assert.Equal(4294967295.0f, result);
+            }
+        }
+
+        [Fact]
+        public static void op_SubtractionTest()
+        {
+            AssertBitwiseEqual(float.NegativeInfinity, SubtractionOperatorsHelper<float, float, float>.op_Subtraction(float.NegativeInfinity, 1.0f));
+            AssertBitwiseEqual(float.MinValue, SubtractionOperatorsHelper<float, float, float>.op_Subtraction(float.MinValue, 1.0f));
+            AssertBitwiseEqual(-2.0f, SubtractionOperatorsHelper<float, float, float>.op_Subtraction(-1.0f, 1.0f));
+            AssertBitwiseEqual(-1.0f, SubtractionOperatorsHelper<float, float, float>.op_Subtraction(-MinNormal, 1.0f));
+            AssertBitwiseEqual(-1.0f, SubtractionOperatorsHelper<float, float, float>.op_Subtraction(-MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(-1.0f, SubtractionOperatorsHelper<float, float, float>.op_Subtraction(-float.Epsilon, 1.0f));
+            AssertBitwiseEqual(-1.0f, SubtractionOperatorsHelper<float, float, float>.op_Subtraction(-0.0f, 1.0f));
+            AssertBitwiseEqual(float.NaN, SubtractionOperatorsHelper<float, float, float>.op_Subtraction(float.NaN, 1.0f));
+            AssertBitwiseEqual(-1.0f, SubtractionOperatorsHelper<float, float, float>.op_Subtraction(0.0f, 1.0f));
+            AssertBitwiseEqual(-1.0f, SubtractionOperatorsHelper<float, float, float>.op_Subtraction(float.Epsilon, 1.0f));
+            AssertBitwiseEqual(-1.0f, SubtractionOperatorsHelper<float, float, float>.op_Subtraction(MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(-1.0f, SubtractionOperatorsHelper<float, float, float>.op_Subtraction(MinNormal, 1.0f));
+            AssertBitwiseEqual(0.0f, SubtractionOperatorsHelper<float, float, float>.op_Subtraction(1.0f, 1.0f));
+            AssertBitwiseEqual(float.MaxValue, SubtractionOperatorsHelper<float, float, float>.op_Subtraction(float.MaxValue, 1.0f));
+            AssertBitwiseEqual(float.PositiveInfinity, SubtractionOperatorsHelper<float, float, float>.op_Subtraction(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void op_CheckedSubtractionTest()
+        {
+            AssertBitwiseEqual(float.NegativeInfinity, SubtractionOperatorsHelper<float, float, float>.op_CheckedSubtraction(float.NegativeInfinity, 1.0f));
+            AssertBitwiseEqual(float.MinValue, SubtractionOperatorsHelper<float, float, float>.op_CheckedSubtraction(float.MinValue, 1.0f));
+            AssertBitwiseEqual(-2.0f, SubtractionOperatorsHelper<float, float, float>.op_CheckedSubtraction(-1.0f, 1.0f));
+            AssertBitwiseEqual(-1.0f, SubtractionOperatorsHelper<float, float, float>.op_CheckedSubtraction(-MinNormal, 1.0f));
+            AssertBitwiseEqual(-1.0f, SubtractionOperatorsHelper<float, float, float>.op_CheckedSubtraction(-MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(-1.0f, SubtractionOperatorsHelper<float, float, float>.op_CheckedSubtraction(-float.Epsilon, 1.0f));
+            AssertBitwiseEqual(-1.0f, SubtractionOperatorsHelper<float, float, float>.op_CheckedSubtraction(-0.0f, 1.0f));
+            AssertBitwiseEqual(float.NaN, SubtractionOperatorsHelper<float, float, float>.op_CheckedSubtraction(float.NaN, 1.0f));
+            AssertBitwiseEqual(-1.0f, SubtractionOperatorsHelper<float, float, float>.op_CheckedSubtraction(0.0f, 1.0f));
+            AssertBitwiseEqual(-1.0f, SubtractionOperatorsHelper<float, float, float>.op_CheckedSubtraction(float.Epsilon, 1.0f));
+            AssertBitwiseEqual(-1.0f, SubtractionOperatorsHelper<float, float, float>.op_CheckedSubtraction(MaxSubnormal, 1.0f));
+            AssertBitwiseEqual(-1.0f, SubtractionOperatorsHelper<float, float, float>.op_CheckedSubtraction(MinNormal, 1.0f));
+            AssertBitwiseEqual(0.0f, SubtractionOperatorsHelper<float, float, float>.op_CheckedSubtraction(1.0f, 1.0f));
+            AssertBitwiseEqual(float.MaxValue, SubtractionOperatorsHelper<float, float, float>.op_CheckedSubtraction(float.MaxValue, 1.0f));
+            AssertBitwiseEqual(float.PositiveInfinity, SubtractionOperatorsHelper<float, float, float>.op_CheckedSubtraction(float.PositiveInfinity, 1.0f));
+        }
+
+        [Fact]
+        public static void op_UnaryNegationTest()
+        {
+            AssertBitwiseEqual(float.PositiveInfinity, UnaryNegationOperatorsHelper<float, float>.op_UnaryNegation(float.NegativeInfinity));
+            AssertBitwiseEqual(float.MaxValue, UnaryNegationOperatorsHelper<float, float>.op_UnaryNegation(float.MinValue));
+            AssertBitwiseEqual(1.0f, UnaryNegationOperatorsHelper<float, float>.op_UnaryNegation(-1.0f));
+            AssertBitwiseEqual(MinNormal, UnaryNegationOperatorsHelper<float, float>.op_UnaryNegation(-MinNormal));
+            AssertBitwiseEqual(MaxSubnormal, UnaryNegationOperatorsHelper<float, float>.op_UnaryNegation(-MaxSubnormal));
+            AssertBitwiseEqual(float.Epsilon, UnaryNegationOperatorsHelper<float, float>.op_UnaryNegation(-float.Epsilon));
+            AssertBitwiseEqual(0.0f, UnaryNegationOperatorsHelper<float, float>.op_UnaryNegation(-0.0f));
+            AssertBitwiseEqual(float.NaN, UnaryNegationOperatorsHelper<float, float>.op_UnaryNegation(float.NaN));
+            AssertBitwiseEqual(-0.0f, UnaryNegationOperatorsHelper<float, float>.op_UnaryNegation(0.0f));
+            AssertBitwiseEqual(-float.Epsilon, UnaryNegationOperatorsHelper<float, float>.op_UnaryNegation(float.Epsilon));
+            AssertBitwiseEqual(-MaxSubnormal, UnaryNegationOperatorsHelper<float, float>.op_UnaryNegation(MaxSubnormal));
+            AssertBitwiseEqual(-MinNormal, UnaryNegationOperatorsHelper<float, float>.op_UnaryNegation(MinNormal));
+            AssertBitwiseEqual(-1.0f, UnaryNegationOperatorsHelper<float, float>.op_UnaryNegation(1.0f));
+            AssertBitwiseEqual(float.MinValue, UnaryNegationOperatorsHelper<float, float>.op_UnaryNegation(float.MaxValue));
+            AssertBitwiseEqual(float.NegativeInfinity, UnaryNegationOperatorsHelper<float, float>.op_UnaryNegation(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_CheckedUnaryNegationTest()
+        {
+            AssertBitwiseEqual(float.PositiveInfinity, UnaryNegationOperatorsHelper<float, float>.op_CheckedUnaryNegation(float.NegativeInfinity));
+            AssertBitwiseEqual(float.MaxValue, UnaryNegationOperatorsHelper<float, float>.op_CheckedUnaryNegation(float.MinValue));
+            AssertBitwiseEqual(1.0f, UnaryNegationOperatorsHelper<float, float>.op_CheckedUnaryNegation(-1.0f));
+            AssertBitwiseEqual(MinNormal, UnaryNegationOperatorsHelper<float, float>.op_CheckedUnaryNegation(-MinNormal));
+            AssertBitwiseEqual(MaxSubnormal, UnaryNegationOperatorsHelper<float, float>.op_CheckedUnaryNegation(-MaxSubnormal));
+            AssertBitwiseEqual(float.Epsilon, UnaryNegationOperatorsHelper<float, float>.op_CheckedUnaryNegation(-float.Epsilon));
+            AssertBitwiseEqual(0.0f, UnaryNegationOperatorsHelper<float, float>.op_CheckedUnaryNegation(-0.0f));
+            AssertBitwiseEqual(float.NaN, UnaryNegationOperatorsHelper<float, float>.op_CheckedUnaryNegation(float.NaN));
+            AssertBitwiseEqual(-0.0f, UnaryNegationOperatorsHelper<float, float>.op_CheckedUnaryNegation(0.0f));
+            AssertBitwiseEqual(-float.Epsilon, UnaryNegationOperatorsHelper<float, float>.op_CheckedUnaryNegation(float.Epsilon));
+            AssertBitwiseEqual(-MaxSubnormal, UnaryNegationOperatorsHelper<float, float>.op_CheckedUnaryNegation(MaxSubnormal));
+            AssertBitwiseEqual(-MinNormal, UnaryNegationOperatorsHelper<float, float>.op_CheckedUnaryNegation(MinNormal));
+            AssertBitwiseEqual(-1.0f, UnaryNegationOperatorsHelper<float, float>.op_CheckedUnaryNegation(1.0f));
+            AssertBitwiseEqual(float.MinValue, UnaryNegationOperatorsHelper<float, float>.op_CheckedUnaryNegation(float.MaxValue));
+            AssertBitwiseEqual(float.NegativeInfinity, UnaryNegationOperatorsHelper<float, float>.op_CheckedUnaryNegation(float.PositiveInfinity));
+        }
+
+        [Fact]
+        public static void op_UnaryPlusTest()
+        {
+            AssertBitwiseEqual(float.NegativeInfinity, UnaryPlusOperatorsHelper<float, float>.op_UnaryPlus(float.NegativeInfinity));
+            AssertBitwiseEqual(float.MinValue, UnaryPlusOperatorsHelper<float, float>.op_UnaryPlus(float.MinValue));
+            AssertBitwiseEqual(-1.0f, UnaryPlusOperatorsHelper<float, float>.op_UnaryPlus(-1.0f));
+            AssertBitwiseEqual(-MinNormal, UnaryPlusOperatorsHelper<float, float>.op_UnaryPlus(-MinNormal));
+            AssertBitwiseEqual(-MaxSubnormal, UnaryPlusOperatorsHelper<float, float>.op_UnaryPlus(-MaxSubnormal));
+            AssertBitwiseEqual(-float.Epsilon, UnaryPlusOperatorsHelper<float, float>.op_UnaryPlus(-float.Epsilon));
+            AssertBitwiseEqual(-0.0f, UnaryPlusOperatorsHelper<float, float>.op_UnaryPlus(-0.0f));
+            AssertBitwiseEqual(float.NaN, UnaryPlusOperatorsHelper<float, float>.op_UnaryPlus(float.NaN));
+            AssertBitwiseEqual(0.0f, UnaryPlusOperatorsHelper<float, float>.op_UnaryPlus(0.0f));
+            AssertBitwiseEqual(float.Epsilon, UnaryPlusOperatorsHelper<float, float>.op_UnaryPlus(float.Epsilon));
+            AssertBitwiseEqual(MaxSubnormal, UnaryPlusOperatorsHelper<float, float>.op_UnaryPlus(MaxSubnormal));
+            AssertBitwiseEqual(MinNormal, UnaryPlusOperatorsHelper<float, float>.op_UnaryPlus(MinNormal));
+            AssertBitwiseEqual(1.0f, UnaryPlusOperatorsHelper<float, float>.op_UnaryPlus(1.0f));
+            AssertBitwiseEqual(float.MaxValue, UnaryPlusOperatorsHelper<float, float>.op_UnaryPlus(float.MaxValue));
+            AssertBitwiseEqual(float.PositiveInfinity, UnaryPlusOperatorsHelper<float, float>.op_UnaryPlus(float.PositiveInfinity));
+        }
+
         [Theory]
         [MemberData(nameof(SingleTests.Parse_Valid_TestData), MemberType = typeof(SingleTests))]
         public static void ParseValidStringTest(string value, NumberStyles style, IFormatProvider provider, float expected)


### PR DESCRIPTION
These apparently didn't get checked in alongside the integer tests like they should've. I've extracted them from https://github.com/dotnet/runtime/pull/67939 since that is otherwise blocked (hopefully due to something specific to the changes in that PR)

There are no changes from #67939 which has already been reviewed/approved, so you shouldn't feel the need to re-review the files.