### PR TITLE
Fix `impBoxPatternMatch`

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -6983,9 +6983,14 @@ int Compiler::impBoxPatternMatch(CORINFO_RESOLVED_TOKEN* pResolvedToken,
                     if (((treeToBox->gtFlags & GTF_SIDE_EFFECT) == GTF_EXCEPT) &&
                         treeToBox->OperIs(GT_OBJ, GT_BLK, GT_IND))
                     {
-                        // Yes, we just need to perform a null check if needed.
+                        // If the only side effect comes from the dereference itself, yes.
                         GenTree* const addr = treeToBox->AsOp()->gtGetOp1();
-                        if (fgAddrCouldBeNull(addr))
+
+                        if ((addr->gtFlags & GTF_SIDE_EFFECT) != 0)
+                        {
+                            canOptimize = false;
+                        }
+                        else if (fgAddrCouldBeNull(addr))
                         {
                             treeToNullcheck = addr;
                         }

--- a/src/tests/JIT/Methodical/Boxing/boxunbox/BoxPatternMatchAndSideEffects.cs
+++ b/src/tests/JIT/Methodical/Boxing/boxunbox/BoxPatternMatchAndSideEffects.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class BoxPatternMatchAndSideEffects
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        if (!Problem(new Struct[0]))
+        {
+            return 101;
+        }
+
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Problem(Struct[] a)
+    {
+        bool result = false;
+
+        try
+        {
+            // Make sure the "box(x) != null" optimization does not drop the side-effect of indexing into the array.
+            if ((object)a[int.MaxValue] != null)
+            {
+                result = false;
+            }
+        }
+        catch (IndexOutOfRangeException)
+        {
+            result = true;
+        }
+
+        return result;
+    }
+
+    struct Struct { }
+}

--- a/src/tests/JIT/Methodical/Boxing/boxunbox/BoxPatternMatchAndSideEffects.csproj
+++ b/src/tests/JIT/Methodical/Boxing/boxunbox/BoxPatternMatchAndSideEffects.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
For the `BOX;BR[COND]` case, the issue was that the code assumed that we only need to hold onto the original address tree in case a null check is needed, which is not the case -- the address could be both non-null and itself side-effecting (e. g. `ADDR(INDEX)`).

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1765495&view=ms.vss-build-web.run-extensions-tab).