### PR TITLE
Enable runtime tests on Windows ARM64v8 queues

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1106,6 +1106,7 @@ jobs:
     - OSX_x64
     - Linux_x64
     - Linux_musl_x64
+    - windows_arm64
     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
     jobParameters:
       isOfficialBuild: false
@@ -1130,6 +1131,7 @@ jobs:
     - Linux_musl_arm
     - Linux_musl_arm64
     - windows_x86
+    - windows_arm64
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     helixQueueGroup: libraries
     jobParameters:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -738,6 +738,7 @@ jobs:
     - OSX_x64
     - windows_x64
     - FreeBSD_x64
+    - windows_arm64
     - ${{ if eq(variables['isRollingBuild'], false) }}:
       # we need to build windows_x86 for debug on PRs in order to test
       # against a checked runtime when the PR contains coreclr changes
@@ -785,6 +786,7 @@ jobs:
     jobTemplate: /eng/pipelines/libraries/build-job.yml
     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
     platforms:
+    - windows_arm64
     - windows_x64
     jobParameters:
       framework: allConfigurations


### PR DESCRIPTION
Related to #67076.

Purpose of this PR is just to test if the regulat test failures in jitstress pipelines reproduce on regular runs as well.