### PR TITLE
Fix compiled / source generated lazy loop stack handling

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -3526,8 +3526,10 @@ namespace System.Text.RegularExpressions
                 // goto endLoop;
                 BrFar(endLoop);
 
-                // Now handle what happens when an iteration fails.  We need to reset state to what it was before just that iteration
-                // started.  That includes resetting pos and clearing out any captures from that iteration.
+                // Now handle what happens when an iteration fails (and since a lazy loop only executes an iteration
+                // when it's required to satisfy the loop (by definition of being lazy), the loop is failing).  We need
+                // to reset state to what it was before just that iteration started.  That includes resetting pos and
+                // clearing out any captures from that iteration.
                 MarkLabel(iterationFailedLabel);
 
                 // iterationCount--;
@@ -3563,11 +3565,27 @@ namespace System.Text.RegularExpressions
 
                 if (doneLabel == originalDoneLabel)
                 {
+                    // Since the only reason we'd end up revisiting previous iterations of the lazy loop is if the child had backtracking constructs
+                    // we'd backtrack into, and the child doesn't, the whole loop is failed and done. If we successfully processed any iterations,
+                    // we thus need to pop all of the state we pushed onto the stack for those iterations, as we're exiting out to the parent who
+                    // will expect the stack to be cleared of any child state.
+                    int entriesPerIteration = 3 + (expressionHasCaptures ? 1 : 0);
+
+                    // stackpos -= entriesPerIteration * iterationCount;
                     // goto originalDoneLabel;
+                    Ldloc(stackpos);
+                    Ldc(entriesPerIteration);
+                    Ldloc(iterationCount);
+                    Mul();
+                    Sub();
+                    Stloc(stackpos);
                     BrFar(originalDoneLabel);
                 }
                 else
                 {
+                    // The child has backtracking constructs.  If we have no successful iterations previously processed, just bail.
+                    // If we do have successful iterations previously processed, however, we need to backtrack back into the last one.
+
                     // if (iterationCount == 0) goto originalDoneLabel;
                     // goto doneLabel;
                     Ldloc(iterationCount);

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -237,6 +237,8 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@"(\d{2,3}?){2}", "1234", RegexOptions.None, 0, 4, true, "1234");
                 yield return (@"((\d{2,3}?)){2}", "1234", RegexOptions.None, 0, 4, true, "1234");
                 yield return (@"(abc\d{2,3}?){2}", "abc123abc4567", RegexOptions.None, 0, 12, true, "abc123abc45");
+                yield return (@"(b|a|aa)((?:aa)+?)+?$", "aaaaaaaa", RegexOptions.None, 0, 8, true, "aaaaaaaa");
+                yield return (@"(|a|aa)(((?:aa)+?)+?|aaaaab)\w$", "aaaaaabc", RegexOptions.None, 0, 8, true, "aaaaaabc");
 
                 // Testing selected FindOptimizations finds the right prefix
                 yield return (@"(^|a+)bc", " aabc", RegexOptions.None, 0, 5, true, "aabc");


### PR DESCRIPTION
When a lazy loop has completed iterations but then ends up failing, and the thing it's looping around has no backtracking constructs, we're incorrectly leaving some state associated with the loop on the backtracking stack. That matters if something earlier in the expression will backtrack and pop associated state from the stack, as it could read the lazy loop's leftover state instead of its own. 