### PR TITLE
Fix incorrect definition of LSA_FOREST_TRUST_RECORD in System.DirectoryServices

### DIFF
--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ForestTrustRelationshipInformation.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ForestTrustRelationshipInformation.cs
@@ -187,7 +187,6 @@ namespace System.DirectoryServices.ActiveDirectory
                         {
                             throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
                         }
-                        record.DomainInfo = new LSA_FOREST_TRUST_DOMAIN_INFO();
                         record.DomainInfo.sid = pSid;
                         sidList.Add(pSid);
                         record.DomainInfo.DNSNameBuffer = Marshal.StringToHGlobalUni(tmp.DnsName);
@@ -214,7 +213,6 @@ namespace System.DirectoryServices.ActiveDirectory
                         record.Time = (LARGE_INTEGER)_binaryDataTime[i]!;
                         record.Data.Length = ((byte[])_binaryData[i]!).Length;
                         record.ForestTrustType = (LSA_FOREST_TRUST_RECORD_TYPE)_binaryRecordType[i]!;
-                        record.Data = new LSA_FOREST_TRUST_BINARY_DATA();
                         if (record.Data.Length == 0)
                         {
                             record.Data.Buffer = (IntPtr)0;
@@ -381,7 +379,7 @@ namespace System.DirectoryServices.ActiveDirectory
                                 if (record.ForestTrustType == LSA_FOREST_TRUST_RECORD_TYPE.ForestTrustTopLevelName)
                                 {
                                     IntPtr myPtr = IntPtr.Add(addr, 16);
-                                    Marshal.PtrToStructure(myPtr, record.TopLevelName);
+                                    record.TopLevelName = (global::Interop.UNICODE_STRING)Marshal.PtrToStructure(myPtr, typeof(global::Interop.UNICODE_STRING))!;
                                     TopLevelName TLN = new TopLevelName(record.Flags, record.TopLevelName, record.Time);
                                     tmpTLNs.Add(TLN);
                                 }
@@ -389,7 +387,7 @@ namespace System.DirectoryServices.ActiveDirectory
                                 {
                                     // get the excluded TLN and put it in our collection
                                     IntPtr myPtr = IntPtr.Add(addr, 16);
-                                    Marshal.PtrToStructure(myPtr, record.TopLevelName);
+                                    record.TopLevelName = (global::Interop.UNICODE_STRING)Marshal.PtrToStructure(myPtr, typeof(global::Interop.UNICODE_STRING))!;
                                     string excludedName = Marshal.PtrToStringUni(record.TopLevelName.Buffer, record.TopLevelName.Length / 2);
                                     tmpExcludedTLNs.Add(excludedName);
                                     tmpExcludedNameTime.Add(excludedName, record.Time);
@@ -397,14 +395,14 @@ namespace System.DirectoryServices.ActiveDirectory
                                 else if (record.ForestTrustType == LSA_FOREST_TRUST_RECORD_TYPE.ForestTrustDomainInfo)
                                 {
                                     IntPtr myPtr = IntPtr.Add(addr, 16);
-                                    Marshal.PtrToStructure(myPtr, record.DomainInfo!);
+                                    record.DomainInfo = (LSA_FOREST_TRUST_DOMAIN_INFO)Marshal.PtrToStructure(myPtr, typeof(LSA_FOREST_TRUST_DOMAIN_INFO))!;
                                     ForestTrustDomainInformation dom = new ForestTrustDomainInformation(record.Flags, record.DomainInfo!, record.Time);
                                     tmpDomainInformation.Add(dom);
                                 }
                                 else
                                 {
                                     IntPtr myPtr = IntPtr.Add(addr, 16);
-                                    Marshal.PtrToStructure(myPtr, record.Data);
+                                    record.Data = (LSA_FOREST_TRUST_BINARY_DATA)Marshal.PtrToStructure(myPtr, typeof(LSA_FOREST_TRUST_BINARY_DATA))!;
                                     int length = record.Data.Length;
                                     byte[] byteArray = new byte[length];
                                     if ((record.Data.Buffer != (IntPtr)0) && (length != 0))

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ForestTrustRelationshipInformation.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ForestTrustRelationshipInformation.cs
@@ -315,7 +315,7 @@ namespace System.DirectoryServices.ActiveDirectory
             catch { throw; }
         }
 
-        private void GetForestTrustInfoHelper()
+        private unsafe void GetForestTrustInfoHelper()
         {
             IntPtr forestTrustInfo = (IntPtr)0;
             SafeLsaPolicyHandle? handle = null;
@@ -379,7 +379,7 @@ namespace System.DirectoryServices.ActiveDirectory
                                 if (record.ForestTrustType == LSA_FOREST_TRUST_RECORD_TYPE.ForestTrustTopLevelName)
                                 {
                                     IntPtr myPtr = IntPtr.Add(addr, 16);
-                                    record.TopLevelName = (global::Interop.UNICODE_STRING)Marshal.PtrToStructure(myPtr, typeof(global::Interop.UNICODE_STRING))!;
+                                    record.TopLevelName = *(global::Interop.UNICODE_STRING*)myPtr;
                                     TopLevelName TLN = new TopLevelName(record.Flags, record.TopLevelName, record.Time);
                                     tmpTLNs.Add(TLN);
                                 }
@@ -387,7 +387,7 @@ namespace System.DirectoryServices.ActiveDirectory
                                 {
                                     // get the excluded TLN and put it in our collection
                                     IntPtr myPtr = IntPtr.Add(addr, 16);
-                                    record.TopLevelName = (global::Interop.UNICODE_STRING)Marshal.PtrToStructure(myPtr, typeof(global::Interop.UNICODE_STRING))!;
+                                    record.TopLevelName = *(global::Interop.UNICODE_STRING*)myPtr;
                                     string excludedName = Marshal.PtrToStringUni(record.TopLevelName.Buffer, record.TopLevelName.Length / 2);
                                     tmpExcludedTLNs.Add(excludedName);
                                     tmpExcludedNameTime.Add(excludedName, record.Time);
@@ -395,14 +395,14 @@ namespace System.DirectoryServices.ActiveDirectory
                                 else if (record.ForestTrustType == LSA_FOREST_TRUST_RECORD_TYPE.ForestTrustDomainInfo)
                                 {
                                     IntPtr myPtr = IntPtr.Add(addr, 16);
-                                    record.DomainInfo = (LSA_FOREST_TRUST_DOMAIN_INFO)Marshal.PtrToStructure(myPtr, typeof(LSA_FOREST_TRUST_DOMAIN_INFO))!;
+                                    record.DomainInfo = *(LSA_FOREST_TRUST_DOMAIN_INFO*)myPtr;
                                     ForestTrustDomainInformation dom = new ForestTrustDomainInformation(record.Flags, record.DomainInfo!, record.Time);
                                     tmpDomainInformation.Add(dom);
                                 }
                                 else
                                 {
                                     IntPtr myPtr = IntPtr.Add(addr, 16);
-                                    record.Data = (LSA_FOREST_TRUST_BINARY_DATA)Marshal.PtrToStructure(myPtr, typeof(LSA_FOREST_TRUST_BINARY_DATA))!;
+                                    record.Data = *(LSA_FOREST_TRUST_BINARY_DATA*)myPtr;
                                     int length = record.Data.Length;
                                     byte[] byteArray = new byte[length];
                                     if ((record.Data.Buffer != (IntPtr)0) && (length != 0))

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/UnsafeNativeMethods.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/UnsafeNativeMethods.cs
@@ -432,7 +432,6 @@ namespace System.DirectoryServices.ActiveDirectory
         }
     }
 
-    [StructLayout(LayoutKind.Sequential)]
     internal struct LSA_FOREST_TRUST_DOMAIN_INFO
     {
         public IntPtr sid;
@@ -444,7 +443,6 @@ namespace System.DirectoryServices.ActiveDirectory
         public IntPtr NetBIOSNameBuffer;
     }
 
-    [StructLayout(LayoutKind.Sequential)]
     internal struct LSA_FOREST_TRUST_BINARY_DATA
     {
         public int Length;

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/UnsafeNativeMethods.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/UnsafeNativeMethods.cs
@@ -414,9 +414,9 @@ namespace System.DirectoryServices.ActiveDirectory
         [FieldOffset(16)]
         public global::Interop.UNICODE_STRING TopLevelName;
         [FieldOffset(16)]
-        public LSA_FOREST_TRUST_BINARY_DATA Data = null!;
+        public LSA_FOREST_TRUST_BINARY_DATA Data;
         [FieldOffset(16)]
-        public LSA_FOREST_TRUST_DOMAIN_INFO? DomainInfo;
+        public LSA_FOREST_TRUST_DOMAIN_INFO DomainInfo;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -433,7 +433,7 @@ namespace System.DirectoryServices.ActiveDirectory
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    internal sealed class LSA_FOREST_TRUST_DOMAIN_INFO
+    internal struct LSA_FOREST_TRUST_DOMAIN_INFO
     {
         public IntPtr sid;
         public short DNSNameLength;
@@ -445,7 +445,7 @@ namespace System.DirectoryServices.ActiveDirectory
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    internal sealed class LSA_FOREST_TRUST_BINARY_DATA
+    internal struct LSA_FOREST_TRUST_BINARY_DATA
     {
         public int Length;
         public IntPtr Buffer;

--- a/src/libraries/System.DirectoryServices/tests/System/DirectoryServices/DirectoryServicesTests.cs
+++ b/src/libraries/System.DirectoryServices/tests/System/DirectoryServices/DirectoryServicesTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections;
 using Xunit;
 using Xunit.Sdk;
+using System.Reflection;
 
 namespace System.DirectoryServices.Tests
 {
@@ -13,6 +14,13 @@ namespace System.DirectoryServices.Tests
     {
         internal static bool IsLdapConfigurationExist => LdapConfiguration.Configuration != null;
         internal static bool IsActiveDirectoryServer => IsLdapConfigurationExist && LdapConfiguration.Configuration.IsActiveDirectoryServer;
+
+        [Fact]
+        public void TestGetAllTypes()
+        {
+            Type[] allTypes = typeof(DirectoryEntry).Assembly.GetTypes();
+            Assert.Contains(typeof(DirectoryEntry), allTypes);
+        }
 
         [ConditionalFact(nameof(IsLdapConfigurationExist))]
         public void TestOU() // adding and removing organization unit


### PR DESCRIPTION
Fixes #68240

Switch `LSA_FOREST_TRUST_DOMAIN_INFO` and  `LSA_FOREST_TRUST_BINARY_DATA` to be structs as well.

Added a test that just loads all types in `System.DirectoryServices`.

Manually ran:
```csharp
Forest forest = Forest.GetCurrentForest();
foreach (var t in forest.GetAllTrustRelationships())
{
    if (t is ForestTrustRelationshipInformation f)
    {
        Console.WriteLine("TopLevelNames");
        foreach (var name in f.TopLevelNames)
        {
            Console.WriteLine($"  {((TopLevelName)name).Name}");
        }
        Console.WriteLine("ExcludedTopLevelNames");
        foreach (string name in f.ExcludedTopLevelNames)
        {
            Console.WriteLine($"  {name}");
        }
        Console.WriteLine("TrustedDomainInformation");
        foreach (var info in f.TrustedDomainInformation)
        {
            Console.WriteLine($"  {((ForestTrustDomainInformation)info).DnsName}");
        }
    }
}
```

cc @AaronRobinsonMSFT @jkoritzinsky I broke this back in December when we were switching things to the p/invoke source generator