### PR TITLE
Added `TestEventListener`

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/TestEventListener.cs
+++ b/src/libraries/Common/tests/TestUtilities/TestEventListener.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
+using System.IO;
 using System.Text;
 using Xunit.Abstractions;
 
@@ -11,45 +13,87 @@ namespace TestUtilities;
 /// <summary>
 /// Logging helper for tests.
 /// Logs event source events into test output.
+/// Example usage:
+///   // Put the following line into your test method:
+///   using var listener = new TestEventListener(_output, TestEventListener.NetworkingEvents);
 /// </summary>
 public sealed class TestEventListener : EventListener
 {
-    private readonly ITestOutputHelper _output;
+    public static string[] NetworkingEvents => new[]
+    {
+        "System.Net.Http",
+        "System.Net.NameResolution",
+        "System.Net.Sockets",
+        "System.Net.Security",
+        "System.Net.TestLogging",
+        "Private.InternalDiagnostics.System.Net.Http",
+        "Private.InternalDiagnostics.System.Net.NameResolution",
+        "Private.InternalDiagnostics.System.Net.Sockets",
+        "Private.InternalDiagnostics.System.Net.Security",
+        "Private.InternalDiagnostics.System.Net.Quic",
+        "Private.InternalDiagnostics.System.Net.Http.WinHttpHandler",
+        "Private.InternalDiagnostics.System.Net.HttpListener",
+        "Private.InternalDiagnostics.System.Net.Mail",
+        "Private.InternalDiagnostics.System.Net.NetworkInformation",
+        "Private.InternalDiagnostics.System.Net.Ping",
+        "Private.InternalDiagnostics.System.Net.Primitives",
+        "Private.InternalDiagnostics.System.Net.Requests",
+    };
+
+    private readonly Action<string> _writeFunc;
     private readonly HashSet<string> _sourceNames;
 
     // Until https://github.com/dotnet/runtime/issues/63979 is solved.
     private List<EventSource> _eventSources = new List<EventSource>();
 
+    public TestEventListener(TextWriter output, params string[] sourceNames)
+        : this(str => output.WriteLine(str), sourceNames)
+    { }
+
     public TestEventListener(ITestOutputHelper output, params string[] sourceNames)
+        : this(str => output.WriteLine(str), sourceNames)
+    { }
+
+    public TestEventListener(Action<string> writeFunc, params string[] sourceNames)
     {
-        _output = output;
-        _sourceNames = new HashSet<string>(sourceNames);
-        foreach (var eventSource in _eventSources)
+        lock (this)
         {
-            OnEventSourceCreated(eventSource);
+            _writeFunc = writeFunc;
+            _sourceNames = new HashSet<string>(sourceNames);
+            foreach (var eventSource in _eventSources)
+            {
+                OnEventSourceCreated(eventSource);
+            }
+            _eventSources = null;
         }
-        _eventSources = null;
     }
 
     protected override void OnEventSourceCreated(EventSource eventSource)
     {
-        // We're called from base ctor, just save the event source for later initialization.
-        if (_sourceNames is null)
+        lock (this)
         {
-            _eventSources.Add(eventSource);
-            return;
-        }
+            // We're called from base ctor, just save the event source for later initialization.
+            if (_sourceNames is null)
+            {
+                _eventSources.Add(eventSource);
+                return;
+            }
 
-        // Second pass called from our ctor, allow logging for specified source names.
-        if (_sourceNames.Contains(eventSource.Name))
-        {
-            EnableEvents(eventSource, EventLevel.LogAlways);
+            // Second pass called from our ctor, allow logging for specified source names.
+            if (_sourceNames.Contains(eventSource.Name))
+            {
+                EnableEvents(eventSource, EventLevel.LogAlways);
+            }
         }
     }
 
     protected override void OnEventWritten(EventWrittenEventArgs eventData)
     {
+#if NETCOREAPP2_2_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         var sb = new StringBuilder().Append($"{eventData.TimeStamp:HH:mm:ss.fffffff}[{eventData.EventName}] ");
+#else
+        var sb = new StringBuilder().Append($"[{eventData.EventName}] ");
+#endif
         for (int i = 0; i < eventData.Payload?.Count; i++)
         {
             if (i > 0)
@@ -58,7 +102,7 @@ public sealed class TestEventListener : EventListener
         }
         try
         {
-            _output.WriteLine(sb.ToString());
+            _writeFunc(sb.ToString());
         }
         catch { }
     }

--- a/src/libraries/Common/tests/TestUtilities/TestEventListener.cs
+++ b/src/libraries/Common/tests/TestUtilities/TestEventListener.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Text;
+using Xunit.Abstractions;
+
+namespace TestUtilities;
+
+/// <summary>
+/// Logging helper for tests.
+/// Logs event source events into test output.
+/// </summary>
+public sealed class TestEventListener : EventListener
+{
+    private readonly ITestOutputHelper _output;
+    private readonly HashSet<string> _sourceNames;
+
+    // Until https://github.com/dotnet/runtime/issues/63979 is solved.
+    private List<EventSource> _eventSources = new List<EventSource>();
+
+    public TestEventListener(ITestOutputHelper output, params string[] sourceNames)
+    {
+        _output = output;
+        _sourceNames = new HashSet<string>(sourceNames);
+        foreach (var eventSource in _eventSources)
+        {
+            OnEventSourceCreated(eventSource);
+        }
+        _eventSources = null;
+    }
+
+    protected override void OnEventSourceCreated(EventSource eventSource)
+    {
+        // We're called from base ctor, just save the event source for later initialization.
+        if (_sourceNames is null)
+        {
+            _eventSources.Add(eventSource);
+            return;
+        }
+
+        // Second pass called from our ctor, allow logging for specified source names.
+        if (_sourceNames.Contains(eventSource.Name))
+        {
+            EnableEvents(eventSource, EventLevel.LogAlways);
+        }
+    }
+
+    protected override void OnEventWritten(EventWrittenEventArgs eventData)
+    {
+        var sb = new StringBuilder().Append($"{eventData.TimeStamp:HH:mm:ss.fffffff}[{eventData.EventName}] ");
+        for (int i = 0; i < eventData.Payload?.Count; i++)
+        {
+            if (i > 0)
+                sb.Append(", ");
+            sb.Append(eventData.PayloadNames?[i]).Append(": ").Append(eventData.Payload[i]);
+        }
+        try
+        {
+            _output.WriteLine(sb.ToString());
+        }
+        catch { }
+    }
+}

--- a/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
+++ b/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
@@ -47,6 +47,8 @@
 
     <Compile Include="RandomTestCaseOrderer.cs" />
     <Compile Include="RandomTestCollectionOrderer.cs" />
+
+    <Compile Include="TestEventListener.cs" />
   </ItemGroup>
   <!-- Windows imports -->
   <ItemGroup>


### PR DESCRIPTION
Allows logging of specific event sources into test output. Useful for test debugging. Usage:
```C#
private TestEventListener _listener;

public MsQuicQuicStreamConformanceTests(ITestOutputHelper output)
{
    _output = output;
    _listener = new TestEventListener(_output, "Private.InternalDiagnostics.System.Net.Quic");
}
protected override void Dispose(bool disposing)
{
    _listener.Dispose();
    base.Dispose(disposing);
}
```