### PR TITLE
Add more diagnostics to LookupProperty (more diagnostics to flaky tests)

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -27,7 +27,8 @@ namespace System.Text.Json
 #if DEBUG
             if (state.Current.JsonTypeInfo.PropertyInfoForTypeInfo.ConverterStrategy != ConverterStrategy.Object)
             {
-                Debug.Fail(GetLookupPropertyDebugInfo(obj, unescapedPropertyName, ref state));
+                string objTypeName = obj?.GetType().FullName ?? "<null>";
+                Debug.Fail($"obj.GetType() => {objTypeName}; {state.Current.JsonTypeInfo.GetPropertyDebugInfo(unescapedPropertyName)}");
             }
 #endif
 
@@ -67,16 +68,6 @@ namespace System.Text.Json
             state.Current.NumberHandling = jsonPropertyInfo.EffectiveNumberHandling;
             return jsonPropertyInfo;
         }
-
-#if DEBUG
-        private static string GetLookupPropertyDebugInfo(object? obj, ReadOnlySpan<byte> unescapedPropertyName, ref ReadStack state)
-        {
-            JsonTypeInfo jti = state.Current.JsonTypeInfo;
-            string objTypeName = obj?.GetType().FullName ?? "<null>";
-            string propertyName = JsonHelpers.Utf8GetString(unescapedPropertyName);
-            return $"ConverterStrategy is {jti.PropertyInfoForTypeInfo.ConverterStrategy}. propertyName = {propertyName}; obj.GetType() => {objTypeName}; DebugInfo={jti.GetDebugInfo()}";
-        }
-#endif
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ReadOnlySpan<byte> GetPropertyName(

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
@@ -172,17 +172,22 @@ namespace System.Text.Json.Serialization.Metadata
             }
 
             // No cached item was found. Try the main dictionary which has all of the properties.
-            Debug.Assert(PropertyCache != null);
+#if DEBUG
+            if (PropertyCache == null)
+            {
+                Debug.Fail($"Property cache is null. {GetPropertyDebugInfo(propertyName)}");
+            }
+#endif
 
             if (PropertyCache.TryGetValue(JsonHelpers.Utf8GetString(propertyName), out JsonPropertyInfo? info))
             {
-                Debug.Assert(info != null);
+                Debug.Assert(info != null, "PropertyCache contains null JsonPropertyInfo");
 
                 if (Options.PropertyNameCaseInsensitive)
                 {
                     if (propertyName.SequenceEqual(info.NameAsUtf8Bytes))
                     {
-                        Debug.Assert(key == GetKey(info.NameAsUtf8Bytes.AsSpan()));
+                        Debug.Assert(key == GetKey(info.NameAsUtf8Bytes.AsSpan()), "key does not match re-computed value for the same sequence (case-insensitive)");
 
                         // Use the existing byte[] reference instead of creating another one.
                         utf8PropertyName = info.NameAsUtf8Bytes!;
@@ -195,7 +200,7 @@ namespace System.Text.Json.Serialization.Metadata
                 }
                 else
                 {
-                    Debug.Assert(key == GetKey(info.NameAsUtf8Bytes.AsSpan()));
+                    Debug.Assert(key == GetKey(info.NameAsUtf8Bytes.AsSpan()), "key does not match re-computed value for the same sequence (case-sensitive)");
                     utf8PropertyName = info.NameAsUtf8Bytes;
                 }
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
@@ -179,7 +179,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
 #endif
 
-            if (PropertyCache.TryGetValue(JsonHelpers.Utf8GetString(propertyName), out JsonPropertyInfo? info))
+            if (PropertyCache!.TryGetValue(JsonHelpers.Utf8GetString(propertyName), out JsonPropertyInfo? info))
             {
                 Debug.Assert(info != null, "PropertyCache contains null JsonPropertyInfo");
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -241,6 +241,12 @@ namespace System.Text.Json.Serialization.Metadata
         }
 
 #if DEBUG
+        internal string GetPropertyDebugInfo(ReadOnlySpan<byte> unescapedPropertyName)
+        {
+            string propertyName = JsonHelpers.Utf8GetString(unescapedPropertyName);
+            return $"propertyName = {propertyName}; DebugInfo={GetDebugInfo()}";
+        }
+
         internal string GetDebugInfo()
         {
             ConverterStrategy strat = PropertyInfoForTypeInfo.ConverterStrategy;


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/runtime/issues/67816

Seems there was more asserts in LookupProperty I missed last time because AggressiveInlining which caused the stack trace to skip the correct method name