### PR TITLE
If the user has < 65 cores and passes in an affinitized range for the 0th CPU group, if valid, honor it.

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -43845,12 +43845,12 @@ HRESULT GCHeap::Initialize()
     AffinitySet config_affinity_set;
     GCConfigStringHolder cpu_index_ranges_holder(GCConfig::GetGCHeapAffinitizeRanges());
 
-    if (!ParseGCHeapAffinitizeRanges(cpu_index_ranges_holder.Get(), &config_affinity_set))
+    uintptr_t config_affinity_mask; 
+    if (!ParseGCHeapAffinitizeRanges(cpu_index_ranges_holder.Get(), &config_affinity_set, config_affinity_mask))
     {
         return CLR_E_GC_BAD_AFFINITY_CONFIG_FORMAT;
     }
 
-    uintptr_t config_affinity_mask = static_cast<uintptr_t>(GCConfig::GetGCHeapAffinitizeMask());
     const AffinitySet* process_affinity_set = GCToOSInterface::SetGCThreadsAffinitySet(config_affinity_mask, &config_affinity_set);
 
     if (process_affinity_set->IsEmpty())

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -43845,7 +43845,7 @@ HRESULT GCHeap::Initialize()
     AffinitySet config_affinity_set;
     GCConfigStringHolder cpu_index_ranges_holder(GCConfig::GetGCHeapAffinitizeRanges());
 
-    uintptr_t config_affinity_mask = 0; 
+    uintptr_t config_affinity_mask = static_cast<uintptr_t>(GCConfig::GetGCHeapAffinitizeMask());
     if (!ParseGCHeapAffinitizeRanges(cpu_index_ranges_holder.Get(), &config_affinity_set, config_affinity_mask))
     {
         return CLR_E_GC_BAD_AFFINITY_CONFIG_FORMAT;

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -43845,7 +43845,7 @@ HRESULT GCHeap::Initialize()
     AffinitySet config_affinity_set;
     GCConfigStringHolder cpu_index_ranges_holder(GCConfig::GetGCHeapAffinitizeRanges());
 
-    uintptr_t config_affinity_mask; 
+    uintptr_t config_affinity_mask = 0; 
     if (!ParseGCHeapAffinitizeRanges(cpu_index_ranges_holder.Get(), &config_affinity_set, config_affinity_mask))
     {
         return CLR_E_GC_BAD_AFFINITY_CONFIG_FORMAT;

--- a/src/coreclr/gc/gcconfig.cpp
+++ b/src/coreclr/gc/gcconfig.cpp
@@ -85,45 +85,62 @@ bool ParseGCHeapAffinitizeRanges(const char* cpu_index_ranges, AffinitySet* conf
 {
     bool success = true;
 
-    // Unix:
-    //  The cpu index ranges is a comma separated list of indices or ranges of indices (e.g. 1-5).
-    //  Example 1,3,5,7-9,12
-    // Windows:
-    //  The cpu index ranges is a comma separated list of group-annotated indices or ranges of indices.
-    //  The group number always prefixes index or range and is followed by colon.
-    //  Example 0:1,0:3,0:5,1:7-9,1:12
+    config_affinity_mask = static_cast<uintptr_t>(GCConfig::GetGCHeapAffinitizeMask());
 
-    if (cpu_index_ranges != NULL)
+    // Case 1: config_affinity_mask and config_affinity_set are both null. No affinitization. 
+    // Case 2: config_affinity_mask is not null but config_affinity_set is null. Affinitization is based on config_affinity_mask.
+    if (cpu_index_ranges == nullptr)
     {
-        const char* number_end = cpu_index_ranges;
-
-        do
-        {
-            size_t start_index, end_index;
-            if (!GCToOSInterface::ParseGCHeapAffinitizeRangesEntry(&cpu_index_ranges, &start_index, &end_index))
-            {
-                break;
-            }
-
-            if ((start_index >= MAX_SUPPORTED_CPUS) || (end_index >= MAX_SUPPORTED_CPUS) || (end_index < start_index))
-            {
-                // Invalid CPU index values or range
-                break;
-            }
-
-            for (size_t i = start_index; i <= end_index; i++)
-            {
-                config_affinity_set->Add(i);
-            }
-
-            number_end = cpu_index_ranges;
-            cpu_index_ranges++;
-        }
-        while (*number_end == ',');
-
-        success = (*number_end == '\0');
+        return success;
     }
 
-    config_affinity_mask = static_cast<uintptr_t>(GCConfig::GetGCHeapAffinitizeMask());
+    // Case 3: config_affinity_mask is null but cpu_index_ranges isn't.
+    // To facilitate the case where there are less than 65 cores but the user passes in an affinitized range associated
+    // with the 0th CPU Group, we override the config_affinity_mask with the same contents as the cpu_index_ranges. 
+    else if (config_affinity_mask == 0 && cpu_index_ranges != nullptr)
+    {
+        // Unix:
+        //  The cpu index ranges is a comma separated list of indices or ranges of indices (e.g. 1-5).
+        //  Example 1,3,5,7-9,12
+        // Windows:
+        //  The cpu index ranges is a comma separated list of group-annotated indices or ranges of indices.
+        //  The group number always prefixes index or range and is followed by colon.
+        //  Example 0:1,0:3,0:5,1:7-9,1:12
+
+        if (cpu_index_ranges != nullptr)
+        {
+            const char* number_end = cpu_index_ranges;
+
+            do
+            {
+                size_t start_index, end_index;
+                if (!GCToOSInterface::ParseGCHeapAffinitizeRangesEntry(&cpu_index_ranges, &start_index, &end_index))
+                {
+                    break;
+                }
+
+                if ((start_index >= MAX_SUPPORTED_CPUS) || (end_index >= MAX_SUPPORTED_CPUS) || (end_index < start_index))
+                {
+                    // Invalid CPU index values or range
+                    break;
+                }
+
+                static const size_t BitsPerBitsetEntry = 8 * sizeof(uintptr_t);
+
+                for (size_t i = start_index; i <= end_index; i++)
+                {
+                    config_affinity_set->Add(i);
+                    config_affinity_mask |= (uintptr_t)1 << (i & (BitsPerBitsetEntry - 1));
+                }
+
+                number_end = cpu_index_ranges;
+                cpu_index_ranges++;
+            }
+            while (*number_end == ',');
+
+            success = (*number_end == '\0');
+        }
+    }
+
     return success;
 }

--- a/src/coreclr/gc/gcconfig.cpp
+++ b/src/coreclr/gc/gcconfig.cpp
@@ -91,6 +91,13 @@ bool ParseGCHeapAffinitizeRanges(const char* cpu_index_ranges, AffinitySet* conf
     // Case 2: config_affinity_mask is not null but config_affinity_set is null. Affinitization is based on config_affinity_mask.
     if (cpu_index_ranges == nullptr)
     {
+        // Case 2.5: If CPU Groups are enabled, however, if the user passes in the config_affinity_mask, it can't apply. 
+        // Therefore, we return a CLR_E_GC_BAD_AFFINITY_CONFIG_FORMAT error.
+        if (config_affinity_mask != 0 && GCToOSInterface::CanEnableGCCPUGroups())
+        {
+            success = false;
+        }
+
         return success;
     }
 

--- a/src/coreclr/gc/gcconfig.cpp
+++ b/src/coreclr/gc/gcconfig.cpp
@@ -81,7 +81,7 @@ bool ParseIndexOrRange(const char** config_string, size_t* start_index, size_t* 
     return true;
 }
 
-bool ParseGCHeapAffinitizeRanges(const char* cpu_index_ranges, AffinitySet* config_affinity_set)
+bool ParseGCHeapAffinitizeRanges(const char* cpu_index_ranges, AffinitySet* config_affinity_set, uintptr_t& config_affinity_mask)
 {
     bool success = true;
 
@@ -124,5 +124,6 @@ bool ParseGCHeapAffinitizeRanges(const char* cpu_index_ranges, AffinitySet* conf
         success = (*number_end == '\0');
     }
 
+    config_affinity_mask = static_cast<uintptr_t>(GCConfig::GetGCHeapAffinitizeMask());
     return success;
 }

--- a/src/coreclr/gc/gcconfig.cpp
+++ b/src/coreclr/gc/gcconfig.cpp
@@ -85,8 +85,6 @@ bool ParseGCHeapAffinitizeRanges(const char* cpu_index_ranges, AffinitySet* conf
 {
     bool success = true;
 
-    config_affinity_mask = static_cast<uintptr_t>(GCConfig::GetGCHeapAffinitizeMask());
-
     // Case 1: config_affinity_mask and config_affinity_set are both null. No affinitization. 
     // Case 2: config_affinity_mask is not null but config_affinity_set is null. Affinitization is based on config_affinity_mask.
     if (cpu_index_ranges == nullptr)

--- a/src/coreclr/gc/gcconfig.h
+++ b/src/coreclr/gc/gcconfig.h
@@ -179,6 +179,6 @@ static void Initialize();
 
 };
 
-bool ParseGCHeapAffinitizeRanges(const char* cpu_index_ranges, AffinitySet* config_affinity_set);
+bool ParseGCHeapAffinitizeRanges(const char* cpu_index_ranges, AffinitySet* config_affinity_set, uintptr_t& config_affinity_mask);
 
 #endif // __GCCONFIG_H__

--- a/src/coreclr/gc/windows/gcenv.windows.cpp
+++ b/src/coreclr/gc/windows/gcenv.windows.cpp
@@ -944,17 +944,6 @@ const AffinitySet* GCToOSInterface::SetGCThreadsAffinitySet(uintptr_t configAffi
                 }
             }
         }
-        else if (!configAffinitySet->IsEmpty())
-        {
-            // Update the process affinity set using the configured set
-            for (size_t i = 0; i < MAX_SUPPORTED_CPUS; i++)
-            {
-                if (g_processAffinitySet.Contains(i) && !configAffinitySet->Contains(i))
-                {
-                    g_processAffinitySet.Remove(i);
-                }
-            }
-        }
     }
 
     return &g_processAffinitySet;

--- a/src/coreclr/gc/windows/gcenv.windows.cpp
+++ b/src/coreclr/gc/windows/gcenv.windows.cpp
@@ -944,6 +944,17 @@ const AffinitySet* GCToOSInterface::SetGCThreadsAffinitySet(uintptr_t configAffi
                 }
             }
         }
+        else if (!configAffinitySet->IsEmpty())
+        {
+            // Update the process affinity set using the configured set
+            for (size_t i = 0; i < MAX_SUPPORTED_CPUS; i++)
+            {
+                if (g_processAffinitySet.Contains(i) && !configAffinitySet->Contains(i))
+                {
+                    g_processAffinitySet.Remove(i);
+                }
+            }
+        }
     }
 
     return &g_processAffinitySet;

--- a/src/coreclr/vm/gcenv.os.cpp
+++ b/src/coreclr/vm/gcenv.os.cpp
@@ -737,17 +737,6 @@ const AffinitySet* GCToOSInterface::SetGCThreadsAffinitySet(uintptr_t configAffi
                 }
             }
         }
-        else if (!configAffinitySet->IsEmpty())
-        {
-            // Update the process affinity set using the configured set
-            for (size_t i = 0; i < MAX_SUPPORTED_CPUS; i++)
-            {
-                if (g_processAffinitySet.Contains(i) && !configAffinitySet->Contains(i))
-                {
-                    g_processAffinitySet.Remove(i);
-                }
-            }
-        }
     }
 #endif // !TARGET_UNIX
 

--- a/src/coreclr/vm/gcenv.os.cpp
+++ b/src/coreclr/vm/gcenv.os.cpp
@@ -1172,14 +1172,14 @@ bool GCToOSInterface::ParseGCHeapAffinitizeRangesEntry(const char** config_strin
     }
 
     // If the user passes in 0 as the CPU group and they don't have > 64 cores, 
-    // honor the afinitized range passed in by bypassing the check.                                                                       
-    bool bypass_cpu_range_check_p = !CanEnableGCCPUGroups() && group_number == 0;
+    // honor the affinitized range passed in by bypassing the check.                                                                       
+    bool bypass_cpu_range_check = !CanEnableGCCPUGroups() && group_number == 0;
 
     WORD group_begin;
     WORD group_size;
     if (!CPUGroupInfo::GetCPUGroupRange((WORD)group_number, &group_begin, &group_size))
     {
-        if (!bypass_cpu_range_check_p)
+        if (!bypass_cpu_range_check)
         {
             // group number out of range
             return false;


### PR DESCRIPTION
## Summary

For cases where the user is running on a machine with < 65 cores and has passed in a ``GCHeapAffinitizeRanges`` for _just_ the 0th CPU group, apply the affinitized range rather than returning a ``CLR_E_GC_BAD_AFFINITY_CONFIG_FORMAT``.  And fail if:

- Any other CPU group is passed in if the machine has < 65 cores.
- If a user passes in a range that's > max processors available if the machine has < 65 cores and 0 is passed in as the CPU group.

NOTE: If both the Affinitized Range and the Affinitized Mask are passed, the Affinitized Mask is used if there are no CPU groups available on the machine. 

## Implementation Details

1. The check to see if we can bypass the Affinitized Ranges is simply to check if the user passed in the 0th CPU Group and if CPU Groups are not available.
2. If CPU Groups are not available, the affinitization will be based on the Affinitized Mask; to facilitate this cleanly, we are applying the CPU Group Affinitized Range on the Affinitized Mask so that down the road, it'll be successfully used. 
