### PR TITLE
Treat SuperPMI failures in AzDO pipelines as pipeline failures

### DIFF
--- a/eng/pipelines/coreclr/templates/run-superpmi-asmdiffs-checked-release-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-asmdiffs-checked-release-job.yml
@@ -84,7 +84,6 @@ jobs:
         BuildConfig: ${{ parameters.buildConfig }}
         osGroup: ${{ parameters.osGroup }}
         archType: ${{ parameters.archType }}
-        shouldContinueOnError: true # Run the future step i.e. upload superpmi logs
 
       # Always upload the available logs for diagnostics
     - task: CopyFiles@2

--- a/eng/pipelines/coreclr/templates/run-superpmi-asmdiffs-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-asmdiffs-job.yml
@@ -92,7 +92,6 @@ jobs:
         BuildConfig: ${{ parameters.buildConfig }}
         osGroup: ${{ parameters.osGroup }}
         archType: ${{ parameters.archType }}
-        shouldContinueOnError: true # Run the future step i.e. upload superpmi logs
 
       # Always upload the available logs for diagnostics
     - task: CopyFiles@2

--- a/eng/pipelines/coreclr/templates/run-superpmi-replay-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-replay-job.yml
@@ -89,7 +89,6 @@ jobs:
         BuildConfig: ${{ parameters.buildConfig }}
         osGroup: ${{ parameters.osGroup }}
         archType: ${{ parameters.archType }}
-        shouldContinueOnError: true # Run the future step i.e. upload superpmi logs
 
       # Always upload the available logs for diagnostics
     - task: CopyFiles@2


### PR DESCRIPTION
Now, any SuperPMI failure in the replay, asmdiffs, and checked/release
asmdiffs pipeplines is ignored, and doesn't cause AzDO to treat the entire
job as failed. The job does get a "!" icon, but that's only if you visit the
AzDO UI: the GitHub page on a PR doesn't see that failure.

Now that we have more experience with these pipelines, and we are using
replay and asmdiffs with JIT PRs, we want the failures to be more visible,
and treated as failures.

Note that asm diffs should not be treated as failures.