### PR TITLE
Only build the GC simulator tests in the GC simulator leg

### DIFF
--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -102,7 +102,7 @@ jobs:
       - ${{ if eq(parameters.testGroup, 'gc-simulator') }}:
         - ${{ if eq(parameters.osGroup, 'windows') }}:
           - name: testTreeFilterArg
-            value: '-tree GC/Scenarios/GCSimulator'
+            value: 'tree GC/Scenarios/GCSimulator'
         - ${{ if ne(parameters.osGroup, 'windows') }}:
           - name: testTreeFilterArg
             value: '-tree:GC/Scenarios/GCSimulator'

--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -95,6 +95,18 @@ jobs:
         - name: runtimeFlavorArgs
           value: '-mono'
 
+      - name: testTreeFilterArg
+        value: ''
+      
+      # Only build GCSimulator tests when the gc-simulator group is specified.
+      - ${{ if eq(parameters.testGroup, 'gc-simulator') }}:
+        - ${{ if eq(parameters.osGroup, 'windows') }}:
+          - name: testTreeFilterArg
+            value: '-tree GC/Scenarios/GCSimulator'
+        - ${{ if ne(parameters.osGroup, 'windows') }}:
+          - name: testTreeFilterArg
+            value: '-tree:GC/Scenarios/GCSimulator'
+
     steps:
 
     # Install test build dependencies
@@ -113,7 +125,7 @@ jobs:
         displayName: Disk Usage before Build
 
     # Build managed test components
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)Managed allTargets skipnative skipgeneratelayout skiptestwrappers $(buildConfig) $(archType) $(runtimeFlavorArgs) $(crossArg) $(priorityArg) ci /p:TargetOS=AnyOS
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)Managed allTargets skipnative skipgeneratelayout skiptestwrappers $(buildConfig) $(archType) $(runtimeFlavorArgs) $(crossArg) $(priorityArg) $(testTreeFilterArg) ci /p:TargetOS=AnyOS
       displayName: Build managed test components
 
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -134,6 +134,18 @@ jobs:
         - name: LogNamePrefix
           value: TestRunLogs_R2R_CG2_Composite
 
+      - name: testTreeFilterArg
+        value: ''
+      
+      # Only build GCSimulator tests when the gc-simulator group is specified.
+      - ${{ if eq(parameters.testGroup, 'gc-simulator') }}:
+        - ${{ if eq(parameters.osGroup, 'windows') }}:
+          - name: testTreeFilterArg
+            value: '-tree GC/Scenarios/GCSimulator'
+        - ${{ if ne(parameters.osGroup, 'windows') }}:
+          - name: testTreeFilterArg
+            value: '-tree:GC/Scenarios/GCSimulator'
+
     # Set job timeouts
     #
     # "timeoutPerTestCollectionInMinutes" is the time needed for the "biggest" xUnit test collection to complete.
@@ -287,7 +299,7 @@ jobs:
     # and directly unzip them there after download). Unfortunately the logic to copy
     # the native artifacts to the final test folders is dependent on availability of the
     # managed test artifacts.
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) copynativeonly $(logRootNameArg)Native $(runtimeFlavorArgs) $(crossgenArg) $(buildConfig) $(archType) $(priorityArg) $(librariesOverrideArg)
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) copynativeonly $(logRootNameArg)Native $(runtimeFlavorArgs) $(crossgenArg) $(buildConfig) $(archType) $(priorityArg) $(testTreeFilterArg) $(librariesOverrideArg)
       displayName: Copy native test components to test output folder
 
 

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -141,7 +141,7 @@ jobs:
     - ${{ if eq(parameters.testGroup, 'gc-simulator') }}:
       - ${{ if eq(parameters.osGroup, 'windows') }}:
         - name: testTreeFilterArg
-          value: '-tree GC/Scenarios/GCSimulator'
+          value: 'tree GC/Scenarios/GCSimulator'
       - ${{ if ne(parameters.osGroup, 'windows') }}:
         - name: testTreeFilterArg
           value: '-tree:GC/Scenarios/GCSimulator'

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -134,17 +134,17 @@ jobs:
         - name: LogNamePrefix
           value: TestRunLogs_R2R_CG2_Composite
 
-      - name: testTreeFilterArg
-        value: ''
-      
-      # Only build GCSimulator tests when the gc-simulator group is specified.
-      - ${{ if eq(parameters.testGroup, 'gc-simulator') }}:
-        - ${{ if eq(parameters.osGroup, 'windows') }}:
-          - name: testTreeFilterArg
-            value: '-tree GC/Scenarios/GCSimulator'
-        - ${{ if ne(parameters.osGroup, 'windows') }}:
-          - name: testTreeFilterArg
-            value: '-tree:GC/Scenarios/GCSimulator'
+    - name: testTreeFilterArg
+      value: ''
+    
+    # Only build GCSimulator tests when the gc-simulator group is specified.
+    - ${{ if eq(parameters.testGroup, 'gc-simulator') }}:
+      - ${{ if eq(parameters.osGroup, 'windows') }}:
+        - name: testTreeFilterArg
+          value: '-tree GC/Scenarios/GCSimulator'
+      - ${{ if ne(parameters.osGroup, 'windows') }}:
+        - name: testTreeFilterArg
+          value: '-tree:GC/Scenarios/GCSimulator'
 
     # Set job timeouts
     #

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -299,7 +299,7 @@ jobs:
     # and directly unzip them there after download). Unfortunately the logic to copy
     # the native artifacts to the final test folders is dependent on availability of the
     # managed test artifacts.
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) copynativeonly $(logRootNameArg)Native $(runtimeFlavorArgs) $(crossgenArg) $(buildConfig) $(archType) $(priorityArg) $(testTreeFilterArg) $(librariesOverrideArg)
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) copynativeonly $(logRootNameArg)Native $(testTreeFilterArg) $(runtimeFlavorArgs) $(crossgenArg) $(buildConfig) $(archType) $(priorityArg) $(librariesOverrideArg)
       displayName: Copy native test components to test output folder
 
 

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -307,21 +307,21 @@
         Condition="'@(_MergedWrapperOutOfProcessTestMarkers)' != ''" />
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'@(_MergedWrapperMarker)' != ''" >
       <_MergedPayloadGroups Include="$(_MergedWrapperName)" />
       <_MergedPayloadFiles Include="$(_MergedWrapperDirectory)/**" />
       <_MergedPayloadFiles Include="@(_MergedWrapperOutOfProcessTestFiles)" />
-      <_MergedPayloadFiles Update="@(_MergedPayloadFiles)">
+      <_MergedPayloadFiles Update="@(_MergedPayloadFiles)" Condition="'@(_MergedPayloadFiles)' != ''" >
         <!-- Never use [MSBuild]::MakeRelative here! We have some files containing Unicode characters in their %(FullPath) and
              MakeRelative function calls Escape function internally that replaces all the Unicode characters with %<xx>. -->
         <FileRelativeToPayloadsRootDirectory>$([System.IO.Path]::GetRelativePath($(TestBinDir), %(FullPath)))</FileRelativeToPayloadsRootDirectory>
       </_MergedPayloadFiles>
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'@(_MergedPayloadFiles)' != ''" >
       <!-- Remove the managed pdbs from our payloads.
            This is for performance reasons to reduce our helix payload size  -->
-      <ReducedMergedPayloadFilesFinal Include="@(_MergedPayloadFiles)" Condition=" '%(Extension)' != '.pdb' and '%(Extension)' != '.OutOfProcessTest' " />
+      <ReducedMergedPayloadFilesFinal Include="@(_MergedPayloadFiles)" Condition=" '%(Extension)' != '.pdb' and '%(Extension)' != '.OutOfProcessTest'" />
     </ItemGroup>
 
     <ItemGroup>
@@ -332,7 +332,7 @@
       <HelixCommandLines Condition="'$(RuntimeVariant)' != 'llvmfullaot'" Include="$(_MergedWrapperRunScriptRelative)" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(ReducedMergedPayloadFilesFinal)" DestinationFiles="@(ReducedMergedPayloadFilesFinal->'$(MergedPayloadsRootDirectory)\$(_MergedWrapperName)\%(FileRelativeToPayloadsRootDirectory)')" />
+    <Copy SourceFiles="@(ReducedMergedPayloadFilesFinal)" DestinationFiles="@(ReducedMergedPayloadFilesFinal->'$(MergedPayloadsRootDirectory)\$(_MergedWrapperName)\%(FileRelativeToPayloadsRootDirectory)')" Condition="'@(ReducedMergedPayloadFilesFinal)' != ''" />
     <WriteLinesToFile File="$(MergedPayloadsRootDirectory)\$(_MergedWrapperName)\HelixCommand.txt" Lines="@(HelixCommandLines)" />
   </Target>
 

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -577,9 +577,15 @@
       <XUnitWrapperDlls>$([System.String]::Join(' ', $([System.IO.Directory]::GetFiles(%(FullPath), '*.XUnitWrapper.dll', SearchOption.AllDirectories))).Replace($([MSBuild]::EnsureTrailingSlash(%(FullPath))),''))</XUnitWrapperDlls>
     </LegacyPayloads>
     <LegacyPayloads Update="@(LegacyPayloads)">
+      <!-- Specify the test group from the payload name. For explicitly named groups, PayloadGroup specifies the subset of tests we want to run in this Helix Work Item -->
       <TestGroup>%(PayloadGroup)</TestGroup>
-      <!-- When Payload contains more than one *.XUnitWrapper.dll TestGroup should not be specified. -->
+      <!-- When Payload contains more than one *.XUnitWrapper.dll TestGroup should not be specified. When we specify multiple assemblies, we aren't trying to run only a subset of tests within one assembly. -->
       <TestGroup Condition=" $([MSBuild]::ValueOrDefault(%(XUnitWrapperDlls), '').IndexOf('.XUnitWrapper.dll')) != $([MSBuild]::ValueOrDefault(%(XUnitWrapperDlls), '').LastIndexOf('.XUnitWrapper.dll')) "></TestGroup>
+      <!--
+        PayloadGroup0 is just a synthesized name for a bundle of multiple test assemblies that we send as one payload.
+        Normally the condition above catches this case; however, when we're only sending one assembly, passing PayloadGroup0 to Helix means that no tests will be run.
+      -->
+      <TestGroup Condition="'%(PayloadGroup)' == 'PayloadGroup0'"></TestGroup>
       <PayloadZipFile>$(LegacyPayloadsRootDirectory)\%(PayloadGroup).zip</PayloadZipFile>
     </LegacyPayloads>
   </ItemGroup>


### PR DESCRIPTION
Only build the GC simluator tests instead of all Pri1 tests. When we build all Pri1 tests in this leg, nearly all tests are skipped as only the GCSimluator tests are actually run. These skipped tests leave a ton of files on disk, causing issues in Helix. By only building the actual tests we are going to run, we can avoid this additional infrastructure cost.

Contributes to #68176

cc: @dotnet/gc 