### PR TITLE
Allow custom attribute filtering with an open generic type.

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
@@ -1289,7 +1289,7 @@ namespace System.Reflection
             attributeType = (decoratedModule.ResolveType(scope.GetParentToken(caCtorToken), null, null) as RuntimeType)!;
 
             // Test attribute type against user provided attribute type filter
-            if (!attributeFilterType.IsAssignableFrom(attributeType))
+            if (!MatchesTypeFilter(attributeType, attributeFilterType))
                 return false;
 
             // Ensure if attribute type must be inheritable that it is inheritable
@@ -1369,6 +1369,23 @@ namespace System.Reflection
 
             GC.KeepAlive(ctorWithParameters);
             return result;
+        }
+
+        private static bool MatchesTypeFilter(RuntimeType attributeType, RuntimeType attributeFilterType)
+        {
+            if (attributeFilterType.IsGenericTypeDefinition)
+            {
+                for (RuntimeType? type = attributeType; type != null; type = (RuntimeType?)type.BaseType)
+                {
+                    if (type.IsConstructedGenericType && type.GetGenericTypeDefinition() == attributeFilterType)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            return attributeFilterType.IsAssignableFrom(attributeType);
         }
         #endregion
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeSearcher.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeSearcher.cs
@@ -74,6 +74,30 @@ namespace Internal.Reflection.Extensions.NonPortable
                         return true;
                     };
             }
+            else if (optionalAttributeTypeFilter.IsGenericTypeDefinition)
+            {
+                passesFilter =
+                    delegate (Type actualType)
+                    {
+                        if (actualType.IsConstructedGenericType && actualType.GetGenericTypeDefinition() == optionalAttributeTypeFilter)
+                        {
+                            return true;
+                        }
+
+                        if (!typeFilterKnownToBeSealed)
+                        {
+                            for (Type? type = actualType.BaseType; type != null; type = type.BaseType)
+                            {
+                                if (type.IsConstructedGenericType && type.GetGenericTypeDefinition() == optionalAttributeTypeFilter)
+                                {
+                                    return true;
+                                }
+                            }
+                        }
+
+                        return false;
+                    };
+            }
             else
             {
                 passesFilter =

--- a/src/libraries/System.Runtime/tests/System/Attributes.cs
+++ b/src/libraries/System.Runtime/tests/System/Attributes.cs
@@ -300,9 +300,15 @@ namespace System.Tests
         public static void GetCustomAttributesOnOpenGenericTypeRetrievesDerivedAttributes()
         {
             Attribute[] attributes = Attribute.GetCustomAttributes(typeof(HasGenericAttribute), typeof(GenericAttribute<>));
+            Assert.Equal(3, attributes.Length);
+            Assert.Equal(1, attributes.Count(a => a.GetType() == typeof(DerivesFromGenericAttribute)));
+            Assert.Equal(1, attributes.Count(a => a.GetType() == typeof(GenericAttribute<bool>)));
+            Assert.Equal(1, attributes.Count(a => a.GetType() == typeof(GenericAttribute<string>)));
+
+            attributes = Attribute.GetCustomAttributes(typeof(HasGenericAttribute), typeof(GenericAttribute<bool>));
             Assert.Equal(2, attributes.Length);
-            Assert.Equal(1, attributes.OfType<DerivesFromGenericAttribute>().Count());
-            Assert.Equal(1, attributes.OfType<GenericAttribute<string>>().Count());
+            Assert.Equal(1, attributes.Count(a => a.GetType() == typeof(DerivesFromGenericAttribute)));
+            Assert.Equal(1, attributes.Count(a => a.GetType() == typeof(GenericAttribute<bool>)));
         }
 
         private static void GenericAttributesTestHelper<TGenericParameter>(Func<Type, Attribute[]> getCustomAttributes)
@@ -922,6 +928,7 @@ namespace System.Tests
     [Nameable]
     public class ExampleWithAttribute { }
 
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
     public class GenericAttribute<T> : Attribute
     {
     }
@@ -932,6 +939,7 @@ namespace System.Tests
 
     [DerivesFromGeneric]
     [GenericAttribute<string>]
+    [GenericAttribute<bool>]
     public class HasGenericAttribute
     {
         [GenericAttribute<TimeSpan>]

--- a/src/tests/reflection/GenericAttribute/GenericAttributeTests.cs
+++ b/src/tests/reflection/GenericAttribute/GenericAttributeTests.cs
@@ -18,8 +18,8 @@ class Program
         Assert(((ICustomAttributeProvider)assembly).IsDefined(typeof(SingleAttribute<int>), true));
         Assert(CustomAttributeExtensions.IsDefined(assembly, typeof(SingleAttribute<bool>)));
         Assert(((ICustomAttributeProvider)assembly).IsDefined(typeof(SingleAttribute<bool>), true));
-        Assert(!CustomAttributeExtensions.GetCustomAttributes(assembly, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());
-        Assert(!CustomAttributeExtensions.GetCustomAttributes(assembly, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());
+        Assert(CustomAttributeExtensions.GetCustomAttributes(assembly, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());
+        Assert(CustomAttributeExtensions.GetCustomAttributes(assembly, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());
 */
 
         // Uncomment when https://github.com/dotnet/runtime/issues/66168 is resolved
@@ -27,8 +27,8 @@ class Program
         // AssertAny(CustomAttributeExtensions.GetCustomAttributes(module), a => a is SingleAttribute<long>);
         // Assert(CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<long>)).GetEnumerator().MoveNext());
         // Assert(CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<long>)).GetEnumerator().MoveNext());
-        // Assert(!CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());
-        // Assert(!CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());	
+        // Assert(CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());
+        // Assert(CustomAttributeExtensions.GetCustomAttributes(module, typeof(SingleAttribute<>)).GetEnumerator().MoveNext());	
 
         TypeInfo programTypeInfo = typeof(Class).GetTypeInfo();
         Assert(CustomAttributeExtensions.GetCustomAttribute<SingleAttribute<int>>(programTypeInfo) != null);
@@ -161,9 +161,9 @@ class Program
         AssertAny(b10, a => (a as MultiAttribute<Type>)?.Value == typeof(Class));
         AssertAny(b10, a => (a as MultiAttribute<Type>)?.Value == typeof(Class.Derive));
 
-        Assert(!CustomAttributeExtensions.GetCustomAttributes(programTypeInfo, typeof(MultiAttribute<>), false).GetEnumerator().MoveNext());
-        Assert(!CustomAttributeExtensions.GetCustomAttributes(programTypeInfo, typeof(MultiAttribute<>), true).GetEnumerator().MoveNext());
-        Assert(!((ICustomAttributeProvider)programTypeInfo).GetCustomAttributes(typeof(MultiAttribute<>), true).GetEnumerator().MoveNext());
+        Assert(CustomAttributeExtensions.GetCustomAttributes(programTypeInfo, typeof(MultiAttribute<>), false).GetEnumerator().MoveNext());
+        Assert(CustomAttributeExtensions.GetCustomAttributes(programTypeInfo, typeof(MultiAttribute<>), true).GetEnumerator().MoveNext());
+        Assert(((ICustomAttributeProvider)programTypeInfo).GetCustomAttributes(typeof(MultiAttribute<>), true).GetEnumerator().MoveNext());
 
         // Test coverage for CustomAttributeData api surface
         var a1_data = CustomAttributeData.GetCustomAttributes(programTypeInfo);


### PR DESCRIPTION
Filtering on an open generic type retrieves all attributes that are or
are derived from constructed instances of that type.

fix #64169