### PR TITLE
Move test that uses the network to outerloop

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Diagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Diagnostics.cs
@@ -293,6 +293,7 @@ partial class Test
         }
 
         [Fact]
+        [OuterLoop("Uses the network for downlevel ref packs")]
         public async Task StringMarshallingForwardingNotSupported_ReportsDiagnostic()
         {
             string source = @"


### PR DESCRIPTION
One more `LibraryImportGenerator` unit test that hits the network for down-level ref packs.