### PR TITLE
Reduce pressure on backtracking stack in RegexCompiler / source generator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -2719,20 +2719,6 @@ namespace System.Text.RegularExpressions
         /// <summary>Gets whether the node is a Notone/Notoneloop/Notoneloopatomic/Notonelazy node.</summary>
         public bool IsNotoneFamily => Kind is RegexNodeKind.Notone or RegexNodeKind.Notoneloop or RegexNodeKind.Notoneloopatomic or RegexNodeKind.Notonelazy;
 
-        /// <summary>Gets whether this node is contained inside of a loop.</summary>
-        public bool IsInLoop()
-        {
-            for (RegexNode? parent = Parent; parent is not null; parent = parent.Parent)
-            {
-                if (parent.Kind is RegexNodeKind.Loop or RegexNodeKind.Lazyloop)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
 #if DEBUG
         [ExcludeFromCodeCoverage]
         public override string ToString()

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTreeAnalyzer.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTreeAnalyzer.cs
@@ -13,10 +13,10 @@ namespace System.Text.RegularExpressions
         public static AnalysisResults Analyze(RegexTree regexTree)
         {
             var results = new AnalysisResults(regexTree);
-            results._complete = TryAnalyze(regexTree.Root, results, isAtomicByAncestor: true);
+            results._complete = TryAnalyze(regexTree.Root, results, isAtomicByAncestor: true, isInLoop: false);
             return results;
 
-            static bool TryAnalyze(RegexNode node, AnalysisResults results, bool isAtomicByAncestor)
+            static bool TryAnalyze(RegexNode node, AnalysisResults results, bool isAtomicByAncestor, bool isInLoop)
             {
                 if (!StackHelper.TryEnsureSufficientExecutionStack())
                 {
@@ -26,6 +26,12 @@ namespace System.Text.RegularExpressions
                 // Track whether we've seen any nodes with various options set.
                 results._hasIgnoreCase |= (node.Options & RegexOptions.IgnoreCase) != 0;
                 results._hasRightToLeft |= (node.Options & RegexOptions.RightToLeft) != 0;
+
+                // Track whether this node is inside of a loop.
+                if (isInLoop)
+                {
+                    (results._inLoops ??= new HashSet<RegexNode>()).Add(node);
+                }
 
                 if (isAtomicByAncestor)
                 {
@@ -63,6 +69,12 @@ namespace System.Text.RegularExpressions
                     // Track any nodes that are themselves captures.
                     case RegexNodeKind.Capture:
                         results._containsCapture.Add(node);
+                        break;
+
+                    // Track whether we've recurred into a loop
+                    case RegexNodeKind.Loop:
+                    case RegexNodeKind.Lazyloop:
+                        isInLoop = true;
                         break;
                 }
 
@@ -103,7 +115,7 @@ namespace System.Text.RegularExpressions
                     };
 
                     // Now analyze the child.
-                    if (!TryAnalyze(child, results, treatChildAsAtomic))
+                    if (!TryAnalyze(child, results, treatChildAsAtomic, isInLoop))
                     {
                         return false;
                     }
@@ -148,6 +160,8 @@ namespace System.Text.RegularExpressions
         internal readonly HashSet<RegexNode> _containsCapture = new(); // the root is a capture, so this will always contain at least the root node
         /// <summary>Set of nodes that directly or indirectly contain backtracking constructs that aren't hidden internaly by atomic constructs.</summary>
         internal HashSet<RegexNode>? _mayBacktrack;
+        /// <summary>Set of nodes contained inside loops.</summary>
+        internal HashSet<RegexNode>? _inLoops;
         /// <summary>Whether any node has <see cref="RegexOptions.IgnoreCase"/> set.</summary>
         internal bool _hasIgnoreCase;
         /// <summary>Whether any node has <see cref="RegexOptions.RightToLeft"/> set.</summary>
@@ -188,6 +202,26 @@ namespace System.Text.RegularExpressions
         /// this returns true.
         /// </remarks>
         public bool MayBacktrack(RegexNode node) => !_complete || (_mayBacktrack?.Contains(node) ?? false);
+
+        /// <summary>Gets whether a node may be contained inside of one or more loops.</summary>
+        /// <remarks>
+        /// Constructs sometimes need to maintain state about their execution such that if they're backtracked
+        /// to, they have the necessary context to make a different choice and continue execution.  Such state
+        /// can often be maintained in locals dedicated to that construct.  If, however, the construct is inside
+        /// of a loop, an additional iteration of that outerloop could invoke the inner construct and cause those
+        /// locals to have their state overwritten.  In such situations, the constructs can't rely on the locals
+        /// maintaining the state and instead need to push the state on to a stack.  That pushing/popping has
+        /// additional cost, however, both in terms of run-time overheads and in terms of the additional code
+        /// required to handle it.  Code generators then can consult this <see cref="IsInLoop"/> to determine
+        /// whether locals are sufficient to maintain the state or whether the state needs to be pushed on to a stack.
+        ///
+        /// Loops are not considered to be "in" themselves.  This will only return true for a loop node if it's
+        /// nested inside of another loop node.
+        ///
+        /// If the whole tree couldn't be examined, this returns true.  That could lead to additional
+        /// backtracking-related code being emitted, but it's functionally the safe choice.
+        /// </remarks>
+        public bool IsInLoop(RegexNode node) => !_complete || (_inLoops?.Contains(node) ?? false);
 
         /// <summary>Gets whether a node might have <see cref="RegexOptions.IgnoreCase"/> set.</summary>
         /// <remarks>

--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexTreeAnalyzerTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexTreeAnalyzerTests.cs
@@ -14,8 +14,8 @@ namespace System.Text.RegularExpressions.Tests
         {
             (RegexTree tree, AnalysisResults analysis) = Analyze("abc");
 
-            RegexNode rootCapture = AssertNode(analysis, tree.Root, RegexNodeKind.Capture, atomicByAncestor: true, backtracks: false, captures: true);
-            RegexNode abc = AssertNode(analysis, rootCapture.Child(0), RegexNodeKind.Multi, atomicByAncestor: true, backtracks: false, captures: false);
+            RegexNode rootCapture = AssertNode(analysis, tree.Root, RegexNodeKind.Capture, atomicByAncestor: true, backtracks: false, captures: true, inLoop: false);
+            RegexNode abc = AssertNode(analysis, rootCapture.Child(0), RegexNodeKind.Multi, atomicByAncestor: true, backtracks: false, captures: false, inLoop: false);
         }
 
         [Fact]
@@ -23,21 +23,21 @@ namespace System.Text.RegularExpressions.Tests
         {
             (RegexTree tree, AnalysisResults analysis) = Analyze("abc|d(e)f|(ghi)");
 
-            RegexNode rootCapture = AssertNode(analysis, tree.Root, RegexNodeKind.Capture, atomicByAncestor: true, backtracks: false, captures: true);
-            RegexNode implicitAtomic = AssertNode(analysis, rootCapture.Child(0), RegexNodeKind.Atomic, atomicByAncestor: true, backtracks: false, captures: true);
-            RegexNode alternation = AssertNode(analysis, implicitAtomic.Child(0), RegexNodeKind.Alternate, atomicByAncestor: true, backtracks: false, captures: true);
+            RegexNode rootCapture = AssertNode(analysis, tree.Root, RegexNodeKind.Capture, atomicByAncestor: true, backtracks: false, captures: true, inLoop: false);
+            RegexNode implicitAtomic = AssertNode(analysis, rootCapture.Child(0), RegexNodeKind.Atomic, atomicByAncestor: true, backtracks: false, captures: true, inLoop: false);
+            RegexNode alternation = AssertNode(analysis, implicitAtomic.Child(0), RegexNodeKind.Alternate, atomicByAncestor: true, backtracks: false, captures: true, inLoop: false);
 
-            RegexNode abc = AssertNode(analysis, alternation.Child(0), RegexNodeKind.Multi, atomicByAncestor: true, backtracks: false, captures: false);
-            RegexNode def = AssertNode(analysis, alternation.Child(1), RegexNodeKind.Concatenate, atomicByAncestor: true, backtracks: false, captures: true);
-            RegexNode ghiCapture = AssertNode(analysis, alternation.Child(2), RegexNodeKind.Capture, atomicByAncestor: true, backtracks: false, captures: true);
+            RegexNode abc = AssertNode(analysis, alternation.Child(0), RegexNodeKind.Multi, atomicByAncestor: true, backtracks: false, captures: false, inLoop: false);
+            RegexNode def = AssertNode(analysis, alternation.Child(1), RegexNodeKind.Concatenate, atomicByAncestor: true, backtracks: false, captures: true, inLoop: false);
+            RegexNode ghiCapture = AssertNode(analysis, alternation.Child(2), RegexNodeKind.Capture, atomicByAncestor: true, backtracks: false, captures: true, inLoop: false);
 
-            RegexNode d = AssertNode(analysis, def.Child(0), RegexNodeKind.One, atomicByAncestor: false, backtracks: false, captures: false);
-            RegexNode eCapture = AssertNode(analysis, def.Child(1), RegexNodeKind.Capture, atomicByAncestor: false, backtracks: false, captures: true);
-            RegexNode f = AssertNode(analysis, def.Child(2), RegexNodeKind.One, atomicByAncestor: true, backtracks: false, captures: false);
+            RegexNode d = AssertNode(analysis, def.Child(0), RegexNodeKind.One, atomicByAncestor: false, backtracks: false, captures: false, inLoop: false);
+            RegexNode eCapture = AssertNode(analysis, def.Child(1), RegexNodeKind.Capture, atomicByAncestor: false, backtracks: false, captures: true, inLoop: false);
+            RegexNode f = AssertNode(analysis, def.Child(2), RegexNodeKind.One, atomicByAncestor: true, backtracks: false, captures: false, inLoop: false);
 
-            RegexNode e = AssertNode(analysis, eCapture.Child(0), RegexNodeKind.One, atomicByAncestor: false, backtracks: false, captures: false);
+            RegexNode e = AssertNode(analysis, eCapture.Child(0), RegexNodeKind.One, atomicByAncestor: false, backtracks: false, captures: false, inLoop: false);
 
-            RegexNode ghi = AssertNode(analysis, ghiCapture.Child(0), RegexNodeKind.Multi, atomicByAncestor: true, backtracks: false, captures: false);
+            RegexNode ghi = AssertNode(analysis, ghiCapture.Child(0), RegexNodeKind.Multi, atomicByAncestor: true, backtracks: false, captures: false, inLoop: false);
         }
 
         [Fact]
@@ -45,15 +45,15 @@ namespace System.Text.RegularExpressions.Tests
         {
             (RegexTree tree, AnalysisResults analysis) = Analyze("a*(b*)c*");
 
-            RegexNode rootCapture = AssertNode(analysis, tree.Root, RegexNodeKind.Capture, atomicByAncestor: true, backtracks: false, captures: true);
-            RegexNode concat = AssertNode(analysis, rootCapture.Child(0), RegexNodeKind.Concatenate, atomicByAncestor: true, backtracks: false, captures: true);
+            RegexNode rootCapture = AssertNode(analysis, tree.Root, RegexNodeKind.Capture, atomicByAncestor: true, backtracks: false, captures: true, inLoop: false);
+            RegexNode concat = AssertNode(analysis, rootCapture.Child(0), RegexNodeKind.Concatenate, atomicByAncestor: true, backtracks: false, captures: true, inLoop: false);
 
-            RegexNode aStar = AssertNode(analysis, concat.Child(0), RegexNodeKind.Oneloopatomic, atomicByAncestor: false, backtracks: false, captures: false);
-            RegexNode implicitBumpalong = AssertNode(analysis, concat.Child(1), RegexNodeKind.UpdateBumpalong, atomicByAncestor: false, backtracks: false, captures: false);
-            RegexNode bStarCapture = AssertNode(analysis, concat.Child(2), RegexNodeKind.Capture, atomicByAncestor: false, backtracks: false, captures: true);
-            RegexNode cStar = AssertNode(analysis, concat.Child(3), RegexNodeKind.Oneloopatomic, atomicByAncestor: true, backtracks: false, captures: false);
+            RegexNode aStar = AssertNode(analysis, concat.Child(0), RegexNodeKind.Oneloopatomic, atomicByAncestor: false, backtracks: false, captures: false, inLoop: false);
+            RegexNode implicitBumpalong = AssertNode(analysis, concat.Child(1), RegexNodeKind.UpdateBumpalong, atomicByAncestor: false, backtracks: false, captures: false, inLoop: false);
+            RegexNode bStarCapture = AssertNode(analysis, concat.Child(2), RegexNodeKind.Capture, atomicByAncestor: false, backtracks: false, captures: true, inLoop: false);
+            RegexNode cStar = AssertNode(analysis, concat.Child(3), RegexNodeKind.Oneloopatomic, atomicByAncestor: true, backtracks: false, captures: false, inLoop: false);
 
-            RegexNode bStar = AssertNode(analysis, bStarCapture.Child(0), RegexNodeKind.Oneloopatomic, atomicByAncestor: false, backtracks: false, captures: false);
+            RegexNode bStar = AssertNode(analysis, bStarCapture.Child(0), RegexNodeKind.Oneloopatomic, atomicByAncestor: false, backtracks: false, captures: false, inLoop: false);
         }
 
         [Fact]
@@ -61,18 +61,40 @@ namespace System.Text.RegularExpressions.Tests
         {
             (RegexTree tree, AnalysisResults analysis) = Analyze("[ab]*(?>[bc]*[cd])[ef]");
 
-            RegexNode rootCapture = AssertNode(analysis, tree.Root, RegexNodeKind.Capture, atomicByAncestor: true, backtracks: true, captures: true);
-            RegexNode rootConcat = AssertNode(analysis, rootCapture.Child(0), RegexNodeKind.Concatenate, atomicByAncestor: true, backtracks: true, captures: false);
+            RegexNode rootCapture = AssertNode(analysis, tree.Root, RegexNodeKind.Capture, atomicByAncestor: true, backtracks: true, captures: true, inLoop: false);
+            RegexNode rootConcat = AssertNode(analysis, rootCapture.Child(0), RegexNodeKind.Concatenate, atomicByAncestor: true, backtracks: true, captures: false, inLoop: false);
 
-            RegexNode abStar = AssertNode(analysis, rootConcat.Child(0), RegexNodeKind.Setloop, atomicByAncestor: false, backtracks: true, captures: false);
-            RegexNode implicitBumpalong = AssertNode(analysis, rootConcat.Child(1), RegexNodeKind.UpdateBumpalong, atomicByAncestor: false, backtracks: false, captures: false);
-            RegexNode atomic = AssertNode(analysis, rootConcat.Child(2), RegexNodeKind.Atomic, atomicByAncestor: false, backtracks: false, captures: false);
-            RegexNode ef = AssertNode(analysis, rootConcat.Child(3), RegexNodeKind.Set, atomicByAncestor: true, backtracks: false, captures: false);
+            RegexNode abStar = AssertNode(analysis, rootConcat.Child(0), RegexNodeKind.Setloop, atomicByAncestor: false, backtracks: true, captures: false, inLoop: false);
+            RegexNode implicitBumpalong = AssertNode(analysis, rootConcat.Child(1), RegexNodeKind.UpdateBumpalong, atomicByAncestor: false, backtracks: false, captures: false, inLoop: false);
+            RegexNode atomic = AssertNode(analysis, rootConcat.Child(2), RegexNodeKind.Atomic, atomicByAncestor: false, backtracks: false, captures: false, inLoop: false);
+            RegexNode ef = AssertNode(analysis, rootConcat.Child(3), RegexNodeKind.Set, atomicByAncestor: true, backtracks: false, captures: false, inLoop: false);
 
-            RegexNode atomicConcat = AssertNode(analysis, atomic.Child(0), RegexNodeKind.Concatenate, atomicByAncestor: true, backtracks: true, captures: false);
+            RegexNode atomicConcat = AssertNode(analysis, atomic.Child(0), RegexNodeKind.Concatenate, atomicByAncestor: true, backtracks: true, captures: false, inLoop: false);
 
-            RegexNode bcStar = AssertNode(analysis, atomicConcat.Child(0), RegexNodeKind.Setloop, atomicByAncestor: false, backtracks: true, captures: false);
-            RegexNode cd = AssertNode(analysis, atomicConcat.Child(1), RegexNodeKind.Set, atomicByAncestor: true, backtracks: false, captures: false);
+            RegexNode bcStar = AssertNode(analysis, atomicConcat.Child(0), RegexNodeKind.Setloop, atomicByAncestor: false, backtracks: true, captures: false, inLoop: false);
+            RegexNode cd = AssertNode(analysis, atomicConcat.Child(1), RegexNodeKind.Set, atomicByAncestor: true, backtracks: false, captures: false, inLoop: false);
+        }
+
+        [Fact]
+        public void LoopsAroundVariousConstructs()
+        {
+            (RegexTree tree, AnalysisResults analysis) = Analyze("(abc|def)*(?:[ab]*[cd])+?d");
+
+            RegexNode rootCapture = AssertNode(analysis, tree.Root, RegexNodeKind.Capture, atomicByAncestor: true, backtracks: true, captures: true, inLoop: false);
+            RegexNode rootConcat = AssertNode(analysis, rootCapture.Child(0), RegexNodeKind.Concatenate, atomicByAncestor: true, backtracks: true, captures: true, inLoop: false);
+
+            RegexNode loop = AssertNode(analysis, rootConcat.Child(0), RegexNodeKind.Loop, atomicByAncestor: false, backtracks: true, captures: true, inLoop: false);
+            RegexNode loopCapture = AssertNode(analysis, loop.Child(0), RegexNodeKind.Capture, atomicByAncestor: false, backtracks: true, captures: true, inLoop: true);
+            RegexNode alternation = AssertNode(analysis, loopCapture.Child(0), RegexNodeKind.Alternate, atomicByAncestor: false, backtracks: true, captures: false, inLoop: true);
+            RegexNode abc = AssertNode(analysis, alternation.Child(0), RegexNodeKind.Multi, atomicByAncestor: false, backtracks: false, captures: false, inLoop: true);
+            RegexNode def = AssertNode(analysis, alternation.Child(1), RegexNodeKind.Multi, atomicByAncestor: false, backtracks: false, captures: false, inLoop: true);
+
+            RegexNode lazyLoop = AssertNode(analysis, rootConcat.Child(1), RegexNodeKind.Lazyloop, atomicByAncestor: false, backtracks: true, captures: false, inLoop: false);
+            RegexNode lazyLoopConcat = AssertNode(analysis, lazyLoop.Child(0), RegexNodeKind.Concatenate, atomicByAncestor: false, backtracks: false, captures: false, inLoop: true);
+            RegexNode abStar = AssertNode(analysis, lazyLoopConcat.Child(0), RegexNodeKind.Setloopatomic, atomicByAncestor: false, backtracks: false, captures: false, inLoop: true);
+            RegexNode cd = AssertNode(analysis, lazyLoopConcat.Child(1), RegexNodeKind.Set, atomicByAncestor: false, backtracks: false, captures: false, inLoop: true);
+
+            RegexNode d = AssertNode(analysis, rootConcat.Child(2), RegexNodeKind.One, atomicByAncestor: true, backtracks: false, captures: false, inLoop: false);
         }
 
         private static (RegexTree Tree, AnalysisResults Analysis) Analyze(string pattern)
@@ -81,7 +103,7 @@ namespace System.Text.RegularExpressions.Tests
             return (tree, RegexTreeAnalyzer.Analyze(tree));
         }
 
-        private static RegexNode AssertNode(AnalysisResults analysis, RegexNode node, RegexNodeKind kind, bool atomicByAncestor, bool backtracks, bool captures)
+        private static RegexNode AssertNode(AnalysisResults analysis, RegexNode node, RegexNodeKind kind, bool atomicByAncestor, bool backtracks, bool captures, bool inLoop)
         {
             Assert.Equal(kind, node.Kind);
 
@@ -98,6 +120,11 @@ namespace System.Text.RegularExpressions.Tests
             if (captures != analysis.MayContainCapture(node))
             {
                 throw new XunitException($"Expected captures == {captures} for {node.Kind}, got {!captures}");
+            }
+
+            if (inLoop != analysis.IsInLoop(node))
+            {
+                throw new XunitException($"Expected inLoop == {inLoop} for {node.Kind}, got {!inLoop}");
             }
 
             return node;


### PR DESCRIPTION
Various regex operations require keeping some state that's required if backtracking occurs, e.g. an alternation needs to know what branch it last tried so it can try the next one when backtracking.  In RegexCompiler / source generator, most of the constructs are pushing this state onto the backtracking stack.  However, if the state is already being held in a local specific to that operation, we only need to push it onto the stack if the construct is part of a loop.  If it's part of a loop, subsequent iterations can overwrite the state in the local, and thus we need to be able to store the state per iteration, hence the stack.  But if it's not part of a loop, and those locals are dedicated to that construct, the values they contain won't change while processing subsequent parts of the expression, so nothing need to be pushed/popped onto the stack.

Also, for loops, we currently emit state tracking and additional checks to handle the possibility that the loop might match empty iterations.  But we can check whether that's even possible (it's not possible if the min required length of the child node is positive), and if it's not possible, avoid emitting that extra stuff.