### PR TITLE
[release/6.0] Prevent debugger deadlock with code versioning logic

### DIFF
--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -41,7 +41,7 @@
 #include "threadsuspend.h"
 
 
-//#ifdef DEBUGGING_SUPPORTED
+#ifdef DEBUGGING_SUPPORTED
 
 #ifdef _DEBUG
 // Reg key. We can set this and then any debugger-lazy-init code will assert.

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -41,7 +41,7 @@
 #include "threadsuspend.h"
 
 
-#ifdef DEBUGGING_SUPPORTED
+//#ifdef DEBUGGING_SUPPORTED
 
 #ifdef _DEBUG
 // Reg key. We can set this and then any debugger-lazy-init code will assert.
@@ -2719,7 +2719,6 @@ DebuggerJitInfo *Debugger::GetJitInfoWorker(MethodDesc *fd, const BYTE *pbAddr, 
     // This may take the lock and lazily create an entry, so we do it up front.
     dji = dmi->GetLatestJitInfo(fd);
 
-
     DebuggerDataLockHolder debuggerDataLockHolder(this);
 
     // Note the call to GetLatestJitInfo() will lazily create the first DJI if we don't already have one.
@@ -2730,6 +2729,7 @@ DebuggerJitInfo *Debugger::GetJitInfoWorker(MethodDesc *fd, const BYTE *pbAddr, 
             break;
         }
     }
+
     LOG((LF_CORDB, LL_INFO1000, "D::GJI: for md:0x%x (%s::%s), got dmi:0x%x.\n",
          fd, fd->m_pszDebugClassName, fd->m_pszDebugMethodName,
          dmi));
@@ -2757,7 +2757,9 @@ DebuggerJitInfo *Debugger::GetJitInfoWorker(MethodDesc *fd, const BYTE *pbAddr, 
             LOG((LF_CORDB,LL_INFO1000,"Couldn't find a DJI by address 0x%p, "
                 "so it might be a stub or thunk\n", pbAddr));
             TraceDestination trace;
-
+            // Nothing here needs the data lock anymore, and GetJitInfo will grab the lock as needed.
+            // However, tracing may go into code versioning paths and this lock can't be held for that.
+            debuggerDataLockHolder.Release();
             g_pEEInterface->TraceStub((const BYTE *)pbAddr, &trace);
 
             if ((trace.GetTraceType() == TRACE_MANAGED) && (pbAddr != (const BYTE *)trace.GetAddress()))
@@ -16507,7 +16509,7 @@ HRESULT DebuggerHeap::Init(BOOL fExecutable)
             return E_OUTOFMEMORY;
         }
     }
-#endif    
+#endif
 
 #endif // !DACCESS_COMPILE
 


### PR DESCRIPTION
This issue has been fixed on main, but a backport is more invasive than needed.

# Description

Various operations can result in deadlock (step in, step out, and some others) if the transitions happen to need to get to get the code versioning lock and there's a code load or a JIT happening in the background while the debugger is trying to complete a step. Each thread will lock for the other's execution operation to complete. 

# Customer Impact

Deadlocks while stepping or running under a debugger if any code versioning feature is enabled are possible - killing the process is the only solution and there's no feasible workaround for scenarios like debugger attach.

# Regression

It's a regression with respect to 3.1.

# Testing

Pending customer validation.

# Risk

Small - debugger only change. Auditing shows all callees grab the lock as needed. There are other bugs that remain around data correctness, but that change is more invasive. 

# Package authoring signed off?

N/A