### PR TITLE
Fix CircleInConvex test

### DIFF
--- a/src/tests/JIT/SIMD/CircleInConvex.cs
+++ b/src/tests/JIT/SIMD/CircleInConvex.cs
@@ -189,10 +189,10 @@ namespace ClassLibrary
 
         static int cmp(Point a, Point b)
         {
-            if (a.X < b.X || a.X == b.X && a.Y < b.Y)
-                return 1;
+            if (a.X == b.X)
+                return a.Y < b.Y ? 1 : a.Y > b.Y ? -1 : 0;
             else
-                return 0;
+                return a.X < b.X ? 1 : a.X > b.X ? -1 : 0;
         }
 
         static bool cw(Point a, Point b, Point c)
@@ -258,8 +258,8 @@ namespace ClassLibrary
             float r;
             FindCircle(points, out O, out r);
 
-            float expRes = 75656240.0F;
-            float ulp    =        8.0F;
+            float expRes = 1191233374.188854F;
+            float ulp    =             384.0F;
             if (Math.Abs(r - expRes) <= ulp)
                 return 100;
             return 0;


### PR DESCRIPTION
Cherry-picked from #68436.

The original cmp function in CircleInConvex test is malformed:

```csharp
static int cmp(Point a, Point b)
{
    if (a.X < b.X || a.X == b.X && a.Y < b.Y)
        return 1;
    else
        return 0;
}
```

The above cmp function results in indeterminate behavior, which is strongly coupled with introsort behavior (code really shouldn't assume Array.Sort having a introsort implementation).

Note that If I switch to sort algorithm other than intersort such as heap sort, insertion sort and etc, or even keep the introsort but sort it twice, the CircleInConvex will also fail without this change.

Also, the original `expRes` was incorrect. The new `expRes` is verified using a convex-hull algorithm locally:

Convex-hull points:

| X | Y |
| -- | -- |
| -1.7994474E+09 | -1.2456694E-05 |
| -14.506294 | 2.1465364E+09 |
| 1.3253972E+09 | 6.081364E-10 |
| 0.37576595 | -1.6159191E+09 |

Origin: (-146892800, 117045950)
Radius: 1.191233E+09

/cc: @jkotas