### PR TITLE
Fix cmake RPATH CMP0068 warnings

### DIFF
--- a/src/coreclr/dlls/mscordbi/CMakeLists.txt
+++ b/src/coreclr/dlls/mscordbi/CMakeLists.txt
@@ -2,10 +2,13 @@
 # Set the RPATH of mscordbi so that it can find dependencies without needing to set LD_LIBRARY_PATH
 # For more information: http://www.cmake.org/Wiki/CMake_RPATH_handling.
 if(CORECLR_SET_RPATH)
-  set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
   if(CLR_CMAKE_HOST_OSX)
+    set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
+    set(CMAKE_INSTALL_NAME_DIR "@rpath")
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
     set(CMAKE_INSTALL_RPATH "@loader_path")
   else()
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
     set(CMAKE_INSTALL_RPATH "\$ORIGIN")
   endif(CLR_CMAKE_HOST_OSX)
 endif(CORECLR_SET_RPATH)

--- a/src/coreclr/pal/tests/palsuite/exception_handling/pal_sxs/test1/CMakeLists.txt
+++ b/src/coreclr/pal/tests/palsuite/exception_handling/pal_sxs/test1/CMakeLists.txt
@@ -6,6 +6,8 @@ endif(CLR_CMAKE_HOST_UNIX)
 # For more information: http://www.cmake.org/Wiki/CMake_RPATH_handling.
 if(CORECLR_SET_RPATH)
   if(CLR_CMAKE_HOST_OSX)
+    set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
+    set(CMAKE_INSTALL_NAME_DIR "@rpath")
     set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
     set(CMAKE_INSTALL_RPATH "@loader_path")
   endif(CLR_CMAKE_HOST_OSX)


### PR DESCRIPTION
Fixes issue #41084.

The DBI module's install name, dependences and RPATHs are still the same as before and the warnings are gone.

```
$ otool -D libmscordbi.dylib
libmscordbi.dylib:
@rpath/libmscordbi.dylib

$ otool -L libmscordbi.dylib
libmscordbi.dylib:
        @rpath/libmscordbi.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libmscordaccore.dylib (compatibility version 0.0.0, current version 0.0.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1200.3.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.0.0)

$ otool -l libmscordbi.dylib | grep -i LC_RPATH -A2
          cmd LC_RPATH
      cmdsize 32
         path @loader_path (offset 12)

```