### PR TITLE
Remove CallArgABIInfo::ArgNum and fill out function headers

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1343,6 +1343,12 @@ CallArgs::CallArgs()
 //---------------------------------------------------------------
 // FindByNode: Find the argument containing the specified early or late node.
 //
+// Parameters:
+//   node - The node to find.
+//
+// Returns:
+//   A pointer to the found CallArg, or otherwise nullptr.
+//
 CallArg* CallArgs::FindByNode(GenTree* node)
 {
     assert(node != nullptr);
@@ -1359,6 +1365,12 @@ CallArg* CallArgs::FindByNode(GenTree* node)
 
 //---------------------------------------------------------------
 // FindWellKnownArg: Find a specific well-known argument.
+//
+// Parameters:
+//   arg - The type of well-known argument.
+//
+// Returns:
+//   A pointer to the found CallArg, or null if it was not found.
 //
 // Remarks:
 //   For the 'this' arg or the return buffer arg there are more efficient
@@ -1381,6 +1393,9 @@ CallArg* CallArgs::FindWellKnownArg(WellKnownArg arg)
 //---------------------------------------------------------------
 // GetThisArg: Get the this-pointer argument.
 //
+// Returns:
+//   A pointer to the 'this' arg, or nullptr if there is no such arg.
+//
 // Remarks:
 //   This is only the managed 'this' arg. We consider the 'this' pointer for
 //   unmanaged instance calling conventions as normal (non-this) arguments.
@@ -1401,6 +1416,9 @@ CallArg* CallArgs::GetThisArg()
 
 //---------------------------------------------------------------
 // GetRetBufferArg: Get the return buffer arg.
+//
+// Returns:
+//   A pointer to the ret-buffer arg, or nullptr if there is no such arg.
 //
 // Remarks:
 //   This is the actual (per-ABI) return buffer argument. On some ABIs this
@@ -1428,12 +1446,21 @@ CallArg* CallArgs::GetRetBufferArg()
 //---------------------------------------------------------------
 // GetArgByIndex: Get an argument with the specified index.
 //
+// Parameters:
+//   index - The index of the argument to find.
+//
+// Returns:
+//   A pointer to the argument.
+//
+// Remarks:
+//   This function assumes enough arguments exist.
+//
 CallArg* CallArgs::GetArgByIndex(unsigned index)
 {
     CallArg* cur = m_head;
     for (unsigned i = 0; i < index; i++)
     {
-        assert(cur != nullptr);
+        assert((cur != nullptr) && "Not enough arguments in GetArgByIndex");
         cur = cur->GetNext();
     }
 
@@ -1442,6 +1469,12 @@ CallArg* CallArgs::GetArgByIndex(unsigned index)
 
 //---------------------------------------------------------------
 // GetIndex: Get the index for the specified argument.
+//
+// Parameters:
+//   arg - The argument to obtain the index of.
+//
+// Returns:
+//   The index.
 //
 unsigned CallArgs::GetIndex(CallArg* arg)
 {
@@ -1499,6 +1532,9 @@ void CallArgs::Reverse(unsigned index, unsigned count)
 //---------------------------------------------------------------
 // AddedWellKnownArg: Record details when a well known arg was added.
 //
+// Parameters:
+//   arg - The type of well-known arg that was just added.
+//
 // Remarks:
 //   This is used to improve performance of some common argument lookups.
 //
@@ -1519,6 +1555,9 @@ void CallArgs::AddedWellKnownArg(WellKnownArg arg)
 
 //---------------------------------------------------------------
 // RemovedWellKnownArg: Record details when a well known arg was removed.
+//
+// Parameters:
+//   arg - The type of well-known arg that was just removed.
 //
 void CallArgs::RemovedWellKnownArg(WellKnownArg arg)
 {
@@ -1632,6 +1671,14 @@ regNumber CallArgs::GetCustomRegister(Compiler* comp, CorInfoCallConvExtension c
 //---------------------------------------------------------------
 // IsNonStandard: Check if an argument is passed with a non-standard calling
 // convention.
+//
+// Parameters:
+//   comp - The compiler object.
+//   call - The call node containing these args.
+//   arg  - The specific arg to check whether is non-standard.
+//
+// Returns:
+//   True if the argument is non-standard.
 //
 bool CallArgs::IsNonStandard(Compiler* comp, GenTreeCall* call, CallArg* arg)
 {
@@ -1784,6 +1831,9 @@ CallArg* CallArgs::InsertAfterThisOrFirst(Compiler* comp, GenTree* node, WellKno
 //---------------------------------------------------------------
 // PushLateBack: Insert an argument at the end of the 'late' argument list.
 //
+// Parameters:
+//   arg - The arg to add to the late argument list.
+//
 // Remarks:
 //   This function should only be used if adding arguments after the call has
 //   already been morphed.
@@ -1801,6 +1851,9 @@ void CallArgs::PushLateBack(CallArg* arg)
 
 //---------------------------------------------------------------
 // Remove: Remove an argument from the argument list.
+//
+// Parameters:
+//   arg - The arg to remove.
 //
 // Remarks:
 //   This function cannot be used after morph. It will also invalidate ABI
@@ -1869,7 +1922,7 @@ regMaskTP GenTreeCall::GetOtherRegMask() const
 //    performed.
 //
 // Arguments:
-//    Copiler - the compiler context.
+//    compiler - the compiler context.
 //
 // Returns:
 //    True if the call is pure; false otherwise.
@@ -12237,8 +12290,6 @@ void Compiler::gtGetLateArgMsg(GenTreeCall* call, CallArg* arg, char* bufp, unsi
 //
 void Compiler::gtDispArgList(GenTreeCall* call, GenTree* lastCallOperand, IndentStack* indentStack)
 {
-    unsigned argNum = 0;
-
     for (CallArg& arg : call->gtArgs.Args())
     {
         if (!arg.GetEarlyNode()->IsNothingNode() && !arg.GetEarlyNode()->IsArgPlaceHolderNode())

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4017,8 +4017,7 @@ const char* getWellKnownArgName(WellKnownArg arg);
 struct CallArgABIInformation
 {
     CallArgABIInformation()
-        : ArgNum((unsigned)-1)
-        , NumRegs(0)
+        : NumRegs(0)
         , ByteOffset(0)
         , ByteSize(0)
         , ByteAlignment(0)
@@ -4049,10 +4048,6 @@ struct CallArgABIInformation
             RegNums[i] = REG_NA;
         }
     }
-
-    // The original argument number, also specifies the required argument
-    // evaluation order from the IL
-    unsigned ArgNum;
 
 private:
     // The registers to use when passing this argument, set to REG_STK for

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2414,7 +2414,6 @@ void Lowering::LowerCFGCall(GenTreeCall* call)
             call->gtArgs.PushLateBack(targetArg);
 
             // Set up ABI information for this arg.
-            targetArg->AbiInfo.ArgNum  = call->gtArgs.CountArgs() - 1;
             targetArg->AbiInfo.ArgType = callTarget->TypeGet();
             targetArg->AbiInfo.SetRegNum(0, REG_DISPATCH_INDIRECT_CALL_ADDR);
             targetArg->AbiInfo.NumRegs = 1;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -635,8 +635,7 @@ const char* getWellKnownArgName(WellKnownArg arg)
 //
 void CallArg::Dump(Compiler* comp)
 {
-    printf("CallArg[arg %u", AbiInfo.ArgNum);
-    printf(" [%06u].%s", comp->dspTreeID(GetNode()), GenTree::OpName(GetEarlyNode()->OperGet()));
+    printf("CallArg[[%06u].%s", comp->dspTreeID(GetNode()), GenTree::OpName(GetEarlyNode()->OperGet()));
     printf(" %s", varTypeName(AbiInfo.ArgType));
     printf(" (%s)", AbiInfo.PassedByRef ? "By ref" : "By value");
     if (AbiInfo.GetRegNum() != REG_STK)
@@ -1909,6 +1908,10 @@ GenTree* Compiler::fgInsertCommaFormTemp(GenTree** ppTree, CORINFO_CLASS_HANDLE 
 // AddFinalArgsAndDetermineABIInfo:
 //   Add final arguments and determine the argument ABI information.
 //
+// Parameters:
+//   comp - The compiler object.
+//   call - The call to which the CallArgs belongs.
+//
 // Remarks:
 //   This adds the final "non-standard" arguments to the call and categorizes
 //   all the ABI information required for downstream JIT phases. This function
@@ -2810,7 +2813,6 @@ void CallArgs::AddFinalArgsAndDetermineABIInfo(Compiler* comp, GenTreeCall* call
 #endif // TARGET_ARM
 
         arg.AbiInfo          = {};
-        arg.AbiInfo.ArgNum   = argIndex;
         arg.AbiInfo.ArgType  = argx->TypeGet();
         arg.AbiInfo.IsStruct = isStructArg;
 
@@ -3113,7 +3115,7 @@ unsigned CallArgs::CountArgs()
 // fgMorphArgs: Walk and transform (morph) the arguments of a call
 //
 // Arguments:
-//    callNode - the call for which we are doing the argument morphing
+//    call - the call for which we are doing the argument morphing
 //
 // Return Value:
 //    Like most morph methods, this method returns the morphed node,
@@ -8268,7 +8270,7 @@ GenTree* Compiler::fgGetStubAddrArg(GenTreeCall* call)
 //
 unsigned Compiler::fgGetArgParameterLclNum(GenTreeCall* call, CallArg* arg)
 {
-    unsigned num = arg->AbiInfo.ArgNum;
+    unsigned num = 0;
 
     for (CallArg& otherArg : call->gtArgs.Args())
     {
@@ -8276,11 +8278,12 @@ unsigned Compiler::fgGetArgParameterLclNum(GenTreeCall* call, CallArg* arg)
         {
             break;
         }
+
         // Late added args add extra args that do not map to IL parameters and that we should not reassign.
         if (!otherArg.IsArgAddedLate())
-            continue;
-
-        num--;
+        {
+            num++;
+        }
     }
 
     return num;


### PR DESCRIPTION
CallArgABIInfo::ArgNum is essentially unnecessary now that arguments are
stored in order so remove it.

Also address some feedback from the refactoring and fill out some
function headers.

cc @dotnet/jit-contrib PTAL @AndyAyersMS 