### PR TITLE
Add ServiceCollection.MakeReadOnly()

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public System.Collections.Generic.IEnumerator<Microsoft.Extensions.DependencyInjection.ServiceDescriptor> GetEnumerator() { throw null; }
         public int IndexOf(Microsoft.Extensions.DependencyInjection.ServiceDescriptor item) { throw null; }
         public void Insert(int index, Microsoft.Extensions.DependencyInjection.ServiceDescriptor item) { }
+        public void MakeReadOnly() { }
         public bool Remove(Microsoft.Extensions.DependencyInjection.ServiceDescriptor item) { throw null; }
         public void RemoveAt(int index) { }
         void System.Collections.Generic.ICollection<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>.Add(Microsoft.Extensions.DependencyInjection.ServiceDescriptor item) { }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Resources/Strings.resx
@@ -133,6 +133,9 @@
     <value>No service for type '{0}' has been registered.</value>
     <comment>{0} = service type</comment>
   </data>
+  <data name="ServiceCollectionReadOnly" xml:space="preserve">
+    <value>The service collection cannot be modified because it is read-only.</value>
+  </data>
   <data name="TryAddIndistinguishableTypeToEnumerable" xml:space="preserve">
     <value>Implementation type cannot be '{0}' because it is indistinguishable from other services registered for '{1}'.</value>
     <comment>{0} = implementation type, {1} = service type</comment>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceCollection.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceCollection.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -12,12 +13,13 @@ namespace Microsoft.Extensions.DependencyInjection
     public class ServiceCollection : IServiceCollection
     {
         private readonly List<ServiceDescriptor> _descriptors = new List<ServiceDescriptor>();
+        private bool _isReadOnly;
 
         /// <inheritdoc />
         public int Count => _descriptors.Count;
 
         /// <inheritdoc />
-        public bool IsReadOnly => false;
+        public bool IsReadOnly => _isReadOnly;
 
         /// <inheritdoc />
         public ServiceDescriptor this[int index]
@@ -28,6 +30,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
             set
             {
+                CheckReadOnly();
                 _descriptors[index] = value;
             }
         }
@@ -35,6 +38,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <inheritdoc />
         public void Clear()
         {
+            CheckReadOnly();
             _descriptors.Clear();
         }
 
@@ -53,6 +57,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <inheritdoc />
         public bool Remove(ServiceDescriptor item)
         {
+            CheckReadOnly();
             return _descriptors.Remove(item);
         }
 
@@ -64,6 +69,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         void ICollection<ServiceDescriptor>.Add(ServiceDescriptor item)
         {
+            CheckReadOnly();
             _descriptors.Add(item);
         }
 
@@ -81,13 +87,37 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <inheritdoc />
         public void Insert(int index, ServiceDescriptor item)
         {
+            CheckReadOnly();
             _descriptors.Insert(index, item);
         }
 
         /// <inheritdoc />
         public void RemoveAt(int index)
         {
+            CheckReadOnly();
             _descriptors.RemoveAt(index);
         }
+
+        /// <summary>
+        /// Makes this collection read-only.
+        /// </summary>
+        /// <remarks>
+        /// After the collection is marked as read-only, any further attempt to modify it throws an <see cref="InvalidOperationException" />.
+        /// </remarks>
+        public void MakeReadOnly()
+        {
+            _isReadOnly = true;
+        }
+
+        private void CheckReadOnly()
+        {
+            if (_isReadOnly)
+            {
+                ThrowReadOnlyException();
+            }
+        }
+
+        private static void ThrowReadOnlyException() =>
+            throw new InvalidOperationException(SR.ServiceCollectionReadOnly);
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceCollectionTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceCollectionTests.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
+using Xunit;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public class ServiceCollectionTests
+    {
+        [Fact]
+        public void TestMakeReadOnly()
+        {
+            var serviceCollection = new ServiceCollection();
+            var descriptor = new ServiceDescriptor(typeof(IFakeService), new FakeService());
+            serviceCollection.Add(descriptor);
+
+            serviceCollection.MakeReadOnly();
+
+            var descriptor2 = new ServiceDescriptor(typeof(IFakeEveryService), new FakeService());
+
+            Assert.Throws<InvalidOperationException>(() => serviceCollection[0] = descriptor2);
+            Assert.Throws<InvalidOperationException>(() => serviceCollection.Clear());
+            Assert.Throws<InvalidOperationException>(() => serviceCollection.Remove(descriptor));
+            Assert.Throws<InvalidOperationException>(() => serviceCollection.Add(descriptor2));
+            Assert.Throws<InvalidOperationException>(() => serviceCollection.Insert(0, descriptor2));
+            Assert.Throws<InvalidOperationException>(() => serviceCollection.RemoveAt(0));
+
+            Assert.True(serviceCollection.IsReadOnly);
+            Assert.Equal(1, serviceCollection.Count);
+            foreach (ServiceDescriptor d in serviceCollection)
+            {
+                Assert.Equal(descriptor, d);
+            }
+            Assert.Equal(descriptor, serviceCollection[0]);
+            Assert.True(serviceCollection.Contains(descriptor));
+            Assert.Equal(0, serviceCollection.IndexOf(descriptor));
+
+            ServiceDescriptor[] copyArray = new ServiceDescriptor[1];
+            serviceCollection.CopyTo(copyArray, 0);
+            Assert.Equal(descriptor, copyArray[0]);
+
+            // ensure MakeReadOnly can be called twice, and it is just ignored
+            serviceCollection.MakeReadOnly();
+            Assert.True(serviceCollection.IsReadOnly);
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilder.cs
@@ -4,7 +4,6 @@
 #nullable enable
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -22,7 +21,7 @@ namespace Microsoft.Extensions.Hosting
     public sealed class HostApplicationBuilder
     {
         private readonly HostBuilderContext _hostBuilderContext;
-        private readonly CheckedServiceCollection _checkedServiceCollection = new();
+        private readonly ServiceCollection _serviceCollection = new();
 
         private Func<IServiceProvider> _createServiceProvider;
         private Action<object> _configureContainer = _ => { };
@@ -165,7 +164,7 @@ namespace Microsoft.Extensions.Hosting
         /// <summary>
         /// A collection of services for the application to compose. This is useful for adding user provided or framework provided services.
         /// </summary>
-        public IServiceCollection Services => _checkedServiceCollection;
+        public IServiceCollection Services => _serviceCollection;
 
         /// <summary>
         /// A collection of logging providers for the application to compose. This is useful for adding new logging providers.
@@ -224,7 +223,7 @@ namespace Microsoft.Extensions.Hosting
             _appServices = _createServiceProvider();
 
             // Prevent further modification of the service collection now that the provider is built.
-            _checkedServiceCollection.IsReadOnly = true;
+            _serviceCollection.MakeReadOnly();
 
             return HostBuilder.ResolveHost(_appServices, diagnosticListener);
         }
@@ -359,69 +358,6 @@ namespace Microsoft.Extensions.Hosting
                     ?? throw new ArgumentNullException(nameof(configureDelegate))));
 
                 return this;
-            }
-        }
-
-        private sealed class CheckedServiceCollection : IServiceCollection
-        {
-            private readonly IServiceCollection _services = new ServiceCollection();
-
-            public bool IsReadOnly { get; set; }
-            public int Count => _services.Count;
-
-            public ServiceDescriptor this[int index]
-            {
-                get => _services[index];
-                set
-                {
-                    CheckReadOnly();
-                    _services[index] = value;
-                }
-            }
-
-            public IEnumerator<ServiceDescriptor> GetEnumerator() => _services.GetEnumerator();
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-            public int IndexOf(ServiceDescriptor item) => _services.IndexOf(item);
-            public bool Contains(ServiceDescriptor item) => _services.Contains(item);
-            public void CopyTo(ServiceDescriptor[] array, int arrayIndex) => _services.CopyTo(array, arrayIndex);
-
-            public void Add(ServiceDescriptor item)
-            {
-                CheckReadOnly();
-                _services.Add(item);
-            }
-
-            public void Clear()
-            {
-                CheckReadOnly();
-                _services.Clear();
-            }
-
-            public void Insert(int index, ServiceDescriptor item)
-            {
-                CheckReadOnly();
-                _services.Insert(index, item);
-            }
-
-            public bool Remove(ServiceDescriptor item)
-            {
-                CheckReadOnly();
-                return _services.Remove(item);
-            }
-
-            public void RemoveAt(int index)
-            {
-                CheckReadOnly();
-                _services.RemoveAt(index);
-            }
-
-            private void CheckReadOnly()
-            {
-                if (IsReadOnly)
-                {
-                    throw new InvalidOperationException(SR.ServiceCollectionModificationInvalidAfterBuild);
-                }
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Resources/Strings.resx
@@ -144,7 +144,4 @@
   <data name="ResolverReturnedNull" xml:space="preserve">
     <value>The resolver returned a null IServiceProviderFactory</value>
   </data>
-  <data name="ServiceCollectionModificationInvalidAfterBuild" xml:space="preserve">
-    <value>The service collection cannot be modified after the application is built.</value>
-  </data>
 </root>


### PR DESCRIPTION
With new hosting API patterns, it is useful to be able to mark a ServiceCollection
as read-only and disallow for any more modifications to it.

Fix #66126