### PR TITLE
Add missing RUC annotation to IAsyncEnumerableConverterFactory

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableConverterFactory.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Reflection;
 using System.Text.Json.Serialization.Converters;
 
@@ -13,8 +14,13 @@ namespace System.Text.Json.Serialization
     /// </summary>
     internal sealed class IAsyncEnumerableConverterFactory : JsonConverterFactory
     {
+        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
+        public IAsyncEnumerableConverterFactory() { }
+
         public override bool CanConvert(Type typeToConvert) => GetAsyncEnumerableInterface(typeToConvert) is not null;
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "The ctor is marked RequiresUnreferencedCode.")]
         public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
         {
             Type? asyncEnumerableInterface = GetAsyncEnumerableInterface(typeToConvert);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpTypeConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpTypeConverterFactory.cs
@@ -10,8 +10,6 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class FSharpTypeConverterFactory : JsonConverterFactory
     {
-        // Temporary solution to account for not implemented support for type-level attributes
-        // TODO remove once addressed https://github.com/mono/linker/issues/1742#issuecomment-875036480
         [RequiresUnreferencedCode(FSharpCoreReflectionProxy.FSharpCoreUnreferencedCodeMessage)]
         public FSharpTypeConverterFactory() { }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverterFactory.cs
@@ -16,21 +16,14 @@ namespace System.Text.Json.Serialization.Converters
             return type.IsEnum;
         }
 
-        public override JsonConverter CreateConverter(Type type, JsonSerializerOptions options) =>
-            Create(type, EnumConverterOptions.AllowNumbers, options);
+        public override JsonConverter CreateConverter(Type type, JsonSerializerOptions options)
+            => Create(type, EnumConverterOptions.AllowNumbers, namingPolicy: null, options);
 
-        internal static JsonConverter Create(Type enumType, EnumConverterOptions converterOptions, JsonSerializerOptions serializerOptions)
+        internal static JsonConverter Create(Type enumType, EnumConverterOptions converterOptions, JsonNamingPolicy? namingPolicy, JsonSerializerOptions options)
         {
             return (JsonConverter)Activator.CreateInstance(
                 GetEnumConverterType(enumType),
-                new object[] { converterOptions, serializerOptions })!;
-        }
-
-        internal static JsonConverter Create(Type enumType, EnumConverterOptions converterOptions, JsonNamingPolicy? namingPolicy, JsonSerializerOptions serializerOptions)
-        {
-            return (JsonConverter)Activator.CreateInstance(
-                GetEnumConverterType(enumType),
-                new object?[] { converterOptions, namingPolicy, serializerOptions })!;
+                new object?[] { converterOptions, namingPolicy, options })!;
         }
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2055:MakeGenericType",


### PR DESCRIPTION
Plus other minor cleanups while auditing JsonConverterFactory implementations for linker annotations.

Related to #67582