### PR TITLE
[release/6.0] add support for parsing Unified TLS hello

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -510,9 +510,8 @@ namespace System.Net.Security
                     }
                     break;
                 case TlsContentType.Handshake:
-                    byte handshakeType = _framing == Framing.SinceSSL3 ?
-                                            _handshakeBuffer.ActiveReadOnlySpan[HandshakeTypeOffsetTls] :
-                                            _handshakeBuffer.ActiveReadOnlySpan[HandshakeTypeOffsetSsl2];
+                    byte handshakeType = _handshakeBuffer.ActiveReadOnlySpan[_framing == Framing.SinceSSL3 ? HandshakeTypeOffsetTls : HandshakeTypeOffsetSsl2];
+
                     if (!_isRenego &&
                         (_sslAuthenticationOptions!.ServerCertSelectionDelegate != null || _sslAuthenticationOptions!.ServerOptionDelegate != null) &&
                         (handshakeType == (byte)TlsHandshakeType.ClientHello))

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -477,9 +477,8 @@ namespace System.Net.Security
 #pragma warning disable 0618
                 _lastFrame.Header.Version = SslProtocols.Ssl2;
 #pragma warning restore 0618
-                _lastFrame.Header.Type = TlsContentType.Handshake;  // Assume. Needed for check bellow.
+                _lastFrame.Header.Type = TlsContentType.Handshake;  // Implied. We only call this during handshake and SSL2 does not have framing layer.
                 _lastFrame.Header.Length = GetFrameSize(_handshakeBuffer.ActiveReadOnlySpan) - TlsFrameHelper.HeaderSize;
-
             }
             else
             {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsFrameHelper.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsFrameHelper.cs
@@ -179,27 +179,51 @@ namespace System.Net.Security
             {
                 header.Type = (TlsContentType)frame[0];
 
-                if (frame.Length >= 3)
+                if (frame.Length > 4)
                 {
                     // SSLv3, TLS or later
                     if (frame[1] == 3)
                     {
-                        if (frame.Length > 4)
+                        header.Length = ((frame[3] << 8) | frame[4]);
+                        header.Version = TlsMinorVersionToProtocol(frame[2]);
+                        return true;
+                    }
+                    else if (frame[2] == (byte)TlsHandshakeType.ClientHello &&
+                       frame[3] == 3) // SSL3 or above
+                    {
+                        int length;
+                        if ((frame[0] & 0x80) != 0)
                         {
-                            header.Length = ((frame[3] << 8) | frame[4]);
+                            // Two bytes
+                            length = (((frame[0] & 0x7f) << 8) | frame[1]) + 2;
+                        }
+                        else
+                        {
+                            // Three bytes
+                            length = (((frame[0] & 0x3f) << 8) | frame[1]) + 3;
                         }
 
-                        header.Version = TlsMinorVersionToProtocol(frame[2]);
-                    }
-                    else
-                    {
-                        header.Length = -1;
-                        header.Version = SslProtocols.None;
+                        // max frame for SSLv2 is 32767.
+                        // However, we expect something reasonable for initial HELLO
+                        // We don't have enough logic to verify full validity,
+                        // the limits bellow are queses.
+                        if (length > 20 && length < 1000)
+                        {
+#pragma warning disable CS0618 // Ssl2 and Ssl3 are obsolete
+                            header.Version = SslProtocols.Ssl2;
+#pragma warning restore CS0618
+                            header.Length = length;
+                            header.Type = TlsContentType.Handshake;
+                            return true;
+                        }
                     }
                 }
             }
 
-            return result;
+            header.Length = -1;
+            header.Version = SslProtocols.None;
+
+                return result;
         }
 
         // Returns frame size e.g. header + content
@@ -252,6 +276,18 @@ namespace System.Net.Security
             }
 
             info.HandshakeType = (TlsHandshakeType)frame[HandshakeTypeOffset];
+#pragma warning disable CS0618 // Ssl2 and Ssl3 are obsolete
+            if (info.Header.Version == SslProtocols.Ssl2)
+            {
+                // This is safe. We would not get here if the length is too small.
+                info.SupportedVersions |= TlsMinorVersionToProtocol(frame[4]);
+                // We only recognize Unified ClientHello at the moment.
+                // This is needed to trigger certificate selection callback in SslStream.
+                info.HandshakeType = TlsHandshakeType.ClientHello;
+                // There is no more parsing for old protocols.
+                return true;
+            }
+#pragma warning restore CS0618
 
             // Check if we have full frame.
             bool isComplete = frame.Length >= HeaderSize + info.Header.Length;
@@ -404,10 +440,10 @@ namespace System.Net.Security
             // Skip compression methods (max size 2^8-1 => size fits in 1 byte)
             p = SkipOpaqueType1(p);
 
-            // is invalid structure or no extensions?
+            // no extensions
             if (p.IsEmpty)
             {
-                return false;
+                return true;
             }
 
             // client_hello_extension_list (max size 2^16-1 => size fits in 2 bytes)


### PR DESCRIPTION
## Customer Impact
This may prevent TLS handshake from some older clients. While the basic parsing should work, the certificate selection callback is not invoked and it breaks scenarios like Kestrel and YARP that depend on it. 

This currently impacts Azure App service and their YARP setup. 

## Testing
Private binaries were verified by AppService. We currently don't have test coverage for this as it depends on particular client device (some IoT in this particular case)

## Risk
small. This essentially adds ability to process some new variations but does not change or replace old code. 


fixes #68310

## Details

This covers cases when client sends TLS 1.x hello in Sslv2 frame format. As described in the linked issue, server will respond with normal response and TLS 1.x will be negotiated. 

The TLS Parser is essentially dup of https://github.com/microsoft/reverse-proxy/pull/1656

Both changes were verified by App Service.  

Note that main will need more work because of https://github.com/dotnet/runtime/pull/64322.
We may need to bring back some fragments but I would like to do more testing before that. 