### PR TITLE
Vectorized MemoryExtensions.CommonPrefixLength

### DIFF
--- a/src/libraries/System.Memory/tests/Span/CommonPrefixLength.T.cs
+++ b/src/libraries/System.Memory/tests/Span/CommonPrefixLength.T.cs
@@ -62,7 +62,7 @@ namespace System.SpanTests
         }
 
         [Fact]
-        public static void PartialEquals_ReturnsPrefixLength_ValueType()
+        public static void PartialEquals_ReturnsPrefixLength_Byte()
         {
             byte[] arr1 = new byte[] { 1, 2, 3, 4, 5 };
             byte[] arr2 = new byte[] { 1, 2, 3, 6, 7 };
@@ -76,6 +76,51 @@ namespace System.SpanTests
             Assert.Equal(3, MemoryExtensions.CommonPrefixLength((Span<byte>)arr1, arr2, null));
             Assert.Equal(3, MemoryExtensions.CommonPrefixLength((Span<byte>)arr1, arr2, EqualityComparer<byte>.Default));
             Assert.Equal(3, MemoryExtensions.CommonPrefixLength((Span<byte>)arr1, arr2, NonDefaultEqualityComparer<byte>.Instance));
+
+            // Vectorized code path
+            arr1 = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+            arr2 = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 42, 15, 16, 17 };
+
+            Assert.Equal(13, MemoryExtensions.CommonPrefixLength((ReadOnlySpan<byte>)arr1, arr2));
+            Assert.Equal(13, MemoryExtensions.CommonPrefixLength((ReadOnlySpan<byte>)arr1, arr2, null));
+            Assert.Equal(13, MemoryExtensions.CommonPrefixLength((ReadOnlySpan<byte>)arr1, arr2, EqualityComparer<byte>.Default));
+            Assert.Equal(13, MemoryExtensions.CommonPrefixLength((ReadOnlySpan<byte>)arr1, arr2, NonDefaultEqualityComparer<byte>.Instance));
+
+            Assert.Equal(13, MemoryExtensions.CommonPrefixLength((Span<byte>)arr1, arr2));
+            Assert.Equal(13, MemoryExtensions.CommonPrefixLength((Span<byte>)arr1, arr2, null));
+            Assert.Equal(13, MemoryExtensions.CommonPrefixLength((Span<byte>)arr1, arr2, EqualityComparer<byte>.Default));
+            Assert.Equal(13, MemoryExtensions.CommonPrefixLength((Span<byte>)arr1, arr2, NonDefaultEqualityComparer<byte>.Instance));
+        }
+
+        [Fact]
+        public static void PartialEquals_ReturnsPrefixLength_ValueType()
+        {
+            int[] arr1 = new int[] { 1, 2, 3 };
+            int[] arr2 = new int[] { 1, 2, 6 };
+
+            Assert.Equal(2, MemoryExtensions.CommonPrefixLength((ReadOnlySpan<int>)arr1, arr2));
+            Assert.Equal(2, MemoryExtensions.CommonPrefixLength((ReadOnlySpan<int>)arr1, arr2, null));
+            Assert.Equal(2, MemoryExtensions.CommonPrefixLength((ReadOnlySpan<int>)arr1, arr2, EqualityComparer<int>.Default));
+            Assert.Equal(2, MemoryExtensions.CommonPrefixLength((ReadOnlySpan<int>)arr1, arr2, NonDefaultEqualityComparer<int>.Instance));
+
+            Assert.Equal(2, MemoryExtensions.CommonPrefixLength((Span<int>)arr1, arr2));
+            Assert.Equal(2, MemoryExtensions.CommonPrefixLength((Span<int>)arr1, arr2, null));
+            Assert.Equal(2, MemoryExtensions.CommonPrefixLength((Span<int>)arr1, arr2, EqualityComparer<int>.Default));
+            Assert.Equal(2, MemoryExtensions.CommonPrefixLength((Span<int>)arr1, arr2, NonDefaultEqualityComparer<int>.Instance));
+
+            // Vectorized code path
+            arr1 = new int[] { 1, 2, 3, 4, 5 };
+            arr2 = new int[] { 1, 2, 3, 6, 7 };
+
+            Assert.Equal(3, MemoryExtensions.CommonPrefixLength((ReadOnlySpan<int>)arr1, arr2));
+            Assert.Equal(3, MemoryExtensions.CommonPrefixLength((ReadOnlySpan<int>)arr1, arr2, null));
+            Assert.Equal(3, MemoryExtensions.CommonPrefixLength((ReadOnlySpan<int>)arr1, arr2, EqualityComparer<int>.Default));
+            Assert.Equal(3, MemoryExtensions.CommonPrefixLength((ReadOnlySpan<int>)arr1, arr2, NonDefaultEqualityComparer<int>.Instance));
+
+            Assert.Equal(3, MemoryExtensions.CommonPrefixLength((Span<int>)arr1, arr2));
+            Assert.Equal(3, MemoryExtensions.CommonPrefixLength((Span<int>)arr1, arr2, null));
+            Assert.Equal(3, MemoryExtensions.CommonPrefixLength((Span<int>)arr1, arr2, EqualityComparer<int>.Default));
+            Assert.Equal(3, MemoryExtensions.CommonPrefixLength((Span<int>)arr1, arr2, NonDefaultEqualityComparer<int>.Instance));
         }
 
         [Fact]

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -2042,6 +2042,17 @@ namespace System
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(other)),
                     length * size);
 
+                // A byte-wise comparison in CommonPrefixLength can be used for multi-byte types,
+                // that are bitwise-equatable, too. In order to get the correct index in terms of type T
+                // of the first mismatch, integer division by the size of T is used.
+                //
+                // Example for short:
+                // index (byte-based):   b-1,  b,    b+1,    b+2,  b+3
+                // index (short-based):  s-1,  s,            s+1
+                // byte sequence 1:    { ..., [0x42, 0x43], [0x37, 0x38], ... }
+                // byte sequence 2:    { ..., [0x42, 0x43], [0x37, 0xAB], ... }
+                // So the mismatch is a byte-index b+3, which gives integer divided by the size of short:
+                // 3 / 2 = 1, thus the expected index short-based.
                 return (int)(index / size);
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -2115,6 +2115,8 @@ namespace System
         {
             nuint i;
 
+            // It is ordered this way to match the default branch predictor rules, to don't have too much
+            // overhead for short input-lengths.
             if (!Vector128.IsHardwareAccelerated || length < (nuint)Vector128<byte>.Count)
             {
                 // To have kind of fast path for small inputs, we handle as much elements needed


### PR DESCRIPTION
Functional implementation of the new API got added in https://github.com/dotnet/runtime/pull/67929
This PR vectorizes the implementation.

```
|     Method | LengthAndIndexOfMatch |      Mean |     Error |    StdDev | Ratio | RatioSD |
|----------- |---------------------- |----------:|----------:|----------:|------:|--------:|
|    Default |               (10, 5) |  5.432 ns | 0.1167 ns | 0.0975 ns |  1.00 |    0.00 |
| PR_Unroll4 |               (10, 5) |  4.601 ns | 0.0991 ns | 0.0927 ns |  0.85 |    0.02 |
|            |                       |           |           |           |       |         |
|    Default |               (10, 9) |  7.185 ns | 0.1153 ns | 0.1078 ns |  1.00 |    0.00 |
| PR_Unroll4 |               (10, 9) |  5.813 ns | 0.1311 ns | 0.1095 ns |  0.81 |    0.02 |
|            |                       |           |           |           |       |         |
|    Default |             (100, 16) | 11.043 ns | 0.2307 ns | 0.2158 ns |  1.00 |    0.00 |
| PR_Unroll4 |             (100, 16) |  4.112 ns | 0.0898 ns | 0.0840 ns |  0.37 |    0.01 |
|            |                       |           |           |           |       |         |
|    Default |             (100, 99) | 66.556 ns | 0.8823 ns | 0.8253 ns |  1.00 |    0.00 |
| PR_Unroll4 |             (100, 99) |  8.013 ns | 0.1776 ns | 0.1974 ns |  0.12 |    0.00 |
|            |                       |           |           |           |       |         |
|    Default |              (20, 13) |  9.158 ns | 0.1724 ns | 0.1613 ns |  1.00 |    0.00 |
| PR_Unroll4 |              (20, 13) |  3.134 ns | 0.0843 ns | 0.0789 ns |  0.34 |    0.01 |
|            |                       |           |           |           |       |         |
|    Default |                (3, 2) |  4.505 ns | 0.0481 ns | 0.0427 ns |  1.00 |    0.00 |
| PR_Unroll4 |                (3, 2) |  3.658 ns | 0.0733 ns | 0.0686 ns |  0.81 |    0.02 |
```

Note: I tried different unroll-levels, 4 gave best results.

Benchmarks aren't in https://github.com/dotnet/performance
Should these be added? Or is it covered via usage in other parts, or too niche to have it covered?

<details>
  <summary>Benchmark code</summary>

```c#
using System.Diagnostics;
using System.Numerics;
using System.Runtime.CompilerServices;
using System.Runtime.InteropServices;
using System.Runtime.Intrinsics;
using BenchmarkDotNet.Attributes;

namespace ConsoleApp3;

//[ShortRunJob]
//[DisassemblyDiagnoser]
public class CommonPrefixLengthBenchmark
{
    public static void Run()
    {
        CommonPrefixLengthBenchmark bench = new();
        bench.Setup();
        Console.WriteLine(bench.Default());
        Console.WriteLine(bench.PR_Unroll4());
    }

    public record Args(int Length, int IndexOfMatch)
    {
        public override string ToString() => $"({this.Length}, {this.IndexOfMatch})";
    }

    public static IEnumerable<Args> Arguments()
    {
        yield return new Args(3, 2);
        yield return new Args(10, 5);
        yield return new Args(10, 9);
        yield return new Args(20, 13);
        yield return new Args(100, 16);
        yield return new Args(100, 99);
    }

    [ParamsSource(nameof(Arguments))]
    public Args LengthAndIndexOfMatch { get; set; } = new Args(3, 2);

    private byte[]? _arr0;
    private byte[]? _arr1;

    [GlobalSetup]
    public void Setup()
    {
        _arr0 = new byte[this.LengthAndIndexOfMatch.Length];
        Random.Shared.NextBytes(_arr0);

        _arr1 = _arr0.AsSpan().ToArray();
        _arr1[this.LengthAndIndexOfMatch.IndexOfMatch] = 0xff;
    }

    [Benchmark(Baseline = true)]
    public int Default() => SpanHelpers.CommonPrefixLength<byte>(_arr0, _arr1);

    [Benchmark]
    public int PR_Unroll4() => SpanHelpers.CommonPrefixLength_PRUnroll4<byte>(_arr0, _arr1);
}

public static class SpanHelpers
{
    public static int CommonPrefixLength<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> other)
    {
        // Shrink one of the spans if necessary to ensure they're both the same length. We can then iterate until
        // the Length of one of them and at least have bounds checks removed from that one.
        if (other.Length > span.Length)
        {
            other = other.Slice(0, span.Length);
        }
        else if (span.Length > other.Length)
        {
            span = span.Slice(0, other.Length);
        }
        Debug.Assert(span.Length == other.Length);

        // Find the first element pairwise that is not equal, and return its index as the length
        // of the sequence before it that matches.
        for (int i = 0; i < span.Length; i++)
        {
            if (!EqualityComparer<T>.Default.Equals(span[i], other[i]))
            {
                return i;
            }
        }

        return span.Length;
    }

    public static int CommonPrefixLength_PRUnroll4<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> other)
    {
        if (typeof(T) == typeof(byte))
        {
            nuint length = Math.Min((nuint)(uint)span.Length, (nuint)(uint)other.Length);
            nuint size = (nuint)Unsafe.SizeOf<T>();

            return (int)CommonPrefixLengthUnroll4(
                ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(other)),
                length * size);
        }

        // Shrink one of the spans if necessary to ensure they're both the same length. We can then iterate until
        // the Length of one of them and at least have bounds checks removed from that one.
        if (other.Length > span.Length)
        {
            other = other.Slice(0, span.Length);
        }
        else if (span.Length > other.Length)
        {
            span = span.Slice(0, other.Length);
        }
        Debug.Assert(span.Length == other.Length);

        // Find the first element pairwise that is not equal, and return its index as the length
        // of the sequence before it that matches.
        for (int i = 0; i < span.Length; i++)
        {
            if (!EqualityComparer<T>.Default.Equals(span[i], other[i]))
            {
                return i;
            }
        }

        return span.Length;
    }

    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    private static nuint CommonPrefixLengthUnroll4(ref byte first, ref byte second, nuint length)
    {
        nuint i;

        if (!Vector128.IsHardwareAccelerated || length < (nuint)Vector128<byte>.Count)
        {
            // To have kind of fast path for small inputs, we handle as much elements needed
            // so that either we are done or can use the unrolled loop below.
            i = length % 4;

            if (i > 0)
            {
                if (first != second)
                {
                    return 0;
                }

                if (i > 1)
                {
                    if (Unsafe.Add(ref first, 1) != Unsafe.Add(ref second, 1))
                    {
                        return 1;
                    }

                    if (i > 2 && Unsafe.Add(ref first, 2) != Unsafe.Add(ref second, 2))
                    {
                        return 2;
                    }
                }
            }

            for (; (nint)i <= (nint)length - 4; i += 4)
            {
                if (Unsafe.Add(ref first, i + 0) != Unsafe.Add(ref second, i + 0)) return i + 0;
                if (Unsafe.Add(ref first, i + 1) != Unsafe.Add(ref second, i + 1)) return i + 1;
                if (Unsafe.Add(ref first, i + 2) != Unsafe.Add(ref second, i + 2)) return i + 2;
                if (Unsafe.Add(ref first, i + 3) != Unsafe.Add(ref second, i + 3)) return i + 3;
            }

            return length;
        }

        Debug.Assert(length >= (uint)Vector128<byte>.Count);

        int mask;
        nuint lengthToExamine = length - (nuint)Vector128<byte>.Count;

        Vector128<byte> firstVec;
        Vector128<byte> secondVec;
        Vector128<byte> maskVec;
        i = 0;

        if (lengthToExamine != 0)
        {
            do
            {
                firstVec = Vector128.LoadUnsafe(ref first, i);
                secondVec = Vector128.LoadUnsafe(ref second, i);
                maskVec = Vector128.Equals(firstVec, secondVec);
                mask = (int)maskVec.ExtractMostSignificantBits();

                if (mask != 0xFFFF)
                {
                    goto Found;
                }

                i += (nuint)Vector128<byte>.Count;
            } while (i < lengthToExamine);
        }

        // Do final compare as Vector128<byte>.Count from end rather than start
        i = lengthToExamine;
        firstVec = Vector128.LoadUnsafe(ref first, i);
        secondVec = Vector128.LoadUnsafe(ref second, i);
        maskVec = Vector128.Equals(firstVec, secondVec);
        mask = (int)maskVec.ExtractMostSignificantBits();

        if (mask != 0xFFFF)
        {
            goto Found;
        }

        return length;

    Found:
        mask = ~mask;
        return i + (uint)BitOperations.TrailingZeroCount(mask);
    }
}
```
</details>

---

I tried forwarding `SequenceEqual` to `CommonPrefixLength`, but this regressed as in `SequenceEqual` some nice tricks are employed. These can't be used for `CommonPrefixLength`, as here we need the actual `index` of the difference, and not only `true/false`.

---

@stephentoub: in regards to https://github.com/dotnet/runtime/pull/67929#discussion_r849325433 I know you favored https://github.com/dotnet/runtime/issues/67942, but the PR for the CommonPrefixLength is merged, and I had already similar code lying around.
And for my usecase (a kind of parser) I'd prefer to use the (optimized) implementation in .NET instead of having to use my own (which in this case is the same code anyway :wink:).
