### PR TITLE
Use and support OpenSSL 3 on macOS

### DIFF
--- a/docs/workflow/requirements/macos-requirements.md
+++ b/docs/workflow/requirements/macos-requirements.md
@@ -27,7 +27,7 @@ Install the following packages:
 
 - cmake 3.15.5 or newer
 - icu4c
-- openssl 1.1
+- openssl@1.1 or openssl@3
 - pkg-config
 - python3
 - ninja (optional, enables building native code with ninja instead of make)

--- a/eng/Brewfile
+++ b/eng/Brewfile
@@ -1,5 +1,5 @@
 brew "cmake"
 brew "icu4c"
-brew "openssl@1.1"
+brew "openssl@3"
 brew "pkg-config"
 brew "python3"

--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -35,7 +35,7 @@ check_prereqs()
         if ! pkg-config openssl ; then
             # We export the proper PKG_CONFIG_PATH where openssl was installed by Homebrew
             # It's important to _export_ it since build-commons.sh is sourced by other scripts such as build-native.sh
-            export PKG_CONFIG_PATH=$(brew --prefix)/opt/openssl@1.1/lib/pkgconfig:$(brew --prefix)/opt/openssl/lib/pkgconfig
+            export PKG_CONFIG_PATH=$(brew --prefix)/opt/openssl@3/lib/pkgconfig:$(brew --prefix)/opt/openssl@1.1/lib/pkgconfig:$(brew --prefix)/opt/openssl/lib/pkgconfig
             # We try again with the PKG_CONFIG_PATH in place, if pkg-config still can't find OpenSSL, exit with an error, cmake won't find OpenSSL either
             pkg-config openssl || { echo >&2 "Please install openssl before running this script, see https://github.com/dotnet/runtime/blob/main/docs/workflow/requirements/macos-requirements.md"; exit 1; }
         fi


### PR DESCRIPTION
This changes macOS builds and runs to use OpenSSL 3, as well as support it for pkg-config.