### PR TITLE
upgrade docker to get clang9 to prevent coreclr crashes

### DIFF
--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/Dockerfile
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20211022152710-047508b
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20220421022739-9c434db
 
 # Prevents dialog prompting when installing packages
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
it seems like compiler bug. We look at it with @janvorli and coreclr runs ok if compiled with clang9 instead of 3.9.
This change pulls in updated image from https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/606

fixes #66970