### PR TITLE
Fix leaks after unsuccessful assembly load

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2159,6 +2159,9 @@
   <data name="FileNotFound_ResolveAssembly" xml:space="preserve">
     <value>Could not resolve assembly '{0}'.</value>
   </data>
+  <data name="FileNotFound_LoadFile" xml:space="preserve">
+    <value>Could not load file or assembly '{0}'. The system cannot find the file specified.</value>
+  </data>
   <data name="Format_AttributeUsage" xml:space="preserve">
     <value>Duplicate AttributeUsageAttribute found on attribute type {0}.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
@@ -251,6 +251,9 @@ namespace System.Reflection
                 if (s_loadfile.TryGetValue(normalizedPath, out result))
                     return result;
 
+                if (!File.Exists(normalizedPath))
+                    throw new FileNotFoundException(SR.Format(SR.FileNotFound_LoadFile, normalizedPath), normalizedPath);
+
                 AssemblyLoadContext alc = new IndividualAssemblyLoadContext($"Assembly.LoadFile({normalizedPath})");
                 result = alc.LoadFromAssemblyPath(normalizedPath);
                 s_loadfile.Add(normalizedPath, result);


### PR DESCRIPTION
This is about regular (not collectible) assembly loads. Unsuccessful load leaves stuff behind that can accumulate rather quickly if the client, such as serializer, opportunistically loads various non-existant things. 
The leak is a regression compared to .net FX.

As the load fails we leak both the managed and the native parts of the context into which we loaded nothing.

Fixes:#58093