### PR TITLE
JIT: fix patchpoint offset encoding

### DIFF
--- a/src/coreclr/inc/patchpointinfo.h
+++ b/src/coreclr/inc/patchpointinfo.h
@@ -149,20 +149,15 @@ struct PatchpointInfo
         return ((m_offsetAndExposureData[localNum] & EXPOSURE_MASK) != 0);
     }
 
-    void SetIsExposed(unsigned localNum)
-    {
-        m_offsetAndExposureData[localNum] |= EXPOSURE_MASK;
-    }
-
     // FP relative offset of this local in the original method
     int Offset(unsigned localNum) const
     {
-        return (m_offsetAndExposureData[localNum] & ~EXPOSURE_MASK);
+        return (m_offsetAndExposureData[localNum] >> OFFSET_SHIFT);
     }
 
-    void SetOffset(unsigned localNum, int offset)
+    void SetOffsetAndExposure(unsigned localNum, int offset, bool isExposed)
     {
-        m_offsetAndExposureData[localNum] = offset;
+        m_offsetAndExposureData[localNum] = (offset << OFFSET_SHIFT) | (isExposed ? EXPOSURE_MASK : 0);
     }
 
     // Callee save registers saved by the original method.
@@ -181,6 +176,7 @@ struct PatchpointInfo
 private:
     enum
     {
+        OFFSET_SHIFT = 0x1,
         EXPOSURE_MASK = 0x1
     };
 

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5298,14 +5298,10 @@ void Compiler::generatePatchpointInfo()
         assert(varDsc->lvFramePointerBased);
 
         // Record FramePtr relative offset (no localloc yet)
-        patchpointInfo->SetOffset(lclNum, varDsc->GetStackOffset() + offsetAdjust);
-
         // Note if IL stream contained an address-of that potentially leads to exposure.
-        // This bit of IL may be skipped by OSR partial importation.
-        if (varDsc->lvHasLdAddrOp)
-        {
-            patchpointInfo->SetIsExposed(lclNum);
-        }
+        // That bit of IL might be skipped by OSR partial importation.
+        const bool isExposed = varDsc->lvHasLdAddrOp;
+        patchpointInfo->SetOffsetAndExposure(lclNum, varDsc->GetStackOffset() + offsetAdjust, isExposed);
 
         JITDUMP("--OSR-- V%02u is at virtual offset %d%s%s\n", lclNum, patchpointInfo->Offset(lclNum),
                 patchpointInfo->IsExposed(lclNum) ? " (exposed)" : "", (varNum != lclNum) ? " (shadowed)" : "");


### PR DESCRIPTION
We can now have Tier0 locals at byte offsets, so rework how the offset
information is incoded in patchpoints to make this possible.

Closes #68194.