### PR TITLE
Allow sharing of input tar file for read

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarFile.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarFile.cs
@@ -175,7 +175,7 @@ namespace System.Formats.Tar
                 Access = FileAccess.Read,
                 BufferSize = 0x1000,
                 Mode = FileMode.Open,
-                Share = FileShare.None
+                Share = FileShare.Read
             };
 
             using FileStream archive = File.Open(sourceFileName, fileStreamOptions);


### PR DESCRIPTION
I assume this was a typo. It might deserve its own test: the linked issue was a race.

Fix https://github.com/dotnet/runtime/issues/68357