### PR TITLE
Fixes incorrect service resolution in Development environment

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -132,6 +132,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private void ValidateService(ServiceDescriptor descriptor)
         {
+            // Skip validation for generic service types
             if (descriptor.ServiceType.IsGenericType)
             {
                 return;

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private void ValidateService(ServiceDescriptor descriptor)
         {
-            if (descriptor.ServiceType.IsGenericType && !descriptor.ServiceType.IsConstructedGenericType)
+            if (descriptor.ServiceType.IsGenericType)
             {
                 return;
             }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -132,7 +132,10 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private void ValidateService(ServiceDescriptor descriptor)
         {
-            // Skip validation for generic service types
+            // Skip validation for generic service types during validation.
+            // Because we could end up with an incomplete set of call site caches for open generics during validation.
+            // It could also lead to incorrect slot ordering for the call sites generated upon a get service call.
+            // For more info, visit issue dotnet/runtime#65145.
             if (descriptor.ServiceType.IsGenericType)
             {
                 return;

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
@@ -1125,6 +1125,30 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             Assert.Equal(1, disposable.DisposeCount);
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ValidateOnBuild_True_ResolvesConstrainedOpenGeneric(bool validateOnBuild)
+        {
+            var services = new ServiceCollection();
+
+            services.AddTransient<IBB<AA>, BB>();
+            services.AddTransient(typeof(IBB<>), typeof(GenericBB<>));
+
+            var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions() { ValidateOnBuild = validateOnBuild });
+            var handlers = serviceProvider
+                .GetServices<IBB<AA>>()
+                .ToList();
+
+            Assert.Equal(2, handlers.Count);
+            var handlersTypes = handlers
+                .Select(h => h.GetType())
+                .ToList();
+
+            Assert.Contains(typeof(BB), handlersTypes);
+            Assert.Contains(typeof(GenericBB<AA>), handlersTypes);
+        }
+
         private class FakeDisposable : IDisposable
         {
             public bool IsDisposed { get; private set; }
@@ -1319,5 +1343,10 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             }
             public A PropertyA { get; }
         }
+        private interface IAA { }
+        private interface IBB<T> { }
+        private class AA : IAA { }
+        private class BB : IBB<AA> { }
+        private class GenericBB<T> : IBB<T> where T : IAA { }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
@@ -1134,19 +1134,21 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
             services.AddTransient<IBB<AA>, BB>();
             services.AddTransient(typeof(IBB<>), typeof(GenericBB<>));
+            services.AddTransient(typeof(IBB<>), typeof(ConstrainedGenericBB<>));
 
             var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions() { ValidateOnBuild = validateOnBuild });
             var handlers = serviceProvider
                 .GetServices<IBB<AA>>()
                 .ToList();
 
-            Assert.Equal(2, handlers.Count);
+            Assert.Equal(3, handlers.Count);
             var handlersTypes = handlers
                 .Select(h => h.GetType())
                 .ToList();
 
             Assert.Contains(typeof(BB), handlersTypes);
             Assert.Contains(typeof(GenericBB<AA>), handlersTypes);
+            Assert.Contains(typeof(ConstrainedGenericBB<AA>), handlersTypes);
         }
 
         private class FakeDisposable : IDisposable
@@ -1347,6 +1349,8 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         private interface IBB<T> { }
         private class AA : IAA { }
         private class BB : IBB<AA> { }
-        private class GenericBB<T> : IBB<T> where T : IAA { }
+        private class GenericBB<T> : IBB<T> { }
+        private class ConstrainedGenericBB<T> : IBB<T> where T : IAA { }
+
     }
 }


### PR DESCRIPTION
Today, if the service type is generic (constrained or not) `ValidateService` would cause a bug and incorrectly resolve the generics.

---

#### Debug notes

Given: 

```cs
        public interface IAA { }
        public interface IBB<T> { }
        public class AA : IAA { }
        public class BB : IBB<AA> { }
        public class GenericBB<T> : IBB<T> { }
        public class ConstrainedGenericBB<T> : IBB<T> where T : IAA { }
```
When `BuildServiceProvider` gets called for:

```cs
            services.AddTransient<IBB<AA>, BB>();
            services.AddTransient(typeof(IBB<>), typeof(ConstrainedGenericBB<>));
            var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions() { ValidateOnBuild = true });
```

`ValidateOnBuild` makes `CallSiteFactory` store some service call sites into `_callSiteCache`.

Currently because of the if condition:

https://github.com/dotnet/runtime/blob/205632116bd764abfe019564256908202082c9a9/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs#L133-L142

for the first transient descriptor a cache item gets created for `IBB<AA>` in `_callSiteCache`, but skips to add another cache item for `IBB<>` to with implementation type `ConstrainedGenericBB`.

Then when we call

```c#
serviceProvider.GetServices<IBB<AA>>()
```
DI thinks it already has all the cache info it needs to resolve this and resolves twice with the one cache item rather than also resolving with `ConstrainedGenericBB`.

---

#### Proposed fix

I think the expectation and fix here should be to skip `ValidateOnBuild` on generics. We already have the test below expecting `ValidateOnBuild` to be skipped for generics anyway, so that makes me more convinced that this is the fix we want for the reported bug:

https://github.com/dotnet/runtime/blob/8ea879af03852e3d7d916badcf836af61fabb33c/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderValidationTests.cs#L137-L146

When we recently added more support for generic service resolution (open generics), we missed out on testing it with `ValidateOnBuild`. PR that added support for constrained open generics: https://github.com/dotnet/runtime/pull/39540

This bug fix helps properly resolve `IEnumerable<>` services set with `ValidateOnBuild` using `GetServices` when dealing with constrained open generics.

Fixes https://github.com/dotnet/runtime/issues/65145

cc @jbogard 