### PR TITLE
Do not use '.NET Core' anymore in error messages

### DIFF
--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -609,7 +609,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 command.WaitForExit(true)
                     .Should().Fail()
                     .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(appExe)}' - error code: 0x{expectedErrorCode}")
-                    .And.HaveStdErrContaining("To run this application, you need to install a newer version of .NET.");
+                    .And.HaveStdErrContaining("You must install or update .NET to run this application.")
+                    .And.HaveStdErrContaining("App host version:")
+                    .And.HaveStdErrContaining("apphost_version=");
             }
         }
 

--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -609,7 +609,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 command.WaitForExit(true)
                     .Should().Fail()
                     .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(appExe)}' - error code: 0x{expectedErrorCode}")
-                    .And.HaveStdErrContaining("To run this application, you need to install a newer version of .NET");
+                    .And.HaveStdErrContaining("To run this application, you need to install a newer version of .NET.");
             }
         }
 

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundledAppWithSubDirs.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundledAppWithSubDirs.cs
@@ -57,7 +57,7 @@ namespace AppHost.Bundle.Tests
         }
 
         [Fact]
-        public void Bundle_Framework_dependent_Old_Hostfxr()
+        public void Bundle_Framework_dependent_NoBundleEntryPoint()
         {
             var fixture = sharedTestState.TestFrameworkDependentFixture.Copy();
             UseFrameworkDependentHost(fixture);
@@ -76,8 +76,9 @@ namespace AppHost.Bundle.Tests
                 RunTheApp(singleFile, dotnet)
                     .Should()
                     .Fail()
-                    .And
-                    .HaveStdErrContaining("To run this application, you need to install a newer version of .NET.");
+                    .And.HaveStdErrContaining("You must install or update .NET to run this application.")
+                    .And.HaveStdErrContaining("App host version:")
+                    .And.HaveStdErrContaining("apphost_version=");
             }
         }
 

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundledAppWithSubDirs.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundledAppWithSubDirs.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using BundleTests.Helpers;
+using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Microsoft.DotNet.CoreSetup.Test;
 using Microsoft.NET.HostModel.Bundle;
@@ -22,16 +23,20 @@ namespace AppHost.Bundle.Tests
 
         private void RunTheApp(string path, TestProjectFixture fixture)
         {
-            Command.Create(path)
-                .EnableTracingAndCaptureOutputs()
-                .EnvironmentVariable("DOTNET_ROOT", fixture.BuiltDotnet.BinPath)
-                .EnvironmentVariable("DOTNET_ROOT(x86)", fixture.BuiltDotnet.BinPath)
-                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
-                .Execute()
+            RunTheApp(path, fixture.BuiltDotnet)
                 .Should()
                 .Pass()
                 .And
                 .HaveStdOutContaining("Wow! We now say hello to the big world and you.");
+        }
+
+        private CommandResult RunTheApp(string path, DotNetCli dotnet)
+        {
+            return Command.Create(path)
+                .EnableTracingAndCaptureOutputs()
+                .DotNetRoot(dotnet.BinPath)
+                .MultilevelLookup(false)
+                .Execute();
         }
 
         [InlineData(BundleOptions.None)]
@@ -49,6 +54,31 @@ namespace AppHost.Bundle.Tests
 
             // Run the bundled app again (reuse extracted files)
             RunTheApp(singleFile, fixture);
+        }
+
+        [Fact]
+        public void Bundle_Framework_dependent_Old_Hostfxr()
+        {
+            var fixture = sharedTestState.TestFrameworkDependentFixture.Copy();
+            UseFrameworkDependentHost(fixture);
+            var singleFile = BundleHelper.BundleApp(fixture, BundleOptions.None);
+
+            string dotnetWithMockHostFxr = SharedFramework.CalculateUniqueTestDirectory(Path.Combine(TestArtifact.TestArtifactsPath, "guiErrors"));
+            using (new TestArtifact(dotnetWithMockHostFxr))
+            {
+                Directory.CreateDirectory(dotnetWithMockHostFxr);
+                var dotnetBuilder = new DotNetBuilder(dotnetWithMockHostFxr, sharedTestState.RepoDirectories.BuiltDotnet, "mockhostfxrFrameworkMissingFailure")
+                    .RemoveHostFxr()
+                    .AddMockHostFxr(new Version(2, 2, 0));
+                var dotnet = dotnetBuilder.Build();
+
+                // Run the bundled app (extract files)
+                RunTheApp(singleFile, dotnet)
+                    .Should()
+                    .Fail()
+                    .And
+                    .HaveStdErrContaining("To run this application, you need to install a newer version of .NET.");
+            }
         }
 
         [InlineData(BundleOptions.None)]

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/StaticHost.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/StaticHost.cs
@@ -18,7 +18,7 @@ namespace AppHost.Bundle.Tests
         }
 
         [Fact]
-        private void Can_Run_App_With_StatiHost()
+        private void Can_Run_App_With_StaticHost()
         {
             var fixture = sharedTestState.TestFixture.Copy();
 
@@ -35,7 +35,7 @@ namespace AppHost.Bundle.Tests
         }
 
         [Fact]
-        private void Can_Run_SingleFile_App_With_StatiHost()
+        private void Can_Run_SingleFile_App_With_StaticHost()
         {
             var fixture = sharedTestState.TestFixture.Copy();
 

--- a/src/native/corehost/apphost/apphost.windows.cpp
+++ b/src/native/corehost/apphost/apphost.windows.cpp
@@ -70,13 +70,19 @@ namespace
         return false;
     }
 
-    pal::string_t get_runtime_not_found_message()
+    pal::string_t get_apphost_details_message()
     {
-        pal::string_t msg = INSTALL_NET_DESKTOP_ERROR_MESSAGE _X("\n\n")
-            _X("Architecture: ");
+        pal::string_t msg = _X("Architecture: ");
         msg.append(get_arch());
         msg.append(_X("\n")
             _X("App host version: ") _STRINGIFY(COMMON_HOST_PKG_VER) _X("\n\n"));
+        return msg;
+    }
+
+    pal::string_t get_runtime_not_found_message()
+    {
+        pal::string_t msg = INSTALL_NET_DESKTOP_ERROR_MESSAGE _X("\n\n");
+        msg.append(get_apphost_details_message());
         return msg;
     }
 
@@ -108,6 +114,7 @@ namespace
             dialogMsg = pal::string_t(INSTALL_OR_UPDATE_NET_ERROR_MESSAGE _X("\n\n"));
             pal::string_t line;
             pal::stringstream_t ss(g_buffered_errors);
+            bool foundCustomMessage = false;
             while (std::getline(ss, line, _X('\n')))
             {
                 const pal::char_t prefix[] = _X("Framework: '");
@@ -119,18 +126,23 @@ namespace
                 {
                     dialogMsg.append(line);
                     dialogMsg.append(_X("\n\n"));
+                    foundCustomMessage = true;
                 }
                 else if (utils::starts_with(line, custom_prefix, true))
                 {
                     dialogMsg.erase();
                     dialogMsg.append(line.substr(utils::strlen(custom_prefix)));
                     dialogMsg.append(_X("\n\n"));
+                    foundCustomMessage = true;
                 }
                 else if (try_get_url_from_line(line, url))
                 {
                     break;
                 }
             }
+
+            if (!foundCustomMessage)
+                dialogMsg.append(get_apphost_details_message());
         }
         else if (error_code == StatusCode::BundleExtractionFailure)
         {

--- a/src/native/corehost/corehost.cpp
+++ b/src/native/corehost/corehost.cpp
@@ -87,7 +87,7 @@ bool is_exe_enabled_for_execution(pal::string_t* app_dll)
 void need_newer_framework_error()
 {
     pal::string_t url = get_download_url();
-    trace::error(_X("  _ To run this application, you need to install a newer version of .NET Core."));
+    trace::error(_X("  _ To run this application, you need to install a newer version of .NET."));
     trace::error(_X(""));
     trace::error(_X("  - %s&apphost_version=%s"), url.c_str(), _STRINGIFY(COMMON_HOST_PKG_VER));
 }


### PR DESCRIPTION
Added a test for a single-file FDD running over old hostfxr

In reaction to https://github.com/dotnet/runtime/discussions/67427.