### PR TITLE
fix(wasm): Discriminate satellite assemblies loading based on culture

### DIFF
--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -467,7 +467,8 @@ async function mono_download_assets(config: MonoConfig | MonoConfigError | undef
                 });
             }
 
-            Module.addRunDependency(asset.name);
+            let moduleDependencyId = asset.name + (asset.culture || "");
+            Module.addRunDependency(moduleDependencyId);
 
             const sourcesList = asset.load_remote ? config.remote_sources! : [""];
             let error = undefined;
@@ -538,7 +539,7 @@ async function mono_download_assets(config: MonoConfig | MonoConfigError | undef
                 if (!isOkToFail)
                     throw error;
             }
-            Module.removeRunDependency(asset.name);
+            Module.removeRunDependency(moduleDependencyId);
 
             return result;
         };

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -467,7 +467,7 @@ async function mono_download_assets(config: MonoConfig | MonoConfigError | undef
                 });
             }
 
-            let moduleDependencyId = asset.name + (asset.culture || "");
+            const moduleDependencyId = asset.name + (asset.culture || "");
             Module.addRunDependency(moduleDependencyId);
 
             const sourcesList = asset.load_remote ? config.remote_sources! : [""];

--- a/src/mono/wasm/test-main.js
+++ b/src/mono/wasm/test-main.js
@@ -325,6 +325,24 @@ function processArguments(incomingArguments) {
         } else if (currentArg.startsWith("--working-dir=")) {
             const arg = currentArg.substring("--working-dir=".length);
             working_dir = arg;
+        } else if (currentArg.startsWith("--fetch-random-delay=")) {
+            const arg = currentArg.substring("--fetch-random-delay=".length);
+            if (is_browser) {
+                const delayms = Number.parseInt(arg) || 100;
+                const originalFetch = globalThis.fetch;
+                globalThis.fetch = async (url, options) => {
+                    // random sleep
+                    const ms = delayms + (Math.random() * delayms);
+                    console.log(`fetch ${url} started ${ms}`)
+                    await new Promise(resolve => setTimeout(resolve, ms));
+                    console.log(`fetch ${url} delayed ${ms}`)
+                    const res = await originalFetch(url, options);
+                    console.log(`fetch ${url} done ${ms}`)
+                    return res;
+                }
+            } else {
+                console.warn("--fetch-random-delay only works on browser")
+            }
         } else {
             break;
         }

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
@@ -129,7 +129,8 @@ namespace Wasm.Build.Tests
                                            int expectedExitCode = 0,
                                            string? args = null,
                                            Dictionary<string, string>? envVars = null,
-                                           string targetFramework = DefaultTargetFramework)
+                                           string targetFramework = DefaultTargetFramework,
+                                           string? extraXHarnessMonoArgs = null)
         {
             buildDir ??= _projectDir;
             envVars ??= new();
@@ -164,7 +165,9 @@ namespace Wasm.Build.Tests
                                 envVars: envVars,
                                 expectedAppExitCode: expectedExitCode,
                                 extraXHarnessArgs: extraXHarnessArgs,
-                                appArgs: args);
+                                appArgs: args,
+                                extraXHarnessMonoArgs: extraXHarnessMonoArgs
+                                );
 
             if (buildArgs.AOT)
             {
@@ -185,7 +188,7 @@ namespace Wasm.Build.Tests
 
         protected static string RunWithXHarness(string testCommand, string testLogPath, string projectName, string bundleDir,
                                         ITestOutputHelper _testOutput, IDictionary<string, string>? envVars=null,
-                                        int expectedAppExitCode=0, int xharnessExitCode=0, string? extraXHarnessArgs=null, string? appArgs=null)
+                                        int expectedAppExitCode=0, int xharnessExitCode=0, string? extraXHarnessArgs=null, string? appArgs=null, string? extraXHarnessMonoArgs = null)
         {
             Console.WriteLine($"============== {testCommand} =============");
             Directory.CreateDirectory(testLogPath);
@@ -199,7 +202,10 @@ namespace Wasm.Build.Tests
             args.Append($" {extraXHarnessArgs ?? string.Empty}");
 
             args.Append(" -- ");
-
+            if (extraXHarnessMonoArgs != null)
+            {
+                args.Append($" {extraXHarnessMonoArgs}");
+            }
             // App arguments
             if (envVars != null)
             {

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/SatelliteAssembliesTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/SatelliteAssembliesTests.cs
@@ -47,7 +47,10 @@ namespace Wasm.Build.Tests
             buildArgs = buildArgs with { ProjectName = projectName };
             buildArgs = ExpandBuildArgs(buildArgs,
                                         projectTemplate: s_resourcesProjectTemplate,
-                                        extraProperties: nativeRelink ? $"<WasmBuildNative>true</WasmBuildNative>" : string.Empty);
+                                        extraProperties: (nativeRelink ? $"<WasmBuildNative>true</WasmBuildNative>" : string.Empty)
+                                        // make ASSERTIONS=1 so that we test with it
+                                        + $"<EmccCompileOptimizationFlag>{ (buildArgs.Config == "Debug" ? "-O0 -sASSERTIONS=1" : "-O0 -sASSERTIONS=1")}</EmccCompileOptimizationFlag>"
+                                        );
 
             BuildProject(buildArgs,
                             id: id,
@@ -62,7 +65,9 @@ namespace Wasm.Build.Tests
             string output = RunAndTestWasmApp(
                                 buildArgs, expectedExitCode: 42,
                                 args: argCulture,
-                                host: host, id: id);
+                                host: host, id: id,
+                                // check that downloading assets doesn't have timing race conditions
+                                extraXHarnessMonoArgs: "--fetch-random-delay=200");
 
             Assert.Contains(expectedOutput, output);
         }


### PR DESCRIPTION
Fixes #68192

I could not find unit/integration tests for this. Where could I add some to validate this scenario?