### PR TITLE
Add a test for ECDSA signatures at zero

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.netcoreapp.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.netcoreapp.cs
@@ -286,5 +286,62 @@ namespace System.Security.Cryptography.EcDsa.Tests
                     () => SignData(ecdsa, new byte[] { 1, 2, 3, 4, 5 }, HashAlgorithmName.SHA256));
             }
         }
+
+        [Theory]
+        [MemberData(nameof(TestCurves))]
+        public void SignaturesAtZeroDoNotVerify_IEEEP1363(CurveDef curveDef)
+        {
+            using (ECDsa ec = ECDsaFactory.Create(curveDef.Curve))
+            {
+                byte[] data = new byte[] { 1, 2, 3, 4 };
+                byte[] signature = ec.SignData(data, HashAlgorithmName.SHA256, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+
+                // Verify it now.
+                bool verified = ec.VerifyData(
+                    data,
+                    signature,
+                    HashAlgorithmName.SHA256,
+                    DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+                Assert.True(verified, nameof(ec.VerifyData));
+
+                // Since the signature is fixed field, create a zero signature just by zeroing it out.
+                // The important thing is that it is the right length.
+                Array.Clear(signature);
+
+                verified = ec.VerifyData(
+                    data,
+                    signature,
+                    HashAlgorithmName.SHA256,
+                    DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+                Assert.False(verified, nameof(ec.VerifyData));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCurves))]
+        public void SignaturesAtZeroDoNotVerify_DER(CurveDef curveDef)
+        {
+            using (ECDsa ec = ECDsaFactory.Create(curveDef.Curve))
+            {
+                byte[] data = new byte[] { 1, 2, 3, 4 };
+
+                // ASN.1:
+                // SEQUENCE {
+                //    INTEGER 0,
+                //    INTEGER 0
+                // }
+                byte[] zeroSignature = new byte[]
+                {
+                    0x30, 0x06, 0x02, 0x01, 0x00, 0x02, 0x01, 0x00
+                };
+
+                bool verified = ec.VerifyData(
+                    data,
+                    zeroSignature,
+                    HashAlgorithmName.SHA256,
+                    DSASignatureFormat.Rfc3279DerSequence);
+                Assert.False(verified, nameof(ec.VerifyData));
+            }
+        }
     }
 }


### PR DESCRIPTION
This add a test to make sure no cryptographic implementation will verify an ECDSA signature when the signature is "zero".