### PR TITLE
[mono] Validate public APIs have an implementation

### DIFF
--- a/src/mono/mono/metadata/external-only.c
+++ b/src/mono/mono/metadata/external-only.c
@@ -313,6 +313,22 @@ mono_class_is_subclass_of (MonoClass *klass, MonoClass *klassc, gboolean check_i
 	MONO_EXTERNAL_ONLY_GC_UNSAFE (gboolean, mono_class_is_subclass_of_internal (klass, klassc, check_interfaces));
 }
 
+MonoDomain *
+mono_domain_create_appdomain (char *friendly_name, char *configuration_file)
+{
+	return NULL;
+}
+
+void
+mono_domain_try_unload (MonoDomain *domain, MonoObject **exc)
+{
+}
+
+void
+mono_domain_unload (MonoDomain *domain)
+{
+}
+
 /**
  * mono_domain_set_internal:
  * \param domain the new domain
@@ -595,6 +611,26 @@ mono_domain_foreach (MonoDomainFunc func, gpointer user_data)
  */
 void
 mono_context_init (MonoDomain *domain)
+{
+}
+
+void *
+mono_load_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, void **res)
+{
+	return NULL;
+}
+
+MonoObject *
+mono_load_remote_field_new (MonoObject *this_obj, MonoClass *klass, MonoClassField *field)
+{
+	return NULL;
+}
+
+void mono_store_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, void* val)
+{
+}
+
+void mono_store_remote_field_new (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, MonoObject *arg)
 {
 }
 

--- a/src/mono/mono/metadata/mono-config.c
+++ b/src/mono/mono/metadata/mono-config.c
@@ -169,6 +169,11 @@ mono_config_cleanup (void)
 }
 
 void
+mono_config_parse_memory (const char *buffer)
+{
+}
+
+void
 mono_config_parse (const char *filename)
 {
 }

--- a/src/mono/mono/mini/CMakeLists.txt
+++ b/src/mono/mono/mini/CMakeLists.txt
@@ -499,7 +499,7 @@ if(NOT DISABLE_EXECUTABLES)
   endif()
 
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    target_link_libraries(mono-sgen PRIVATE monoapi-validate)
+    target_sources(mono-sgen PRIVATE ${mono_validate_apis_source})
   endif()
 
   install(TARGETS mono-sgen RUNTIME)

--- a/src/mono/mono/mini/CMakeLists.txt
+++ b/src/mono/mono/mini/CMakeLists.txt
@@ -118,6 +118,7 @@ set(mini_common_sources
     aot-compiler.h
     aot-compiler.c
     aot-runtime.c
+    aot-runtime-wasm.c
     graph.c
     mini-codegen.c
     mini-exceptions.c
@@ -212,7 +213,6 @@ set(wasm_sources
     mini-wasm.c
     tramp-wasm.c
     exceptions-wasm.c
-    aot-runtime-wasm.c
     wasm_m2n_invoke.g.h
     cpu-wasm.h)
 
@@ -497,6 +497,11 @@ if(NOT DISABLE_EXECUTABLES)
   if(ICU_LDFLAGS)
     set_property(TARGET mono-sgen APPEND_STRING PROPERTY LINK_FLAGS " ${ICU_LDFLAGS}")
   endif()
+
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_link_libraries(mono-sgen PRIVATE monoapi-validate)
+  endif()
+
   install(TARGETS mono-sgen RUNTIME)
   if(HOST_WIN32)
     install(FILES $<TARGET_PDB_FILE:mono-sgen> DESTINATION bin OPTIONAL)

--- a/src/mono/mono/mini/aot-runtime-wasm.c
+++ b/src/mono/mono/mini/aot-runtime-wasm.c
@@ -134,6 +134,10 @@ mono_wasm_get_native_to_interp_trampoline (MonoMethod *method, gpointer extra_ar
 
 #else /* TARGET_WASM */
 
-MONO_EMPTY_SOURCE_FILE (aot_runtime_wasm);
+void
+mono_wasm_install_get_native_to_interp_tramp (MonoWasmGetNativeToInterpTramp cb)
+{
+	g_assert_not_reached ();
+}
 
 #endif /* TARGET_WASM */

--- a/src/native/public/monoapi.cmake
+++ b/src/native/public/monoapi.cmake
@@ -1,7 +1,7 @@
 
 add_library(monoapi_utils INTERFACE)
 
-set(utils_public_headers_base
+set(utils_public_headers
     mono-logger.h
     mono-error.h
     mono-forward.h
@@ -11,7 +11,7 @@ set(utils_public_headers_base
     mono-private-unstable.h
     mono-counters.h
     )
-set(utils_public_headers_details_base
+set(utils_public_headers_details
     details/mono-publib-types.h
     details/mono-publib-functions.h
     details/mono-logger-types.h
@@ -23,8 +23,8 @@ set(utils_public_headers_details_base
     details/mono-counters-types.h
     details/mono-counters-functions.h
     )
-addprefix(utils_public_headers mono/utils "${utils_public_headers_base}")
-addprefix(utils_public_headers_details mono/utils "${utils_public_headers_details_base}")
+list(TRANSFORM utils_public_headers PREPEND "mono/utils/")
+list(TRANSFORM utils_public_headers_details PREPEND "mono/utils/")
 
 target_sources(monoapi_utils INTERFACE ${utils_public_headers} ${utils_public_headers_details})
 
@@ -32,7 +32,7 @@ target_include_directories(monoapi_utils INTERFACE .)
 
 add_library(monoapi_metadata INTERFACE)
 
-set(metadata_public_headers_base
+set(metadata_public_headers
 	appdomain.h
 	assembly.h
 	attrdefs.h
@@ -61,7 +61,7 @@ set(metadata_public_headers_base
 	tokentype.h
 	verify.h
 	)
-set(metadata_public_headers_details_base
+set(metadata_public_headers_details
 	details/environment-functions.h
 	details/opcodes-types.h
 	details/opcodes-functions.h
@@ -100,8 +100,8 @@ set(metadata_public_headers_details_base
 	details/mono-private-unstable-types.h
 	details/mono-private-unstable-functions.h
 	)
-addprefix(metadata_public_headers mono/metadata "${metadata_public_headers_base}")
-addprefix(metadata_public_headers_details mono/metadata "${metadata_public_headers_details_base}")
+list(TRANSFORM metadata_public_headers PREPEND "mono/metadata/")
+list(TRANSFORM metadata_public_headers_details PREPEND "mono/metadata/")
 
 target_sources(monoapi_metadata INTERFACE ${metadata_public_headers} ${metadata_public_headers_details})
 
@@ -109,18 +109,18 @@ target_include_directories(monoapi_metadata INTERFACE .)
 
 add_library(monoapi_jit INTERFACE)
 
-set(jit_public_headers_base
+set(jit_public_headers
   jit.h
   mono-private-unstable.h
   )
-set(jit_public_headers_details_base
+set(jit_public_headers_details
   details/jit-types.h
   details/jit-functions.h
   details/mono-private-unstable-types.h
   details/mono-private-unstable-functions.h
   )
-addprefix(jit_public_headers mono/jit "${jit_public_headers_base}")
-addprefix(jit_public_headers_details mono/jit "${jit_public_headers_details_base}")
+list(TRANSFORM jit_public_headers PREPEND "mono/jit/")
+list(TRANSFORM jit_public_headers_details PREPEND "mono/jit/")
 
 target_sources(monoapi_jit INTERFACE ${jit_public_headers} ${jit_public_headers_details})
 
@@ -138,3 +138,23 @@ if(INSTALL_MONO_API)
   install(FILES ${jit_public_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mono-2.0/mono/jit)
   install(FILES ${jit_public_headers_details} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mono-2.0/mono/jit/details)
 endif()
+
+
+# create a helper source file to validate an implementation exists for each public API,
+# it is linked into mono-sgen and will cause a linking failure there if an API is missing
+foreach(header IN LISTS jit_public_headers metadata_public_headers utils_public_headers)
+	if(NOT header MATCHES "profiler-events.h") # profiler-events.h doesn't define APIs which causes an issue
+		string(APPEND publicapis_headers_include "#include <${header}>\n")
+	endif()
+endforeach()
+
+foreach(header IN LISTS jit_public_headers_details metadata_public_headers_details utils_public_headers_details)
+	if(header MATCHES "-functions.h")
+		string(APPEND publicapis_headers_details_include "#include <${header}>\n")
+	endif()
+endforeach()
+
+configure_file(validate-apis.c.in ${CMAKE_CURRENT_BINARY_DIR}/validate-apis.c @ONLY)
+
+add_library(monoapi-validate INTERFACE)
+target_sources(monoapi-validate INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/validate-apis.c)

--- a/src/native/public/monoapi.cmake
+++ b/src/native/public/monoapi.cmake
@@ -141,7 +141,7 @@ endif()
 
 
 # create a helper source file to validate an implementation exists for each public API,
-# it is linked into mono-sgen and will cause a linking failure there if an API is missing
+# it is compiled into mono-sgen and will cause a linking failure there if an API is missing
 foreach(header IN LISTS jit_public_headers metadata_public_headers utils_public_headers)
 	if(NOT header MATCHES "profiler-events.h") # profiler-events.h doesn't define APIs which causes an issue
 		string(APPEND publicapis_headers_include "#include <${header}>\n")
@@ -154,7 +154,5 @@ foreach(header IN LISTS jit_public_headers_details metadata_public_headers_detai
 	endif()
 endforeach()
 
+set(mono_validate_apis_source ${CMAKE_CURRENT_BINARY_DIR}/validate-apis.c PARENT_SCOPE)
 configure_file(validate-apis.c.in ${CMAKE_CURRENT_BINARY_DIR}/validate-apis.c @ONLY)
-
-add_library(monoapi-validate INTERFACE)
-target_sources(monoapi-validate INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/validate-apis.c)

--- a/src/native/public/validate-apis.c.in
+++ b/src/native/public/validate-apis.c.in
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+// This file includes all headers and references all public APIs so if you try to link it
+// without providing an implementation for all functions the linker will report an error
+
+#include <config.h>
+
+#include <mono/utils/mono-publib.h>
+
+#undef MONO_RT_EXTERNAL_ONLY
+#define MONO_RT_EXTERNAL_ONLY /* disable external-only checking here */
+
+@publicapis_headers_include@
+
+void
+mono_validate_public_apis (void);
+
+void
+mono_validate_public_apis (void)
+{
+    // redefine MONO_API_FUNCTION so we can emit a reference to the API
+    #define MONO_API_FUNCTION(ret,name,args) printf ("%p", (void*)&name);
+    @publicapis_headers_details_include@
+}


### PR DESCRIPTION
Adds some validation logic to make sure an implementation exists for each public API.
The way it works is that we generate a source file which references every API, compiling that into mono-sgen will cause a linker error if an implementation is missing.

This uncovered a couple APIs we accidentally dropped.

Fixes https://github.com/dotnet/runtime/issues/67985