### PR TITLE
Support d8 instead of dx in ApkBuilder

### DIFF
--- a/src/tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -210,6 +210,7 @@ public class ApkBuilder
 
         // tools:
         string dx = Path.Combine(buildToolsFolder, "dx");
+        string d8 = Path.Combine(buildToolsFolder, "d8");
         string aapt = Path.Combine(buildToolsFolder, "aapt");
         string zipalign = Path.Combine(buildToolsFolder, "zipalign");
         string apksigner = Path.Combine(buildToolsFolder, "apksigner");
@@ -394,7 +395,20 @@ public class ApkBuilder
         string javaCompilerArgs = $"-d obj -classpath src -bootclasspath {androidJar} -source 1.8 -target 1.8 ";
         Utils.RunProcess(logger, javac, javaCompilerArgs + javaActivityPath, workingDir: OutputDir);
         Utils.RunProcess(logger, javac, javaCompilerArgs + monoRunnerPath, workingDir: OutputDir);
-        Utils.RunProcess(logger, dx, "--dex --output=classes.dex obj", workingDir: OutputDir);
+
+        if (File.Exists(d8))
+        {
+            string[] classFiles = Directory.GetFiles(Path.Combine(OutputDir, "obj"), "*.class", SearchOption.AllDirectories);
+
+            if (!classFiles.Any())
+                throw new InvalidOperationException("Didn't find any .class files");
+
+            Utils.RunProcess(logger, d8, $"--no-desugaring {string.Join(" ", classFiles)}", workingDir: OutputDir);
+        }
+        else
+        {
+            Utils.RunProcess(logger, dx, "--dex --output=classes.dex obj", workingDir: OutputDir);
+        }
 
         // 3. Generate APK
 


### PR DESCRIPTION
dx has officially been removed from Android SDK since build-tools version 31.0.0.

Fixes https://github.com/dotnet/runtime/issues/65087