### PR TITLE
JIT: fix assert seen in some OSR cases

### DIFF
--- a/src/coreclr/jit/gschecks.cpp
+++ b/src/coreclr/jit/gschecks.cpp
@@ -52,17 +52,24 @@ void Compiler::gsCopyShadowParams()
         return;
     }
 
-    // Allocate array for shadow param info
-    gsShadowVarInfo = new (this, CMK_Unknown) ShadowParamVarInfo[lvaCount]();
-
     // Find groups of variables assigned to each other, and also
     // tracks variables which are dereferenced and marks them as ptrs.
     // Look for assignments to *p, and ptrs passed to functions
-    if (gsFindVulnerableParams())
+    //
+    if (!gsFindVulnerableParams())
     {
-        // Replace vulnerable params by shadow copies.
-        gsParamsToShadows();
+        // There are no vulnerable params.
+        //
+        return;
     }
+
+    // Allocate array for shadow param info
+    //
+    gsShadowVarInfo = new (this, CMK_Unknown) ShadowParamVarInfo[lvaCount]();
+
+    // Replace vulnerable params by shadow copies.
+    //
+    gsParamsToShadows();
 }
 
 // This struct tracks how a tree is being used

--- a/src/coreclr/jit/gschecks.cpp
+++ b/src/coreclr/jit/gschecks.cpp
@@ -52,24 +52,27 @@ void Compiler::gsCopyShadowParams()
         return;
     }
 
-    // Find groups of variables assigned to each other, and also
-    // tracks variables which are dereferenced and marks them as ptrs.
-    // Look for assignments to *p, and ptrs passed to functions
-    //
-    if (!gsFindVulnerableParams())
-    {
-        // There are no vulnerable params.
-        //
-        return;
-    }
-
     // Allocate array for shadow param info
     //
     gsShadowVarInfo = new (this, CMK_Unknown) ShadowParamVarInfo[lvaCount]();
 
-    // Replace vulnerable params by shadow copies.
+    // Find groups of variables assigned to each other, and also
+    // tracks variables which are dereferenced and marks them as ptrs.
+    // Look for assignments to *p, and ptrs passed to functions
     //
-    gsParamsToShadows();
+    if (gsFindVulnerableParams())
+    {
+        // Replace vulnerable params by shadow copies.
+        //
+        gsParamsToShadows();
+    }
+    else
+    {
+        // There are no vulnerable params.
+        // Clear out the info to avoid looking at stale data.
+        //
+        gsShadowVarInfo = nullptr;
+    }
 }
 
 // This struct tracks how a tree is being used


### PR DESCRIPTION
As a result of #67884, OSR compilations were looking at data in the
`gsShadowVarInfo` array in cases where it was not initialized.

Fix is to null out `gsShadowVarInfo` array if there are no shadowed params.

Fixes #68003.