### PR TITLE
Treat `INDEX` as a potentially throwing operation

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6494,6 +6494,7 @@ bool GenTree::OperMayThrow(Compiler* comp)
         case GT_ARR_OFFSET:
         case GT_LCLHEAP:
         case GT_CKFINITE:
+        case GT_INDEX:
         case GT_INDEX_ADDR:
             return true;
 

--- a/src/tests/JIT/Methodical/Arrays/misc/IndexingSideEffects.cs
+++ b/src/tests/JIT/Methodical/Arrays/misc/IndexingSideEffects.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class IndexingSideEffects
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        if (!Problem())
+        {
+            return 101;
+        }
+
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Problem()
+    {
+        bool result = false;
+
+        try
+        {
+            TryIndexing(new int[0]);
+        }
+        catch (IndexOutOfRangeException)
+        {
+            result = true;
+        }
+
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TryIndexing(int[] a)
+    {
+        // Make sure that early flowgraph simplification does not remove the side effect of indexing
+        // when deleting the relop.
+        if (a[int.MaxValue] == 0)
+        {
+            NopInlinedCall();
+        }
+    }
+
+    private static void NopInlinedCall() { }
+}

--- a/src/tests/JIT/Methodical/Arrays/misc/IndexingSideEffects.csproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/IndexingSideEffects.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Not doing so can lead to early dead code elimination dropping it.