### PR TITLE
Fix JITDUMP alignment of promoted fields

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11310,7 +11310,7 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
                         }
 
                         printf("\n");
-                        printf("                                                  ");
+                        printf("                                                            ");
                         printIndent(indentStack);
                         printf("    %-6s V%02u.%s (offs=0x%02x) -> ", varTypeName(fieldVarDsc->TypeGet()),
                                tree->AsLclVarCommon()->GetLclNum(), fieldName, fieldVarDsc->lvFldOffset);


### PR DESCRIPTION
In #67238 I have changed calls to show more types of arguments in jit dumps, e.g. for a call `i.Foo(1, 2)` to an interface method `S24 Foo(int a, int b);` we now show
```scala
N012 ( 30, 30) [000003] SACXG-------                        ▌  CALLV stub void   I.Foo
N007 (  3,  3) [000005] ------------ retbuf in rdx          ├──▌  ADDR      long  
N006 (  3,  2) [000004] D------N----                        │  └──▌  LCL_VAR   struct<S24, 24>(RB) V02 tmp1         
N008 (  3,  2) [000000] ------------ this in rcx            ├──▌  LCL_VAR   ref    V00 arg0         
N009 (  2, 10) [000010] H----------- vsd cell in r11        ├──▌  CNS_INT(h) long   0x7ffa20c80008 ftn REG r11
N010 (  1,  1) [000001] ------------ arg3 in r8             ├──▌  CNS_INT   int    1
N011 (  1,  1) [000002] ------------ arg4 in r9             └──▌  CNS_INT   int    2
```
instead of
```scala
N012 ( 30, 30) [000003] SACXG-------              ▌  CALLV stub void   I.Foo
N007 (  3,  3) [000005] ------------ arg2 in rdx  ├──▌  ADDR      long  
N006 (  3,  2) [000004] D------N----              │  └──▌  LCL_VAR   struct<S24, 24>(RB) V02 tmp1         
N008 (  3,  2) [000000] ------------ this in rcx  ├──▌  LCL_VAR   ref    V00 arg0         
N009 (  2, 10) [000010] H----------- arg1 in r11  ├──▌  CNS_INT(h) long   0x7ffa31320008 ftn REG r11
N010 (  1,  1) [000001] ------------ arg3 in r8   ├──▌  CNS_INT   int    1
N011 (  1,  1) [000002] ------------ arg4 in r9   └──▌  CNS_INT   int    2
```

I had to increase the margin by a bit to fit this new info and I did not notice that this string also needed to change.



cc @dotnet/jit-contrib