### PR TITLE
Dynamically sized stacks in EventPipe buffer manager

### DIFF
--- a/src/native/eventpipe/ep-block.c
+++ b/src/native/eventpipe/ep-block.c
@@ -671,12 +671,12 @@ ep_event_block_base_write_event (
 	}
 
 	if (block->format == EP_SERIALIZATION_FORMAT_NETPERF_V3) {
-		uint32_t stack_size = ep_stack_contents_get_size (ep_event_instance_get_stack_contents_ref (event_instance));
+		uint32_t stack_size = ep_stack_contents_instance_get_size (ep_event_instance_get_stack_contents_instance_ref (event_instance));
 		memcpy (write_pointer, &stack_size, sizeof (stack_size));
 		write_pointer += sizeof (stack_size);
 
 		if (stack_size > 0) {
-			memcpy (write_pointer, ep_stack_contents_get_pointer (ep_event_instance_get_stack_contents_ref (event_instance)), stack_size);
+			memcpy (write_pointer, ep_stack_contents_instance_get_pointer (ep_event_instance_get_stack_contents_instance_ref (event_instance)), stack_size);
 			write_pointer += stack_size;
 		}
 	}
@@ -1052,13 +1052,13 @@ bool
 ep_stack_block_write_stack (
 	EventPipeStackBlock *stack_block,
 	uint32_t stack_id,
-	EventPipeStackContents *stack)
+	EventPipeStackContentsInstance *stack)
 {
 	bool result = true;
 
 	EP_ASSERT (stack_block != NULL);
 
-	uint32_t stack_size = ep_stack_contents_get_size (stack);
+	uint32_t stack_size = ep_stack_contents_instance_get_size (stack);
 	uint32_t total_size = sizeof (stack_size) + stack_size;
 	EventPipeBlock *block = &stack_block->block;
 	uint8_t *write_pointer = block->write_pointer;
@@ -1076,7 +1076,7 @@ ep_stack_block_write_stack (
 	write_pointer += sizeof (stack_size);
 
 	if (stack_size > 0) {
-		memcpy (write_pointer, ep_stack_contents_get_pointer (stack), stack_size);
+		memcpy (write_pointer, ep_stack_contents_instance_get_pointer (stack), stack_size);
 		write_pointer += stack_size;
 	}
 

--- a/src/native/eventpipe/ep-block.h
+++ b/src/native/eventpipe/ep-block.h
@@ -350,7 +350,7 @@ bool
 ep_stack_block_write_stack (
 	EventPipeStackBlock *stack_block,
 	uint32_t stack_id,
-	EventPipeStackContents *stack);
+	EventPipeStackContentsInstance *stack);
 
 static
 inline

--- a/src/native/eventpipe/ep-buffer.c
+++ b/src/native/eventpipe/ep-buffer.c
@@ -83,13 +83,6 @@ ep_buffer_write_event (
 
 	bool success = true;
 
-	// Calculate the size of the event.
-	uint32_t event_size = sizeof (EventPipeEventInstance) + ep_event_payload_get_size (payload);
-
-	// Make sure we have enough space to write the event.
-	if(buffer->current + event_size > buffer->limit)
-		ep_raise_error ();
-
 	// Calculate the location of the data payload.
 	uint8_t *data_dest;
 	data_dest = (ep_event_payload_get_size (payload) == 0 ? NULL : buffer->current + sizeof(EventPipeEventInstance));
@@ -101,6 +94,13 @@ ep_buffer_write_event (
 		ep_walk_managed_stack_for_current_thread (current_stack_contents);
 		stack = current_stack_contents;
 	}
+
+	// Calculate the size of the event.
+	uint32_t event_size = sizeof (EventPipeEventInstance) - sizeof (EventPipeStackContents) + ep_stack_contents_get_total_size (stack) + ep_event_payload_get_size (payload);
+
+	// Make sure we have enough space to write the event.
+	if(buffer->current + event_size > buffer->limit)
+		ep_raise_error ();
 
 	uint32_t proc_number;
 	proc_number = ep_rt_current_processor_get_number ();

--- a/src/native/eventpipe/ep-buffer.c
+++ b/src/native/eventpipe/ep-buffer.c
@@ -93,10 +93,10 @@ ep_buffer_write_event (
 
 	// Calculate the location of the data payload.
 	uint8_t *data_dest;
-	data_dest = (ep_event_payload_get_size (payload) == 0 ? NULL : buffer->current + sizeof(EventPipeEventInstance) - sizeof (EventPipeStackContents) + ep_stack_contents_get_total_size (stack));
+	data_dest = (ep_event_payload_get_size (payload) == 0 ? NULL : buffer->current + sizeof(EventPipeEventInstance) - sizeof (EventPipeStackContentsInstance) + ep_stack_contents_get_instance_size (stack));
 
 	// Calculate the size of the event.
-	uint32_t event_size = sizeof (EventPipeEventInstance) - sizeof (EventPipeStackContents) + ep_stack_contents_get_total_size (stack) + ep_event_payload_get_size (payload);
+	uint32_t event_size = sizeof (EventPipeEventInstance) - sizeof (EventPipeStackContentsInstance) + ep_stack_contents_get_instance_size (stack) + ep_event_payload_get_size (payload);
 
 	// Make sure we have enough space to write the event.
 	if(buffer->current + event_size > buffer->limit)
@@ -118,7 +118,7 @@ ep_buffer_write_event (
 
 	// Copy the stack if a separate stack trace was provided.
 	if (stack != NULL)
-		ep_stack_contents_copyto (stack, ep_event_instance_get_stack_contents_ref (instance));
+		ep_stack_contents_flatten (stack, ep_event_instance_get_stack_contents_instance_ref (instance));
 
 	// Write the event payload data to the buffer.
 	if (ep_event_payload_get_size (payload) > 0)

--- a/src/native/eventpipe/ep-buffer.c
+++ b/src/native/eventpipe/ep-buffer.c
@@ -83,14 +83,6 @@ ep_buffer_write_event (
 
 	bool success = true;
 
-	EventPipeStackContents stack_contents;
-	EventPipeStackContents *current_stack_contents;
-	current_stack_contents = ep_stack_contents_init (&stack_contents);
-	if (stack == NULL && ep_event_get_need_stack (ep_event) && !ep_session_get_rundown_enabled (session)) {
-		ep_walk_managed_stack_for_current_thread (current_stack_contents);
-		stack = current_stack_contents;
-	}
-
 	// Calculate the location of the data payload.
 	uint8_t *data_dest;
 	data_dest = (ep_event_payload_get_size (payload) == 0 ? NULL : buffer->current + sizeof(EventPipeEventInstance) - sizeof (EventPipeStackContentsInstance) + ep_stack_contents_get_instance_size (stack));

--- a/src/native/eventpipe/ep-event-instance.c
+++ b/src/native/eventpipe/ep-event-instance.c
@@ -69,7 +69,7 @@ ep_event_instance_init (
 
 #ifdef EP_CHECKED_BUILD
 	event_instance->debug_event_start = 0xDEADBEEF;
-	event_instance->debug_event_end = 0x0DDBA11;
+	event_instance->debug_event_end = 0xC0DEC0DE;
 #endif
 
 	event_instance->ep_event = ep_event;
@@ -113,7 +113,7 @@ ep_event_instance_ensure_consistency (const EventPipeEventInstance *ep_event_ins
 {
 #ifdef EP_CHECKED_BUILD
 	EP_ASSERT (ep_event_instance->debug_event_start == 0xDEADBEEF);
-	EP_ASSERT (ep_event_instance->debug_event_end == 0x0DDBA11);
+	EP_ASSERT (ep_event_instance->debug_event_end == 0xC0DEC0DE);
 #endif
 
 	return true;

--- a/src/native/eventpipe/ep-event-instance.c
+++ b/src/native/eventpipe/ep-event-instance.c
@@ -69,7 +69,7 @@ ep_event_instance_init (
 
 #ifdef EP_CHECKED_BUILD
 	event_instance->debug_event_start = 0xDEADBEEF;
-	event_instance->debug_event_end = 0xCAFEBABE;
+	event_instance->debug_event_end = 0x0DDBA11;
 #endif
 
 	event_instance->ep_event = ep_event;
@@ -113,7 +113,7 @@ ep_event_instance_ensure_consistency (const EventPipeEventInstance *ep_event_ins
 {
 #ifdef EP_CHECKED_BUILD
 	EP_ASSERT (ep_event_instance->debug_event_start == 0xDEADBEEF);
-	EP_ASSERT (ep_event_instance->debug_event_end == 0xCAFEBABE);
+	EP_ASSERT (ep_event_instance->debug_event_end == 0x0DDBA11);
 #endif
 
 	return true;
@@ -148,7 +148,7 @@ ep_event_instance_get_aligned_total_size (
 			// Prepended stack payload size in bytes
 			sizeof (uint32_t) +
 			// Stack payload size
-			ep_stack_contents_get_size (&ep_event_instance->stack_contents);
+			ep_stack_contents_instance_get_size (&ep_event_instance->stack_contents_instance);
 	} else if (format == EP_SERIALIZATION_FORMAT_NETTRACE_V4) {
 		payload_len =
 			// Metadata ID
@@ -207,7 +207,7 @@ ep_event_instance_serialize_to_json_file (
 		ep_event_get_event_version (ep_event_instance->ep_event));
 
 	if (characters_written > 0 && characters_written < (int32_t)ARRAY_SIZE (buffer))
-		ep_json_file_write_event_data (json_file, ep_event_instance->timestamp, ep_rt_uint64_t_to_thread_id_t (ep_event_instance->thread_id), buffer, &ep_event_instance->stack_contents);
+		ep_json_file_write_event_data (json_file, ep_event_instance->timestamp, ep_rt_uint64_t_to_thread_id_t (ep_event_instance->thread_id), buffer, &ep_event_instance->stack_contents_instance);
 }
 #else
 void

--- a/src/native/eventpipe/ep-event-instance.h
+++ b/src/native/eventpipe/ep-event-instance.h
@@ -31,15 +31,15 @@ struct _EventPipeEventInstance_Internal {
 	uint32_t metadata_id;
 	uint32_t proc_num;
 	uint32_t data_len;
+#ifdef EP_CHECKED_BUILD
+	uint32_t debug_event_start;
+	uint32_t debug_event_end;
+#endif
 	// TODO: Look at optimizing this when writing into buffer manager.
 	// Only write up to next available frame to better utilize memory.
 	// Even events not requesting a stack will still waste space in buffer manager.
 	// Needs to go last since number of frames will set size in stream.
 	EventPipeStackContents stack_contents;
-#ifdef EP_CHECKED_BUILD
-	uint32_t debug_event_start;
-	uint32_t debug_event_end;
-#endif
 };
 
 #if !defined(EP_INLINE_GETTER_SETTER) && !defined(EP_IMPL_EVENT_INSTANCE_GETTER_SETTER)
@@ -100,6 +100,17 @@ void
 ep_event_instance_serialize_to_json_file (
 	EventPipeEventInstance *ep_event_instance,
 	EventPipeJsonFile *json_file);
+
+static
+inline
+uint32_t
+ep_event_instance_get_flattened_size (const EventPipeEventInstance *ep_event_instance)
+{
+	EP_ASSERT (ep_event_instance != NULL);
+	return ep_event_instance_get_data (ep_event_instance) ?
+		sizeof (EventPipeEventInstance) - sizeof (EventPipeStackContents) + ep_stack_contents_get_total_size (ep_event_instance_get_stack_contents_cref (ep_event_instance)) + ep_event_instance_get_data_len (ep_event_instance) :
+		sizeof (EventPipeEventInstance) - sizeof (EventPipeStackContents) + ep_stack_contents_get_total_size (ep_event_instance_get_stack_contents_cref (ep_event_instance));
+}
 
 /*
  * EventPipeSequencePoint.

--- a/src/native/eventpipe/ep-event-instance.h
+++ b/src/native/eventpipe/ep-event-instance.h
@@ -35,11 +35,7 @@ struct _EventPipeEventInstance_Internal {
 	uint32_t debug_event_start;
 	uint32_t debug_event_end;
 #endif
-	// TODO: Look at optimizing this when writing into buffer manager.
-	// Only write up to next available frame to better utilize memory.
-	// Even events not requesting a stack will still waste space in buffer manager.
-	// Needs to go last since number of frames will set size in stream.
-	EventPipeStackContents stack_contents;
+	EventPipeStackContentsInstance stack_contents_instance;
 };
 
 #if !defined(EP_INLINE_GETTER_SETTER) && !defined(EP_IMPL_EVENT_INSTANCE_GETTER_SETTER)
@@ -59,7 +55,7 @@ EP_DEFINE_GETTER_ARRAY_REF(EventPipeEventInstance *, event_instance, uint8_t *, 
 EP_DEFINE_GETTER_ARRAY_REF(EventPipeEventInstance *, event_instance, uint8_t *, const uint8_t *, related_activity_id, related_activity_id[0])
 EP_DEFINE_GETTER(EventPipeEventInstance *, event_instance, const uint8_t *, data)
 EP_DEFINE_GETTER(EventPipeEventInstance *, event_instance, uint32_t, data_len)
-EP_DEFINE_GETTER_REF(EventPipeEventInstance *, event_instance, EventPipeStackContents *, stack_contents)
+EP_DEFINE_GETTER_REF(EventPipeEventInstance *, event_instance, EventPipeStackContentsInstance *, stack_contents_instance)
 
 EventPipeEventInstance *
 ep_event_instance_alloc (
@@ -108,8 +104,8 @@ ep_event_instance_get_flattened_size (const EventPipeEventInstance *ep_event_ins
 {
 	EP_ASSERT (ep_event_instance != NULL);
 	return ep_event_instance_get_data (ep_event_instance) ?
-		sizeof (EventPipeEventInstance) - sizeof (EventPipeStackContents) + ep_stack_contents_get_total_size (ep_event_instance_get_stack_contents_cref (ep_event_instance)) + ep_event_instance_get_data_len (ep_event_instance) :
-		sizeof (EventPipeEventInstance) - sizeof (EventPipeStackContents) + ep_stack_contents_get_total_size (ep_event_instance_get_stack_contents_cref (ep_event_instance));
+		sizeof (EventPipeEventInstance) - sizeof (EventPipeStackContentsInstance) + ep_stack_contents_instance_get_total_size (ep_event_instance_get_stack_contents_instance_cref (ep_event_instance)) + ep_event_instance_get_data_len (ep_event_instance) :
+		sizeof (EventPipeEventInstance) - sizeof (EventPipeStackContentsInstance) + ep_stack_contents_instance_get_total_size (ep_event_instance_get_stack_contents_instance_cref (ep_event_instance));
 }
 
 /*

--- a/src/native/eventpipe/ep-file.c
+++ b/src/native/eventpipe/ep-file.c
@@ -152,7 +152,7 @@ file_get_stack_id (
 	EP_ASSERT (file->stack_block != NULL);
 
 	uint32_t stack_id = 0;
-	EventPipeStackContents *stack_contents = ep_event_instance_get_stack_contents_ref (event_instance);
+	EventPipeStackContentsInstance *stack_contents = ep_event_instance_get_stack_contents_instance_ref (event_instance);
 	EventPipeStackBlock *stack_block = file->stack_block;
 	ep_rt_stack_hash_map_t *stack_hash = &file->stack_hash;
 	StackHashEntry *entry = NULL;
@@ -540,13 +540,13 @@ ep_stack_hash_entry_get_key (StackHashEntry *stack_hash_entry)
 
 StackHashEntry *
 ep_stack_hash_entry_alloc (
-	const EventPipeStackContents *stack_contents,
+	const EventPipeStackContentsInstance *stack_contents,
 	uint32_t id,
 	uint32_t hash)
 {
 	EP_ASSERT (stack_contents != NULL);
 
-	uint32_t stack_size = ep_stack_contents_get_size (stack_contents);
+	uint32_t stack_size = ep_stack_contents_instance_get_size (stack_contents);
 	StackHashEntry *entry = (StackHashEntry *)ep_rt_byte_array_alloc (offsetof (StackHashEntry, stack_bytes) + stack_size);
 	ep_raise_error_if_nok (entry != NULL);
 
@@ -554,7 +554,7 @@ ep_stack_hash_entry_alloc (
 	entry->key.hash = hash;
 	entry->key.stack_size_in_bytes = stack_size;
 	entry->key.stack_bytes = entry->stack_bytes;
-	memcpy (entry->stack_bytes, ep_stack_contents_get_pointer (stack_contents), stack_size);
+	memcpy (entry->stack_bytes, ep_stack_contents_instance_get_pointer (stack_contents), stack_size);
 
 ep_on_exit:
 	return entry;
@@ -593,13 +593,13 @@ hash_bytes (const uint8_t *data, size_t data_len)
 StackHashKey *
 ep_stack_hash_key_init (
 	StackHashKey *key,
-	const EventPipeStackContents *stack_contents)
+	const EventPipeStackContentsInstance *stack_contents)
 {
 	EP_ASSERT (key != NULL);
 	EP_ASSERT (stack_contents != NULL);
 
-	key->stack_bytes = ep_stack_contents_get_pointer (stack_contents);
-	key->stack_size_in_bytes = ep_stack_contents_get_size (stack_contents);
+	key->stack_bytes = ep_stack_contents_instance_get_pointer (stack_contents);
+	key->stack_size_in_bytes = ep_stack_contents_instance_get_size (stack_contents);
 	key->hash = hash_bytes (key->stack_bytes, key->stack_size_in_bytes);
 
 	return key;

--- a/src/native/eventpipe/ep-file.h
+++ b/src/native/eventpipe/ep-file.h
@@ -123,7 +123,7 @@ EP_DEFINE_GETTER(StackHashKey *, stack_hash_key, uint32_t, hash)
 StackHashKey *
 ep_stack_hash_key_init (
 	StackHashKey *key,
-	const EventPipeStackContents *stack_contents);
+	const EventPipeStackContentsInstance *stack_contents);
 
 void
 ep_stack_hash_key_fini (StackHashKey *key);
@@ -163,7 +163,7 @@ ep_stack_hash_entry_get_key (StackHashEntry *stack_hash_entry);
 
 StackHashEntry *
 ep_stack_hash_entry_alloc (
-	const EventPipeStackContents *stack_contents,
+	const EventPipeStackContentsInstance *stack_contents,
 	uint32_t id,
 	uint32_t hash);
 

--- a/src/native/eventpipe/ep-json-file.c
+++ b/src/native/eventpipe/ep-json-file.c
@@ -124,14 +124,16 @@ ep_json_file_write_event_data (
 	ep_char8_t method_name [MAX_METHOD_NAME_LEN];
 
 	for (uint32_t i = 0; i < ep_stack_contents_get_length (stack_contents); ++i) {
-		ep_rt_method_desc_t *method = ep_stack_contents_get_method (stack_contents, i);
+		// ep_rt_method_desc_t *method = ep_stack_contents_get_method (stack_contents, i);
 
-		if (!ep_rt_method_get_simple_assembly_name (method, assembly_name, ARRAY_SIZE (assembly_name))) {
+		// if (!ep_rt_method_get_simple_assembly_name (method, assembly_name, ARRAY_SIZE (assembly_name))) {
+		if (true) {
 			assembly_name [0] = '?';
 			assembly_name [1] = 0;
 		}
 
-		if (!ep_rt_method_get_full_name (method, method_name, ARRAY_SIZE (method_name))) {
+		// if (!ep_rt_method_get_full_name (method, method_name, ARRAY_SIZE (method_name))) {
+		if (true) {
 			method_name [0] = '?';
 			method_name [1] = 0;
 		}

--- a/src/native/eventpipe/ep-json-file.c
+++ b/src/native/eventpipe/ep-json-file.c
@@ -95,7 +95,7 @@ ep_json_file_write_event_data (
 	ep_timestamp_t timestamp,
 	ep_rt_thread_id_t thread_id,
 	const ep_char8_t *message,
-	EventPipeStackContents *stack_contents)
+	EventPipeStackContentsInstance *stack_contents)
 {
 	ep_return_void_if_nok (json_file != NULL);
 	ep_return_void_if_nok (json_file->file_stream != NULL && !json_file->write_error_encountered );
@@ -123,17 +123,15 @@ ep_json_file_write_event_data (
 	ep_char8_t assembly_name [MAX_ASSEMBLY_NAME_LEN];
 	ep_char8_t method_name [MAX_METHOD_NAME_LEN];
 
-	for (uint32_t i = 0; i < ep_stack_contents_get_length (stack_contents); ++i) {
-		// ep_rt_method_desc_t *method = ep_stack_contents_get_method (stack_contents, i);
+	for (uint32_t i = 0; i < ep_stack_contents_instance_get_length (stack_contents); ++i) {
+		ep_rt_method_desc_t *method = ep_stack_contents_instance_get_method (stack_contents, i);
 
-		// if (!ep_rt_method_get_simple_assembly_name (method, assembly_name, ARRAY_SIZE (assembly_name))) {
-		if (true) {
+		if (!ep_rt_method_get_simple_assembly_name (method, assembly_name, ARRAY_SIZE (assembly_name))) {
 			assembly_name [0] = '?';
 			assembly_name [1] = 0;
 		}
 
-		// if (!ep_rt_method_get_full_name (method, method_name, ARRAY_SIZE (method_name))) {
-		if (true) {
+		if (!ep_rt_method_get_full_name (method, method_name, ARRAY_SIZE (method_name))) {
 			method_name [0] = '?';
 			method_name [1] = 0;
 		}

--- a/src/native/eventpipe/ep-json-file.h
+++ b/src/native/eventpipe/ep-json-file.h
@@ -52,7 +52,7 @@ ep_json_file_write_event_data (
 	ep_timestamp_t timestamp,
 	ep_rt_thread_id_t thread_id,
 	const ep_char8_t *message,
-	EventPipeStackContents *stack_contents);
+	EventPipeStackContentsInstance *stack_contents);
 
 #endif /* EP_CHECKED_BUILD */
 #endif /* ENABLE_PERFTRACING */

--- a/src/native/eventpipe/ep-stack-contents.c
+++ b/src/native/eventpipe/ep-stack-contents.c
@@ -50,6 +50,49 @@ ep_stack_contents_free (EventPipeStackContents *stack_contents)
 	ep_rt_object_free (stack_contents);
 }
 
+/*
+ * EventPipeStackContentsInstance.
+ */
+
+EventPipeStackContentsInstance *
+ep_stack_contents_instance_alloc (void)
+{
+	EventPipeStackContentsInstance *instance = ep_rt_object_alloc (EventPipeStackContentsInstance);
+	ep_raise_error_if_nok (instance != NULL);
+	ep_raise_error_if_nok (ep_stack_contents_instance_init (instance) != NULL);
+
+ep_on_exit:
+	return instance;
+
+ep_on_error:
+	ep_stack_contents_instance_free (instance);
+	instance = NULL;
+	ep_exit_error_handler ();
+}
+
+EventPipeStackContentsInstance *
+ep_stack_contents_instance_init (EventPipeStackContentsInstance *stack_contents_instance)
+{
+	EP_ASSERT (stack_contents_instance != NULL);
+
+	ep_stack_contents_instance_reset (stack_contents_instance);
+	return stack_contents_instance;
+}
+
+void
+ep_stack_contents_instance_fini (EventPipeStackContentsInstance *stack_contents_instance)
+{
+	;
+}
+
+void
+ep_stack_contents_instance_free (EventPipeStackContentsInstance *stack_contents_instance)
+{
+	ep_return_void_if_nok (stack_contents_instance != NULL);
+	ep_stack_contents_instance_fini (stack_contents_instance);
+	ep_rt_object_free (stack_contents_instance);
+}
+
 #endif /* !defined(EP_INCLUDE_SOURCE_FILES) || defined(EP_FORCE_INCLUDE_SOURCE_FILES) */
 #endif /* ENABLE_PERFTRACING */
 

--- a/src/native/eventpipe/ep-stack-contents.h
+++ b/src/native/eventpipe/ep-stack-contents.h
@@ -30,11 +30,11 @@ struct _EventPipeStackContents_Internal {
 	// Array of IP values from a stack crawl.
 	// Top of stack is at index 0.
 	uintptr_t stack_frames [EP_MAX_STACK_DEPTH];
-#ifdef EP_CHECKED_BUILD
-	// Parallel array of MethodDesc pointers.
-	// Used for debug-only stack printing.
-	ep_rt_method_desc_t *methods [EP_MAX_STACK_DEPTH];
-#endif
+// #ifdef EP_CHECKED_BUILD
+// 	// Parallel array of MethodDesc pointers.
+// 	// Used for debug-only stack printing.
+// 	ep_rt_method_desc_t *methods [EP_MAX_STACK_DEPTH];
+// #endif
 
 };
 
@@ -45,9 +45,9 @@ struct _EventPipeStackContents {
 #endif
 
 EP_DEFINE_GETTER_ARRAY_REF(EventPipeStackContents *, stack_contents, uintptr_t *, const uintptr_t *, stack_frames, stack_frames[0])
-#ifdef EP_CHECKED_BUILD
-EP_DEFINE_GETTER_ARRAY_REF(EventPipeStackContents *, stack_contents, ep_rt_method_desc_t **, ep_rt_method_desc_t *const*, methods, methods[0])
-#endif
+// #ifdef EP_CHECKED_BUILD
+// EP_DEFINE_GETTER_ARRAY_REF(EventPipeStackContents *, stack_contents, ep_rt_method_desc_t **, ep_rt_method_desc_t *const*, methods, methods[0])
+// #endif
 EP_DEFINE_GETTER(EventPipeStackContents *, stack_contents, uint32_t, next_available_frame)
 EP_DEFINE_SETTER(EventPipeStackContents *, stack_contents, uint32_t, next_available_frame)
 
@@ -75,12 +75,12 @@ ep_stack_contents_copyto (
 		ep_stack_contents_get_stack_frames_ref (stack_contents),
 		ep_stack_contents_get_next_available_frame (stack_contents) * sizeof (uintptr_t));
 
-#ifdef EP_CHECKED_BUILD
-	memcpy (
-		ep_stack_contents_get_methods_ref (dest),
-		ep_stack_contents_get_methods_ref (stack_contents),
-		ep_stack_contents_get_next_available_frame (stack_contents) * sizeof (ep_rt_method_desc_t *));
-#endif
+// #ifdef EP_CHECKED_BUILD
+// 	memcpy (
+// 		ep_stack_contents_get_methods_ref (dest),
+// 		ep_stack_contents_get_methods_ref (stack_contents),
+// 		ep_stack_contents_get_next_available_frame (stack_contents) * sizeof (ep_rt_method_desc_t *));
+// #endif
 
 	ep_stack_contents_set_next_available_frame (dest, ep_stack_contents_get_next_available_frame (stack_contents));
 }
@@ -109,21 +109,21 @@ ep_stack_contents_get_length (EventPipeStackContents *stack_contents)
 	return ep_stack_contents_get_next_available_frame (stack_contents);
 }
 
-#ifdef EP_CHECKED_BUILD
-static
-inline
-ep_rt_method_desc_t *
-ep_stack_contents_get_method (
-	EventPipeStackContents *stack_contents,
-	uint32_t frame_index)
-{
-	EP_ASSERT (frame_index < EP_MAX_STACK_DEPTH);
-	if (frame_index >= EP_MAX_STACK_DEPTH)
-		return NULL;
+// #ifdef EP_CHECKED_BUILD
+// static
+// inline
+// ep_rt_method_desc_t *
+// ep_stack_contents_get_method (
+// 	EventPipeStackContents *stack_contents,
+// 	uint32_t frame_index)
+// {
+// 	EP_ASSERT (frame_index < EP_MAX_STACK_DEPTH);
+// 	if (frame_index >= EP_MAX_STACK_DEPTH)
+// 		return NULL;
 
-	return ep_stack_contents_get_methods_cref (stack_contents)[frame_index];
-}
-#endif
+// 	return ep_stack_contents_get_methods_cref (stack_contents)[frame_index];
+// }
+// #endif
 
 static
 inline
@@ -137,9 +137,9 @@ ep_stack_contents_append (
 	uint32_t next_frame = ep_stack_contents_get_next_available_frame (stack_contents);
 	if (next_frame < EP_MAX_STACK_DEPTH) {
 		ep_stack_contents_get_stack_frames_ref (stack_contents)[next_frame] = control_pc;
-#ifdef EP_CHECKED_BUILD
-		ep_stack_contents_get_methods_ref (stack_contents)[next_frame] = method;
-#endif
+// #ifdef EP_CHECKED_BUILD
+// 		ep_stack_contents_get_methods_ref (stack_contents)[next_frame] = method;
+// #endif
 		next_frame++;
 		ep_stack_contents_set_next_available_frame (stack_contents, next_frame);
 	}
@@ -169,7 +169,7 @@ uint32_t
 ep_stack_contents_get_total_size (const EventPipeStackContents *stack_contents)
 {
 	// The total size including the size
-	return stack_contents ? (ep_stack_contents_get_next_available_frame (stack_contents) * sizeof (uintptr_t)) + sizeof (uint32_t) : 0;
+	return stack_contents ? (ep_stack_contents_get_next_available_frame (stack_contents) * sizeof (uintptr_t)) + sizeof (uint32_t) : sizeof (uint32_t);
 }
 
 #endif /* ENABLE_PERFTRACING */

--- a/src/native/eventpipe/ep-stack-contents.h
+++ b/src/native/eventpipe/ep-stack-contents.h
@@ -21,21 +21,16 @@ struct _EventPipeStackContents {
 #else
 struct _EventPipeStackContents_Internal {
 #endif
-	// TODO: Look at optimizing this when writing into buffer manager.
-	// Only write up to next available frame to better utilize memory.
-	// Even events not requesting a stack will still waste space in buffer manager.
-	// Needs to go first since it dictates size of struct.
 	// The next available slot in stack_frames.
 	uint32_t next_available_frame;
 	// Array of IP values from a stack crawl.
 	// Top of stack is at index 0.
 	uintptr_t stack_frames [EP_MAX_STACK_DEPTH];
-// #ifdef EP_CHECKED_BUILD
-// 	// Parallel array of MethodDesc pointers.
-// 	// Used for debug-only stack printing.
-// 	ep_rt_method_desc_t *methods [EP_MAX_STACK_DEPTH];
-// #endif
-
+#ifdef EP_CHECKED_BUILD
+	// Parallel array of MethodDesc pointers.
+	// Used for debug-only stack printing.
+	ep_rt_method_desc_t *methods [EP_MAX_STACK_DEPTH];
+#endif
 };
 
 #if !defined(EP_INLINE_GETTER_SETTER) && !defined(EP_IMPL_STACK_CONTENTS_GETTER_SETTER)
@@ -45,9 +40,9 @@ struct _EventPipeStackContents {
 #endif
 
 EP_DEFINE_GETTER_ARRAY_REF(EventPipeStackContents *, stack_contents, uintptr_t *, const uintptr_t *, stack_frames, stack_frames[0])
-// #ifdef EP_CHECKED_BUILD
-// EP_DEFINE_GETTER_ARRAY_REF(EventPipeStackContents *, stack_contents, ep_rt_method_desc_t **, ep_rt_method_desc_t *const*, methods, methods[0])
-// #endif
+#ifdef EP_CHECKED_BUILD
+EP_DEFINE_GETTER_ARRAY_REF(EventPipeStackContents *, stack_contents, ep_rt_method_desc_t **, ep_rt_method_desc_t *const*, methods, methods[0])
+#endif
 EP_DEFINE_GETTER(EventPipeStackContents *, stack_contents, uint32_t, next_available_frame)
 EP_DEFINE_SETTER(EventPipeStackContents *, stack_contents, uint32_t, next_available_frame)
 
@@ -62,28 +57,6 @@ ep_stack_contents_fini (EventPipeStackContents *stack_contents);
 
 void
 ep_stack_contents_free (EventPipeStackContents *stack_contents);
-
-static
-inline
-void
-ep_stack_contents_copyto (
-	EventPipeStackContents *stack_contents,
-	EventPipeStackContents *dest)
-{
-	memcpy (
-		ep_stack_contents_get_stack_frames_ref (dest),
-		ep_stack_contents_get_stack_frames_ref (stack_contents),
-		ep_stack_contents_get_next_available_frame (stack_contents) * sizeof (uintptr_t));
-
-// #ifdef EP_CHECKED_BUILD
-// 	memcpy (
-// 		ep_stack_contents_get_methods_ref (dest),
-// 		ep_stack_contents_get_methods_ref (stack_contents),
-// 		ep_stack_contents_get_next_available_frame (stack_contents) * sizeof (ep_rt_method_desc_t *));
-// #endif
-
-	ep_stack_contents_set_next_available_frame (dest, ep_stack_contents_get_next_available_frame (stack_contents));
-}
 
 static
 inline
@@ -109,21 +82,21 @@ ep_stack_contents_get_length (EventPipeStackContents *stack_contents)
 	return ep_stack_contents_get_next_available_frame (stack_contents);
 }
 
-// #ifdef EP_CHECKED_BUILD
-// static
-// inline
-// ep_rt_method_desc_t *
-// ep_stack_contents_get_method (
-// 	EventPipeStackContents *stack_contents,
-// 	uint32_t frame_index)
-// {
-// 	EP_ASSERT (frame_index < EP_MAX_STACK_DEPTH);
-// 	if (frame_index >= EP_MAX_STACK_DEPTH)
-// 		return NULL;
+#ifdef EP_CHECKED_BUILD
+static
+inline
+ep_rt_method_desc_t *
+ep_stack_contents_get_method (
+	EventPipeStackContents *stack_contents,
+	uint32_t frame_index)
+{
+	EP_ASSERT (frame_index < EP_MAX_STACK_DEPTH);
+	if (frame_index >= EP_MAX_STACK_DEPTH)
+		return NULL;
 
-// 	return ep_stack_contents_get_methods_cref (stack_contents)[frame_index];
-// }
-// #endif
+	return ep_stack_contents_get_methods_cref (stack_contents)[frame_index];
+}
+#endif
 
 static
 inline
@@ -137,9 +110,9 @@ ep_stack_contents_append (
 	uint32_t next_frame = ep_stack_contents_get_next_available_frame (stack_contents);
 	if (next_frame < EP_MAX_STACK_DEPTH) {
 		ep_stack_contents_get_stack_frames_ref (stack_contents)[next_frame] = control_pc;
-// #ifdef EP_CHECKED_BUILD
-// 		ep_stack_contents_get_methods_ref (stack_contents)[next_frame] = method;
-// #endif
+#ifdef EP_CHECKED_BUILD
+		ep_stack_contents_get_methods_ref (stack_contents)[next_frame] = method;
+#endif
 		next_frame++;
 		ep_stack_contents_set_next_available_frame (stack_contents, next_frame);
 	}
@@ -166,10 +139,163 @@ ep_stack_contents_get_size (const EventPipeStackContents *stack_contents)
 static
 inline
 uint32_t
-ep_stack_contents_get_total_size (const EventPipeStackContents *stack_contents)
+ep_stack_contents_get_instance_size (const EventPipeStackContents *stack_contents)
 {
 	// The total size including the size
+#ifdef EP_CHECKED_BUILD
+	return stack_contents ? (ep_stack_contents_get_next_available_frame (stack_contents) * sizeof (uintptr_t) * 2) + sizeof (uint32_t) : sizeof (uint32_t);
+#else /* EP_CHECKED_BUILD */
 	return stack_contents ? (ep_stack_contents_get_next_available_frame (stack_contents) * sizeof (uintptr_t)) + sizeof (uint32_t) : sizeof (uint32_t);
+#endif
+}
+
+/*
+ * EventPipeStackContentsInstance.
+ */
+
+#if defined(EP_INLINE_GETTER_SETTER) || defined(EP_IMPL_STACK_CONTENTS_GETTER_SETTER)
+struct _EventPipeStackContentsInstance {
+#else
+struct _EventPipeStackContentsInstance_Internal {
+#endif
+	// The next available slot in stack_frames.
+	uint32_t next_available_frame;
+	// Array of IP values from a stack crawl.
+	// Top of stack is at index 0.
+	// In checked builds, there is room for a
+	// parallel array of ep_rt_method_desc_t*
+	// starting at (stack_data + next_available_frame)
+	uintptr_t stack_frames [1];
+};
+
+#if !defined(EP_INLINE_GETTER_SETTER) && !defined(EP_IMPL_STACK_CONTENTS_GETTER_SETTER)
+struct _EventPipeStackContentsInstance {
+	uint8_t _internal [sizeof (struct _EventPipeStackContentsInstance_Internal)];
+};
+#endif
+
+EP_DEFINE_GETTER_ARRAY_REF(EventPipeStackContentsInstance *, stack_contents_instance, uintptr_t *, const uintptr_t *, stack_frames, stack_frames[0])
+EP_DEFINE_GETTER(EventPipeStackContentsInstance *, stack_contents_instance, uint32_t, next_available_frame)
+EP_DEFINE_SETTER(EventPipeStackContentsInstance *, stack_contents_instance, uint32_t, next_available_frame)
+
+#ifdef EP_CHECKED_BUILD
+static
+inline
+ep_rt_method_desc_t *const*
+ep_stack_contents_instance_get_methods_ref (EventPipeStackContentsInstance *stack_contents_instance)
+{
+	return (ep_rt_method_desc_t *const*)(ep_stack_contents_instance_get_stack_frames_ref (stack_contents_instance) + ep_stack_contents_instance_get_next_available_frame (stack_contents_instance));
+}
+
+static
+inline
+ep_rt_method_desc_t *const*const
+ep_stack_contents_instance_get_methods_cref (EventPipeStackContentsInstance *stack_contents_instance)
+{
+	return (ep_rt_method_desc_t *const*const)ep_stack_contents_instance_get_methods_ref (stack_contents_instance);
+}
+
+static
+inline
+ep_rt_method_desc_t *
+ep_stack_contents_instance_get_method (
+	EventPipeStackContentsInstance *stack_contents,
+	uint32_t frame_index)
+{
+	EP_ASSERT (frame_index < EP_MAX_STACK_DEPTH);
+	if (frame_index >= EP_MAX_STACK_DEPTH)
+		return NULL;
+
+	return ep_stack_contents_instance_get_methods_cref (stack_contents)[frame_index];
+}
+#endif
+
+EventPipeStackContentsInstance *
+ep_stack_contents_instance_alloc (void);
+
+EventPipeStackContentsInstance *
+ep_stack_contents_instance_init (EventPipeStackContentsInstance *stack_contents);
+
+void
+ep_stack_contents_instance_fini (EventPipeStackContentsInstance *stack_contents);
+
+void
+ep_stack_contents_instance_free (EventPipeStackContentsInstance *stack_contents);
+
+static
+inline
+void
+ep_stack_contents_instance_reset (EventPipeStackContentsInstance *stack_contents)
+{
+	ep_stack_contents_instance_set_next_available_frame (stack_contents, 0);
+}
+
+static
+inline
+uint32_t
+ep_stack_contents_instance_get_size (const EventPipeStackContentsInstance *stack_contents)
+{
+	EP_ASSERT (stack_contents != NULL);
+	return (ep_stack_contents_instance_get_next_available_frame (stack_contents) * sizeof (uintptr_t));
+}
+
+static
+inline
+uint32_t
+ep_stack_contents_instance_get_length (EventPipeStackContentsInstance *stack_contents)
+{
+	return ep_stack_contents_instance_get_next_available_frame (stack_contents);
+}
+
+inline
+uint32_t
+ep_stack_contents_instance_get_total_size (const EventPipeStackContentsInstance *stack_contents_instance)
+{
+	// The total size including the size
+#ifdef EP_CHECKED_BUILD
+	return stack_contents_instance ? (ep_stack_contents_instance_get_next_available_frame (stack_contents_instance) * sizeof (uintptr_t) * 2) + sizeof (uint32_t) : sizeof (uint32_t);
+#else /* EP_CHECKED_BUILD */
+	return stack_contents_instance ? (ep_stack_contents_instance_get_next_available_frame (stack_contents_instance) * sizeof (uintptr_t)) + sizeof (uint32_t) : sizeof (uint32_t);
+#endif
+}
+
+static
+inline
+bool
+ep_stack_contents_instance_is_empty (EventPipeStackContentsInstance *stack_contents)
+{
+	return (ep_stack_contents_instance_get_next_available_frame (stack_contents) == 0);
+}
+
+static
+inline
+uint8_t *
+ep_stack_contents_instance_get_pointer (const EventPipeStackContentsInstance *stack_contents_instance)
+{
+	EP_ASSERT (stack_contents_instance != NULL);
+	return (uint8_t *)ep_stack_contents_instance_get_stack_frames_cref (stack_contents_instance);
+}
+
+static
+inline
+void
+ep_stack_contents_flatten (
+	EventPipeStackContents *stack_contents,
+	EventPipeStackContentsInstance *dest)
+{
+	ep_stack_contents_instance_set_next_available_frame (dest, ep_stack_contents_get_next_available_frame (stack_contents));
+
+	memcpy (
+		ep_stack_contents_instance_get_stack_frames_ref (dest),
+		ep_stack_contents_get_stack_frames_ref (stack_contents),
+		ep_stack_contents_get_next_available_frame (stack_contents) * sizeof (uintptr_t));
+
+#ifdef EP_CHECKED_BUILD
+	memcpy (
+		(void*)ep_stack_contents_instance_get_methods_ref (dest),
+		ep_stack_contents_get_methods_ref (stack_contents),
+		ep_stack_contents_get_next_available_frame (stack_contents) * sizeof (ep_rt_method_desc_t *));
+#endif
 }
 
 #endif /* ENABLE_PERFTRACING */

--- a/src/native/eventpipe/ep-stack-contents.h
+++ b/src/native/eventpipe/ep-stack-contents.h
@@ -247,6 +247,7 @@ ep_stack_contents_instance_get_length (EventPipeStackContentsInstance *stack_con
 	return ep_stack_contents_instance_get_next_available_frame (stack_contents);
 }
 
+static
 inline
 uint32_t
 ep_stack_contents_instance_get_total_size (const EventPipeStackContentsInstance *stack_contents_instance)

--- a/src/native/eventpipe/ep-types-forward.h
+++ b/src/native/eventpipe/ep-types-forward.h
@@ -61,7 +61,7 @@ typedef struct _StreamWriterVtable StreamWriterVtable;
 
 #define EP_ACTIVITY_ID_SIZE EP_GUID_SIZE
 
-#define EP_MAX_STACK_DEPTH 512
+#define EP_MAX_STACK_DEPTH 200
 
 /*
  * EventPipe Enums.

--- a/src/native/eventpipe/ep-types-forward.h
+++ b/src/native/eventpipe/ep-types-forward.h
@@ -39,6 +39,7 @@ typedef struct _EventPipeSequencePoint EventPipeSequencePoint;
 typedef struct _EventPipeSequencePointBlock EventPipeSequencePointBlock;
 typedef struct _EventPipeStackBlock EventPipeStackBlock;
 typedef struct _EventPipeStackContents EventPipeStackContents;
+typedef struct _EventPipeStackContentsInstance EventPipeStackContentsInstance;
 typedef struct _EventPipeSystemTime EventPipeSystemTime;
 typedef struct _EventPipeThread EventPipeThread;
 typedef struct _EventPipeThreadHolder EventPipeThreadHolder;
@@ -60,7 +61,7 @@ typedef struct _StreamWriterVtable StreamWriterVtable;
 
 #define EP_ACTIVITY_ID_SIZE EP_GUID_SIZE
 
-#define EP_MAX_STACK_DEPTH 100
+#define EP_MAX_STACK_DEPTH 512
 
 /*
  * EventPipe Enums.

--- a/src/native/eventpipe/ep-types-forward.h
+++ b/src/native/eventpipe/ep-types-forward.h
@@ -61,7 +61,7 @@ typedef struct _StreamWriterVtable StreamWriterVtable;
 
 #define EP_ACTIVITY_ID_SIZE EP_GUID_SIZE
 
-#define EP_MAX_STACK_DEPTH 200
+#define EP_MAX_STACK_DEPTH 100
 
 /*
  * EventPipe Enums.


### PR DESCRIPTION
## Summary

Currently, the buffer manager in EventPipe uses a fixed size stack struct with room for 100 frames. This means that we are using 800 bytes per event on 64-bit systems even if the stack isn't that large. This can add up very fast when we are sending hundreds of thousands to millions of events per second per thread. N.B.: we only ever write extant stack frames to the event stream, so this wasn't an issue for the streaming data.

This patch changes the buffering behavior to only store the number of frames that were in the stack trace. This is more efficient and should result in better use of the buffers.

Local testing on my 2017 MacBook Pro with an `Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz` (4 physical cores; 8 logical cores) and 16GB of RAM shows a 44% improvement in events read and a 19% improvement in total throughput (read+ dropped). In other words, this increases the number of events attempted overall _and_ the number of events we successfully send.

#### configuration:
```
Configuration: event_size=100, event_rate=-1, cores=8, num_threads=8, reader=Stream, event_rate=-1, burst_pattern=NONE, slow_reader=0, duration=45
```

### baseline
```
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| stat                              | Min                | Max                | Average            | Standard Deviation |
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| Events Read                       |       26,769,854.00|       26,769,854.00|       26,769,854.00|                0.00|
| Events Dropped                    |       15,239,212.00|       15,239,212.00|       15,239,212.00|                0.00|
| Throughput Efficiency (%)         |               63.72|               63.72|               63.72|                0.00|
| Event Throughput (events/sec)     |          606,396.12|          606,396.12|          606,396.12|                0.00|
| Data Throughput (Bytes/sec)       |      121,279,223.90|      121,279,223.90|      121,279,223.90|                0.00|
| Duration (seconds)                |           44.145820|           44.145820|           44.145820|            0.000000|
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
```

### patch
```
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| stat                              | Min                | Max                | Average            | Standard Deviation |
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
| Events Read                       |       38,534,370.00|       38,534,370.00|       38,534,370.00|                0.00|
| Events Dropped                    |       11,319,666.00|       11,319,666.00|       11,319,666.00|                0.00|
| Throughput Efficiency (%)         |               77.29|               77.29|               77.29|                0.00|
| Event Throughput (events/sec)     |          850,760.76|          850,760.76|          850,760.76|                0.00|
| Data Throughput (Bytes/sec)       |      170,152,151.87|      170,152,151.87|      170,152,151.87|                0.00|
| Duration (seconds)                |           45.294014|           45.294014|           45.294014|            0.000000|
|-----------------------------------|--------------------|--------------------|--------------------|--------------------|
```

Some more extensive testing should be done before claiming victory on the perf improvement though. Specifically, we should run some performance testing on higher core machines and all platforms.

CC @lateralusX 