### PR TITLE
fix the srcBufferLength check

### DIFF
--- a/eng/pipelines/coreclr/superpmi-replay.yml
+++ b/eng/pipelines/coreclr/superpmi-replay.yml
@@ -11,6 +11,7 @@ pr:
   paths:
     include:
     - src/coreclr/jit/*
+    - src/coreclr/tools/superpmi/*
     exclude:
     - src/coreclr/inc/jiteeversionguid.h
 

--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
@@ -4820,7 +4820,7 @@ int MethodContext::repGetStringLiteral(CORINFO_MODULE_HANDLE module, unsigned me
         DD value = GetStringLiteral->Get(key);
         DEBUG_REP(dmpGetStringLiteral(key, value));
         int srcBufferLength = (int)value.A;
-        if (buffer != nullptr && srcBufferLength != -1)
+        if (buffer != nullptr && srcBufferLength > 0)
         {
             char16_t* srcBuffer = (char16_t*)GetStringLiteral->GetBuffer(value.B);
             Assert(srcBuffer != nullptr);


### PR DESCRIPTION
Should only get the buffer if it is > 0.

Fix failures in superpmi replay. 