### PR TITLE
CheckValue is not a fast path for all callers

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
@@ -279,7 +279,11 @@ namespace System.Reflection
             {
                 RuntimeType fieldType = (RuntimeType)FieldType;
                 bool _ = false;
-                fieldType.CheckValue(ref val, ref _, binder, culture, invokeAttr);
+
+                if (!ReferenceEquals(val.GetType(), fieldType))
+                {
+                    fieldType.CheckValue(ref val, ref _, binder, culture, invokeAttr);
+                }
             }
 
             Invoker.SetValue(obj, val);

--- a/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -1685,9 +1685,6 @@ namespace System
             CultureInfo? culture,
             BindingFlags invokeAttr)
         {
-            // Already fast-pathed by the caller.
-            Debug.Assert(!ReferenceEquals(value?.GetType(), this));
-
             copyBack = true;
 
             CheckValueStatus status = TryConvertToType(ref value);

--- a/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -1685,6 +1685,9 @@ namespace System
             CultureInfo? culture,
             BindingFlags invokeAttr)
         {
+            // Already fast-pathed by the caller.
+            Debug.Assert(!ReferenceEquals(value?.GetType(), this));
+
             copyBack = true;
 
             CheckValueStatus status = TryConvertToType(ref value);


### PR DESCRIPTION
Fixes #68029

The assertion is not valid when called from here :
https://github.com/dotnet/runtime/blob/0f8dd11a97c1079c868a4865d83b702684895b05/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs#L282

For example, `this` and `value` point to `Castle.DynamicProxy.ProxyGenerationOptions` in `RuntimeType.CheckValue` call from `Microsoft.Extensions.Configuration.Test.ConfigurationRootTest.RootDisposesChangeTokenRegistrations` test.