### PR TITLE
[Release/6.0] Backport test fixes

### DIFF
--- a/src/libraries/Common/tests/System/Net/SslProtocolSupport.cs
+++ b/src/libraries/Common/tests/System/Net/SslProtocolSupport.cs
@@ -61,10 +61,12 @@ namespace System.Net.Test.Common
             {
                 foreach (SslProtocols protocol in Enum.GetValues(typeof(SslProtocols)))
                 {
-                    if (protocol != SslProtocols.None && (protocol & SupportedSslProtocols) == protocol)
+#pragma warning disable 0618 // SSL2/3 are deprecated
+                    if (protocol != SslProtocols.None && protocol != SslProtocols.Default && (protocol & SupportedSslProtocols) == protocol)
                     {
                         yield return new object[] { protocol };
                     }
+#pragma warning restore 0618
                 }
             }
 

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -428,7 +428,7 @@ namespace System
             // Windows depend on registry, enabled by default on all supported versions.
             if (IsWindows)
             {
-                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls, defaultProtocolSupport: true);
+                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls, defaultProtocolSupport: true) && !IsWindows10Version20348OrGreater;
             }
 
             return OpenSslGetTlsSupport(SslProtocols.Tls);
@@ -445,7 +445,7 @@ namespace System
                 }
 
                 // It is enabled on other versions unless explicitly disabled.
-                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls11, defaultProtocolSupport: true);
+                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls11, defaultProtocolSupport: true) && !IsWindows10Version20348OrGreater;
             }
             // on macOS and Android TLS 1.1 is supported.
             else if (IsOSXLike || IsAndroid)

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -339,7 +339,7 @@ namespace System
             return (IsLinux && File.Exists("/.dockerenv"));
         }
 
-        private static bool GetProtocolSupportFromWindowsRegistry(SslProtocols protocol, bool defaultProtocolSupport)
+        private static bool GetProtocolSupportFromWindowsRegistry(SslProtocols protocol, bool defaultProtocolSupport, bool disabledByDefault = false)
         {
             string registryProtocolName = protocol switch
             {
@@ -359,13 +359,18 @@ namespace System
             string serverKey = @$"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\{registryProtocolName}\Server";
 
             object client, server;
+            object clientDefault, serverDefault;
             try
             {
                 client = Registry.GetValue(clientKey, "Enabled", defaultProtocolSupport ? 1 : 0);
                 server = Registry.GetValue(serverKey, "Enabled", defaultProtocolSupport ? 1 : 0);
-                if (client is int c && server is int s)
+
+                clientDefault = Registry.GetValue(clientKey, "DisabledByDefault", 1);
+                serverDefault = Registry.GetValue(serverKey, "DisabledByDefault", 1);
+
+                if (client is int c && server is int s && clientDefault is int cd && serverDefault is int sd)
                 {
-                    return c == 1 && s == 1;
+                    return (c == 1 && s == 1) && (!disabledByDefault || (cd == 0 && sd == 0));
                 }
             }
             catch (SecurityException)
@@ -414,14 +419,16 @@ namespace System
 
         private static bool GetTls10Support()
         {
-            // on Windows, macOS, and Android TLS1.0/1.1 are supported.
+            // on macOS and Android TLS 1.0 is supported.
             if (IsOSXLike || IsAndroid)
             {
                 return true;
             }
+
+            // Windows depend on registry, enabled by default on all supported versions.
             if (IsWindows)
             {
-                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls, true);
+                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls, defaultProtocolSupport: true);
             }
 
             return OpenSslGetTlsSupport(SslProtocols.Tls);
@@ -429,13 +436,18 @@ namespace System
 
         private static bool GetTls11Support()
         {
-            // on Windows, macOS, and Android TLS1.0/1.1 are supported.
             if (IsWindows)
             {
-                // TLS 1.1 and 1.2 can work on Windows7 but it is not enabled by default.
-                bool defaultProtocolSupport = !IsWindows7;
-                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls11, defaultProtocolSupport);
+                // TLS 1.1 can work on Windows 7 but it is disabled by default.
+                if (IsWindows7)
+                {
+                    return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls11, defaultProtocolSupport: false, disabledByDefault: true);
+                }
+
+                // It is enabled on other versions unless explicitly disabled.
+                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls11, defaultProtocolSupport: true);
             }
+            // on macOS and Android TLS 1.1 is supported.
             else if (IsOSXLike || IsAndroid)
             {
                 return true;
@@ -446,9 +458,19 @@ namespace System
 
         private static bool GetTls12Support()
         {
-            // TLS 1.1 and 1.2 can work on Windows7 but it is not enabled by default.
-            bool defaultProtocolSupport =  !IsWindows7;
-            return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls12, defaultProtocolSupport);
+            if (IsWindows)
+            {
+                // TLS 1.2 can work on Windows 7 but it is disabled by default.
+                if (IsWindows7)
+                {
+                    return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls12, defaultProtocolSupport: false, disabledByDefault: true);
+                }
+
+                // It is enabled on other versions unless explicitly disabled.
+                return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls12, defaultProtocolSupport: true);
+            }
+
+            return true;
         }
 
         private static bool GetTls13Support()

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
@@ -27,7 +27,7 @@ namespace System.Net.Security.Tests
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "X509 certificate store is not supported on iOS or tvOS.")] // Match SslStream_StreamToStream_Authentication_Success
         public void EventSource_EventsRaisedAsExpected()
         {
-            RemoteExecutor.Invoke(async () =>
+          RemoteExecutor.Invoke(async () =>
             {
                 try
                 {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.DotNet.XUnitExtensions;
@@ -25,27 +24,27 @@ namespace System.Net.Security.Tests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "X509 certificate store is not supported on iOS or tvOS.")] // Match SslStream_StreamToStream_Authentication_Success
         public void EventSource_EventsRaisedAsExpected()
         {
-            if (PlatformDetection.IsWindows10Version22000OrGreater)
+            RemoteExecutor.Invoke(async () =>
             {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/58927")]
-                throw new SkipTestException("Unstable on Windows 11");
-            }
-
-            RemoteExecutor.Invoke(() =>
-            {
-                using (var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.Security", EventLevel.Verbose))
+                try
                 {
+                    using var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.Security", EventLevel.Verbose);
                     var events = new ConcurrentQueue<EventWrittenEventArgs>();
-                    listener.RunWithCallback(events.Enqueue, () =>
+                    await listener.RunWithCallbackAsync(events.Enqueue, async () =>
                     {
                         // Invoke tests that'll cause some events to be generated
                         var test = new SslStreamStreamToStreamTest_Async();
-                        test.SslStream_StreamToStream_Authentication_Success().GetAwaiter().GetResult();
+                        await test.SslStream_StreamToStream_Authentication_Success();
                     });
                     Assert.DoesNotContain(events, ev => ev.EventId == 0); // errors from the EventSource itself
                     Assert.InRange(events.Count, 1, int.MaxValue);
+                }
+                catch (SkipTestException)
+                {
+                    // Don't throw inside RemoteExecutor if SslStream_StreamToStream_Authentication_Success chose to skip the test
                 }
             }).Dispose();
         }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
@@ -96,7 +96,10 @@ namespace System.Net.Security.Tests
                     else
                     {
                         var ae = await Assert.ThrowsAsync<AuthenticationException>(() => sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false));
-                        Assert.IsType<PlatformNotSupportedException>(ae.InnerException);
+                        if (!OperatingSystem.IsWindows())
+                        {
+                            Assert.IsType<PlatformNotSupportedException>(ae.InnerException);
+                        }
                     }
                 }
             }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -72,7 +72,6 @@ namespace System.Net.Security.Tests
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "X509 certificate store is not supported on iOS or tvOS.")]
         public async Task SslStream_StreamToStream_Authentication_Success(X509Certificate serverCert = null, X509Certificate clientCert = null)
         {
-
             if (PlatformDetection.IsWindows10Version20348OrGreater)
             {
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/58927")]

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -38,7 +38,21 @@ namespace System.Net.Security.Tests
             // On Windows, null ciphers (no encryption) are supported.
             if (OperatingSystem.IsWindows())
             {
-                return true;
+                if (!PlatformDetection.IsWindows10OrLater)
+                {
+                    // All old versions support null encryption
+                    return true;
+                }
+
+                try
+                {
+                    // New Windows can support null but it may be disabled in Azure images
+                    using (Process p = Process.Start(new ProcessStartInfo("powershell", "-Command Get-TlsCipherSuite") { RedirectStandardOutput = true, RedirectStandardError = true }))
+                    {
+                        return p.StandardOutput.ReadToEnd().Contains("WITH_NULL");
+                    }
+                }
+                catch { return true; }  // assume availability
             }
 
             // On macOS and Android, the null cipher (no encryption) is not supported.


### PR DESCRIPTION
Backports #67935, #68083, #65322, #65105, #65120

Fixes #67946

# Description

Backport several test-only changes to fix frequent test failures on CI pipelines.
It was caused (intentionally) by Helix update (https://github.com/dotnet/core-eng/issues/15858)-- which re-enabled older TLS versions on all OS versions (so that we can get better test coverage - once we got exception from security folks). However, Win7 and Server 2022 **currently** don't support the full range of all TLS versions and we need to react accordingly in what the tests expect on these platforms.
Note: There will be likely follow up Helix changes removing further restrictions on Win7 and/or Server 2022. Those will need as well reactions from us when it happens.

# Customer Impact

None, Test only change.

# Regression

Yes, introduced by recent Helix changes -- see above.

# Testing

See CI report for this PR

# Risk

Very low, Test only change.
