### PR TITLE
Fix unintentional boxing on every newline in GetCharKindWithAnchor

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DfaMatchingState.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DfaMatchingState.cs
@@ -9,7 +9,7 @@ using System.Net;
 namespace System.Text.RegularExpressions.Symbolic
 {
     /// <summary>Captures a state of a DFA explored during matching.</summary>
-    internal sealed class DfaMatchingState<TSet> where TSet : IComparable<TSet>
+    internal sealed class DfaMatchingState<TSet> where TSet : IComparable<TSet>, IEquatable<TSet>
     {
         internal DfaMatchingState(SymbolicRegexNode<TSet> node, uint prevCharKind)
         {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DgmlWriter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DgmlWriter.cs
@@ -11,7 +11,7 @@ using System.Net;
 namespace System.Text.RegularExpressions.Symbolic
 {
     [ExcludeFromCodeCoverage(Justification = "Currently only used for testing")]
-    internal static class DgmlWriter<TSet> where TSet : IComparable<TSet>
+    internal static class DgmlWriter<TSet> where TSet : IComparable<TSet>, IEquatable<TSet>
     {
         /// <summary>Write the DFA or NFA in DGML format into the TextWriter.</summary>
         /// <param name="matcher">The <see cref="SymbolicRegexMatcher"/> for the regular expression.</param>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicNFA.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicNFA.cs
@@ -9,7 +9,7 @@ using System.Diagnostics;
 namespace System.Text.RegularExpressions.Symbolic
 {
     /// <summary>Represents the exploration of a symbolic regex as a symbolic NFA</summary>
-    internal sealed class SymbolicNFA<TSet> where TSet : IComparable<TSet>
+    internal sealed class SymbolicNFA<TSet> where TSet : IComparable<TSet>, IEquatable<TSet>
     {
         private readonly ISolver<TSet> _solver;
         private readonly Transition[] _transitionFunction;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
@@ -16,7 +16,7 @@ namespace System.Text.RegularExpressions.Symbolic
     /// TSet is the type of the set of elements.
     /// Used to convert .NET regexes to symbolic regexes.
     /// </summary>
-    internal sealed class SymbolicRegexBuilder<TSet> where TSet : IComparable<TSet>
+    internal sealed class SymbolicRegexBuilder<TSet> where TSet : IComparable<TSet>, IEquatable<TSet>
     {
         internal readonly CharSetSolver _charSetSolver;
         internal readonly ISolver<TSet> _solver;
@@ -376,7 +376,7 @@ namespace System.Text.RegularExpressions.Symbolic
         }
 
         internal SymbolicRegexNode<TNewSet> Transform<TNewSet>(SymbolicRegexNode<TSet> sr, SymbolicRegexBuilder<TNewSet> builder, Func<SymbolicRegexBuilder<TNewSet>, TSet, TNewSet> setTransformer)
-            where TNewSet : IComparable<TNewSet>
+            where TNewSet : IComparable<TNewSet>, IEquatable<TNewSet>
         {
             if (!StackHelper.TryEnsureSufficientExecutionStack())
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -37,7 +37,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
     /// <summary>Represents a regex matching engine that performs regex matching using symbolic derivatives.</summary>
     /// <typeparam name="TSet">Character set type.</typeparam>
-    internal sealed class SymbolicRegexMatcher<TSet> : SymbolicRegexMatcher where TSet : IComparable<TSet>
+    internal sealed class SymbolicRegexMatcher<TSet> : SymbolicRegexMatcher where TSet : IComparable<TSet>, IEquatable<TSet>
     {
         /// <summary>Maximum number of built states before switching over to NFA mode.</summary>
         /// <remarks>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -10,7 +10,7 @@ using System.Threading;
 namespace System.Text.RegularExpressions.Symbolic
 {
     /// <summary>Represents an abstract syntax tree node of a symbolic regex.</summary>
-    internal sealed class SymbolicRegexNode<TSet> where TSet : IComparable<TSet>
+    internal sealed class SymbolicRegexNode<TSet> where TSet : IComparable<TSet>, IEquatable<TSet>
     {
         internal const string EmptyCharClass = "[]";
         /// <summary>Some byte other than 0 to represent true</summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexRunnerFactory.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexRunnerFactory.cs
@@ -40,7 +40,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// all runner instances, but the runner itself has state (e.g. for captures, positions, etc.)
         /// and must not be shared between concurrent uses.
         /// </remarks>
-        private sealed class Runner<TSet> : RegexRunner where TSet : IComparable<TSet>
+        private sealed class Runner<TSet> : RegexRunner where TSet : IComparable<TSet>, IEquatable<TSet>
         {
             /// <summary>The matching engine.</summary>
             /// <remarks>The matcher is stateless and may be shared by any number of threads executing concurrently.</remarks>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSampler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSampler.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 
 namespace System.Text.RegularExpressions.Symbolic
 {
-    internal sealed class SymbolicRegexSampler<TSet> where TSet : IComparable<TSet>
+    internal sealed class SymbolicRegexSampler<TSet> where TSet : IComparable<TSet>, IEquatable<TSet>
     {
         private Random _random;
         private SymbolicRegexNode<TSet> _root;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSet.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSet.cs
@@ -10,7 +10,7 @@ using System.Runtime.CompilerServices;
 namespace System.Text.RegularExpressions.Symbolic
 {
     /// <summary>Represents a set of symbolic regexes that is either a disjunction or a conjunction</summary>
-    internal sealed class SymbolicRegexSet<TSet> : IEnumerable<SymbolicRegexNode<TSet>> where TSet : IComparable<TSet>
+    internal sealed class SymbolicRegexSet<TSet> : IEnumerable<SymbolicRegexNode<TSet>> where TSet : IComparable<TSet>, IEquatable<TSet>
     {
         internal readonly SymbolicRegexBuilder<TSet> _builder;
 
@@ -403,7 +403,7 @@ namespace System.Text.RegularExpressions.Symbolic
         }
 
         internal SymbolicRegexSet<TNewSet> Transform<TNewSet>(SymbolicRegexBuilder<TNewSet> builderT, Func<SymbolicRegexBuilder<TNewSet>, TSet, TNewSet> setTransformer)
-            where TNewSet : IComparable<TNewSet>
+            where TNewSet : IComparable<TNewSet>, IEquatable<TNewSet>
         {
             // This function is mutually recursive with the one in SymbolicRegexBuilder, which has stack overflow avoidance
             return SymbolicRegexSet<TNewSet>.CreateMulti(builderT, TransformElements(builderT, setTransformer), _kind);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/TransitionRegex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/TransitionRegex.cs
@@ -10,7 +10,7 @@ using System.Threading;
 namespace System.Text.RegularExpressions.Symbolic
 {
     /// <summary>Represents a symbolic derivative created from a symbolic regex without using minterms</summary>
-    internal sealed class TransitionRegex<TSet> where TSet : IComparable<TSet>
+    internal sealed class TransitionRegex<TSet> where TSet : IComparable<TSet>, IEquatable<TSet>
     {
         public readonly SymbolicRegexBuilder<TSet> _builder;
         public readonly TransitionRegexKind _kind;


### PR DESCRIPTION
The generic type wasn't constrained to `IEquatable<T>`, so it was invoking the `object.Equals` overload, boxing the struct-based set.