### PR TITLE
Consistently use forward slashes in test exclusion lists

### DIFF
--- a/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
@@ -140,7 +140,7 @@ public class TestFilter
 
     public bool ShouldRunTest(string fullyQualifiedName, string displayName, string[]? traits = null)
     {
-        if (_testExclusionList is not null && _testExclusionList.Contains(displayName))
+        if (_testExclusionList is not null && _testExclusionList.Contains(displayName.Replace("\\", "/")))
         {
             return false;
         }

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -4020,9 +4020,9 @@
     <Target Name="GetFilteredExcludeList" Returns="@(FilteredExcludeList)">
         <ItemGroup>
             <FilteredExcludeList
-                Include="$([System.IO.Path]::GetRelativePath('$(XunitTestBinBase)', '%(ExcludeList.FullPath)'))"
+                Include="$([System.IO.Path]::GetRelativePath('$(XunitTestBinBase)', '%(ExcludeList.FullPath)').Replace('\', '/'))"
                 Condition="'%(ExcludeList.Extension)' == '.dll'" />
-            <FilteredExcludeList Include="$([System.IO.Path]::ChangeExtension('$([System.IO.Path]::GetRelativePath('$(XunitTestBinBase)', '%(ExcludeList.RootDir)%(ExcludeList.Directory)%(ExcludeList.FileName)'))', '.cmd'))"
+            <FilteredExcludeList Include="$([System.IO.Path]::ChangeExtension('$([System.IO.Path]::GetRelativePath('$(XunitTestBinBase)', '%(ExcludeList.RootDir)%(ExcludeList.Directory)%(ExcludeList.FileName)'))', '.cmd').Replace('\', '/'))"
                 Condition="'%(ExcludeList.Extension)' == '.OutOfProcessTest'" />
       </ItemGroup>
     </Target>


### PR DESCRIPTION
Fixes: #68187 

/cc @dotnet/runtime-infrastructure 