### PR TITLE
JIT: fix issue with invalid operand size in OSR prolog on arm64

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -4864,7 +4864,7 @@ void CodeGen::genEnregisterOSRArgsAndLocals()
         // Note we are always reading from the tier0 frame here
         //
         const var_types lclTyp  = varDsc->GetStackSlotHomeType();
-        const emitAttr  size    = emitTypeSize(lclTyp);
+        const emitAttr  size    = emitActualTypeSize(lclTyp);
         const int       stkOffs = patchpointInfo->Offset(lclNum) + fieldOffset;
 
 #if defined(TARGET_AMD64)

--- a/src/tests/JIT/opt/OSR/shortenregisteredlocal.cs
+++ b/src/tests/JIT/opt/OSR/shortenregisteredlocal.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT licens
+
+// Found by Antigen
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+public class ShortEnregisteredLocal
+{
+    public struct S2
+    {
+        public short short_1;
+    }
+    static byte s_byte_3 = 4;
+    static int s_int_8 = -1;
+    static float s_float_11 = -5f;
+    static S2 s_s2_17 = new S2();
+    int int_24 = 5;
+    float float_27 = 5.1025643f;
+    S2 s2_33 = new S2();
+    static int s_loopInvariant = 0;
+    public byte LeafMethod1()
+    {
+        unchecked
+        {
+            return 15%4;
+        }
+    }
+    public float LeafMethod9()
+    {
+        unchecked
+        {
+            return float_27;
+        }
+    }
+    public float Method1(ref float p_float_34, out S2 p_s2_35, byte p_byte_36, S2 p_s2_37, ref int p_int_38)
+    {
+        unchecked
+        {
+            uint uint_51 = 5;
+            S2 s2_54 = new S2();
+            S2 s2_55 = s2_54;
+            p_s2_35 = s2_33;
+            for (int __loopvar4 = s_loopInvariant; s_int_8 < s_int_8; __loopvar4 += 3, uint_51 &= 15/4)
+{}                                                            Log("s2_55", s2_55);
+            return float_27 /= 15+4;
+        }
+    }
+    public void Method0()
+    {
+        unchecked
+        {
+            S2 s2_137 = new S2();
+            do
+            {
+            }
+            while (Method1(ref float_27, out s_s2_17, s_byte_3, s2_137, ref int_24) - LeafMethod9()== (s_float_11 *= 15+4)/ Method1(ref float_27, out s2_33, LeafMethod1(), s2_33, ref s_int_8)+ 21);
+            return;
+        }
+    }
+    public static int Main(string[] args)
+    {
+        new ShortEnregisteredLocal().Method0();
+        return 100;
+    }
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Log(string varName, object varValue)
+    {
+    }
+}

--- a/src/tests/JIT/opt/OSR/shortenregisteredlocal.csproj
+++ b/src/tests/JIT/opt/OSR/shortenregisteredlocal.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType />
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_TieredCompilation=1
+set COMPlus_TC_QuickJitForLoops=1
+set COMPlus_TC_OnStackReplacement=1
+set COMPlus_TC_OnStackReplacement_InitialCounter=1
+set COMPlus_OSR_HitLimit=2
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_TieredCompilation=1
+export COMPlus_TC_QuickJitForLoops=1
+export COMPlus_TC_OnStackReplacement=1
+export COMPlus_TC_OnStackReplacement_InitialCounter=1
+export COMPlus_OSR_HitLimit=2
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Need to use `emitActualTypeSize` for the operand size.

Fixes #68170.