### PR TITLE
disable Tls 1.0 and 1.1 tests on new Windows

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -450,7 +450,7 @@ namespace System
             // Windows depend on registry, enabled by default on all supported versions.
             if (IsWindows)
             {
-                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls, defaultProtocolSupport: true);
+                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls, defaultProtocolSupport: true) && !IsWindows10Version20348OrGreater;
             }
 
             return OpenSslGetTlsSupport(SslProtocols.Tls);
@@ -467,7 +467,7 @@ namespace System
                 }
 
                 // It is enabled on other versions unless explicitly disabled.
-                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls11, defaultProtocolSupport: true);
+                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls11, defaultProtocolSupport: true) && !IsWindows10Version20348OrGreater;
             }
             // on macOS and Android TLS 1.1 is supported.
             else if (IsOSXLike || IsAndroid)


### PR DESCRIPTION
contributes to #67682, #67685  and perhaps others. 

This is related to recent Server 2022 failures. When Server 2022 rolled out, all the older protocols were disables by Azure secure pack. We got approval to roll that back so we don't loose test coverage. However, there is catch. 
While the older protocols were enabled by recent Helix change, the systems still has disabled weaker cipher suites and algorithms. So in practice the handshake fails with `System.ComponentModel.Win32Exception : The client and server cannot communicate, because they do not possess a common algorithm.`

This is smallest change to ge t clean CI again. (extra platforms) 
Longer term we should either improve PlatformDetection to see if we have at least viable cipher suite for each TLS protocol version or improve CI machine configuration so each protocol can actually work when enable. (or both) 

btw we should take this back  to relase/* @carlossanlop to stabilize runs on server 2022.
