### PR TITLE
Delete libkrb5-dev from NativeAOT prereqs

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -86,7 +86,6 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-lm" />
       <LinkerArg Include="-lz" />
       <LinkerArg Include="-static" Condition="'$(StaticallyLinked)' == 'true'" />
-      <LinkerArg Include="-lgssapi_krb5" Condition="'$(TargetOS)' != 'OSX' and '$(StaticallyLinked)' != 'true'" />
       <LinkerArg Include="-lrt" Condition="'$(TargetOS)' != 'OSX'" />
       <LinkerArg Include="-licucore" Condition="'$(TargetOS)' == 'OSX'" />
       <LinkerArg Include="-dynamiclib" Condition="'$(TargetOS)' == 'OSX' and '$(NativeLib)' == 'Shared'" />

--- a/src/coreclr/nativeaot/docs/prerequisites.md
+++ b/src/coreclr/nativeaot/docs/prerequisites.md
@@ -33,7 +33,7 @@ the `%ProgramFiles(x86)%\Microsoft Visual Studio\Installer` directory.
 * Install `clang` and developer packages for libraries that .NET Core depends on:
 
 ```sh
-sudo dnf install clang zlib-devel krb5-libs krb5-devel ncurses-compat-libs
+sudo dnf install clang zlib-devel ncurses-compat-libs
 ```
 
 This was tested on Fedora 31, but will most likely work on lower versions too.
@@ -43,7 +43,7 @@ This was tested on Fedora 31, but will most likely work on lower versions too.
 * Install `clang` and developer packages for libraries that .NET Core depends on:
 
 ```sh
-sudo apt-get install clang zlib1g-dev libkrb5-dev
+sudo apt-get install clang zlib1g-dev
 ```
 
 # macOS (10.13+)


### PR DESCRIPTION
We load the library dynamically after #55037 so it is not necessary to have the export lib available for the build.