### PR TITLE
[TODO-List-Cleanup] Implement `fgSetTreeSeq` via `GenTreeVisitor`

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5501,14 +5501,7 @@ private:
 #endif
 
     //-------- Determine the order in which the trees will be evaluated -------
-
-    unsigned fgTreeSeqNum;
-    GenTree* fgTreeSeqLst;
-    GenTree* fgTreeSeqBeg;
-
-    GenTree* fgSetTreeSeq(GenTree* tree, GenTree* prev = nullptr, bool isLIR = false);
-    void fgSetTreeSeqHelper(GenTree* tree, bool isLIR);
-    void fgSetTreeSeqFinish(GenTree* tree, bool isLIR);
+    GenTree* fgSetTreeSeq(GenTree* tree, bool isLIR = false);
     void fgSetStmtSeq(Statement* stmt);
     void fgSetBlockOrder(BasicBlock* block);
 

--- a/src/coreclr/jit/lir.cpp
+++ b/src/coreclr/jit/lir.cpp
@@ -1683,7 +1683,7 @@ LIR::Range LIR::SeqTree(Compiler* compiler, GenTree* tree)
     // point.
 
     compiler->gtSetEvalOrder(tree);
-    return Range(compiler->fgSetTreeSeq(tree, nullptr, true), tree);
+    return Range(compiler->fgSetTreeSeq(tree, /* isLIR */ true), tree);
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
Lets one more custom traversal go.

Also results in some ~0.17% fewer instructions according to PIN.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1732839&view=ms.vss-build-web.run-extensions-tab).