### PR TITLE
Overhaul when/where we check for Regex timeouts

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Timeout.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Timeout.cs
@@ -7,35 +7,56 @@ namespace System.Text.RegularExpressions
 {
     public partial class Regex
     {
-        // We need this because time is queried using Environment.TickCount for performance reasons
-        // (Environment.TickCount returns milliseconds as an int and cycles):
+        /// <summary>The maximum allowed timeout duration.</summary>
+        /// <remarks>
+        /// Previously the timeout was based on Environment.TickCount, which can overflow.  The implementation now uses Environment.TickCount64,
+        /// such that this constraint could be relaxed in the future if desired.
+        /// </remarks>
         private const ulong MaximumMatchTimeoutTicks = 10_000UL * (int.MaxValue - 1); // TimeSpan.FromMilliseconds(int.MaxValue - 1).Ticks;
 
-        // During static initialisation of Regex we check
+        /// <summary>Name of the AppContext slot that may be set to a default timeout override.</summary>
+        /// <remarks>
+        /// Setting this to a valid TimeSpan will cause that TimeSpan to be used as the timeout for <see cref="Regex"/> instances created
+        /// without a timeout.  If a timeout is explicitly provided, even if it's infinite, this value will be ignored.
+        /// </remarks>
         private const string DefaultMatchTimeout_ConfigKeyName = "REGEX_DEFAULT_MATCH_TIMEOUT";
 
-        // Number of ticks represented by InfiniteMatchTimeout
+        /// <summary>Number of ticks represented by <see cref="InfiniteMatchTimeout"/>.</summary>
         private const long InfiniteMatchTimeoutTicks = -10_000; // InfiniteMatchTimeout.Ticks
 
-        // InfiniteMatchTimeout specifies that match timeout is switched OFF. It allows for faster code paths
-        // compared to simply having a very large timeout.
-        // We do not want to ask users to use System.Threading.Timeout.InfiniteTimeSpan as a parameter because:
-        //   (1) We do not want to imply any relation between using a Regex timeout and using multi-threading.
-        //   (2) We do not want to require users to take ref to a contract assembly for threading just to use RegEx.
-        // We create a public Regex.InfiniteMatchTimeout constant, which for consistency uses the same underlying
-        // value as Timeout.InfiniteTimeSpan, creating an implementation detail dependency only.
+        // Historical note:
+        // Regex.InifiniteMatchTimeout was created instead of Timeout.InfiniteTimeSpan because of:
+        // 1) Concerns about a connection between Regex and multi-threading.
+        // 2) Concerns around requiring an extra contract assembly reference to access Timeout.
+        // Neither of these would motivate such an addition now, but the API exists.
+
+        /// <summary>Specifies that a pattern-matching operation should not time out.</summary>
         public static readonly TimeSpan InfiniteMatchTimeout = Timeout.InfiniteTimeSpan;
 
-        // DefaultMatchTimeout specifies the match timeout to use if no other timeout was specified
-        // by one means or another. Typically, it is set to InfiniteMatchTimeout.
+        /// <summary>
+        /// The default timeout value to use if one isn't explicitly specified when creating the <see cref="Regex"/>
+        /// or using its static methods (which implicitly create one if one can't be found in the cache).
+        /// </summary>
+        /// <remarks>
+        /// The default defaults to <see cref="InfiniteMatchTimeout"/> but can be overridden by setting
+        /// the <see cref="DefaultMatchTimeout_ConfigKeyName"/> <see cref="AppContext"/> slot.
+        /// </remarks>
         internal static readonly TimeSpan s_defaultMatchTimeout = InitDefaultMatchTimeout();
 
-        // timeout for the execution of this regex
+        /// <summary>Timeout for the execution of this <see cref="Regex"/>.</summary>
         protected internal TimeSpan internalMatchTimeout;
 
-        /// <summary>
-        /// The match timeout used by this Regex instance.
-        /// </summary>
+        /// <summary>Gets the timeout interval of the current instance.</summary>
+        /// <remarks>
+        /// The <see cref="MatchTimeout"/> property defines the approximate maximum time interval for a <see cref="Regex"/> instance to execute a single matching
+        /// operation before the operation times out. The regular expression engine throws a <see cref="RegexMatchTimeoutException"/> exception during
+        /// its next timing check after the timeout interval has elapsed. This prevents the regular expression engine from processing input strings
+        /// that require excessive backtracking.  The backtracking implementations guarantee that no more than O(N) work (N == length of the input)
+        /// will be performed between timeout checks, though may check more frequently.  This enables the implementations to use mechanisms like
+        /// <see cref="string.IndexOf(char)"/> to search the input.  Timeouts are considered optional for non-backtracking implementations
+        /// (<see cref="RegexOptions.NonBacktracking"/>), as the purpose of the timeout is to thwart excessive backtracking.  Such implementations
+        /// may incur up to O(N * M) operations (N == length of the input, M == length of the pattern) as part of processing input.
+        /// </remarks>
         public TimeSpan MatchTimeout => internalMatchTimeout;
 
         /// <summary>Gets the default matching timeout value.</summary>
@@ -48,28 +69,30 @@ namespace System.Text.RegularExpressions
         {
             object? defaultTimeout = AppContext.GetData(DefaultMatchTimeout_ConfigKeyName);
 
-            // If no default is specified, use fallback
-            if (defaultTimeout is null)
+            if (defaultTimeout is not TimeSpan defaultMatchTimeOut)
             {
-                return InfiniteMatchTimeout;
-            }
-
-            if (defaultTimeout is TimeSpan defaultMatchTimeOut)
-            {
-                // If default timeout is outside the valid range, throw. It will result in a TypeInitializationException:
-                try
+                // If not default was specified in AppContext, default to infinite.
+                if (defaultTimeout is null)
                 {
-                    ValidateMatchTimeout(defaultMatchTimeOut);
-                }
-                catch (ArgumentOutOfRangeException)
-                {
-                    throw new ArgumentOutOfRangeException(SR.Format(SR.IllegalDefaultRegexMatchTimeoutInAppDomain, DefaultMatchTimeout_ConfigKeyName, defaultMatchTimeOut));
+                    return InfiniteMatchTimeout;
                 }
 
-                return defaultMatchTimeOut;
+                // If a default was specified that's not a TimeSpan, throw.
+                throw new InvalidCastException(SR.Format(SR.IllegalDefaultRegexMatchTimeoutInAppDomain, DefaultMatchTimeout_ConfigKeyName, defaultTimeout));
             }
 
-            throw new InvalidCastException(SR.Format(SR.IllegalDefaultRegexMatchTimeoutInAppDomain, DefaultMatchTimeout_ConfigKeyName, defaultTimeout));
+            // If default timeout is outside the valid range, throw. As this is used in the static cctor, it will result in a TypeInitializationException
+            // for all subsequent Regex use.
+            try
+            {
+                ValidateMatchTimeout(defaultMatchTimeOut);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                throw new ArgumentOutOfRangeException(SR.Format(SR.IllegalDefaultRegexMatchTimeoutInAppDomain, DefaultMatchTimeout_ConfigKeyName, defaultMatchTimeOut));
+            }
+
+            return defaultMatchTimeOut;
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Timeout.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Timeout.cs
@@ -9,7 +9,7 @@ namespace System.Text.RegularExpressions
     {
         /// <summary>The maximum allowed timeout duration.</summary>
         /// <remarks>
-        /// Previously the timeout was based on Environment.TickCount, which can overflow.  The implementation now uses Environment.TickCount64,
+        /// Previously the timeout was based on Environment.TickCount, which can overflow. The implementation now uses Environment.TickCount64,
         /// such that this constraint could be relaxed in the future if desired.
         /// </remarks>
         private const ulong MaximumMatchTimeoutTicks = 10_000UL * (int.MaxValue - 1); // TimeSpan.FromMilliseconds(int.MaxValue - 1).Ticks;
@@ -17,7 +17,7 @@ namespace System.Text.RegularExpressions
         /// <summary>Name of the AppContext slot that may be set to a default timeout override.</summary>
         /// <remarks>
         /// Setting this to a valid TimeSpan will cause that TimeSpan to be used as the timeout for <see cref="Regex"/> instances created
-        /// without a timeout.  If a timeout is explicitly provided, even if it's infinite, this value will be ignored.
+        /// without a timeout. If a timeout is explicitly provided, even if it's infinite, this value will be ignored.
         /// </remarks>
         private const string DefaultMatchTimeout_ConfigKeyName = "REGEX_DEFAULT_MATCH_TIMEOUT";
 
@@ -51,10 +51,10 @@ namespace System.Text.RegularExpressions
         /// The <see cref="MatchTimeout"/> property defines the approximate maximum time interval for a <see cref="Regex"/> instance to execute a single matching
         /// operation before the operation times out. The regular expression engine throws a <see cref="RegexMatchTimeoutException"/> exception during
         /// its next timing check after the timeout interval has elapsed. This prevents the regular expression engine from processing input strings
-        /// that require excessive backtracking.  The backtracking implementations guarantee that no more than O(N) work (N == length of the input)
-        /// will be performed between timeout checks, though may check more frequently.  This enables the implementations to use mechanisms like
-        /// <see cref="string.IndexOf(char)"/> to search the input.  Timeouts are considered optional for non-backtracking implementations
-        /// (<see cref="RegexOptions.NonBacktracking"/>), as the purpose of the timeout is to thwart excessive backtracking.  Such implementations
+        /// that require excessive backtracking. The backtracking implementations guarantee that no more than O(N) work (N == length of the input)
+        /// will be performed between timeout checks, though may check more frequently. This enables the implementations to use mechanisms like
+        /// <see cref="string.IndexOf(char)"/> to search the input. Timeouts are considered optional for non-backtracking implementations
+        /// (<see cref="RegexOptions.NonBacktracking"/>), as the purpose of the timeout is to thwart excessive backtracking. Such implementations
         /// may incur up to O(N * M) operations (N == length of the input, M == length of the pattern) as part of processing input.
         /// </remarks>
         public TimeSpan MatchTimeout => internalMatchTimeout;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -154,7 +154,6 @@ namespace System.Text.RegularExpressions
         /// <exception cref="ArgumentOutOfRangeException">If the specified timeout is not within a valid range.</exception>
         protected internal static void ValidateMatchTimeout(TimeSpan matchTimeout)
         {
-            // make sure timeout is positive but not longer then Environment.Ticks cycle length
             long matchTimeoutTicks = matchTimeout.Ticks;
             if (matchTimeoutTicks != InfiniteMatchTimeoutTicks && ((ulong)(matchTimeoutTicks - 1) >= MaximumMatchTimeoutTicks))
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -31,8 +31,6 @@ namespace System.Text.RegularExpressions
     /// <summary>Executes a block of regular expression codes while consuming input.</summary>
     internal sealed class RegexInterpreter : RegexRunner
     {
-        private const int LoopTimeoutCheckCount = 2048; // conservative value to provide reasonably-accurate timeout handling.
-
         private readonly RegexInterpreterCode _code;
         private readonly TextInfo? _textInfo;
 
@@ -136,6 +134,8 @@ namespace System.Text.RegularExpressions
 
         private void Backtrack()
         {
+            CheckTimeout();
+
             int newpos = runtrack![runtrackpos];
             runtrackpos++;
 
@@ -379,8 +379,6 @@ namespace System.Text.RegularExpressions
                     DebugTraceCurrentState();
                 }
 #endif
-                CheckTimeout();
-
                 switch (_operator)
                 {
                     case RegexOpcode.Stop:
@@ -929,12 +927,6 @@ namespace System.Text.RegularExpressions
 
                             while (c-- > 0)
                             {
-                                // Check the timeout every 2048th iteration.
-                                if ((uint)c % LoopTimeoutCheckCount == 0)
-                                {
-                                    CheckTimeout();
-                                }
-
                                 if (!RegexCharClass.CharInClass(Forwardcharnext(inputSpan), set, ref setLookup))
                                 {
                                     goto BreakBackward;
@@ -1022,12 +1014,6 @@ namespace System.Text.RegularExpressions
 
                             for (i = len; i > 0; i--)
                             {
-                                // Check the timeout every 2048th iteration.
-                                if ((uint)i % LoopTimeoutCheckCount == 0)
-                                {
-                                    CheckTimeout();
-                                }
-
                                 if (!RegexCharClass.CharInClass(Forwardcharnext(inputSpan), set, ref setLookup))
                                 {
                                     Backwardnext();

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -134,7 +134,7 @@ namespace System.Text.RegularExpressions
 
         private void Backtrack()
         {
-            CheckTimeout();
+            CheckTimeout(); // to ensure that any backtracking operation has a timeout check
 
             int newpos = runtrack![runtrackpos];
             runtrackpos++;
@@ -685,6 +685,7 @@ namespace System.Text.RegularExpressions
                         break;                                    // Backtrack
 
                     case RegexOpcode.Setjump:
+                        CheckTimeout(); // to ensure that positive/negative lookarounds have a timeout check
                         StackPush(Trackpos(), Crawlpos());
                         TrackPush();
                         advance = 0;


### PR DESCRIPTION
Regex timeouts have never been about guaranteeing exact timeout handling; rather, they're about avoiding catastrophic backtracking.  As such, we already allow an O(n) amount of work in many cases between timeout checks.  This change formalizes that, such that we now check for a timeout at every place where we could do at least an O(n) amount of work, which essentially means every time we match at a new index and every time we backtrack.  It also removes the counting logic that previously translated only 1 out of 1000 CheckTimeout calls into a timeout check; now every CheckTimeout will query the current tick count.

This will fail CI until https://github.com/dotnet/runtime/pull/68138 is merged.

(This does not change how we do timeout checks in the NonBacktracking implementation.  Based on the above criteria, timeout checks in NonBacktracking are optional.  However, we'll likely want to continue doing them periodically, for consistency and some level of predictability.)