### PR TITLE
Use generic math to dedup Enumerable.Min/Max

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Min.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Min.cs
@@ -8,15 +8,70 @@ namespace System.Linq
 {
     public static partial class Enumerable
     {
-        public static int Min(this IEnumerable<int> source)
+        public static int Min(this IEnumerable<int> source) => MinInteger(source);
+
+        public static long Min(this IEnumerable<long> source) => MinInteger(source);
+
+        public static int? Min(this IEnumerable<int?> source) => MinInteger(source);
+
+        public static long? Min(this IEnumerable<long?> source) => MinInteger(source);
+
+        private static T MinInteger<T>(this IEnumerable<T> source) where T : struct, IBinaryInteger<T>
         {
-            if (source.TryGetSpan(out ReadOnlySpan<int> span))
+            T value;
+
+            if (source.TryGetSpan(out ReadOnlySpan<T> span))
             {
-                return Min(span);
+                if (span.IsEmpty)
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                // Vectorize the search if possible.
+                int index;
+                if (Vector.IsHardwareAccelerated && span.Length >= Vector<T>.Count * 2)
+                {
+                    // The span is at least two vectors long. Create a vector from the first N elements,
+                    // and then repeatedly compare that against the next vector from the span.  At the end,
+                    // the resulting vector will contain the minimum values found, and we then need only
+                    // to find the min of those.
+                    var mins = new Vector<T>(span);
+                    index = Vector<T>.Count;
+                    do
+                    {
+                        mins = Vector.Min(mins, new Vector<T>(span.Slice(index)));
+                        index += Vector<T>.Count;
+                    }
+                    while (index + Vector<T>.Count <= span.Length);
+
+                    value = mins[0];
+                    for (int i = 1; i < Vector<T>.Count; i++)
+                    {
+                        if (mins[i] < value)
+                        {
+                            value = mins[i];
+                        }
+                    }
+                }
+                else
+                {
+                    value = span[0];
+                    index = 1;
+                }
+
+                // Iterate through the remaining elements, comparing against the min.
+                for (int i = index; (uint)i < (uint)span.Length; i++)
+                {
+                    if (span[i] < value)
+                    {
+                        value = span[i];
+                    }
+                }
+
+                return value;
             }
 
-            int value;
-            using (IEnumerator<int> e = source.GetEnumerator())
+            using (IEnumerator<T> e = source.GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -26,7 +81,7 @@ namespace System.Linq
                 value = e.Current;
                 while (e.MoveNext())
                 {
-                    int x = e.Current;
+                    T x = e.Current;
                     if (x < value)
                     {
                         value = x;
@@ -37,68 +92,17 @@ namespace System.Linq
             return value;
         }
 
-        private static int Min(ReadOnlySpan<int> span)
-        {
-            if (span.IsEmpty)
-            {
-                ThrowHelper.ThrowNoElementsException();
-            }
-
-            // Vectorize the search if possible.
-            int index, value;
-            if (Vector.IsHardwareAccelerated && span.Length >= Vector<int>.Count * 2)
-            {
-                // The span is at least two vectors long. Create a vector from the first N elements,
-                // and then repeatedly compare that against the next vector from the span.  At the end,
-                // the resulting vector will contain the minimum values found, and we then need only
-                // to find the min of those.
-                var mins = new Vector<int>(span);
-                index = Vector<int>.Count;
-                do
-                {
-                    mins = Vector.Min(mins, new Vector<int>(span.Slice(index)));
-                    index += Vector<int>.Count;
-                }
-                while (index + Vector<int>.Count <= span.Length);
-
-                value = mins[0];
-                for (int i = 1; i < Vector<int>.Count; i++)
-                {
-                    if (mins[i] < value)
-                    {
-                        value = mins[i];
-                    }
-                }
-            }
-            else
-            {
-                value = span[0];
-                index = 1;
-            }
-
-            // Iterate through the remaining elements, comparing against the min.
-            for (int i = index; (uint)i < (uint)span.Length; i++)
-            {
-                if (span[i] < value)
-                {
-                    value = span[i];
-                }
-            }
-
-            return value;
-        }
-
-        public static int? Min(this IEnumerable<int?> source)
+        private static T? MinInteger<T>(this IEnumerable<T?> source) where T : struct, IBinaryInteger<T>
         {
             if (source == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            int? value = null;
-            using (IEnumerator<int?> e = source.GetEnumerator())
+            T? value = null;
+            using (IEnumerator<T?> e = source.GetEnumerator())
             {
-                // Start off knowing that we've a non-null value (or exit here, knowing we don't)
+                // Start off knowing that we have a non-null value (or exit here, knowing we don't)
                 // so we don't have to keep testing for nullity.
                 do
                 {
@@ -113,11 +117,11 @@ namespace System.Linq
 
                 // Keep hold of the wrapped value, and do comparisons on that, rather than
                 // using the lifted operation each time.
-                int valueVal = value.GetValueOrDefault();
+                T valueVal = value.GetValueOrDefault();
                 while (e.MoveNext())
                 {
-                    int? cur = e.Current;
-                    int x = cur.GetValueOrDefault();
+                    T? cur = e.Current;
+                    T x = cur.GetValueOrDefault();
 
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
@@ -132,136 +136,43 @@ namespace System.Linq
             return value;
         }
 
-        public static long Min(this IEnumerable<long> source)
-        {
-            if (source.TryGetSpan(out ReadOnlySpan<long> span))
-            {
-                return Min(span);
-            }
+        public static float Min(this IEnumerable<float> source) => MinFloat(source);
 
-            long value;
-            using (IEnumerator<long> e = source.GetEnumerator())
+        public static float? Min(this IEnumerable<float?> source) => MinFloat(source);
+
+        public static double Min(this IEnumerable<double> source) => MinFloat(source);
+
+        public static double? Min(this IEnumerable<double?> source) => MinFloat(source);
+
+        private static T MinFloat<T>(this IEnumerable<T> source) where T : struct, IFloatingPointIeee754<T>
+        {
+            T value;
+
+            if (source.TryGetSpan(out ReadOnlySpan<T> span))
             {
-                if (!e.MoveNext())
+                if (span.IsEmpty)
                 {
                     ThrowHelper.ThrowNoElementsException();
                 }
 
-                value = e.Current;
-                while (e.MoveNext())
-                {
-                    long x = e.Current;
-                    if (x < value)
-                    {
-                        value = x;
-                    }
-                }
-            }
-
-            return value;
-        }
-
-        private static long Min(ReadOnlySpan<long> span)
-        {
-            if (span.IsEmpty)
-            {
-                ThrowHelper.ThrowNoElementsException();
-            }
-
-            // Vectorize the search if possible.
-            int index;
-            long value;
-            if (Vector.IsHardwareAccelerated && span.Length >= Vector<long>.Count * 2)
-            {
-                // The span is at least two vectors long. Create a vector from the first N elements,
-                // and then repeatedly compare that against the next vector from the span.  At the end,
-                // the resulting vector will contain the minimum values found, and we then need only
-                // to find the min of those.
-                var mins = new Vector<long>(span);
-                index = Vector<long>.Count;
-                do
-                {
-                    mins = Vector.Min(mins, new Vector<long>(span.Slice(index)));
-                    index += Vector<long>.Count;
-                }
-                while (index + Vector<long>.Count <= span.Length);
-
-                value = mins[0];
-                for (int i = 1; i < Vector<long>.Count; i++)
-                {
-                    if (mins[i] < value)
-                    {
-                        value = mins[i];
-                    }
-                }
-            }
-            else
-            {
                 value = span[0];
-                index = 1;
-            }
-
-            // Iterate through the remaining elements, comparing against the min.
-            for (int i = index; (uint)i < (uint)span.Length; i++)
-            {
-                if (span[i] < value)
+                for (int i = 1; (uint)i < (uint)span.Length; i++)
                 {
-                    value = span[i];
-                }
-            }
-
-            return value;
-        }
-
-        public static long? Min(this IEnumerable<long?> source)
-        {
-            if (source == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
-            }
-
-            long? value = null;
-            using (IEnumerator<long?> e = source.GetEnumerator())
-            {
-                do
-                {
-                    if (!e.MoveNext())
+                    T f = span[i];
+                    if (f < value)
                     {
-                        return value;
+                        value = f;
                     }
-
-                    value = e.Current;
-                }
-                while (!value.HasValue);
-
-                long valueVal = value.GetValueOrDefault();
-                while (e.MoveNext())
-                {
-                    long? cur = e.Current;
-                    long x = cur.GetValueOrDefault();
-
-                    // Do not replace & with &&. The branch prediction cost outweighs the extra operation
-                    // unless nulls either never happen or always happen.
-                    if (cur.HasValue & x < valueVal)
+                    else if (T.IsNaN(f))
                     {
-                        valueVal = x;
-                        value = cur;
+                        return f;
                     }
                 }
+
+                return value;
             }
 
-            return value;
-        }
-
-        public static float Min(this IEnumerable<float> source)
-        {
-            if (source.TryGetSpan(out ReadOnlySpan<float> span))
-            {
-                return Min(span);
-            }
-
-            float value;
-            using (IEnumerator<float> e = source.GetEnumerator())
+            using (IEnumerator<T> e = source.GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -269,14 +180,14 @@ namespace System.Linq
                 }
 
                 value = e.Current;
-                if (float.IsNaN(value))
+                if (T.IsNaN(value))
                 {
                     return value;
                 }
 
                 while (e.MoveNext())
                 {
-                    float x = e.Current;
+                    T x = e.Current;
                     if (x < value)
                     {
                         value = x;
@@ -290,7 +201,7 @@ namespace System.Linq
                     // negative infinity.
                     // Not testing for NaN therefore isn't an option, but since we
                     // can't find a smaller value, we can short-circuit.
-                    else if (float.IsNaN(x))
+                    else if (T.IsNaN(x))
                     {
                         return x;
                     }
@@ -300,39 +211,15 @@ namespace System.Linq
             return value;
         }
 
-        private static float Min(ReadOnlySpan<float> span)
-        {
-            if (span.IsEmpty)
-            {
-                ThrowHelper.ThrowNoElementsException();
-            }
-
-            float value = span[0];
-            for (int i = 1; (uint)i < (uint)span.Length; i++)
-            {
-                float f = span[i];
-                if (f < value)
-                {
-                    value = f;
-                }
-                else if (float.IsNaN(f))
-                {
-                    return f;
-                }
-            }
-
-            return value;
-        }
-
-        public static float? Min(this IEnumerable<float?> source)
+        private static T? MinFloat<T>(this IEnumerable<T?> source) where T : struct, IFloatingPointIeee754<T>
         {
             if (source == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            float? value = null;
-            using (IEnumerator<float?> e = source.GetEnumerator())
+            T? value = null;
+            using (IEnumerator<T?> e = source.GetEnumerator())
             {
                 do
                 {
@@ -345,135 +232,24 @@ namespace System.Linq
                 }
                 while (!value.HasValue);
 
-                float valueVal = value.GetValueOrDefault();
-                if (float.IsNaN(valueVal))
+                T valueVal = value.GetValueOrDefault();
+                if (T.IsNaN(valueVal))
                 {
                     return value;
                 }
 
                 while (e.MoveNext())
                 {
-                    float? cur = e.Current;
+                    T? cur = e.Current;
                     if (cur.HasValue)
                     {
-                        float x = cur.GetValueOrDefault();
+                        T x = cur.GetValueOrDefault();
                         if (x < valueVal)
                         {
                             valueVal = x;
                             value = cur;
                         }
-                        else if (float.IsNaN(x))
-                        {
-                            return cur;
-                        }
-                    }
-                }
-            }
-
-            return value;
-        }
-
-        public static double Min(this IEnumerable<double> source)
-        {
-            if (source.TryGetSpan(out ReadOnlySpan<double> span))
-            {
-                return Min(span);
-            }
-
-            double value;
-            using (IEnumerator<double> e = source.GetEnumerator())
-            {
-                if (!e.MoveNext())
-                {
-                    ThrowHelper.ThrowNoElementsException();
-                }
-
-                value = e.Current;
-                if (double.IsNaN(value))
-                {
-                    return value;
-                }
-
-                while (e.MoveNext())
-                {
-                    double x = e.Current;
-                    if (x < value)
-                    {
-                        value = x;
-                    }
-                    else if (double.IsNaN(x))
-                    {
-                        return x;
-                    }
-                }
-            }
-
-            return value;
-        }
-
-        private static double Min(ReadOnlySpan<double> span)
-        {
-            if (span.IsEmpty)
-            {
-                ThrowHelper.ThrowNoElementsException();
-            }
-
-            double value = span[0];
-            for (int i = 1; (uint)i < (uint)span.Length; i++)
-            {
-                double d = span[i];
-                if (d < value)
-                {
-                    value = d;
-                }
-                else if (double.IsNaN(d))
-                {
-                    return d;
-                }
-            }
-
-            return value;
-        }
-
-        public static double? Min(this IEnumerable<double?> source)
-        {
-            if (source == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
-            }
-
-            double? value = null;
-            using (IEnumerator<double?> e = source.GetEnumerator())
-            {
-                do
-                {
-                    if (!e.MoveNext())
-                    {
-                        return value;
-                    }
-
-                    value = e.Current;
-                }
-                while (!value.HasValue);
-
-                double valueVal = value.GetValueOrDefault();
-                if (double.IsNaN(valueVal))
-                {
-                    return value;
-                }
-
-                while (e.MoveNext())
-                {
-                    double? cur = e.Current;
-                    if (cur.HasValue)
-                    {
-                        double x = cur.GetValueOrDefault();
-                        if (x < valueVal)
-                        {
-                            valueVal = x;
-                            value = cur;
-                        }
-                        else if (double.IsNaN(x))
+                        else if (T.IsNaN(x))
                         {
                             return cur;
                         }
@@ -486,12 +262,27 @@ namespace System.Linq
 
         public static decimal Min(this IEnumerable<decimal> source)
         {
+            decimal value;
+
             if (source.TryGetSpan(out ReadOnlySpan<decimal> span))
             {
-                return Min(span);
+                if (span.IsEmpty)
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                value = span[0];
+                for (int i = 1; (uint)i < (uint)span.Length; i++)
+                {
+                    if (span[i] < value)
+                    {
+                        value = span[i];
+                    }
+                }
+
+                return value;
             }
 
-            decimal value;
             using (IEnumerator<decimal> e = source.GetEnumerator())
             {
                 if (!e.MoveNext())
@@ -507,25 +298,6 @@ namespace System.Linq
                     {
                         value = x;
                     }
-                }
-            }
-
-            return value;
-        }
-
-        private static decimal Min(ReadOnlySpan<decimal> span)
-        {
-            if (span.IsEmpty)
-            {
-                ThrowHelper.ThrowNoElementsException();
-            }
-
-            decimal value = span[0];
-            for (int i = 1; (uint)i < (uint)span.Length; i++)
-            {
-                if (span[i] < value)
-                {
-                    value = span[i];
                 }
             }
 
@@ -773,7 +545,15 @@ namespace System.Linq
             return value;
         }
 
-        public static int Min<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector)
+        public static int Min<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector) => MinInteger(source, selector);
+
+        public static int? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector) => MinInteger(source, selector);
+
+        public static long Min<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector) => MinInteger(source, selector);
+
+        public static long? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector) => MinInteger(source, selector);
+
+        private static TResult MinInteger<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector) where TResult : struct, IBinaryInteger<TResult>
         {
             if (source == null)
             {
@@ -785,7 +565,7 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
 
-            int value;
+            TResult value;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 if (!e.MoveNext())
@@ -796,7 +576,7 @@ namespace System.Linq
                 value = selector(e.Current);
                 while (e.MoveNext())
                 {
-                    int x = selector(e.Current);
+                    TResult x = selector(e.Current);
                     if (x < value)
                     {
                         value = x;
@@ -807,7 +587,7 @@ namespace System.Linq
             return value;
         }
 
-        public static int? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
+        private static TResult? MinInteger<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult?> selector) where TResult : struct, IBinaryInteger<TResult>
         {
             if (source == null)
             {
@@ -819,7 +599,7 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
 
-            int? value = null;
+            TResult? value = null;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 // Start off knowing that we've a non-null value (or exit here, knowing we don't)
@@ -837,11 +617,11 @@ namespace System.Linq
 
                 // Keep hold of the wrapped value, and do comparisons on that, rather than
                 // using the lifted operation each time.
-                int valueVal = value.GetValueOrDefault();
+                TResult valueVal = value.GetValueOrDefault();
                 while (e.MoveNext())
                 {
-                    int? cur = selector(e.Current);
-                    int x = cur.GetValueOrDefault();
+                    TResult? cur = selector(e.Current);
+                    TResult x = cur.GetValueOrDefault();
 
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
@@ -856,7 +636,15 @@ namespace System.Linq
             return value;
         }
 
-        public static long Min<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector)
+        public static float Min<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector) => MinFloat(source, selector);
+
+        public static float? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector) => MinFloat(source, selector);
+
+        public static double Min<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector) => MinFloat(source, selector);
+
+        public static double? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector) => MinFloat(source, selector);
+
+        private static TResult MinFloat<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector) where TResult : struct, IFloatingPointIeee754<TResult>
         {
             if (source == null)
             {
@@ -868,7 +656,7 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
 
-            long value;
+            TResult value;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 if (!e.MoveNext())
@@ -877,93 +665,14 @@ namespace System.Linq
                 }
 
                 value = selector(e.Current);
-                while (e.MoveNext())
-                {
-                    long x = selector(e.Current);
-                    if (x < value)
-                    {
-                        value = x;
-                    }
-                }
-            }
-
-            return value;
-        }
-
-        public static long? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
-        {
-            if (source == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
-            }
-
-            if (selector == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
-            }
-
-            long? value = null;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
-            {
-                do
-                {
-                    if (!e.MoveNext())
-                    {
-                        return value;
-                    }
-
-                    value = selector(e.Current);
-                }
-                while (!value.HasValue);
-
-                long valueVal = value.GetValueOrDefault();
-                while (e.MoveNext())
-                {
-                    long? cur = selector(e.Current);
-                    long x = cur.GetValueOrDefault();
-
-                    // Do not replace & with &&. The branch prediction cost outweighs the extra operation
-                    // unless nulls either never happen or always happen.
-                    if (cur.HasValue & x < valueVal)
-                    {
-                        valueVal = x;
-                        value = cur;
-                    }
-                }
-            }
-
-            return value;
-        }
-
-        public static float Min<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector)
-        {
-            if (source == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
-            }
-
-            if (selector == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
-            }
-
-            float value;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
-            {
-                if (!e.MoveNext())
-                {
-                    ThrowHelper.ThrowNoElementsException();
-                }
-
-                value = selector(e.Current);
-                if (float.IsNaN(value))
+                if (TResult.IsNaN(value))
                 {
                     return value;
                 }
 
                 while (e.MoveNext())
                 {
-                    float x = selector(e.Current);
+                    TResult x = selector(e.Current);
                     if (x < value)
                     {
                         value = x;
@@ -977,7 +686,7 @@ namespace System.Linq
                     // negative infinity.
                     // Not testing for NaN therefore isn't an option, but since we
                     // can't find a smaller value, we can short-circuit.
-                    else if (float.IsNaN(x))
+                    else if (TResult.IsNaN(x))
                     {
                         return x;
                     }
@@ -987,7 +696,7 @@ namespace System.Linq
             return value;
         }
 
-        public static float? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
+        private static TResult? MinFloat<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult?> selector) where TResult : struct, IFloatingPointIeee754<TResult>
         {
             if (source == null)
             {
@@ -999,7 +708,7 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
 
-            float? value = null;
+            TResult? value = null;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 do
@@ -1013,121 +722,24 @@ namespace System.Linq
                 }
                 while (!value.HasValue);
 
-                float valueVal = value.GetValueOrDefault();
-                if (float.IsNaN(valueVal))
+                TResult valueVal = value.GetValueOrDefault();
+                if (TResult.IsNaN(valueVal))
                 {
                     return value;
                 }
 
                 while (e.MoveNext())
                 {
-                    float? cur = selector(e.Current);
+                    TResult? cur = selector(e.Current);
                     if (cur.HasValue)
                     {
-                        float x = cur.GetValueOrDefault();
+                        TResult x = cur.GetValueOrDefault();
                         if (x < valueVal)
                         {
                             valueVal = x;
                             value = cur;
                         }
-                        else if (float.IsNaN(x))
-                        {
-                            return cur;
-                        }
-                    }
-                }
-            }
-
-            return value;
-        }
-
-        public static double Min<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector)
-        {
-            if (source == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
-            }
-
-            if (selector == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
-            }
-
-            double value;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
-            {
-                if (!e.MoveNext())
-                {
-                    ThrowHelper.ThrowNoElementsException();
-                }
-
-                value = selector(e.Current);
-                if (double.IsNaN(value))
-                {
-                    return value;
-                }
-
-                while (e.MoveNext())
-                {
-                    double x = selector(e.Current);
-                    if (x < value)
-                    {
-                        value = x;
-                    }
-                    else if (double.IsNaN(x))
-                    {
-                        return x;
-                    }
-                }
-            }
-
-            return value;
-        }
-
-        public static double? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
-        {
-            if (source == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
-            }
-
-            if (selector == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
-            }
-
-            double? value = null;
-            using (IEnumerator<TSource> e = source.GetEnumerator())
-            {
-                do
-                {
-                    if (!e.MoveNext())
-                    {
-                        return value;
-                    }
-
-                    value = selector(e.Current);
-                }
-                while (!value.HasValue);
-
-                double valueVal = value.GetValueOrDefault();
-                if (double.IsNaN(valueVal))
-                {
-                    return value;
-                }
-
-                while (e.MoveNext())
-                {
-                    double? cur = selector(e.Current);
-                    if (cur.HasValue)
-                    {
-                        double x = cur.GetValueOrDefault();
-                        if (x < valueVal)
-                        {
-                            valueVal = x;
-                            value = cur;
-                        }
-                        else if (double.IsNaN(x))
+                        else if (TResult.IsNaN(x))
                         {
                             return cur;
                         }

--- a/src/libraries/System.Linq/src/System/Linq/Min.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Min.cs
@@ -158,14 +158,14 @@ namespace System.Linq
                 value = span[0];
                 for (int i = 1; (uint)i < (uint)span.Length; i++)
                 {
-                    T f = span[i];
-                    if (f < value)
+                    T current = span[i];
+                    if (current < value)
                     {
-                        value = f;
+                        value = current;
                     }
-                    else if (T.IsNaN(f))
+                    else if (T.IsNaN(current))
                     {
-                        return f;
+                        return current;
                     }
                 }
 


### PR DESCRIPTION
For each method where the same code was duplicated for multiple types, I just made one of the implementations generic and private and delegated to it from each of the public signatures.  I did not change any logic, though I did tweak a few of the existing comments.