### PR TITLE
Add retries to ModulesAreDisposedWhenProcessIsDisposed

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessModuleTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessModuleTests.cs
@@ -84,7 +84,7 @@ namespace System.Diagnostics.Tests
             RetryHelper.Execute(() =>
             {
                 modulesCollection = process.Modules;
-            }, maxAttempts:5, backoffFunc:null, retryWhen:e => { return (e.GetType() == typeof(Win32Exception)); });
+            }, maxAttempts: 5, backoffFunc: null, retryWhen: e => e.GetType() == typeof(Win32Exception));
 
             int expectedCount = 0;
             int disposedCount = 0;

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessModuleTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessModuleTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
 using System.Linq;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
@@ -76,7 +77,15 @@ namespace System.Diagnostics.Tests
         {
             Process process = CreateDefaultProcess();
 
-            ProcessModuleCollection modulesCollection = process.Modules;
+            // Very rarely, this call will fail with ERROR_PARTIAL_COPY; it only happened
+            // so far on this particular test, the only one that creates a new process.
+            // Assumption is that we need to give a little extra time.
+            ProcessModuleCollection modulesCollection = null;
+            RetryHelper.Execute(() =>
+            {
+                modulesCollection = process.Modules;
+            }, maxAttempts:5, backoffFunc:null, retryWhen:e => { return (e.GetType() == typeof(Win32Exception)); });
+
             int expectedCount = 0;
             int disposedCount = 0;
             foreach (ProcessModule processModule in modulesCollection)


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/68035

It seems that EnumProcessModules is prone to returning ERROR_PARTIAL_COPY when invoked on a process that is in the process of starting (in some terms). We already have 50ms of retries inside the product for this; possibly that should be more retries, and only for ERROR_PARTIAL_COPY. However I'm reluctant to to modify that without more evidence. Meantime, just adding retries to this one test that calls it immediately after starting a process.