### PR TITLE
Fix linux-x86 compilation for clr.alljits subset

### DIFF
--- a/src/coreclr/inc/clrnt.h
+++ b/src/coreclr/inc/clrnt.h
@@ -833,7 +833,7 @@ RtlVirtualUnwind_Unsafe(
 //
 
 #ifdef TARGET_X86
-#ifndef TARGET_UNIX
+#ifndef HOST_UNIX
 //
 // x86 ABI does not define RUNTIME_FUNCTION. Define our own to allow unification between x86 and other platforms.
 //
@@ -847,7 +847,7 @@ typedef struct _DISPATCHER_CONTEXT {
     _EXCEPTION_REGISTRATION_RECORD* RegistrationPointer;
 } DISPATCHER_CONTEXT, *PDISPATCHER_CONTEXT;
 #endif // HOST_X86
-#endif // !TARGET_UNIX
+#endif // !HOST_UNIX
 
 #define RUNTIME_FUNCTION__BeginAddress(prf)             (prf)->BeginAddress
 #define RUNTIME_FUNCTION__SetBeginAddress(prf,addr)     ((prf)->BeginAddress = (addr))


### PR DESCRIPTION
Fixes #68044 

I don't know if this is the right solution - I haven't tested compiling on windows.  Compiling native linux-x64 with this change also seems to work still.

With this fix the resulting product SDK functions, I can create, compile and run a hello world.