### PR TITLE
Add parts of an assert back

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6425,7 +6425,7 @@ void Lowering::CheckCallArg(GenTree* arg)
 {
     if (!arg->IsValue() && !arg->OperIsPutArgStk())
     {
-        assert(arg->OperIsStore() || arg->OperIsCopyBlkOp());
+        assert(arg->OperIsStore() || arg->IsNothingNode() || arg->OperIsCopyBlkOp());
         return;
     }
 


### PR DESCRIPTION
Under JitRepeatOpts we sometimes turn early-arg stores into GT_NOP
nodes.

Fix #68472 (the test there runs under JitRepeatOpts=*).

This assert can be removed in #68460 again.