### PR TITLE
Do not reset assigned interval twice

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -5261,7 +5261,6 @@ void LinearScan::allocateRegisters()
                 if (physRegRecord->assignedInterval == currentInterval)
                 {
                     unassignPhysRegNoSpill(physRegRecord);
-                    physRegRecord->assignedInterval = nullptr;
                     clearConstantReg(assignedRegister, currentInterval->registerType);
                 }
                 currentRefPosition->moveReg = true;

--- a/src/tests/JIT/Regression/JitBlue/GitHub_67102/GitHub_67102.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_67102/GitHub_67102.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+// Note: In linux-arm, for double type variable, we assign pair of registers
+//       to an interval. During unassigning, if the current interval doesn't
+//       have any more reference, we would restore the register pair to the
+//       previously assigned interval. However, after that, we were again
+//       resetting the assignedInterval of single register out of the pair
+//       to `nullptr` thinking that we just need to unassign. This was not
+//       needed and because of that we would see mismatch in assigned
+//       interval for those two registers.
+using System;
+
+public class Program_67102
+{
+    public static int Main()
+    {
+        new Func<double, double, Size>(new OrientationBasedMeasures().MinorMajorSize)(1, 2);
+        return 100;
+    }
+}
+
+internal enum ScrollOrientation
+{
+    Vertical,
+    Horizontal,
+}
+
+internal class OrientationBasedMeasures
+{
+    public ScrollOrientation ScrollOrientation { get; set; } = ScrollOrientation.Vertical;
+    public Size MinorMajorSize(double minor, double major)
+    {
+        return ScrollOrientation == ScrollOrientation.Vertical ?
+            new Size(minor, major) :
+            new Size(major, minor);
+    }
+}
+
+public record struct Size(double Width, double Height);

--- a/src/tests/JIT/Regression/JitBlue/GitHub_67102/GitHub_67102.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_67102/GitHub_67102.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_67102.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
In linux-arm, for double type variable, we assign a pair of registers to an interval. If that pair is reassigned to a different variable, we would unassign those registers from current interval. If the current interval doesn't have any more reference, we would restore the register pair to the previously assigned interval. However, after that, we were again resetting the assignedInterval of single register out of the pair to `nullptr` thinking that we just need to unassign. This was not needed and because of that we would see mismatch in assigned interval for those two registers. 

This was introduced in #45135 and while I don't remember the original intention, it was not still incorrect because it was just setting the assignedInterval of a single register of the pair. 

Fixes: https://github.com/dotnet/runtime/issues/67102