### PR TITLE
Fix a race condition in the thread pool

### DIFF
--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -1053,7 +1053,7 @@ namespace System.Threading.ThreadPools.Tests
                         return result;
                     }
 
-                    for (int j = 0; j < 1000; j++)
+                    for (int j = 0; j < 100; j++)
                     {
                         using var fileStream =
                             new FileStream(

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -1017,6 +1018,65 @@ namespace System.Threading.ThreadPools.Tests
 
                     done.CheckedWait();
                 }).Dispose();
+            }).Dispose();
+        }
+
+        [ConditionalFact(nameof(IsThreadingAndRemoteExecutorSupported))]
+        public void FileStreamFlushAsyncThreadPoolDeadlockTest()
+        {
+            // This test was occasionally causing the deadlock described in https://github.com/dotnet/runtime/pull/68171. Run it
+            // in a remote process to test it with a dedicated thread pool.
+            RemoteExecutor.Invoke(async () =>
+            {
+                const int OneKibibyte = 1 << 10;
+                const int FourKibibytes = OneKibibyte << 2;
+                const int FileSize = 1024;
+
+                string destinationFilePath = null;
+                try
+                {
+                    destinationFilePath = CreateFileWithRandomContent(FileSize);
+
+                    static string CreateFileWithRandomContent(int fileSize)
+                    {
+                        string filePath = Path.GetTempFileName();
+                        File.WriteAllBytes(filePath, CreateArray(fileSize));
+                        return filePath;
+                    }
+
+                    static byte[] CreateArray(int count)
+                    {
+                        var result = new byte[count];
+                        const int Seed = 12345;
+                        var random = new Random(Seed);
+                        random.NextBytes(result);
+                        return result;
+                    }
+
+                    for (int j = 0; j < 1000; j++)
+                    {
+                        using var fileStream =
+                            new FileStream(
+                                destinationFilePath,
+                                FileMode.Create,
+                                FileAccess.Write,
+                                FileShare.Read,
+                                FourKibibytes,
+                                FileOptions.None);
+                        for (int i = 0; i < FileSize; i++)
+                        {
+                            fileStream.WriteByte(default);
+                            await fileStream.FlushAsync();
+                        }
+                    }
+                }
+                finally
+                {
+                    if (!string.IsNullOrEmpty(destinationFilePath) && File.Exists(destinationFilePath))
+                    {
+                        File.Delete(destinationFilePath);
+                    }
+                }
             }).Dispose();
         }
 


### PR DESCRIPTION
There is a case where on a work-stealing queue, both `LocalPop()` and `TrySteal()` fail when running concurrently, and lead to a case where there is a work item but no threads are released to process it. Fixed to always ensure that there's a thread request when there was a missed steal. Also when `LocalPop()` fails, the thread does not attempt to pop anymore and that can be an issue if that thread is the last thread to look for work items. Fixed to always check the local queue. The issues were introduced by https://github.com/dotnet/runtime/pull/64834.

Fixes https://github.com/dotnet/runtime/issues/67545