### PR TITLE
Fix JIT using too wide indirections when returning small structs

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3644,7 +3644,7 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
     assert(ret->OperIs(GT_RETURN));
     assert(varTypeIsStruct(ret));
 
-    GenTree* retVal = ret->gtGetOp1();
+    GenTree*  retVal           = ret->gtGetOp1();
     var_types nativeReturnType = comp->info.compRetNativeType;
     // Note: small types are returned as INT.
     ret->ChangeType(genActualType(nativeReturnType));

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3645,14 +3645,14 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
     assert(varTypeIsStruct(ret));
 
     GenTree* retVal = ret->gtGetOp1();
+    var_types nativeReturnType = comp->info.compRetNativeType;
     // Note: small types are returned as INT.
-    var_types nativeReturnType = genActualType(comp->info.compRetNativeType);
-    ret->ChangeType(nativeReturnType);
+    ret->ChangeType(genActualType(nativeReturnType));
 
     switch (retVal->OperGet())
     {
         case GT_CALL:
-            assert(retVal->TypeIs(nativeReturnType)); // Type should be changed during call processing.
+            assert(retVal->TypeIs(genActualType(nativeReturnType))); // Type should be changed during call processing.
             break;
 
         case GT_CNS_INT:

--- a/src/tests/JIT/Regression/JitBlue/Runtime_58874/Runtime_58874.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_58874/Runtime_58874.cs
@@ -54,21 +54,21 @@ unsafe class Runtime_58874
                 const int PAGE_READWRITE = 0x04;
 
                 // Reserve 2 pages
-                void* pages = VirtualAlloc(null, 0x2000, MEM_RESERVE, PAGE_READWRITE);
-                if (pages == null)
+                mem = VirtualAlloc(null, 0x2000, MEM_RESERVE, PAGE_READWRITE);
+                if (mem != null)
                 {
-                    return null;
-                }
-                // Commit first page
-                mem = VirtualAlloc(pages, 0x1000, MEM_COMMIT, PAGE_READWRITE);
-                if (mem != pages)
-                {
-                    return null;
+                    // Commit first page
+                    mem = VirtualAlloc(mem, 0x1000, MEM_COMMIT, PAGE_READWRITE);
                 }
             }
             else
             {
                 mem = NativeMemory.Alloc(0x1000);
+            }
+
+            if (mem == null)
+            {
+                return null;
             }
 
             return new EndOfPage { _addr = mem };

--- a/src/tests/JIT/Regression/JitBlue/Runtime_58874/Runtime_58874.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_58874/Runtime_58874.cs
@@ -9,12 +9,10 @@ unsafe class Runtime_58874
     private static int Main(string[] args)
     {
         using EndOfPage endOfPage = EndOfPage.Create();
-        if (endOfPage == null)
+        if (endOfPage != null)
         {
-            return 100;
+            Foo(endOfPage.Pointer);
         }
-
-        Foo(endOfPage.Pointer);
         return 100;
     }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_58874/Runtime_58874.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_58874/Runtime_58874.cs
@@ -1,10 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-unsafe class Runtime_58874
+public unsafe class Runtime_58874
 {
     private static int Main(string[] args)
     {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_58874/Runtime_58874.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_58874/Runtime_58874.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+unsafe class Runtime_58874
+{
+    private static int Main(string[] args)
+    {
+        void* mem;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            const int MEM_COMMIT = 0x1000;
+            const int MEM_RESERVE = 0x2000;
+            const int PAGE_READWRITE = 0x04;
+
+            // Reserve 2 pages
+            void* pages = VirtualAlloc(null, 0x2000, MEM_RESERVE, PAGE_READWRITE);
+            if (pages == null)
+            {
+                return 100;
+            }
+            // Commit first page
+            mem = VirtualAlloc(pages, 0x1000, MEM_COMMIT, PAGE_READWRITE);
+            if (mem != pages)
+            {
+                return 100;
+            }
+        }
+        else
+        {
+            mem = NativeMemory.Alloc(0x1000);
+        }
+
+        ref Test validRef = ref *(Test*)((byte*)mem + 0x1000 - sizeof(Test));
+        validRef = default;
+        Foo(ref validRef);
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Test Foo(ref Test t)
+    {
+        // This read was too wide.
+        return t;
+    }
+
+    [DllImport("kernel32")]
+    private static extern void* VirtualAlloc(void* lpAddress, nuint dwSize, uint flAllocationType, uint flProtect);
+}
+
+struct Test
+{
+    public byte A, B;
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_58874/Runtime_58874.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_58874/Runtime_58874.cs
@@ -54,21 +54,28 @@ unsafe class Runtime_58874
                 const int PAGE_READWRITE = 0x04;
 
                 // Reserve 2 pages
-                mem = VirtualAlloc(null, 0x2000, MEM_RESERVE, PAGE_READWRITE);
-                if (mem != null)
+                void* pages = VirtualAlloc(null, 0x2000, MEM_RESERVE, PAGE_READWRITE);
+                if (pages == null)
                 {
-                    // Commit first page
-                    mem = VirtualAlloc(mem, 0x1000, MEM_COMMIT, PAGE_READWRITE);
+                    return null;
+                }
+                // Commit first page
+                mem = VirtualAlloc(pages, 0x1000, MEM_COMMIT, PAGE_READWRITE);
+                if (mem != pages)
+                {
+                    return null;
                 }
             }
             else
             {
-                mem = NativeMemory.Alloc(0x1000);
-            }
-
-            if (mem == null)
-            {
-                return null;
+                try
+                {
+                    mem = NativeMemory.Alloc(0x1000);
+                }
+                catch (OutOfMemoryException)
+                {
+                    return null;
+                }
             }
 
             return new EndOfPage { _addr = mem };

--- a/src/tests/JIT/Regression/JitBlue/Runtime_58874/Runtime_58874.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_58874/Runtime_58874.cs
@@ -8,46 +8,81 @@ unsafe class Runtime_58874
 {
     private static int Main(string[] args)
     {
-        void* mem;
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        using EndOfPage endOfPage = EndOfPage.Create();
+        if (endOfPage == null)
         {
-            const int MEM_COMMIT = 0x1000;
-            const int MEM_RESERVE = 0x2000;
-            const int PAGE_READWRITE = 0x04;
-
-            // Reserve 2 pages
-            void* pages = VirtualAlloc(null, 0x2000, MEM_RESERVE, PAGE_READWRITE);
-            if (pages == null)
-            {
-                return 100;
-            }
-            // Commit first page
-            mem = VirtualAlloc(pages, 0x1000, MEM_COMMIT, PAGE_READWRITE);
-            if (mem != pages)
-            {
-                return 100;
-            }
-        }
-        else
-        {
-            mem = NativeMemory.Alloc(0x1000);
+            return 100;
         }
 
-        ref Test validRef = ref *(Test*)((byte*)mem + 0x1000 - sizeof(Test));
-        validRef = default;
-        Foo(ref validRef);
+        Foo(endOfPage.Pointer);
         return 100;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static Test Foo(ref Test t)
+    private static Test Foo(Test* t)
     {
         // This read was too wide.
-        return t;
+        return *t;
     }
 
-    [DllImport("kernel32")]
-    private static extern void* VirtualAlloc(void* lpAddress, nuint dwSize, uint flAllocationType, uint flProtect);
+    private class EndOfPage : IDisposable
+    {
+        private void* _addr;
+        private EndOfPage()
+        {
+        }
+
+        public Test* Pointer => (Test*)((byte*)_addr + 0x1000 - sizeof(Test));
+        public void Dispose()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                const int MEM_RELEASE = 0x8000;
+                VirtualFree(_addr, 0, MEM_RELEASE);
+            }
+            else
+            {
+                NativeMemory.Free(_addr);
+            }
+        }
+
+        public static EndOfPage Create()
+        {
+            void* mem;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                const int MEM_COMMIT = 0x1000;
+                const int MEM_RESERVE = 0x2000;
+                const int PAGE_READWRITE = 0x04;
+
+                // Reserve 2 pages
+                void* pages = VirtualAlloc(null, 0x2000, MEM_RESERVE, PAGE_READWRITE);
+                if (pages == null)
+                {
+                    return null;
+                }
+                // Commit first page
+                mem = VirtualAlloc(pages, 0x1000, MEM_COMMIT, PAGE_READWRITE);
+                if (mem != pages)
+                {
+                    return null;
+                }
+            }
+            else
+            {
+                mem = NativeMemory.Alloc(0x1000);
+            }
+
+            return new EndOfPage { _addr = mem };
+        }
+
+        [DllImport("kernel32")]
+        private static extern void* VirtualAlloc(void* lpAddress, nuint dwSize, uint flAllocationType, uint flProtect);
+
+        [DllImport("kernel32")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool VirtualFree(void* lpAddress, nuint dwSize, uint dwFreeType);
+    }
 }
 
 struct Test

--- a/src/tests/JIT/Regression/JitBlue/Runtime_58874/Runtime_58874.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_58874/Runtime_58874.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_58874/Runtime_58874.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_58874/Runtime_58874.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
Fix #58874
Fix #64802
Fix #68157

We should backport this given the two customer reports.