### PR TITLE
Add retries to some FSW tests

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Security;
 using System.Security.Authentication;
@@ -21,6 +22,8 @@ namespace System
         // means that one exception anywhere means all tests using PlatformDetection fail. If you feel a value is worth latching,
         // do it in a way that failures don't cascade.
         //
+
+        public static readonly bool IsInHelix = Environment.GetEnvironmentVariables().Keys.Cast<string>().Where(key => key.StartsWith("HELIX")).Any();
 
         public static bool IsNetCore => Environment.Version.Major >= 5 || RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase);
         public static bool IsMonoRuntime => Type.GetType("Mono.RuntimeStructs") != null;

--- a/src/libraries/Common/tests/TestUtilities/System/RetryHelper.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/RetryHelper.cs
@@ -55,16 +55,15 @@ namespace System
                     }
                 }
 
-                string diagnostic = $"RetryHelper: retrying {testName} {i}th time of {maxAttempts}: got {lastException.Message}";
-                if (PlatformDetection.IsInHelix && testName.Contains("FileSystemWatcher_"))
+                if (PlatformDetection.IsInHelix)
                 {
                     // Dump into the console output so we can mine it
-                    Console.WriteLine(diagnostic);
+                    Console.WriteLine($"RetryHelper: retrying {testName} {i}th time of {maxAttempts}: got {lastException.Message}");
                 }
 
                 if (s_debug)
                 {
-                    Debug.WriteLine(diagnostic);
+                    Debug.WriteLine($"RetryHelper: retrying {testName} {i}th time of {maxAttempts}: got {lastException.Message}");
                 }
 
                 Thread.Sleep((backoffFunc ?? s_defaultBackoffFunc)(i));

--- a/src/libraries/Common/tests/TestUtilities/System/RetryHelper.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/RetryHelper.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,13 +13,14 @@ namespace System
     {
         private static readonly Func<int, int> s_defaultBackoffFunc = i => Math.Min(i * 100, 60_000);
         private static readonly Predicate<Exception> s_defaultRetryWhenFunc = _ => true;
+        private static readonly bool s_debug = Environment.GetEnvironmentVariable("DEBUG_RETRYHELPER") == "1";
 
         /// <summary>Executes the <paramref name="test"/> action up to a maximum of <paramref name="maxAttempts"/> times.</summary>
         /// <param name="maxAttempts">The maximum number of times to invoke <paramref name="test"/>.</param>
         /// <param name="test">The test to invoke.</param>
         /// <param name="backoffFunc">After a failure, invoked to determine how many milliseconds to wait before the next attempt.  It's passed the number of iterations attempted.</param>
         /// <param name="retryWhen">Invoked to select the exceptions to retry on. If not set, any exception will trigger a retry.</param>
-        public static void Execute(Action test, int maxAttempts = 5, Func<int, int> backoffFunc = null, Predicate<Exception> retryWhen = null)
+        public static void Execute(Action test, int maxAttempts = 5, Func<int, int> backoffFunc = null, Predicate<Exception> retryWhen = null, [CallerMemberName] string? testName = null)
         {
             // Validate arguments
             if (maxAttempts < 1)
@@ -35,6 +38,7 @@ namespace System
             var exceptions = new List<Exception>();
             for (int i = 1; i <= maxAttempts; i++)
             {
+                Exception lastException;
                 try
                 {
                     test();
@@ -42,11 +46,17 @@ namespace System
                 }
                 catch (Exception e) when (retryWhen(e))
                 {
+                    lastException = e;
                     exceptions.Add(e);
                     if (i == maxAttempts)
                     {
                         throw new AggregateException(exceptions);
                     }
+                }
+
+                if (s_debug)
+                {
+                    Debug.WriteLine($"RetryHelper: retrying {testName} {i}th time of {maxAttempts}: got {lastException.Message}");
                 }
 
                 Thread.Sleep((backoffFunc ?? s_defaultBackoffFunc)(i));
@@ -58,7 +68,7 @@ namespace System
         /// <param name="test">The test to invoke.</param>
         /// <param name="backoffFunc">After a failure, invoked to determine how many milliseconds to wait before the next attempt.  It's passed the number of iterations attempted.</param>
         /// <param name="retryWhen">Invoked to select the exceptions to retry on. If not set, any exception will trigger a retry.</param>
-        public static async Task ExecuteAsync(Func<Task> test, int maxAttempts = 5, Func<int, int> backoffFunc = null, Predicate<Exception> retryWhen = null)
+        public static async Task ExecuteAsync(Func<Task> test, int maxAttempts = 5, Func<int, int> backoffFunc = null, Predicate<Exception> retryWhen = null, [CallerMemberName] string? testName = null)
         {
             // Validate arguments
             if (maxAttempts < 1)

--- a/src/libraries/Common/tests/TestUtilities/System/RetryHelper.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/RetryHelper.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -54,9 +55,16 @@ namespace System
                     }
                 }
 
+                string diagnostic = $"RetryHelper: retrying {testName} {i}th time of {maxAttempts}: got {lastException.Message}";
+                if (PlatformDetection.IsInHelix && testName.Contains("FileSystemWatcher_"))
+                {
+                    // Dump into the console output so we can mine it
+                    Console.WriteLine(diagnostic);
+                }
+
                 if (s_debug)
                 {
-                    Debug.WriteLine($"RetryHelper: retrying {testName} {i}th time of {maxAttempts}: got {lastException.Message}");
+                    Debug.WriteLine(diagnostic);
                 }
 
                 Thread.Sleep((backoffFunc ?? s_defaultBackoffFunc)(i));

--- a/src/libraries/Common/tests/TestUtilities/System/RetryHelper.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/RetryHelper.cs
@@ -55,15 +55,11 @@ namespace System
                     }
                 }
 
-                if (PlatformDetection.IsInHelix)
-                {
-                    // Dump into the console output so we can mine it
-                    Console.WriteLine($"RetryHelper: retrying {testName} {i}th time of {maxAttempts}: got {lastException.Message}");
-                }
-
                 if (s_debug)
                 {
-                    Debug.WriteLine($"RetryHelper: retrying {testName} {i}th time of {maxAttempts}: got {lastException.Message}");
+                    string diagnostic = $"RetryHelper: retrying {testName} {i}th time of {maxAttempts}: got {lastException.Message}";
+                    Console.WriteLine(diagnostic);
+                    Debug.WriteLine(diagnostic);
                 }
 
                 Thread.Sleep((backoffFunc ?? s_defaultBackoffFunc)(i));

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Changed.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Changed.cs
@@ -12,7 +12,7 @@ namespace System.IO.Tests
         [Fact]
         public void FileSystemWatcher_Directory_Changed_LastWrite()
         {
-            RetryHelper.Execute(() =>
+            FileSystemWatcherTest.Execute(() =>
             {
                 using (var testDirectory = new TempDirectory(GetTestFilePath()))
                 using (var dir = new TempDirectory(Path.Combine(testDirectory.Path, "dir")))

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Changed.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Changed.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.InteropServices;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.IO.Tests
 {
@@ -11,15 +12,18 @@ namespace System.IO.Tests
         [Fact]
         public void FileSystemWatcher_Directory_Changed_LastWrite()
         {
-            using (var testDirectory = new TempDirectory(GetTestFilePath()))
-            using (var dir = new TempDirectory(Path.Combine(testDirectory.Path, "dir")))
-            using (var watcher = new FileSystemWatcher(testDirectory.Path, Path.GetFileName(dir.Path)))
+            RetryHelper.Execute(() =>
             {
-                Action action = () => Directory.SetLastWriteTime(dir.Path, DateTime.Now + TimeSpan.FromSeconds(10));
+                using (var testDirectory = new TempDirectory(GetTestFilePath()))
+                using (var dir = new TempDirectory(Path.Combine(testDirectory.Path, "dir")))
+                using (var watcher = new FileSystemWatcher(testDirectory.Path, Path.GetFileName(dir.Path)))
+                {
+                    Action action = () => Directory.SetLastWriteTime(dir.Path, DateTime.Now + TimeSpan.FromSeconds(10));
 
-                WatcherChangeTypes expected = WatcherChangeTypes.Changed;
-                ExpectEvent(watcher, expected, action, expectedPath: dir.Path);
-            }
+                    WatcherChangeTypes expected = WatcherChangeTypes.Changed;
+                    ExpectEvent(watcher, expected, action, expectedPath: dir.Path);
+                }
+            }, maxAttempts: DefaultAttemptsForExpectedEvent, backoffFunc: (iteration) => RetryDelayMilliseconds, retryWhen: e => e is XunitException);
         }
 
         [Fact]

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.NotifyFilter.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.NotifyFilter.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.IO.Tests
 {
@@ -21,27 +23,30 @@ namespace System.IO.Tests
         [MemberData(nameof(FilterTypes))]
         public void FileSystemWatcher_Directory_NotifyFilter_Attributes(NotifyFilters filter)
         {
-            using (var testDirectory = new TempDirectory(GetTestFilePath()))
-            using (var dir = new TempDirectory(Path.Combine(testDirectory.Path, "dir")))
-            using (var watcher = new FileSystemWatcher(testDirectory.Path, Path.GetFileName(dir.Path)))
+            RetryHelper.Execute(() =>
             {
-                watcher.NotifyFilter = filter;
-                var attributes = File.GetAttributes(dir.Path);
+                using (var testDirectory = new TempDirectory(GetTestFilePath()))
+                using (var dir = new TempDirectory(Path.Combine(testDirectory.Path, "dir")))
+                using (var watcher = new FileSystemWatcher(testDirectory.Path, Path.GetFileName(dir.Path)))
+                {
+                    watcher.NotifyFilter = filter;
+                    var attributes = File.GetAttributes(dir.Path);
 
-                Action action = () => File.SetAttributes(dir.Path, attributes | FileAttributes.ReadOnly);
-                Action cleanup = () => File.SetAttributes(dir.Path, attributes);
+                    Action action = () => File.SetAttributes(dir.Path, attributes | FileAttributes.ReadOnly);
+                    Action cleanup = () => File.SetAttributes(dir.Path, attributes);
 
-                WatcherChangeTypes expected = 0;
-                if (filter == NotifyFilters.Attributes)
-                    expected |= WatcherChangeTypes.Changed;
-                else if (OperatingSystem.IsLinux() && ((filter & LinuxFiltersForAttribute) > 0))
-                    expected |= WatcherChangeTypes.Changed;
-                else if (OperatingSystem.IsMacOS() && ((filter & OSXFiltersForModify) > 0))
-                    expected |= WatcherChangeTypes.Changed;
-                else if (OperatingSystem.IsMacOS() && ((filter & NotifyFilters.Security) > 0))
-                    expected |= WatcherChangeTypes.Changed; // Attribute change on OSX is a ChangeOwner operation which passes the Security NotifyFilter.
-                ExpectEvent(watcher, expected, action, cleanup, dir.Path);
-            }
+                    WatcherChangeTypes expected = 0;
+                    if (filter == NotifyFilters.Attributes)
+                        expected |= WatcherChangeTypes.Changed;
+                    else if (OperatingSystem.IsLinux() && ((filter & LinuxFiltersForAttribute) > 0))
+                        expected |= WatcherChangeTypes.Changed;
+                    else if (OperatingSystem.IsMacOS() && ((filter & OSXFiltersForModify) > 0))
+                        expected |= WatcherChangeTypes.Changed;
+                    else if (OperatingSystem.IsMacOS() && ((filter & NotifyFilters.Security) > 0))
+                        expected |= WatcherChangeTypes.Changed; // Attribute change on OSX is a ChangeOwner operation which passes the Security NotifyFilter.
+                    ExpectEvent(watcher, expected, action, cleanup, dir.Path);
+                }
+            }, maxAttempts: DefaultAttemptsForExpectedEvent, backoffFunc: (iteration) => RetryDelayMilliseconds, retryWhen: e => e is XunitException);
         }
 
         [Theory]

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.NotifyFilter.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.NotifyFilter.cs
@@ -23,7 +23,7 @@ namespace System.IO.Tests
         [MemberData(nameof(FilterTypes))]
         public void FileSystemWatcher_Directory_NotifyFilter_Attributes(NotifyFilters filter)
         {
-            RetryHelper.Execute(() =>
+            FileSystemWatcherTest.Execute(() =>
             {
                 using (var testDirectory = new TempDirectory(GetTestFilePath()))
                 using (var dir = new TempDirectory(Path.Combine(testDirectory.Path, "dir")))

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Create.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Create.cs
@@ -32,7 +32,7 @@ namespace System.IO.Tests
         [OuterLoop]
         public void FileSystemWatcher_File_Create_EnablingDisablingNotAffectRaisingEvent()
         {
-            RetryHelper.Execute(() =>
+            FileSystemWatcherTest.Execute(() =>
             {
                 using (var testDirectory = new TempDirectory(GetTestFilePath()))
                 using (var watcher = new FileSystemWatcher(testDirectory.Path))
@@ -146,7 +146,7 @@ namespace System.IO.Tests
         [Fact]
         public void FileSystemWatcher_File_Create_SynchronizingObject()
         {
-            RetryHelper.Execute(() =>
+            FileSystemWatcherTest.Execute(() =>
             {
                 using (var testDirectory = new TempDirectory(GetTestFilePath()))
                 using (var watcher = new FileSystemWatcher(testDirectory.Path))

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Create.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Create.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.IO.Tests
 {
@@ -30,7 +32,7 @@ namespace System.IO.Tests
         [OuterLoop]
         public void FileSystemWatcher_File_Create_EnablingDisablingNotAffectRaisingEvent()
         {
-            ExecuteWithRetry(() =>
+            RetryHelper.Execute(() =>
             {
                 using (var testDirectory = new TempDirectory(GetTestFilePath()))
                 using (var watcher = new FileSystemWatcher(testDirectory.Path))
@@ -62,7 +64,7 @@ namespace System.IO.Tests
                     Assert.False(autoResetEvent.WaitOne(SubsequentExpectedWait));
                     Assert.True(numberOfRaisedEvents == 1);
                 }
-            });
+            }, DefaultAttemptsForExpectedEvent, (iteration) => RetryDelayMilliseconds);
         }
 
         [Fact]
@@ -144,21 +146,24 @@ namespace System.IO.Tests
         [Fact]
         public void FileSystemWatcher_File_Create_SynchronizingObject()
         {
-            using (var testDirectory = new TempDirectory(GetTestFilePath()))
-            using (var watcher = new FileSystemWatcher(testDirectory.Path))
+            RetryHelper.Execute(() =>
             {
-                TestISynchronizeInvoke invoker = new TestISynchronizeInvoke();
-                watcher.SynchronizingObject = invoker;
+                using (var testDirectory = new TempDirectory(GetTestFilePath()))
+                using (var watcher = new FileSystemWatcher(testDirectory.Path))
+                {
+                    TestISynchronizeInvoke invoker = new TestISynchronizeInvoke();
+                    watcher.SynchronizingObject = invoker;
 
-                string fileName = Path.Combine(testDirectory.Path, "file");
-                watcher.Filter = Path.GetFileName(fileName);
+                    string fileName = Path.Combine(testDirectory.Path, "file");
+                    watcher.Filter = Path.GetFileName(fileName);
 
-                Action action = () => File.Create(fileName).Dispose();
-                Action cleanup = () => File.Delete(fileName);
+                    Action action = () => File.Create(fileName).Dispose();
+                    Action cleanup = () => File.Delete(fileName);
 
-                ExpectEvent(watcher, WatcherChangeTypes.Created, action, cleanup, fileName);
-                Assert.True(invoker.BeginInvoke_Called);
-            }
+                    ExpectEvent(watcher, WatcherChangeTypes.Created, action, cleanup, fileName);
+                    Assert.True(invoker.BeginInvoke_Called);
+                }
+            }, maxAttempts: DefaultAttemptsForExpectedEvent, backoffFunc: (iteration) => RetryDelayMilliseconds, retryWhen: e => e is XunitException);
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Delete.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Delete.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.IO.Tests
 {
@@ -91,19 +92,22 @@ namespace System.IO.Tests
         [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         public void FileSystemWatcher_File_Delete_SymLink()
         {
-            using (var testDirectory = new TempDirectory(GetTestFilePath()))
-            using (var dir = new TempDirectory(Path.Combine(testDirectory.Path, "dir")))
-            using (var temp = new TempFile(GetTestFilePath()))
-            using (var watcher = new FileSystemWatcher(dir.Path, "*"))
+            RetryHelper.Execute(() =>
             {
-                // Make the symlink in our path (to the temp file) and make sure an event is raised
-                string symLinkPath = Path.Combine(dir.Path, GetRandomLinkName());
-                Action action = () => File.Delete(symLinkPath);
-                Action cleanup = () => Assert.True(MountHelper.CreateSymbolicLink(symLinkPath, temp.Path, false));
-                cleanup();
+                using (var testDirectory = new TempDirectory(GetTestFilePath()))
+                using (var dir = new TempDirectory(Path.Combine(testDirectory.Path, "dir")))
+                using (var temp = new TempFile(GetTestFilePath()))
+                using (var watcher = new FileSystemWatcher(dir.Path, "*"))
+                {
+                    // Make the symlink in our path (to the temp file) and make sure an event is raised
+                    string symLinkPath = Path.Combine(dir.Path, GetRandomLinkName());
+                    Action action = () => File.Delete(symLinkPath);
+                    Action cleanup = () => Assert.True(MountHelper.CreateSymbolicLink(symLinkPath, temp.Path, false));
+                    cleanup();
 
-                ExpectEvent(watcher, WatcherChangeTypes.Deleted, action, cleanup, symLinkPath);
-            }
+                    ExpectEvent(watcher, WatcherChangeTypes.Deleted, action, cleanup, symLinkPath);
+                }
+            }, maxAttempts: DefaultAttemptsForExpectedEvent, backoffFunc: (iteration) => RetryDelayMilliseconds, retryWhen: e => e is XunitException);
         }
 
         [Fact]

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Delete.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Delete.cs
@@ -92,7 +92,7 @@ namespace System.IO.Tests
         [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         public void FileSystemWatcher_File_Delete_SymLink()
         {
-            RetryHelper.Execute(() =>
+            FileSystemWatcherTest.Execute(() =>
             {
                 using (var testDirectory = new TempDirectory(GetTestFilePath()))
                 using (var dir = new TempDirectory(Path.Combine(testDirectory.Path, "dir")))

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.NotifyFilter.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.NotifyFilter.cs
@@ -1,11 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.IO.Tests
 {
@@ -51,23 +53,26 @@ namespace System.IO.Tests
         [MemberData(nameof(FilterTypes))]
         public void FileSystemWatcher_File_NotifyFilter_CreationTime(NotifyFilters filter)
         {
-            using (var testDirectory = new TempDirectory(GetTestFilePath()))
-            using (var file = new TempFile(Path.Combine(testDirectory.Path, "file")))
-            using (var watcher = new FileSystemWatcher(testDirectory.Path, Path.GetFileName(file.Path)))
+            RetryHelper.Execute(() =>
             {
-                watcher.NotifyFilter = filter;
-                Action action = () => File.SetCreationTime(file.Path, DateTime.Now + TimeSpan.FromSeconds(10));
+                using (var testDirectory = new TempDirectory(GetTestFilePath()))
+                using (var file = new TempFile(Path.Combine(testDirectory.Path, "file")))
+                using (var watcher = new FileSystemWatcher(testDirectory.Path, Path.GetFileName(file.Path)))
+                {
+                    watcher.NotifyFilter = filter;
+                    Action action = () => File.SetCreationTime(file.Path, DateTime.Now + TimeSpan.FromSeconds(10));
 
-                WatcherChangeTypes expected = 0;
-                if (filter == NotifyFilters.CreationTime)
-                    expected |= WatcherChangeTypes.Changed;
-                else if (OperatingSystem.IsLinux() && ((filter & LinuxFiltersForAttribute) > 0))
-                    expected |= WatcherChangeTypes.Changed;
-                else if (OperatingSystem.IsMacOS() && ((filter & OSXFiltersForModify) > 0))
-                    expected |= WatcherChangeTypes.Changed;
+                    WatcherChangeTypes expected = 0;
+                    if (filter == NotifyFilters.CreationTime)
+                        expected |= WatcherChangeTypes.Changed;
+                    else if (OperatingSystem.IsLinux() && ((filter & LinuxFiltersForAttribute) > 0))
+                        expected |= WatcherChangeTypes.Changed;
+                    else if (OperatingSystem.IsMacOS() && ((filter & OSXFiltersForModify) > 0))
+                        expected |= WatcherChangeTypes.Changed;
 
-                ExpectEvent(watcher, expected, action, expectedPath: file.Path);
-            }
+                    ExpectEvent(watcher, expected, action, expectedPath: file.Path);
+                }
+            }, maxAttempts: DefaultAttemptsForExpectedEvent, backoffFunc: (iteration) => RetryDelayMilliseconds, retryWhen: e => e is XunitException);
         }
 
         [Theory]

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.NotifyFilter.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.NotifyFilter.cs
@@ -53,7 +53,7 @@ namespace System.IO.Tests
         [MemberData(nameof(FilterTypes))]
         public void FileSystemWatcher_File_NotifyFilter_CreationTime(NotifyFilters filter)
         {
-            RetryHelper.Execute(() =>
+            FileSystemWatcherTest.Execute(() =>
             {
                 using (var testDirectory = new TempDirectory(GetTestFilePath()))
                 using (var file = new TempFile(Path.Combine(testDirectory.Path, "file")))

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.SymbolicLink.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.SymbolicLink.cs
@@ -80,7 +80,7 @@ namespace System.IO.Tests
         [Fact]
         public void FileSystemWatcher_SymbolicLink_TargetsDirectory_Create_IncludeSubdirectories()
         {
-            RetryHelper.Execute(() =>
+            FileSystemWatcherTest.Execute(() =>
             {
                 // Arrange
                 const string subDir = "subDir";

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.SymbolicLink.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.SymbolicLink.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.IO.Tests
 {
@@ -78,30 +80,33 @@ namespace System.IO.Tests
         [Fact]
         public void FileSystemWatcher_SymbolicLink_TargetsDirectory_Create_IncludeSubdirectories()
         {
-            // Arrange
-            const string subDir = "subDir";
-            const string subDirLv2 = "subDirLv2";
-            using var tempDir = new TempDirectory(GetTestFilePath());
-            using var tempSubDir = new TempDirectory(Path.Combine(tempDir.Path, subDir));
+            RetryHelper.Execute(() =>
+            {
+                // Arrange
+                const string subDir = "subDir";
+                const string subDirLv2 = "subDirLv2";
+                using var tempDir = new TempDirectory(GetTestFilePath());
+                using var tempSubDir = new TempDirectory(Path.Combine(tempDir.Path, subDir));
 
-            string linkPath = CreateSymbolicLinkToTarget(tempDir.Path, isDirectory: true);
-            using var watcher = new FileSystemWatcher(linkPath);
-            watcher.NotifyFilter = NotifyFilters.DirectoryName;
+                string linkPath = CreateSymbolicLinkToTarget(tempDir.Path, isDirectory: true);
+                using var watcher = new FileSystemWatcher(linkPath);
+                watcher.NotifyFilter = NotifyFilters.DirectoryName;
 
-            string subDirLv2Path = Path.Combine(tempSubDir.Path, subDirLv2);
+                string subDirLv2Path = Path.Combine(tempSubDir.Path, subDirLv2);
 
-            // Act - Assert
-            ExpectNoEvent(watcher, WatcherChangeTypes.Created,
-                action: () => Directory.CreateDirectory(subDirLv2Path),
-                cleanup: () => Directory.Delete(subDirLv2Path));
+                // Act - Assert
+                ExpectNoEvent(watcher, WatcherChangeTypes.Created,
+                    action: () => Directory.CreateDirectory(subDirLv2Path),
+                    cleanup: () => Directory.Delete(subDirLv2Path));
 
-            // Turn include subdirectories on.
-            watcher.IncludeSubdirectories = true;
+                // Turn include subdirectories on.
+                watcher.IncludeSubdirectories = true;
 
-            ExpectEvent(watcher, WatcherChangeTypes.Created,
-                action: () => Directory.CreateDirectory(subDirLv2Path),
-                cleanup: () => Directory.Delete(subDirLv2Path),
-                expectedPath: Path.Combine(linkPath, subDir, subDirLv2));
+                ExpectEvent(watcher, WatcherChangeTypes.Created,
+                    action: () => Directory.CreateDirectory(subDirLv2Path),
+                    cleanup: () => Directory.Delete(subDirLv2Path),
+                    expectedPath: Path.Combine(linkPath, subDir, subDirLv2));
+            }, maxAttempts: DefaultAttemptsForExpectedEvent, backoffFunc: (iteration) => RetryDelayMilliseconds, retryWhen: e => e is XunitException);
         }
 
         [Fact]

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.cs
@@ -180,7 +180,7 @@ namespace System.IO.Tests
         [InlineData(false)]
         public void EndInit_ResumesPausedEnableRaisingEvents(bool setBeforeBeginInit)
         {
-            RetryHelper.Execute(() =>
+            FileSystemWatcherTest.Execute(() =>
             {
                 using (var testDirectory = new TempDirectory(GetTestFilePath()))
                 using (var watcher = new TestFileSystemWatcher(testDirectory.Path, "*"))

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.cs
@@ -175,7 +175,6 @@ namespace System.IO.Tests
         /// <summary>
         /// EndInit will begin EnableRaisingEvents if we previously set EnableRaisingEvents=true
         /// </summary>
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/24181", TestPlatforms.OSX)]
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
@@ -954,7 +954,7 @@ namespace System.IO.Tests
         [Fact]
         public void FileSystemWatcher_File_Delete_MultipleFilters()
         {
-            RetryHelper.Execute(() =>
+            FileSystemWatcherTest.Execute(() =>
             {
                 // Check delete events against multiple filters
 
@@ -981,7 +981,7 @@ namespace System.IO.Tests
         [Fact]
         public void FileSystemWatcher_Directory_Create_MultipleFilters()
         {
-            RetryHelper.Execute(() =>
+            FileSystemWatcherTest.Execute(() =>
             {
                 // Check create events against multiple filters
 
@@ -1005,7 +1005,7 @@ namespace System.IO.Tests
         [Fact]
         public void FileSystemWatcher_Directory_Create_Filter_Ctor()
         {
-            RetryHelper.Execute(() =>
+            FileSystemWatcherTest.Execute(() =>
             {
                 // Check create events against multiple filters
 
@@ -1047,7 +1047,7 @@ namespace System.IO.Tests
         [Fact]
         public void FileSystemWatcher_File_Create_MultipleFilters()
         {
-            RetryHelper.Execute(() =>
+            FileSystemWatcherTest.Execute(() =>
             {
                 DirectoryInfo directory = Directory.CreateDirectory(GetTestFilePath());
                 FileInfo fileOne = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
@@ -1069,7 +1069,7 @@ namespace System.IO.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void FileSystemWatcher_ModifyFiltersConcurrentWithEvents()
         {
-            RetryHelper.Execute(() =>
+            FileSystemWatcherTest.Execute(() =>
             {
                 DirectoryInfo directory = Directory.CreateDirectory(GetTestFilePath());
                 FileInfo fileOne = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
@@ -11,6 +12,7 @@ using Microsoft.DotNet.XUnitExtensions;
 
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace System.IO.Tests
 {
@@ -952,66 +954,75 @@ namespace System.IO.Tests
         [Fact]
         public void FileSystemWatcher_File_Delete_MultipleFilters()
         {
-            // Check delete events against multiple filters
-
-            DirectoryInfo directory = Directory.CreateDirectory(GetTestFilePath());
-            FileInfo fileOne = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
-            FileInfo fileTwo = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
-            FileInfo fileThree = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
-            fileOne.Create().Dispose();
-            fileTwo.Create().Dispose();
-            fileThree.Create().Dispose();
-
-            using (var watcher = new FileSystemWatcher(directory.FullName))
+            RetryHelper.Execute(() =>
             {
-                watcher.Filters.Add(fileOne.Name);
-                watcher.Filters.Add(fileTwo.Name);
+                // Check delete events against multiple filters
 
-                ExpectEvent(watcher, WatcherChangeTypes.Deleted, () => fileOne.Delete(), cleanup: null, expectedPath : fileOne.FullName);
-                ExpectEvent(watcher, WatcherChangeTypes.Deleted, () => fileTwo.Delete(), cleanup: null, expectedPath: fileTwo.FullName );
-                ExpectNoEvent(watcher, WatcherChangeTypes.Deleted, () => fileThree.Delete(), cleanup: null, expectedPath: fileThree.FullName);
-            }
+                DirectoryInfo directory = Directory.CreateDirectory(GetTestFilePath());
+                FileInfo fileOne = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
+                FileInfo fileTwo = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
+                FileInfo fileThree = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
+                fileOne.Create().Dispose();
+                fileTwo.Create().Dispose();
+                fileThree.Create().Dispose();
+
+                using (var watcher = new FileSystemWatcher(directory.FullName))
+                {
+                    watcher.Filters.Add(fileOne.Name);
+                    watcher.Filters.Add(fileTwo.Name);
+
+                    ExpectEvent(watcher, WatcherChangeTypes.Deleted, () => fileOne.Delete(), cleanup: null, expectedPath : fileOne.FullName);
+                    ExpectEvent(watcher, WatcherChangeTypes.Deleted, () => fileTwo.Delete(), cleanup: null, expectedPath: fileTwo.FullName );
+                    ExpectNoEvent(watcher, WatcherChangeTypes.Deleted, () => fileThree.Delete(), cleanup: null, expectedPath: fileThree.FullName);
+                }
+            }, maxAttempts: DefaultAttemptsForExpectedEvent, backoffFunc: (iteration) => RetryDelayMilliseconds, retryWhen: e => e is XunitException);
         }
 
         [Fact]
         public void FileSystemWatcher_Directory_Create_MultipleFilters()
         {
-            // Check create events against multiple filters
-
-            DirectoryInfo directory = Directory.CreateDirectory(GetTestFilePath());
-            string directoryOne = Path.Combine(directory.FullName, GetTestFileName());
-            string directoryTwo = Path.Combine(directory.FullName, GetTestFileName());
-            string directoryThree = Path.Combine(directory.FullName, GetTestFileName());
-
-            using (var watcher = new FileSystemWatcher(directory.FullName))
+            RetryHelper.Execute(() =>
             {
-                watcher.Filters.Add(Path.GetFileName(directoryOne));
-                watcher.Filters.Add(Path.GetFileName(directoryTwo));
+                // Check create events against multiple filters
 
-                ExpectEvent(watcher, WatcherChangeTypes.Created, () => Directory.CreateDirectory(directoryOne), cleanup: null, expectedPath: directoryOne);
-                ExpectEvent(watcher, WatcherChangeTypes.Created, () => Directory.CreateDirectory(directoryTwo), cleanup: null, expectedPath: directoryTwo);
-                ExpectNoEvent(watcher, WatcherChangeTypes.Created, () => Directory.CreateDirectory(directoryThree), cleanup: null, expectedPath: directoryThree);
-            }
+                DirectoryInfo directory = Directory.CreateDirectory(GetTestFilePath());
+                string directoryOne = Path.Combine(directory.FullName, GetTestFileName());
+                string directoryTwo = Path.Combine(directory.FullName, GetTestFileName());
+                string directoryThree = Path.Combine(directory.FullName, GetTestFileName());
+
+                using (var watcher = new FileSystemWatcher(directory.FullName))
+                {
+                    watcher.Filters.Add(Path.GetFileName(directoryOne));
+                    watcher.Filters.Add(Path.GetFileName(directoryTwo));
+
+                    ExpectEvent(watcher, WatcherChangeTypes.Created, () => Directory.CreateDirectory(directoryOne), cleanup: null, expectedPath: directoryOne);
+                    ExpectEvent(watcher, WatcherChangeTypes.Created, () => Directory.CreateDirectory(directoryTwo), cleanup: null, expectedPath: directoryTwo);
+                    ExpectNoEvent(watcher, WatcherChangeTypes.Created, () => Directory.CreateDirectory(directoryThree), cleanup: null, expectedPath: directoryThree);
+                }
+            }, maxAttempts: DefaultAttemptsForExpectedEvent, backoffFunc: (iteration) => RetryDelayMilliseconds, retryWhen: e => e is XunitException);
         }
 
         [Fact]
         public void FileSystemWatcher_Directory_Create_Filter_Ctor()
         {
-            // Check create events against multiple filters
-
-            DirectoryInfo directory = Directory.CreateDirectory(GetTestFilePath());
-            string directoryOne = Path.Combine(directory.FullName, GetTestFileName());
-            string directoryTwo = Path.Combine(directory.FullName, GetTestFileName());
-            string directoryThree = Path.Combine(directory.FullName, GetTestFileName());
-
-            using (var watcher = new FileSystemWatcher(directory.FullName, Path.GetFileName(directoryOne)))
+            RetryHelper.Execute(() =>
             {
-                watcher.Filters.Add(Path.GetFileName(directoryTwo));
+                // Check create events against multiple filters
 
-                ExpectEvent(watcher, WatcherChangeTypes.Created, () => Directory.CreateDirectory(directoryOne), cleanup: null, expectedPath: directoryOne);
-                ExpectEvent(watcher, WatcherChangeTypes.Created, () => Directory.CreateDirectory(directoryTwo), cleanup: null, expectedPath: directoryTwo);
-                ExpectNoEvent(watcher, WatcherChangeTypes.Created, () => Directory.CreateDirectory(directoryThree), cleanup: null, expectedPath: directoryThree);
-            }
+                DirectoryInfo directory = Directory.CreateDirectory(GetTestFilePath());
+                string directoryOne = Path.Combine(directory.FullName, GetTestFileName());
+                string directoryTwo = Path.Combine(directory.FullName, GetTestFileName());
+                string directoryThree = Path.Combine(directory.FullName, GetTestFileName());
+
+                using (var watcher = new FileSystemWatcher(directory.FullName, Path.GetFileName(directoryOne)))
+                {
+                    watcher.Filters.Add(Path.GetFileName(directoryTwo));
+
+                    ExpectEvent(watcher, WatcherChangeTypes.Created, () => Directory.CreateDirectory(directoryOne), cleanup: null, expectedPath: directoryOne);
+                    ExpectEvent(watcher, WatcherChangeTypes.Created, () => Directory.CreateDirectory(directoryTwo), cleanup: null, expectedPath: directoryTwo);
+                    ExpectNoEvent(watcher, WatcherChangeTypes.Created, () => Directory.CreateDirectory(directoryThree), cleanup: null, expectedPath: directoryThree);
+                }
+            }, maxAttempts: DefaultAttemptsForExpectedEvent, backoffFunc: (iteration) => RetryDelayMilliseconds, retryWhen: e => e is XunitException);
         }
 
         [Fact]
@@ -1036,55 +1047,61 @@ namespace System.IO.Tests
         [Fact]
         public void FileSystemWatcher_File_Create_MultipleFilters()
         {
-            DirectoryInfo directory = Directory.CreateDirectory(GetTestFilePath());
-            FileInfo fileOne = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
-            FileInfo fileTwo = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
-            FileInfo fileThree = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
-
-            using (var watcher = new FileSystemWatcher(directory.FullName))
+            RetryHelper.Execute(() =>
             {
-                watcher.Filters.Add(fileOne.Name);
-                watcher.Filters.Add(fileTwo.Name);
+                DirectoryInfo directory = Directory.CreateDirectory(GetTestFilePath());
+                FileInfo fileOne = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
+                FileInfo fileTwo = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
+                FileInfo fileThree = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
 
-                ExpectEvent(watcher, WatcherChangeTypes.Created, () => fileOne.Create().Dispose(), cleanup: null, expectedPath: fileOne.FullName);
-                ExpectEvent(watcher, WatcherChangeTypes.Created, () => fileTwo.Create().Dispose(), cleanup: null, expectedPath: fileTwo.FullName);
-                ExpectNoEvent(watcher, WatcherChangeTypes.Created, () => fileThree.Create().Dispose(), cleanup: null, expectedPath: fileThree.FullName);
-            }
+                using (var watcher = new FileSystemWatcher(directory.FullName))
+                {
+                    watcher.Filters.Add(fileOne.Name);
+                    watcher.Filters.Add(fileTwo.Name);
+
+                    ExpectEvent(watcher, WatcherChangeTypes.Created, () => fileOne.Create().Dispose(), cleanup: null, expectedPath: fileOne.FullName);
+                    ExpectEvent(watcher, WatcherChangeTypes.Created, () => fileTwo.Create().Dispose(), cleanup: null, expectedPath: fileTwo.FullName);
+                    ExpectNoEvent(watcher, WatcherChangeTypes.Created, () => fileThree.Create().Dispose(), cleanup: null, expectedPath: fileThree.FullName);
+                }
+            }, maxAttempts: DefaultAttemptsForExpectedEvent, backoffFunc: (iteration) => RetryDelayMilliseconds, retryWhen: e => e is XunitException);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void FileSystemWatcher_ModifyFiltersConcurrentWithEvents()
         {
-            DirectoryInfo directory = Directory.CreateDirectory(GetTestFilePath());
-            FileInfo fileOne = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
-            FileInfo fileTwo = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
-            FileInfo fileThree = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
-
-            using (var watcher = new FileSystemWatcher(directory.FullName))
+            RetryHelper.Execute(() =>
             {
-                watcher.Filters.Add(fileOne.Name);
-                watcher.Filters.Add(fileTwo.Name);
+                DirectoryInfo directory = Directory.CreateDirectory(GetTestFilePath());
+                FileInfo fileOne = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
+                FileInfo fileTwo = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
+                FileInfo fileThree = new FileInfo(Path.Combine(directory.FullName, GetTestFileName()));
 
-                var cts = new CancellationTokenSource();
-                Thread thread = ThreadTestHelpers.CreateGuardedThread(out Action waitForThread, () =>
+                using (var watcher = new FileSystemWatcher(directory.FullName))
                 {
-                    string otherFilter = Guid.NewGuid().ToString("N");
-                    while (!cts.IsCancellationRequested)
+                    watcher.Filters.Add(fileOne.Name);
+                    watcher.Filters.Add(fileTwo.Name);
+
+                    var cts = new CancellationTokenSource();
+                    Thread thread = ThreadTestHelpers.CreateGuardedThread(out Action waitForThread, () =>
                     {
-                        watcher.Filters.Add(otherFilter);
-                        watcher.Filters.RemoveAt(2);
-                    }
-                });
-                thread.IsBackground = true;
-                thread.Start();
+                        string otherFilter = Guid.NewGuid().ToString("N");
+                        while (!cts.IsCancellationRequested)
+                        {
+                            watcher.Filters.Add(otherFilter);
+                            watcher.Filters.RemoveAt(2);
+                        }
+                    });
+                    thread.IsBackground = true;
+                    thread.Start();
 
-                ExpectEvent(watcher, WatcherChangeTypes.Created, () => fileOne.Create().Dispose(), cleanup: null, expectedPath: fileOne.FullName);
-                ExpectEvent(watcher, WatcherChangeTypes.Created, () => fileTwo.Create().Dispose(), cleanup: null, expectedPath: fileTwo.FullName);
-                ExpectNoEvent(watcher, WatcherChangeTypes.Created, () => fileThree.Create().Dispose(), cleanup: null, expectedPath: fileThree.FullName);
+                    ExpectEvent(watcher, WatcherChangeTypes.Created, () => fileOne.Create().Dispose(), cleanup: null, expectedPath: fileOne.FullName);
+                    ExpectEvent(watcher, WatcherChangeTypes.Created, () => fileTwo.Create().Dispose(), cleanup: null, expectedPath: fileTwo.FullName);
+                    ExpectNoEvent(watcher, WatcherChangeTypes.Created, () => fileThree.Create().Dispose(), cleanup: null, expectedPath: fileThree.FullName);
 
-                cts.Cancel();
-                waitForThread();
-            }
+                    cts.Cancel();
+                    waitForThread();
+                }
+            }, maxAttempts: DefaultAttemptsForExpectedEvent, backoffFunc: (iteration) => RetryDelayMilliseconds, retryWhen: e => e is XunitException);
         }
     }
 

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Xunit;
 using Xunit.Sdk;
@@ -198,6 +199,67 @@ namespace System.IO.Tests
 
                 if (cleanup != null)
                     cleanup();
+            }
+        }
+
+        // Pasted from RetryHelper.cs in order to force FSW tests to log retries to the Helix console.
+        // We don't want to do that for tests in general.
+        // Once we've gotten enough data, delete this and go back to the regular RetryHelper.
+        private static readonly Func<int, int> s_defaultBackoffFunc = i => Math.Min(i * 100, 60_000);
+        private static readonly Predicate<Exception> s_defaultRetryWhenFunc = _ => true;
+        private static readonly bool s_debug = Environment.GetEnvironmentVariable("DEBUG_RETRYHELPER") == "1";
+
+        /// <summary>Executes the <paramref name="test"/> action up to a maximum of <paramref name="maxAttempts"/> times.</summary>
+        /// <param name="maxAttempts">The maximum number of times to invoke <paramref name="test"/>.</param>
+        /// <param name="test">The test to invoke.</param>
+        /// <param name="backoffFunc">After a failure, invoked to determine how many milliseconds to wait before the next attempt.  It's passed the number of iterations attempted.</param>
+        /// <param name="retryWhen">Invoked to select the exceptions to retry on. If not set, any exception will trigger a retry.</param>
+        public static void Execute(Action test, int maxAttempts = 5, Func<int, int> backoffFunc = null, Predicate<Exception> retryWhen = null, [CallerMemberName] string? testName = null)
+        {
+            // Validate arguments
+            if (maxAttempts < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxAttempts));
+            }
+            if (test == null)
+            {
+                throw new ArgumentNullException(nameof(test));
+            }
+
+            retryWhen ??= s_defaultRetryWhenFunc;
+
+            // Execute the test until it either passes or we run it maxAttempts times
+            var exceptions = new List<Exception>();
+            for (int i = 1; i <= maxAttempts; i++)
+            {
+                Exception lastException;
+                try
+                {
+                    test();
+                    return;
+                }
+                catch (Exception e) when (retryWhen(e))
+                {
+                    lastException = e;
+                    exceptions.Add(e);
+                    if (i == maxAttempts)
+                    {
+                        throw new AggregateException(exceptions);
+                    }
+                }
+
+                if (PlatformDetection.IsInHelix)
+                {
+                    // Dump into the console output so we can mine it
+                    Console.WriteLine($"RetryHelper: retrying {testName} {i}th time of {maxAttempts}: got {lastException.Message}");
+                }
+
+                if (s_debug)
+                {
+                    Debug.WriteLine($"RetryHelper: retrying {testName} {i}th time of {maxAttempts}: got {lastException.Message}");
+                }
+
+                Thread.Sleep((backoffFunc ?? s_defaultBackoffFunc)(i));
             }
         }
 

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
@@ -248,7 +248,7 @@ namespace System.IO.Tests
                     }
                 }
 
-                if (PlatformDetection.IsInHelix)
+                if (PlatformDetection.IsInHelix || s_debug)
                 {
                     // Dump into the console output so we can mine it
                     Console.WriteLine($"RetryHelper: retrying {testName} {i}th time of {maxAttempts}: got {lastException.Message}");

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
@@ -201,25 +201,6 @@ namespace System.IO.Tests
             }
         }
 
-        /// <summary>Invokes the specified test action with retry on failure (other than assertion failure).</summary>
-        /// <param name="action">The test action.</param>
-        /// <param name="maxAttempts">The maximum number of times to attempt to run the test.</param>
-        public static void ExecuteWithRetry(Action action, int maxAttempts = DefaultAttemptsForExpectedEvent)
-        {
-            for (int retry = 0; retry < maxAttempts; retry++)
-            {
-                try
-                {
-                    action();
-                    return;
-                }
-                catch (Exception e) when (!(e is XunitException) && retry < maxAttempts - 1)
-                {
-                    Thread.Sleep(RetryDelayMilliseconds);
-                }
-            }
-        }
-
         /// <summary>
         /// Does verification that the given watcher will not throw exactly/only the events in "expectedEvents" when
         /// "action" is executed.

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -16,13 +16,11 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
         // When running both inner and outer loop together, dump only once
         private static bool s_dumpedRuntimeInfo = false;
 
-        private static readonly bool s_isInHelix = Environment.GetEnvironmentVariables().Keys.Cast<string>().Where(key => key.StartsWith("HELIX")).Any();
-
         [Fact]
         [SkipOnPlatform(TestPlatforms.Browser, "throws PNSE when binariesLocation is not an empty string.")]
         public void DumpRuntimeInformationToConsole()
         {
-            if (s_dumpedRuntimeInfo || !s_isInHelix)
+            if (s_dumpedRuntimeInfo || !PlatformDetection.IsInHelix)
                 return;
 
             s_dumpedRuntimeInfo = true;


### PR DESCRIPTION
* Fix https://github.com/dotnet/runtime/issues/67601 by adding retries to the ones that failed in the last 60 days. If we see this helps, we can add to others that fail or all of them.
* Fix https://github.com/dotnet/runtime/issues/24181 and enable test
* Enable debugging output from RetryHelper showing the test that is being retried and why when an env var DEBUG_RETRYHELPER=1
* Enable console output from RetryHelper when in Helix and it's a FSW test. This will allow us to look at recent console logs to see whether retrying is happening and where.
* Remove previous custom retry method. The one test it was applied to has not recently failed.