### PR TITLE
Fix very adventurous LIR::Use::GetDummyUse

### DIFF
--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -157,7 +157,7 @@ GenTree* DecomposeLongs::DecomposeNode(GenTree* tree)
     LIR::Use use;
     if (!Range().TryGetUse(tree, &use))
     {
-        use = LIR::Use::GetDummyUse(Range(), tree);
+        LIR::Use::MakeDummyUse(Range(), tree, &use);
     }
 
     GenTree* nextNode = nullptr;

--- a/src/coreclr/jit/lir.cpp
+++ b/src/coreclr/jit/lir.cpp
@@ -52,7 +52,7 @@ LIR::Use& LIR::Use::operator=(Use&& other)
 }
 
 //------------------------------------------------------------------------
-// LIR::Use::GetDummyUse: Returns a dummy use for a node.
+// LIR::Use::MakeDummyUse: Make a use into a dummy use.
 //
 // This method is provided as a convenience to allow transforms to work
 // uniformly over Use values. It allows the creation of a Use given a node
@@ -61,20 +61,17 @@ LIR::Use& LIR::Use::operator=(Use&& other)
 // Arguments:
 //    range - The range that contains the node.
 //    node - The node for which to create a dummy use.
+//    dummyUse - [out] the resulting dummy use
 //
-// Return Value:
-//
-LIR::Use LIR::Use::GetDummyUse(Range& range, GenTree* node)
+void LIR::Use::MakeDummyUse(Range& range, GenTree* node, LIR::Use* dummyUse)
 {
     assert(node != nullptr);
 
-    Use dummyUse;
-    dummyUse.m_range = &range;
-    dummyUse.m_user  = node;
-    dummyUse.m_edge  = &dummyUse.m_user;
+    dummyUse->m_range = &range;
+    dummyUse->m_user  = node;
+    dummyUse->m_edge  = &dummyUse->m_user;
 
-    assert(dummyUse.IsInitialized());
-    return dummyUse;
+    assert(dummyUse->IsInitialized());
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/lir.h
+++ b/src/coreclr/jit/lir.h
@@ -64,7 +64,7 @@ public:
         Use& operator=(const Use& other);
         Use& operator=(Use&& other);
 
-        static Use GetDummyUse(Range& range, GenTree* node);
+        static void MakeDummyUse(Range& range, GenTree* node, Use* dummyUse);
 
         GenTree* Def() const;
         GenTree* User() const;

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -585,7 +585,7 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, Compiler::Ge
     LIR::Use use;
     if (parentStack.Height() < 2)
     {
-        use = LIR::Use::GetDummyUse(BlockRange(), *useEdge);
+        LIR::Use::MakeDummyUse(BlockRange(), *useEdge, &use);
     }
     else
     {


### PR DESCRIPTION
This only happened to work due to Named RVO and is UB in any case.

cc @dotnet/jit-contrib