### PR TITLE
Only set the assembly binder on success when binding to SPCL

### DIFF
--- a/src/coreclr/binder/defaultassemblybinder.cpp
+++ b/src/coreclr/binder/defaultassemblybinder.cpp
@@ -200,9 +200,9 @@ HRESULT DefaultAssemblyBinder::BindToSystem(BINDER_SPACE::Assembly** ppSystemAss
         {
             _ASSERTE(pAsm != NULL);
             *ppSystemAssembly = pAsm.Extract();
+            (*ppSystemAssembly)->SetBinder(this);
         }
 
-        (*ppSystemAssembly)->SetBinder(this);
     }
     EX_CATCH_HRESULT(hr);
 


### PR DESCRIPTION
cc @janvorli @PeterSolMS 