### PR TITLE
[release/6.0] Fix passing too small args for PUTARG_STK on macOS arm64 ABI

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_66720/Runtime_66720.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_66720/Runtime_66720.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+public class Runtime_66720
+{
+    public static int Main()
+    {
+        return Test(0);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Test(in short zero)
+    {
+        // Fill arg stack slot with all ones
+        LastArg(0, 0, 0, 0, 0, 0, 0, 0, -1);
+        // Bug was that the last arg passed here would write only 16 bits
+        // instead of 32 bits
+        int last = LastArg(0, 0, 0, 0, 0, 0, 0, 0, zero);
+        return last == 0 ? 100 : -1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int LastArg(int a, int b, int c, int d, int e, int f, int g, int h, int i)
+    {
+        return i;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_66720/Runtime_66720.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_66720/Runtime_66720.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of #68108 to release/6.0

# Customer Impact
The JIT may pass garbled values for certain arguments on macOS arm64 devices under the following conditions:
1. The argument is passed on stack, i.e. all 8 argument registers are already taken up by previous arguments
2. The type of the receiving parameter is a 4-byte sized integer, i.e. `int` or `uint`
3. The type of the argument passed to the parameter is `byte`, `sbyte`, `short` or `ushort`
4. The argument is a memory read, for example a field/array access or pointer/byref dereference

Under these conditions the JIT may only pass 1 or 2 bytes on the stack instead of the full 4 bytes. Reported by customer in #66720.

# Testing
Regression test included.

# Risk
Low; the code change only affects behavior for macOS arm64 and there we need the above 4 conditions before it kicks in.
