### PR TITLE
Fix passing too small args for PUTARG_STK on macOS arm64 ABI

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_66720/Runtime_66720.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_66720/Runtime_66720.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+public class Program
+{
+    public static int Main()
+    {
+        return Test(0);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Test(in short zero)
+    {
+        // Fill arg stack slot with all ones
+        LastArg(0, 0, 0, 0, 0, 0, 0, 0, -1);
+        // Bug was that the last arg passed here would write only 16 bits
+        // instead of 32 bits
+        int last = LastArg(0, 0, 0, 0, 0, 0, 0, 0, zero);
+        return last == 0 ? 100 : -1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int LastArg(int a, int b, int c, int d, int e, int f, int g, int h, int i)
+    {
+        return i;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_66720/Runtime_66720.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_66720/Runtime_66720.cs
@@ -3,7 +3,7 @@
 
 using System.Runtime.CompilerServices;
 
-public class Program
+public class Runtime_66720
 {
     public static int Main()
     {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_66720/Runtime_66720.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_66720/Runtime_66720.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fix #66720

I got far enough that I figured I would submit what I think is a good fix.

cc @dotnet/jit-contrib PTAL @AndyAyersMS 