### PR TITLE
ARM32: stop allocating a register for null checks on instance calls

### DIFF
--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -3196,14 +3196,14 @@ void CodeGen::genCall(GenTreeCall* call)
     }
 
     // If fast tail call, then we are done here, we just have to load the call
-    // target into the right registers. We ensure in RA that target is loaded
-    // into a volatile register that won't be restored by epilog sequence.
+    // target into the right registers if we used an internal register for it.
+    // We ensure in RA that target is loaded into a volatile register that
+    // won't be restored by epilog sequence.
     if (call->IsFastTailCall())
     {
 #ifdef FEATURE_READYTORUN
-        if (call->IsR2ROrVirtualStubRelativeIndir())
+        if ((target == nullptr) && call->IsR2ROrVirtualStubRelativeIndir())
         {
-            assert(target == nullptr);
             assert(((call->IsR2RRelativeIndir()) && (call->gtEntryPoint.accessType == IAT_PVALUE)) ||
                    ((call->IsVirtualStubRelativeIndir()) && (call->gtEntryPoint.accessType == IAT_VALUE)));
             assert(call->gtControlExpr == nullptr);

--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -205,11 +205,6 @@ int LinearScan::BuildCall(GenTreeCall* call)
         buildInternalIntRegisterDefForNode(call);
     }
 
-    if (call->NeedsNullCheck())
-    {
-        buildInternalIntRegisterDefForNode(call);
-    }
-
 #endif // TARGET_ARM
 
     RegisterType registerType = call->TypeGet();


### PR DESCRIPTION
For interface tail calls we currently end up allocating two internal
registers where one of them is forced into R12. LSRA currently does not
always handle the low amount of freedom, in particular with some
jitstressregs scenarios.

Since LR is always free going into a call we can just stop allocating a
register for the null check and use LR always to avoid the problem and
also give LSRA a little less work to do.

Fix #66563

cc @dotnet/jit-contrib 