### PR TITLE
JIT: Remove unneeded unconditional jumps

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -623,7 +623,7 @@ protected:
     }
 
 #endif // !FEATURE_EH_FUNCLETS
-
+    void genUpdateLiveRangesForTruncatedIGs();
     void genGeneratePrologsAndEpilogs();
 
 #if defined(DEBUG) && defined(TARGET_ARM64)

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2001,11 +2001,13 @@ void CodeGen::genUpdateLiveRangesForTruncatedIGs()
                 unsigned int liveVarCount = varLiveKeeper->getVarCount();
                 if (liveVarCount > 0)
                 {
+#ifdef DEBUG
                     if (compiler->verbose)
                     {
                         JITDUMP("IG%02u is marked with IGF_UPD_ICOUNT and has %d live variables\n", ig->igNum,
                                 liveVarCount);
                     }
+#endif
                     for (unsigned int varNum = 0; varNum < liveVarCount; varNum++)
                     {
                         if (compiler->compMap2ILvarNum(varNum) == (unsigned int)ICorDebugInfo::UNKNOWN_ILNUM)
@@ -2030,11 +2032,13 @@ void CodeGen::genUpdateLiveRangesForTruncatedIGs()
                                 if (liveRange.m_StartEmitLocation.GetIG()->igNum == ig->igNum &&
                                     liveRange.m_StartEmitLocation.GetInsNum() > ig->igInsCnt)
                                 {
+#ifdef DEBUG
                                     if (compiler->verbose)
                                     {
                                         JITDUMP("IG%02u varNum %d StartEmitLocation InsCnt changed from %d to %d\n", ig,
                                                 liveVarCount, liveRange.m_StartEmitLocation.GetInsNum(), ig->igInsCnt);
                                     }
+#endif
                                     liveRange.m_StartEmitLocation.SetInsNum(ig->igInsCnt);
                                     assert(liveRange.m_StartEmitLocation.GetInsNum() == ig->igInsCnt);
                                     updatedGroup = true;
@@ -2044,11 +2048,13 @@ void CodeGen::genUpdateLiveRangesForTruncatedIGs()
                                     liveRange.m_EndEmitLocation.GetInsNum() > ig->igInsCnt)
                                 {
                                     liveRange.m_EndEmitLocation.SetInsNum(ig->igInsCnt);
+#ifdef DEBUG
                                     if (compiler->verbose)
                                     {
                                         JITDUMP("IG%02u varNum %d EndEmitLocation InsCnt changed from %d to %d\n", ig,
                                                 liveVarCount, liveRange.m_StartEmitLocation.GetInsNum(), ig->igInsCnt);
                                     }
+#endif
                                     assert(liveRange.m_EndEmitLocation.GetInsNum() == ig->igInsCnt);
                                     updatedGroup = true;
                                 }
@@ -2058,10 +2064,12 @@ void CodeGen::genUpdateLiveRangesForTruncatedIGs()
                 }
                 else
                 {
+#ifdef DEBUG
                     if (compiler->verbose)
                     {
                         JITDUMP("IG%02u is marked with IGF_UPD_ICOUNT but has no live variables\n", ig);
                     }
+#endif
                 }
 
                 ig->igFlags ^= IGF_UPD_ICOUNT;
@@ -2070,12 +2078,13 @@ void CodeGen::genUpdateLiveRangesForTruncatedIGs()
             ig = ig->igNext;
         }
     }
-
+#ifdef DEBUG
     if (updatedGroup && verbose)
     {
         printf("\nlvaTable after genUpdateLiveRangesForTruncatedIGs\n");
         compiler->lvaTableDump();
     }
+#endif
 }
 
 //----------------------------------------------------------------------

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1989,7 +1989,7 @@ void CodeGen::genUpdateLiveRangesForTruncatedIGs()
     }
 #endif
     bool updatedGroup = false;
-   
+
     if (compiler->lvaCount > 0)
     {
         insGroup* ig = GetEmitter()->emitIGlist;
@@ -2003,7 +2003,8 @@ void CodeGen::genUpdateLiveRangesForTruncatedIGs()
                 {
                     if (compiler->verbose)
                     {
-                        JITDUMP("IG%02u is marked with IGF_UPD_ICOUNT and has %d live variables\n", ig->igNum, liveVarCount);
+                        JITDUMP("IG%02u is marked with IGF_UPD_ICOUNT and has %d live variables\n", ig->igNum,
+                                liveVarCount);
                     }
                     for (unsigned int varNum = 0; varNum < liveVarCount; varNum++)
                     {
@@ -2023,7 +2024,7 @@ void CodeGen::genUpdateLiveRangesForTruncatedIGs()
                             {
                                 liveRanges = varLiveKeeper->getLiveRangesForVarForBody(varNum);
                             }
-                            
+
                             for (VariableLiveKeeper::VariableLiveRange& liveRange : *liveRanges)
                             {
                                 if (liveRange.m_StartEmitLocation.GetIG()->igNum == ig->igNum &&
@@ -2065,7 +2066,7 @@ void CodeGen::genUpdateLiveRangesForTruncatedIGs()
 
                 ig->igFlags ^= IGF_UPD_ICOUNT;
             }
-    
+
             ig = ig->igNext;
         }
     }

--- a/src/coreclr/jit/codegeninterface.h
+++ b/src/coreclr/jit/codegeninterface.h
@@ -744,6 +744,7 @@ public:
         LiveRangeList* getLiveRangesForVarForBody(unsigned int varNum) const;
         LiveRangeList* getLiveRangesForVarForProlog(unsigned int varNum) const;
         size_t getLiveRangesCount() const;
+        unsigned int getVarCount() const;
 
         // For parameters locations on prolog
         void psiStartVariableLiveRange(CodeGenInterface::siVarLoc varLocation, unsigned int varNum);

--- a/src/coreclr/jit/codegeninterface.h
+++ b/src/coreclr/jit/codegeninterface.h
@@ -743,7 +743,7 @@ public:
 
         LiveRangeList* getLiveRangesForVarForBody(unsigned int varNum) const;
         LiveRangeList* getLiveRangesForVarForProlog(unsigned int varNum) const;
-        size_t getLiveRangesCount() const;
+        size_t       getLiveRangesCount() const;
         unsigned int getVarCount() const;
 
         // For parameters locations on prolog

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -4150,8 +4150,8 @@ void emitter::emitJumpDistBind()
 
     int jmp_iteration = 1;
 #ifdef TARGET_XARCH
-    int jmp_removal   = 1;
-    bool jmpRemoved    = false;
+    int  jmp_removal = 1;
+    bool jmpRemoved  = false;
 #endif
 
 /*****************************************************************************/
@@ -4178,7 +4178,6 @@ AGAIN:
     adjLJ         = 0;
     adjIG         = 0;
     minShortExtra = (UNATIVE_OFFSET)-1;
-
 
 #ifdef TARGET_XARCH
     // try to remove unconditional jumps at the end of a group to the next group
@@ -4214,21 +4213,21 @@ AGAIN:
                         assert(instructionDescriptor != nullptr);
                         // instructionDescriptor is now the last instruction in the group
 
-                        if (instructionDescriptor->idIns() == jmp->idIns() &&
-                            jmp == instructionDescriptor)
+                        if (instructionDescriptor->idIns() == jmp->idIns() && jmp == instructionDescriptor)
                         {
                             // the last instruction in the group is the jmp we're looking for
                             // and it jumps to the next instruction group so we don't really need it
 
                             if (EMITVERBOSE)
                             {
-                                printf("Removing unconditional jump [%08X/%03u] from the last instruction in IG%02u to the next IG IG%02u label %s\n",
+                                printf("Removing unconditional jump [%08X/%03u] from the last instruction in IG%02u to "
+                                       "the next IG IG%02u label %s\n",
                                        dspPtr(jmp), jmp->idDebugOnlyInfo()->idNum, group->igNum, targetGroup->igNum,
                                        emitLabelString(targetGroup));
                             }
-                            
+
                             UNATIVE_OFFSET sizeRemoved = instructionDescriptor->idCodeSize();
-                            
+
                             // set state needed at the end of the loop in ADJUST_GROUP
                             adjIG      = sizeRemoved;
                             lstIG      = group;
@@ -4258,7 +4257,7 @@ AGAIN:
 
                             // flag the group as resized and recounted
                             group->igFlags |= (IGF_UPD_ISZ | IGF_UPD_ICOUNT);
-                            
+
                             // cleanup
                             instructionDescriptor = nullptr;
                             jmp                   = nullptr;
@@ -4904,7 +4903,7 @@ AGAIN:
     } // end for each jump
 
 #ifdef TARGET_XARCH
-    ADJUST_GROUP:
+ADJUST_GROUP:
 #endif
 
     /* Did we shorten any jumps? */
@@ -4954,7 +4953,7 @@ AGAIN:
 #ifdef TARGET_XARCH
         if (jmpRemoved)
         {
-            
+
             jmp_removal++;
 #ifdef DEBUG
             if (EMITVERBOSE)
@@ -4984,7 +4983,6 @@ AGAIN:
 
             goto AGAIN;
         }
-
     }
 #ifdef DEBUG
     if (EMIT_INSTLIST_VERBOSE)

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -4215,9 +4215,9 @@ AGAIN:
 
                         if (instructionDescriptor->idIns() == jmp->idIns() && jmp == instructionDescriptor)
                         {
-                            // the last instruction in the group is the jmp we're looking for
-                            // and it jumps to the next instruction group so we don't really need it
-
+// the last instruction in the group is the jmp we're looking for
+// and it jumps to the next instruction group so we don't really need it
+#ifdef DEBUG
                             if (EMITVERBOSE)
                             {
                                 printf("Removing unconditional jump [%08X/%03u] from the last instruction in IG%02u to "
@@ -4225,7 +4225,7 @@ AGAIN:
                                        dspPtr(jmp), jmp->idDebugOnlyInfo()->idNum, group->igNum, targetGroup->igNum,
                                        emitLabelString(targetGroup));
                             }
-
+#endif
                             UNATIVE_OFFSET sizeRemoved = instructionDescriptor->idCodeSize();
 
                             // set state needed at the end of the loop in ADJUST_GROUP

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -160,6 +160,7 @@ public:
     }
 
     int GetInsNum() const;
+    void SetInsNum(int insNum);
 
     bool operator!=(const emitLocation& other) const
     {
@@ -277,6 +278,7 @@ struct insGroup
                                   // and the emitter should continue to track GC info as if there was no new block.
 #define IGF_HAS_ALIGN 0x0400      // this group contains an alignment instruction(s) at the end to align either the next
                                   // IG, or, if this IG contains with an unconditional branch, some subsequent IG.
+#define IGF_UPD_ICOUNT 0x0800     // instruction was removed from the marked group and the live range end will not match this ig instruction count
 
 // Mask of IGF_* flags that should be propagated to new blocks when they are created.
 // This allows prologs and epilogs to be any number of IGs, but still be

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -159,7 +159,7 @@ public:
         return ig;
     }
 
-    int GetInsNum() const;
+    int  GetInsNum() const;
     void SetInsNum(int insNum);
 
     bool operator!=(const emitLocation& other) const
@@ -278,7 +278,9 @@ struct insGroup
                                   // and the emitter should continue to track GC info as if there was no new block.
 #define IGF_HAS_ALIGN 0x0400      // this group contains an alignment instruction(s) at the end to align either the next
                                   // IG, or, if this IG contains with an unconditional branch, some subsequent IG.
-#define IGF_UPD_ICOUNT 0x0800     // instruction was removed from the marked group and the live range end will not match this ig instruction count
+#define IGF_UPD_ICOUNT                                                                                                 \
+    0x0800 // instruction was removed from the marked group and the live range end will not match this ig instruction
+           // count
 
 // Mask of IGF_* flags that should be propagated to new blocks when they are created.
 // This allows prologs and epilogs to be any number of IGs, but still be


### PR DESCRIPTION
fixes https://github.com/dotnet/runtime/issues/4326

When compilng some simple methods a jmp instruction is generated that ends up jumping to the next instruction which is not needed. The example provided is:

```csharp
public static int Main(string[] args)
{
    // first test case
    return Math.Max(args.Length, 42);
}
```

This produces the assembly:
```diff
G_M22359_IG01:              ;; offset=0000H
						;; size=0 bbWeight=1    PerfScore 0.00
G_M22359_IG02:              ;; offset=0000H
       8B4108               mov      eax, dword ptr [rcx+8]
       83F82A               cmp      eax, 42
       7D07                 jge      SHORT G_M22359_IG04
						;; size=8 bbWeight=1    PerfScore 3.25
G_M22359_IG03:              ;; offset=0008H
       B82A000000           mov      eax, 42
+      EB00                 jmp      SHORT G_M22359_IG04
						;; size=7 bbWeight=0.18 PerfScore 0.41
G_M22359_IG04:              ;; offset=000FH
       C3                   ret      
```

where you can see that the jmp to `SHORT G_M22359_IG04` is not needed because that is the next instruction, we will save 2 bytes and possibly some cpu jump tracking resources by not including the jump.

The jump is added in the emitter phase and cannot be seen before that so the changes i have made are all very late in the compilation process. The jump exists because a basic block between the blocks that create instruction groups 3 and 4 generates no instructions. Emission of instructions is linear so at the time when IG03 is generated there is a jump present from BB03 to BB05 and this causes an unconditional jump to be generated at the end of IG03. When BB04 is processed it generates no instructions because there is no need anything and the process moves on to BB05 (which will generate IG04) but we're left with a weird looking jump.

The unneeded jumps can be identified once instruction groups have been generated but this must be done before label sizes and alignment are calculated which gives a small window of opportunity. I chose to integrate this process into the `emitter::emitJumpDistBind()` function because it was correctly placed to have all the information needed and already contained logic for looping around the jumps and adjusting the size of instructions (but not groups). I have added a loop around each jump in the emitter jump list which attempts to identify if the jump is 
1) unconditional
2) the last instruction in the instruction group
3) has a target which is the next instruction group

if these conditions are met the jump is removed for the emitter jump list and the instruction group then the instruction groups is flagged as needing a size recalculation and as having an update instruction count. Once this is done the remaining jumps are sized and updated as normal.

The second change needs to be done at the codegen level and it involves updating any live ranges which include the instruction which has been removed. I have added a new function `genUpdateLiveRangesForTruncatedIGs` which is run after `emitJumpDistBind` where we know that all instructions that are going to be removed have been and before `emitLoopAlignAdjustments` which will check alignments and may need to emit additional nops into the instruction groups. The live range checks need a new count accessor function because they haven't been finalized yet at the point when the count is needed.

Once all that is done the unconditional jumps are removed. It looks like they get removed from some very basic and commonly used functions which end up bieng inlined almost everywhere. The spmi replays are clean and the asm diffs are surprising.

```
1869 total files with Code Size differences (1868 improved, 1 regressed), 1 unchanged.
237 total files with Code Size differences (235 improved, 2 regressed), 4 unchanged.
48082 total files with Code Size differences (48082 improved, 0 regressed), 0 unchanged.
1869 total files with Code Size differences (1868 improved, 1 regressed), 1 unchanged.
1855 total files with Code Size differences (1854 improved, 1 regressed), 2 unchanged.
```

all regressions are caused by alignment changes.

## benchmarks.run.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 10580904 (overridden on cmd)
Total bytes of diff: 10580088 (overridden on cmd)
Total bytes of delta: -816 (-0.01 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          12 : 13391.dasm (0.15% of base)
          12 : 8191.dasm (0.10% of base)

Top file improvements (bytes):
         -39 : 36669.dasm (-0.35% of base)
         -27 : 30229.dasm (-0.38% of base)
         -22 : 27327.dasm (-0.56% of base)
         -20 : 9681.dasm (-0.31% of base)
         -20 : 1007.dasm (-1.72% of base)
         -12 : 27372.dasm (-0.59% of base)
         -12 : 14055.dasm (-0.21% of base)
         -11 : 7383.dasm (-1.04% of base)
         -10 : 27328.dasm (-0.89% of base)
          -8 : 14652.dasm (-0.07% of base)
          -8 : 1011.dasm (-0.47% of base)
          -8 : 27522.dasm (-1.53% of base)
          -8 : 1002.dasm (-0.85% of base)
          -8 : 14646.dasm (-0.12% of base)
          -8 : 1008.dasm (-0.84% of base)
          -8 : 28537.dasm (-1.80% of base)
          -8 : 30085.dasm (-0.57% of base)
          -8 : 30130.dasm (-0.62% of base)
          -8 : 25526.dasm (-0.14% of base)
          -8 : 27805.dasm (-0.89% of base)

237 total files with Code Size differences (235 improved, 2 regressed), 4 unchanged.

Top method regressions (bytes):
          12 ( 0.15% of base) : 13391.dasm - Jil.Deserialize.Methods:_ReadISO8601DateWithOffset(System.IO.TextReader,System.Char[]):System.DateTimeOffset
          12 ( 0.10% of base) : 8191.dasm - Jil.Deserialize.Methods:_ReadISO8601DateWithOffsetThunkReader(byref,System.Char[]):System.DateTimeOffset

Top method improvements (bytes):
         -39 (-0.35% of base) : 36669.dasm - Jil.Deserialize.Methods:_ReadISO8601DateThunkReader(byref,System.Char[]):System.DateTime
         -27 (-0.38% of base) : 30229.dasm - Jil.Deserialize.Methods:_ReadISO8601Date(System.IO.TextReader,System.Char[]):System.DateTime
         -22 (-0.56% of base) : 27327.dasm - Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions:ValidateOptions(Microsoft.CodeAnalysis.PooledObjects.ArrayBuilder`1[[Microsoft.CodeAnalysis.Diagnostic, Microsoft.CodeAnalysis, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):this
         -20 (-0.31% of base) : 9681.dasm - MessagePack.Formatters.MicroBenchmarks_Serializers_LocationFormatter1:Serialize(byref,int,MicroBenchmarks.Serializers.Location,MessagePack.IFormatterResolver):int:this
         -20 (-1.72% of base) : 1007.dasm - System.Text.RegularExpressions.RegexNode:ComputeMinLength():int:this
         -12 (-0.59% of base) : 27372.dasm - Microsoft.CodeAnalysis.CSharp.MergedNamespaceDeclaration:MakeChildren():System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.CSharp.MergedNamespaceOrTypeDeclaration, Microsoft.CodeAnalysis.CSharp, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
         -12 (-0.21% of base) : 14055.dasm - Utf8Json.Formatters.DictionaryFormatterBase`5[Int32,__Canon,__Canon,Enumerator,__Canon][System.Int32,System.__Canon,System.__Canon,System.Collections.Generic.Dictionary`2+Enumerator[System.Int32,System.__Canon],System.__Canon]:Serialize(byref,System.__Canon,Utf8Json.IJsonFormatterResolver):this
         -11 (-1.04% of base) : 7383.dasm - System.Text.RegularExpressions.RegexNode:ComputeMaxLength():System.Nullable`1[Int32]:this
         -10 (-0.89% of base) : 27328.dasm - Microsoft.CodeAnalysis.CompilationOptions:ValidateOptions(Microsoft.CodeAnalysis.PooledObjects.ArrayBuilder`1[[Microsoft.CodeAnalysis.Diagnostic, Microsoft.CodeAnalysis, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],Microsoft.CodeAnalysis.CommonMessageProvider):this
          -8 (-0.14% of base) : 25526.dasm - MessagePack.Formatters.DateTimeArrayFormatter:Serialize(byref,int,System.DateTime[],MessagePack.IFormatterResolver):int:this
          -8 (-1.80% of base) : 28537.dasm - Microsoft.CodeAnalysis.CSharp.Emit.PEAssemblyBuilderBase:GetEmbeddedTypes(Microsoft.CodeAnalysis.DiagnosticBag):System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.CSharp.Symbols.NamedTypeSymbol, Microsoft.CodeAnalysis.CSharp, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
          -8 (-0.57% of base) : 30085.dasm - Microsoft.CodeAnalysis.CSharp.LocalScopeBinder:LookupSymbolsInSingleBinder(Microsoft.CodeAnalysis.CSharp.LookupResult,System.String,int,Roslyn.Utilities.ConsList`1[[Microsoft.CodeAnalysis.CSharp.Symbol, Microsoft.CodeAnalysis.CSharp, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],int,Microsoft.CodeAnalysis.CSharp.Binder,bool,byref):this
          -8 (-0.26% of base) : 27530.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PENamedTypeSymbol:LoadMembers():this
          -8 (-0.89% of base) : 27805.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol:AddSynthesizedConstructorsIfNecessary(Microsoft.CodeAnalysis.PooledObjects.ArrayBuilder`1[[Microsoft.CodeAnalysis.CSharp.Symbol, Microsoft.CodeAnalysis.CSharp, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],Microsoft.CodeAnalysis.PooledObjects.ArrayBuilder`1[ImmutableArray`1],Microsoft.CodeAnalysis.DiagnosticBag):this
          -8 (-1.53% of base) : 27522.dasm - Microsoft.CodeAnalysis.RuntimeMembers.MemberDescriptor:ParseType(Builder[Byte],System.IO.Stream,bool)
          -8 (-0.62% of base) : 30130.dasm - NodeMapBuilder:Visit(Microsoft.CodeAnalysis.CSharp.BoundNode):Microsoft.CodeAnalysis.CSharp.BoundNode:this
          -8 (-0.85% of base) : 1002.dasm - System.Text.RegularExpressions.RegexNode:EliminateEndingBacktracking():this
          -8 (-0.84% of base) : 1008.dasm - System.Text.RegularExpressions.RegexPrefixAnalyzer:FindLeadingOrTrailingAnchor(System.Text.RegularExpressions.RegexNode,bool):int
          -8 (-0.47% of base) : 1011.dasm - System.Text.RegularExpressions.RegexPrefixAnalyzer:FindLiteralFollowingLeadingLoop(System.Text.RegularExpressions.RegexNode):System.Nullable`1[[System.ValueTuple`2[[System.Text.RegularExpressions.RegexNode, System.Text.RegularExpressions, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a],[System.ValueTuple`3[[System.Char, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Char[], System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
          -8 (-0.07% of base) : 14652.dasm - Utf8Json.Formatters.MicroBenchmarks_Serializers_CampaignSummaryViewModelFormatter3:Serialize(byref,MicroBenchmarks.Serializers.CampaignSummaryViewModel,Utf8Json.IJsonFormatterResolver):this

Top method regressions (percentages):
          12 ( 0.15% of base) : 13391.dasm - Jil.Deserialize.Methods:_ReadISO8601DateWithOffset(System.IO.TextReader,System.Char[]):System.DateTimeOffset
          12 ( 0.10% of base) : 8191.dasm - Jil.Deserialize.Methods:_ReadISO8601DateWithOffsetThunkReader(byref,System.Char[]):System.DateTimeOffset

Top method improvements (percentages):
          -2 (-3.92% of base) : 31994.dasm - Benchstone.MDBenchI.MDMidpoint:Inner(byref,byref,byref):int
          -2 (-2.78% of base) : 9550.dasm - System.Text.Json.Serialization.ReadBufferState:.ctor(int):this
          -4 (-2.22% of base) : 14268.dasm - V8.Richards.IdleTask:run(V8.Richards.Packet):V8.Richards.TaskControlBlock:this
          -5 (-2.09% of base) : 991.dasm - System.Text.RegularExpressions.RegexNode:ReduceAlternation():System.Text.RegularExpressions.RegexNode:this
          -8 (-1.80% of base) : 28537.dasm - Microsoft.CodeAnalysis.CSharp.Emit.PEAssemblyBuilderBase:GetEmbeddedTypes(Microsoft.CodeAnalysis.DiagnosticBag):System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.CSharp.Symbols.NamedTypeSymbol, Microsoft.CodeAnalysis.CSharp, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
         -20 (-1.72% of base) : 1007.dasm - System.Text.RegularExpressions.RegexNode:ComputeMinLength():int:this
          -2 (-1.64% of base) : 1212.dasm - System.Text.RegularExpressions.RegexNode:ReduceGroup():System.Text.RegularExpressions.RegexNode:this
          -2 (-1.59% of base) : 1442.dasm - System.Reflection.RuntimePropertyInfo:GetValue(System.Object,System.Object[]):System.Object:this
          -6 (-1.57% of base) : 28543.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.AnonymousTypeManager:GetCreatedAnonymousTypeTemplates(Microsoft.CodeAnalysis.PooledObjects.ArrayBuilder`1[[Microsoft.CodeAnalysis.CSharp.Symbols.AnonymousTypeManager+AnonymousTypeTemplateSymbol, Microsoft.CodeAnalysis.CSharp, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):this
          -8 (-1.53% of base) : 27522.dasm - Microsoft.CodeAnalysis.RuntimeMembers.MemberDescriptor:ParseType(Builder[Byte],System.IO.Stream,bool)
          -4 (-1.45% of base) : 27911.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.MemberSignatureComparer:GetHashCode(Microsoft.CodeAnalysis.CSharp.Symbol):int:this
          -2 (-1.45% of base) : 997.dasm - System.Text.RegularExpressions.RegexNode:FindBranchOneOrMultiStart():System.Text.RegularExpressions.RegexNode:this
          -6 (-1.39% of base) : 29221.dasm - System.Reflection.PortableExecutable.ManagedPEBuilder:CreateSections():System.Collections.Immutable.ImmutableArray`1[Section]:this
          -4 (-1.29% of base) : 479.dasm - System.Reflection.RuntimePropertyInfo:GetIndexParametersNoCopy():System.Reflection.ParameterInfo[]:this
          -2 (-1.26% of base) : 27524.dasm - Microsoft.CodeAnalysis.RuntimeMembers.MemberDescriptor:ParseGenericTypeInstance(Builder[Byte],System.IO.Stream)
          -2 (-1.21% of base) : 27521.dasm - Microsoft.CodeAnalysis.RuntimeMembers.MemberDescriptor:ParseMethodOrPropertySignature(Builder[Byte],System.IO.Stream)
          -2 (-1.21% of base) : 31.dasm - System.Environment:.cctor()
          -2 (-1.20% of base) : 1208.dasm - System.Text.RegularExpressions.RegexCompiler:<EmitTryMatchAtCurrentPosition>g__GetSubsequent|120_38(int,System.Text.RegularExpressions.RegexNode,System.Text.RegularExpressions.RegexNode):System.Text.RegularExpressions.RegexNode
          -4 (-1.18% of base) : 989.dasm - System.Text.RegularExpressions.RegexNode:ReduceConcatenation():System.Text.RegularExpressions.RegexNode:this
          -2 (-1.14% of base) : 27205.dasm - Builder[Int32][System.Int32]:set_Count(int):this

237 total methods with Code Size differences (235 improved, 2 regressed), 4 unchanged.

```

</details>

--------------------------------------------------------------------------------

## coreclr_tests.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 130694636 (overridden on cmd)
Total bytes of diff: 130582864 (overridden on cmd)
Total bytes of delta: -111772 (-0.09 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
        -118 : 12778.dasm (-0.62% of base)
        -106 : 238801.dasm (-2.20% of base)
        -100 : 12776.dasm (-0.86% of base)
         -92 : 5059.dasm (-0.16% of base)
         -92 : 11192.dasm (-0.18% of base)
         -78 : 32097.dasm (-0.58% of base)
         -66 : 4618.dasm (-0.33% of base)
         -56 : 11203.dasm (-0.18% of base)
         -56 : 11170.dasm (-0.16% of base)
         -42 : 187038.dasm (-2.14% of base)
         -42 : 187039.dasm (-1.85% of base)
         -42 : 187063.dasm (-2.34% of base)
         -42 : 187064.dasm (-2.25% of base)
         -42 : 187065.dasm (-1.90% of base)
         -42 : 189643.dasm (-1.72% of base)
         -42 : 189644.dasm (-1.76% of base)
         -42 : 189655.dasm (-1.76% of base)
         -42 : 189656.dasm (-1.72% of base)
         -42 : 193186.dasm (-3.04% of base)
         -42 : 193187.dasm (-2.78% of base)

48082 total files with Code Size differences (48082 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
        -118 (-0.62% of base) : 12778.dasm - Class1:foo(int)
        -106 (-2.20% of base) : 238801.dasm - myclass:Main():int
        -100 (-0.86% of base) : 12776.dasm - Class1:foo(int)
         -92 (-0.16% of base) : 5059.dasm - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
         -92 (-0.18% of base) : 11192.dasm - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
         -78 (-0.58% of base) : 32097.dasm - ILGEN_0x372a9ae6:Method_0xdc6ff1a4(byte,byte,int,long,ushort,double,long,long):int
         -66 (-0.33% of base) : 4618.dasm - testout1:Sub_Funclet_0():int
         -56 (-0.18% of base) : 11203.dasm - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
         -56 (-0.16% of base) : 11170.dasm - IntelHardwareIntrinsicTest.Program:Main(System.String[]):int
         -42 (-1.89% of base) : 40609.dasm - ConvTest:Main():int
         -42 (-2.50% of base) : 187227.dasm - testout1:Sub_Funclet_116():double
         -42 (-2.62% of base) : 190466.dasm - testout1:Sub_Funclet_116():float
         -42 (-3.23% of base) : 193350.dasm - testout1:Sub_Funclet_116():int
         -42 (-3.37% of base) : 183586.dasm - testout1:Sub_Funclet_116():int
         -42 (-2.14% of base) : 187228.dasm - testout1:Sub_Funclet_117():double
         -42 (-2.22% of base) : 190467.dasm - testout1:Sub_Funclet_117():float
         -42 (-2.71% of base) : 183587.dasm - testout1:Sub_Funclet_117():int
         -42 (-2.67% of base) : 193351.dasm - testout1:Sub_Funclet_117():int
         -42 (-1.69% of base) : 185990.dasm - testout1:Sub_Funclet_119():double
         -42 (-1.72% of base) : 189643.dasm - testout1:Sub_Funclet_119():float

Top method improvements (percentages):
          -2 (-66.67% of base) : 44199.dasm - ExceptionRegionTests:Leave.ToFirstInstrOfNestedDisjointTry_Valid():this
          -2 (-10.53% of base) : 260721.dasm - ABIStress.Win64Abi:ApproximateArgStackAreaSize(System.Collections.Generic.List`1[[ABIStress.TypeEx, pinvokes_do, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]]):int:this
          -2 (-6.90% of base) : 55078.dasm - Tester:bar(T)
          -2 (-6.06% of base) : 61871.dasm - ILGEN_0x6a2f58fb:Method_0x89b7ef42(int,float):int
          -4 (-4.94% of base) : 60488.dasm - switchdefaultonly1:Main(System.String[]):int
          -4 (-4.94% of base) : 60490.dasm - switchdefaultonly1:Main(System.String[]):int
          -2 (-4.76% of base) : 237276.dasm - testout1:Func_0_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1():float
          -2 (-4.76% of base) : 237564.dasm - testout1:Func_0_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1():float
          -2 (-4.65% of base) : 62209.dasm - bbFlags:f():int
          -2 (-4.65% of base) : 62143.dasm - test:f1()
          -6 (-4.48% of base) : 60487.dasm - switchdefaultonly1:Main(System.String[]):int
          -2 (-4.44% of base) : 42316.dasm - ClassLibrary.test:dist(float,float,Line):float
          -2 (-4.35% of base) : 57570.dasm - JitInliningTest.IfElse:Main():int
          -4 (-4.30% of base) : 27881.dasm - catch1:f2()
         -34 (-4.30% of base) : 182385.dasm - testout1:Sub_Funclet_0():int
          -2 (-4.26% of base) : 27878.dasm - CTest:test():int:this
          -2 (-4.26% of base) : 59252.dasm - Test_DevDiv_359736:GetVal():ubyte
          -2 (-4.26% of base) : 4617.dasm - testout1:func_sb_false():bool
          -2 (-4.17% of base) : 62024.dasm - ILGEN_0x4601be46:Method_0x9c86375f(long,ubyte):int
          -2 (-4.08% of base) : 27144.dasm - Test_Rotate:flag():bool

48082 total methods with Code Size differences (48082 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.crossgen2.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 34275595 (overridden on cmd)
Total bytes of diff: 34274377 (overridden on cmd)
Total bytes of delta: -1218 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -20 : 211250.dasm (-0.88% of base)
         -12 : 182021.dasm (-1.79% of base)
         -10 : 181779.dasm (-0.05% of base)
         -10 : 181796.dasm (-0.10% of base)
          -8 : 111913.dasm (-0.05% of base)
          -8 : 211728.dasm (-0.72% of base)
          -8 : 150086.dasm (-0.49% of base)
          -6 : 114473.dasm (-0.17% of base)
          -6 : 98598.dasm (-1.15% of base)
          -6 : 171492.dasm (-2.68% of base)
          -6 : 221653.dasm (-1.75% of base)
          -6 : 17836.dasm (-0.57% of base)
          -6 : 189898.dasm (-0.57% of base)
          -6 : 114270.dasm (-0.19% of base)
          -6 : 54407.dasm (-0.36% of base)
          -6 : 190763.dasm (-0.12% of base)
          -6 : 217004.dasm (-0.63% of base)
          -6 : 68303.dasm (-0.43% of base)
          -6 : 114427.dasm (-0.61% of base)
          -6 : 182002.dasm (-1.37% of base)

496 total files with Code Size differences (496 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -20 (-0.88% of base) : 211250.dasm - OleDbParameterConverter:ConvertToInstanceDescriptor(System.Data.OleDb.OleDbParameter):System.ComponentModel.Design.Serialization.InstanceDescriptor
         -12 (-1.79% of base) : 182021.dasm - System.Management.RelatedObjectQuery:BuildQuery():this
         -10 (-0.05% of base) : 181779.dasm - System.Management.ManagementClassGenerator:GenerateMethods():this
         -10 (-0.10% of base) : 181796.dasm - System.Management.ManagementClassGenerator:GenerateProperties():this
          -8 (-0.49% of base) : 150086.dasm - Microsoft.Diagnostics.Tracing.ActivityComputer:ResolveWellKnownSymbols():this
          -8 (-0.05% of base) : 111913.dasm - System.Data.BinaryNode:EvalBinaryOp(int,System.Data.ExpressionNode,System.Data.ExpressionNode,System.Data.DataRow,int,System.Int32[]):System.Object:this
          -8 (-0.72% of base) : 211728.dasm - System.Data.OleDb.OleDbDataReader:AppendSchemaInfo():this
          -6 (-1.15% of base) : 98598.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Blender:ExtendToAffectedRange(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,Microsoft.CodeAnalysis.Text.TextChangeRange):Microsoft.CodeAnalysis.Text.TextChangeRange
          -6 (-0.12% of base) : 190763.dasm - Microsoft.VisualBasic.CompilerServices.VBBinder:GetMostSpecific(System.Reflection.MethodBase,System.Reflection.MethodBase,System.Int32[],System.Object[],bool,int,int,System.Object[]):int:this
          -6 (-0.75% of base) : 69824.dasm - OperatorIntrinsics:GetArraySlice4D(System.__Canon[,,,],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32],Microsoft.FSharp.Core.FSharpOption`1[System.Int32]):System.__Canon[,,,]
          -6 (-1.07% of base) : 119937.dasm - Reader:Read(System.Char[],int,int):int:this
          -6 (-0.63% of base) : 217004.dasm - System.ComponentModel.Composition.Hosting.ImportEngine:TrySatisfyImportsStateMachine(System.ComponentModel.Composition.Hosting.ImportEngine+PartManager,System.ComponentModel.Composition.Primitives.ComposablePart):System.ComponentModel.Composition.CompositionResult:this
          -6 (-0.17% of base) : 114473.dasm - System.Data.XmlDataLoader:LoadTable(System.Data.DataTable,bool):this
          -6 (-0.61% of base) : 114427.dasm - System.Data.XmlTreeGen:AddColumnProperties(System.Data.DataColumn,System.Xml.XmlElement):this
          -6 (-0.19% of base) : 114270.dasm - System.Data.XSDSchema:InstantiateTable(System.Xml.Schema.XmlSchemaElement,System.Xml.Schema.XmlSchemaComplexType,bool):System.Data.DataTable:this
          -6 (-0.57% of base) : 17836.dasm - System.DefaultBinder:FindMostSpecific(System.Reflection.ParameterInfo[],System.Int32[],System.Type,System.Reflection.ParameterInfo[],System.Int32[],System.Type,System.Type[],System.Object[]):int
          -6 (-0.57% of base) : 189898.dasm - System.DefaultBinder:FindMostSpecific(System.Reflection.ParameterInfo[],System.Int32[],System.Type,System.Reflection.ParameterInfo[],System.Int32[],System.Type,System.Type[],System.Object[]):int
          -6 (-1.75% of base) : 221653.dasm - System.IO.Pipelines.StreamPipeWriter:AllocateSegment(int):System.IO.Pipelines.BufferSegment:this
          -6 (-0.47% of base) : 84294.dasm - System.Linq.Expressions.Compiler.StackSpiller:RewriteMemberInitExpression(System.Linq.Expressions.Expression,int):System.Linq.Expressions.Compiler.StackSpiller+Result:this
          -6 (-1.37% of base) : 182002.dasm - System.Management.RelationshipQuery:BuildQuery():this

Top method improvements (percentages):
          -2 (-11.11% of base) : 76821.dasm - Microsoft.FSharp.Collections.PrivateListHelpers:sliceSkip(int,Microsoft.FSharp.Collections.FSharpList`1[System.Int32]):Microsoft.FSharp.Collections.FSharpList`1[System.Int32]
          -2 (-11.11% of base) : 4529.dasm - System.Reflection.Emit.MethodBuilder:get_ReflectedType():System.Type:this
          -2 (-10.00% of base) : 120569.dasm - Roslyn.Utilities.WeakList`1:GetExpandedSize(int):int
          -2 (-9.52% of base) : 23080.dasm - ToInterfaceConversionClassifier:get_Result():int:this
          -2 (-9.09% of base) : 180241.dasm - System.Data.Odbc.OdbcError:ToString():System.String:this
          -2 (-9.09% of base) : 211705.dasm - System.Data.OleDb.OleDbError:ToString():System.String:this
          -2 (-9.09% of base) : 181991.dasm - System.Management.WqlEventQuery:get_QueryLanguage():System.String:this
          -2 (-9.09% of base) : 4899.dasm - System.Reflection.Emit.ConstructorBuilder:get_DeclaringType():System.Type:this
          -2 (-9.09% of base) : 4900.dasm - System.Reflection.Emit.ConstructorBuilder:get_ReflectedType():System.Type:this
          -2 (-9.09% of base) : 56993.dasm - System.Xml.Schema.SchemaAttDef:System.Xml.IDtdDefaultAttributeInfo.get_DefaultValueExpanded():System.String:this
          -2 (-8.70% of base) : 41993.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeSubstitution:GetSubstitutionForGenericDefinition(Microsoft.CodeAnalysis.VisualBasic.Symbol):Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeSubstitution:this
          -2 (-7.41% of base) : 69170.dasm - Microsoft.FSharp.Collections.PrivateListHelpers:sliceSkip(int,Microsoft.FSharp.Collections.FSharpList`1[System.__Canon]):Microsoft.FSharp.Collections.FSharpList`1[System.__Canon]
          -2 (-7.41% of base) : 216233.dasm - System.Net.Authorization:set_ProtectionRealm(System.String[]):this
          -2 (-6.67% of base) : 180117.dasm - System.Data.Odbc.OdbcParameter:ToString():System.String:this
          -2 (-6.67% of base) : 212212.dasm - System.Data.OleDb.OleDbParameter:ToString():System.String:this
          -2 (-5.71% of base) : 202689.dasm - System.IO.Ports.SerialStream:ReadByte():int:this
          -2 (-5.71% of base) : 128105.dasm - System.Runtime.Serialization.XmlReaderDelegator:GetArrayLengthQuota(System.Runtime.Serialization.XmlObjectSerializerReadContext):int
          -2 (-5.56% of base) : 44814.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE.PENamedTypeSymbol:get_MarshallingCharSet():int:this
          -2 (-5.00% of base) : 43172.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceMemberMethodSymbol:GetQuickAttributes():ubyte:this
          -2 (-5.00% of base) : 167902.dasm - TakeOrSkipQueryOperatorResults:get_ElementsCount():int:this

496 total methods with Code Size differences (496 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 49822398 (overridden on cmd)
Total bytes of diff: 49816762 (overridden on cmd)
Total bytes of delta: -5636 (-0.01 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
           7 : 154960.dasm (0.48% of base)

Top file improvements (bytes):
         -46 : 95756.dasm (-1.31% of base)
         -40 : 73299.dasm (-0.59% of base)
         -34 : 28603.dasm (-0.84% of base)
         -30 : 130902.dasm (-1.00% of base)
         -30 : 68146.dasm (-0.64% of base)
         -30 : 8958.dasm (-1.20% of base)
         -26 : 68147.dasm (-0.82% of base)
         -24 : 72246.dasm (-0.59% of base)
         -24 : 31906.dasm (-0.55% of base)
         -24 : 70102.dasm (-0.52% of base)
         -20 : 192349.dasm (-0.75% of base)
         -20 : 28599.dasm (-0.80% of base)
         -20 : 28604.dasm (-0.84% of base)
         -18 : 72651.dasm (-0.69% of base)
         -18 : 227852.dasm (-0.67% of base)
         -18 : 101218.dasm (-0.92% of base)
         -18 : 73253.dasm (-0.70% of base)
         -16 : 28624.dasm (-0.63% of base)
         -16 : 28626.dasm (-0.63% of base)
         -16 : 72253.dasm (-0.46% of base)

1869 total files with Code Size differences (1868 improved, 1 regressed), 1 unchanged.

Top method regressions (bytes):
           7 ( 0.48% of base) : 154960.dasm - System.Text.ISO2022Encoding:GetCharsCP5022xJP(long,int,long,int,ISO2022Decoder):int:this

Top method improvements (bytes):
         -46 (-1.31% of base) : 95756.dasm - Microsoft.CodeAnalysis.Emit.DeltaMetadataWriter:PopulateEncMapTableRows(System.Collections.Generic.List`1[EncMapRow],System.Collections.Immutable.ImmutableArray`1[Int32]):this
         -40 (-0.59% of base) : 73299.dasm - Microsoft.CodeAnalysis.CSharp.SymbolDisplayVisitor:VisitMethod(Microsoft.CodeAnalysis.IMethodSymbol):this
         -34 (-0.84% of base) : 28603.dasm - Microsoft.CodeAnalysis.VisualBasic.SymbolDisplayVisitor:AddMethodKind(Microsoft.CodeAnalysis.IMethodSymbol):this
         -30 (-0.64% of base) : 68146.dasm - Microsoft.CodeAnalysis.CSharp.OverloadResolution:GetEnumOperation(int,Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.ArrayBuilder`1[BinaryOperatorSignature]):this
         -30 (-1.20% of base) : 8958.dasm - Microsoft.CodeAnalysis.VisualBasic.DataFlowPass:MakeSlotsForExpression(Microsoft.CodeAnalysis.VisualBasic.BoundExpression):SlotCollection:this
         -30 (-1.00% of base) : 130902.dasm - System.Data.XSDSchema:HandleElementColumn(System.Xml.Schema.XmlSchemaElement,System.Data.DataTable,bool):this
         -26 (-0.82% of base) : 68147.dasm - Microsoft.CodeAnalysis.CSharp.OverloadResolution:GetPointerArithmeticOperators(int,Microsoft.CodeAnalysis.CSharp.Symbols.PointerTypeSymbol,Microsoft.CodeAnalysis.ArrayBuilder`1[BinaryOperatorSignature]):this
         -24 (-0.59% of base) : 72246.dasm - Microsoft.CodeAnalysis.CSharp.AsyncMethodToStateMachineRewriter:GenerateMoveNext(Microsoft.CodeAnalysis.CSharp.BoundStatement,Microsoft.CodeAnalysis.CSharp.Symbols.MethodSymbol):this
         -24 (-0.52% of base) : 70102.dasm - Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions:ValidateOptions(Microsoft.CodeAnalysis.ArrayBuilder`1[[Microsoft.CodeAnalysis.Diagnostic, Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):this
         -24 (-0.55% of base) : 31906.dasm - Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilationOptions:ValidateOptions(Microsoft.CodeAnalysis.ArrayBuilder`1[[Microsoft.CodeAnalysis.Diagnostic, Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):this
         -20 (-0.84% of base) : 28604.dasm - Microsoft.CodeAnalysis.VisualBasic.SymbolDisplayVisitor:AddMethodName(Microsoft.CodeAnalysis.IMethodSymbol):this
         -20 (-0.80% of base) : 28599.dasm - Microsoft.CodeAnalysis.VisualBasic.SymbolDisplayVisitor:VisitProperty(Microsoft.CodeAnalysis.IPropertySymbol):this
         -20 (-0.75% of base) : 192349.dasm - OleDbParameterConverter:ConvertToInstanceDescriptor(System.Data.OleDb.OleDbParameter):System.ComponentModel.Design.Serialization.InstanceDescriptor
         -18 (-0.69% of base) : 72651.dasm - Microsoft.CodeAnalysis.CSharp.LocalRewriter:AddObjectInitializer(byref,byref,Microsoft.CodeAnalysis.ArrayBuilder`1[[Microsoft.CodeAnalysis.CSharp.BoundExpression, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.BoundAssignmentOperator):this
         -18 (-0.70% of base) : 73253.dasm - Microsoft.CodeAnalysis.CSharp.SymbolDisplayVisitor:AddNameAndTypeArgumentsOrParameters(Microsoft.CodeAnalysis.INamedTypeSymbol):this
         -18 (-0.92% of base) : 101218.dasm - Microsoft.Diagnostics.Tracing.Etlx.TraceCodeAddresses:OpenPdbForModuleFile(Microsoft.Diagnostics.Symbols.SymbolReader,Microsoft.Diagnostics.Tracing.Etlx.TraceModuleFile):Microsoft.Diagnostics.Symbols.ManagedSymbolModule:this
         -18 (-0.67% of base) : 227852.dasm - System.Runtime.Serialization.Formatters.Binary.ObjectWriter:WriteArray(System.Runtime.Serialization.Formatters.Binary.WriteObjectInfo,System.Runtime.Serialization.Formatters.Binary.NameInfo,System.Runtime.Serialization.Formatters.Binary.WriteObjectInfo):this
         -16 (-0.46% of base) : 72253.dasm - Microsoft.CodeAnalysis.CSharp.AsyncMethodToStateMachineRewriter:GenerateAwaitForIncompleteTask(Microsoft.CodeAnalysis.CSharp.Symbols.LocalSymbol):Microsoft.CodeAnalysis.CSharp.BoundBlock:this
         -16 (-0.62% of base) : 92685.dasm - Microsoft.CodeAnalysis.ErrorLogger:GetPropertiesValue(Issue):Value:this
         -16 (-0.63% of base) : 28626.dasm - Microsoft.CodeAnalysis.VisualBasic.SymbolDisplayVisitor:AddNameAndTypeArgumentsOrParameters(Microsoft.CodeAnalysis.INamedTypeSymbol,bool):this

Top method regressions (percentages):
           7 ( 0.48% of base) : 154960.dasm - System.Text.ISO2022Encoding:GetCharsCP5022xJP(long,int,long,int,ISO2022Decoder):int:this

Top method improvements (percentages):
          -2 (-14.29% of base) : 66078.dasm - Microsoft.FSharp.Collections.PrivateListHelpers:sliceSkip(int,Microsoft.FSharp.Collections.FSharpList`1[Byte]):Microsoft.FSharp.Collections.FSharpList`1[Byte]
          -2 (-10.00% of base) : 97604.dasm - Roslyn.Utilities.WeakList`1[__Canon][System.__Canon]:GetExpandedSize(int):int
          -2 (-9.52% of base) : 34744.dasm - ToInterfaceConversionClassifier:get_Result():int:this
          -2 (-8.70% of base) : 14352.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeSubstitution:GetSubstitutionForGenericDefinition(Microsoft.CodeAnalysis.VisualBasic.Symbol):Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeSubstitution:this
          -2 (-8.70% of base) : 66077.dasm - Microsoft.FSharp.Collections.PrivateListHelpers:sliceSkip(int,Microsoft.FSharp.Collections.FSharpList`1[__Canon]):Microsoft.FSharp.Collections.FSharpList`1[__Canon]
          -2 (-8.33% of base) : 201322.dasm - System.IO.Ports.SerialStream:ReadByte():int:this
          -2 (-8.00% of base) : 190450.dasm - System.Data.Odbc.OdbcError:ToString():System.String:this
          -2 (-8.00% of base) : 190512.dasm - System.Data.Odbc.OdbcParameter:ToString():System.String:this
          -2 (-8.00% of base) : 191859.dasm - System.Data.OleDb.OleDbError:ToString():System.String:this
          -2 (-8.00% of base) : 191382.dasm - System.Data.OleDb.OleDbParameter:ToString():System.String:this
          -2 (-8.00% of base) : 211871.dasm - System.Management.WqlObjectQuery:get_QueryLanguage():System.String:this
          -2 (-8.00% of base) : 43463.dasm - System.Xml.Schema.SchemaAttDef:System.Xml.IDtdDefaultAttributeInfo.get_DefaultValueExpanded():System.String:this
          -2 (-7.69% of base) : 217405.dasm - System.Net.Authorization:set_ProtectionRealm(System.String[]):this
          -2 (-6.25% of base) : 11485.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE.PENamedTypeSymbol:get_MarshallingCharSet():int:this
          -2 (-5.00% of base) : 13217.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceMemberMethodSymbol:GetQuickAttributes():ubyte:this
          -2 (-4.44% of base) : 172169.dasm - R2RDump.Disassembler:EnsureIndentation(System.Text.StringBuilder,int,int)
          -2 (-4.35% of base) : 28118.dasm - Microsoft.CodeAnalysis.VisualBasic.SyntaxFacts:ReturnFullWidthOrSelf(ushort):ushort
          -2 (-4.26% of base) : 211875.dasm - System.Management.SelectQuery:get_QueryString():System.String:this
          -2 (-4.26% of base) : 211934.dasm - System.Management.WqlEventQuery:get_QueryString():System.String:this
          -2 (-4.17% of base) : 101136.dasm - Microsoft.Diagnostics.Tracing.Etlx.TraceLoadedModule:get_FilePath():System.String:this

1869 total methods with Code Size differences (1868 improved, 1 regressed), 1 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries_tests.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 129381006 (overridden on cmd)
Total bytes of diff: 129375761 (overridden on cmd)
Total bytes of delta: -5245 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          20 : 294223.dasm (0.59% of base)

Top file improvements (bytes):
         -36 : 220355.dasm (-0.33% of base)
         -34 : 253459.dasm (-0.37% of base)
         -28 : 143738.dasm (-0.86% of base)
         -28 : 53093.dasm (-0.19% of base)
         -28 : 11644.dasm (-0.62% of base)
         -20 : 221552.dasm (-0.81% of base)
         -20 : 278972.dasm (-0.40% of base)
         -20 : 294395.dasm (-1.45% of base)
         -18 : 53075.dasm (-0.13% of base)
         -18 : 53081.dasm (-0.17% of base)
         -18 : 53087.dasm (-0.15% of base)
         -16 : 293635.dasm (-1.37% of base)
         -16 : 339159.dasm (-0.30% of base)
         -16 : 145367.dasm (-0.93% of base)
         -16 : 7029.dasm (-1.35% of base)
         -16 : 294224.dasm (-1.07% of base)
         -16 : 61.dasm (-1.37% of base)
         -16 : 143302.dasm (-1.24% of base)
         -16 : 221610.dasm (-0.21% of base)
         -16 : 294397.dasm (-1.42% of base)

1855 total files with Code Size differences (1854 improved, 1 regressed), 2 unchanged.

Top method regressions (bytes):
          20 ( 0.59% of base) : 294223.dasm - System.Text.RegularExpressions.RegexNode:CanBeMadeAtomic(System.Text.RegularExpressions.RegexNode,System.Text.RegularExpressions.RegexNode,bool):bool

Top method improvements (bytes):
         -36 (-0.33% of base) : 220355.dasm - DryIoc.WrappersSupport:BuildSupportedWrappers():ImTools.ImMap`1[[ImTools.ImMap+KValue`1[[System.Type, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], DryIoc, Version=4.7.0.0, Culture=neutral, PublicKeyToken=dfbf2bd50fcf7768]]
         -34 (-0.37% of base) : 253459.dasm - <>c:<TestRecordingMeasurementsWithTagList>b__15_0():this
         -28 (-0.19% of base) : 53093.dasm - ManagedTests.DynamicCSharp.Conformance.dynamic.statements.cnst.cnst05.cnst05.Test:MainMethod():int
         -28 (-0.86% of base) : 143738.dasm - Microsoft.CodeAnalysis.CSharp.CodeGeneration.MethodGenerator:GenerateModifiers(Microsoft.CodeAnalysis.IMethodSymbol,int,Microsoft.CodeAnalysis.CSharp.CodeGeneration.CSharpCodeGenerationOptions):Microsoft.CodeAnalysis.SyntaxTokenList
         -28 (-0.62% of base) : 11644.dasm - Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles.EditorConfigNamingStyleParser:ParseSymbolKindList(System.String):System.Collections.Immutable.ImmutableArray`1[SymbolKindOrTypeKind]
         -20 (-0.81% of base) : 221552.dasm - Registry:IsRegistered(System.Type,System.Object,int,System.Func`2[[DryIoc.Factory, DryIoc, Version=4.7.0.0, Culture=neutral, PublicKeyToken=dfbf2bd50fcf7768],[System.Boolean, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):bool:this
         -20 (-0.40% of base) : 278972.dasm - System.Reflection.Metadata.Ecma335.Tests.InstructionEncoderTests:Branch():this
         -20 (-1.45% of base) : 294395.dasm - System.Text.RegularExpressions.Tests.RegexTreeAnalyzerTests:AlternationWithCaptures():this
         -18 (-0.15% of base) : 53087.dasm - ManagedTests.DynamicCSharp.Conformance.dynamic.statements.cnst.readonly01a.readonly01a.Test:MainMethod():int
         -18 (-0.17% of base) : 53081.dasm - ManagedTests.DynamicCSharp.Conformance.dynamic.statements.cnst.readonly02.readonly02.Test:MainMethod():int
         -18 (-0.13% of base) : 53075.dasm - ManagedTests.DynamicCSharp.Conformance.dynamic.statements.cnst.readonly03.readonly03.Test:MainMethod():int
         -16 (-0.21% of base) : 221610.dasm - <>c__DisplayClass39_0:<UseInstance>b__0(Registry):Registry:this
         -16 (-1.24% of base) : 143302.dasm - Microsoft.CodeAnalysis.CSharp.CodeGeneration.CSharpCodeGenerationHelpers:AddAccessibilityModifiers(int,Microsoft.CodeAnalysis.PooledObjects.ArrayBuilder`1[SyntaxToken],Microsoft.CodeAnalysis.CSharp.CodeGeneration.CSharpCodeGenerationOptions,int)
         -16 (-1.35% of base) : 7029.dasm - Microsoft.CodeAnalysis.Shared.Utilities.SymbolEquivalenceComparer:.ctor(System.Collections.Generic.IEqualityComparer`1[[Microsoft.CodeAnalysis.IAssemblySymbol, Microsoft.CodeAnalysis, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],bool,bool,bool):this
         -16 (-0.93% of base) : 145367.dasm - Microsoft.CodeAnalysis.VisualBasic.CodeGeneration.VisualBasicCodeGenerationHelpers:AddAccessibilityModifiers(int,Microsoft.CodeAnalysis.PooledObjects.ArrayBuilder`1[SyntaxToken],int,Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationOptions,int)
         -16 (-0.30% of base) : 339159.dasm - System.IO.Tests.UmaTests:UmaReadWrite()
         -16 (-1.37% of base) : 293635.dasm - System.Text.RegularExpressions.RegexNode:ComputeMinLength():int:this
         -16 (-1.07% of base) : 294224.dasm - System.Text.RegularExpressions.RegexNode:ComputeMinLength():int:this
         -16 (-1.37% of base) : 61.dasm - System.Text.RegularExpressions.RegexNode:ComputeMinLength():int:this
         -16 (-1.42% of base) : 294397.dasm - System.Text.RegularExpressions.Tests.RegexTreeAnalyzerTests:AtomicGroupAroundBacktracking():this

Top method regressions (percentages):
          20 ( 0.59% of base) : 294223.dasm - System.Text.RegularExpressions.RegexNode:CanBeMadeAtomic(System.Text.RegularExpressions.RegexNode,System.Text.RegularExpressions.RegexNode,bool):bool

Top method improvements (percentages):
          -2 (-8.00% of base) : 211164.dasm - System.Data.SqlClient.SqlCommandBuilder:get_QuoteSuffix():System.String:this
          -2 (-8.00% of base) : 206862.dasm - System.Data.SqlClient.SqlCommandBuilder:get_QuoteSuffix():System.String:this
          -2 (-5.26% of base) : 218590.dasm - ImTools.Hasher:Combine(int,System.Nullable`1[Int32]):int
          -2 (-5.26% of base) : 228150.dasm - LamarCodeGeneration.Util.Hasher:Combine(int,System.Nullable`1[Int32]):int
         -10 (-4.93% of base) : 6181.dasm - Microsoft.CodeAnalysis.PooledObjects.ArrayBuilder`1[Byte][System.Byte]:AddRange(Microsoft.CodeAnalysis.PooledObjects.ArrayBuilder`1[Byte],System.Func`2[Byte,Byte]):this
          -2 (-4.76% of base) : 3691.dasm - Microsoft.CodeAnalysis.ImmutableArrayExtensions:NullToEmpty(System.Nullable`1[ImmutableArray`1]):System.Collections.Immutable.ImmutableArray`1[__Canon]
          -2 (-4.65% of base) : 218588.dasm - ImTools.Hasher:Combine(ubyte,System.Nullable`1[Int32]):int
          -2 (-4.65% of base) : 228148.dasm - LamarCodeGeneration.Util.Hasher:Combine(ubyte,System.Nullable`1[Int32]):int
          -2 (-4.65% of base) : 9625.dasm - Microsoft.CodeAnalysis.Formatting.FormattingExtensions:GetNewIndentationForComments(System.String,int,bool,int,int,int):int
          -2 (-4.55% of base) : 218589.dasm - ImTools.Hasher:Combine(short,System.Nullable`1[Int32]):int
          -2 (-4.55% of base) : 228149.dasm - LamarCodeGeneration.Util.Hasher:Combine(short,System.Nullable`1[Int32]):int
          -2 (-4.08% of base) : 218593.dasm - ImTools.Hasher:Combine(long,System.Nullable`1[Int32]):int
          -2 (-4.08% of base) : 228153.dasm - LamarCodeGeneration.Util.Hasher:Combine(long,System.Nullable`1[Int32]):int
          -2 (-4.00% of base) : 345952.dasm - System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes:Method():System.String
          -2 (-3.70% of base) : 218592.dasm - ImTools.Hasher:Combine(System.Numerics.Vector`1[Single],System.Nullable`1[Int32]):int
          -2 (-3.70% of base) : 228152.dasm - LamarCodeGeneration.Util.Hasher:Combine(System.Numerics.Vector`1[Single],System.Nullable`1[Int32]):int
          -2 (-3.51% of base) : 229692.dasm - Leaf5[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:GetEntryOrNull(int):Entry[__Canon,Nullable`1]:this
          -2 (-3.51% of base) : 229836.dasm - Leaf5[__Canon][System.__Canon]:GetEntryOrNull(int):LamarCodeGeneration.Util.ImMapEntry`1[__Canon]:this
          -2 (-3.51% of base) : 229701.dasm - Leaf5[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:GetEntryOrNull(int):Entry[Byte,Nullable`1]:this
          -2 (-3.51% of base) : 229844.dasm - Leaf5[Byte][System.Byte]:GetEntryOrNull(int):LamarCodeGeneration.Util.ImMapEntry`1[Byte]:this

1855 total methods with Code Size differences (1854 improved, 1 regressed), 2 unchanged.

```

</details>

--------------------------------------------------------------------------------

/cc @jit-contrib

