### PR TITLE
Assign PropertyCache after it's configured for source gen in attempt to fix JSON LookupProperty assert failing

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
@@ -92,9 +92,9 @@ namespace System.Text.Json.Serialization.Metadata
             return new JsonMetadataServicesConverter<T>(converterCreator, strategy);
         }
 
-        internal override void LateAddProperties()
+        internal override JsonPropertyDictionary<JsonPropertyInfo>? LateAddProperties()
         {
-            AddPropertiesUsingSourceGenInfo();
+            return AddPropertiesUsingSourceGenInfo();
         }
 
         internal override JsonParameterInfoValues[] GetParameterInfoValues()
@@ -110,11 +110,11 @@ namespace System.Text.Json.Serialization.Metadata
             return array;
         }
 
-        internal void AddPropertiesUsingSourceGenInfo()
+        internal JsonPropertyDictionary<JsonPropertyInfo>? AddPropertiesUsingSourceGenInfo()
         {
             if (PropertyInfoForTypeInfo.ConverterStrategy != ConverterStrategy.Object)
             {
-                return;
+                return null;
             }
 
             JsonSerializerContext? context = Options.JsonSerializerContext;
@@ -123,23 +123,23 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 if (typeof(T) == typeof(object))
                 {
-                    return;
+                    return null;
                 }
 
                 if (PropertyInfoForTypeInfo.ConverterBase.ElementType != null)
                 {
                     // Nullable<> or F# optional converter's strategy is set to element's strategy
-                    return;
+                    return null;
                 }
 
                 if (SerializeHandler != null && Options.JsonSerializerContext?.CanUseSerializationLogic == true)
                 {
                     ThrowOnDeserialize = true;
-                    return;
+                    return null;
                 }
 
                 ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeProperties(context, Type);
-                return;
+                return null;
             }
 
             Dictionary<string, JsonPropertyInfo>? ignoredMembers = null;
@@ -179,7 +179,7 @@ namespace System.Text.Json.Serialization.Metadata
                 CacheMember(jsonPropertyInfo, propertyCache, ref ignoredMembers);
             }
 
-            PropertyCache = propertyCache;
+            return propertyCache;
         }
 
         private void SetCreateObjectFunc(Func<T>? createObjectFunc)


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/runtime/issues/67816

Fixing one potential threading issue related to LookupProperty assert failing. This could possibly happen for source gen when two threads start using same JsonTypeInfo at the same time since. For source gen properties are late assigned meaning if one thread has already assigned and configured them the other might reset that state and first thread might start using it before the second thread finishes configuring. This PR changes so that assignment happens after cache is already configured so that we don't start using semi configured cache in neither thread.

I'm not 100% certain this will fix the issue (I don't have a local repro) but it's likely. Once this is merged I'll observe if this repros again for another couple of days and if not we can assume it's fixed.