### PR TITLE
Avoid duplicate Strings.resx import & code-cleanup

### DIFF
--- a/eng/resources.targets
+++ b/eng/resources.targets
@@ -25,6 +25,5 @@
     <Compile Include="$(CommonPath)/System/SR$(DefaultLanguageSourceExtension)"
              Visible="true" />
              Link="Resources/Common/SR$(DefaultLanguageSourceExtension)" />
-    </Compile>
   </ItemGroup>
 </Project>

--- a/eng/resources.targets
+++ b/eng/resources.targets
@@ -1,9 +1,6 @@
 <Project>
   <PropertyGroup>
-    <ResourcesSourceFileExtension Condition="'$(MSBuildProjectExtension)' == '.csproj'">.cs</ResourcesSourceFileExtension>
-    <ResourcesSourceFileExtension Condition="'$(MSBuildProjectExtension)' == '.vbproj'">.vb</ResourcesSourceFileExtension>
-
-    <StringResourcesPath Condition="'$(StringResourcesPath)' == '' and Exists('$(MSBuildProjectDirectory)/Resources/Strings.resx')">$(MSBuildProjectDirectory)/Resources/Strings.resx</StringResourcesPath>
+    <StringResourcesPath Condition="'$(StringResourcesPath)' == '' and Exists('$(MSBuildProjectDirectory)\Resources\Strings.resx')">$(MSBuildProjectDirectory)\Resources\Strings.resx</StringResourcesPath>
     <StringResourcesNamespace Condition="'$(StringResourcesNamespace)' == ''">System</StringResourcesNamespace>
     <StringResourcesClassName Condition="'$(StringResourcesClassName)' == ''">SR</StringResourcesClassName>
     <StringResourcesName Condition="'$(StringResourcesName)' == ''">FxResources.$(AssemblyName).$(StringResourcesClassName)</StringResourcesName>
@@ -15,20 +12,19 @@
   </PropertyGroup>
 
   <!-- Include files under StringResourcesPath by convention unless OmitResources is set. -->
-  <ItemGroup Condition="'$(StringResourcesPath)' != '' and '$(OmitResources)' != 'true'">
-    <EmbeddedResource Include="$(StringResourcesPath)">
-      <Visible>true</Visible>
-      <ManifestResourceName>$(StringResourcesName)</ManifestResourceName>
-      <GenerateSource>true</GenerateSource>
-      <ClassName>$(StringResourcesNamespace).$(StringResourcesClassName)</ClassName>
-    </EmbeddedResource>
-  </ItemGroup>
-
-  <!-- Include common SR helper when resources are included unless SkipCommonResourcesIncludes is set. -->
-  <ItemGroup Condition="Exists('$(StringResourcesPath)') and '$(OmitResources)' != 'true' and '$(SkipCommonResourcesIncludes)' == ''">
-    <Compile Include="$(CommonPath)/System/SR$(ResourcesSourceFileExtension)">
-      <Visible>true</Visible>
-      <Link>Resources/Common/SR$(ResourcesSourceFileExtension)</Link>
+  <ItemGroup Condition="'$(StringResourcesPath)' != '' and '$(OmitResources)' != 'true'"> 
+    <!-- Delete the embedded resource item pointing to StringResourcesPath in case the
+         EnableDefaultEmbeddedResourceItems glob didn't include it and include it again. -->
+    <EmbeddedResource Remove="$(StringResourcesPath)" Condition="'$(EnableDefaultEmbeddedResourceItems)' == 'true'" />
+    <EmbeddedResource Include="$(StringResourcesPath)"
+                      Visible="true"
+                      ManifestResourceName="$(StringResourcesName)"
+                      GenerateSource="true"
+                      ClassName="$(StringResourcesNamespace).$(StringResourcesClassName)" />
+    <!-- Include common SR helper when resources are included. -->
+    <Compile Include="$(CommonPath)/System/SR$(DefaultLanguageSourceExtension)"
+             Visible="true" />
+             Link="Resources/Common/SR$(DefaultLanguageSourceExtension)" />
     </Compile>
   </ItemGroup>
 </Project>

--- a/eng/resources.targets
+++ b/eng/resources.targets
@@ -23,7 +23,7 @@
                       ClassName="$(StringResourcesNamespace).$(StringResourcesClassName)" />
     <!-- Include common SR helper when resources are included. -->
     <Compile Include="$(CommonPath)/System/SR$(DefaultLanguageSourceExtension)"
-             Visible="true" />
+             Visible="true"
              Link="Resources/Common/SR$(DefaultLanguageSourceExtension)" />
   </ItemGroup>
 </Project>

--- a/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -41,7 +41,6 @@
     <DefineConstants>MONO;NETCOREAPP;SYSTEM_PRIVATE_CORELIB</DefineConstants>
     <DisableImplicitConfigurationDefines>true</DisableImplicitConfigurationDefines>
 
-    <SkipCommonResourcesIncludes>true</SkipCommonResourcesIncludes>
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
     <SlnGenSolutionFolder>src</SlnGenSolutionFolder>
   </PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/68218

Makes assemblies with String.resx resources smaller by avoiding the duplicate resources.