### PR TITLE
add support for parsing empty user and password as DefaultCredentials

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -49,7 +49,6 @@ namespace System.Net.Http
             {
                 httpsCred = GetCredentialsFromString(httpsProxy.UserInfo);
             }
-
             if (httpCred == null && httpsCred == null)
             {
                 return null;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -67,7 +67,7 @@ namespace System.Net.Http
 
             if (value == ":")
             {
-                return CredentialCache.DefaultNetworkCredentials ;
+                return CredentialCache.DefaultNetworkCredentials;
             }
 
             value = Uri.UnescapeDataString(value);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -206,7 +206,7 @@ namespace System.Net.Http
 
                 Uri uri = ub.Uri;
 
-                // if both user and password exist and empty we should preserve that and use default credentials.
+                // if both user and password exist and are empty we should preserve that and use default credentials.
                 // UriBuilder does not handle that now e.g. does not distinguish between empty and missing.
                 if (user == "" && password == "")
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -15,6 +15,7 @@ namespace System.Net.Http
         private readonly NetworkCredential? _httpsCred;
         private readonly Uri? _httpProxy;
         private readonly Uri? _httpsProxy;
+        internal static readonly string s_defaultCredentialsPlaceholder = "$";
 
         public HttpEnvironmentProxyCredentials(Uri? httpProxy, NetworkCredential? httpCred,
                                                 Uri? httpsProxy, NetworkCredential? httpsCred)
@@ -48,6 +49,7 @@ namespace System.Net.Http
             {
                 httpsCred = GetCredentialsFromString(httpsProxy.UserInfo);
             }
+
             if (httpCred == null && httpsCred == null)
             {
                 return null;
@@ -63,6 +65,11 @@ namespace System.Net.Http
             if (string.IsNullOrWhiteSpace(value))
             {
                 return null;
+            }
+
+            if (value == s_defaultCredentialsPlaceholder)
+            {
+                return CredentialCache.DefaultNetworkCredentials ;
             }
 
             value = Uri.UnescapeDataString(value);
@@ -191,7 +198,10 @@ namespace System.Net.Http
                 UriBuilder ub = new UriBuilder("http", host, port);
                 if (user != null)
                 {
-                    ub.UserName = Uri.EscapeDataString(user);
+                    // if both user and password exist and empty we should use default credentials
+                    ub.UserName = (user == "" && password == "") ?
+                                    HttpEnvironmentProxyCredentials.s_defaultCredentialsPlaceholder :
+                                    Uri.EscapeDataString(user);
                 }
 
                 if (password != null)

--- a/src/libraries/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
@@ -222,6 +222,11 @@ namespace System.Net.Http.Tests
                 Assert.NotNull(p);
                 Assert.Equal(CredentialCache.DefaultCredentials, p.Credentials.GetCredential(p.GetProxy(fooHttp), ""));
                 Assert.Equal(CredentialCache.DefaultCredentials, p.Credentials.GetCredential(p.GetProxy(fooHttps), ""));
+
+                Environment.SetEnvironmentVariable("http_proxy", "http://:@[::1]:80");
+                Assert.True(HttpEnvironmentProxy.TryCreate(out p));
+                Assert.NotNull(p);
+                Assert.Equal(CredentialCache.DefaultCredentials, p.Credentials.GetCredential(p.GetProxy(fooHttp), ""));
             }).Dispose();
         }
 

--- a/src/libraries/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
@@ -209,6 +209,23 @@ namespace System.Net.Http.Tests
             }).Dispose();
         }
 
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void HttpProxy_CredentialParsing_DefaultCredentials()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                IWebProxy p;
+
+                Environment.SetEnvironmentVariable("all_proxy", "http://:@1.1.1.1:3000");
+                //Environment.SetEnvironmentVariable("all_proxy", "http://1.1.1.1:3000");
+                Assert.True(HttpEnvironmentProxy.TryCreate(out p));
+                Assert.NotNull(p);
+                Assert.Equal(CredentialCache.DefaultCredentials, p.Credentials.GetCredential(p.GetProxy(fooHttp), ""));
+                Assert.Equal(CredentialCache.DefaultCredentials, p.Credentials.GetCredential(p.GetProxy(fooHttps), ""));
+            }).Dispose();
+        }
+
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void HttpProxy_Exceptions_Match()
         {

--- a/src/libraries/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
@@ -218,7 +218,6 @@ namespace System.Net.Http.Tests
                 IWebProxy p;
 
                 Environment.SetEnvironmentVariable("all_proxy", "http://:@1.1.1.1:3000");
-                //Environment.SetEnvironmentVariable("all_proxy", "http://1.1.1.1:3000");
                 Assert.True(HttpEnvironmentProxy.TryCreate(out p));
                 Assert.NotNull(p);
                 Assert.Equal(CredentialCache.DefaultCredentials, p.Credentials.GetCredential(p.GetProxy(fooHttp), ""));


### PR DESCRIPTION
I'm not sure if there is better way how to distinguish between no user info and empty user info in Uri @mihazupan.
They both seems to return empty string when accessing UserInfo. 

For now, I set the user to placeholder value unlike to ever collide with real user name. 
If we don't like it, we can plumb extra two booleans through the call chain. 

fixes #66587

