### PR TITLE
Exposing MaxMagnitudeNumber, MaxNumber, MinMagnitudeNumber, and MinNumber

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
@@ -1014,12 +1014,12 @@ namespace System
 
             static unsafe bool IsNegativeZero(Half value)
             {
-                return (*(uint*)(&value)) == 0x80000000;
+                return (*(ushort*)(&value)) == 0x8000;
             }
 
             static unsafe bool IsPositiveZero(Half value)
             {
-                return (*(uint*)(&value)) == 0x00000000;
+                return (*(ushort*)(&value)) == 0x0000;
             }
 
             // We have a custom ToString here to ensure that edge cases (specifically +-0.0,

--- a/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
@@ -592,5 +592,466 @@ namespace System
                 Remain = remain;
             }
         }
+
+        /// <summary>Verifies that two <see cref="double"/> values are equal, within the <paramref name="allowedVariance"/>.</summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="actual">The value to be compared against</param>
+        /// <param name="allowedVariance">The total variance allowed between the expected and actual results.</param>
+        /// <exception cref="EqualException">Thrown when the values are not equal</exception>
+        public static void Equal(double expected, double actual, double variance)
+        {
+            if (double.IsNaN(expected))
+            {
+                if (double.IsNaN(actual))
+                {
+                    return;
+                }
+
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+            else if (double.IsNaN(actual))
+            {
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+
+            if (double.IsNegativeInfinity(expected))
+            {
+                if (double.IsNegativeInfinity(actual))
+                {
+                    return;
+                }
+
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+            else if (double.IsNegativeInfinity(actual))
+            {
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+
+            if (double.IsPositiveInfinity(expected))
+            {
+                if (double.IsPositiveInfinity(actual))
+                {
+                    return;
+                }
+
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+            else if (double.IsPositiveInfinity(actual))
+            {
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+
+            if (IsNegativeZero(expected))
+            {
+                if (IsNegativeZero(actual))
+                {
+                    return;
+                }
+
+                if (IsPositiveZero(variance) || IsNegativeZero(variance))
+                {
+                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+                }
+
+                // When the variance is not +-0.0, then we are handling a case where
+                // the actual result is expected to not be exactly -0.0 on some platforms
+                // and we should fallback to checking if it is within the allowed variance instead.
+            }
+            else if (IsNegativeZero(actual))
+            {
+                if (IsPositiveZero(variance) || IsNegativeZero(variance))
+                {
+                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+                }
+
+                // When the variance is not +-0.0, then we are handling a case where
+                // the actual result is expected to not be exactly -0.0 on some platforms
+                // and we should fallback to checking if it is within the allowed variance instead.
+            }
+
+            if (IsPositiveZero(expected))
+            {
+                if (IsPositiveZero(actual))
+                {
+                    return;
+                }
+
+                if (IsPositiveZero(variance) || IsNegativeZero(variance))
+                {
+                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+                }
+
+                // When the variance is not +-0.0, then we are handling a case where
+                // the actual result is expected to not be exactly +0.0 on some platforms
+                // and we should fallback to checking if it is within the allowed variance instead.
+            }
+            else if (IsPositiveZero(actual))
+            {
+                if (IsPositiveZero(variance) || IsNegativeZero(variance))
+                {
+                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+                }
+
+                // When the variance is not +-0.0, then we are handling a case where
+                // the actual result is expected to not be exactly +0.0 on some platforms
+                // and we should fallback to checking if it is within the allowed variance instead.
+            }
+
+            var delta = Math.Abs(actual - expected);
+
+            if (delta > variance)
+            {
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+
+            static unsafe bool IsNegativeZero(double value)
+            {
+                return (*(ulong*)(&value)) == 0x8000000000000000;
+            }
+
+            static unsafe bool IsPositiveZero(double value)
+            {
+                return (*(ulong*)(&value)) == 0x0000000000000000;
+            }
+
+            // We have a custom ToString here to ensure that edge cases (specifically +-0.0,
+            // but also NaN and +-infinity) are correctly and consistently represented.
+            static string ToStringPadded(double value)
+            {
+                if (double.IsNaN(value))
+                {
+                    return "NaN".PadLeft(20);
+                }
+                else if (double.IsPositiveInfinity(value))
+                {
+                    return "+\u221E".PadLeft(20);
+                }
+                else if (double.IsNegativeInfinity(value))
+                {
+                    return "-\u221E".PadLeft(20);
+                }
+                else if (IsNegativeZero(value))
+                {
+                    return "-0.0".PadLeft(20);
+                }
+                else if (IsPositiveZero(value))
+                {
+                    return "+0.0".PadLeft(20);
+                }
+                else
+                {
+                    return $"{value,20:G17}";
+                }
+            }
+        }
+
+        /// <summary>Verifies that two <see cref="float"/> values are equal, within the <paramref name="variance"/>.</summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="actual">The value to be compared against</param>
+        /// <param name="variance">The total variance allowed between the expected and actual results.</param>
+        /// <exception cref="EqualException">Thrown when the values are not equal</exception>
+        public static void Equal(float expected, float actual, float variance)
+        {
+            if (float.IsNaN(expected))
+            {
+                if (float.IsNaN(actual))
+                {
+                    return;
+                }
+
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+            else if (float.IsNaN(actual))
+            {
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+
+            if (float.IsNegativeInfinity(expected))
+            {
+                if (float.IsNegativeInfinity(actual))
+                {
+                    return;
+                }
+
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+            else if (float.IsNegativeInfinity(actual))
+            {
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+
+            if (float.IsPositiveInfinity(expected))
+            {
+                if (float.IsPositiveInfinity(actual))
+                {
+                    return;
+                }
+
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+            else if (float.IsPositiveInfinity(actual))
+            {
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+
+            if (IsNegativeZero(expected))
+            {
+                if (IsNegativeZero(actual))
+                {
+                    return;
+                }
+
+                if (IsPositiveZero(variance) || IsNegativeZero(variance))
+                {
+                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+                }
+
+                // When the variance is not +-0.0, then we are handling a case where
+                // the actual result is expected to not be exactly -0.0 on some platforms
+                // and we should fallback to checking if it is within the allowed variance instead.
+            }
+            else if (IsNegativeZero(actual))
+            {
+                if (IsPositiveZero(variance) || IsNegativeZero(variance))
+                {
+                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+                }
+
+                // When the variance is not +-0.0, then we are handling a case where
+                // the actual result is expected to not be exactly -0.0 on some platforms
+                // and we should fallback to checking if it is within the allowed variance instead.
+            }
+
+            if (IsPositiveZero(expected))
+            {
+                if (IsPositiveZero(actual))
+                {
+                    return;
+                }
+
+                if (IsPositiveZero(variance) || IsNegativeZero(variance))
+                {
+                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+                }
+
+                // When the variance is not +-0.0, then we are handling a case where
+                // the actual result is expected to not be exactly +0.0 on some platforms
+                // and we should fallback to checking if it is within the allowed variance instead.
+            }
+            else if (IsPositiveZero(actual))
+            {
+                if (IsPositiveZero(variance) || IsNegativeZero(variance))
+                {
+                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+                }
+
+                // When the variance is not +-0.0, then we are handling a case where
+                // the actual result is expected to not be exactly +0.0 on some platforms
+                // and we should fallback to checking if it is within the allowed variance instead.
+            }
+
+            var delta = Math.Abs(actual - expected);
+
+            if (delta > variance)
+            {
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+
+            static unsafe bool IsNegativeZero(float value)
+            {
+                return (*(uint*)(&value)) == 0x80000000;
+            }
+
+            static unsafe bool IsPositiveZero(float value)
+            {
+                return (*(uint*)(&value)) == 0x00000000;
+            }
+
+            // We have a custom ToString here to ensure that edge cases (specifically +-0.0,
+            // but also NaN and +-infinity) are correctly and consistently represented.
+            static string ToStringPadded(float value)
+            {
+                if (float.IsNaN(value))
+                {
+                    return "NaN".PadLeft(10);
+                }
+                else if (float.IsPositiveInfinity(value))
+                {
+                    return "+\u221E".PadLeft(10);
+                }
+                else if (float.IsNegativeInfinity(value))
+                {
+                    return "-\u221E".PadLeft(10);
+                }
+                else if (IsNegativeZero(value))
+                {
+                    return "-0.0".PadLeft(10);
+                }
+                else if (IsPositiveZero(value))
+                {
+                    return "+0.0".PadLeft(10);
+                }
+                else
+                {
+                    return $"{value,10:G9}";
+                }
+            }
+        }
+
+#if NET6_0_OR_GREATER
+        /// <summary>Verifies that two <see cref="Half"/> values are equal, within the <paramref name="variance"/>.</summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="actual">The value to be compared against</param>
+        /// <param name="variance">The total variance allowed between the expected and actual results.</param>
+        /// <exception cref="EqualException">Thrown when the values are not equal</exception>
+        public static void Equal(Half expected, Half actual, Half variance)
+        {
+            if (Half.IsNaN(expected))
+            {
+                if (Half.IsNaN(actual))
+                {
+                    return;
+                }
+
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+            else if (Half.IsNaN(actual))
+            {
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+
+            if (Half.IsNegativeInfinity(expected))
+            {
+                if (Half.IsNegativeInfinity(actual))
+                {
+                    return;
+                }
+
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+            else if (Half.IsNegativeInfinity(actual))
+            {
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+
+            if (Half.IsPositiveInfinity(expected))
+            {
+                if (Half.IsPositiveInfinity(actual))
+                {
+                    return;
+                }
+
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+            else if (Half.IsPositiveInfinity(actual))
+            {
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+
+            if (IsNegativeZero(expected))
+            {
+                if (IsNegativeZero(actual))
+                {
+                    return;
+                }
+
+                if (IsPositiveZero(variance) || IsNegativeZero(variance))
+                {
+                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+                }
+
+                // When the variance is not +-0.0, then we are handling a case where
+                // the actual result is expected to not be exactly -0.0 on some platforms
+                // and we should fallback to checking if it is within the allowed variance instead.
+            }
+            else if (IsNegativeZero(actual))
+            {
+                if (IsPositiveZero(variance) || IsNegativeZero(variance))
+                {
+                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+                }
+
+                // When the variance is not +-0.0, then we are handling a case where
+                // the actual result is expected to not be exactly -0.0 on some platforms
+                // and we should fallback to checking if it is within the allowed variance instead.
+            }
+
+            if (IsPositiveZero(expected))
+            {
+                if (IsPositiveZero(actual))
+                {
+                    return;
+                }
+
+                if (IsPositiveZero(variance) || IsNegativeZero(variance))
+                {
+                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+                }
+
+                // When the variance is not +-0.0, then we are handling a case where
+                // the actual result is expected to not be exactly +0.0 on some platforms
+                // and we should fallback to checking if it is within the allowed variance instead.
+            }
+            else if (IsPositiveZero(actual))
+            {
+                if (IsPositiveZero(variance) || IsNegativeZero(variance))
+                {
+                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+                }
+
+                // When the variance is not +-0.0, then we are handling a case where
+                // the actual result is expected to not be exactly +0.0 on some platforms
+                // and we should fallback to checking if it is within the allowed variance instead.
+            }
+
+            var delta = (Half)Math.Abs((float)actual - (float)expected);
+
+            if (delta > variance)
+            {
+                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
+            }
+
+            static unsafe bool IsNegativeZero(Half value)
+            {
+                return (*(uint*)(&value)) == 0x80000000;
+            }
+
+            static unsafe bool IsPositiveZero(Half value)
+            {
+                return (*(uint*)(&value)) == 0x00000000;
+            }
+
+            // We have a custom ToString here to ensure that edge cases (specifically +-0.0,
+            // but also NaN and +-infinity) are correctly and consistently represented.
+            static string ToStringPadded(Half value)
+            {
+                if (Half.IsNaN(value))
+                {
+                    return "NaN".PadLeft(5);
+                }
+                else if (Half.IsPositiveInfinity(value))
+                {
+                    return "+\u221E".PadLeft(5);
+                }
+                else if (Half.IsNegativeInfinity(value))
+                {
+                    return "-\u221E".PadLeft(5);
+                }
+                else if (IsNegativeZero(value))
+                {
+                    return "-0.0".PadLeft(5);
+                }
+                else if (IsPositiveZero(value))
+                {
+                    return "+0.0".PadLeft(5);
+                }
+                else
+                {
+                    return $"{value,5:G5}";
+                }
+            }
+        }
+#endif
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -763,6 +763,100 @@ namespace System
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ILogB(TSelf)" />
         public static int ILogB(double x) => Math.ILogB(x);
 
+        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        public static double MaxMagnitudeNumber(double x, double y)
+        {
+            // This matches the IEEE 754:2019 `maximumMagnitudeNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the input with a larger magnitude.
+            // It treats +0 as larger than -0 as per the specification.
+
+            double ax = Abs(x);
+            double ay = Abs(y);
+
+            if ((ax > ay) || IsNaN(ay))
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                return IsNegative(x) ? y : x;
+            }
+
+            return y;
+        }
+
+        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxNumber(TSelf, TSelf)" />
+        public static double MaxNumber(double x, double y)
+        {
+            // This matches the IEEE 754:2019 `maximumNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the larger of the inputs. It
+            // treats +0 as larger than -0 as per the specification.
+
+            if (x != y)
+            {
+                if (!IsNaN(y))
+                {
+                    return y < x ? x : y;
+                }
+
+                return x;
+            }
+
+            return IsNegative(y) ? x : y;
+        }
+
+        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        public static double MinMagnitudeNumber(double x, double y)
+        {
+            // This matches the IEEE 754:2019 `minimumMagnitudeNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the input with a larger magnitude.
+            // It treats +0 as larger than -0 as per the specification.
+
+            double ax = Abs(x);
+            double ay = Abs(y);
+
+            if ((ax < ay) || IsNaN(ay))
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                return IsNegative(x) ? x : y;
+            }
+
+            return y;
+        }
+
+        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinNumber(TSelf, TSelf)" />
+        public static double MinNumber(double x, double y)
+        {
+            // This matches the IEEE 754:2019 `minimumNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the larger of the inputs. It
+            // treats +0 as larger than -0 as per the specification.
+
+            if (x != y)
+            {
+                if (!IsNaN(y))
+                {
+                    return x < y ? x : y;
+                }
+
+                return x;
+            }
+
+            return IsNegative(x) ? x : y;
+        }
+
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ReciprocalEstimate(TSelf)" />
         public static double ReciprocalEstimate(double x) => Math.ReciprocalEstimate(x);
 
@@ -774,18 +868,6 @@ namespace System
 
         // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.Compound(TSelf, TSelf)" />
         // public static double Compound(double x, double n) => Math.Compound(x, n);
-
-        // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
-        // public static double MaxMagnitudeNumber(double x, double y) => Math.MaxMagnitudeNumber(x, y);
-
-        // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxNumber(TSelf, TSelf)" />
-        // public static double MaxNumber(double x, double y) => Math.MaxNumber(x, y);
-
-        // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
-        // public static double MinMagnitudeNumber(double x, double y) => Math.MinMagnitudeNumber(x, y);
-
-        // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinNumber(TSelf, TSelf)" />
-        // public static double MinNumber(double x, double y) => Math.MinNumber(x, y);
 
         //
         // IHyperbolicFunctions

--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -972,6 +972,100 @@ namespace System
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ILogB(TSelf)" />
         public static int ILogB(Half x) => MathF.ILogB((float)x);
 
+        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        public static Half MaxMagnitudeNumber(Half x, Half y)
+        {
+            // This matches the IEEE 754:2019 `maximumMagnitudeNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the input with a larger magnitude.
+            // It treats +0 as larger than -0 as per the specification.
+
+            Half ax = Abs(x);
+            Half ay = Abs(y);
+
+            if ((ax > ay) || IsNaN(ay))
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                return IsNegative(x) ? y : x;
+            }
+
+            return y;
+        }
+
+        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxNumber(TSelf, TSelf)" />
+        public static Half MaxNumber(Half x, Half y)
+        {
+            // This matches the IEEE 754:2019 `maximumNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the larger of the inputs. It
+            // treats +0 as larger than -0 as per the specification.
+
+            if (x != y)
+            {
+                if (!IsNaN(y))
+                {
+                    return y < x ? x : y;
+                }
+
+                return x;
+            }
+
+            return IsNegative(y) ? x : y;
+        }
+
+        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        public static Half MinMagnitudeNumber(Half x, Half y)
+        {
+            // This matches the IEEE 754:2019 `minimumMagnitudeNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the input with a larger magnitude.
+            // It treats +0 as larger than -0 as per the specification.
+
+            Half ax = Abs(x);
+            Half ay = Abs(y);
+
+            if ((ax < ay) || IsNaN(ay))
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                return IsNegative(x) ? x : y;
+            }
+
+            return y;
+        }
+
+        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinNumber(TSelf, TSelf)" />
+        public static Half MinNumber(Half x, Half y)
+        {
+            // This matches the IEEE 754:2019 `minimumNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the larger of the inputs. It
+            // treats +0 as larger than -0 as per the specification.
+
+            if (x != y)
+            {
+                if (!IsNaN(y))
+                {
+                    return x < y ? x : y;
+                }
+
+                return x;
+            }
+
+            return IsNegative(x) ? x : y;
+        }
+
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ReciprocalEstimate(TSelf)" />
         public static Half ReciprocalEstimate(Half x) => (Half)MathF.ReciprocalEstimate((float)x);
 
@@ -983,18 +1077,6 @@ namespace System
 
         // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.Compound(TSelf, TSelf)" />
         // public static Half Compound(Half x, Half n) => (Half)MathF.Compound((float)x, (float)n);
-
-        // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
-        // public static Half MaxMagnitudeNumber(Half x, Half y) => (Half)MathF.MaxMagnitudeNumber((float)x, (float)y);
-
-        // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxNumber(TSelf, TSelf)" />
-        // public static Half MaxNumber(Half x, Half y) => (Half)MathF.MaxNumber((float)x, (float)y);
-
-        // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
-        // public static Half MinMagnitudeNumber(Half x, Half y) => (Half)MathF.MinMagnitudeNumber((float)x, (float)y);
-
-        // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinNumber(TSelf, TSelf)" />
-        // public static Half MinNumber(Half x, Half y) => (Half)MathF.MinNumber((float)x, (float)y);
 
         //
         // IHyperbolicFunctions

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IFloatingPointIeee754.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IFloatingPointIeee754.cs
@@ -102,6 +102,34 @@ namespace System.Numerics
         /// <returns><c>true</c> if <paramref name="value" /> is subnormal; otherwise, <c>false</c>.</returns>
         static abstract bool IsSubnormal(TSelf value);
 
+        /// <summary>Compares two values to compute which is greater.</summary>
+        /// <param name="x">The value to compare with <paramref name="y" />.</param>
+        /// <param name="y">The value to compare with <paramref name="x" />.</param>
+        /// <returns><paramref name="x" /> if it is greater than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
+        /// <remarks>For <see cref="IFloatingPointIeee754{TSelf}" /> this method matches the IEEE 754:2019 <c>maximumMagnitudeNumber</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
+        static abstract TSelf MaxMagnitudeNumber(TSelf x, TSelf y);
+
+        /// <summary>Compares two values to compute which is greater.</summary>
+        /// <param name="x">The value to compare with <paramref name="y" />.</param>
+        /// <param name="y">The value to compare with <paramref name="x" />.</param>
+        /// <returns><paramref name="x" /> if it is greater than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
+        /// <remarks>For <see cref="IFloatingPoint{TSelf}" /> this method matches the IEEE 754:2019 <c>maximumNumber</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
+        static abstract TSelf MaxNumber(TSelf x, TSelf y);
+
+        /// <summary>Compares two values to compute which is lesser.</summary>
+        /// <param name="x">The value to compare with <paramref name="y" />.</param>
+        /// <param name="y">The value to compare with <paramref name="x" />.</param>
+        /// <returns><paramref name="x" /> if it is less than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
+        /// <remarks>For <see cref="IFloatingPointIeee754{TSelf}" /> this method matches the IEEE 754:2019 <c>minimumMagnitudeNumber</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
+        static abstract TSelf MinMagnitudeNumber(TSelf x, TSelf y);
+
+        /// <summary>Compares two values to compute which is lesser.</summary>
+        /// <param name="x">The value to compare with <paramref name="y" />.</param>
+        /// <param name="y">The value to compare with <paramref name="x" />.</param>
+        /// <returns><paramref name="x" /> if it is less than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
+        /// <remarks>For <see cref="IFloatingPoint{TSelf}" /> this method matches the IEEE 754:2019 <c>minimumNumber</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
+        static abstract TSelf MinNumber(TSelf x, TSelf y);
+
         /// <summary>Computes an estimate of the reciprocal of a value.</summary>
         /// <param name="x">The value whose estimate of the reciprocal is to be computed.</param>
         /// <returns>An estimate of the reciprocal of <paramref name="x" />.</returns>
@@ -120,9 +148,5 @@ namespace System.Numerics
 
         // The following methods are approved but not yet implemented in the libraries
         // * static abstract TSelf Compound(TSelf x, TSelf n);
-        // * static abstract TSelf MaxMagnitudeNumber(TSelf x, TSelf y);
-        // * static abstract TSelf MaxNumber(TSelf x, TSelf y);
-        // * static abstract TSelf MinMagnitudeNumber(TSelf x, TSelf y);
-        // * static abstract TSelf MinNumber(TSelf x, TSelf y);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IFloatingPointIeee754.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IFloatingPointIeee754.cs
@@ -102,28 +102,28 @@ namespace System.Numerics
         /// <returns><c>true</c> if <paramref name="value" /> is subnormal; otherwise, <c>false</c>.</returns>
         static abstract bool IsSubnormal(TSelf value);
 
-        /// <summary>Compares two values to compute which is greater.</summary>
+        /// <summary>Compares two values to compute which has the greater magnitude and returning the other value if an input is <c>NaN</c>.</summary>
         /// <param name="x">The value to compare with <paramref name="y" />.</param>
         /// <param name="y">The value to compare with <paramref name="x" />.</param>
         /// <returns><paramref name="x" /> if it is greater than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
         /// <remarks>For <see cref="IFloatingPointIeee754{TSelf}" /> this method matches the IEEE 754:2019 <c>maximumMagnitudeNumber</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
         static abstract TSelf MaxMagnitudeNumber(TSelf x, TSelf y);
 
-        /// <summary>Compares two values to compute which is greater.</summary>
+        /// <summary>Compares two values to compute which is greater and returning the other value if an input is <c>NaN</c>.</summary>
         /// <param name="x">The value to compare with <paramref name="y" />.</param>
         /// <param name="y">The value to compare with <paramref name="x" />.</param>
         /// <returns><paramref name="x" /> if it is greater than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
         /// <remarks>For <see cref="IFloatingPoint{TSelf}" /> this method matches the IEEE 754:2019 <c>maximumNumber</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
         static abstract TSelf MaxNumber(TSelf x, TSelf y);
 
-        /// <summary>Compares two values to compute which is lesser.</summary>
+        /// <summary>Compares two values to compute which has the lesser magnitude and returning the other value if an input is <c>NaN</c>.</summary>
         /// <param name="x">The value to compare with <paramref name="y" />.</param>
         /// <param name="y">The value to compare with <paramref name="x" />.</param>
         /// <returns><paramref name="x" /> if it is less than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
         /// <remarks>For <see cref="IFloatingPointIeee754{TSelf}" /> this method matches the IEEE 754:2019 <c>minimumMagnitudeNumber</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
         static abstract TSelf MinMagnitudeNumber(TSelf x, TSelf y);
 
-        /// <summary>Compares two values to compute which is lesser.</summary>
+        /// <summary>Compares two values to compute which is lesser and returning the other value if an input is <c>NaN</c>.</summary>
         /// <param name="x">The value to compare with <paramref name="y" />.</param>
         /// <param name="y">The value to compare with <paramref name="x" />.</param>
         /// <returns><paramref name="x" /> if it is less than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/INumber.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/INumber.cs
@@ -76,7 +76,7 @@ namespace System.Numerics
         /// <param name="x">The value to compare with <paramref name="y" />.</param>
         /// <param name="y">The value to compare with <paramref name="x" />.</param>
         /// <returns><paramref name="x" /> if it is greater than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
-        /// <remarks>For <see cref="IFloatingPointIeee754{TSelf}" /> this method matches the IEEE 754:2019 <c>maximumMagnitude</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
+        /// <remarks>For <see cref="IFloatingPointIeee754{TSelf}" /> this method matches the IEEE 754:2019 <c>maximumMagnitude</c> function. This requires NaN inputs to be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
         static abstract TSelf MaxMagnitude(TSelf x, TSelf y);
 
         /// <summary>Compares two values to compute which is lesser.</summary>
@@ -90,7 +90,7 @@ namespace System.Numerics
         /// <param name="x">The value to compare with <paramref name="y" />.</param>
         /// <param name="y">The value to compare with <paramref name="x" />.</param>
         /// <returns><paramref name="x" /> if it is less than <paramref name="y" />; otherwise, <paramref name="y" />.</returns>
-        /// <remarks>For <see cref="IFloatingPointIeee754{TSelf}" /> this method matches the IEEE 754:2019 <c>minimumMagnitude</c> function. This requires NaN inputs to not be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
+        /// <remarks>For <see cref="IFloatingPointIeee754{TSelf}" /> this method matches the IEEE 754:2019 <c>minimumMagnitude</c> function. This requires NaN inputs to be propagated back to the caller and for <c>-0.0</c> to be treated as less than <c>+0.0</c>.</remarks>
         static abstract TSelf MinMagnitude(TSelf x, TSelf y);
 
         /// <summary>Parses a string into a value.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NFloat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NFloat.cs
@@ -958,6 +958,18 @@ namespace System.Runtime.InteropServices
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ILogB(TSelf)" />
         public static int ILogB(NFloat x) => NativeType.ILogB(x._value);
 
+        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        public static NFloat MaxMagnitudeNumber(NFloat x, NFloat y) => new NFloat(NativeType.MaxMagnitudeNumber(x._value, y._value));
+
+        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxNumber(TSelf, TSelf)" />
+        public static NFloat MaxNumber(NFloat x, NFloat y) => new NFloat(NativeType.MaxNumber(x._value, y._value));
+
+        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        public static NFloat MinMagnitudeNumber(NFloat x, NFloat y) => new NFloat(NativeType.MinMagnitudeNumber(x._value, y._value));
+
+        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinNumber(TSelf, TSelf)" />
+        public static NFloat MinNumber(NFloat x, NFloat y) => new NFloat(NativeType.MinNumber(x._value, y._value));
+
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ReciprocalEstimate(TSelf)" />
         public static NFloat ReciprocalEstimate(NFloat x) => new NFloat(NativeType.ReciprocalEstimate(x._value));
 
@@ -969,18 +981,6 @@ namespace System.Runtime.InteropServices
 
         // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.Compound(TSelf, TSelf)" />
         // public static NFloat Compound(NFloat x, NFloat n) => new NFloat(NativeType.Compound(x._value, n._value));
-
-        // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
-        // public static NFloat MaxMagnitudeNumber(NFloat x, NFloat y) => new NFloat(NativeType.MaxMagnitudeNumber(x._value, y._value));
-
-        // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxNumber(TSelf, TSelf)" />
-        // public static NFloat MaxNumber(NFloat x, NFloat y) => new NFloat(NativeType.MaxNumber(x._value, y._value));
-
-        // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
-        // public static NFloat MinMagnitudeNumber(NFloat x, NFloat y) => new NFloat(NativeType.MinMagnitudeNumber(x._value, y._value));
-
-        // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinNumber(TSelf, TSelf)" />
-        // public static NFloat MinNumber(NFloat x, NFloat y) => new NFloat(NativeType.MinNumber(x._value, y._value));
 
         //
         // IHyperbolicFunctions

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -758,6 +758,100 @@ namespace System
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ILogB(TSelf)" />
         public static int ILogB(float x) => MathF.ILogB(x);
 
+        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
+        public static float MaxMagnitudeNumber(float x, float y)
+        {
+            // This matches the IEEE 754:2019 `maximumMagnitudeNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the input with a larger magnitude.
+            // It treats +0 as larger than -0 as per the specification.
+
+            float ax = Abs(x);
+            float ay = Abs(y);
+
+            if ((ax > ay) || IsNaN(ay))
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                return IsNegative(x) ? y : x;
+            }
+
+            return y;
+        }
+
+        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxNumber(TSelf, TSelf)" />
+        public static float MaxNumber(float x, float y)
+        {
+            // This matches the IEEE 754:2019 `maximumNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the larger of the inputs. It
+            // treats +0 as larger than -0 as per the specification.
+
+            if (x != y)
+            {
+                if (!IsNaN(y))
+                {
+                    return y < x ? x : y;
+                }
+
+                return x;
+            }
+
+            return IsNegative(y) ? x : y;
+        }
+
+        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
+        public static float MinMagnitudeNumber(float x, float y)
+        {
+            // This matches the IEEE 754:2019 `minimumMagnitudeNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the input with a larger magnitude.
+            // It treats +0 as larger than -0 as per the specification.
+
+            float ax = Abs(x);
+            float ay = Abs(y);
+
+            if ((ax < ay) || IsNaN(ay))
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                return IsNegative(x) ? x : y;
+            }
+
+            return y;
+        }
+
+        /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinNumber(TSelf, TSelf)" />
+        public static float MinNumber(float x, float y)
+        {
+            // This matches the IEEE 754:2019 `minimumNumber` function
+            //
+            // It does not propagate NaN inputs back to the caller and
+            // otherwise returns the larger of the inputs. It
+            // treats +0 as larger than -0 as per the specification.
+
+            if (x != y)
+            {
+                if (!IsNaN(y))
+                {
+                    return x < y ? x : y;
+                }
+
+                return x;
+            }
+
+            return IsNegative(x) ? x : y;
+        }
+
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ReciprocalEstimate(TSelf)" />
         public static float ReciprocalEstimate(float x) => MathF.ReciprocalEstimate(x);
 
@@ -769,18 +863,6 @@ namespace System
 
         // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.Compound(TSelf, TSelf)" />
         // public static float Compound(float x, float n) => MathF.Compound(x, n);
-
-        // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxMagnitudeNumber(TSelf, TSelf)" />
-        // public static float MaxMagnitudeNumber(float x, float y) => MathF.MaxMagnitudeNumber(x, y);
-
-        // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MaxNumber(TSelf, TSelf)" />
-        // public static float MaxNumber(float x, float y) => MathF.MaxNumber(x, y);
-
-        // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinMagnitudeNumber(TSelf, TSelf)" />
-        // public static float MinMagnitudeNumber(float x, float y) => MathF.MinMagnitudeNumber(x, y);
-
-        // /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.MinNumber(TSelf, TSelf)" />
-        // public static float MinNumber(float x, float y) => MathF.MinNumber(x, y);
 
         //
         // IHyperbolicFunctions

--- a/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
@@ -343,15 +343,15 @@ namespace System.Tests
         // but also NaN and +-infinity) are correctly and consistently represented.
         private static string ToStringPadded(float value)
         {
-            if (double.IsNaN(value))
+            if (float.IsNaN(value))
             {
                 return "NaN".PadLeft(10);
             }
-            else if (double.IsPositiveInfinity(value))
+            else if (float.IsPositiveInfinity(value))
             {
                 return "+\u221E".PadLeft(10);
             }
-            else if (double.IsNegativeInfinity(value))
+            else if (float.IsNegativeInfinity(value))
             {
                 return "-\u221E".PadLeft(10);
             }
@@ -2854,12 +2854,22 @@ namespace System.Tests
 
         [Theory]
         [InlineData(double.NegativeInfinity, double.PositiveInfinity, double.PositiveInfinity)]
+        [InlineData(double.PositiveInfinity, double.NegativeInfinity, double.PositiveInfinity)]
         [InlineData(double.MinValue, double.MaxValue, double.MaxValue)]
+        [InlineData(double.MaxValue, double.MinValue, double.MaxValue)]
         [InlineData(double.NaN, double.NaN, double.NaN)]
-        [InlineData(-0.0, 0.0, 0.0)]
-        [InlineData(2.0, -3.0, -3.0)]
-        [InlineData(3.0, -2.0, 3.0)]
+        [InlineData(double.NaN, 1.0, double.NaN)]
+        [InlineData(1.0, double.NaN, double.NaN)]
         [InlineData(double.PositiveInfinity, double.NaN, double.NaN)]
+        [InlineData(double.NegativeInfinity, double.NaN, double.NaN)]
+        [InlineData(double.NaN, double.PositiveInfinity, double.NaN)]
+        [InlineData(double.NaN, double.NegativeInfinity, double.NaN)]
+        [InlineData(-0.0, 0.0, 0.0)]
+        [InlineData(0.0, -0.0, 0.0)]
+        [InlineData(2.0, -3.0, -3.0)]
+        [InlineData(-3.0, 2.0, -3.0)]
+        [InlineData(3.0, -2.0, 3.0)]
+        [InlineData(-2.0, 3.0, 3.0)]
         public static void MaxMagnitude(double x, double y, double expectedResult)
         {
             AssertEqual(expectedResult, Math.MaxMagnitude(x, y), 0.0);
@@ -2867,12 +2877,22 @@ namespace System.Tests
 
         [Theory]
         [InlineData(double.NegativeInfinity, double.PositiveInfinity, double.NegativeInfinity)]
+        [InlineData(double.PositiveInfinity, double.NegativeInfinity, double.NegativeInfinity)]
         [InlineData(double.MinValue, double.MaxValue, double.MinValue)]
+        [InlineData(double.MaxValue, double.MinValue, double.MinValue)]
         [InlineData(double.NaN, double.NaN, double.NaN)]
-        [InlineData(-0.0, 0.0, -0.0)]
-        [InlineData(2.0, -3.0, 2.0)]
-        [InlineData(3.0, -2.0, -2.0)]
+        [InlineData(double.NaN, 1.0, double.NaN)]
+        [InlineData(1.0, double.NaN, double.NaN)]
         [InlineData(double.PositiveInfinity, double.NaN, double.NaN)]
+        [InlineData(double.NegativeInfinity, double.NaN, double.NaN)]
+        [InlineData(double.NaN, double.PositiveInfinity, double.NaN)]
+        [InlineData(double.NaN, double.NegativeInfinity, double.NaN)]
+        [InlineData(-0.0, 0.0, -0.0)]
+        [InlineData(0.0, -0.0, -0.0)]
+        [InlineData(2.0, -3.0, 2.0)]
+        [InlineData(-3.0, 2.0, 2.0)]
+        [InlineData(3.0, -2.0, -2.0)]
+        [InlineData(-2.0, 3.0, -2.0)]
         public static void MinMagnitude(double x, double y, double expectedResult)
         {
             AssertEqual(expectedResult, Math.MinMagnitude(x, y), 0.0);

--- a/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
-using Xunit.Sdk;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -45,119 +44,6 @@ namespace System.Tests
         // no more than approx. 1.5 * 2^-7 (approx 1.17e-02).
         private const double CrossPlatformMachineEpsilonForEstimates = 1.171875e-02;
 
-        /// <summary>Verifies that two <see cref="double"/> values are equal, within the <paramref name="allowedVariance"/>.</summary>
-        /// <param name="expected">The expected value</param>
-        /// <param name="actual">The value to be compared against</param>
-        /// <param name="allowedVariance">The total variance allowed between the expected and actual results.</param>
-        /// <exception cref="EqualException">Thrown when the values are not equal</exception>
-        private static void AssertEqual(double expected, double actual, double variance)
-        {
-            if (double.IsNaN(expected))
-            {
-                if (double.IsNaN(actual))
-                {
-                    return;
-                }
-
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-            else if (double.IsNaN(actual))
-            {
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-
-            if (double.IsNegativeInfinity(expected))
-            {
-                if (double.IsNegativeInfinity(actual))
-                {
-                    return;
-                }
-
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-            else if (double.IsNegativeInfinity(actual))
-            {
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-
-            if (double.IsPositiveInfinity(expected))
-            {
-                if (double.IsPositiveInfinity(actual))
-                {
-                    return;
-                }
-
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-            else if (double.IsPositiveInfinity(actual))
-            {
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-
-            if (IsNegativeZero(expected))
-            {
-                if (IsNegativeZero(actual))
-                {
-                    return;
-                }
-
-                if (IsPositiveZero(variance) || IsNegativeZero(variance))
-                {
-                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-                }
-
-                // When the variance is not +-0.0, then we are handling a case where
-                // the actual result is expected to not be exactly -0.0 on some platforms
-                // and we should fallback to checking if it is within the allowed variance instead.
-            }
-            else if (IsNegativeZero(actual))
-            {
-                if (IsPositiveZero(variance) || IsNegativeZero(variance))
-                {
-                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-                }
-
-                // When the variance is not +-0.0, then we are handling a case where
-                // the actual result is expected to not be exactly -0.0 on some platforms
-                // and we should fallback to checking if it is within the allowed variance instead.
-            }
-
-            if (IsPositiveZero(expected))
-            {
-                if (IsPositiveZero(actual))
-                {
-                    return;
-                }
-
-                if (IsPositiveZero(variance) || IsNegativeZero(variance))
-                {
-                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-                }
-
-                // When the variance is not +-0.0, then we are handling a case where
-                // the actual result is expected to not be exactly +0.0 on some platforms
-                // and we should fallback to checking if it is within the allowed variance instead.
-            }
-            else if (IsPositiveZero(actual))
-            {
-                if (IsPositiveZero(variance) || IsNegativeZero(variance))
-                {
-                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-                }
-
-                // When the variance is not +-0.0, then we are handling a case where
-                // the actual result is expected to not be exactly +0.0 on some platforms
-                // and we should fallback to checking if it is within the allowed variance instead.
-            }
-
-            var delta = Math.Abs(actual - expected);
-
-            if (delta > variance)
-            {
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-        }
-
         [Fact]
         public static void E()
         {
@@ -174,199 +60,6 @@ namespace System.Tests
         public static void Tau()
         {
             Assert.Equal(unchecked((long)0x401921FB54442D18), BitConverter.DoubleToInt64Bits(Math.Tau));
-        }
-
-        /// <summary>Verifies that two <see cref="float"/> values are equal, within the <paramref name="variance"/>.</summary>
-        /// <param name="expected">The expected value</param>
-        /// <param name="actual">The value to be compared against</param>
-        /// <param name="variance">The total variance allowed between the expected and actual results.</param>
-        /// <exception cref="EqualException">Thrown when the values are not equal</exception>
-        private static void AssertEqual(float expected, float actual, float variance)
-        {
-            if (float.IsNaN(expected))
-            {
-                if (float.IsNaN(actual))
-                {
-                    return;
-                }
-
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-            else if (float.IsNaN(actual))
-            {
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-
-            if (float.IsNegativeInfinity(expected))
-            {
-                if (float.IsNegativeInfinity(actual))
-                {
-                    return;
-                }
-
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-            else if (float.IsNegativeInfinity(actual))
-            {
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-
-            if (float.IsPositiveInfinity(expected))
-            {
-                if (float.IsPositiveInfinity(actual))
-                {
-                    return;
-                }
-
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-            else if (float.IsPositiveInfinity(actual))
-            {
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-
-            if (IsNegativeZero(expected))
-            {
-                if (IsNegativeZero(actual))
-                {
-                    return;
-                }
-
-                if (IsPositiveZero(variance) || IsNegativeZero(variance))
-                {
-                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-                }
-
-                // When the variance is not +-0.0, then we are handling a case where
-                // the actual result is expected to not be exactly -0.0 on some platforms
-                // and we should fallback to checking if it is within the allowed variance instead.
-            }
-            else if (IsNegativeZero(actual))
-            {
-                if (IsPositiveZero(variance) || IsNegativeZero(variance))
-                {
-                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-                }
-
-                // When the variance is not +-0.0, then we are handling a case where
-                // the actual result is expected to not be exactly -0.0 on some platforms
-                // and we should fallback to checking if it is within the allowed variance instead.
-            }
-
-            if (IsPositiveZero(expected))
-            {
-                if (IsPositiveZero(actual))
-                {
-                    return;
-                }
-
-                if (IsPositiveZero(variance) || IsNegativeZero(variance))
-                {
-                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-                }
-
-                // When the variance is not +-0.0, then we are handling a case where
-                // the actual result is expected to not be exactly +0.0 on some platforms
-                // and we should fallback to checking if it is within the allowed variance instead.
-            }
-            else if (IsPositiveZero(actual))
-            {
-                if (IsPositiveZero(variance) || IsNegativeZero(variance))
-                {
-                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-                }
-
-                // When the variance is not +-0.0, then we are handling a case where
-                // the actual result is expected to not be exactly +0.0 on some platforms
-                // and we should fallback to checking if it is within the allowed variance instead.
-            }
-
-            var delta = Math.Abs(actual - expected);
-
-            if (delta > variance)
-            {
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-        }
-
-        private static unsafe bool IsNegativeZero(double value)
-        {
-            return (*(ulong*)(&value)) == 0x8000000000000000;
-        }
-
-        private static unsafe bool IsNegativeZero(float value)
-        {
-            return (*(uint*)(&value)) == 0x80000000;
-        }
-
-        private static unsafe bool IsPositiveZero(double value)
-        {
-            return (*(ulong*)(&value)) == 0x0000000000000000;
-        }
-
-        private static unsafe bool IsPositiveZero(float value)
-        {
-            return (*(uint*)(&value)) == 0x00000000;
-        }
-
-        // We have a custom ToString here to ensure that edge cases (specifically +-0.0,
-        // but also NaN and +-infinity) are correctly and consistently represented.
-        private static string ToStringPadded(double value)
-        {
-            if (double.IsNaN(value))
-            {
-                return "NaN".PadLeft(20);
-            }
-            else if (double.IsPositiveInfinity(value))
-            {
-                return "+\u221E".PadLeft(20);
-            }
-            else if (double.IsNegativeInfinity(value))
-            {
-                return "-\u221E".PadLeft(20);
-            }
-            else if (IsNegativeZero(value))
-            {
-                return "-0.0".PadLeft(20);
-            }
-            else if (IsPositiveZero(value))
-            {
-                return "+0.0".PadLeft(20);
-            }
-            else
-            {
-                return $"{value,20:G17}";
-            }
-        }
-
-        // We have a custom ToString here to ensure that edge cases (specifically +-0.0,
-        // but also NaN and +-infinity) are correctly and consistently represented.
-        private static string ToStringPadded(float value)
-        {
-            if (float.IsNaN(value))
-            {
-                return "NaN".PadLeft(10);
-            }
-            else if (float.IsPositiveInfinity(value))
-            {
-                return "+\u221E".PadLeft(10);
-            }
-            else if (float.IsNegativeInfinity(value))
-            {
-                return "-\u221E".PadLeft(10);
-            }
-            else if (IsNegativeZero(value))
-            {
-                return "-0.0".PadLeft(10);
-            }
-            else if (IsPositiveZero(value))
-            {
-                return "+0.0".PadLeft(10);
-            }
-            else
-            {
-                return $"{value,10:G9}";
-            }
         }
 
         [Fact]
@@ -415,7 +108,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity, double.PositiveInfinity, 0.0)]
         public static void Abs_Double(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Abs(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Abs(value), allowedVariance);
         }
 
         [Fact]
@@ -499,7 +192,7 @@ namespace System.Tests
         [InlineData( float.PositiveInfinity, float.PositiveInfinity, 0.0f)]
         public static void Abs_Single(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Abs(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Abs(value), allowedVariance);
         }
 
         [Theory]
@@ -530,7 +223,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity, double.NaN,          0.0 )]
         public static void Acos(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Acos(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Acos(value), allowedVariance);
         }
 
         [Theory]
@@ -573,7 +266,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  double.NaN,          0.0)]
         public static void Asin(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Asin(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Asin(value), allowedVariance);
         }
 
         [Theory]
@@ -608,7 +301,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  1.5707963267948966,  CrossPlatformMachineEpsilon * 10)]  // expected:  (pi / 2)
         public static void Atan(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Atan(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Atan(value), allowedVariance);
         }
 
         public static IEnumerable<object[]> Atan2_TestData
@@ -713,7 +406,7 @@ namespace System.Tests
         [MemberData(nameof(Atan2_TestData))]
         public static void Atan2(double y, double x, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Atan2(y, x), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Atan2(y, x), allowedVariance);
         }
 
         [Theory]
@@ -723,7 +416,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity, double.PositiveInfinity,  0.78539816339744831, CrossPlatformMachineEpsilon)]         // expected:  (pi / 4)
         public static void Atan2_IEEE(double y, double x, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Atan2(y, x), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Atan2(y, x), allowedVariance);
         }
 
         [Fact]
@@ -764,7 +457,7 @@ namespace System.Tests
         [InlineData(double.PositiveInfinity, double.PositiveInfinity,  0.0)]
         public static void Ceiling_Double(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Ceiling(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Ceiling(value), allowedVariance);
         }
 
         [Theory]
@@ -776,7 +469,7 @@ namespace System.Tests
         [InlineData(-0.31830988618379067,    -0.0,                     0.0)]    // value: -(1 / pi)
         public static void Ceiling_Double_IEEE(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Ceiling(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Ceiling(value), allowedVariance);
         }
 
         [Theory]
@@ -815,7 +508,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  double.NaN,          0.0)]
         public static void Cos(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Cos(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Cos(value), allowedVariance);
         }
 
         [Theory]
@@ -854,7 +547,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity, double.PositiveInfinity, 0.0)]
         public static void Cosh(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Cosh(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Cosh(value), allowedVariance);
         }
 
         [Theory]
@@ -893,7 +586,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity, double.PositiveInfinity, 0.0)]
         public static void Exp(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Exp(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Exp(value), allowedVariance);
         }
 
         [Fact]
@@ -939,14 +632,14 @@ namespace System.Tests
         [InlineData(double.PositiveInfinity,  double.PositiveInfinity, 0.0)]
         public static void Floor_Double(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Floor(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Floor(value), allowedVariance);
         }
 
         [Theory]
         [InlineData(-0.0,                    -0.0,                     0.0)]
         public static void Floor_Double_IEEE(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Floor(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Floor(value), allowedVariance);
         }
 
         [Fact]
@@ -1007,7 +700,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  double.PositiveInfinity, 0.0)]
         public static void Log(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Log(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Log(value), allowedVariance);
         }
 
         [Fact]
@@ -1065,7 +758,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  double.PositiveInfinity, 0.0)]
         public static void Log10(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Log10(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Log10(value), allowedVariance);
         }
 
         [Fact]
@@ -1102,7 +795,7 @@ namespace System.Tests
         [InlineData(-2.0,                    3.0,                     3.0)]
         public static void Max_Double_NotNetFramework(double x, double y, double expectedResult)
         {
-            AssertEqual(expectedResult, Math.Max(x, y), 0.0);
+            AssertExtensions.Equal(expectedResult, Math.Max(x, y), 0.0);
         }
 
         [Fact]
@@ -1160,7 +853,7 @@ namespace System.Tests
         [InlineData(-2.0,                   3.0,                    3.0)]
         public static void Max_Single_NotNetFramework(float x, float y, float expectedResult)
         {
-            AssertEqual(expectedResult, Math.Max(x, y), 0.0f);
+            AssertExtensions.Equal(expectedResult, Math.Max(x, y), 0.0f);
         }
 
         [Fact]
@@ -1225,7 +918,7 @@ namespace System.Tests
         [InlineData(-2.0,                    3.0,                     -2.0)]
         public static void Min_Double_NotNetFramework(double x, double y, double expectedResult)
         {
-            AssertEqual(expectedResult, Math.Min(x, y), 0.0);
+            AssertExtensions.Equal(expectedResult, Math.Min(x, y), 0.0);
         }
 
         [Fact]
@@ -1283,7 +976,7 @@ namespace System.Tests
         [InlineData(-2.0,                   3.0,                    -2.0)]
         public static void Min_Single_NotNetFramework(float x, float y, float expectedResult)
         {
-            AssertEqual(expectedResult, Math.Min(x, y), 0.0f);
+            AssertExtensions.Equal(expectedResult, Math.Min(x, y), 0.0f);
         }
 
         [Fact]
@@ -1469,7 +1162,7 @@ namespace System.Tests
         [MemberData(nameof(Pow_TestData))]
         public static void Pow(double x, double y, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Pow(x, y), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Pow(x, y), allowedVariance);
         }
 
         [Theory]
@@ -1480,7 +1173,7 @@ namespace System.Tests
         [InlineData( 1.0,         double.NaN,              1.0, CrossPlatformMachineEpsilon * 10)]
         public static void Pow_IEEE(float x, float y, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Pow(x, y), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Pow(x, y), allowedVariance);
         }
 
         [Theory]
@@ -1519,7 +1212,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  0.0,                     0.0)]
         public static void ReciprocalEstimate(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.ReciprocalEstimate(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.ReciprocalEstimate(value), allowedVariance);
         }
 
         [Theory]
@@ -1558,7 +1251,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  0.0,                     0.0)]
         public static void ReciprocalSqrtEstimate(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.ReciprocalSqrtEstimate(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.ReciprocalSqrtEstimate(value), allowedVariance);
         }
 
         [Fact]
@@ -1707,7 +1400,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  double.NaN,          0.0)]
         public static void Sin(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Sin(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Sin(value), allowedVariance);
         }
 
         [Theory]
@@ -1747,8 +1440,8 @@ namespace System.Tests
         public static void SinCos(double value, double expectedResultSin, double expectedResultCos, double allowedVarianceSin, double allowedVarianceCos)
         {
             (double resultSin, double resultCos) = Math.SinCos(value);
-            AssertEqual(expectedResultSin, resultSin, allowedVarianceSin);
-            AssertEqual(expectedResultCos, resultCos, allowedVarianceCos);
+            AssertExtensions.Equal(expectedResultSin, resultSin, allowedVarianceSin);
+            AssertExtensions.Equal(expectedResultCos, resultCos, allowedVarianceCos);
         }
 
         [Theory]
@@ -1787,7 +1480,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  double.PositiveInfinity, 0.0)]
         public static void Sinh(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Sinh(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Sinh(value), allowedVariance);
         }
 
         [Theory]
@@ -1826,7 +1519,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity, double.PositiveInfinity, 0.0)]
         public static void Sqrt(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Sqrt(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Sqrt(value), allowedVariance);
         }
 
         [Theory]
@@ -1863,7 +1556,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  double.NaN,              0.0)]
         public static void Tan(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Tan(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Tan(value), allowedVariance);
         }
 
         [Theory]
@@ -1871,7 +1564,7 @@ namespace System.Tests
         [InlineData( 1.5707963267948966,       16331239353195370.0,     0.0)]                               // value:  (pi / 2)
         public static void Tan_PiOver2(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Tan(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Tan(value), allowedVariance);
         }
 
         [Theory]
@@ -1910,7 +1603,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  1.0,                 CrossPlatformMachineEpsilon * 10)]
         public static void Tanh(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Tanh(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Tanh(value), allowedVariance);
         }
 
         [Fact]
@@ -2295,7 +1988,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity, double.PositiveInfinity, 0.0)]
         public static void Acosh(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Acosh(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Acosh(value), allowedVariance);
         }
 
         [Theory]
@@ -2334,7 +2027,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  double.PositiveInfinity, 0.0)]
         public static void Asinh(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Asinh(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Asinh(value), allowedVariance);
         }
 
         [Theory]
@@ -2381,7 +2074,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  double.NaN,              0.0)]
         public static void Atanh(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Atanh(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Atanh(value), allowedVariance);
         }
 
         [Theory]
@@ -2420,7 +2113,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  double.MaxValue)]
         public static void BitDecrement(double value, double expectedResult)
         {
-            AssertEqual(expectedResult, Math.BitDecrement(value), 0.0);
+            AssertExtensions.Equal(expectedResult, Math.BitDecrement(value), 0.0);
         }
 
         [Theory]
@@ -2459,7 +2152,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  double.PositiveInfinity)]
         public static void BitIncrement(double value, double expectedResult)
         {
-            AssertEqual(expectedResult, Math.BitIncrement(value), 0.0);
+            AssertExtensions.Equal(expectedResult, Math.BitIncrement(value), 0.0);
         }
 
         [Theory]
@@ -2498,7 +2191,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  double.PositiveInfinity, 0.0)]
         public static void Cbrt(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Cbrt(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Cbrt(value), allowedVariance);
         }
 
         [Theory]
@@ -2686,7 +2379,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  double.PositiveInfinity,  double.PositiveInfinity)]
         public static void CopySign(double x, double y, double expectedResult)
         {
-            AssertEqual(expectedResult, Math.CopySign(x, y), 0.0);
+            AssertExtensions.Equal(expectedResult, Math.CopySign(x, y), 0.0);
         }
 
         [Theory]
@@ -2758,7 +2451,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  double.PositiveInfinity,  double.NegativeInfinity,  double.NaN)]
         public static void FusedMultiplyAdd(double x, double y, double z, double expectedResult)
         {
-            AssertEqual(expectedResult, Math.FusedMultiplyAdd(x, y, z), 0.0);
+            AssertExtensions.Equal(expectedResult, Math.FusedMultiplyAdd(x, y, z), 0.0);
         }
 
         [Theory]
@@ -2849,7 +2542,7 @@ namespace System.Tests
         [InlineData( double.PositiveInfinity,  double.PositiveInfinity, 0.0)]
         public static void Log2(double value, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.Log2(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.Log2(value), allowedVariance);
         }
 
         [Theory]
@@ -2872,7 +2565,7 @@ namespace System.Tests
         [InlineData(-2.0, 3.0, 3.0)]
         public static void MaxMagnitude(double x, double y, double expectedResult)
         {
-            AssertEqual(expectedResult, Math.MaxMagnitude(x, y), 0.0);
+            AssertExtensions.Equal(expectedResult, Math.MaxMagnitude(x, y), 0.0);
         }
 
         [Theory]
@@ -2895,7 +2588,7 @@ namespace System.Tests
         [InlineData(-2.0, 3.0, -2.0)]
         public static void MinMagnitude(double x, double y, double expectedResult)
         {
-            AssertEqual(expectedResult, Math.MinMagnitude(x, y), 0.0);
+            AssertExtensions.Equal(expectedResult, Math.MinMagnitude(x, y), 0.0);
         }
 
         [Theory]
@@ -2972,7 +2665,7 @@ namespace System.Tests
         [InlineData( -0.6787637026394024,      7,                             -86.88175393784351,       CrossPlatformMachineEpsilon * 100)]
         public static void ScaleB(double x, int n, double expectedResult, double allowedVariance)
         {
-            AssertEqual(expectedResult, Math.ScaleB(x, n), allowedVariance);
+            AssertExtensions.Equal(expectedResult, Math.ScaleB(x, n), allowedVariance);
         }
 
 

--- a/src/libraries/System.Runtime.Extensions/tests/System/MathF.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/MathF.cs
@@ -1225,12 +1225,22 @@ namespace System.Tests
 
         [Theory]
         [InlineData(float.NegativeInfinity, float.PositiveInfinity, float.PositiveInfinity)]
+        [InlineData(float.PositiveInfinity, float.NegativeInfinity, float.PositiveInfinity)]
         [InlineData(float.MinValue, float.MaxValue, float.MaxValue)]
+        [InlineData(float.MaxValue, float.MinValue, float.MaxValue)]
         [InlineData(float.NaN, float.NaN, float.NaN)]
-        [InlineData(-0.0f, 0.0f, 0.0f)]
-        [InlineData(2.0f, -3.0f, 2.0f)]
-        [InlineData(3.0f, -2.0f, 3.0f)]
+        [InlineData(float.NaN, 1.0f, float.NaN)]
+        [InlineData(1.0f, float.NaN, float.NaN)]
         [InlineData(float.PositiveInfinity, float.NaN, float.NaN)]
+        [InlineData(float.NegativeInfinity, float.NaN, float.NaN)]
+        [InlineData(float.NaN, float.PositiveInfinity, float.NaN)]
+        [InlineData(float.NaN, float.NegativeInfinity, float.NaN)]
+        [InlineData(-0.0f, 0.0f, 0.0f)]
+        [InlineData(0.0f, -0.0f, 0.0f)]
+        [InlineData(2.0f, -3.0f, 2.0f)]
+        [InlineData(-3.0f, 2.0f, 2.0f)]
+        [InlineData(3.0f, -2.0f, 3.0f)]
+        [InlineData(-2.0f, 3.0f, 3.0f)]
         public static void Max(float x, float y, float expectedResult)
         {
             AssertEqual(expectedResult, MathF.Max(x, y), 0.0f);
@@ -1238,12 +1248,22 @@ namespace System.Tests
 
         [Theory]
         [InlineData(float.NegativeInfinity, float.PositiveInfinity, float.PositiveInfinity)]
+        [InlineData(float.PositiveInfinity, float.NegativeInfinity, float.PositiveInfinity)]
         [InlineData(float.MinValue, float.MaxValue, float.MaxValue)]
+        [InlineData(float.MaxValue, float.MinValue, float.MaxValue)]
         [InlineData(float.NaN, float.NaN, float.NaN)]
-        [InlineData(-0.0f, 0.0f, 0.0f)]
-        [InlineData(2.0f, -3.0f, -3.0f)]
-        [InlineData(3.0f, -2.0f, 3.0f)]
+        [InlineData(float.NaN, 1.0f, float.NaN)]
+        [InlineData(1.0f, float.NaN, float.NaN)]
         [InlineData(float.PositiveInfinity, float.NaN, float.NaN)]
+        [InlineData(float.NegativeInfinity, float.NaN, float.NaN)]
+        [InlineData(float.NaN, float.PositiveInfinity, float.NaN)]
+        [InlineData(float.NaN, float.NegativeInfinity, float.NaN)]
+        [InlineData(-0.0f, 0.0f, 0.0f)]
+        [InlineData(0.0f, -0.0f, 0.0f)]
+        [InlineData(2.0f, -3.0f, -3.0f)]
+        [InlineData(-3.0f, 2.0f, -3.0f)]
+        [InlineData(3.0f, -2.0f, 3.0f)]
+        [InlineData(-2.0f, 3.0f, 3.0f)]
         public static void MaxMagnitude(float x, float y, float expectedResult)
         {
             AssertEqual(expectedResult, MathF.MaxMagnitude(x, y), 0.0f);
@@ -1251,12 +1271,22 @@ namespace System.Tests
 
         [Theory]
         [InlineData(float.NegativeInfinity, float.PositiveInfinity, float.NegativeInfinity)]
+        [InlineData(float.PositiveInfinity, float.NegativeInfinity, float.NegativeInfinity)]
         [InlineData(float.MinValue, float.MaxValue, float.MinValue)]
+        [InlineData(float.MaxValue, float.MinValue, float.MinValue)]
         [InlineData(float.NaN, float.NaN, float.NaN)]
-        [InlineData(-0.0f, 0.0f, -0.0f)]
-        [InlineData(2.0f, -3.0f, -3.0f)]
-        [InlineData(3.0f, -2.0f, -2.0f)]
+        [InlineData(float.NaN, 1.0f, float.NaN)]
+        [InlineData(1.0f, float.NaN, float.NaN)]
         [InlineData(float.PositiveInfinity, float.NaN, float.NaN)]
+        [InlineData(float.NegativeInfinity, float.NaN, float.NaN)]
+        [InlineData(float.NaN, float.PositiveInfinity, float.NaN)]
+        [InlineData(float.NaN, float.NegativeInfinity, float.NaN)]
+        [InlineData(-0.0f, 0.0f, -0.0f)]
+        [InlineData(0.0f, -0.0f, -0.0f)]
+        [InlineData(2.0f, -3.0f, -3.0f)]
+        [InlineData(-3.0f, 2.0f, -3.0f)]
+        [InlineData(3.0f, -2.0f, -2.0f)]
+        [InlineData(-2.0f, 3.0f, -2.0f)]
         public static void Min(float x, float y, float expectedResult)
         {
             AssertEqual(expectedResult, MathF.Min(x, y), 0.0f);
@@ -1264,12 +1294,22 @@ namespace System.Tests
 
         [Theory]
         [InlineData(float.NegativeInfinity, float.PositiveInfinity, float.NegativeInfinity)]
+        [InlineData(float.PositiveInfinity, float.NegativeInfinity, float.NegativeInfinity)]
         [InlineData(float.MinValue, float.MaxValue, float.MinValue)]
+        [InlineData(float.MaxValue, float.MinValue, float.MinValue)]
         [InlineData(float.NaN, float.NaN, float.NaN)]
-        [InlineData(-0.0f, 0.0f, -0.0f)]
-        [InlineData(2.0f, -3.0f, 2.0f)]
-        [InlineData(3.0f, -2.0f, -2.0f)]
+        [InlineData(float.NaN, 1.0f, float.NaN)]
+        [InlineData(1.0f, float.NaN, float.NaN)]
         [InlineData(float.PositiveInfinity, float.NaN, float.NaN)]
+        [InlineData(float.NegativeInfinity, float.NaN, float.NaN)]
+        [InlineData(float.NaN, float.PositiveInfinity, float.NaN)]
+        [InlineData(float.NaN, float.NegativeInfinity, float.NaN)]
+        [InlineData(-0.0f, 0.0f, -0.0f)]
+        [InlineData(0.0f, -0.0f, -0.0f)]
+        [InlineData(2.0f, -3.0f, 2.0f)]
+        [InlineData(-3.0f, 2.0f, 2.0f)]
+        [InlineData(3.0f, -2.0f, -2.0f)]
+        [InlineData(-2.0f, 3.0f, -2.0f)]
         public static void MinMagnitude(float x, float y, float expectedResult)
         {
             AssertEqual(expectedResult, MathF.MinMagnitude(x, y), 0.0f);

--- a/src/libraries/System.Runtime.Extensions/tests/System/MathF.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/MathF.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
-using Xunit.Sdk;
 using System.Collections.Generic;
 
 #pragma warning disable xUnit1025 // reporting duplicate test cases due to not distinguishing 0.0 from -0.0
@@ -29,159 +28,6 @@ namespace System.Tests
         // or perform one Newton-Raphson iteration which, for the currently tested values, gives an error of
         // no more than approx. 1.5 * 2^-7 (approx 1.17e-02).
         private const double CrossPlatformMachineEpsilonForEstimates = 1.171875e-02f;
-
-        /// <summary>Verifies that two <see cref="float"/> values are equal, within the <paramref name="variance"/>.</summary>
-        /// <param name="expected">The expected value</param>
-        /// <param name="actual">The value to be compared against</param>
-        /// <param name="variance">The total variance allowed between the expected and actual results.</param>
-        /// <exception cref="EqualException">Thrown when the values are not equal</exception>
-        private static void AssertEqual(float expected, float actual, float variance)
-        {
-            if (float.IsNaN(expected))
-            {
-                if (float.IsNaN(actual))
-                {
-                    return;
-                }
-
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-            else if (float.IsNaN(actual))
-            {
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-
-            if (float.IsNegativeInfinity(expected))
-            {
-                if (float.IsNegativeInfinity(actual))
-                {
-                    return;
-                }
-
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-            else if (float.IsNegativeInfinity(actual))
-            {
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-
-            if (float.IsPositiveInfinity(expected))
-            {
-                if (float.IsPositiveInfinity(actual))
-                {
-                    return;
-                }
-
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-            else if (float.IsPositiveInfinity(actual))
-            {
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-
-            if (IsNegativeZero(expected))
-            {
-                if (IsNegativeZero(actual))
-                {
-                    return;
-                }
-
-                if (IsPositiveZero(variance) || IsNegativeZero(variance))
-                {
-                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-                }
-
-                // When the variance is not +-0.0, then we are handling a case where
-                // the actual result is expected to not be exactly -0.0 on some platforms
-                // and we should fallback to checking if it is within the allowed variance instead.
-            }
-            else if (IsNegativeZero(actual))
-            {
-                if (IsPositiveZero(variance) || IsNegativeZero(variance))
-                {
-                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-                }
-
-                // When the variance is not +-0.0, then we are handling a case where
-                // the actual result is expected to not be exactly -0.0 on some platforms
-                // and we should fallback to checking if it is within the allowed variance instead.
-            }
-
-            if (IsPositiveZero(expected))
-            {
-                if (IsPositiveZero(actual))
-                {
-                    return;
-                }
-
-                if (IsPositiveZero(variance) || IsNegativeZero(variance))
-                {
-                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-                }
-
-                // When the variance is not +-0.0, then we are handling a case where
-                // the actual result is expected to not be exactly +0.0 on some platforms
-                // and we should fallback to checking if it is within the allowed variance instead.
-            }
-            else if (IsPositiveZero(actual))
-            {
-                if (IsPositiveZero(variance) || IsNegativeZero(variance))
-                {
-                    throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-                }
-
-                // When the variance is not +-0.0, then we are handling a case where
-                // the actual result is expected to not be exactly +0.0 on some platforms
-                // and we should fallback to checking if it is within the allowed variance instead.
-            }
-
-            var delta = MathF.Abs(actual - expected);
-
-            if (delta > variance)
-            {
-                throw new EqualException(ToStringPadded(expected), ToStringPadded(actual));
-            }
-        }
-
-        private static unsafe bool IsNegativeZero(float value)
-        {
-            return (*(uint*)(&value)) == 0x80000000;
-        }
-
-        private static unsafe bool IsPositiveZero(float value)
-        {
-            return (*(uint*)(&value)) == 0x00000000;
-        }
-
-        // We have a custom ToString here to ensure that edge cases (specifically +-0.0,
-        // but also NaN and +-infinity) are correctly and consistently represented.
-        private static string ToStringPadded(float value)
-        {
-            if (float.IsNaN(value))
-            {
-                return "NaN".PadLeft(10);
-            }
-            else if (float.IsPositiveInfinity(value))
-            {
-                return "+\u221E".PadLeft(10);
-            }
-            else if (float.IsNegativeInfinity(value))
-            {
-                return "-\u221E".PadLeft(10);
-            }
-            else if (IsNegativeZero(value))
-            {
-                return "-0.0".PadLeft(10);
-            }
-            else if (IsPositiveZero(value))
-            {
-                return "+0.0".PadLeft(10);
-            }
-            else
-            {
-                return $"{value,10:G9}";
-            }
-        }
 
         [Fact]
         public static void E()
@@ -237,7 +83,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.PositiveInfinity, 0.0f)]
         public static void Abs(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Abs(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Abs(value), allowedVariance);
         }
 
         [Theory]
@@ -268,7 +114,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.NaN, 0.0f)]
         public static void Acos(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Acos(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Acos(value), allowedVariance);
         }
 
         [Theory]
@@ -300,7 +146,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.PositiveInfinity, 0.0f)]
         public static void Acosh(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Acosh(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Acosh(value), allowedVariance);
         }
 
         [Theory]
@@ -343,7 +189,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.NaN, 0.0f)]
         public static void Asin(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Asin(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Asin(value), allowedVariance);
         }
 
         [Theory]
@@ -382,7 +228,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.PositiveInfinity, 0.0f)]
         public static void Asinh(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Asinh(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Asinh(value), allowedVariance);
         }
 
         [Theory]
@@ -417,7 +263,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, 1.57079633f, CrossPlatformMachineEpsilon * 10)]  // expected:  (pi / 2)
         public static void Atan(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Atan(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Atan(value), allowedVariance);
         }
 
         [Theory]
@@ -514,7 +360,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, 1.0f, 1.57079633f, CrossPlatformMachineEpsilon * 10)]     // expected:  (pi / 2)
         public static void Atan2(float y, float x, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Atan2(y, x), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Atan2(y, x), allowedVariance);
         }
 
         [Theory]
@@ -524,7 +370,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.PositiveInfinity, 0.785398163f, CrossPlatformMachineEpsilon)]          // expected:  (pi / 4)
         public static void Atan2_IEEE(float y, float x, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Atan2(y, x), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Atan2(y, x), allowedVariance);
         }
 
         [Theory]
@@ -571,7 +417,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.NaN, 0.0f)]
         public static void Atanh(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Atanh(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Atanh(value), allowedVariance);
         }
 
         [Theory]
@@ -610,7 +456,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.MaxValue)]
         public static void BitDecrement(float value, float expectedResult)
         {
-            AssertEqual(expectedResult, MathF.BitDecrement(value), 0.0f);
+            AssertExtensions.Equal(expectedResult, MathF.BitDecrement(value), 0.0f);
         }
 
         [Theory]
@@ -649,7 +495,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.PositiveInfinity)]
         public static void BitIncrement(float value, float expectedResult)
         {
-            AssertEqual(expectedResult, MathF.BitIncrement(value), 0.0f);
+            AssertExtensions.Equal(expectedResult, MathF.BitIncrement(value), 0.0f);
         }
 
         [Theory]
@@ -688,7 +534,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.PositiveInfinity, 0.0f)]
         public static void Cbrt(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Cbrt(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Cbrt(value), allowedVariance);
         }
 
         [Theory]
@@ -727,7 +573,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.PositiveInfinity, 0.0f)]
         public static void Ceiling(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Ceiling(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Ceiling(value), allowedVariance);
         }
 
         [Theory]
@@ -782,7 +628,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity)]
         public static void CopySign(float x, float y, float expectedResult)
         {
-            AssertEqual(expectedResult, MathF.CopySign(x, y), 0.0f);
+            AssertExtensions.Equal(expectedResult, MathF.CopySign(x, y), 0.0f);
         }
 
         [Theory]
@@ -821,7 +667,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.NaN, 0.0f)]
         public static void Cos(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Cos(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Cos(value), allowedVariance);
         }
 
         [Theory]
@@ -860,7 +706,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.PositiveInfinity, 0.0f)]
         public static void Cosh(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Cosh(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Cosh(value), allowedVariance);
         }
 
         [Theory]
@@ -899,7 +745,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.PositiveInfinity, 0.0f)]
         public static void Exp(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Exp(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Exp(value), allowedVariance);
         }
 
         [Theory]
@@ -938,7 +784,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.PositiveInfinity, 0.0f)]
         public static void Floor(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Floor(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Floor(value), allowedVariance);
         }
 
         [Theory]
@@ -1010,7 +856,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.PositiveInfinity, float.NegativeInfinity, float.NaN)]
         public static void FusedMultiplyAdd(float x, float y, float z, float expectedResult)
         {
-            AssertEqual(expectedResult, MathF.FusedMultiplyAdd(x, y, z), 0.0f);
+            AssertExtensions.Equal(expectedResult, MathF.FusedMultiplyAdd(x, y, z), 0.0f);
         }
 
         [Fact]
@@ -1021,11 +867,11 @@ namespace System.Tests
             Assert.Equal(1.0f, MathF.IEEERemainder(10.0f, 3.0f));
             Assert.Equal(-1.0f, MathF.IEEERemainder(11.0f, 3.0f));
             Assert.Equal(-2.0f, MathF.IEEERemainder(28.0f, 5.0f));
-            AssertEqual(1.8f, MathF.IEEERemainder(17.8f, 4.0f), CrossPlatformMachineEpsilon * 10);
-            AssertEqual(1.4f, MathF.IEEERemainder(17.8f, 4.1f), CrossPlatformMachineEpsilon * 10);
-            AssertEqual(0.1000004f, MathF.IEEERemainder(-16.3f, 4.1f), CrossPlatformMachineEpsilon / 10);
-            AssertEqual(1.4f, MathF.IEEERemainder(17.8f, -4.1f), CrossPlatformMachineEpsilon * 10);
-            AssertEqual(-1.4f, MathF.IEEERemainder(-17.8f, -4.1f), CrossPlatformMachineEpsilon * 10);
+            AssertExtensions.Equal(1.8f, MathF.IEEERemainder(17.8f, 4.0f), CrossPlatformMachineEpsilon * 10);
+            AssertExtensions.Equal(1.4f, MathF.IEEERemainder(17.8f, 4.1f), CrossPlatformMachineEpsilon * 10);
+            AssertExtensions.Equal(0.1000004f, MathF.IEEERemainder(-16.3f, 4.1f), CrossPlatformMachineEpsilon / 10);
+            AssertExtensions.Equal(1.4f, MathF.IEEERemainder(17.8f, -4.1f), CrossPlatformMachineEpsilon * 10);
+            AssertExtensions.Equal(-1.4f, MathF.IEEERemainder(-17.8f, -4.1f), CrossPlatformMachineEpsilon * 10);
         }
 
         [Theory]
@@ -1121,14 +967,14 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.PositiveInfinity, 0.0f)]
         public static void Log(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Log(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Log(value), allowedVariance);
         }
 
         [Fact]
         public static void LogWithBase()
         {
             Assert.Equal(1.0f, MathF.Log(3.0f, 3.0f));
-            AssertEqual(2.40217350f, MathF.Log(14.0f, 3.0f), CrossPlatformMachineEpsilon * 10);
+            AssertExtensions.Equal(2.40217350f, MathF.Log(14.0f, 3.0f), CrossPlatformMachineEpsilon * 10);
             Assert.Equal(float.NegativeInfinity, MathF.Log(0.0f, 3.0f));
             Assert.Equal(float.NaN, MathF.Log(-3.0f, 3.0f));
             Assert.Equal(float.NaN, MathF.Log(float.NaN, 3.0f));
@@ -1174,7 +1020,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.PositiveInfinity, 0.0f)]
         public static void Log2(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Log2(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Log2(value), allowedVariance);
         }
 
         [Theory]
@@ -1220,7 +1066,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.PositiveInfinity, 0.0f)]
         public static void Log10(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Log10(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Log10(value), allowedVariance);
         }
 
         [Theory]
@@ -1243,7 +1089,7 @@ namespace System.Tests
         [InlineData(-2.0f, 3.0f, 3.0f)]
         public static void Max(float x, float y, float expectedResult)
         {
-            AssertEqual(expectedResult, MathF.Max(x, y), 0.0f);
+            AssertExtensions.Equal(expectedResult, MathF.Max(x, y), 0.0f);
         }
 
         [Theory]
@@ -1266,7 +1112,7 @@ namespace System.Tests
         [InlineData(-2.0f, 3.0f, 3.0f)]
         public static void MaxMagnitude(float x, float y, float expectedResult)
         {
-            AssertEqual(expectedResult, MathF.MaxMagnitude(x, y), 0.0f);
+            AssertExtensions.Equal(expectedResult, MathF.MaxMagnitude(x, y), 0.0f);
         }
 
         [Theory]
@@ -1289,7 +1135,7 @@ namespace System.Tests
         [InlineData(-2.0f, 3.0f, -2.0f)]
         public static void Min(float x, float y, float expectedResult)
         {
-            AssertEqual(expectedResult, MathF.Min(x, y), 0.0f);
+            AssertExtensions.Equal(expectedResult, MathF.Min(x, y), 0.0f);
         }
 
         [Theory]
@@ -1312,7 +1158,7 @@ namespace System.Tests
         [InlineData(-2.0f, 3.0f, -2.0f)]
         public static void MinMagnitude(float x, float y, float expectedResult)
         {
-            AssertEqual(expectedResult, MathF.MinMagnitude(x, y), 0.0f);
+            AssertExtensions.Equal(expectedResult, MathF.MinMagnitude(x, y), 0.0f);
         }
 
         [Theory]
@@ -1462,7 +1308,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, 0.0f)]
         public static void Pow(float x, float y, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Pow(x, y), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Pow(x, y), allowedVariance);
         }
 
         [Theory]
@@ -1473,7 +1319,7 @@ namespace System.Tests
         [InlineData(1.0f, float.NaN, 1.0f, CrossPlatformMachineEpsilon * 10)]
         public static void Pow_IEEE(float x, float y, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Pow(x, y), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Pow(x, y), allowedVariance);
         }
 
         [Theory]
@@ -1512,7 +1358,7 @@ namespace System.Tests
         [InlineData( float.PositiveInfinity,  0.0f,                   0.0f)]
         public static void ReciprocalEstimate(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.ReciprocalEstimate(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.ReciprocalEstimate(value), allowedVariance);
         }
 
         [Theory]
@@ -1551,7 +1397,7 @@ namespace System.Tests
         [InlineData( float.PositiveInfinity,  0.0f,                   0.0f)]
         public static void ReciprocalSqrtEstimate(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.ReciprocalSqrtEstimate(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.ReciprocalSqrtEstimate(value), allowedVariance);
         }
 
         public static IEnumerable<object[]> Round_Digits_TestData
@@ -1623,7 +1469,7 @@ namespace System.Tests
         [MemberData(nameof(Round_Digits_TestData))]
         public static void Round_Digits(float x, float expected, int digits, MidpointRounding mode)
         {
-            AssertEqual(expected, MathF.Round(x, digits, mode), CrossPlatformMachineEpsilon * 10);
+            AssertExtensions.Equal(expected, MathF.Round(x, digits, mode), CrossPlatformMachineEpsilon * 10);
         }
 
         [Theory]
@@ -1693,7 +1539,7 @@ namespace System.Tests
         [InlineData(8.82497783f, 3, 70.5998226f, CrossPlatformMachineEpsilon * 100)]
         public static void ScaleB(float x, int n, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.ScaleB(x, n), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.ScaleB(x, n), allowedVariance);
         }
 
         [Fact]
@@ -1744,7 +1590,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.NaN, 0.0f)]
         public static void Sin(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Sin(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Sin(value), allowedVariance);
         }
 
         [Theory]
@@ -1784,8 +1630,8 @@ namespace System.Tests
         public static void SinCos(float value, float expectedResultSin, float expectedResultCos, float allowedVarianceSin, float allowedVarianceCos)
         {
             (float resultSin, float resultCos) = MathF.SinCos(value);
-            AssertEqual(expectedResultSin, resultSin, allowedVarianceSin);
-            AssertEqual(expectedResultCos, resultCos, allowedVarianceCos);
+            AssertExtensions.Equal(expectedResultSin, resultSin, allowedVarianceSin);
+            AssertExtensions.Equal(expectedResultCos, resultCos, allowedVarianceCos);
         }
 
         [Theory]
@@ -1824,7 +1670,7 @@ namespace System.Tests
         [InlineData( float.PositiveInfinity,  float.PositiveInfinity, 0.0f)]
         public static void Sinh(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Sinh(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Sinh(value), allowedVariance);
         }
 
         [Theory]
@@ -1863,7 +1709,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.PositiveInfinity, 0.0f)]
         public static void Sqrt(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Sqrt(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Sqrt(value), allowedVariance);
         }
 
         [Theory]
@@ -1902,7 +1748,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, float.NaN, 0.0f)]
         public static void Tan(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Tan(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Tan(value), allowedVariance);
         }
 
         [Theory]
@@ -1941,7 +1787,7 @@ namespace System.Tests
         [InlineData(float.PositiveInfinity, 1.0f, CrossPlatformMachineEpsilon * 10)]
         public static void Tanh(float value, float expectedResult, float allowedVariance)
         {
-            AssertEqual(expectedResult, MathF.Tanh(value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, MathF.Tanh(value), allowedVariance);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -942,8 +942,12 @@ namespace System.Runtime.InteropServices
         public static System.Runtime.InteropServices.NFloat Log2(System.Runtime.InteropServices.NFloat value) { throw null; }
         public static System.Runtime.InteropServices.NFloat Max(System.Runtime.InteropServices.NFloat x, System.Runtime.InteropServices.NFloat y) { throw null; }
         public static System.Runtime.InteropServices.NFloat MaxMagnitude(System.Runtime.InteropServices.NFloat x, System.Runtime.InteropServices.NFloat y) { throw null; }
+        public static System.Runtime.InteropServices.NFloat MaxMagnitudeNumber(System.Runtime.InteropServices.NFloat x, System.Runtime.InteropServices.NFloat y) { throw null; }
+        public static System.Runtime.InteropServices.NFloat MaxNumber(System.Runtime.InteropServices.NFloat x, System.Runtime.InteropServices.NFloat y) { throw null; }
         public static System.Runtime.InteropServices.NFloat Min(System.Runtime.InteropServices.NFloat x, System.Runtime.InteropServices.NFloat y) { throw null; }
         public static System.Runtime.InteropServices.NFloat MinMagnitude(System.Runtime.InteropServices.NFloat x, System.Runtime.InteropServices.NFloat y) { throw null; }
+        public static System.Runtime.InteropServices.NFloat MinMagnitudeNumber(System.Runtime.InteropServices.NFloat x, System.Runtime.InteropServices.NFloat y) { throw null; }
+        public static System.Runtime.InteropServices.NFloat MinNumber(System.Runtime.InteropServices.NFloat x, System.Runtime.InteropServices.NFloat y) { throw null; }
         public static System.Runtime.InteropServices.NFloat operator +(System.Runtime.InteropServices.NFloat left, System.Runtime.InteropServices.NFloat right) { throw null; }
         public static System.Runtime.InteropServices.NFloat operator --(System.Runtime.InteropServices.NFloat value) { throw null; }
         public static System.Runtime.InteropServices.NFloat operator /(System.Runtime.InteropServices.NFloat left, System.Runtime.InteropServices.NFloat right) { throw null; }

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.cs
@@ -8,6 +8,8 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
+#pragma warning disable xUnit1025 // reporting duplicate test cases due to not distinguishing 0.0 from -0.0, NaN from -NaN
+
 namespace System.Runtime.InteropServices.Tests
 {
     public class NFloatTests
@@ -915,6 +917,190 @@ namespace System.Runtime.InteropServices.Tests
             NFloat nfloat = new NFloat(value);
 
             Assert.Equal(value.ToString(), nfloat.ToString());
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
+        [InlineData(float.NegativeInfinity, float.PositiveInfinity, float.PositiveInfinity)]
+        [InlineData(float.PositiveInfinity, float.NegativeInfinity, float.PositiveInfinity)]
+        [InlineData(float.MinValue, float.MaxValue, float.MaxValue)]
+        [InlineData(float.MaxValue, float.MinValue, float.MaxValue)]
+        [InlineData(float.NaN, float.NaN, float.NaN)]
+        [InlineData(float.NaN, 1.0f, 1.0f)]
+        [InlineData(1.0f, float.NaN, 1.0f)]
+        [InlineData(float.PositiveInfinity, float.NaN, float.PositiveInfinity)]
+        [InlineData(float.NegativeInfinity, float.NaN, float.NegativeInfinity)]
+        [InlineData(float.NaN, float.PositiveInfinity, float.PositiveInfinity)]
+        [InlineData(float.NaN, float.NegativeInfinity, float.NegativeInfinity)]
+        [InlineData(-0.0f, 0.0f, 0.0f)]
+        [InlineData(0.0f, -0.0f, 0.0f)]
+        [InlineData(2.0f, -3.0f, -3.0f)]
+        [InlineData(-3.0f, 2.0f, -3.0f)]
+        [InlineData(3.0f, -2.0f, 3.0f)]
+        [InlineData(-2.0f, 3.0f, 3.0f)]
+        public static void MaxMagnitudeNumberTest32(float x, float y, float expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, (float)NFloat.MaxMagnitudeNumber(x, y), 0.0f);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
+        [InlineData(float.NegativeInfinity, float.PositiveInfinity, float.PositiveInfinity)]
+        [InlineData(float.PositiveInfinity, float.NegativeInfinity, float.PositiveInfinity)]
+        [InlineData(float.MinValue, float.MaxValue, float.MaxValue)]
+        [InlineData(float.MaxValue, float.MinValue, float.MaxValue)]
+        [InlineData(float.NaN, float.NaN, float.NaN)]
+        [InlineData(float.NaN, 1.0f, 1.0f)]
+        [InlineData(1.0f, float.NaN, 1.0f)]
+        [InlineData(float.PositiveInfinity, float.NaN, float.PositiveInfinity)]
+        [InlineData(float.NegativeInfinity, float.NaN, float.NegativeInfinity)]
+        [InlineData(float.NaN, float.PositiveInfinity, float.PositiveInfinity)]
+        [InlineData(float.NaN, float.NegativeInfinity, float.NegativeInfinity)]
+        [InlineData(-0.0f, 0.0f, 0.0f)]
+        [InlineData(0.0f, -0.0f, 0.0f)]
+        [InlineData(2.0f, -3.0f, 2.0f)]
+        [InlineData(-3.0f, 2.0f, 2.0f)]
+        [InlineData(3.0f, -2.0f, 3.0f)]
+        [InlineData(-2.0f, 3.0f, 3.0f)]
+        public static void MaxNumberTest32(float x, float y, float expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, (float)NFloat.MaxNumber(x, y), 0.0f);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
+        [InlineData(float.NegativeInfinity, float.PositiveInfinity, float.NegativeInfinity)]
+        [InlineData(float.PositiveInfinity, float.NegativeInfinity, float.NegativeInfinity)]
+        [InlineData(float.MinValue, float.MaxValue, float.MinValue)]
+        [InlineData(float.MaxValue, float.MinValue, float.MinValue)]
+        [InlineData(float.NaN, float.NaN, float.NaN)]
+        [InlineData(float.NaN, 1.0f, 1.0f)]
+        [InlineData(1.0f, float.NaN, 1.0f)]
+        [InlineData(float.PositiveInfinity, float.NaN, float.PositiveInfinity)]
+        [InlineData(float.NegativeInfinity, float.NaN, float.NegativeInfinity)]
+        [InlineData(float.NaN, float.PositiveInfinity, float.PositiveInfinity)]
+        [InlineData(float.NaN, float.NegativeInfinity, float.NegativeInfinity)]
+        [InlineData(-0.0f, 0.0f, -0.0f)]
+        [InlineData(0.0f, -0.0f, -0.0f)]
+        [InlineData(2.0f, -3.0f, 2.0f)]
+        [InlineData(-3.0f, 2.0f, 2.0f)]
+        [InlineData(3.0f, -2.0f, -2.0f)]
+        [InlineData(-2.0f, 3.0f, -2.0f)]
+        public static void MinMagnitudeNumberTest32(float x, float y, float expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, (float)NFloat.MinMagnitudeNumber(x, y), 0.0f);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
+        [InlineData(float.NegativeInfinity, float.PositiveInfinity, float.NegativeInfinity)]
+        [InlineData(float.PositiveInfinity, float.NegativeInfinity, float.NegativeInfinity)]
+        [InlineData(float.MinValue, float.MaxValue, float.MinValue)]
+        [InlineData(float.MaxValue, float.MinValue, float.MinValue)]
+        [InlineData(float.NaN, float.NaN, float.NaN)]
+        [InlineData(float.NaN, 1.0f, 1.0f)]
+        [InlineData(1.0f, float.NaN, 1.0f)]
+        [InlineData(float.PositiveInfinity, float.NaN, float.PositiveInfinity)]
+        [InlineData(float.NegativeInfinity, float.NaN, float.NegativeInfinity)]
+        [InlineData(float.NaN, float.PositiveInfinity, float.PositiveInfinity)]
+        [InlineData(float.NaN, float.NegativeInfinity, float.NegativeInfinity)]
+        [InlineData(-0.0f, 0.0f, -0.0f)]
+        [InlineData(0.0f, -0.0f, -0.0f)]
+        [InlineData(2.0f, -3.0f, -3.0f)]
+        [InlineData(-3.0f, 2.0f, -3.0f)]
+        [InlineData(3.0f, -2.0f, -2.0f)]
+        [InlineData(-2.0f, 3.0f, -2.0f)]
+        public static void MinNumberTest32(float x, float y, float expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, (float)NFloat.MinNumber(x, y), 0.0f);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+        [InlineData(double.NegativeInfinity, double.PositiveInfinity, double.PositiveInfinity)]
+        [InlineData(double.PositiveInfinity, double.NegativeInfinity, double.PositiveInfinity)]
+        [InlineData(double.MinValue, double.MaxValue, double.MaxValue)]
+        [InlineData(double.MaxValue, double.MinValue, double.MaxValue)]
+        [InlineData(double.NaN, double.NaN, double.NaN)]
+        [InlineData(double.NaN, 1.0, 1.0)]
+        [InlineData(1.0, double.NaN, 1.0)]
+        [InlineData(double.PositiveInfinity, double.NaN, double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity, double.NaN, double.NegativeInfinity)]
+        [InlineData(double.NaN, double.PositiveInfinity, double.PositiveInfinity)]
+        [InlineData(double.NaN, double.NegativeInfinity, double.NegativeInfinity)]
+        [InlineData(-0.0, 0.0, 0.0)]
+        [InlineData(0.0, -0.0, 0.0)]
+        [InlineData(2.0, -3.0, -3.0)]
+        [InlineData(-3.0, 2.0, -3.0)]
+        [InlineData(3.0, -2.0, 3.0)]
+        [InlineData(-2.0, 3.0, 3.0)]
+        public static void MaxMagnitudeNumberTest64(double x, double y, double expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, NFloat.MaxMagnitudeNumber((NFloat)x, (NFloat)y), 0.0);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+        [InlineData(double.NegativeInfinity, double.PositiveInfinity, double.PositiveInfinity)]
+        [InlineData(double.PositiveInfinity, double.NegativeInfinity, double.PositiveInfinity)]
+        [InlineData(double.MinValue, double.MaxValue, double.MaxValue)]
+        [InlineData(double.MaxValue, double.MinValue, double.MaxValue)]
+        [InlineData(double.NaN, double.NaN, double.NaN)]
+        [InlineData(double.NaN, 1.0, 1.0)]
+        [InlineData(1.0, double.NaN, 1.0)]
+        [InlineData(double.PositiveInfinity, double.NaN, double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity, double.NaN, double.NegativeInfinity)]
+        [InlineData(double.NaN, double.PositiveInfinity, double.PositiveInfinity)]
+        [InlineData(double.NaN, double.NegativeInfinity, double.NegativeInfinity)]
+        [InlineData(-0.0, 0.0, 0.0)]
+        [InlineData(0.0, -0.0, 0.0)]
+        [InlineData(2.0, -3.0, 2.0)]
+        [InlineData(-3.0, 2.0, 2.0)]
+        [InlineData(3.0, -2.0, 3.0)]
+        [InlineData(-2.0, 3.0, 3.0)]
+        public static void MaxNumberTest64(double x, double y, double expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, NFloat.MaxNumber((NFloat)x, (NFloat)y), 0.0);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+        [InlineData(double.NegativeInfinity, double.PositiveInfinity, double.NegativeInfinity)]
+        [InlineData(double.PositiveInfinity, double.NegativeInfinity, double.NegativeInfinity)]
+        [InlineData(double.MinValue, double.MaxValue, double.MinValue)]
+        [InlineData(double.MaxValue, double.MinValue, double.MinValue)]
+        [InlineData(double.NaN, double.NaN, double.NaN)]
+        [InlineData(double.NaN, 1.0, 1.0)]
+        [InlineData(1.0, double.NaN, 1.0)]
+        [InlineData(double.PositiveInfinity, double.NaN, double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity, double.NaN, double.NegativeInfinity)]
+        [InlineData(double.NaN, double.PositiveInfinity, double.PositiveInfinity)]
+        [InlineData(double.NaN, double.NegativeInfinity, double.NegativeInfinity)]
+        [InlineData(-0.0, 0.0, -0.0)]
+        [InlineData(0.0, -0.0, -0.0)]
+        [InlineData(2.0, -3.0, 2.0)]
+        [InlineData(-3.0, 2.0, 2.0)]
+        [InlineData(3.0, -2.0, -2.0)]
+        [InlineData(-2.0, 3.0, -2.0)]
+        public static void MinMagnitudeNumberTest(double x, double y, double expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, NFloat.MinMagnitudeNumber((NFloat)x, (NFloat)y), 0.0);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+        [InlineData(double.NegativeInfinity, double.PositiveInfinity, double.NegativeInfinity)]
+        [InlineData(double.PositiveInfinity, double.NegativeInfinity, double.NegativeInfinity)]
+        [InlineData(double.MinValue, double.MaxValue, double.MinValue)]
+        [InlineData(double.MaxValue, double.MinValue, double.MinValue)]
+        [InlineData(double.NaN, double.NaN, double.NaN)]
+        [InlineData(double.NaN, 1.0, 1.0)]
+        [InlineData(1.0, double.NaN, 1.0)]
+        [InlineData(double.PositiveInfinity, double.NaN, double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity, double.NaN, double.NegativeInfinity)]
+        [InlineData(double.NaN, double.PositiveInfinity, double.PositiveInfinity)]
+        [InlineData(double.NaN, double.NegativeInfinity, double.NegativeInfinity)]
+        [InlineData(-0.0, 0.0, -0.0)]
+        [InlineData(0.0, -0.0, -0.0)]
+        [InlineData(2.0, -3.0, -3.0)]
+        [InlineData(-3.0, 2.0, -3.0)]
+        [InlineData(3.0, -2.0, -2.0)]
+        [InlineData(-2.0, 3.0, -2.0)]
+        public static void MinNumberTest(double x, double y, double expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, NFloat.MinNumber((NFloat)x, (NFloat)y), 0.0);
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.cs
@@ -1075,7 +1075,7 @@ namespace System.Runtime.InteropServices.Tests
         [InlineData(-3.0, 2.0, 2.0)]
         [InlineData(3.0, -2.0, -2.0)]
         [InlineData(-2.0, 3.0, -2.0)]
-        public static void MinMagnitudeNumberTest(double x, double y, double expectedResult)
+        public static void MinMagnitudeNumberTest64(double x, double y, double expectedResult)
         {
             AssertExtensions.Equal(expectedResult, NFloat.MinMagnitudeNumber((NFloat)x, (NFloat)y), 0.0);
         }
@@ -1098,7 +1098,7 @@ namespace System.Runtime.InteropServices.Tests
         [InlineData(-3.0, 2.0, -3.0)]
         [InlineData(3.0, -2.0, -2.0)]
         [InlineData(-2.0, 3.0, -2.0)]
-        public static void MinNumberTest(double x, double y, double expectedResult)
+        public static void MinNumberTest64(double x, double y, double expectedResult)
         {
             AssertExtensions.Equal(expectedResult, NFloat.MinNumber((NFloat)x, (NFloat)y), 0.0);
         }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2103,8 +2103,12 @@ namespace System
         public static double Log2(double value) { throw null; }
         public static double Max(double x, double y) { throw null; }
         public static double MaxMagnitude(double x, double y) { throw null; }
+        public static double MaxMagnitudeNumber(double x, double y) { throw null; }
+        public static double MaxNumber(double x, double y) { throw null; }
         public static double Min(double x, double y) { throw null; }
         public static double MinMagnitude(double x, double y) { throw null; }
+        public static double MinMagnitudeNumber(double x, double y) { throw null; }
+        public static double MinNumber(double x, double y) { throw null; }
         public static bool operator ==(double left, double right) { throw null; }
         public static bool operator >(double left, double right) { throw null; }
         public static bool operator >=(double left, double right) { throw null; }
@@ -2687,8 +2691,12 @@ namespace System
         public static System.Half Log2(System.Half value) { throw null; }
         public static System.Half Max(System.Half x, System.Half y) { throw null; }
         public static System.Half MaxMagnitude(System.Half x, System.Half y) { throw null; }
+        public static System.Half MaxMagnitudeNumber(System.Half x, System.Half y) { throw null; }
+        public static System.Half MaxNumber(System.Half x, System.Half y) { throw null; }
         public static System.Half Min(System.Half x, System.Half y) { throw null; }
         public static System.Half MinMagnitude(System.Half x, System.Half y) { throw null; }
+        public static System.Half MinMagnitudeNumber(System.Half x, System.Half y) { throw null; }
+        public static System.Half MinNumber(System.Half x, System.Half y) { throw null; }
         public static System.Half operator +(System.Half left, System.Half right) { throw null; }
         public static System.Half operator --(System.Half value) { throw null; }
         public static System.Half operator /(System.Half left, System.Half right) { throw null; }
@@ -4289,8 +4297,12 @@ namespace System
         public static float Log2(float value) { throw null; }
         public static float Max(float x, float y) { throw null; }
         public static float MaxMagnitude(float x, float y) { throw null; }
+        public static float MaxMagnitudeNumber(float x, float y) { throw null; }
+        public static float MaxNumber(float x, float y) { throw null; }
         public static float Min(float x, float y) { throw null; }
         public static float MinMagnitude(float x, float y) { throw null; }
+        public static float MinMagnitudeNumber(float x, float y) { throw null; }
+        public static float MinNumber(float x, float y) { throw null; }
         public static bool operator ==(float left, float right) { throw null; }
         public static bool operator >(float left, float right) { throw null; }
         public static bool operator >=(float left, float right) { throw null; }
@@ -9633,6 +9645,10 @@ namespace System.Numerics
         static abstract bool IsNormal(TSelf value);
         static abstract bool IsPositiveInfinity(TSelf value);
         static abstract bool IsSubnormal(TSelf value);
+        static abstract TSelf MaxMagnitudeNumber(TSelf x, TSelf y);
+        static abstract TSelf MaxNumber(TSelf x, TSelf y);
+        static abstract TSelf MinMagnitudeNumber(TSelf x, TSelf y);
+        static abstract TSelf MinNumber(TSelf x, TSelf y);
         static abstract TSelf ReciprocalEstimate(TSelf x);
         static abstract TSelf ReciprocalSqrtEstimate(TSelf x);
         static abstract TSelf ScaleB(TSelf x, int n);

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.cs
@@ -815,5 +815,97 @@ namespace System.Tests
             string s = string.Format(ci, "{0}", 158.68);
             Assert.Equal(-158.68, double.Parse("-" + s, NumberStyles.Number, ci));
         }
+
+        [Theory]
+        [InlineData(double.NegativeInfinity, double.PositiveInfinity, double.PositiveInfinity)]
+        [InlineData(double.PositiveInfinity, double.NegativeInfinity, double.PositiveInfinity)]
+        [InlineData(double.MinValue, double.MaxValue, double.MaxValue)]
+        [InlineData(double.MaxValue, double.MinValue, double.MaxValue)]
+        [InlineData(double.NaN, double.NaN, double.NaN)]
+        [InlineData(double.NaN, 1.0, 1.0)]
+        [InlineData(1.0, double.NaN, 1.0)]
+        [InlineData(double.PositiveInfinity, double.NaN, double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity, double.NaN, double.NegativeInfinity)]
+        [InlineData(double.NaN, double.PositiveInfinity, double.PositiveInfinity)]
+        [InlineData(double.NaN, double.NegativeInfinity, double.NegativeInfinity)]
+        [InlineData(-0.0, 0.0, 0.0)]
+        [InlineData(0.0, -0.0, 0.0)]
+        [InlineData(2.0, -3.0, -3.0)]
+        [InlineData(-3.0, 2.0, -3.0)]
+        [InlineData(3.0, -2.0, 3.0)]
+        [InlineData(-2.0, 3.0, 3.0)]
+        public static void MaxMagnitudeNumberTest(double x, double y, double expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, double.MaxMagnitudeNumber(x, y), 0.0);
+        }
+
+        [Theory]
+        [InlineData(double.NegativeInfinity, double.PositiveInfinity, double.PositiveInfinity)]
+        [InlineData(double.PositiveInfinity, double.NegativeInfinity, double.PositiveInfinity)]
+        [InlineData(double.MinValue, double.MaxValue, double.MaxValue)]
+        [InlineData(double.MaxValue, double.MinValue, double.MaxValue)]
+        [InlineData(double.NaN, double.NaN, double.NaN)]
+        [InlineData(double.NaN, 1.0, 1.0)]
+        [InlineData(1.0, double.NaN, 1.0)]
+        [InlineData(double.PositiveInfinity, double.NaN, double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity, double.NaN, double.NegativeInfinity)]
+        [InlineData(double.NaN, double.PositiveInfinity, double.PositiveInfinity)]
+        [InlineData(double.NaN, double.NegativeInfinity, double.NegativeInfinity)]
+        [InlineData(-0.0, 0.0, 0.0)]
+        [InlineData(0.0, -0.0, 0.0)]
+        [InlineData(2.0, -3.0, 2.0)]
+        [InlineData(-3.0, 2.0, 2.0)]
+        [InlineData(3.0, -2.0, 3.0)]
+        [InlineData(-2.0, 3.0, 3.0)]
+        public static void MaxNumberTest(double x, double y, double expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, double.MaxNumber(x, y), 0.0);
+        }
+
+        [Theory]
+        [InlineData(double.NegativeInfinity, double.PositiveInfinity, double.NegativeInfinity)]
+        [InlineData(double.PositiveInfinity, double.NegativeInfinity, double.NegativeInfinity)]
+        [InlineData(double.MinValue, double.MaxValue, double.MinValue)]
+        [InlineData(double.MaxValue, double.MinValue, double.MinValue)]
+        [InlineData(double.NaN, double.NaN, double.NaN)]
+        [InlineData(double.NaN, 1.0, 1.0)]
+        [InlineData(1.0, double.NaN, 1.0)]
+        [InlineData(double.PositiveInfinity, double.NaN, double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity, double.NaN, double.NegativeInfinity)]
+        [InlineData(double.NaN, double.PositiveInfinity, double.PositiveInfinity)]
+        [InlineData(double.NaN, double.NegativeInfinity, double.NegativeInfinity)]
+        [InlineData(-0.0, 0.0, -0.0)]
+        [InlineData(0.0, -0.0, -0.0)]
+        [InlineData(2.0, -3.0, 2.0)]
+        [InlineData(-3.0, 2.0, 2.0)]
+        [InlineData(3.0, -2.0, -2.0)]
+        [InlineData(-2.0, 3.0, -2.0)]
+        public static void MinMagnitudeNumberTest(double x, double y, double expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, double.MinMagnitudeNumber(x, y), 0.0);
+        }
+
+        [Theory]
+        [InlineData(double.NegativeInfinity, double.PositiveInfinity, double.NegativeInfinity)]
+        [InlineData(double.PositiveInfinity, double.NegativeInfinity, double.NegativeInfinity)]
+        [InlineData(double.MinValue, double.MaxValue, double.MinValue)]
+        [InlineData(double.MaxValue, double.MinValue, double.MinValue)]
+        [InlineData(double.NaN, double.NaN, double.NaN)]
+        [InlineData(double.NaN, 1.0, 1.0)]
+        [InlineData(1.0, double.NaN, 1.0)]
+        [InlineData(double.PositiveInfinity, double.NaN, double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity, double.NaN, double.NegativeInfinity)]
+        [InlineData(double.NaN, double.PositiveInfinity, double.PositiveInfinity)]
+        [InlineData(double.NaN, double.NegativeInfinity, double.NegativeInfinity)]
+        [InlineData(-0.0, 0.0, -0.0)]
+        [InlineData(0.0, -0.0, -0.0)]
+        [InlineData(2.0, -3.0, -3.0)]
+        [InlineData(-3.0, 2.0, -3.0)]
+        [InlineData(3.0, -2.0, -2.0)]
+        [InlineData(-2.0, 3.0, -2.0)]
+        public static void MinNumberTest(double x, double y, double expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, double.MinNumber(x, y), 0.0);
+        }
     }
 }

--- a/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
@@ -408,12 +408,18 @@ namespace System.Tests
         public static void op_ModulusTest()
         {
             AssertBitwiseEqual(Half.NaN, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.NegativeInfinity, PositiveTwo));
-            AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.MinValue, PositiveTwo));
+
+            // https://github.com/dotnet/runtime/issues/67993
+            // AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.MinValue, PositiveTwo));
+
             AssertBitwiseEqual(NegativeOne, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(NegativeOne, PositiveTwo));
             AssertBitwiseEqual(-MinNormal, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(-MinNormal, PositiveTwo));
             AssertBitwiseEqual(-MaxSubnormal, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(-MaxSubnormal, PositiveTwo));
             AssertBitwiseEqual(-Half.Epsilon, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(-Half.Epsilon, PositiveTwo)); ;
-            AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(NegativeZero, PositiveTwo));
+
+            // https://github.com/dotnet/runtime/issues/67993
+            // AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(NegativeZero, PositiveTwo));
+
             AssertBitwiseEqual(Half.NaN, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.NaN, PositiveTwo));
             AssertBitwiseEqual(PositiveZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(PositiveZero, PositiveTwo));
             AssertBitwiseEqual(Half.Epsilon, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.Epsilon, PositiveTwo));

--- a/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
@@ -408,18 +408,12 @@ namespace System.Tests
         public static void op_ModulusTest()
         {
             AssertBitwiseEqual(Half.NaN, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.NegativeInfinity, PositiveTwo));
-
-            // https://github.com/dotnet/runtime/issues/67993
-            // AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.MinValue, PositiveTwo));
-
+            AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.MinValue, PositiveTwo));
             AssertBitwiseEqual(NegativeOne, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(NegativeOne, PositiveTwo));
             AssertBitwiseEqual(-MinNormal, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(-MinNormal, PositiveTwo));
             AssertBitwiseEqual(-MaxSubnormal, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(-MaxSubnormal, PositiveTwo));
             AssertBitwiseEqual(-Half.Epsilon, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(-Half.Epsilon, PositiveTwo)); ;
-
-            // https://github.com/dotnet/runtime/issues/67993
-            // AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(NegativeZero, PositiveTwo));
-
+            AssertBitwiseEqual(NegativeZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(NegativeZero, PositiveTwo));
             AssertBitwiseEqual(Half.NaN, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.NaN, PositiveTwo));
             AssertBitwiseEqual(PositiveZero, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(PositiveZero, PositiveTwo));
             AssertBitwiseEqual(Half.Epsilon, ModulusOperatorsHelper<Half, Half, Half>.op_Modulus(Half.Epsilon, PositiveTwo));

--- a/src/libraries/System.Runtime/tests/System/HalfTests.cs
+++ b/src/libraries/System.Runtime/tests/System/HalfTests.cs
@@ -3,8 +3,8 @@
 
 using System.Collections.Generic;
 using System.Globalization;
-using System.Runtime.CompilerServices;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.Tests
 {
@@ -1099,6 +1099,118 @@ namespace System.Tests
             Assert.True(Half.NaN.Equals(Half.NaN));
             Assert.False(Half.NaN == Half.NaN);
             Assert.Equal(Half.NaN, Half.NaN);
+        }
+
+        public static IEnumerable<object[]> MaxMagnitudeNumber_TestData()
+        {
+            yield return new object[] { Half.NegativeInfinity, Half.PositiveInfinity, Half.PositiveInfinity };
+            yield return new object[] { Half.PositiveInfinity, Half.NegativeInfinity, Half.PositiveInfinity };
+            yield return new object[] { Half.MinValue, Half.MaxValue, Half.MaxValue };
+            yield return new object[] { Half.MaxValue, Half.MinValue, Half.MaxValue };
+            yield return new object[] { Half.NaN, Half.NaN, Half.NaN };
+            yield return new object[] { Half.NaN, (Half)1.0f, (Half)1.0f };
+            yield return new object[] { (Half)1.0f, Half.NaN, (Half)1.0f };
+            yield return new object[] { Half.PositiveInfinity, Half.NaN, Half.PositiveInfinity };
+            yield return new object[] { Half.NegativeInfinity, Half.NaN, Half.NegativeInfinity };
+            yield return new object[] { Half.NaN, Half.PositiveInfinity, Half.PositiveInfinity };
+            yield return new object[] { Half.NaN, Half.NegativeInfinity, Half.NegativeInfinity };
+            yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)0.0f };
+            yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)0.0f };
+            yield return new object[] { (Half)2.0f, (Half)(-3.0f), (Half)(-3.0f) };
+            yield return new object[] { (Half)(-3.0f), (Half)2.0f, (Half)(-3.0f) };
+            yield return new object[] { (Half)3.0f, (Half)(-2.0f), (Half)3.0f };
+            yield return new object[] { (Half)(-2.0f), (Half)3.0f, (Half)3.0f };
+        }
+
+        [Theory]
+        [MemberData(nameof(MaxMagnitudeNumber_TestData))]
+        public static void MaxMagnitudeNumberTest(Half x, Half y, Half expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, Half.MaxMagnitudeNumber(x, y), (Half)0.0f);
+        }
+
+        public static IEnumerable<object[]> MaxNumber_TestData()
+        {
+            yield return new object[] { Half.NegativeInfinity, Half.PositiveInfinity, Half.PositiveInfinity };
+            yield return new object[] { Half.PositiveInfinity, Half.NegativeInfinity, Half.PositiveInfinity };
+            yield return new object[] { Half.MinValue, Half.MaxValue, Half.MaxValue };
+            yield return new object[] { Half.MaxValue, Half.MinValue, Half.MaxValue };
+            yield return new object[] { Half.NaN, Half.NaN, Half.NaN };
+            yield return new object[] { Half.NaN, (Half)1.0f, (Half)1.0f };
+            yield return new object[] { (Half)1.0f, Half.NaN, (Half)1.0f };
+            yield return new object[] { Half.PositiveInfinity, Half.NaN, Half.PositiveInfinity };
+            yield return new object[] { Half.NegativeInfinity, Half.NaN, Half.NegativeInfinity };
+            yield return new object[] { Half.NaN, Half.PositiveInfinity, Half.PositiveInfinity };
+            yield return new object[] { Half.NaN, Half.NegativeInfinity, Half.NegativeInfinity };
+            yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)0.0f };
+            yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)0.0f };
+            yield return new object[] { (Half)2.0f, (Half)(-3.0f), (Half)2.0f };
+            yield return new object[] { (Half)(-3.0f), (Half)2.0f, (Half)2.0f };
+            yield return new object[] { (Half)3.0f, (Half)(-2.0f), (Half)3.0f };
+            yield return new object[] { (Half)(-2.0f), (Half)3.0f, (Half)3.0f };
+        }
+
+        [Theory]
+        [MemberData(nameof(MaxNumber_TestData))]
+        public static void MaxNumberTest(Half x, Half y, Half expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, Half.MaxNumber(x, y), (Half)0.0f);
+        }
+
+        public static IEnumerable<object[]> MinMagnitudeNumber_TestData()
+        {
+            yield return new object[] { Half.NegativeInfinity, Half.PositiveInfinity, Half.NegativeInfinity };
+            yield return new object[] { Half.PositiveInfinity, Half.NegativeInfinity, Half.NegativeInfinity };
+            yield return new object[] { Half.MinValue, Half.MaxValue, Half.MinValue };
+            yield return new object[] { Half.MaxValue, Half.MinValue, Half.MinValue };
+            yield return new object[] { Half.NaN, Half.NaN, Half.NaN };
+            yield return new object[] { Half.NaN, (Half)1.0f, (Half)1.0f };
+            yield return new object[] { (Half)1.0f, Half.NaN, (Half)1.0f };
+            yield return new object[] { Half.PositiveInfinity, Half.NaN, Half.PositiveInfinity };
+            yield return new object[] { Half.NegativeInfinity, Half.NaN, Half.NegativeInfinity };
+            yield return new object[] { Half.NaN, Half.PositiveInfinity, Half.PositiveInfinity };
+            yield return new object[] { Half.NaN, Half.NegativeInfinity, Half.NegativeInfinity };
+            yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)(-0.0f) };
+            yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)(-0.0f) };
+            yield return new object[] { (Half)2.0f, (Half)(-3.0f), (Half)2.0f };
+            yield return new object[] { (Half)(-3.0f), (Half)2.0f, (Half)2.0f };
+            yield return new object[] { (Half)3.0f, (Half)(-2.0f), (Half)(-2.0f) };
+            yield return new object[] { (Half)(-2.0f), (Half)3.0f, (Half)(-2.0f) };
+        }
+
+        [Theory]
+        [MemberData(nameof(MinMagnitudeNumber_TestData))]
+        public static void MinMagnitudeNumberTest(Half x, Half y, Half expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, Half.MinMagnitudeNumber(x, y), (Half)0.0f);
+        }
+
+        public static IEnumerable<object[]> MinNumber_TestData()
+        {
+            yield return new object[] { Half.NegativeInfinity, Half.PositiveInfinity, Half.NegativeInfinity };
+            yield return new object[] { Half.PositiveInfinity, Half.NegativeInfinity, Half.NegativeInfinity };
+            yield return new object[] { Half.MinValue, Half.MaxValue, Half.MinValue };
+            yield return new object[] { Half.MaxValue, Half.MinValue, Half.MinValue };
+            yield return new object[] { Half.NaN, Half.NaN, Half.NaN };
+            yield return new object[] { Half.NaN, (Half)1.0f, (Half)1.0f };
+            yield return new object[] { (Half)1.0f, Half.NaN, (Half)1.0f };
+            yield return new object[] { Half.PositiveInfinity, Half.NaN, Half.PositiveInfinity };
+            yield return new object[] { Half.NegativeInfinity, Half.NaN, Half.NegativeInfinity };
+            yield return new object[] { Half.NaN, Half.PositiveInfinity, Half.PositiveInfinity };
+            yield return new object[] { Half.NaN, Half.NegativeInfinity, Half.NegativeInfinity };
+            yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)(-0.0f) };
+            yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)(-0.0f) };
+            yield return new object[] { (Half)2.0f, (Half)(-3.0f), (Half)(-3.0f) };
+            yield return new object[] { (Half)(-3.0f), (Half)2.0f, (Half)(-3.0f) };
+            yield return new object[] { (Half)3.0f, (Half)(-2.0f), (Half)(-2.0f) };
+            yield return new object[] { (Half)(-2.0f), (Half)3.0f, (Half)(-2.0f) };
+        }
+
+        [Theory]
+        [MemberData(nameof(MinNumber_TestData))]
+        public static void MinNumberTest(Half x, Half y, Half expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, Half.MinNumber(x, y), (Half)0.0f);
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System/HalfTests.cs
+++ b/src/libraries/System.Runtime/tests/System/HalfTests.cs
@@ -1118,7 +1118,9 @@ namespace System.Tests
             // https://github.com/dotnet/runtime/issues/67993
             // yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)0.0f };
 
-            yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)0.0f };
+            // https://github.com/dotnet/runtime/issues/67993
+            // yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)0.0f };
+
             yield return new object[] { (Half)2.0f, (Half)(-3.0f), (Half)(-3.0f) };
             yield return new object[] { (Half)(-3.0f), (Half)2.0f, (Half)(-3.0f) };
             yield return new object[] { (Half)3.0f, (Half)(-2.0f), (Half)3.0f };
@@ -1149,7 +1151,9 @@ namespace System.Tests
             // https://github.com/dotnet/runtime/issues/67993
             // yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)0.0f };
 
-            yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)0.0f };
+            // https://github.com/dotnet/runtime/issues/67993
+            // yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)0.0f };
+
             yield return new object[] { (Half)2.0f, (Half)(-3.0f), (Half)2.0f };
             yield return new object[] { (Half)(-3.0f), (Half)2.0f, (Half)2.0f };
             yield return new object[] { (Half)3.0f, (Half)(-2.0f), (Half)3.0f };
@@ -1180,7 +1184,9 @@ namespace System.Tests
             // https://github.com/dotnet/runtime/issues/67993
             // yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)(-0.0f) };
 
-            yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)(-0.0f) };
+            // https://github.com/dotnet/runtime/issues/67993
+            // yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)(-0.0f) };
+
             yield return new object[] { (Half)2.0f, (Half)(-3.0f), (Half)2.0f };
             yield return new object[] { (Half)(-3.0f), (Half)2.0f, (Half)2.0f };
             yield return new object[] { (Half)3.0f, (Half)(-2.0f), (Half)(-2.0f) };
@@ -1211,7 +1217,9 @@ namespace System.Tests
             // https://github.com/dotnet/runtime/issues/67993
             // yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)(-0.0f) };
 
-            yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)(-0.0f) };
+            // https://github.com/dotnet/runtime/issues/67993
+            // yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)(-0.0f) };
+
             yield return new object[] { (Half)2.0f, (Half)(-3.0f), (Half)(-3.0f) };
             yield return new object[] { (Half)(-3.0f), (Half)2.0f, (Half)(-3.0f) };
             yield return new object[] { (Half)3.0f, (Half)(-2.0f), (Half)(-2.0f) };

--- a/src/libraries/System.Runtime/tests/System/HalfTests.cs
+++ b/src/libraries/System.Runtime/tests/System/HalfTests.cs
@@ -1114,7 +1114,10 @@ namespace System.Tests
             yield return new object[] { Half.NegativeInfinity, Half.NaN, Half.NegativeInfinity };
             yield return new object[] { Half.NaN, Half.PositiveInfinity, Half.PositiveInfinity };
             yield return new object[] { Half.NaN, Half.NegativeInfinity, Half.NegativeInfinity };
-            yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)0.0f };
+
+            // https://github.com/dotnet/runtime/issues/67993
+            // yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)0.0f };
+
             yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)0.0f };
             yield return new object[] { (Half)2.0f, (Half)(-3.0f), (Half)(-3.0f) };
             yield return new object[] { (Half)(-3.0f), (Half)2.0f, (Half)(-3.0f) };
@@ -1142,7 +1145,10 @@ namespace System.Tests
             yield return new object[] { Half.NegativeInfinity, Half.NaN, Half.NegativeInfinity };
             yield return new object[] { Half.NaN, Half.PositiveInfinity, Half.PositiveInfinity };
             yield return new object[] { Half.NaN, Half.NegativeInfinity, Half.NegativeInfinity };
-            yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)0.0f };
+
+            // https://github.com/dotnet/runtime/issues/67993
+            // yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)0.0f };
+
             yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)0.0f };
             yield return new object[] { (Half)2.0f, (Half)(-3.0f), (Half)2.0f };
             yield return new object[] { (Half)(-3.0f), (Half)2.0f, (Half)2.0f };
@@ -1170,7 +1176,10 @@ namespace System.Tests
             yield return new object[] { Half.NegativeInfinity, Half.NaN, Half.NegativeInfinity };
             yield return new object[] { Half.NaN, Half.PositiveInfinity, Half.PositiveInfinity };
             yield return new object[] { Half.NaN, Half.NegativeInfinity, Half.NegativeInfinity };
-            yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)(-0.0f) };
+
+            // https://github.com/dotnet/runtime/issues/67993
+            // yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)(-0.0f) };
+
             yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)(-0.0f) };
             yield return new object[] { (Half)2.0f, (Half)(-3.0f), (Half)2.0f };
             yield return new object[] { (Half)(-3.0f), (Half)2.0f, (Half)2.0f };
@@ -1198,7 +1207,10 @@ namespace System.Tests
             yield return new object[] { Half.NegativeInfinity, Half.NaN, Half.NegativeInfinity };
             yield return new object[] { Half.NaN, Half.PositiveInfinity, Half.PositiveInfinity };
             yield return new object[] { Half.NaN, Half.NegativeInfinity, Half.NegativeInfinity };
-            yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)(-0.0f) };
+
+            // https://github.com/dotnet/runtime/issues/67993
+            // yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)(-0.0f) };
+
             yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)(-0.0f) };
             yield return new object[] { (Half)2.0f, (Half)(-3.0f), (Half)(-3.0f) };
             yield return new object[] { (Half)(-3.0f), (Half)2.0f, (Half)(-3.0f) };

--- a/src/libraries/System.Runtime/tests/System/HalfTests.cs
+++ b/src/libraries/System.Runtime/tests/System/HalfTests.cs
@@ -1114,13 +1114,8 @@ namespace System.Tests
             yield return new object[] { Half.NegativeInfinity, Half.NaN, Half.NegativeInfinity };
             yield return new object[] { Half.NaN, Half.PositiveInfinity, Half.PositiveInfinity };
             yield return new object[] { Half.NaN, Half.NegativeInfinity, Half.NegativeInfinity };
-
-            // https://github.com/dotnet/runtime/issues/67993
-            // yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)0.0f };
-
-            // https://github.com/dotnet/runtime/issues/67993
-            // yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)0.0f };
-
+            yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)0.0f };
+            yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)0.0f };
             yield return new object[] { (Half)2.0f, (Half)(-3.0f), (Half)(-3.0f) };
             yield return new object[] { (Half)(-3.0f), (Half)2.0f, (Half)(-3.0f) };
             yield return new object[] { (Half)3.0f, (Half)(-2.0f), (Half)3.0f };
@@ -1147,13 +1142,8 @@ namespace System.Tests
             yield return new object[] { Half.NegativeInfinity, Half.NaN, Half.NegativeInfinity };
             yield return new object[] { Half.NaN, Half.PositiveInfinity, Half.PositiveInfinity };
             yield return new object[] { Half.NaN, Half.NegativeInfinity, Half.NegativeInfinity };
-
-            // https://github.com/dotnet/runtime/issues/67993
-            // yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)0.0f };
-
-            // https://github.com/dotnet/runtime/issues/67993
-            // yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)0.0f };
-
+            yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)0.0f };
+            yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)0.0f };
             yield return new object[] { (Half)2.0f, (Half)(-3.0f), (Half)2.0f };
             yield return new object[] { (Half)(-3.0f), (Half)2.0f, (Half)2.0f };
             yield return new object[] { (Half)3.0f, (Half)(-2.0f), (Half)3.0f };
@@ -1180,13 +1170,8 @@ namespace System.Tests
             yield return new object[] { Half.NegativeInfinity, Half.NaN, Half.NegativeInfinity };
             yield return new object[] { Half.NaN, Half.PositiveInfinity, Half.PositiveInfinity };
             yield return new object[] { Half.NaN, Half.NegativeInfinity, Half.NegativeInfinity };
-
-            // https://github.com/dotnet/runtime/issues/67993
-            // yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)(-0.0f) };
-
-            // https://github.com/dotnet/runtime/issues/67993
-            // yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)(-0.0f) };
-
+            yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)(-0.0f) };
+            yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)(-0.0f) };
             yield return new object[] { (Half)2.0f, (Half)(-3.0f), (Half)2.0f };
             yield return new object[] { (Half)(-3.0f), (Half)2.0f, (Half)2.0f };
             yield return new object[] { (Half)3.0f, (Half)(-2.0f), (Half)(-2.0f) };
@@ -1213,13 +1198,8 @@ namespace System.Tests
             yield return new object[] { Half.NegativeInfinity, Half.NaN, Half.NegativeInfinity };
             yield return new object[] { Half.NaN, Half.PositiveInfinity, Half.PositiveInfinity };
             yield return new object[] { Half.NaN, Half.NegativeInfinity, Half.NegativeInfinity };
-
-            // https://github.com/dotnet/runtime/issues/67993
-            // yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)(-0.0f) };
-
-            // https://github.com/dotnet/runtime/issues/67993
-            // yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)(-0.0f) };
-
+            yield return new object[] { (Half)(-0.0f), (Half)0.0f, (Half)(-0.0f) };
+            yield return new object[] { (Half)0.0f, (Half)(-0.0f), (Half)(-0.0f) };
             yield return new object[] { (Half)2.0f, (Half)(-3.0f), (Half)(-3.0f) };
             yield return new object[] { (Half)(-3.0f), (Half)2.0f, (Half)(-3.0f) };
             yield return new object[] { (Half)3.0f, (Half)(-2.0f), (Half)(-2.0f) };

--- a/src/libraries/System.Runtime/tests/System/SingleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/SingleTests.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 using System.Globalization;
-using System.Runtime.CompilerServices;
-using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 #pragma warning disable xUnit1025 // reporting duplicate test cases due to not distinguishing 0.0 from -0.0, NaN from -NaN
@@ -747,6 +745,98 @@ namespace System.Tests
         {
             float result = float.Parse(value.ToString("R"));
             Assert.Equal(BitConverter.SingleToInt32Bits(value), BitConverter.SingleToInt32Bits(result));
+        }
+
+        [Theory]
+        [InlineData(float.NegativeInfinity, float.PositiveInfinity, float.PositiveInfinity)]
+        [InlineData(float.PositiveInfinity, float.NegativeInfinity, float.PositiveInfinity)]
+        [InlineData(float.MinValue, float.MaxValue, float.MaxValue)]
+        [InlineData(float.MaxValue, float.MinValue, float.MaxValue)]
+        [InlineData(float.NaN, float.NaN, float.NaN)]
+        [InlineData(float.NaN, 1.0f, 1.0f)]
+        [InlineData(1.0f, float.NaN, 1.0f)]
+        [InlineData(float.PositiveInfinity, float.NaN, float.PositiveInfinity)]
+        [InlineData(float.NegativeInfinity, float.NaN, float.NegativeInfinity)]
+        [InlineData(float.NaN, float.PositiveInfinity, float.PositiveInfinity)]
+        [InlineData(float.NaN, float.NegativeInfinity, float.NegativeInfinity)]
+        [InlineData(-0.0f, 0.0f, 0.0f)]
+        [InlineData(0.0f, -0.0f, 0.0f)]
+        [InlineData(2.0f, -3.0f, -3.0f)]
+        [InlineData(-3.0f, 2.0f, -3.0f)]
+        [InlineData(3.0f, -2.0f, 3.0f)]
+        [InlineData(-2.0f, 3.0f, 3.0f)]
+        public static void MaxMagnitudeNumberTest(float x, float y, float expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, float.MaxMagnitudeNumber(x, y), 0.0f);
+        }
+
+        [Theory]
+        [InlineData(float.NegativeInfinity, float.PositiveInfinity, float.PositiveInfinity)]
+        [InlineData(float.PositiveInfinity, float.NegativeInfinity, float.PositiveInfinity)]
+        [InlineData(float.MinValue, float.MaxValue, float.MaxValue)]
+        [InlineData(float.MaxValue, float.MinValue, float.MaxValue)]
+        [InlineData(float.NaN, float.NaN, float.NaN)]
+        [InlineData(float.NaN, 1.0f, 1.0f)]
+        [InlineData(1.0f, float.NaN, 1.0f)]
+        [InlineData(float.PositiveInfinity, float.NaN, float.PositiveInfinity)]
+        [InlineData(float.NegativeInfinity, float.NaN, float.NegativeInfinity)]
+        [InlineData(float.NaN, float.PositiveInfinity, float.PositiveInfinity)]
+        [InlineData(float.NaN, float.NegativeInfinity, float.NegativeInfinity)]
+        [InlineData(-0.0f, 0.0f, 0.0f)]
+        [InlineData(0.0f, -0.0f, 0.0f)]
+        [InlineData(2.0f, -3.0f, 2.0f)]
+        [InlineData(-3.0f, 2.0f, 2.0f)]
+        [InlineData(3.0f, -2.0f, 3.0f)]
+        [InlineData(-2.0f, 3.0f, 3.0f)]
+        public static void MaxNumberTest(float x, float y, float expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, float.MaxNumber(x, y), 0.0f);
+        }
+
+        [Theory]
+        [InlineData(float.NegativeInfinity, float.PositiveInfinity, float.NegativeInfinity)]
+        [InlineData(float.PositiveInfinity, float.NegativeInfinity, float.NegativeInfinity)]
+        [InlineData(float.MinValue, float.MaxValue, float.MinValue)]
+        [InlineData(float.MaxValue, float.MinValue, float.MinValue)]
+        [InlineData(float.NaN, float.NaN, float.NaN)]
+        [InlineData(float.NaN, 1.0f, 1.0f)]
+        [InlineData(1.0f, float.NaN, 1.0f)]
+        [InlineData(float.PositiveInfinity, float.NaN, float.PositiveInfinity)]
+        [InlineData(float.NegativeInfinity, float.NaN, float.NegativeInfinity)]
+        [InlineData(float.NaN, float.PositiveInfinity, float.PositiveInfinity)]
+        [InlineData(float.NaN, float.NegativeInfinity, float.NegativeInfinity)]
+        [InlineData(-0.0f, 0.0f, -0.0f)]
+        [InlineData(0.0f, -0.0f, -0.0f)]
+        [InlineData(2.0f, -3.0f, 2.0f)]
+        [InlineData(-3.0f, 2.0f, 2.0f)]
+        [InlineData(3.0f, -2.0f, -2.0f)]
+        [InlineData(-2.0f, 3.0f, -2.0f)]
+        public static void MinMagnitudeNumberTest(float x, float y, float expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, float.MinMagnitudeNumber(x, y), 0.0f);
+        }
+
+        [Theory]
+        [InlineData(float.NegativeInfinity, float.PositiveInfinity, float.NegativeInfinity)]
+        [InlineData(float.PositiveInfinity, float.NegativeInfinity, float.NegativeInfinity)]
+        [InlineData(float.MinValue, float.MaxValue, float.MinValue)]
+        [InlineData(float.MaxValue, float.MinValue, float.MinValue)]
+        [InlineData(float.NaN, float.NaN, float.NaN)]
+        [InlineData(float.NaN, 1.0f, 1.0f)]
+        [InlineData(1.0f, float.NaN, 1.0f)]
+        [InlineData(float.PositiveInfinity, float.NaN, float.PositiveInfinity)]
+        [InlineData(float.NegativeInfinity, float.NaN, float.NegativeInfinity)]
+        [InlineData(float.NaN, float.PositiveInfinity, float.PositiveInfinity)]
+        [InlineData(float.NaN, float.NegativeInfinity, float.NegativeInfinity)]
+        [InlineData(-0.0f, 0.0f, -0.0f)]
+        [InlineData(0.0f, -0.0f, -0.0f)]
+        [InlineData(2.0f, -3.0f, -3.0f)]
+        [InlineData(-3.0f, 2.0f, -3.0f)]
+        [InlineData(3.0f, -2.0f, -2.0f)]
+        [InlineData(-2.0f, 3.0f, -2.0f)]
+        public static void MinNumberTest(float x, float y, float expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, float.MinNumber(x, y), 0.0f);
         }
     }
 }


### PR DESCRIPTION
This isn't taking into account https://github.com/dotnet/runtime/issues/68191 yet, that will happen as part of a separate work item after the next API review.