### PR TITLE
avoid allocating collection for intermediate certificates

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/SChannel/UnmanagedCertificateContext.IntPtr.cs
+++ b/src/libraries/Common/src/Interop/Windows/SChannel/UnmanagedCertificateContext.IntPtr.cs
@@ -10,13 +10,11 @@ namespace System.Net
 {
     internal static partial class UnmanagedCertificateContext
     {
-        internal static unsafe X509Certificate2Collection GetRemoteCertificatesFromStoreContext(IntPtr certContext)
+        internal static unsafe void GetRemoteCertificatesFromStoreContext(IntPtr certContext, X509Certificate2Collection result)
         {
-            X509Certificate2Collection result = new X509Certificate2Collection();
-
             if (certContext == IntPtr.Zero)
             {
-                return result;
+                return;
             }
 
             Interop.Crypt32.CERT_CONTEXT context = *(Interop.Crypt32.CERT_CONTEXT*)certContext;
@@ -47,7 +45,7 @@ namespace System.Net
                 }
             }
 
-            return result;
+            return;
         }
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/SChannel/UnmanagedCertificateContext.IntPtr.cs
+++ b/src/libraries/Common/src/Interop/Windows/SChannel/UnmanagedCertificateContext.IntPtr.cs
@@ -44,8 +44,6 @@ namespace System.Net
                     last = next;
                 }
             }
-
-            return;
         }
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/SChannel/UnmanagedCertificateContext.cs
+++ b/src/libraries/Common/src/Interop/Windows/SChannel/UnmanagedCertificateContext.cs
@@ -10,14 +10,14 @@ namespace System.Net
 {
     internal static partial class UnmanagedCertificateContext
     {
-        internal static X509Certificate2Collection GetRemoteCertificatesFromStoreContext(SafeFreeCertContext certContext)
+        internal static void GetRemoteCertificatesFromStoreContext(SafeFreeCertContext certContext, X509Certificate2Collection collection)
         {
             if (certContext.IsInvalid)
             {
-                return new X509Certificate2Collection();
+                return;
             }
 
-            return GetRemoteCertificatesFromStoreContext(certContext.DangerousGetHandle());
+            GetRemoteCertificatesFromStoreContext(certContext.DangerousGetHandle(), collection);
         }
     }
 }

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -274,8 +274,8 @@ namespace System.Net.Http
                     throw WinHttpException.CreateExceptionUsingError(lastError, "WINHTTP_CALLBACK_STATUS_SENDING_REQUEST/WinHttpQueryOption");
                 }
 
-                // Get any additional certificates sent from the remote server during the TLS/SSL handshake.
-                X509Certificate2Collection remoteCertificateStore = new X509Certificate2Collection();
+                    // Get any additional certificates sent from the remote server during the TLS/SSL handshake.
+                    X509Certificate2Collection remoteCertificateStore = new X509Certificate2Collection();
                     UnmanagedCertificateContext.GetRemoteCertificatesFromStoreContext(certHandle, remoteCertificateStore);
 
                 // Create a managed wrapper around the certificate handle. Since this results in duplicating

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -275,8 +275,8 @@ namespace System.Net.Http
                 }
 
                 // Get any additional certificates sent from the remote server during the TLS/SSL handshake.
-                X509Certificate2Collection remoteCertificateStore =
-                    UnmanagedCertificateContext.GetRemoteCertificatesFromStoreContext(certHandle);
+                X509Certificate2Collection remoteCertificateStore = new X509Certificate2Collection();
+                    UnmanagedCertificateContext.GetRemoteCertificatesFromStoreContext(certHandle, remoteCertificateStore);
 
                 // Create a managed wrapper around the certificate handle. Since this results in duplicating
                 // the handle, we will close the original handle after creating the wrapper.

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Android.cs
@@ -40,38 +40,18 @@ namespace System.Net
         //
         // Extracts a remote certificate upon request.
         //
-        internal static X509Certificate2? GetRemoteCertificate(SafeDeleteContext securityContext)
-        {
-            return GetRemoteCertificate(securityContext, null);
-        }
-
-        internal static X509Certificate2? GetRemoteCertificate(
-            SafeDeleteContext? securityContext,
-            out X509Certificate2Collection? remoteCertificateStore)
-        {
-            if (securityContext == null)
-            {
-                remoteCertificateStore = null;
-                return null;
-            }
-
-            remoteCertificateStore = new X509Certificate2Collection();
-            return GetRemoteCertificate(securityContext, remoteCertificateStore);
-        }
 
         private static X509Certificate2? GetRemoteCertificate(
             SafeDeleteContext securityContext,
-            X509Certificate2Collection? remoteCertificateStore)
+            bool retrieveChainCertificates,
+            ref X509Chain? chain)
         {
-            if (securityContext == null)
-                return null;
-
             SafeSslHandle sslContext = ((SafeDeleteSslContext)securityContext).SslContext;
             if (sslContext == null)
                 return null;
 
             X509Certificate2? cert = null;
-            if (remoteCertificateStore == null)
+            if (!retrieveChainCertificates)
             {
                 // Constructing a new X509Certificate2 adds a global reference to the pointer, so we dispose this handle
                 using (SafeX509Handle handle = Interop.AndroidCrypto.SSLStreamGetPeerCertificate(sslContext))
@@ -84,6 +64,11 @@ namespace System.Net
             }
             else
             {
+                if (chain == null)
+                {
+                    chain = new X509Chain();
+                }
+
                 IntPtr[]? ptrs = Interop.AndroidCrypto.SSLStreamGetPeerCertificates(sslContext);
                 if (ptrs != null && ptrs.Length > 0)
                 {
@@ -95,7 +80,7 @@ namespace System.Net
                         // Constructing a new X509Certificate2 adds a global reference to the pointer, so we dispose this handle
                         using (var handle = new SafeX509Handle(ptr))
                         {
-                            remoteCertificateStore.Add(new X509Certificate2(handle.DangerousGetHandle()));
+                            chain.ChainPolicy.ExtraStore.Add(new X509Certificate2(handle.DangerousGetHandle()));
                         }
                     }
 

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Android.cs
@@ -64,11 +64,7 @@ namespace System.Net
             }
             else
             {
-                if (chain == null)
-                {
-                    chain = new X509Chain();
-                }
-
+                chain ??= new X509Chain();
                 IntPtr[]? ptrs = Interop.AndroidCrypto.SSLStreamGetPeerCertificates(sslContext);
                 if (ptrs != null && ptrs.Length > 0)
                 {

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
@@ -72,10 +72,7 @@ namespace System.Net
 
                 if (retrieveChainCertificates)
                 {
-                    if (chain == null)
-                    {
-                        chain = new X509Chain();
-                    }
+                    chain ??= new X509Chain();
 
                     for (int i = 0; i < chainSize; i++)
                     {

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
@@ -47,31 +47,10 @@ namespace System.Net
             return errors;
         }
 
-        //
-        // Extracts a remote certificate upon request.
-        //
-        internal static X509Certificate2? GetRemoteCertificate(SafeDeleteContext securityContext)
-        {
-            return GetRemoteCertificate(securityContext, null);
-        }
-
-        internal static X509Certificate2? GetRemoteCertificate(
-            SafeDeleteContext? securityContext,
-            out X509Certificate2Collection? remoteCertificateStore)
-        {
-            if (securityContext == null)
-            {
-                remoteCertificateStore = null;
-                return null;
-            }
-
-            remoteCertificateStore = new X509Certificate2Collection();
-            return GetRemoteCertificate(securityContext, remoteCertificateStore);
-        }
-
         private static X509Certificate2? GetRemoteCertificate(
             SafeDeleteContext securityContext,
-            X509Certificate2Collection? remoteCertificateStore)
+            bool retrieveChainCertificates,
+            ref X509Chain? chain)
         {
             if (securityContext == null)
             {
@@ -91,12 +70,17 @@ namespace System.Net
             {
                 long chainSize = Interop.AppleCrypto.X509ChainGetChainSize(chainHandle);
 
-                if (remoteCertificateStore != null)
+                if (retrieveChainCertificates)
                 {
+                    if (chain == null)
+                    {
+                        chain = new X509Chain();
+                    }
+
                     for (int i = 0; i < chainSize; i++)
                     {
                         IntPtr certHandle = Interop.AppleCrypto.X509ChainGetCertificateAtIndex(chainHandle, i);
-                        remoteCertificateStore.Add(new X509Certificate2(certHandle));
+                        chain.ChainPolicy.ExtraStore.Add(new X509Certificate2(certHandle));
                     }
                 }
 

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
@@ -47,10 +47,7 @@ namespace System.Net
 
                 if (retrieveChainCertificates)
                 {
-                    if (chain == null)
-                    {
-                        chain = new X509Chain();
-                    }
+                    chain ??= new X509Chain();
 
                     using (SafeSharedX509StackHandle chainStack =
                         Interop.OpenSsl.GetPeerCertificateChain(((SafeDeleteSslContext)securityContext).SslContext))

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
@@ -24,26 +24,7 @@ namespace System.Net
         //
         // Extracts a remote certificate upon request.
         //
-        internal static X509Certificate2? GetRemoteCertificate(SafeDeleteContext securityContext)
-        {
-            return GetRemoteCertificate(securityContext, null);
-        }
-
-        internal static X509Certificate2? GetRemoteCertificate(
-            SafeDeleteContext? securityContext,
-            out X509Certificate2Collection? remoteCertificateStore)
-        {
-            if (securityContext == null)
-            {
-                remoteCertificateStore = null;
-                return null;
-            }
-
-            remoteCertificateStore = new X509Certificate2Collection();
-            return GetRemoteCertificate(securityContext, remoteCertificateStore);
-        }
-
-        private static X509Certificate2? GetRemoteCertificate(SafeDeleteContext? securityContext, X509Certificate2Collection? remoteCertificateStore)
+        private static X509Certificate2? GetRemoteCertificate(SafeDeleteContext? securityContext, bool retrieveChainCertificates, ref X509Chain? chain)
         {
             bool gotReference = false;
 
@@ -64,8 +45,13 @@ namespace System.Net
                     result = new X509Certificate2(remoteContext.DangerousGetHandle());
                 }
 
-                if (remoteCertificateStore != null)
+                if (retrieveChainCertificates)
                 {
+                    if (chain == null)
+                    {
+                        chain = new X509Chain();
+                    }
+
                     using (SafeSharedX509StackHandle chainStack =
                         Interop.OpenSsl.GetPeerCertificateChain(((SafeDeleteSslContext)securityContext).SslContext))
                     {
@@ -81,7 +67,7 @@ namespace System.Net
                                 {
                                     // X509Certificate2(IntPtr) calls X509_dup, so the reference is appropriately tracked.
                                     X509Certificate2 chainCert = new X509Certificate2(certPtr);
-                                    remoteCertificateStore.Add(chainCert);
+                                    chain.ChainPolicy.ExtraStore.Add(chainCert);
                                 }
                             }
                         }

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -28,17 +28,9 @@ namespace System.Net
         // Extracts a remote certificate upon request.
         //
 
-        internal static X509Certificate2? GetRemoteCertificate(SafeDeleteContext? securityContext) =>
-            GetRemoteCertificate(securityContext, retrieveCollection: false, out _);
-
-        internal static X509Certificate2? GetRemoteCertificate(SafeDeleteContext? securityContext, out X509Certificate2Collection? remoteCertificateCollection) =>
-            GetRemoteCertificate(securityContext, retrieveCollection: true, out remoteCertificateCollection);
-
         private static X509Certificate2? GetRemoteCertificate(
-            SafeDeleteContext? securityContext, bool retrieveCollection, out X509Certificate2Collection? remoteCertificateCollection)
+            SafeDeleteContext? securityContext, bool retrieveChainCertificates, ref X509Chain? chain)
         {
-            remoteCertificateCollection = null;
-
             if (securityContext == null)
             {
                 return null;
@@ -54,7 +46,7 @@ namespace System.Net
                 //
                 // We can use retrieveCollection to distinguish between in-handshake and after-handshake calls, because
                 // the collection is retrieved for cert validation purposes after the handshake completes.
-                if (retrieveCollection) // handshake completed
+                if (retrieveChainCertificates) // handshake completed
                 {
                     SSPIWrapper.QueryContextAttributes_SECPKG_ATTR_REMOTE_CERT_CONTEXT(GlobalSSPI.SSPISecureChannel, securityContext, out remoteContext);
                 }
@@ -72,9 +64,14 @@ namespace System.Net
             {
                 if (remoteContext != null && !remoteContext.IsInvalid)
                 {
-                    if (retrieveCollection)
+                    if (retrieveChainCertificates)
                     {
-                        remoteCertificateCollection = UnmanagedCertificateContext.GetRemoteCertificatesFromStoreContext(remoteContext);
+                        if (chain == null)
+                        {
+                            chain = new X509Chain();
+                        }
+
+                        UnmanagedCertificateContext.GetRemoteCertificatesFromStoreContext(remoteContext, chain.ChainPolicy.ExtraStore);
                     }
 
                     remoteContext.Dispose();

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -66,10 +66,7 @@ namespace System.Net
                 {
                     if (retrieveChainCertificates)
                     {
-                        if (chain == null)
-                        {
-                            chain = new X509Chain();
-                        }
+                        chain ??= new X509Chain();
 
                         UnmanagedCertificateContext.GetRemoteCertificatesFromStoreContext(remoteContext, chain.ChainPolicy.ExtraStore);
                     }

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.cs
@@ -8,7 +8,6 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Runtime.InteropServices;
 
-
 namespace System.Net
 {
     internal static partial class CertificateValidationPal
@@ -24,7 +23,6 @@ namespace System.Net
 
         internal static X509Certificate2? GetRemoteCertificate(SafeDeleteContext securityContext, ref X509Chain? chain) =>
             GetRemoteCertificate(securityContext, retrieveChainCertificates: true, ref chain);
-
 
         static partial void CheckSupportsStore(StoreLocation storeLocation, ref bool hasSupport);
 

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Net.Security;
 using System.Security;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Runtime.InteropServices;
+
 
 namespace System.Net
 {
@@ -14,6 +17,14 @@ namespace System.Net
 
         private static volatile X509Store? s_myCertStoreEx;
         private static volatile X509Store? s_myMachineCertStoreEx;
+        private static X509Chain? s_chain;
+
+        internal static X509Certificate2? GetRemoteCertificate(SafeDeleteContext securityContext) =>
+            GetRemoteCertificate(securityContext, retrieveChainCertificates: false, ref s_chain);
+
+        internal static X509Certificate2? GetRemoteCertificate(SafeDeleteContext securityContext, ref X509Chain? chain) =>
+            GetRemoteCertificate(securityContext, retrieveChainCertificates: true, ref chain);
+
 
         static partial void CheckSupportsStore(StoreLocation storeLocation, ref bool hasSupport);
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
@@ -114,7 +114,7 @@ namespace System.Security.Cryptography.X509Certificates
                 if (certificate == null || certificate.Pal == null)
                     throw new ArgumentException(SR.Cryptography_InvalidContextHandle, nameof(certificate));
 
-                if (_chainPolicy != null && _chainPolicy.CustomTrustStore != null)
+                if (_chainPolicy != null && _chainPolicy._customTrustStore != null)
                 {
                     if (_chainPolicy.TrustMode == X509ChainTrustMode.System && _chainPolicy.CustomTrustStore.Count > 0)
                         throw new CryptographicException(SR.Cryptography_CustomTrustCertsInSystemMode);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
@@ -114,17 +114,25 @@ namespace System.Security.Cryptography.X509Certificates
                 if (certificate == null || certificate.Pal == null)
                     throw new ArgumentException(SR.Cryptography_InvalidContextHandle, nameof(certificate));
 
-                if (_chainPolicy != null && _chainPolicy._customTrustStore != null)
+                if (_chainPolicy != null)
                 {
-                    if (_chainPolicy.TrustMode == X509ChainTrustMode.System && _chainPolicy.CustomTrustStore.Count > 0)
-                        throw new CryptographicException(SR.Cryptography_CustomTrustCertsInSystemMode);
-
-                    foreach (X509Certificate2 customCertificate in _chainPolicy.CustomTrustStore)
+                    if (_chainPolicy._customTrustStore != null)
                     {
-                        if (customCertificate == null || customCertificate.Handle == IntPtr.Zero)
+                        if (_chainPolicy.TrustMode == X509ChainTrustMode.System && _chainPolicy.CustomTrustStore.Count > 0)
+                            throw new CryptographicException(SR.Cryptography_CustomTrustCertsInSystemMode);
+
+                        foreach (X509Certificate2 customCertificate in _chainPolicy.CustomTrustStore)
                         {
-                            throw new CryptographicException(SR.Cryptography_InvalidTrustCertificate);
+                            if (customCertificate == null || customCertificate.Handle == IntPtr.Zero)
+                            {
+                                throw new CryptographicException(SR.Cryptography_InvalidTrustCertificate);
+                            }
                         }
+                    }
+
+                    if (_chainPolicy.TrustMode == X509ChainTrustMode.CustomRootTrust && _chainPolicy._customTrustStore == null)
+                    {
+                        _chainPolicy._customTrustStore = new X509Certificate2Collection();
                     }
                 }
 


### PR DESCRIPTION
There are actually two collection we will save in this change for each TLS handshake:

Current code always allocates `X509Certificate2Collection` to store intermediate certificates from handshake just to add all of them to X509Chain before validation. This change fixes the internal API so that we allocate X509Chain as needed and we add any intermediate certificates to it directly without need to allocate extra collection. (using ref X509Chain?)

The second collocation comes surprisingly from `null` check:
```c#
if (_chainPolicy != null && _chainPolicy.CustomTrustStore != null)
```

does not really work well with 
```c#
 public X509Certificate2Collection CustomTrustStore => _customTrustStore ??= new X509Certificate2Collection();
```

`CustomTrustStore` will never be `null` and the check will allocate in typical case. 