### PR TITLE
Enable new CA1311 (ToLower/Upper culture) and CA1852 (seal internal/private types) rules

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -190,6 +190,9 @@ dotnet_diagnostic.CA1309.severity = none
 # CA1310: Specify StringComparison for correctness
 dotnet_diagnostic.CA1310.severity = suggestion
 
+# CA1311: Specify a culture or use an invariant version
+dotnet_diagnostic.CA1311.severity = warning
+
 # CA1401: P/Invokes should not be visible
 dotnet_diagnostic.CA1401.severity = warning
 
@@ -401,6 +404,9 @@ dotnet_diagnostic.CA1850.severity = warning
 
 # CA1851: Possible multiple enumerations of 'IEnumerable' collection
 dotnet_diagnostic.CA1851.severity = suggestion
+
+# CA1852: Seal internal types
+dotnet_diagnostic.CA1852.severity = warning
 
 # CA2000: Dispose objects before losing scope
 dotnet_diagnostic.CA2000.severity = none

--- a/eng/CodeAnalysis.test.globalconfig
+++ b/eng/CodeAnalysis.test.globalconfig
@@ -189,6 +189,9 @@ dotnet_diagnostic.CA1309.severity = none
 # CA1310: Specify StringComparison for correctness
 dotnet_diagnostic.CA1310.severity = none
 
+# CA1311: Specify a culture or use an invariant version
+dotnet_diagnostic.CA1311.severity = none
+
 # CA1401: P/Invokes should not be visible
 dotnet_diagnostic.CA1401.severity = none
 
@@ -398,6 +401,9 @@ dotnet_diagnostic.CA1850.severity = none
 
 # CA1851: Possible multiple enumerations of 'IEnumerable' collection
 dotnet_diagnostic.CA1851.severity = none
+
+# CA1852: Seal internal types
+dotnet_diagnostic.CA1852.severity = none
 
 # CA2000: Dispose objects before losing scope
 dotnet_diagnostic.CA2000.severity = none

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,7 +44,7 @@
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>4.3.0-1.22206.2</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesVersion>4.3.0-1.22206.2</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
     <MicrosoftCodeAnalysisCSharpVersion>4.3.0-1.22206.2</MicrosoftCodeAnalysisCSharpVersion>
-    <MicrosoftCodeAnalysisNetAnalyzersVersion>7.0.0-preview1.22212.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
+    <MicrosoftCodeAnalysisNetAnalyzersVersion>7.0.0-preview1.22218.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftCodeAnalysisVersion>4.3.0-1.22206.2</MicrosoftCodeAnalysisVersion>
     <!--
       TODO: Remove pinned version once arcade supplies a 4.3 compiler.

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -1512,7 +1512,7 @@ namespace System
         #endregion
     }
 
-    internal unsafe class Signature
+    internal sealed unsafe class Signature
     {
         #region Definitions
         internal enum MdSigCallingConvention : byte

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Overlapped.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Overlapped.cs
@@ -27,7 +27,7 @@ namespace System.Threading
 {
     #region class _IOCompletionCallback
 
-    internal unsafe partial class _IOCompletionCallback
+    internal sealed unsafe partial class _IOCompletionCallback
     {
         // call back helper
         internal static void PerformIOCompletionCallback(uint errorCode, uint numBytes, NativeOverlapped* pNativeOverlapped)

--- a/src/coreclr/System.Private.CoreLib/src/System/__Canon.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/__Canon.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable CA1852 // __Canon should not be sealed
+
 using System.Runtime.InteropServices;
 
 namespace System

--- a/src/coreclr/System.Private.CoreLib/src/System/__ComObject.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/__ComObject.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable CA1852 // __ComObject should not be sealed
+
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;

--- a/src/coreclr/nativeaot/Directory.Build.props
+++ b/src/coreclr/nativeaot/Directory.Build.props
@@ -34,7 +34,7 @@
     <NoWarn>$(NoWarn);CS8602;CS8603;CS8604;CS8618;CS8625;CS8632;CS8765</NoWarn>
 
     <!-- we should just fix -->
-    <NoWarn>$(NoWarn);CA1810;CA1823;CA1825;CA2208;SA1129;SA1205;SA1400;SA1517</NoWarn>
+    <NoWarn>$(NoWarn);CA1810;CA1823;CA1825;CA1852;CA2208;SA1129;SA1205;SA1400;SA1517</NoWarn>
 
     <!-- Arrays as attribute arguments is not CLS-compliant -->
     <NoWarn>$(NoWarn);CS3016</NoWarn>

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CompilerServices/FixedBufferAttribute.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CompilerServices/FixedBufferAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Runtime.CompilerServices
 {
-    internal unsafe sealed class FixedBufferAttribute : Attribute
+    internal sealed unsafe class FixedBufferAttribute : Attribute
     {
         public FixedBufferAttribute(Type elementType, int length)
         {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Overlapped.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Overlapped.cs
@@ -27,7 +27,7 @@ namespace System.Threading
 {
     #region class OverlappedData
 
-    internal unsafe sealed class OverlappedData
+    internal sealed unsafe class OverlappedData
     {
         internal IAsyncResult _asyncResult;
         internal object _callback; // IOCompletionCallback or _IOCompletionCallback

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -103,7 +103,7 @@ namespace Internal.Reflection.Execution
         /// </summary>
         /// <param name="runtimeTypeHandle">Runtime handle of the type in question</param>
         /// <param name="qTypeDefinition">TypeDef handle for the type</param>
-        public unsafe sealed override bool TryGetMetadataForNamedType(RuntimeTypeHandle runtimeTypeHandle, out QTypeDefinition qTypeDefinition)
+        public sealed unsafe override bool TryGetMetadataForNamedType(RuntimeTypeHandle runtimeTypeHandle, out QTypeDefinition qTypeDefinition)
         {
             Debug.Assert(!RuntimeAugments.IsGenericType(runtimeTypeHandle));
             return TypeLoaderEnvironment.Instance.TryGetMetadataForNamedType(runtimeTypeHandle, out qTypeDefinition);
@@ -115,7 +115,7 @@ namespace Internal.Reflection.Execution
         // Preconditions:
         //    runtimeTypeHandle is a typedef or a generic type instance (not a constructed type such as an array)
         //
-        public unsafe sealed override bool IsReflectionBlocked(RuntimeTypeHandle runtimeTypeHandle)
+        public sealed unsafe override bool IsReflectionBlocked(RuntimeTypeHandle runtimeTypeHandle)
         {
             // For generic types, use the generic type definition
             runtimeTypeHandle = GetTypeDefinition(runtimeTypeHandle);
@@ -163,7 +163,7 @@ namespace Internal.Reflection.Execution
         /// </summary>
         /// <param name="qTypeDefinition">TypeDef handle for the type to look up</param>
         /// <param name="runtimeTypeHandle">Runtime type handle (MethodTable) for the given type</param>
-        public unsafe sealed override bool TryGetNamedTypeForMetadata(QTypeDefinition qTypeDefinition, out RuntimeTypeHandle runtimeTypeHandle)
+        public sealed unsafe override bool TryGetNamedTypeForMetadata(QTypeDefinition qTypeDefinition, out RuntimeTypeHandle runtimeTypeHandle)
         {
             return TypeLoaderEnvironment.Instance.TryGetOrCreateNamedTypeForMetadata(qTypeDefinition, out runtimeTypeHandle);
         }
@@ -180,7 +180,7 @@ namespace Internal.Reflection.Execution
         /// <param name="runtimeTypeHandle">MethodTable of the type in question</param>
         /// <param name="metadataReader">Metadata reader for the type</param>
         /// <param name="typeRefHandle">Located TypeRef handle</param>
-        public unsafe sealed override bool TryGetTypeReferenceForNamedType(RuntimeTypeHandle runtimeTypeHandle, out MetadataReader metadataReader, out TypeReferenceHandle typeRefHandle)
+        public sealed unsafe override bool TryGetTypeReferenceForNamedType(RuntimeTypeHandle runtimeTypeHandle, out MetadataReader metadataReader, out TypeReferenceHandle typeRefHandle)
         {
             return TypeLoaderEnvironment.TryGetTypeReferenceForNamedType(runtimeTypeHandle, out metadataReader, out typeRefHandle);
         }
@@ -203,7 +203,7 @@ namespace Internal.Reflection.Execution
         /// <param name="metadataReader">Metadata reader for module containing the type reference</param>
         /// <param name="typeRefHandle">TypeRef handle to look up</param>
         /// <param name="runtimeTypeHandle">Resolved MethodTable for the type reference</param>
-        public unsafe sealed override bool TryGetNamedTypeForTypeReference(MetadataReader metadataReader, TypeReferenceHandle typeRefHandle, out RuntimeTypeHandle runtimeTypeHandle)
+        public sealed unsafe override bool TryGetNamedTypeForTypeReference(MetadataReader metadataReader, TypeReferenceHandle typeRefHandle, out RuntimeTypeHandle runtimeTypeHandle)
         {
             return TypeLoaderEnvironment.TryGetNamedTypeForTypeReference(metadataReader, typeRefHandle, out runtimeTypeHandle);
         }
@@ -217,7 +217,7 @@ namespace Internal.Reflection.Execution
         //
         // This is not equivalent to calling TryGetMultiDimTypeForElementType() with a rank of 1!
         //
-        public unsafe sealed override bool TryGetArrayTypeForElementType(RuntimeTypeHandle elementTypeHandle, out RuntimeTypeHandle arrayTypeHandle)
+        public sealed unsafe override bool TryGetArrayTypeForElementType(RuntimeTypeHandle elementTypeHandle, out RuntimeTypeHandle arrayTypeHandle)
         {
             if (RuntimeAugments.IsGenericTypeDefinition(elementTypeHandle))
             {
@@ -238,7 +238,7 @@ namespace Internal.Reflection.Execution
         //
         // This is not equivalent to calling TryGetMultiDimTypeElementType() with a rank of 1!
         //
-        public unsafe sealed override bool TryGetArrayTypeElementType(RuntimeTypeHandle arrayTypeHandle, out RuntimeTypeHandle elementTypeHandle)
+        public sealed unsafe override bool TryGetArrayTypeElementType(RuntimeTypeHandle arrayTypeHandle, out RuntimeTypeHandle elementTypeHandle)
         {
             elementTypeHandle = RuntimeAugments.GetRelatedParameterTypeHandle(arrayTypeHandle);
             return true;
@@ -254,7 +254,7 @@ namespace Internal.Reflection.Execution
         //
         // Calling this with rank 1 is not equivalent to calling TryGetArrayTypeForElementType()!
         //
-        public unsafe sealed override bool TryGetMultiDimArrayTypeForElementType(RuntimeTypeHandle elementTypeHandle, int rank, out RuntimeTypeHandle arrayTypeHandle)
+        public sealed unsafe override bool TryGetMultiDimArrayTypeForElementType(RuntimeTypeHandle elementTypeHandle, int rank, out RuntimeTypeHandle arrayTypeHandle)
         {
             if (RuntimeAugments.IsGenericTypeDefinition(elementTypeHandle))
             {
@@ -277,7 +277,7 @@ namespace Internal.Reflection.Execution
         // Preconditions:
         //     targetTypeHandle is a valid RuntimeTypeHandle.
         //
-        public unsafe sealed override bool TryGetPointerTypeForTargetType(RuntimeTypeHandle targetTypeHandle, out RuntimeTypeHandle pointerTypeHandle)
+        public sealed unsafe override bool TryGetPointerTypeForTargetType(RuntimeTypeHandle targetTypeHandle, out RuntimeTypeHandle pointerTypeHandle)
         {
             return TypeLoaderEnvironment.Instance.TryGetPointerTypeForTargetType(targetTypeHandle, out pointerTypeHandle);
         }
@@ -289,7 +289,7 @@ namespace Internal.Reflection.Execution
         // Preconditions:
         //      pointerTypeHandle is a valid RuntimeTypeHandle of type pointer.
         //
-        public unsafe sealed override bool TryGetPointerTypeTargetType(RuntimeTypeHandle pointerTypeHandle, out RuntimeTypeHandle targetTypeHandle)
+        public sealed unsafe override bool TryGetPointerTypeTargetType(RuntimeTypeHandle pointerTypeHandle, out RuntimeTypeHandle targetTypeHandle)
         {
             targetTypeHandle = RuntimeAugments.GetRelatedParameterTypeHandle(pointerTypeHandle);
             return true;
@@ -302,7 +302,7 @@ namespace Internal.Reflection.Execution
         // Preconditions:
         //     targetTypeHandle is a valid RuntimeTypeHandle.
         //
-        public unsafe sealed override bool TryGetByRefTypeForTargetType(RuntimeTypeHandle targetTypeHandle, out RuntimeTypeHandle byRefTypeHandle)
+        public sealed unsafe override bool TryGetByRefTypeForTargetType(RuntimeTypeHandle targetTypeHandle, out RuntimeTypeHandle byRefTypeHandle)
         {
             return TypeLoaderEnvironment.Instance.TryGetByRefTypeForTargetType(targetTypeHandle, out byRefTypeHandle);
         }
@@ -314,7 +314,7 @@ namespace Internal.Reflection.Execution
         // Preconditions:
         //      byRefTypeHandle is a valid RuntimeTypeHandle of a byref.
         //
-        public unsafe sealed override bool TryGetByRefTypeTargetType(RuntimeTypeHandle byRefTypeHandle, out RuntimeTypeHandle targetTypeHandle)
+        public sealed unsafe override bool TryGetByRefTypeTargetType(RuntimeTypeHandle byRefTypeHandle, out RuntimeTypeHandle targetTypeHandle)
         {
             targetTypeHandle = RuntimeAugments.GetRelatedParameterTypeHandle(byRefTypeHandle);
             return true;
@@ -328,7 +328,7 @@ namespace Internal.Reflection.Execution
         //      runtimeTypeDefinitionHandle is a valid RuntimeTypeHandle for a generic type.
         //      genericTypeArgumentHandles is an array of valid RuntimeTypeHandles.
         //
-        public unsafe sealed override bool TryGetConstructedGenericTypeForComponents(RuntimeTypeHandle genericTypeDefinitionHandle, RuntimeTypeHandle[] genericTypeArgumentHandles, out RuntimeTypeHandle runtimeTypeHandle)
+        public sealed unsafe override bool TryGetConstructedGenericTypeForComponents(RuntimeTypeHandle genericTypeDefinitionHandle, RuntimeTypeHandle[] genericTypeArgumentHandles, out RuntimeTypeHandle runtimeTypeHandle)
         {
             if (TypeLoaderEnvironment.Instance.TryLookupConstructedGenericTypeForComponents(genericTypeDefinitionHandle, genericTypeArgumentHandles, out runtimeTypeHandle))
             {
@@ -1386,7 +1386,7 @@ namespace Internal.Reflection.Execution
         //
         // This resolves RuntimeMethodHandles for methods declared on non-generic types (declaringTypeHandle is an output of this method.)
         //
-        public unsafe sealed override bool TryGetMethodFromHandle(RuntimeMethodHandle runtimeMethodHandle, out RuntimeTypeHandle declaringTypeHandle, out QMethodDefinition methodHandle, out RuntimeTypeHandle[] genericMethodTypeArgumentHandles)
+        public sealed unsafe override bool TryGetMethodFromHandle(RuntimeMethodHandle runtimeMethodHandle, out RuntimeTypeHandle declaringTypeHandle, out QMethodDefinition methodHandle, out RuntimeTypeHandle[] genericMethodTypeArgumentHandles)
         {
             MethodNameAndSignature nameAndSignature;
             methodHandle = default(QMethodDefinition);
@@ -1407,7 +1407,7 @@ namespace Internal.Reflection.Execution
         //
         // This resolves RuntimeFieldHandles for fields declared on non-generic types (declaringTypeHandle is an output of this method.)
         //
-        public unsafe sealed override bool TryGetFieldFromHandle(RuntimeFieldHandle runtimeFieldHandle, out RuntimeTypeHandle declaringTypeHandle, out FieldHandle fieldHandle)
+        public sealed unsafe override bool TryGetFieldFromHandle(RuntimeFieldHandle runtimeFieldHandle, out RuntimeTypeHandle declaringTypeHandle, out FieldHandle fieldHandle)
         {
             fieldHandle = default(FieldHandle);
 

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/PointerTypeFieldAccessorForStaticFields.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/PointerTypeFieldAccessorForStaticFields.cs
@@ -16,7 +16,7 @@ namespace Internal.Reflection.Execution.FieldAccessors
         {
         }
 
-        protected unsafe sealed override object GetFieldBypassCctor()
+        protected sealed unsafe override object GetFieldBypassCctor()
         {
             if (FieldBase == FieldTableFlags.GCStatic)
             {
@@ -33,7 +33,7 @@ namespace Internal.Reflection.Execution.FieldAccessors
             return RuntimeAugments.LoadPointerTypeField(threadStaticRegion, FieldOffset, FieldTypeHandle);
         }
 
-        protected unsafe sealed override void UncheckedSetFieldBypassCctor(object value)
+        protected sealed unsafe override void UncheckedSetFieldBypassCctor(object value)
         {
             if (FieldBase == FieldTableFlags.GCStatic)
             {

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ReferenceTypeFieldAccessorForStaticFields.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ReferenceTypeFieldAccessorForStaticFields.cs
@@ -16,7 +16,7 @@ namespace Internal.Reflection.Execution.FieldAccessors
         {
         }
 
-        protected unsafe sealed override object GetFieldBypassCctor()
+        protected sealed unsafe override object GetFieldBypassCctor()
         {
             if (FieldBase == FieldTableFlags.GCStatic)
             {
@@ -33,7 +33,7 @@ namespace Internal.Reflection.Execution.FieldAccessors
             return RuntimeAugments.LoadReferenceTypeField(threadStaticRegion, FieldOffset);
         }
 
-        protected unsafe sealed override void UncheckedSetFieldBypassCctor(object value)
+        protected sealed unsafe override void UncheckedSetFieldBypassCctor(object value)
         {
             if (FieldBase == FieldTableFlags.GCStatic)
             {

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ValueTypeFieldAccessorForStaticFields.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ValueTypeFieldAccessorForStaticFields.cs
@@ -16,7 +16,7 @@ namespace Internal.Reflection.Execution.FieldAccessors
         {
         }
 
-        protected unsafe sealed override object GetFieldBypassCctor()
+        protected sealed unsafe override object GetFieldBypassCctor()
         {
             if (FieldBase == FieldTableFlags.GCStatic)
             {
@@ -33,7 +33,7 @@ namespace Internal.Reflection.Execution.FieldAccessors
             return RuntimeAugments.LoadValueTypeField(threadStaticRegion, FieldOffset, FieldTypeHandle);
         }
 
-        protected unsafe sealed override void UncheckedSetFieldBypassCctor(object value)
+        protected sealed unsafe override void UncheckedSetFieldBypassCctor(object value)
         {
             if (FieldBase == FieldTableFlags.GCStatic)
             {

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -34,7 +34,7 @@ using ILCompiler.DependencyAnalysis.ReadyToRun;
 
 namespace Internal.JitInterface
 {
-    internal unsafe sealed partial class CorInfoImpl
+    internal sealed unsafe partial class CorInfoImpl
     {
         //
         // Global initialization and state

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataTypeSystemContext.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataTypeSystemContext.cs
@@ -94,7 +94,7 @@ namespace Internal.TypeSystem
             return type;
         }
 
-        protected sealed internal override bool ComputeHasStaticConstructor(TypeDesc type)
+        protected internal sealed override bool ComputeHasStaticConstructor(TypeDesc type)
         {
             if (type is MetadataType)
             {
@@ -103,7 +103,7 @@ namespace Internal.TypeSystem
             return false;
         }
 
-        protected sealed internal override bool IsIDynamicInterfaceCastableInterface(DefType type)
+        protected internal sealed override bool IsIDynamicInterfaceCastableInterface(DefType type)
         {
             MetadataType t = (MetadataType)type;
             return t.Module == SystemModule

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/SymbolReader/UnmanagedPdbSymbolReader.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/SymbolReader/UnmanagedPdbSymbolReader.cs
@@ -148,7 +148,7 @@ namespace Internal.TypeSystem.Ecma
             }
             protected override void ReleaseObjects(IEnumerable objects) => throw new NotImplementedException();
 
-            public unsafe sealed record ClrRuntimeInfoRcw(IntPtr Inst) : ICLRRuntimeInfo, IDisposable
+            public sealed unsafe record ClrRuntimeInfoRcw(IntPtr Inst) : ICLRRuntimeInfo, IDisposable
             {
                 /// <summary>
                 /// List of offsets of methods in the vtable (0-based). First three are from IUnknown.
@@ -381,7 +381,7 @@ namespace Internal.TypeSystem.Ecma
             }
             protected override void ReleaseObjects(IEnumerable objects) => throw new NotImplementedException();
 
-            public unsafe sealed record SymUnmanagedNamespaceRcw(IntPtr Inst) : ISymUnmanagedNamespace
+            public sealed unsafe record SymUnmanagedNamespaceRcw(IntPtr Inst) : ISymUnmanagedNamespace
             {
                 private bool _disposed = false;
 
@@ -494,7 +494,7 @@ namespace Internal.TypeSystem.Ecma
             }
             protected override void ReleaseObjects(IEnumerable objects) => throw new NotImplementedException();
 
-            public unsafe sealed record SymUnmanagedVariableRcw(IntPtr Inst) : ISymUnmanagedVariable
+            public sealed unsafe record SymUnmanagedVariableRcw(IntPtr Inst) : ISymUnmanagedVariable
             {
                 private bool _disposed = false;
 
@@ -578,7 +578,7 @@ namespace Internal.TypeSystem.Ecma
 
             protected override void ReleaseObjects(IEnumerable objects) => throw new NotImplementedException();
 
-            public unsafe sealed record SymUnmanagedScopeRcw(IntPtr Inst) : ISymUnmanagedScope
+            public sealed unsafe record SymUnmanagedScopeRcw(IntPtr Inst) : ISymUnmanagedScope
             {
                 private bool _disposed = false;
 
@@ -862,7 +862,7 @@ namespace Internal.TypeSystem.Ecma
             }
             protected override void ReleaseObjects(IEnumerable objects) => throw new NotImplementedException();
 
-            public unsafe sealed record SymUnmanagedMethodRcw(IntPtr Inst) : ISymUnmanagedMethod
+            public sealed unsafe record SymUnmanagedMethodRcw(IntPtr Inst) : ISymUnmanagedMethod
             {
                 private bool _disposed = false;
 

--- a/src/coreclr/tools/aot/ILCompiler.Diagnostics/ILCompilerComWrappers.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Diagnostics/ILCompilerComWrappers.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.DiaSymReader
 {
-    internal unsafe sealed class ILCompilerComWrappers : ComWrappers
+    internal sealed unsafe class ILCompilerComWrappers : ComWrappers
     {
         protected override unsafe ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags, out int count)
         {

--- a/src/installer/managed/Microsoft.NET.HostModel/ComHost/ClsidMap.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/ComHost/ClsidMap.cs
@@ -249,7 +249,7 @@ namespace Microsoft.NET.HostModel.ComHost
             Unknown
         }
 
-        private class TypeResolver : ICustomAttributeTypeProvider<KnownType>
+        private sealed class TypeResolver : ICustomAttributeTypeProvider<KnownType>
         {
             public KnownType GetPrimitiveType(PrimitiveTypeCode typeCode)
             {

--- a/src/installer/managed/Microsoft.NET.HostModel/ComHost/TypeLibReader.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/ComHost/TypeLibReader.cs
@@ -12,7 +12,7 @@ namespace Microsoft.NET.HostModel.ComHost
     /// We do the reading ourselves instead of calling into the OS so we don't have to worry about the type library's
     /// dependencies being discoverable on disk.
     /// </summary>
-    internal class TypeLibReader
+    internal sealed class TypeLibReader
     {
         private byte[] tlbBytes;
 

--- a/src/installer/managed/Microsoft.NET.HostModel/ResourceUpdater.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/ResourceUpdater.cs
@@ -428,7 +428,7 @@ namespace Microsoft.NET.HostModel
             return true;
         }
 
-        private class EnumResourcesErrorInfo
+        private sealed class EnumResourcesErrorInfo
         {
             public int hResult;
             public bool failedToLockResource;
@@ -457,7 +457,7 @@ namespace Microsoft.NET.HostModel
             }
         }
 
-        private class ResourceNotAvailableException : Exception
+        private sealed class ResourceNotAvailableException : Exception
         {
             public ResourceNotAvailableException(string message) : base(message)
             {

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.QUERY_SERVICE_CONFIG.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.QUERY_SERVICE_CONFIG.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [StructLayout(LayoutKind.Sequential)]
-        internal unsafe class QUERY_SERVICE_CONFIG
+        internal sealed unsafe class QUERY_SERVICE_CONFIG
         {
             internal int dwServiceType;
             internal int dwStartType;

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.WTSSESSION_NOTIFICATION.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.WTSSESSION_NOTIFICATION.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-        public class WTSSESSION_NOTIFICATION
+        public sealed class WTSSESSION_NOTIFICATION
         {
             public int size;
             public int sessionId;

--- a/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.SafeWinHttpHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.SafeWinHttpHandle.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
 {
     internal static partial class WinHttp
     {
-        internal class SafeWinHttpHandle : SafeHandleZeroOrMinusOneIsInvalid
+        internal sealed class SafeWinHttpHandle : SafeHandleZeroOrMinusOneIsInvalid
         {
             private SafeWinHttpHandle? _parentHandle;
 

--- a/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.SafeWinHttpHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.SafeWinHttpHandle.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable CA1852 // unit test project includes this file and derives from SafeWinHttpHandle
+
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
@@ -11,7 +13,7 @@ internal static partial class Interop
 {
     internal static partial class WinHttp
     {
-        internal sealed class SafeWinHttpHandle : SafeHandleZeroOrMinusOneIsInvalid
+        internal class SafeWinHttpHandle : SafeHandleZeroOrMinusOneIsInvalid
         {
             private SafeWinHttpHandle? _parentHandle;
 

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeCertContextHandle.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeCertContextHandle.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable CA1852 // some projects have types deriving from this
+
 using System;
 using System.Diagnostics;
 using static Interop.Crypt32;

--- a/src/libraries/Common/src/System/IO/TempFileCollection.cs
+++ b/src/libraries/Common/src/System/IO/TempFileCollection.cs
@@ -17,7 +17,7 @@ namespace System.IO.Internal
 #if CODEDOM
     public
 #else
-    internal
+    internal sealed
 #endif
     class TempFileCollection : ICollection, IDisposable
     {
@@ -46,7 +46,12 @@ namespace System.IO.Internal
             GC.SuppressFinalize(this);
         }
 
-        protected virtual void Dispose(bool disposing)
+#if CODEDOM
+        protected virtual
+#else
+        internal
+#endif
+        void Dispose(bool disposing)
         {
             SafeDelete();
         }

--- a/src/libraries/Common/src/System/Net/NTAuthentication.Managed.cs
+++ b/src/libraries/Common/src/System/Net/NTAuthentication.Managed.cs
@@ -436,7 +436,7 @@ namespace System.Net
                 using (var hmac = IncrementalHash.CreateHMAC(HashAlgorithmName.MD5, pwHash))
                 {
                     // strangely, user is upper case, domain is not.
-                    byte[] blob = Encoding.Unicode.GetBytes(string.Concat(userName.ToUpper(), domain));
+                    byte[] blob = Encoding.Unicode.GetBytes(string.Concat(userName.ToUpperInvariant(), domain));
                     hmac.AppendData(blob);
                     hmac.GetHashAndReset(hash);
                 }

--- a/src/libraries/Common/src/System/Net/Security/RC4.cs
+++ b/src/libraries/Common/src/System/Net/Security/RC4.cs
@@ -35,7 +35,7 @@ namespace System.Net.Security
     // References:
     // a. Usenet 1994 - RC4 Algorithm revealed
     // http://www.qrst.de/html/dsds/rc4.htm
-    internal class RC4 : IDisposable
+    internal sealed class RC4 : IDisposable
     {
         private byte[]? state;
         private byte x;

--- a/src/libraries/Common/src/System/Net/SocketAddress.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddress.cs
@@ -18,7 +18,7 @@ namespace System.Net.Internals
 #if SYSTEM_NET_PRIMITIVES_DLL
     public
 #else
-    internal
+    internal sealed
 #endif
     class SocketAddress
     {

--- a/src/libraries/Common/src/System/Threading/Tasks/RendezvousAwaitable.cs
+++ b/src/libraries/Common/src/System/Threading/Tasks/RendezvousAwaitable.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable CA1852 // some projects include types derived from this
+
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/ActivatorUtilitiesTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/ActivatorUtilitiesTests.cs
@@ -391,7 +391,7 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
             }
         }
 
-        private class Bar
+        private sealed class Bar
         {
             public Bar()
             {
@@ -399,7 +399,7 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
             }
         }
 
-        private class StaticConstructorClass
+        private sealed class StaticConstructorClass
         {
             static StaticConstructorClass() { }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/ActivatorUtilitiesTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/ActivatorUtilitiesTests.cs
@@ -399,7 +399,7 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
             }
         }
 
-        private sealed class StaticConstructorClass
+        private class StaticConstructorClass
         {
             static StaticConstructorClass() { }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj
@@ -8,6 +8,7 @@
     <CLSCompliant>false</CLSCompliant>
     <IsPackable>true</IsPackable>
     <IsTrimmable>false</IsTrimmable>
+    <NoWarn>$(NoWarn);CA1852</NoWarn>
     <PackageDescription>Suite of xUnit.net tests to check for container compatibility with Microsoft.Extensions.DependencyInjection.</PackageDescription>
     <!-- this assembly doesn't need to be binplaced -->
     <EnableBinPlacing>false</EnableBinPlacing>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/ServiceCollection.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/ServiceCollection.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Extensions.DependencyInjection.Specification
 {
-    internal class TestServiceCollection : List<ServiceDescriptor>, IServiceCollection
+    internal sealed class TestServiceCollection : List<ServiceDescriptor>, IServiceCollection
     {
     }
 }

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/NullLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/NullLifetime.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.Hosting.Internal
     /// <summary>
     /// Minimalistic lifetime that does nothing.
     /// </summary>
-    internal class NullLifetime : IHostLifetime
+    internal sealed class NullLifetime : IHostLifetime
     {
         public Task WaitForStartAsync(CancellationToken cancellationToken)
         {

--- a/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.Http
 {
-    internal class DefaultHttpClientFactory : IHttpClientFactory, IHttpMessageHandlerFactory
+    internal sealed class DefaultHttpClientFactory : IHttpClientFactory, IHttpMessageHandlerFactory
     {
         private static readonly TimerCallback _cleanupCallback = (s) => ((DefaultHttpClientFactory)s!).CleanupTimer_Tick();
         private readonly ILogger _logger;
@@ -194,13 +194,13 @@ namespace Microsoft.Extensions.Http
         }
 
         // Internal so it can be overridden in tests
-        internal virtual void StartHandlerEntryTimer(ActiveHandlerTrackingEntry entry)
+        internal void StartHandlerEntryTimer(ActiveHandlerTrackingEntry entry)
         {
             entry.StartExpiryTimer(_expiryCallback);
         }
 
         // Internal so it can be overridden in tests
-        internal virtual void StartCleanupTimer()
+        internal void StartCleanupTimer()
         {
             lock (_cleanupTimerLock)
             {
@@ -212,7 +212,7 @@ namespace Microsoft.Extensions.Http
         }
 
         // Internal so it can be overridden in tests
-        internal virtual void StopCleanupTimer()
+        internal void StopCleanupTimer()
         {
             lock (_cleanupTimerLock)
             {

--- a/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
@@ -13,9 +13,11 @@ using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
+#pragma warning disable CA1852 // TODO InternalsVisibleTo: https://github.com/dotnet/roslyn-analyzers/pull/5972
+
 namespace Microsoft.Extensions.Http
 {
-    internal sealed class DefaultHttpClientFactory : IHttpClientFactory, IHttpMessageHandlerFactory
+    internal class DefaultHttpClientFactory : IHttpClientFactory, IHttpMessageHandlerFactory
     {
         private static readonly TimerCallback _cleanupCallback = (s) => ((DefaultHttpClientFactory)s!).CleanupTimer_Tick();
         private readonly ILogger _logger;
@@ -194,13 +196,13 @@ namespace Microsoft.Extensions.Http
         }
 
         // Internal so it can be overridden in tests
-        internal void StartHandlerEntryTimer(ActiveHandlerTrackingEntry entry)
+        internal virtual void StartHandlerEntryTimer(ActiveHandlerTrackingEntry entry)
         {
             entry.StartExpiryTimer(_expiryCallback);
         }
 
         // Internal so it can be overridden in tests
-        internal void StartCleanupTimer()
+        internal virtual void StartCleanupTimer()
         {
             lock (_cleanupTimerLock)
             {
@@ -212,7 +214,7 @@ namespace Microsoft.Extensions.Http
         }
 
         // Internal so it can be overridden in tests
-        internal void StopCleanupTimer()
+        internal virtual void StopCleanupTimer()
         {
             lock (_cleanupTimerLock)
             {

--- a/src/libraries/Microsoft.Extensions.Http/src/DefaultTypedHttpClientFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DefaultTypedHttpClientFactory.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Extensions.Http
         // The Cache should be registered as a singleton, so it that it can
         // act as a cache for the Activator. This allows the outer class to be registered
         // as a transient, so that it doesn't close over the application root service provider.
-        public class Cache
+        public sealed class Cache
         {
             private static readonly Func<ObjectFactory> _createActivator = () => ActivatorUtilities.CreateFactory(typeof(TClient), new Type[] { typeof(HttpClient), });
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
@@ -10,7 +10,7 @@ using System.Threading;
 namespace Microsoft.Extensions.Logging.Console
 {
     [UnsupportedOSPlatform("browser")]
-    internal class ConsoleLoggerProcessor : IDisposable
+    internal sealed class ConsoleLoggerProcessor : IDisposable
     {
         private const int _maxQueuedMessages = 1024;
 
@@ -33,7 +33,7 @@ namespace Microsoft.Extensions.Logging.Console
             _outputThread.Start();
         }
 
-        public virtual void EnqueueMessage(LogMessageEntry message)
+        public void EnqueueMessage(LogMessageEntry message)
         {
             if (!_messageQueue.IsAddingCompleted)
             {
@@ -54,7 +54,7 @@ namespace Microsoft.Extensions.Logging.Console
         }
 
         // for testing
-        internal virtual void WriteMessage(LogMessageEntry entry)
+        internal void WriteMessage(LogMessageEntry entry)
         {
             IConsole console = entry.LogAsError ? ErrorConsole : Console;
             console.Write(entry.Message);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
@@ -7,10 +7,12 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Versioning;
 using System.Threading;
 
+#pragma warning disable CA1852 // TODO InternalsVisibleTo: https://github.com/dotnet/roslyn-analyzers/pull/5972
+
 namespace Microsoft.Extensions.Logging.Console
 {
     [UnsupportedOSPlatform("browser")]
-    internal sealed class ConsoleLoggerProcessor : IDisposable
+    internal class ConsoleLoggerProcessor : IDisposable
     {
         private const int _maxQueuedMessages = 1024;
 
@@ -33,7 +35,7 @@ namespace Microsoft.Extensions.Logging.Console
             _outputThread.Start();
         }
 
-        public void EnqueueMessage(LogMessageEntry message)
+        public virtual void EnqueueMessage(LogMessageEntry message)
         {
             if (!_messageQueue.IsAddingCompleted)
             {

--- a/src/libraries/Microsoft.NETCore.Platforms/src/BuildTask.cs
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/BuildTask.cs
@@ -35,7 +35,7 @@ namespace Microsoft.NETCore.Platforms.BuildTasks
         public abstract bool Execute();
     }
 
-    internal class Log : ILog
+    internal sealed class Log : ILog
     {
         private readonly TaskLoggingHelper _logger;
         public Log(TaskLoggingHelper logger)

--- a/src/libraries/Microsoft.NETCore.Platforms/src/RuntimeGroup.cs
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/RuntimeGroup.cs
@@ -78,7 +78,7 @@ namespace Microsoft.NETCore.Platforms.BuildTasks
             }
         }
 
-        internal class RIDMapping
+        internal sealed class RIDMapping
         {
             public RIDMapping(RID runtimeIdentifier)
             {

--- a/src/libraries/System.Composition.TypedParts/src/System/Composition/Hosting/InstanceExportDescriptorProvider.cs
+++ b/src/libraries/System.Composition.TypedParts/src/System/Composition/Hosting/InstanceExportDescriptorProvider.cs
@@ -6,7 +6,7 @@ using System.Composition.Hosting.Core;
 
 namespace System.Composition.Hosting
 {
-    internal class InstanceExportDescriptorProvider : SinglePartExportDescriptorProvider
+    internal sealed class InstanceExportDescriptorProvider : SinglePartExportDescriptorProvider
     {
         private readonly object _exportedInstance;
 

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/BaseConfigurationRecord.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/BaseConfigurationRecord.cs
@@ -3695,7 +3695,7 @@ namespace System.Configuration
                 StringUtil.StartsWithOrdinal(name, "lock");
         }
 
-        protected class ConfigRecordStreamInfo
+        protected sealed class ConfigRecordStreamInfo
         {
             private HybridDictionary _streamInfos;
 

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbConnectionOptions.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbConnectionOptions.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace System.Data.Common
 {
-    internal partial class DbConnectionOptions
+    internal sealed partial class DbConnectionOptions
     {
         // instances of this class are intended to be immutable, i.e readonly
         // used by pooling classes so it is easier to verify correctness
@@ -127,7 +127,7 @@ namespace System.Data.Common
             }
         }
 
-        protected internal virtual string Expand() => _usersConnectionString;
+        internal string Expand() => _usersConnectionString;
 
         internal string ExpandKeyword(string keyword, string replacementValue)
         {

--- a/src/libraries/System.Data.OleDb/src/OleDbComWrappers.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbComWrappers.cs
@@ -15,7 +15,7 @@ namespace System.Data.OleDb
     ///
     /// Supports IErrorInfo COM interface.
     /// </summary>
-    internal unsafe sealed class OleDbComWrappers : ComWrappers
+    internal sealed unsafe class OleDbComWrappers : ComWrappers
     {
         private const int S_OK = (int)OleDbHResult.S_OK;
         private static readonly Guid IID_IErrorInfo = new Guid(0x1CF2B120, 0x547D, 0x101B, 0x8E, 0x65, 0x08, 0x00, 0x2B, 0x2B, 0xD1, 0x19);
@@ -49,7 +49,7 @@ namespace System.Data.OleDb
         }
 
         // Doc and type layout: https://docs.microsoft.com/windows/win32/api/oaidl/nn-oaidl-ierrorinfo
-        private class ErrorInfoWrapper : UnsafeNativeMethods.IErrorInfo, IDisposable
+        private sealed class ErrorInfoWrapper : UnsafeNativeMethods.IErrorInfo, IDisposable
         {
             private readonly IntPtr _wrappedInstance;
 

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/NativeWrapper.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/NativeWrapper.cs
@@ -20,7 +20,7 @@ namespace System.Diagnostics.Eventing.Reader
     /// </summary>
     internal static class NativeWrapper
     {
-        public class SystemProperties
+        public sealed class SystemProperties
         {
             // Indicates if the SystemProperties values were already computed (for this event Instance, surely).
             public bool filled;

--- a/src/libraries/System.DirectoryServices/src/Interop/SafeNativeMethods.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/SafeNativeMethods.cs
@@ -29,7 +29,7 @@ namespace System.DirectoryServices.Interop
         [LibraryImport(global::Interop.Libraries.Activeds, StringMarshalling = StringMarshalling.Utf16)]
         public static partial int ADsSetLastError(int error, string? errorString, string? provider);
 
-        public class EnumVariant
+        public sealed class EnumVariant
         {
             private static readonly object s_noMoreValues = new object();
             private object _currentValue = s_noMoreValues;

--- a/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.Gdi32.cs
+++ b/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.Gdi32.cs
@@ -217,7 +217,7 @@ internal static partial class Interop
         }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
-        public class DEVMODE
+        public sealed class DEVMODE
         {
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
             public string? dmDeviceName;

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/DrawingCom.ComWrappers.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/DrawingCom.ComWrappers.cs
@@ -290,7 +290,7 @@ namespace System.Drawing
             int SaveAsFile(IntPtr pstm, int fSaveMemCopy, int* pcbSize);
         }
 
-        private class PictureWrapper : IPicture
+        private sealed class PictureWrapper : IPicture
         {
             private readonly IntPtr _wrappedInstance;
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/DrawingCom.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/DrawingCom.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Drawing
 {
-    internal partial class DrawingCom
+    internal sealed partial class DrawingCom
     {
         internal readonly struct IStreamWrapper : IDisposable
         {

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -1803,7 +1803,7 @@ namespace System.IO.Ports
         // This is an internal object implementing IAsyncResult with fields
         // for all of the relevant data necessary to complete the IO operation.
         // This is used by AsyncFSCallback and all async methods.
-        internal unsafe sealed class SerialStreamAsyncResult : IAsyncResult
+        internal sealed unsafe class SerialStreamAsyncResult : IAsyncResult
         {
             // User code callback
             internal AsyncCallback _userCallback;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocksException.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocksException.cs
@@ -5,7 +5,7 @@ using System.IO;
 
 namespace System.Net.Http
 {
-    internal class SocksException : IOException
+    internal sealed class SocksException : IOException
     {
         public SocksException(string message) : base(message) { }
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -12,7 +12,7 @@ using static System.Net.Quic.Implementations.MsQuic.Internal.MsQuicNativeMethods
 
 namespace System.Net.Quic.Implementations.MsQuic.Internal
 {
-    internal unsafe sealed class MsQuicApi
+    internal sealed unsafe class MsQuicApi
     {
         private static readonly Version MinWindowsVersion = new Version(10, 0, 20145, 1000);
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicImplementationProviders.Unsupported.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicImplementationProviders.Unsupported.cs
@@ -11,7 +11,7 @@ namespace System.Net.Quic
         public static Implementations.QuicImplementationProvider MsQuic => Default;
         public static Implementations.QuicImplementationProvider Default { get; } = new UnsupportedQuicImplementationProvider();
 
-        private class UnsupportedQuicImplementationProvider : QuicImplementationProvider
+        private sealed class UnsupportedQuicImplementationProvider : QuicImplementationProvider
         {
             internal UnsupportedQuicImplementationProvider() : base(false) { }
             public override bool IsSupported => false;

--- a/src/libraries/System.Private.CoreLib/src/System/DefaultBinder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DefaultBinder.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable CA1852 // DefaultBinder is derived from in some targets
+
 using System.Reflection;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -5016,7 +5016,7 @@ namespace System.Diagnostics.Tracing
 #if FEATURE_ADVANCED_MANAGED_ETW_CHANNELS
     public
 #else
-    internal
+    internal sealed
 #endif
     class EventChannelAttribute : Attribute
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/OSFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/OSFileStreamStrategy.cs
@@ -74,7 +74,7 @@ namespace System.IO.Strategies
 
         public sealed override bool CanWrite => !_fileHandle.IsClosed && (_access & FileAccess.Write) != 0;
 
-        public unsafe sealed override long Length => _fileHandle.GetFileLength();
+        public sealed unsafe override long Length => _fileHandle.GetFileLength();
 
         // in case of concurrent incomplete reads, there can be multiple threads trying to update the position
         // at the same time. That is why we are using Interlocked here.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Overlapped._IOCompletionCallback.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Overlapped._IOCompletionCallback.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 
 namespace System.Threading
 {
-    internal unsafe partial class _IOCompletionCallback
+    internal sealed unsafe partial class _IOCompletionCallback
     {
         private readonly IOCompletionCallback _ioCompletionCallback;
         private readonly ExecutionContext _executionContext;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBoundHandleOverlapped.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBoundHandleOverlapped.cs
@@ -6,7 +6,7 @@ namespace System.Threading
     /// <summary>
     /// Overlapped subclass adding data needed by ThreadPoolBoundHandle.
     /// </summary>
-    internal unsafe sealed class ThreadPoolBoundHandleOverlapped : Overlapped
+    internal sealed unsafe class ThreadPoolBoundHandleOverlapped : Overlapped
     {
         private static readonly IOCompletionCallback s_completionCallback = CompletionCallback;
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
@@ -1897,19 +1897,19 @@ namespace System.Xml
     }
 
     // Same as base text writer class except that elements, attributes, comments, and pi's are indented.
-    internal partial class XmlEncodedRawTextWriterIndent : XmlEncodedRawTextWriter
+    internal sealed partial class XmlEncodedRawTextWriterIndent : XmlEncodedRawTextWriter
     {
         //
         // Fields
         //
-        protected int _indentLevel;
-        protected bool _newLineOnAttributes;
-        protected string _indentChars;
+        private int _indentLevel;
+        private bool _newLineOnAttributes;
+        private string _indentChars;
 
-        protected bool _mixedContent;
+        private bool _mixedContent;
         private BitStack _mixedContentStack;
 
-        protected ConformanceLevel _conformanceLevel = ConformanceLevel.Auto;
+        private ConformanceLevel _conformanceLevel = ConformanceLevel.Auto;
 
         //
         // Constructors

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriter.cs
@@ -1762,19 +1762,19 @@ namespace System.Xml
     }
 
     // Same as base text writer class except that elements, attributes, comments, and pi's are indented.
-    internal partial class XmlUtf8RawTextWriterIndent : XmlUtf8RawTextWriter
+    internal sealed partial class XmlUtf8RawTextWriterIndent : XmlUtf8RawTextWriter
     {
         //
         // Fields
         //
-        protected int _indentLevel;
-        protected bool _newLineOnAttributes;
-        protected string _indentChars;
+        private int _indentLevel;
+        private bool _newLineOnAttributes;
+        private string _indentChars;
 
-        protected bool _mixedContent;
+        private bool _mixedContent;
         private BitStack _mixedContentStack;
 
-        protected ConformanceLevel _conformanceLevel = ConformanceLevel.Auto;
+        private ConformanceLevel _conformanceLevel = ConformanceLevel.Auto;
 
         //
         // Constructors

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ContextAwareTables.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ContextAwareTables.cs
@@ -1,15 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+
 namespace System.Xml.Serialization
 {
-    using System;
-    using System.Collections;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Runtime.CompilerServices;
-    using System.Runtime.Loader;
-
-    internal class ContextAwareTables<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]T> where T : class?
+    internal sealed class ContextAwareTables<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]T> where T : class?
     {
         private Hashtable _defaultTable;
         private ConditionalWeakTable<Type, T> _collectibleTable;

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/ExternalMemoryBlock.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/ExternalMemoryBlock.cs
@@ -6,7 +6,7 @@ namespace System.Reflection.Internal
     /// <summary>
     /// Class representing raw memory but not owning the memory.
     /// </summary>
-    internal unsafe sealed class ExternalMemoryBlock : AbstractMemoryBlock
+    internal sealed unsafe class ExternalMemoryBlock : AbstractMemoryBlock
     {
         // keeps the owner of the memory alive as long as the block is alive:
         private readonly object _memoryOwner;

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/ExternalMemoryBlockProvider.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/ExternalMemoryBlockProvider.cs
@@ -9,7 +9,7 @@ namespace System.Reflection.Internal
     /// <summary>
     /// Represents raw memory owned by an external object.
     /// </summary>
-    internal unsafe sealed class ExternalMemoryBlockProvider : MemoryBlockProvider
+    internal sealed unsafe class ExternalMemoryBlockProvider : MemoryBlockProvider
     {
         private byte* _memory;
         private int _size;

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/MemoryMappedFileBlock.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/MemoryMappedFileBlock.cs
@@ -7,7 +7,7 @@ using System.Threading;
 
 namespace System.Reflection.Internal
 {
-    internal unsafe sealed class MemoryMappedFileBlock : AbstractMemoryBlock
+    internal sealed unsafe class MemoryMappedFileBlock : AbstractMemoryBlock
     {
         private sealed class DisposableData : CriticalDisposableObject
         {

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/NativeHeapMemoryBlock.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/NativeHeapMemoryBlock.cs
@@ -15,7 +15,7 @@ namespace System.Reflection.Internal
     /// </remarks>
     internal sealed class NativeHeapMemoryBlock : AbstractMemoryBlock
     {
-        private unsafe sealed class DisposableData : CriticalDisposableObject
+        private sealed unsafe class DisposableData : CriticalDisposableObject
         {
             private IntPtr _pointer;
 

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ReadOnlyUnmanagedMemoryStream.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ReadOnlyUnmanagedMemoryStream.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Reflection.Internal
 {
-    internal unsafe sealed class ReadOnlyUnmanagedMemoryStream : Stream
+    internal sealed unsafe class ReadOnlyUnmanagedMemoryStream : Stream
     {
         private readonly byte* _data;
         private readonly int _length;

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportFixer.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Interop.Analyzers
             }
         }
 
-        private class CustomFixAllProvider : DocumentBasedFixAllProvider
+        private sealed class CustomFixAllProvider : DocumentBasedFixAllProvider
         {
             public static readonly CustomFixAllProvider Instance = new();
 

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomTypeMarshallerAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomTypeMarshallerAnalyzer.cs
@@ -413,7 +413,7 @@ namespace Microsoft.Interop.Analyzers
             }
         }
 
-        private class PerCompilationAnalyzer
+        private sealed class PerCompilationAnalyzer
         {
             private readonly INamedTypeSymbol _spanOfT;
             private readonly INamedTypeSymbol _readOnlySpanOfT;

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomTypeMarshallerFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomTypeMarshallerFixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Interop.Analyzers
         private const string AddMissingCustomTypeMarshallerMembersKey = nameof(AddMissingCustomTypeMarshallerMembersKey);
         private const string AddMissingCustomTypeMarshallerFeaturesKey = nameof(AddMissingCustomTypeMarshallerFeaturesKey);
 
-        private class CustomFixAllProvider : DocumentBasedFixAllProvider
+        private sealed class CustomFixAllProvider : DocumentBasedFixAllProvider
         {
             protected override async Task<Document> FixAllAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Comparers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Comparers.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Interop
     /// Generic comparer to compare two <see cref="ImmutableArray{T}"/> instances element by element.
     /// </summary>
     /// <typeparam name="T">The type of immutable array element.</typeparam>
-    internal class ImmutableArraySequenceEqualComparer<T> : IEqualityComparer<ImmutableArray<T>>
+    internal sealed class ImmutableArraySequenceEqualComparer<T> : IEqualityComparer<ImmutableArray<T>>
     {
         private readonly IEqualityComparer<T> _elementComparer;
 
@@ -61,7 +61,7 @@ namespace Microsoft.Interop
         }
     }
 
-    internal class SyntaxEquivalentComparer : IEqualityComparer<SyntaxNode>
+    internal sealed class SyntaxEquivalentComparer : IEqualityComparer<SyntaxNode>
     {
         public static readonly SyntaxEquivalentComparer Instance = new();
 
@@ -78,7 +78,7 @@ namespace Microsoft.Interop
         }
     }
 
-    internal class CustomValueTupleElementComparer<T, U> : IEqualityComparer<(T, U)>
+    internal sealed class CustomValueTupleElementComparer<T, U> : IEqualityComparer<(T, U)>
     {
         private readonly IEqualityComparer<T> _item1Comparer;
         private readonly IEqualityComparer<U> _item2Comparer;

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Diagnostics/Events.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Diagnostics/Events.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Interop.Diagnostics
             WriteEvent(StopSourceGenerationEventId);
         }
 
-        private class StartStopEvent : IDisposable
+        private sealed class StartStopEvent : IDisposable
         {
             public StartStopEvent(int methodCount) => Logger.SourceGenerationStart(methodCount);
             public void Dispose() => Logger.SourceGenerationStop();

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/ForwarderMarshallingGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/ForwarderMarshallingGeneratorFactory.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace Microsoft.Interop
 {
-    internal class ForwarderMarshallingGeneratorFactory : IMarshallingGeneratorFactory
+    internal sealed class ForwarderMarshallingGeneratorFactory : IMarshallingGeneratorFactory
     {
         private static readonly Forwarder s_forwarder = new Forwarder();
 

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LanguageSupport.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LanguageSupport.cs
@@ -6,6 +6,7 @@
 namespace System.Runtime.CompilerServices
 {
     // Define IsExternalInit type to support records.
-    internal class IsExternalInit
-    { }
+    internal sealed class IsExternalInit
+    {
+    }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGeneratorOptions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGeneratorOptions.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.Interop
 {
-    internal record LibraryImportGeneratorOptions(bool GenerateForwarders, bool UseMarshalType)
+    internal sealed record LibraryImportGeneratorOptions(bool GenerateForwarders, bool UseMarshalType)
     {
         public LibraryImportGeneratorOptions(AnalyzerConfigOptions options)
             : this(options.GenerateForwarders(), options.UseMarshalType())

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/PInvokeStubContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/PInvokeStubContext.cs
@@ -16,7 +16,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Interop
 {
-    internal record StubEnvironment(
+    internal sealed record StubEnvironment(
         Compilation Compilation,
         TargetFramework TargetFramework,
         Version TargetFrameworkVersion,

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/UnreachableException.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/UnreachableException.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Interop
     /// <summary>
     /// An exception that should be thrown on code-paths that are unreachable.
     /// </summary>
-    internal class UnreachableException : Exception
+    internal sealed class UnreachableException : Exception
     {
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/LanguageSupport.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/LanguageSupport.cs
@@ -6,6 +6,7 @@
 namespace System.Runtime.CompilerServices
 {
     // Define IsExternalInit type to support records.
-    internal class IsExternalInit
-    { }
+    internal sealed class IsExternalInit
+    {
+    }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Interop
     /// <summary>
     /// A context that redefines the 'native' identifier for a TypePositionInfo to be the marshaller identifier.
     /// </summary>
-    internal class CustomNativeTypeWithToFromNativeValueContext : StubCodeContext
+    internal sealed class CustomNativeTypeWithToFromNativeValueContext : StubCodeContext
     {
         public CustomNativeTypeWithToFromNativeValueContext(StubCodeContext parentContext)
         {
@@ -1161,7 +1161,7 @@ namespace Microsoft.Interop
         /// This handles the case where the native type of a non-blittable managed type is a pointer,
         /// which are unsupported in generic type parameters.
         /// </summary>
-        private class PointerNativeTypeAssignmentRewriter : CSharpSyntaxRewriter
+        private sealed class PointerNativeTypeAssignmentRewriter : CSharpSyntaxRewriter
         {
             private readonly string _nativeIdentifier;
             private readonly PointerTypeSyntax _nativeType;

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
@@ -926,7 +926,7 @@ namespace Microsoft.Interop
             return true;
         }
 
-        private class CyclicalCountElementInfoException : Exception
+        private sealed class CyclicalCountElementInfoException : Exception
         {
             public CyclicalCountElementInfoException(ImmutableHashSet<string> elementsInCycle, string startOfCycle)
             {

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/DecryptorPalWindows.Decrypt.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/DecryptorPalWindows.Decrypt.cs
@@ -16,7 +16,7 @@ namespace Internal.Cryptography.Pal.Windows
 {
     internal sealed partial class DecryptorPalWindows : DecryptorPal
     {
-        public unsafe sealed override ContentInfo? TryDecrypt(
+        public sealed unsafe override ContentInfo? TryDecrypt(
             RecipientInfo recipientInfo,
             X509Certificate2? cert,
             AsymmetricAlgorithm? privateKey,

--- a/src/libraries/System.Speech/src/System.Speech.csproj
+++ b/src/libraries/System.Speech/src/System.Speech.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum);netstandard2.0</TargetFrameworks>
     <!-- CS0649: uninitialized interop type fields -->
     <!-- SA1129: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3277 -->
     <!-- CA1846: Prefer 'AsSpan' over 'Substring' when span-based overloads are available -->
-    <NoWarn>$(NoWarn);CS0649;SA1129;CA1846;CA1847;IDE0059;CA1822</NoWarn>
+    <NoWarn>$(NoWarn);CS0649;SA1129;CA1846;CA1847;IDE0059;CA1822;CA1852</NoWarn>
     <Nullable>annotations</Nullable>
     <IsTrimmable>false</IsTrimmable>
     <IsPackable>true</IsPackable>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/AttributePolymorphicTypeConfiguration.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/AttributePolymorphicTypeConfiguration.cs
@@ -9,7 +9,7 @@ namespace System.Text.Json.Serialization.Metadata
     /// <summary>
     /// Maps attribute-based polymorphism configuration to IJsonPolymorphicTypeConfiguration
     /// </summary>
-    internal class AttributePolymorphicTypeConfiguration : IJsonPolymorphicTypeConfiguration
+    internal sealed class AttributePolymorphicTypeConfiguration : IJsonPolymorphicTypeConfiguration
     {
 #pragma warning disable CA2252 // This API requires opting into preview features
         private readonly JsonPolymorphicAttribute? _polymorphicTypeAttribute;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
@@ -232,7 +232,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <summary>
         /// Lazy JsonTypeInfo result holder for a derived type.
         /// </summary>
-        private class DerivedJsonTypeInfo
+        private sealed class DerivedJsonTypeInfo
         {
             private volatile JsonTypeInfo? _jsonTypeInfo;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.Cache.cs
@@ -73,7 +73,7 @@ namespace System.Text.Json.Serialization.Metadata
                 }
             }
 
-            private class CacheEntry
+            private sealed class CacheEntry
             {
                 public readonly object? Value;
                 public long LastUsedTicks;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DgmlWriter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DgmlWriter.cs
@@ -313,7 +313,7 @@ namespace System.Text.RegularExpressions.Symbolic
             public List<Transition> GetTransitions() => _transitions;
         }
 
-        private record Transition(int SourceState, int TargetState, (SymbolicRegexNode<TSet>?, TSet) Label)
+        private sealed record Transition(int SourceState, int TargetState, (SymbolicRegexNode<TSet>?, TSet) Label)
         {
             public bool IsEpsilon => Label.Equals(default);
         }

--- a/src/mono/System.Private.CoreLib/src/Mono/HotReload.cs
+++ b/src/mono/System.Private.CoreLib/src/Mono/HotReload.cs
@@ -86,7 +86,7 @@ internal class InstanceFieldTable
 //
 // Additionally Mono uses this for storing added static fields.
 [StructLayout(LayoutKind.Sequential)]
-internal class FieldStore
+internal sealed class FieldStore
 {
     // keep in sync with hot_reload-internals.h
     private object? _loc;

--- a/src/mono/System.Private.CoreLib/src/System/__ComObject.cs
+++ b/src/mono/System.Private.CoreLib/src/System/__ComObject.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable CA1852 // __ComObject should not be sealed
+
 namespace System
 {
-    internal sealed class __ComObject
+    internal class __ComObject
     {
         private __ComObject()
         {

--- a/src/mono/System.Private.CoreLib/src/System/__ComObject.cs
+++ b/src/mono/System.Private.CoreLib/src/System/__ComObject.cs
@@ -3,7 +3,7 @@
 
 namespace System
 {
-    internal class __ComObject
+    internal sealed class __ComObject
     {
         private __ComObject()
         {

--- a/src/mono/wasm/debugger/BrowserDebugHost/Startup.cs
+++ b/src/mono/wasm/debugger/BrowserDebugHost/Startup.cs
@@ -21,7 +21,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.WebAssembly.Diagnostics
 {
-    internal class Startup
+    internal sealed class Startup
     {
         // This method gets called by the runtime. Use this method to add services to the container.
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -57,7 +57,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         public static readonly Guid SHA256 = new Guid("8829d00f-11b8-4213-878b-770e8597ac16");
     }
 
-    internal class BreakpointRequest
+    internal sealed class BreakpointRequest
     {
         public string Id { get; private set; }
         public string Assembly { get; private set; }
@@ -140,7 +140,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
     }
 
-    internal class VarInfo
+    internal sealed class VarInfo
     {
         public VarInfo(LocalVariable v, MetadataReader pdbReader)
         {
@@ -160,7 +160,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         public override string ToString() => $"(var-info [{Index}] '{Name}')";
     }
 
-    internal class IlLocation
+    internal sealed class IlLocation
     {
         public IlLocation(MethodInfo method, int offset)
         {
@@ -172,7 +172,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         public int Offset { get; }
     }
 
-    internal class SourceLocation
+    internal sealed class SourceLocation
     {
         private SourceId id;
         private int line;
@@ -217,7 +217,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             return new SourceLocation(id, line.Value, column.Value);
         }
 
-        internal class LocationComparer : EqualityComparer<SourceLocation>
+        internal sealed class LocationComparer : EqualityComparer<SourceLocation>
         {
             public override bool Equals(SourceLocation l1, SourceLocation l2)
             {
@@ -246,7 +246,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         };
     }
 
-    internal class SourceId
+    internal sealed class SourceId
     {
         private const string Scheme = "dotnet://";
 
@@ -313,7 +313,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         public static bool operator !=(SourceId a, SourceId b) => !a.Equals(b);
     }
 
-    internal class MethodInfo
+    internal sealed class MethodInfo
     {
         private MethodDefinition methodDef;
         private SourceFile source;
@@ -524,7 +524,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         public override string ToString() => "MethodInfo(" + Name + ")";
 
-        public class DebuggerAttributesInfo
+        public sealed class DebuggerAttributesInfo
         {
             internal bool HasDebuggerHidden { get; set; }
             internal bool HasStepThrough { get; set; }
@@ -563,7 +563,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     (EndLocation.Line == containerMethod.EndLocation.Line && EndLocation.Column < containerMethod.EndLocation.Column));
     }
 
-    internal class ParameterInfo
+    internal sealed class ParameterInfo
     {
         public string Name { get; init; }
 
@@ -638,7 +638,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         }
     }
 
-    internal class TypeInfo
+    internal sealed class TypeInfo
     {
         private readonly ILogger logger;
         internal AssemblyInfo assembly;
@@ -742,7 +742,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         public override string ToString() => "TypeInfo('" + FullName + "')";
     }
 
-    internal class AssemblyInfo
+    internal sealed class AssemblyInfo
     {
         private static int next_id;
         private readonly int id;
@@ -990,7 +990,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             pdbMetadataReader = MetadataReaderProvider.FromPortablePdbStream(pdbStream).GetMetadataReader();
         }
     }
-    internal class SourceFile
+    internal sealed class SourceFile
     {
         private Dictionary<int, MethodInfo> methods;
         private AssemblyInfo assembly;
@@ -1187,7 +1187,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         }
     }
 
-    internal class DebugStore
+    internal sealed class DebugStore
     {
         internal List<AssemblyInfo> assemblies = new List<AssemblyInfo>();
         private readonly HttpClient client;
@@ -1204,7 +1204,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         public DebugStore(MonoProxy monoProxy, ILogger logger) : this(monoProxy, logger, new HttpClient())
         { }
 
-        private class DebugItem
+        private sealed class DebugItem
         {
             public string Url { get; set; }
             public Task<byte[][]> Data { get; set; }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -61,7 +61,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         public bool Equals(MessageId other) => other.sessionId == sessionId && other.id == id;
     }
 
-    internal class DotnetObjectId
+    internal sealed class DotnetObjectId
     {
         public string Scheme { get; }
         public int Value { get; }
@@ -197,7 +197,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         }
     }
 
-    internal class MonoCommands
+    internal sealed class MonoCommands
     {
         public string expression { get; set; }
         public string objectGroup { get; set; } = "mono-debugger";
@@ -245,7 +245,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         public const string EVENT_RAISED = "mono_wasm_debug_event_raised:aef14bca-5519-4dfe-b35a-f867abc123ae";
     }
 
-    internal class Frame
+    internal sealed class Frame
     {
         public Frame(MethodInfoWithDebugInformation method, SourceLocation location, int id)
         {
@@ -259,7 +259,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         public int Id { get; private set; }
     }
 
-    internal class Breakpoint
+    internal sealed class Breakpoint
     {
         public SourceLocation Location { get; private set; }
         public int RemoteId { get; set; }
@@ -308,7 +308,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         All
     }
 
-    internal class ExecutionContext
+    internal sealed class ExecutionContext
     {
         public ExecutionContext(MonoSDBHelper sdbAgent, int id, object auxData)
         {
@@ -371,7 +371,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         }
     }
 
-    internal class PerScopeCache
+    internal sealed class PerScopeCache
     {
         public Dictionary<string, JObject> Locals { get; } = new Dictionary<string, JObject>();
         public Dictionary<string, JObject> MemberReferences { get; } = new Dictionary<string, JObject>();

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsQueue.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsQueue.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.WebAssembly.Diagnostics
 {
-    internal class DevToolsQueue
+    internal sealed class DevToolsQueue
     {
         private Task? current_send;
         private ConcurrentQueue<byte[]> pending;

--- a/src/mono/wasm/debugger/BrowserDebugProxy/EvaluateExpression.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/EvaluateExpression.cs
@@ -32,7 +32,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 typeof(Enumerable).Assembly,
                 typeof(JObject).Assembly
                 ));
-        private class FindVariableNMethodCall : CSharpSyntaxWalker
+        private sealed class FindVariableNMethodCall : CSharpSyntaxWalker
         {
             private static Regex regexForReplaceVarName = new Regex(@"[^A-Za-z0-9_]", RegexOptions.Singleline);
             public List<IdentifierNameSyntax> identifiers = new List<IdentifierNameSyntax>();
@@ -243,7 +243,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         typeRet = "double";
                         break;
                     case "boolean":
-                        valueRet = value?.Value<string>().ToLower();
+                        valueRet = value?.Value<string>().ToLowerInvariant();
                         typeRet = "bool";
                         break;
                     case "object":
@@ -441,7 +441,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
     }
 
-    internal class ReturnAsErrorException : Exception
+    internal sealed class ReturnAsErrorException : Exception
     {
         private Result _error;
         public Result Error

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
@@ -14,7 +14,7 @@ using System.Net.WebSockets;
 
 namespace Microsoft.WebAssembly.Diagnostics
 {
-    internal class MemberReferenceResolver
+    internal sealed class MemberReferenceResolver
     {
         private SessionId sessionId;
         private int scopeId;

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -16,7 +16,7 @@ using System.Net.Http;
 
 namespace Microsoft.WebAssembly.Diagnostics
 {
-    internal class MonoProxy : DevToolsProxy
+    internal sealed class MonoProxy : DevToolsProxy
     {
         private IList<string> urlSymbolServerList;
         private static HttpClient client = new HttpClient();
@@ -1123,7 +1123,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
             foreach (string urlSymbolServer in urlSymbolServerList)
             {
-                string downloadURL = $"{urlSymbolServer}/{pdbName}/{asm.PdbGuid.ToString("N").ToUpper() + asm.PdbAge}/{pdbName}";
+                string downloadURL = $"{urlSymbolServer}/{pdbName}/{asm.PdbGuid.ToString("N").ToUpperInvariant() + asm.PdbAge}/{pdbName}";
 
                 try
                 {

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -464,7 +464,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         public override ulong ReadUInt64() => ReadBigEndian<ulong>();
         public override long ReadInt64() => ReadBigEndian<long>();
 
-        protected unsafe T ReadBigEndian<T>() where T : struct
+        private unsafe T ReadBigEndian<T>() where T : struct
         {
             Span<byte> data = stackalloc byte[Unsafe.SizeOf<T>()];
             T ret = default;
@@ -491,7 +491,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         public override void Write(long val) => WriteBigEndian<long>(val);
         public override void Write(int val) => WriteBigEndian<int>(val);
 
-        protected unsafe void WriteBigEndian<T>(T val) where T : struct
+        private unsafe void WriteBigEndian<T>(T val) where T : struct
         {
             Span<byte> data = stackalloc byte[Unsafe.SizeOf<T>()];
             new Span<byte>(Unsafe.AsPointer(ref val), data.Length).CopyTo(data);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -359,7 +359,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         Line
     }
 
-    internal record ArrayDimensions
+    internal sealed record ArrayDimensions
     {
         internal int Rank { get; }
         internal int [] Bounds { get; }
@@ -403,9 +403,9 @@ namespace Microsoft.WebAssembly.Diagnostics
         }
     }
 
-    internal record MethodInfoWithDebugInformation(MethodInfo Info, int DebugId, string Name);
+    internal sealed record MethodInfoWithDebugInformation(MethodInfo Info, int DebugId, string Name);
 
-    internal class TypeInfoWithDebugInformation
+    internal sealed class TypeInfoWithDebugInformation
     {
         public TypeInfo Info { get; }
         public int DebugId { get; }
@@ -422,7 +422,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         }
     }
 
-    internal class MonoBinaryReader : BinaryReader
+    internal sealed class MonoBinaryReader : BinaryReader
     {
         public bool HasError { get; }
 
@@ -478,7 +478,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         }
     }
 
-    internal class MonoBinaryWriter : BinaryWriter
+    internal sealed class MonoBinaryWriter : BinaryWriter
     {
         public MonoBinaryWriter() : base(new MemoryStream(20)) {}
 
@@ -691,7 +691,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             return (Convert.ToBase64String(segment), segment.Count);
         }
     }
-    internal class FieldTypeClass
+    internal sealed class FieldTypeClass
     {
         public int Id { get; }
         public string Name { get; }
@@ -707,7 +707,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             ProtectionLevel = protectionLevel;
         }
     }
-    internal class ValueTypeClass
+    internal sealed class ValueTypeClass
     {
         private readonly JArray json;
         private readonly int typeId;
@@ -804,7 +804,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         }
     }
 
-    internal class PointerValue
+    internal sealed class PointerValue
     {
         public long address;
         public int typeId;
@@ -817,7 +817,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         }
 
     }
-    internal class MonoSDBHelper
+    internal sealed class MonoSDBHelper
     {
         private static int debuggerObjectId;
         private static int cmdId = 1; //cmdId == 0 is used by events which come from runtime
@@ -1953,7 +1953,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 var retMethod = await InvokeMethod(valueTypeBuffer, methodId, "methodRet", token);
                 description = retMethod["value"]?["value"].Value<string>();
                 if (className.Equals("System.Guid"))
-                    description = description.ToUpper(); //to keep the old behavior
+                    description = description.ToUpperInvariant(); //to keep the old behavior
             }
             else if (isBoxed && numFields == 1) {
                 return fieldValueType;

--- a/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -27,7 +27,7 @@ public class AppleAppBuilderTask : Task
 
         set
         {
-            targetOS = value.ToLower();
+            targetOS = value.ToLowerInvariant();
         }
     }
 

--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -26,7 +26,7 @@ public class XcodeCreateProject : Task
 
         set
         {
-            targetOS = value.ToLower();
+            targetOS = value.ToLowerInvariant();
         }
     }
 
@@ -73,7 +73,7 @@ public class XcodeBuildApp : Task
 
         set
         {
-            targetOS = value.ToLower();
+            targetOS = value.ToLowerInvariant();
         }
     }
 

--- a/src/tasks/WorkloadBuildTasks/PackageInstaller.cs
+++ b/src/tasks/WorkloadBuildTasks/PackageInstaller.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Workload.Build.Tasks
             }
 
             IList<(PackageReference, string)> failedToRestore = references
-                                                             .Select(r => (r, Path.Combine(_packagesDir, r.Name.ToLower(), r.Version)))
+                                                             .Select(r => (r, Path.Combine(_packagesDir, r.Name.ToLowerInvariant(), r.Version)))
                                                              .Where(tuple => !Directory.Exists(tuple.Item2))
                                                              .ToList();
 
@@ -88,7 +88,7 @@ namespace Microsoft.Workload.Build.Tasks
         {
             foreach (var pkgRef in references)
             {
-                var source = Path.Combine(_packagesDir, pkgRef.Name.ToLower(), pkgRef.Version, pkgRef.relativeSourceDir);
+                var source = Path.Combine(_packagesDir, pkgRef.Name.ToLowerInvariant(), pkgRef.Version, pkgRef.relativeSourceDir);
                 if (!Directory.Exists(source))
                 {
                     LogErrorOrWarning($"Failed to restore {pkgRef.Name}/{pkgRef.Version} (could not find {source})", stopOnMissing);

--- a/src/tests/JIT/Regression/VS-ia64-JIT/V1.2-Beta1/b91074/pack8.cs
+++ b/src/tests/JIT/Regression/VS-ia64-JIT/V1.2-Beta1/b91074/pack8.cs
@@ -6,7 +6,7 @@ using System;
 using System.Runtime.InteropServices;
 
 [StructLayoutAttribute(LayoutKind.Sequential, Pack = 8)]
-sealed internal class tagDBPROPSET
+internal sealed class tagDBPROPSET
 {
     public IntPtr rgProperties;
     public Int32 cProperties;


### PR DESCRIPTION
CA1311 flagged a few issues, all addressed by using ToLowerInvariant/ToUpperInvariant.

CA1852 flagged a bunch that previous cleanups around sealing types missed or that are new since.  Sealing types then highlighted places where protected or virtual members were being exposed unnecessarily, so those were fixed, too.  Adding sealed to things also highlighted some discrepancies in the order of "unsafe sealed" keywords, where the vast majority in the repo were "sealed unsafe", so I fixed the few that weren't.