### PR TITLE
Disable failures related to 'refPosition->RegOptional()'

### DIFF
--- a/src/coreclr/scripts/superpmi_replay.py
+++ b/src/coreclr/scripts/superpmi_replay.py
@@ -34,7 +34,8 @@ jit_flags_all = [
     "JitStressRegs=4",
     "JitStressRegs=8",
     "JitStressRegs=0x10",
-    "JitStressRegs=0x80",
+#    See https://github.com/dotnet/runtime/issues/66563
+#    "JitStressRegs=0x80",
     "JitStressRegs=0x1000",
 ]
 

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -196,6 +196,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/eh/nested/nestedtry/throwinnestedtrycatch_il_r/*">
             <Issue>https://github.com/dotnet/runtime/issues/66327</Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_461649/DevDiv_461649/**">
+            <Issue>https://github.com/dotnet/runtime/issues/66563</Issue>
+        </ExcludeList>     
     </ItemGroup>
 
     <!-- Arm64 All OS -->


### PR DESCRIPTION
I will try to investigate https://github.com/dotnet/runtime/issues/66563 tomorrow, but in case I don't find a way to fix it, I will publish this PR.