### PR TITLE
JIT ARM32: Force tailcall nullchecks with LR

### DIFF
--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -207,9 +207,14 @@ int LinearScan::BuildCall(GenTreeCall* call)
 
     if (call->NeedsNullCheck())
     {
-        buildInternalIntRegisterDefForNode(call);
+        // For fast tailcalls we are very constrained here as the only two
+        // volatile registers left are lr and r12 and r12 might be needed for
+        // the target. We do not handle these constraints on the same
+        // refposition too well so we help ourselves a bit here by forcing the
+        // null check with LR.
+        regMaskTP candidates = call->IsFastTailCall() ? RBM_LR : 0;
+        buildInternalIntRegisterDefForNode(call, candidates);
     }
-
 #endif // TARGET_ARM
 
     RegisterType registerType = call->TypeGet();


### PR DESCRIPTION
For interface tail calls we need to allocate registers for both the
target and a null-check. The register that can be used for the target is
highly constrained: it essentially only go into r12 as the arg registers
may be busy and that is the only volatile register left that will not be
overridden by the epilog. This leaves
just `LR` left for the null check, and LSRA does not seem to handle the
low amount of freedom too well (these are all allocated at the same
location, which might have something to do with it).

To help LSRA just force the null-check to happen with LR for fast
tailcalls, which is going to be killed going into the epilog anyway.

Fix #66563

cc @dotnet/jit-contrib @kunalspathak, this is the alternative fix