### PR TITLE
Add ValueTask pooling in more places

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReader.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReader.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -217,6 +218,9 @@ namespace System.IO.Pipelines
 
             return Core(this, tokenSource, cancellationToken);
 
+#if NETCOREAPP
+            [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
             static async ValueTask<ReadResult> Core(StreamPipeReader reader, CancellationTokenSource tokenSource, CancellationToken cancellationToken)
             {
                 CancellationTokenRegistration reg = default;
@@ -302,6 +306,9 @@ namespace System.IO.Pipelines
 
             return Core(this, minimumSize, tokenSource, cancellationToken);
 
+#if NETCOREAPP
+            [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
             static async ValueTask<ReadResult> Core(StreamPipeReader reader, int minimumSize, CancellationTokenSource tokenSource, CancellationToken cancellationToken)
             {
                 CancellationTokenRegistration reg = default;

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -288,6 +289,9 @@ namespace System.IO.Pipelines
             InternalTokenSource.Cancel();
         }
 
+#if NETCOREAPP
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
         private async ValueTask<FlushResult> FlushAsyncInternal(bool writeToStream, ReadOnlyMemory<byte> data, CancellationToken cancellationToken = default)
         {
             // Write all completed segments and whatever remains in the current segment


### PR DESCRIPTION
- Use ValueTask pooling on StreamPipeReader.ReadAsync and ReadAtLeastAsync and StreamPipeWriter.FlushAsync

Fixes https://github.com/dotnet/runtime/issues/30169 and contributes to https://github.com/dotnet/aspnetcore/issues/41343

Here's the allocation profile for the JSON https benchmark:

Crank command line:

```
crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/json.benchmarks.yml --scenario https --profile aspnet-perf-lin --application.options.collectCounters true --application.channel edge --application.framework net7.0 --chart
```

Crank with allocation profile:

```
crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/json.benchmarks.yml --scenario https --profile aspnet-perf-lin --application.options.collectCounters true --application.channel edge --application.framework net7.0 --chart --application.dotnetTrace true --application.dotnetTraceProviders gc-verbose
```

## Before

<HTML>
<BODY>
<!--StartFragment--><TABLE><TR><TD>Name &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</TD><TD>Exc %</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Exc</TD><TD> Exc Ct</TD><TD>Inc %</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Inc</TD><TD> Inc Ct</TD><TD>Fold</TD><TD>Fold Ct</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;When</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;First</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Last</TD></TR><TR><TD>Type AsyncStateMachineBox`1[System.IO.Pipelines.ReadResult,System.IO.Pipelines.StreamPipeReader+&lt;&lt;ReadAsync&gt;g__Core|36_0&gt;d] &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</TD><TD> 37.2</TD><TD>2,525,305,344.000</TD><TD> 23,782</TD><TD> 37.2</TD><TD>2,525,305,344.000</TD><TD> 23,782</TD><TD> &nbsp;&nbsp;0</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0</TD><TD> _034o7777777777577777777777774__</TD><TD> 2,061.743</TD><TD> 32,219.062</TD></TR><TR><TD>Type AsyncStateMachineBox`1[System.Int32,System.Net.Security.SslStream+&lt;ReadAsyncInternal&gt;d__179`1[System.Net.Security.AsyncReadWriteAdapter]] </TD><TD> 31.0</TD><TD> 2,102,077,952</TD><TD> 19,796</TD><TD> 31.0</TD><TD> &nbsp;&nbsp;2,102,077,952</TD><TD> 19,796</TD><TD> &nbsp;&nbsp;0</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0</TD><TD> _023o6565666666466556666666653__</TD><TD> 2,061.098</TD><TD> 32,216.272</TD></TR><TR><TD>Type System.Text.Json.Utf8JsonWriter &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</TD><TD> 19.3</TD><TD> 1,312,253,440</TD><TD> 12,358</TD><TD> 19.3</TD><TD> &nbsp;&nbsp;1,312,253,440</TD><TD> 12,358</TD><TD> &nbsp;&nbsp;0</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0</TD><TD> _012o3433333333333344343433432__</TD><TD> 2,012.742</TD><TD> 32,217.077</TD></TR><TR><TD>Type System.Text.Json.PooledByteBufferWriter &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</TD><TD> &nbsp;8.3</TD><TD> &nbsp;&nbsp;562,264,192</TD><TD> &nbsp;5,295</TD><TD> &nbsp;8.3</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;562,264,192</TD><TD> &nbsp;5,295</TD><TD> &nbsp;&nbsp;0</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0</TD><TD> _001.1111111111111111111111110__</TD><TD> 2,081.391</TD><TD> 32,218.706</TD></TR><TR><TD>Type Benchmarks.Middleware.JsonMessage &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</TD><TD> &nbsp;3.9</TD><TD> &nbsp;&nbsp;262,497,232</TD><TD> &nbsp;2,472</TD><TD> &nbsp;3.9</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;262,497,232</TD><TD> &nbsp;2,472</TD><TD> &nbsp;&nbsp;0</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0</TD><TD> _o000.000000000000000000000000__</TD><TD> 2,069.140</TD><TD> 32,190.121</TD></TR></TABLE>
<!--EndFragment-->
</BODY>
</HTML>

You can see the top allocation is the StreamPipeReader state machine. Here are the client stats:


| load                   |           |                               |
| ---------------------- | --------- | ----------------------------- |
| CPU Usage (%)          | 68        |               ▄██████████████ |
| Cores usage (%)        | 821       |               ▄██████████████ |
| Working Set (MB)       | 49        | ██████████████▃▃▃▃▃▃▃▄▄▄▄▄▄▄▄ |
| Private Memory (MB)    | 376       | ▂▂▂▂▂▂▂▂▂▂▂▂▂▂███████████████ |
| Start Time (ms)        | 0         |                               |
| First Request (ms)     | 208       |                               |
| Requests/sec           | 411,794   |                               |
| Requests               | 6,215,626 |                               |
| Mean latency (ms)      | 1.00      |                               |
| Max latency (ms)       | 65.03     |                               |
| Bad responses          | 0         |                               |
| Socket errors          | 0         |                               |
| Read throughput (MB/s) | 59.69     |                               |
| Latency 50th (ms)      | 0.45      |                               |
| Latency 75th (ms)      | 0.74      |                               |
| Latency 90th (ms)      | 2.30      |                               |
| Latency 99th (ms)      | 8.35      |                               |

## After

Allocation profile

<HTML>
<BODY>
<!--StartFragment--><TABLE><TR><TD>Name &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</TD><TD>Exc %</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Exc</TD><TD> Exc Ct</TD><TD>Inc %</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Inc</TD><TD> Inc Ct</TD><TD>Fold</TD><TD>Fold Ct</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;When</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;First</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Last</TD></TR><TR><TD>Type AsyncStateMachineBox`1[System.Int32,System.Net.Security.SslStream+&lt;ReadAsyncInternal&gt;d__179`1[System.Net.Security.AsyncReadWriteAdapter]] </TD><TD> 57.0</TD><TD>2,424,627,456.000</TD><TD> 22,833</TD><TD> 57.0</TD><TD>2,424,627,456.000</TD><TD> 22,833</TD><TD> &nbsp;&nbsp;0</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0</TD><TD> __460CBBBCBBBBBAB9AABBBAABABBABA</TD><TD> 2,026.491</TD><TD> 32,251.241</TD></TR><TR><TD>Type System.Text.Json.Utf8JsonWriter &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</TD><TD> 31.3</TD><TD> 1,332,481,792</TD><TD> 12,548</TD><TD> 31.3</TD><TD> &nbsp;&nbsp;1,332,481,792</TD><TD> 12,548</TD><TD> &nbsp;&nbsp;0</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0</TD><TD> _o2o6566666656665566666666666666</TD><TD> 1,986.173</TD><TD> 32,255.860</TD></TR><TR><TD>Type System.Text.Json.PooledByteBufferWriter &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</TD><TD> &nbsp;6.6</TD><TD> &nbsp;&nbsp;282,760,640</TD><TD> &nbsp;2,663</TD><TD> &nbsp;6.6</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;282,760,640</TD><TD> &nbsp;2,663</TD><TD> &nbsp;&nbsp;0</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0</TD><TD> __00o111101111111111111110111111</TD><TD> 2,038.833</TD><TD> 32,247.522</TD></TR><TR><TD>Type Benchmarks.Middleware.JsonMessage &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</TD><TD> &nbsp;4.6</TD><TD> &nbsp;&nbsp;195,596,128</TD><TD> &nbsp;1,842</TD><TD> &nbsp;4.6</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;195,596,128</TD><TD> &nbsp;1,842</TD><TD> &nbsp;&nbsp;0</TD><TD> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0</TD><TD> __000000000000000001010100000101</TD><TD> 2,048.108</TD><TD> 32,214.326</TD></TR></TABLE>
<!--EndFragment-->
</BODY>
</HTML>


| load                   |           |                               |
| ---------------------- | --------- | ----------------------------- |
| CPU Usage (%)          | 70        |               ▄██████████████ |
| Cores usage (%)        | 835       |               ▄██████████████ |
| Working Set (MB)       | 49        | ██████████████▃▃▃▄▄▄▄▄▄▄▄▄▄▄▄ |
| Private Memory (MB)    | 376       | ▂▂▂▂▂▂▂▂▂▂▂▂▂▂███████████████ |
| Start Time (ms)        | 0         |                               |
| First Request (ms)     | 211       |                               |
| Requests/sec           | 416,502   |                               |
| Requests               | 6,288,546 |                               |
| Mean latency (ms)      | 1.03      |                               |
| Max latency (ms)       | 37.39     |                               |
| Bad responses          | 0         |                               |
| Socket errors          | 0         |                               |
| Read throughput (MB/s) | 60.38     |                               |
| Latency 50th (ms)      | 0.43      |                               |
| Latency 75th (ms)      | 0.76      |                               |
| Latency 90th (ms)      | 2.49      |                               |
| Latency 99th (ms)      | 8.70      |                               |