### PR TITLE
fixes in transition blowup and removing recursion from RegexNode conversion

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Compile Include="System\Collections\HashtableExtensions.cs" />
     <Compile Include="System\Collections\Generic\ValueListBuilder.Pop.cs" />
+    <Compile Include="System\Text\RegularExpressions\Symbolic\DoublyLinkedList.cs" />
     <Compile Include="System\Text\RegularExpressions\ValueMatch.cs" />
     <Compile Include="System\Threading\StackHelper.cs" />
     <Compile Include="System\Text\SegmentStringBuilder.cs" />

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DoublyLinkedList.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DoublyLinkedList.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace System.Text.RegularExpressions.Symbolic

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DoublyLinkedList.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DoublyLinkedList.cs
@@ -16,7 +16,7 @@ namespace System.Text.RegularExpressions.Symbolic
     ///  the overall number of AST nodes in a given <see cref="RegexNode"/> input.
     /// </summary>
     /// <typeparam name="T">Element type of the list that must be not null</typeparam>
-    internal class DoublyLinkedList<T> where T : notnull
+    internal sealed class DoublyLinkedList<T> where T : notnull
     {
         /// <summary>First node of the list</summary>
         private Node? _first;
@@ -148,7 +148,7 @@ namespace System.Text.RegularExpressions.Symbolic
             }
         }
 
-        private class Node
+        private sealed class Node
         {
             public Node? _next;
             public Node? _prev;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DoublyLinkedList.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DoublyLinkedList.cs
@@ -8,19 +8,24 @@ using System.Diagnostics;
 namespace System.Text.RegularExpressions.Symbolic
 {
     /// <summary>
-    ///  Represents a doubly linked list data structure.
+    ///  Represents a doubly linked list data structure. Used to support O(1) append of two lists,
+    ///  that is currently not possible by using <see cref="Collections.Generic.LinkedList{T}"/>.
+    ///  <see cref="Append(DoublyLinkedList{T})"/> operation is made use
+    ///  of in the <see cref="RegexNodeConverter.ConvertToSymbolicRegexNode(RegexNode)"/> method
+    ///  where it maintains linear construction time in terms of
+    ///  the overall number of AST nodes in a given <see cref="RegexNode"/> input.
     /// </summary>
     /// <typeparam name="T">Element type of the list that must be not null</typeparam>
     internal class DoublyLinkedList<T> where T : notnull
     {
         /// <summary>First node of the list</summary>
-        internal Node? _first;
+        private Node? _first;
         /// <summary>Last node of the list</summary>
-        internal Node? _last;
+        private Node? _last;
         /// <summary>Number of elements in the list (positive integer)</summary>
         internal int _size;
 
-        internal T FirstElement { get { Debug.Assert(_first is not null); return _first._elem; } }
+        internal T FirstElement { get { Debug.Assert(_first is not null && CheckValidity()); return _first._elem; } }
 
         /// <summary>Creates a new empty list</summary>
         public DoublyLinkedList() { }
@@ -39,37 +44,33 @@ namespace System.Text.RegularExpressions.Symbolic
         {
             //self append not allowed to avoid circularity
             Debug.Assert(other != this);
+            Debug.Assert(CheckValidity());
+            Debug.Assert(other.CheckValidity());
 
             if (other._first is null)
             {
-                // the other list is empty
-                Debug.Assert(other._last is null && other._size == 0);
+                other._size = -1;
                 return;
             }
-
-            Debug.Assert(other._last is not null && other._size > 0);
 
             if (_first is null)
             {
                 //this list is empty
-                Debug.Assert(_last is null && _size == 0);
                 _first = other._first;
                 _last = other._last;
                 _size = other._size;
+                other._size = -1;
                 return;
             }
 
             Debug.Assert(_last is not null);
-            //check internal integrity of both lists
-            Debug.Assert(_first._prev is null);
-            Debug.Assert(_last._next is null);
-            Debug.Assert(other._first._prev is null);
-            Debug.Assert(other._last._next is null);
 
             _last._next = other._first;
             other._first._prev = _last;
             _last = other._last;
             _size += other._size;
+
+            other._size = -1;
         }
 
         /// <summary>Append all the elements from all the other lists at the end of this list (O(others.Length) operation, the other lists must be discarded)</summary>
@@ -84,20 +85,16 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <summary>Insert the given element at the end of this list (O(1) operation)</summary>
         public void InsertAtEnd(T elem)
         {
-            if (_first is null)
+            Debug.Assert(CheckValidity());
+
+            if (_last is null)
             {
                 //this list is empty
-                Debug.Assert(_last is null && _size == 0);
                 _first = new(elem);
                 _last = _first;
                 _size = 1;
                 return;
             }
-
-            //check internal integrity of this list
-            Debug.Assert(_last is not null);
-            Debug.Assert(_first._prev is null);
-            Debug.Assert(_last._next is null);
 
             _last._next = new(elem, _last, null);
             _last = _last._next;
@@ -107,27 +104,51 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <summary>Insert the given element at the start of this list (O(1) operation)</summary>
         public void InsertAtStart(T elem)
         {
+            Debug.Assert(CheckValidity());
+
             if (_first is null)
             {
                 //this list is empty
-                Debug.Assert(_last is null && _size == 0);
                 _first = new(elem);
                 _last = _first;
                 _size = 1;
                 return;
             }
 
-            //check internal integrity of this list
-            Debug.Assert(_last is not null);
-            Debug.Assert(_first._prev is null);
-            Debug.Assert(_last._next is null);
-
             _first._prev = new(elem, null, _first);
             _first = _first._prev;
             _size += 1;
         }
 
-        internal class Node
+        /// <summary>Enumerate all elements in the list</summary>
+        /// <param name="inreverse">if true then the enumeration happens in reverse order</param>
+        public IEnumerable<T> Enumerate(bool inreverse = false) => inreverse ? EnumerateBackwards() : EnumerateForwards();
+
+        private IEnumerable<T> EnumerateForwards()
+        {
+            Debug.Assert(CheckValidity());
+
+            Node? current = _first;
+            while (current is not null)
+            {
+                yield return current._elem;
+                current = current._next;
+            }
+        }
+
+        private IEnumerable<T> EnumerateBackwards()
+        {
+            Debug.Assert(CheckValidity());
+
+            Node? current = _last;
+            while (current is not null)
+            {
+                yield return current._elem;
+                current = current._prev;
+            }
+        }
+
+        private class Node
         {
             public Node? _next;
             public Node? _prev;
@@ -138,10 +159,11 @@ namespace System.Text.RegularExpressions.Symbolic
             public Node(T elem, Node? prev, Node? next) { _elem = elem; _prev = prev; _next = next; }
         }
 
-        /// <summary>Displays the list as a comma separated sequence of elements that is enclosed in parenthesis</summary>
         public override string ToString()
         {
             StringBuilder sb = new();
+            sb.Append('#');
+            sb.Append(_size);
             sb.Append('(');
             Node? current = _first;
             while (current is not null)
@@ -156,5 +178,9 @@ namespace System.Text.RegularExpressions.Symbolic
             sb.Append(')');
             return sb.ToString();
         }
+
+        private bool CheckValidity() => _size >= 0 && // _size < 0 means that the list has been invalidated after Append
+            (_size != 0 || (_first is null && _last is null)) && //empty list
+            (_size == 0 || (_first is not null && _last is not null && _first._prev is null && _last._next is null)); //nonempty list
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DoublyLinkedList.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DoublyLinkedList.cs
@@ -1,23 +1,29 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace System.Text.RegularExpressions.Symbolic
 {
     /// <summary>
     ///  Represents a doubly linked list data structure.
-    ///  The list cannot be created empty to avoid null values of fields.
     /// </summary>
     /// <typeparam name="T">Element type of the list that must be not null</typeparam>
     internal class DoublyLinkedList<T> where T : notnull
     {
         /// <summary>First node of the list</summary>
-        internal Node _first;
+        internal Node? _first;
         /// <summary>Last node of the list</summary>
-        internal Node _last;
+        internal Node? _last;
         /// <summary>Number of elements in the list (positive integer)</summary>
         internal int _size;
+
+        internal T FirstElement { get { Debug.Assert(_first is not null); return _first._elem; } }
+
+        /// <summary>Creates a new empty list</summary>
+        public DoublyLinkedList() { }
 
         /// <summary>Creates a new singleton list containing the given element</summary>
         public DoublyLinkedList(T elem)
@@ -33,6 +39,27 @@ namespace System.Text.RegularExpressions.Symbolic
         {
             //self append not allowed to avoid circularity
             Debug.Assert(other != this);
+
+            if (other._first is null)
+            {
+                // the other list is empty
+                Debug.Assert(other._last is null && other._size == 0);
+                return;
+            }
+
+            Debug.Assert(other._last is not null && other._size > 0);
+
+            if (_first is null)
+            {
+                //this list is empty
+                Debug.Assert(_last is null && _size == 0);
+                _first = other._first;
+                _last = other._last;
+                _size = other._size;
+                return;
+            }
+
+            Debug.Assert(_last is not null);
             //check internal integrity of both lists
             Debug.Assert(_first._prev is null);
             Debug.Assert(_last._next is null);
@@ -45,10 +72,30 @@ namespace System.Text.RegularExpressions.Symbolic
             _size += other._size;
         }
 
+        /// <summary>Append all the elements from all the other lists at the end of this list (O(others.Length) operation, the other lists must be discarded)</summary>
+        public void Append(DoublyLinkedList<T>[] others)
+        {
+            for (int i = 0; i < others.Length; ++i)
+            {
+                Append(others[i]);
+            }
+        }
+
         /// <summary>Insert the given element at the end of this list (O(1) operation)</summary>
         public void InsertAtEnd(T elem)
         {
+            if (_first is null)
+            {
+                //this list is empty
+                Debug.Assert(_last is null && _size == 0);
+                _first = new(elem);
+                _last = _first;
+                _size = 1;
+                return;
+            }
+
             //check internal integrity of this list
+            Debug.Assert(_last is not null);
             Debug.Assert(_first._prev is null);
             Debug.Assert(_last._next is null);
 
@@ -60,7 +107,18 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <summary>Insert the given element at the start of this list (O(1) operation)</summary>
         public void InsertAtStart(T elem)
         {
+            if (_first is null)
+            {
+                //this list is empty
+                Debug.Assert(_last is null && _size == 0);
+                _first = new(elem);
+                _last = _first;
+                _size = 1;
+                return;
+            }
+
             //check internal integrity of this list
+            Debug.Assert(_last is not null);
             Debug.Assert(_first._prev is null);
             Debug.Assert(_last._next is null);
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DoublyLinkedList.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DoublyLinkedList.cs
@@ -1,0 +1,104 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System.Text.RegularExpressions.Symbolic
+{
+    /// <summary>
+    ///  Represents a doubly linked list data structure.
+    ///  The list cannot be created empty to avoid null values of fields.
+    /// </summary>
+    /// <typeparam name="T">Element type of the list that must be not null</typeparam>
+    internal class DoublyLinkedList<T> where T : notnull
+    {
+        /// <summary>First node of the list</summary>
+        internal Node _first;
+        /// <summary>Last node of the list</summary>
+        internal Node _last;
+        /// <summary>Number of elements in the list (positive integer)</summary>
+        internal int _size;
+
+        /// <summary>Creates a new singleton list containing the given element</summary>
+        public DoublyLinkedList(T elem)
+        {
+            Node node = new Node(elem);
+            _first = node;
+            _last = node;
+            _size = 1;
+        }
+
+        /// <summary>Append all the elements from the other list at the end of this list (O(1) operation, the other list must be discarded)</summary>
+        public void Append(DoublyLinkedList<T> other)
+        {
+            //self append not allowed to avoid circularity
+            Debug.Assert(other != this);
+            //check internal integrity of both lists
+            Debug.Assert(_first._prev is null);
+            Debug.Assert(_last._next is null);
+            Debug.Assert(other._first._prev is null);
+            Debug.Assert(other._last._next is null);
+
+            _last._next = other._first;
+            other._first._prev = _last;
+            _last = other._last;
+            _size += other._size;
+        }
+
+        /// <summary>Insert the given element at the end of this list (O(1) operation)</summary>
+        public void InsertAtEnd(T elem)
+        {
+            //check internal integrity of this list
+            Debug.Assert(_first._prev is null);
+            Debug.Assert(_last._next is null);
+
+            _last._next = new(elem, _last, null);
+            _last = _last._next;
+            _size += 1;
+        }
+
+        /// <summary>Insert the given element at the start of this list (O(1) operation)</summary>
+        public void InsertAtStart(T elem)
+        {
+            //check internal integrity of this list
+            Debug.Assert(_first._prev is null);
+            Debug.Assert(_last._next is null);
+
+            _first._prev = new(elem, null, _first);
+            _first = _first._prev;
+            _size += 1;
+        }
+
+        internal class Node
+        {
+            public Node? _next;
+            public Node? _prev;
+            public readonly T _elem;
+
+            public Node(T elem) { _elem = elem; }
+
+            public Node(T elem, Node? prev, Node? next) { _elem = elem; _prev = prev; _next = next; }
+        }
+
+        /// <summary>Displays the list as a comma separated sequence of elements that is enclosed in parenthesis</summary>
+        public override string ToString()
+        {
+            StringBuilder sb = new();
+            sb.Append('(');
+            Node? current = _first;
+            while (current is not null)
+            {
+                sb.Append(current._elem);
+                current = current._next;
+                if (current is not null)
+                {
+                    sb.Append(',');
+                }
+            }
+            sb.Append(')');
+            return sb.ToString();
+        }
+    }
+}

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeConverter.cs
@@ -258,7 +258,7 @@ namespace System.Text.RegularExpressions.Symbolic
                                 {
                                     ConversionResult res = childResults[i];
                                     // if res is a non-singleton list then it denotes a concatenation that must be constructed at this point
-                                    SymbolicRegexNode<BDD> elem = res._size == 1 ? res.FirstElement : _builder.CreateConcat(res, top.TryToMarkFixedLength);
+                                    SymbolicRegexNode<BDD> elem = res._size == 1 ? res.FirstElement : _builder.CreateConcatRev(res.Enumerate(true), top.TryToMarkFixedLength);
                                     if (elem.IsNothing)
                                     {
                                         continue;
@@ -279,7 +279,7 @@ namespace System.Text.RegularExpressions.Symbolic
                                 Debug.Assert(childResults.Length == 1);
                                 ConversionResult res = childResults[0];
                                 //convert a list of nodes into a concatenation, do not propagate the length marker flag inside the loop body
-                                SymbolicRegexNode<BDD> body = res._size == 1 ? res.FirstElement : _builder.CreateConcat(res, false);
+                                SymbolicRegexNode<BDD> body = res._size == 1 ? res.FirstElement : _builder.CreateConcatRev(res.Enumerate(true), false);
                                 result.InsertAtEnd(_builder.CreateLoop(body, node.Kind == RegexNodeKind.Lazyloop, node.M, node.N));
                                 break;
                             }
@@ -307,7 +307,7 @@ namespace System.Text.RegularExpressions.Symbolic
             Debug.Assert(rootres._size == 1 || root.Kind == RegexNodeKind.Concatenate || root.Kind == RegexNodeKind.Capture);
 
             // if the root node is a concatenation then the converted concatenation is built with length marker check being true
-            SymbolicRegexNode<BDD> rootresult = rootres._size == 1 ? rootres.FirstElement : _builder.CreateConcat(rootres, true);
+            SymbolicRegexNode<BDD> rootresult = rootres._size == 1 ? rootres.FirstElement : _builder.CreateConcatRev(rootres.Enumerate(true), true);
             return rootresult;
 
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
@@ -429,9 +429,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
         internal SymbolicRegexNode<TSet> CreateDisableBacktrackingSimulation(SymbolicRegexNode<TSet> child)
         {
-            if (child == _nothing)
-                return _nothing;
-            return SymbolicRegexNode<TSet>.CreateDisableBacktrackingSimulation(this, child);
+            return child == _nothing ? _nothing : SymbolicRegexNode<TSet>.CreateDisableBacktrackingSimulation(this, child);
         }
 
         internal SymbolicRegexNode<TNewSet> Transform<TNewSet>(SymbolicRegexNode<TSet> sr, SymbolicRegexBuilder<TNewSet> builder, Func<SymbolicRegexBuilder<TNewSet>, TSet, TNewSet> setTransformer)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -2080,7 +2080,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// Keeps the list of transitions unique, expects higher priority transitions
         /// to be added first and ignores equivalent lower priority transitions.
         /// </summary>
-        private class TransitionList
+        private sealed class TransitionList
         {
             private SymbolicRegexBuilder<TSet> _builder;
             internal List<(SymbolicRegexNode<TSet> Node, DerivativeEffect[] Effects)> _transitions = new();

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -948,18 +948,7 @@ namespace System.Text.RegularExpressions.Symbolic
             {
                 AddTransitions(elem, context, transitions, new List<SymbolicRegexNode<TSet>>(), null, simulateBacktracking: true);
             }
-            //SymbolicRegexNode<TSet> derivative = _builder._nothing;
-            //// Iterate backwards to avoid quadratic rebuilding of the Or nodes, which are always simplified to
-            //// right associative form. Concretely:
-            //// In (a|(b|c)) | d -> (a|(b|(c|d)) the first argument is not a subtree of the result.
-            //// In a | (b|(c|d)) -> (a|(b|(c|d)) the second argument is a subtree of the result.
-            //// The first case performs linear work for each element, leading to a quadratic blowup.
-            //for (int i = transitions.Count - 1; i >= 0; --i)
-            //{
-            //    SymbolicRegexNode<TSet> node = transitions[i].Node;
-            //    Debug.Assert(node._kind != SymbolicRegexNodeKind.DisableBacktrackingSimulation);
-            //    derivative = _builder.OrderedOr(node, derivative);
-            //}
+
             SymbolicRegexNode<TSet> derivative = transitions.Union;
             if (_kind == SymbolicRegexNodeKind.DisableBacktrackingSimulation)
             {
@@ -2086,7 +2075,11 @@ namespace System.Text.RegularExpressions.Symbolic
             }
         }
 
-        /// <summary>Represents a list of transitions without duplicate effect arrays</summary>
+        /// <summary>
+        /// Represents a list of transitions without duplicate effect arrays.
+        /// Keeps the list of transitions unique, expects higher priority transitions
+        /// to be added first and ignores equivalent lower priority transitions.
+        /// </summary>
         private class TransitionList
         {
             private SymbolicRegexBuilder<TSet> _builder;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -936,7 +936,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <returns>the derivative</returns>
         internal SymbolicRegexNode<TSet> CreateDerivative(TSet elem, uint context)
         {
-            List<(SymbolicRegexNode<TSet> Node, DerivativeEffect[])> transitions = new();
+            TransitionList transitions = new(_builder);
             if (_kind == SymbolicRegexNodeKind.DisableBacktrackingSimulation)
             {
                 // Since this node disables backtracking simulation, unwrap the node and pass the corresponding flag as
@@ -948,21 +948,25 @@ namespace System.Text.RegularExpressions.Symbolic
             {
                 AddTransitions(elem, context, transitions, new List<SymbolicRegexNode<TSet>>(), null, simulateBacktracking: true);
             }
-            SymbolicRegexNode<TSet> derivative = _builder._nothing;
-            // Iterate backwards to avoid quadratic rebuilding of the Or nodes, which are always simplified to
-            // right associative form. Concretely:
-            // In (a|(b|c)) | d -> (a|(b|(c|d)) the first argument is not a subtree of the result.
-            // In a | (b|(c|d)) -> (a|(b|(c|d)) the second argument is a subtree of the result.
-            // The first case performs linear work for each element, leading to a quadratic blowup.
-            for (int i = transitions.Count - 1; i >= 0; --i)
-            {
-                SymbolicRegexNode<TSet> node = transitions[i].Node;
-                Debug.Assert(node._kind != SymbolicRegexNodeKind.DisableBacktrackingSimulation);
-                derivative = _builder.OrderedOr(node, derivative);
-            }
+            //SymbolicRegexNode<TSet> derivative = _builder._nothing;
+            //// Iterate backwards to avoid quadratic rebuilding of the Or nodes, which are always simplified to
+            //// right associative form. Concretely:
+            //// In (a|(b|c)) | d -> (a|(b|(c|d)) the first argument is not a subtree of the result.
+            //// In a | (b|(c|d)) -> (a|(b|(c|d)) the second argument is a subtree of the result.
+            //// The first case performs linear work for each element, leading to a quadratic blowup.
+            //for (int i = transitions.Count - 1; i >= 0; --i)
+            //{
+            //    SymbolicRegexNode<TSet> node = transitions[i].Node;
+            //    Debug.Assert(node._kind != SymbolicRegexNodeKind.DisableBacktrackingSimulation);
+            //    derivative = _builder.OrderedOr(node, derivative);
+            //}
+            SymbolicRegexNode<TSet> derivative = transitions.Union;
             if (_kind == SymbolicRegexNodeKind.DisableBacktrackingSimulation)
+            {
                 // Make future derivatives disable backtracking simulation too
                 derivative = _builder.CreateDisableBacktrackingSimulation(derivative);
+            }
+
             return derivative;
         }
 
@@ -984,7 +988,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <returns>the derivative</returns>
         internal List<(SymbolicRegexNode<TSet>, DerivativeEffect[])> CreateNfaDerivativeWithEffects(TSet elem, uint context)
         {
-            List<(SymbolicRegexNode<TSet>, DerivativeEffect[])> transitions = new();
+            TransitionList transitions = new(_builder);
             if (_kind == SymbolicRegexNodeKind.DisableBacktrackingSimulation)
             {
                 // Since this node disables backtracking simulation, unwrap the node and pass the corresponding flag as
@@ -992,18 +996,13 @@ namespace System.Text.RegularExpressions.Symbolic
                 Debug.Assert(_left is not null);
                 _left.AddTransitions(elem, context, transitions, new List<SymbolicRegexNode<TSet>>(), new Stack<DerivativeEffect>(), simulateBacktracking: false);
                 // Make future derivatives disable backtracking simulation too
-                for (int i = 0; i < transitions.Count; ++i)
-                {
-                    var (node, effects) = transitions[i];
-                    Debug.Assert(node._kind != SymbolicRegexNodeKind.DisableBacktrackingSimulation);
-                    transitions[i] = (_builder.CreateDisableBacktrackingSimulation(node), effects);
-                }
+                transitions = transitions.DisableBacktrackingSimulation();
             }
             else
             {
                 AddTransitions(elem, context, transitions, new List<SymbolicRegexNode<TSet>>(), new Stack<DerivativeEffect>(), simulateBacktracking: true);
             }
-            return transitions;
+            return transitions._transitions;
         }
 
         /// <summary>
@@ -1018,7 +1017,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <param name="continuation">a list used in recursive calls to track nodes to concatenate, should be an empty list at the root call</param>
         /// <param name="effects">a stack used in recursive calls to track effects, should be an empty stack at the root call</param>
         /// <param name="simulateBacktracking">whether the derivative should only consider paths that backtracking would take, true by default</param>
-        private void AddTransitions(TSet elem, uint context, List<(SymbolicRegexNode<TSet>, DerivativeEffect[])> transitions,
+        private void AddTransitions(TSet elem, uint context, TransitionList transitions,
             List<SymbolicRegexNode<TSet>> continuation, Stack<DerivativeEffect>? effects, bool simulateBacktracking)
         {
             Debug.Assert(!_builder._solver.IsEmpty(elem), "False element or minterm should not make it into derivative construction.");
@@ -1042,8 +1041,8 @@ namespace System.Text.RegularExpressions.Symbolic
             // For example, d_a( a|ab ) under backtracking simulation transitions to just epsilon, while without
             // backtracking simulation it would transition to epsilon|b.
             // All parts of the function below should consider IsDone and return early when it is true.
-            static bool IsDone(List<(SymbolicRegexNode<TSet> Node, DerivativeEffect[])> transitions, bool simulateBacktracking) =>
-                simulateBacktracking && transitions.Count > 0 && transitions[transitions.Count - 1].Node.IsNullable;
+            static bool IsDone(TransitionList transitions, bool simulateBacktracking) =>
+                simulateBacktracking && transitions.Count > 0 && transitions.LastTransition.Node.IsNullable;
 
             // Nothing and epsilon can't consume a character so they generate no transition
             if (IsNothing || IsEpsilon)
@@ -1056,7 +1055,7 @@ namespace System.Text.RegularExpressions.Symbolic
             {
                 Debug.Assert(!IsDone(transitions, simulateBacktracking));
                 SymbolicRegexNode<TSet> leaf = BuildLeaf(_builder._anyStar, continuation);
-                transitions.Add((leaf, effects?.ToArray() ?? Array.Empty<DerivativeEffect>()));
+                transitions.Add(leaf, effects?.ToArray() ?? Array.Empty<DerivativeEffect>());
                 // Signal early exit if the leaf is unconditionally nullable
                 return;
             }
@@ -1078,7 +1077,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     if (!_builder._solver.IsEmpty(_builder._solver.And(elem, _set)))
                     {
                         SymbolicRegexNode<TSet> leaf = BuildLeaf(_builder.Epsilon, continuation);
-                        transitions.Add((leaf, effects?.ToArray() ?? Array.Empty<DerivativeEffect>()));
+                        transitions.Add(leaf, effects?.ToArray() ?? Array.Empty<DerivativeEffect>());
                         // Signal early exit if the leaf is unconditionally nullable
                         return;
                     }
@@ -1126,7 +1125,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     else
                     {
                         // Helper function for the case where the right side consumes the character
-                        static void RightTransition(SymbolicRegexNode<TSet> node, TSet elem, uint context, List<(SymbolicRegexNode<TSet>, DerivativeEffect[])> transitions,
+                        static void RightTransition(SymbolicRegexNode<TSet> node, TSet elem, uint context, TransitionList transitions,
                             List<SymbolicRegexNode<TSet>> continuation, Stack<DerivativeEffect>? effects, bool simulateBacktracking)
                         {
                             Debug.Assert(node._left is not null && node._right is not null);
@@ -1147,7 +1146,7 @@ namespace System.Text.RegularExpressions.Symbolic
                         }
 
                         // Helper function for the case where the left side consumes the character
-                        static void LeftTransition(SymbolicRegexNode<TSet> node, TSet elem, uint context, List<(SymbolicRegexNode<TSet>, DerivativeEffect[])> transitions,
+                        static void LeftTransition(SymbolicRegexNode<TSet> node, TSet elem, uint context, TransitionList transitions,
                             List<SymbolicRegexNode<TSet>> continuation, Stack<DerivativeEffect>? effects, bool simulateBacktracking)
                         {
                             Debug.Assert(node._left is not null && node._right is not null);
@@ -2084,6 +2083,76 @@ namespace System.Text.RegularExpressions.Symbolic
 
                 default:
                     return this;
+            }
+        }
+
+        /// <summary>Represents a list of transitions without duplicate effect arrays</summary>
+        private class TransitionList
+        {
+            private SymbolicRegexBuilder<TSet> _builder;
+            internal List<(SymbolicRegexNode<TSet> Node, DerivativeEffect[] Effects)> _transitions = new();
+            private readonly HashSet<SymbolicRegexNode<TSet>> _nodes = new();
+
+            public TransitionList(SymbolicRegexBuilder<TSet> builder) { _builder = builder; }
+
+            public int Count => _transitions.Count;
+
+            public (SymbolicRegexNode<TSet> Node, DerivativeEffect[]) this[int i] => _transitions[i];
+
+            public (SymbolicRegexNode<TSet> Node, DerivativeEffect[]) LastTransition => _transitions[_transitions.Count - 1];
+
+            internal void Add(SymbolicRegexNode<TSet> node, DerivativeEffect[] newEffects)
+            {
+                if (_nodes.Add(node))
+                {
+                    _transitions.Add((node, newEffects));
+                }
+            }
+
+            public override string ToString()
+            {
+                StringBuilder sb = new();
+                for (int i = 0; i < _transitions.Count; i++)
+                {
+                    if (i > 0)
+                        sb.Append(",\n");
+                    sb.Append(_transitions[i].Node);
+                    sb.Append("-->(");
+                    for (int j = 0; j < _transitions[i].Effects.Length; j++)
+                    {
+                        if (j > 0)
+                            sb.Append(',');
+                        sb.Append(_transitions[i].Effects[j]);
+                    }
+                    sb.Append(')');
+                }
+
+                return sb.ToString();
+            }
+
+            public SymbolicRegexNode<TSet> Union
+            {
+                get
+                {
+                    SymbolicRegexNode<TSet> union = _builder._nothing;
+                    for (int i = _transitions.Count - 1; i >= 0; --i)
+                    {
+                        Debug.Assert(_transitions[i].Node._kind != SymbolicRegexNodeKind.DisableBacktrackingSimulation);
+                        union = OrderedOr(_builder, _transitions[i].Node, union, true);
+                    }
+                    return union;
+                }
+            }
+
+            public TransitionList DisableBacktrackingSimulation()
+            {
+                TransitionList transitions = new(_builder);
+                for (int i = 0; i < _transitions.Count; ++i)
+                {
+                    Debug.Assert(_transitions[i].Node._kind != SymbolicRegexNodeKind.DisableBacktrackingSimulation);
+                    transitions.Add(_builder.CreateDisableBacktrackingSimulation(_transitions[i].Node), _transitions[i].Effects);
+                }
+                return transitions;
             }
         }
     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexRunnerFactory.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexRunnerFactory.cs
@@ -21,7 +21,7 @@ namespace System.Text.RegularExpressions.Symbolic
             var bddBuilder = new SymbolicRegexBuilder<BDD>(charSetSolver, charSetSolver);
             var converter = new RegexNodeConverter(bddBuilder, culture, regexTree.CaptureNumberSparseMapping);
 
-            SymbolicRegexNode<BDD> rootNode = converter.ConvertToSymbolicRegexNode(regexTree.Root, tryCreateFixedLengthMarker: true);
+            SymbolicRegexNode<BDD> rootNode = converter.ConvertToSymbolicRegexNode(regexTree.Root);
             BDD[] minterms = rootNode.ComputeMinterms();
 
             _matcher = minterms.Length > 64 ?


### PR DESCRIPTION
Partially addressing active issue https://github.com/dotnet/runtime/issues/60645. 
The issue is not fully fixed yet after this pr since more related performance issues are still present.
But at least three key fixes are made, so the PR made sense at this time.

1) Removing quadratic increase in transition creation, through `TransitionList` data structure in `AddTransitions` method.

2) Removing deep recursion in `ConvertToSymbolicRegexNode(RegexNode)` that turned out to be a bottleneck in many stress tests leading to calls of ` StackHelper.CallOnEmptyStack` and construction times in the order of 10sec that was reduced 100x, by rewriting the method with a while loop and local cache of intermediate results.

3) Added `DoublyLinkedList` data structure in order to construct lists of symbolic regex nodes that can be extended both at the start and at the end, as well as append to in `O(1)` cost, and allows walking the list forwards and backwards linearly in the length of the list. It avoids locally creating multiple creations of intermediate transition arrays and mainly avoids deep nesting of concatenations involving captures. 

The use of  `DoublyLinkedList` in  `ConvertToSymbolicRegexNode` relies on the property that 
**no `RegexNode` object is repeated in the AST**
which must be true, since any two different occurrences of `RegexNode` object must also be distinct references. Corresponding `Debug.Assert` calls are also made to make sure that this is indeed the case.