### PR TITLE
Two-phase matching algorithm for NonBacktracking

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DfaMatchingState.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DfaMatchingState.cs
@@ -51,7 +51,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <summary>If true then the state is a dead-end, rejects all inputs.</summary>
         internal bool IsNothing => Node.IsNothing;
 
-        /// <summary>If true then state starts with a ^ or $ or \A or \z or \Z</summary>
+        /// <summary>If true then state starts with a ^ or $ or \Z</summary>
         internal bool StartsWithLineAnchor => Node._info.StartsWithLineAnchor;
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DfaMatchingState.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DfaMatchingState.cs
@@ -134,7 +134,9 @@ namespace System.Text.RegularExpressions.Symbolic
                 // nextCharKind will be the PrevCharKind of the target state
                 // use an existing state instead if one exists already
                 // otherwise create a new new id for it
-                list.Add((Node._builder.CreateState(node, nextCharKind, capturing: true), effects));
+                DfaMatchingState<TSet> state = Node._builder.CreateState(node, nextCharKind, capturing: true);
+                if (!state.IsDeadend)
+                    list.Add((state, effects));
             }
             return list;
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DgmlWriter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DgmlWriter.cs
@@ -191,8 +191,8 @@ namespace System.Text.RegularExpressions.Symbolic
             {
                 _builder = srm._builder;
                 uint startId = reverse ?
-                    (srm._reversePattern._info.StartsWithLineAnchor ? CharKind.BeginningEnd : 0) :
-                    (srm._pattern._info.StartsWithLineAnchor ? CharKind.BeginningEnd : 0);
+                    (srm._reversePattern._info.StartsWithSomeAnchor ? CharKind.BeginningEnd : 0) :
+                    (srm._pattern._info.StartsWithSomeAnchor ? CharKind.BeginningEnd : 0);
 
                 // Create the initial state
                 _initialState = _builder.CreateState(

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
@@ -24,6 +24,7 @@ namespace System.Text.RegularExpressions.Symbolic
         internal readonly SymbolicRegexNode<TSet> _nothing;
         internal readonly SymbolicRegexNode<TSet> _anyChar;
         internal readonly SymbolicRegexNode<TSet> _anyStar;
+        internal readonly SymbolicRegexNode<TSet> _anyStarLazy;
 
         private SymbolicRegexNode<TSet>? _epsilon;
         internal SymbolicRegexNode<TSet> Epsilon => _epsilon ??= SymbolicRegexNode<TSet>.CreateEpsilon(this);
@@ -173,6 +174,7 @@ namespace System.Text.RegularExpressions.Symbolic
             _nothing = SymbolicRegexNode<TSet>.CreateFalse(this);
             _anyChar = SymbolicRegexNode<TSet>.CreateTrue(this);
             _anyStar = SymbolicRegexNode<TSet>.CreateLoop(this, _anyChar, 0, int.MaxValue, isLazy: false);
+            _anyStarLazy = SymbolicRegexNode<TSet>.CreateLoop(this, _anyChar, 0, int.MaxValue, isLazy: true);
 
             // --- initialize singletonCache ---
             _singletonCache[_solver.Empty] = _nothing;

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -754,6 +754,9 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@".*?\dFo{2}", "This1Foo should 2fOo match", RegexOptions.IgnoreCase, 0, 26, true, "This1Foo");
                 yield return (@".*?\dfoo", "1fooThis1FOO should 1foo match", RegexOptions.IgnoreCase, 4, 9, true, "This1FOO");
 
+                // Earliest match, not match with earliest end
+                yield return (@".{5}Foo|Bar", "FooBarFoo", RegexOptions.None, 1, 8, true, "ooBarFoo");
+
                 if (!RegexHelpers.IsNonBacktracking(engine))
                 {
                     // RightToLeft


### PR DESCRIPTION
This PR changes the `RegexOptions.NonBacktracking` matching algorithm to a mostly 2-phase one, fixing https://github.com/dotnet/runtime/issues/65607. Currently the first phase only walks to the first final state position, relying on a third phase to extend the match as far as possible. Now that NonBacktracking is aiming to fully match the semantics of the backtracking engines, this is problematic for some patterns. For example, `.{5}Foo|Bar` on `FooBarFoo` should match on `ooBarFoo`, but with the current algorithm it produces `Bar`, the problem being that the first phase finds the first final state at the end of `Bar` and then fails to walk backwards form that to the starting point of the preferred match.

The new algorithm has the first phase walk to the end of the preferred match, which is now possible with the backtracking simulating derivatives that we added recently. Then the second phase is the same as before, walking back to the matching starting point. The third phase is gone for all cases except for patterns with subcaptures. That third phase is a bit simpler than before too, since it doesn't have to find the end of a match (which is already known at that point).

Critically, the "dot starred" version of a regex `R`, which the first phase operates on is now using a lazy loop: `.*?R`. With the backtracking simulation this causes a partial match `T` to appear on the left side of the core pattern: `T|.*?R`. If `T` ever becomes nullable, then any lower priority parts of the derivative will disappear, allowing the matching procedure to reach a deadend state when all earlier-starting match candidates have been exhausted or extended as far as possible.

One optimization that we lose is the counter-subsumption one. This was already invalid before, but only hit the unit tests with these changes. The problem is that with the new ordered alternation combining `.{0,1}|.{0,2}` into `.{0,2}` loses the information that the shorter match is preferred. This PR removes the optimization.

I also performed a general pass of cleaning up the matching code. To summarize the changes in the PR:
- Move to a 2-phase matching algorithm that fixes semantic differences.
- Add new lazy dot star into the builder and use it for the dot-starred version of the pattern.
- Add a test (the example above) that passes with the new algorithm, but didn't pass before.
- The phase functions in `SymbolicRegexMatcher.cs` are now in the order they are called.
- The matching functions had several places where nullability was checked. The matching loops are now written to first check for nullability/deadends/more input before transitioning, which allows some consolidation of the logic. This cleanup also fixes https://github.com/dotnet/runtime/issues/65606 by removing the special case mentioned in the bug.
- Found and fixed a bug, where the "starts with line anchor" information in `SymbolicRegexInfo` didn't match for which anchors the special handling of an `\n` at the very end of the input was triggered. This was probably introduced before, but surfaced in the new matching algorithm. Removed unused bits from `SymbolicRegexInfo` at the same time.
- Remove the invalid counter optimization (details above).