### PR TITLE
Don't build non shared framework refs in ref build

### DIFF
--- a/src/libraries/System.Net.Http/ref/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Net.Primitives\ref\System.Net.Primitives.csproj" />
-    <ProjectReference Include="..\..\System.Net.Quic\ref\System.Net.Quic.csproj" />
     <ProjectReference Include="..\..\System.Net.Sockets\ref\System.Net.Sockets.csproj" />
     <ProjectReference Include="..\..\System.Net.Security\ref\System.Net.Security.csproj" />
     <ProjectReference Include="..\..\System.Security.Cryptography.X509Certificates\ref\System.Security.Cryptography.X509Certificates.csproj" />

--- a/src/libraries/sfx-ref.proj
+++ b/src/libraries/sfx-ref.proj
@@ -13,7 +13,8 @@
     <NonNetCoreAppProject Include="@(AnyProject)"
                           Exclude="@(NetCoreAppLibrary->'%(Identity)\ref\%(Identity).csproj')" />
     <ProjectReference Include="@(AnyProject)"
-                      Exclude="@(NonNetCoreAppProject)" />
+                      Exclude="@(NonNetCoreAppProject);
+                               @(NetCoreAppLibraryNoReference->'%(Identity)\ref\%(Identity).csproj')" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I noticed that we build ref projects during the `libs.sfx` build that should be built during `libs.oob` like System.Net.Quic.