### PR TITLE
[wasm][debugger] Fix tests broken on 'main'

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -709,7 +709,7 @@ namespace DebuggerTests
             }
         }
 
-        internal async Task CheckProps(JToken actual, object exp_o, string label, int num_fields = -1)
+        internal async Task CheckProps(JToken actual, object exp_o, string label, int num_fields = -1, bool skip_num_fields_check = false)
         {
             if (exp_o.GetType().IsArray || exp_o is JArray)
             {
@@ -738,8 +738,11 @@ namespace DebuggerTests
             if (exp == null)
                 exp = JObject.FromObject(exp_o);
 
-            num_fields = num_fields < 0 ? exp.Values<JToken>().Count() : num_fields;
-            Assert.True(num_fields == actual.Count(), $"[{label}] Number of fields don't match, Expected: {num_fields}, Actual: {actual.Count()}");
+            if (!skip_num_fields_check)
+            {
+                num_fields = num_fields < 0 ? exp.Values<JToken>().Count() : num_fields;
+                Assert.True(num_fields == actual.Count(), $"[{label}] Number of fields don't match, Expected: {num_fields}, Actual: {actual.Count()}");
+            }
 
             foreach (var kvp in exp)
             {
@@ -832,7 +835,7 @@ namespace DebuggerTests
         }
 
         // Find an object with @name, *fetch* the object, and check against @o
-        internal async Task<JToken> CompareObjectPropertiesFor(JToken locals, string name, object o, string label = null, int num_fields = -1)
+        internal async Task<JToken> CompareObjectPropertiesFor(JToken locals, string name, object o, string label = null, int num_fields = -1, bool skip_num_fields_check = false)
         {
             if (label == null)
                 label = name;
@@ -840,7 +843,7 @@ namespace DebuggerTests
             try
             {
                 if (o != null)
-                    await CheckProps(props, o, label, num_fields);
+                    await CheckProps(props, o, label, num_fields, skip_num_fields_check);
                 return props;
             }
             catch

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -563,7 +563,7 @@ namespace DebuggerTests
                     Days = TNumber(3530),
                     Minutes = TNumber(2),
                     Seconds = TNumber(4),
-                }, "ts_props", num_fields: 12);
+                }, "ts_props", skip_num_fields_check: true);
 
             // DateTimeOffset
             await CompareObjectPropertiesFor(frame_locals, "dto",
@@ -572,7 +572,7 @@ namespace DebuggerTests
                     Day = TNumber(2),
                     Year = TNumber(2020),
                     DayOfWeek = TEnum("System.DayOfWeek", "Thursday")
-                }, "dto_props", num_fields: 20);
+                }, "dto_props", skip_num_fields_check: true);
 
             var DT = new DateTime(2004, 10, 15, 1, 2, 3);
             var DTO = new DateTimeOffset(dt0, new TimeSpan(2, 14, 0));


### PR DESCRIPTION
This test broke because it was checking for the number of members on
`System.TimeSpan`, and that changed with
https://github.com/dotnet/runtime/pull/67666 , which added new members
like `TotalNanoseconds`.

The test shouldn't depend on this number anyway, so remove that.

```
  Failed DebuggerTests.MiscTests.InspectLocalsForToStringDescriptions(line: 137, col: 12, method_name: "MethodWithLocalsForToStringTest", call_other: False, invoke_async: False) [758 ms]
  Error Message:
   [ts_props] Number of fields don't match, Expected: 12, Actual: 16
Expected: True
Actual:   False
  Stack Trace:
     at DebuggerTests.DebuggerTestBase.CheckProps(JToken actual, Object exp_o, String label, Int32 num_fields) in /_/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs:line 800
   at DebuggerTests.DebuggerTestBase.CompareObjectPropertiesFor(JToken locals, String name, Object o, String label, Int32 num_fields) in /_/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs:line 908
   at DebuggerTests.MiscTests.InspectLocalsForToStringDescriptions(Int32 line, Int32 col, String method_name, Boolean call_other, Boolean invoke_async) in /_/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs:line 559
```