### PR TITLE
Reduce r2r-extra GC stress level to 0xC per #68060

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -516,7 +516,7 @@ jobs:
           - jitstressregs0x1000
           - jitminopts
           - forcerelocs
-          - gcstress0xf
+          - gcstress0xc
         ${{ if in(parameters.testGroup, 'pgo') }}:
           scenarios:
           - nopgo


### PR DESCRIPTION
The change #65597 switching over JIT/Methodical tests to use merged wrappers has already
received extensive testing most of which works fine with the exception of r2r-extra runs. According
to my investigation it looks like the GCStress mode 0xF has a bug that got uncovered by the larger
merged test - in some cases the finalizer queue can end up in an infinite loop as the finalizations
keep adding more stuff on the finalizer queue. To prevent additional delays in merging in the
JIT/Methodical test merge I propose temporarily downgrading the GC stress level for these tests
to 0xC per Bruce's suggestion. I expect us to revert this change once the primary bug has been fixed.

Thanks

Tomas