### PR TITLE
Fix ILCompiler using wrong ISA for LZCNT

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/HardwareIntrinsicHelpers.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/HardwareIntrinsicHelpers.Aot.cs
@@ -134,7 +134,7 @@ namespace ILCompiler
                     InstructionSet.X64_BMI2 => Bmi2,
                     InstructionSet.X64_BMI2_X64 => Bmi2,
                     InstructionSet.X64_LZCNT => Lzcnt,
-                    InstructionSet.X64_LZCNT_X64 => Popcnt,
+                    InstructionSet.X64_LZCNT_X64 => Lzcnt,
                     InstructionSet.X64_AVXVNNI => AvxVnni,
                     InstructionSet.X64_AVXVNNI_X64 => AvxVnni,
 


### PR DESCRIPTION
Noticed while rebasing my branch.