### PR TITLE
Fixing casing issue with TargetPath

### DIFF
--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -20,7 +20,7 @@
     <ItemGroup>
       <File Include="$(CoreCLRBuildIntegrationDir)*" TargetPath="build" />
       <File Include="$(CoreCLRILCompilerDir)netstandard\*" TargetPath="tools/netstandard" />
-      <File Include="sdk\Sdk.targets" TargetPath="sdk" />
+      <File Include="sdk\Sdk.targets" TargetPath="Sdk" />
     </ItemGroup>
   </Target>
 

--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/sdk/Sdk.targets
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/sdk/Sdk.targets
@@ -1,6 +1,6 @@
 <!--
 ***********************************************************************************************
-Sdk.props
+Sdk.targets
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
           created a backup copy.  Incorrect changes to this file will make it
@@ -11,7 +11,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project>
 
-  <!-- Only import the build props if the ILLink.Tasks package isn't referenced via NuGet. -->
+  <!-- Only import the build props if the NativeAot package isn't referenced via NuGet. -->
   <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.DotNet.ILCompiler.targets" Condition="'$(PublishAot)' == 'true'"/>
 
 </Project>


### PR DESCRIPTION
The SDK seems to be dependent on the casing of the `TargetPath `on non-windows platforms