### PR TITLE
Fix warnings in System.Private.Xml due to two PRs that raced

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/ApplyImportsAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/ApplyImportsAction.cs
@@ -8,7 +8,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml;
     using System.Xml.XPath;
 
-    internal class ApplyImportsAction : CompiledAction
+    internal sealed class ApplyImportsAction : CompiledAction
     {
         private XmlQualifiedName? _mode;
         private Stylesheet? _stylesheet;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/ApplyTemplatesAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/ApplyTemplatesAction.cs
@@ -9,7 +9,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml;
     using System.Xml.XPath;
 
-    internal class ApplyTemplatesAction : ContainerAction
+    internal sealed class ApplyTemplatesAction : ContainerAction
     {
         private const int ProcessedChildren = 2;
         private const int ProcessNextNode = 3;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/AttributeAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/AttributeAction.cs
@@ -8,7 +8,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml;
     using System.Xml.XPath;
 
-    internal class AttributeAction : ContainerAction
+    internal sealed class AttributeAction : ContainerAction
     {
         private const int NameDone = 2;
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/AttributeSetAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/AttributeSetAction.cs
@@ -9,7 +9,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml.XPath;
     using System.Collections;
 
-    internal class AttributeSetAction : ContainerAction
+    internal sealed class AttributeSetAction : ContainerAction
     {
         internal XmlQualifiedName? name;
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/BeginEvent.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/BeginEvent.cs
@@ -8,7 +8,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml;
     using System.Xml.XPath;
 
-    internal class BeginEvent : Event
+    internal sealed class BeginEvent : Event
     {
         private readonly XPathNodeType _nodeType;
         private string _namespaceUri;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/CallTemplateAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/CallTemplateAction.cs
@@ -8,7 +8,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml;
     using System.Xml.XPath;
 
-    internal class CallTemplateAction : ContainerAction
+    internal sealed class CallTemplateAction : ContainerAction
     {
         private const int ProcessedChildren = 2;
         private const int ProcessedTemplate = 3;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/CommentAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/CommentAction.cs
@@ -8,7 +8,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml;
     using System.Xml.XPath;
 
-    internal class CommentAction : ContainerAction
+    internal sealed class CommentAction : ContainerAction
     {
         internal override void Compile(Compiler compiler)
         {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/Compiler.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/Compiler.cs
@@ -46,7 +46,7 @@ namespace System.Xml.Xsl.XsltOld
         CSharp
     }
 
-    internal class Compiler
+    internal sealed class Compiler
     {
         internal const int InvalidQueryKey = -1;
 
@@ -157,8 +157,6 @@ namespace System.Xml.Xsl.XsltOld
         {
             get { return _queryStore; }
         }
-
-        public virtual IXsltDebugger? Debugger { get { return null; } }
 
         internal string GetUnicRtfId()
         {
@@ -301,12 +299,7 @@ namespace System.Xml.Xsl.XsltOld
             }
         }
 
-        protected InputScopeManager ScopeManager
-        {
-            get { return _scopeManager; }
-        }
-
-        internal virtual void PopScope()
+        internal void PopScope()
         {
             _scopeManager.PopScope();
         }
@@ -963,167 +956,167 @@ namespace System.Xml.Xsl.XsltOld
         // Compiler is a class factory for some actions:
         // CompilerDbg override all this methods:
 
-        public virtual ApplyImportsAction CreateApplyImportsAction()
+        public ApplyImportsAction CreateApplyImportsAction()
         {
             ApplyImportsAction action = new ApplyImportsAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual ApplyTemplatesAction CreateApplyTemplatesAction()
+        public ApplyTemplatesAction CreateApplyTemplatesAction()
         {
             ApplyTemplatesAction action = new ApplyTemplatesAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual AttributeAction CreateAttributeAction()
+        public AttributeAction CreateAttributeAction()
         {
             AttributeAction action = new AttributeAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual AttributeSetAction CreateAttributeSetAction()
+        public AttributeSetAction CreateAttributeSetAction()
         {
             AttributeSetAction action = new AttributeSetAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual CallTemplateAction CreateCallTemplateAction()
+        public CallTemplateAction CreateCallTemplateAction()
         {
             CallTemplateAction action = new CallTemplateAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual ChooseAction CreateChooseAction()
+        public ChooseAction CreateChooseAction()
         {//!!! don't need to be here
             ChooseAction action = new ChooseAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual CommentAction CreateCommentAction()
+        public CommentAction CreateCommentAction()
         {
             CommentAction action = new CommentAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual CopyAction CreateCopyAction()
+        public CopyAction CreateCopyAction()
         {
             CopyAction action = new CopyAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual CopyOfAction CreateCopyOfAction()
+        public CopyOfAction CreateCopyOfAction()
         {
             CopyOfAction action = new CopyOfAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual ElementAction CreateElementAction()
+        public ElementAction CreateElementAction()
         {
             ElementAction action = new ElementAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual ForEachAction CreateForEachAction()
+        public ForEachAction CreateForEachAction()
         {
             ForEachAction action = new ForEachAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual IfAction CreateIfAction(IfAction.ConditionType type)
+        public IfAction CreateIfAction(IfAction.ConditionType type)
         {
             IfAction action = new IfAction(type);
             action.Compile(this);
             return action;
         }
 
-        public virtual MessageAction CreateMessageAction()
+        public MessageAction CreateMessageAction()
         {
             MessageAction action = new MessageAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual NewInstructionAction CreateNewInstructionAction()
+        public NewInstructionAction CreateNewInstructionAction()
         {
             NewInstructionAction action = new NewInstructionAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual NumberAction CreateNumberAction()
+        public NumberAction CreateNumberAction()
         {
             NumberAction action = new NumberAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual ProcessingInstructionAction CreateProcessingInstructionAction()
+        public ProcessingInstructionAction CreateProcessingInstructionAction()
         {
             ProcessingInstructionAction action = new ProcessingInstructionAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual void CreateRootAction()
+        public void CreateRootAction()
         {
             this.RootAction = new RootAction();
             this.RootAction.Compile(this);
         }
 
-        public virtual SortAction CreateSortAction()
+        public SortAction CreateSortAction()
         {
             SortAction action = new SortAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual TemplateAction CreateTemplateAction()
+        public TemplateAction CreateTemplateAction()
         {
             TemplateAction action = new TemplateAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual TemplateAction CreateSingleTemplateAction()
+        public TemplateAction CreateSingleTemplateAction()
         {
             TemplateAction action = new TemplateAction();
             action.CompileSingle(this);
             return action;
         }
 
-        public virtual TextAction CreateTextAction()
+        public TextAction CreateTextAction()
         {
             TextAction action = new TextAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual UseAttributeSetsAction CreateUseAttributeSetsAction()
+        public UseAttributeSetsAction CreateUseAttributeSetsAction()
         {
             UseAttributeSetsAction action = new UseAttributeSetsAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual ValueOfAction CreateValueOfAction()
+        public ValueOfAction CreateValueOfAction()
         {
             ValueOfAction action = new ValueOfAction();
             action.Compile(this);
             return action;
         }
 
-        public virtual VariableAction? CreateVariableAction(VariableType type)
+        public VariableAction? CreateVariableAction(VariableType type)
         {
             VariableAction action = new VariableAction(type);
             action.Compile(this);
@@ -1137,7 +1130,7 @@ namespace System.Xml.Xsl.XsltOld
             }
         }
 
-        public virtual WithParamAction CreateWithParamAction()
+        public WithParamAction CreateWithParamAction()
         {
             WithParamAction action = new WithParamAction();
             action.Compile(this);
@@ -1147,12 +1140,12 @@ namespace System.Xml.Xsl.XsltOld
         // Compiler is a class factory for some events:
         // CompilerDbg override all this methods:
 
-        public virtual BeginEvent CreateBeginEvent()
+        public BeginEvent CreateBeginEvent()
         {
             return new BeginEvent(this);
         }
 
-        public virtual TextEvent CreateTextEvent()
+        public TextEvent CreateTextEvent()
         {
             return new TextEvent(this);
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/CopyAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/CopyAction.cs
@@ -9,7 +9,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml.XPath;
     using MS.Internal.Xml.XPath;
 
-    internal class CopyAction : ContainerAction
+    internal sealed class CopyAction : ContainerAction
     {
         // Local execution states
         private const int NamespaceCopy = 5;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/CopyOfAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/CopyOfAction.cs
@@ -9,7 +9,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml.XPath;
     using MS.Internal.Xml.XPath;
 
-    internal class CopyOfAction : CompiledAction
+    internal sealed class CopyOfAction : CompiledAction
     {
         private const int ResultStored = 2;
         private const int NodeSetCopied = 3;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/ElementAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/ElementAction.cs
@@ -8,7 +8,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml;
     using System.Xml.XPath;
 
-    internal class ElementAction : ContainerAction
+    internal sealed class ElementAction : ContainerAction
     {
         private const int NameDone = 2;
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/ForEachAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/ForEachAction.cs
@@ -9,7 +9,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml;
     using System.Xml.XPath;
 
-    internal class ForEachAction : ContainerAction
+    internal sealed class ForEachAction : ContainerAction
     {
         private const int ProcessedSort = 2;
         private const int ProcessNextNode = 3;
@@ -100,7 +100,7 @@ namespace System.Xml.Xsl.XsltOld
             }
         }
 
-        protected void CompileSortElements(Compiler compiler)
+        private void CompileSortElements(Compiler compiler)
         {
             NavigatorInput input = compiler.Input;
             do

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/IfAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/IfAction.cs
@@ -8,7 +8,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml;
     using System.Xml.XPath;
 
-    internal class IfAction : ContainerAction
+    internal sealed class IfAction : ContainerAction
     {
         internal enum ConditionType
         {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/MessageAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/MessageAction.cs
@@ -10,7 +10,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml;
     using System.Xml.XPath;
 
-    internal class MessageAction : ContainerAction
+    internal sealed class MessageAction : ContainerAction
     {
         private bool _Terminate;
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/NumberAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/NumberAction.cs
@@ -12,7 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace System.Xml.Xsl.XsltOld
 {
-    internal class NumberAction : ContainerAction
+    internal sealed class NumberAction : ContainerAction
     {
         internal sealed class FormatInfo
         {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/ProcessingInstructionAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/ProcessingInstructionAction.cs
@@ -7,7 +7,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml;
     using System.Xml.XPath;
 
-    internal class ProcessingInstructionAction : ContainerAction
+    internal sealed class ProcessingInstructionAction : ContainerAction
     {
         private const int NameReady = 3;
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/RootAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/RootAction.cs
@@ -78,7 +78,7 @@ namespace System.Xml.Xsl.XsltOld
         public Hashtable KeyTable { get { return _keyTable; } }
     }
 
-    internal class RootAction : TemplateBaseAction
+    internal sealed class RootAction : TemplateBaseAction
     {
         private const int QueryInitialized = 2;
         private const int RootProcessed = 3;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/SortAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/SortAction.cs
@@ -9,7 +9,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml;
     using System.Xml.XPath;
 
-    internal class SortAction : CompiledAction
+    internal sealed class SortAction : CompiledAction
     {
         private int _selectKey = Compiler.InvalidQueryKey;
         private Avt? _langAvt;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/TemplateAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/TemplateAction.cs
@@ -11,7 +11,7 @@ namespace System.Xml.Xsl.XsltOld
     using MS.Internal.Xml.XPath;
     using System.Globalization;
 
-    internal class TemplateAction : TemplateBaseAction
+    internal sealed class TemplateAction : TemplateBaseAction
     {
         private int _matchKey = Compiler.InvalidQueryKey;
         private XmlQualifiedName? _name;
@@ -78,7 +78,7 @@ namespace System.Xml.Xsl.XsltOld
             AnalyzePriority(compiler);
         }
 
-        internal virtual void CompileSingle(Compiler compiler)
+        internal void CompileSingle(Compiler compiler)
         {
             _matchKey = compiler.AddQuery("/", /*allowVars:*/false, /*allowKey:*/true, /*pattern*/true);
             _priority = Compiler.RootPriority;
@@ -159,7 +159,7 @@ namespace System.Xml.Xsl.XsltOld
             _priority = query.XsltDefaultPriority;
         }
 
-        protected void CompileParameters(Compiler compiler)
+        private void CompileParameters(Compiler compiler)
         {
             NavigatorInput input = compiler.Input;
             do

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/TextAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/TextAction.cs
@@ -8,7 +8,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml;
     using System.Xml.XPath;
 
-    internal class TextAction : CompiledAction
+    internal sealed class TextAction : CompiledAction
     {
         private bool _disableOutputEscaping;
         private string? _text;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/UseAttributeSetsAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/UseAttributeSetsAction.cs
@@ -9,7 +9,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml.XPath;
     using System.Collections;
 
-    internal class UseAttributeSetsAction : CompiledAction
+    internal sealed class UseAttributeSetsAction : CompiledAction
     {
         private XmlQualifiedName[]? _useAttributeSets;
         private string? _useString;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/ValueOfAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/ValueOfAction.cs
@@ -8,7 +8,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml;
     using System.Xml.XPath;
 
-    internal class ValueOfAction : CompiledAction
+    internal sealed class ValueOfAction : CompiledAction
     {
         private const int ResultStored = 2;
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/WithParamAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/WithParamAction.cs
@@ -9,7 +9,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml;
     using System.Xml.XPath;
 
-    internal class WithParamAction : VariableAction
+    internal sealed class WithParamAction : VariableAction
     {
         internal WithParamAction() : base(VariableType.WithParameter) { }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/newinstructionaction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/newinstructionaction.cs
@@ -8,7 +8,7 @@ namespace System.Xml.Xsl.XsltOld
     using System.Xml;
     using System.Xml.XPath;
 
-    internal class NewInstructionAction : ContainerAction
+    internal sealed class NewInstructionAction : ContainerAction
     {
         private string? _name;
         private string? _parent;


### PR DESCRIPTION
One PR enabled new analyzers, another deleted dead code which resulted in additional opportunities for those analyzers to warn.

cc: @danmoseley, @krwq 