### PR TITLE
Disable GetProviderNames_AssertProperties

### DIFF
--- a/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/ProviderMetadataTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/ProviderMetadataTests.cs
@@ -91,7 +91,7 @@ namespace System.Diagnostics.Tests
         }
 
         [ConditionalFact(typeof(Helpers), nameof(Helpers.SupportsEventLogs))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/64153", typeof(PlatformDetection), nameof(PlatformDetection.IsWindowsX86OrX64))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/64153", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
         public void GetProviderNames_AssertProperties()
         {
             const string Prefix = "win:";

--- a/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/ProviderMetadataTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/ProviderMetadataTests.cs
@@ -91,7 +91,7 @@ namespace System.Diagnostics.Tests
         }
 
         [ConditionalFact(typeof(Helpers), nameof(Helpers.SupportsEventLogs))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/64153", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/64153")]
         public void GetProviderNames_AssertProperties()
         {
             const string Prefix = "win:";


### PR DESCRIPTION
- Disable GetProviderNames_AssertProperties - it was running on Windows Arm64

With this we can remove 'blocking-clean-ci' label from https://github.com/dotnet/runtime/issues/64153