### PR TITLE
Rename superpmi-asmdiffs -> superpmi-diffs

### DIFF
--- a/eng/pipelines/coreclr/superpmi-diffs.yml
+++ b/eng/pipelines/coreclr/superpmi-diffs.yml
@@ -30,7 +30,7 @@ jobs:
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-asmdiffs-job.yml
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-diffs-job.yml
     buildConfig: checked
     platforms:
     - windows_x64

--- a/eng/pipelines/coreclr/templates/run-superpmi-diffs-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-diffs-job.yml
@@ -73,10 +73,10 @@ jobs:
         mkdir $(SpmiAsmdiffsLocation)
       displayName: Create directories
 
-    - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi_asmdiffs_setup.py -source_directory $(Build.SourcesDirectory) -product_directory $(buildProductRootFolderPath) -arch $(archType)
-      displayName: ${{ format('SuperPMI asmdiffs setup ({0})', parameters.archType) }}
+    - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi_diffs_setup.py -source_directory $(Build.SourcesDirectory) -product_directory $(buildProductRootFolderPath) -arch $(archType)
+      displayName: ${{ format('SuperPMI diffs setup ({0})', parameters.archType) }}
 
-      # Run superpmi asmdiffs in helix
+      # Run superpmi-diffs.py script in helix
     - template: /eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
       parameters:
         displayName: 'Send job to Helix'
@@ -88,7 +88,7 @@ jobs:
         WorkItemTimeout: 2:00 # 2 hours
         WorkItemDirectory: '$(WorkItemDirectory)'
         CorrelationPayloadDirectory: '$(CorrelationPayloadDirectory)'
-        helixProjectArguments: '$(Build.SourcesDirectory)/src/coreclr/scripts/superpmi-asmdiffs.proj'
+        helixProjectArguments: '$(Build.SourcesDirectory)/src/coreclr/scripts/superpmi-diffs.proj'
         BuildConfig: ${{ parameters.buildConfig }}
         osGroup: ${{ parameters.osGroup }}
         archType: ${{ parameters.archType }}
@@ -118,7 +118,7 @@ jobs:
         targetFolder: '$(SpmiAsmdiffsLocation)'
       condition: always()
 
-    - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi_asmdiffs_summarize.py -diff_summary_dir $(SpmiAsmdiffsLocation) -arch $(archType)
+    - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi_diffs_summarize.py -diff_summary_dir $(SpmiAsmdiffsLocation) -arch $(archType)
       displayName: ${{ format('Summarize ({0})', parameters.archType) }}
       condition: always()
 

--- a/eng/pipelines/coreclr/templates/superpmi-diffs-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-diffs-job.yml
@@ -8,13 +8,13 @@ parameters:
   variables: {}
   helixQueues: ''
   dependOnEvaluatePaths: false
-  runJobTemplate: '/eng/pipelines/coreclr/templates/run-superpmi-asmdiffs-job.yml'
+  runJobTemplate: '/eng/pipelines/coreclr/templates/run-superpmi-diffs-job.yml'
 
 jobs:
 - template: ${{ parameters.runJobTemplate }}
   parameters:
-    jobName: ${{ format('superpmi_asmdiffs_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-    displayName: ${{ format('SuperPMI asmdiffs {0}{1} {2} {3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+    jobName: ${{ format('superpmi_diffs_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+    displayName: ${{ format('SuperPMI diffs {0}{1} {2} {3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
     pool: ${{ parameters.pool }}
     buildConfig: ${{ parameters.buildConfig }}
     archType: ${{ parameters.archType }}

--- a/src/coreclr/scripts/superpmi-diffs.proj
+++ b/src/coreclr/scripts/superpmi-diffs.proj
@@ -6,7 +6,7 @@
     <Project DefaultTargets="printItems">
 
     Once you've done that you can run this to see the results:
-    dotnet msbuild .\superpmi-asmdiffs.proj /v:n
+    dotnet msbuild .\superpmi-diffs.proj /v:n
    -->
 
    <!-- <PropertyGroup>
@@ -30,7 +30,7 @@
     <SuperpmiLogsLocation>%HELIX_WORKITEM_UPLOAD_ROOT%</SuperpmiLogsLocation>
     <!-- Workaround until https://github.com/dotnet/arcade/pull/6179 is not available -->
     <HelixResultsDestinationDir>$(BUILD_SOURCESDIRECTORY)\artifacts\helixresults</HelixResultsDestinationDir>
-    <WorkItemCommand>$(Python) $(ProductDirectory)\superpmi_asmdiffs.py -base_jit_directory $(ProductDirectory)\base -diff_jit_directory $(ProductDirectory)\diff -log_directory $(SuperpmiLogsLocation)</WorkItemCommand>
+    <WorkItemCommand>$(Python) $(ProductDirectory)\superpmi_diffs.py -base_jit_directory $(ProductDirectory)\base -diff_jit_directory $(ProductDirectory)\diff -log_directory $(SuperpmiLogsLocation)</WorkItemCommand>
     <WorkItemTimeout>1:00</WorkItemTimeout>
   </PropertyGroup>
 

--- a/src/coreclr/scripts/superpmi_diffs.py
+++ b/src/coreclr/scripts/superpmi_diffs.py
@@ -3,11 +3,11 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
 #
-# Title               : superpmi_asmdiffs.py
+# Title               : superpmi_diffs.py
 #
 # Notes:
 #
-# Script to run "superpmi asmdiffs" for various collections on the Helix machines.
+# Script to do base-diff jit measurements for various collections on the Helix machines.
 #
 ################################################################################
 ################################################################################
@@ -126,9 +126,9 @@ def copy_dasm_files(spmi_location, upload_directory, tag_name):
 
 
 def main(main_args):
-    """ Run superpmi asmdiffs process on the Helix machines.
+    """ Run base-diff JIT measurements on the Helix machines.
 
-    See superpmi_asmdiffs_setup.py for how the directory structure is set up in the
+    See superpmi_diffs_setup.py for how the directory structure is set up in the
     correlation payload. This script lives in the root of that directory tree.
 
     Args:

--- a/src/coreclr/scripts/superpmi_diffs_setup.py
+++ b/src/coreclr/scripts/superpmi_diffs_setup.py
@@ -3,16 +3,17 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
 #
-# Title               : superpmi_asmdiffs_setup.py
+# Title               : superpmi_diffs_setup.py
 #
 # Notes:
 #
-# Script to setup the directory structure required to perform SuperPMI asmdiffs in CI.
-# It creates `correlation_payload_directory` with `base` and `diff` directories
-# that contain clrjit*.dll. It figures out the baseline commit hash to use for
-# a particular GitHub pull request, and downloads the JIT rolling build for that
-# commit hash. It downloads the jitutils repo and builds the jit-analyze tool. It
-# downloads a version of `git` to be used by jit-analyze.
+# Script to setup the directory structure required to perform base-diff JIT
+# measurements in CI. It creates `correlation_payload_directory` with `base`
+# and `diff` directories # that contain clrjit*.dll. It figures out the baseline
+# commit hash to use for a particular GitHub pull request, and downloads the
+# JIT rolling build for that commit hash. It downloads the jitutils repo and
+# builds the jit-analyze tool. It downloads a version of `git` to be used by
+# jit-analyze.
 #
 ################################################################################
 ################################################################################
@@ -91,7 +92,7 @@ def match_superpmi_tool_files(full_path):
 
 
 def main(main_args):
-    """ Prepare the Helix data for SuperPMI asmdiffs Azure DevOps pipeline.
+    """ Prepare the Helix data for SuperPMI diffs Azure DevOps pipeline.
 
     The Helix correlation payload directory is created and populated as follows:
 

--- a/src/coreclr/scripts/superpmi_diffs_summarize.py
+++ b/src/coreclr/scripts/superpmi_diffs_summarize.py
@@ -4,7 +4,7 @@
 ## The .NET Foundation licenses this file to you under the MIT license.
 #
 ##
-# Title: superpmi_asmdiffs_summarize.py
+# Title: superpmi_diffs_summarize.py
 #
 # Notes:
 #
@@ -78,8 +78,8 @@ def append_diff_file(f, arch, file_name, full_file_path):
     with open(full_file_path, "r") as current_superpmi_md:
         contents = current_superpmi_md.read()
 
-        # Were there actually any diffs? We currently look to see if the file contains the text "No diffs found",
-        # inserted by `superpmi_asmdiffs.py`, instead of just not having a diff summary .md file.
+        # Were there actually any asm diffs? We currently look to see if the file contains the text "No diffs found",
+        # inserted by `superpmi_diffs.py`, instead of just not having a diff summary .md file.
         # (A missing file has the same effect.)
         match_obj = re.search(r'^No diffs found', contents)
         if match_obj is not None:


### PR DESCRIPTION
In anticipation of using this pipeline more generally for any base-diff JIT
comparison in JIT PRs.

I suppose the most frictionless way is to create a new pipeline that points to the new YAML file and delete the old one after merging.

cc @dotnet/jit-contrib @kunalspathak 