### PR TITLE
Copy the SSA name when cloning locals

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7983,22 +7983,24 @@ GenTree* Compiler::gtClone(GenTree* tree, bool complexOK)
             break;
 
         case GT_LCL_VAR:
-            // Remember that the LclVar node has been cloned. The flag will be set
-            // on 'copy' as well.
-            tree->gtFlags |= GTF_VAR_CLONED;
+        case GT_LCL_VAR_ADDR:
             copy = gtNewLclvNode(tree->AsLclVarCommon()->GetLclNum(),
-                                 tree->gtType DEBUGARG(tree->AsLclVar()->gtLclILoffs));
-            break;
+                                 tree->TypeGet() DEBUGARG(tree->AsLclVar()->gtLclILoffs));
+            goto FINISH_CLONING_LCL_NODE;
 
         case GT_LCL_FLD:
         case GT_LCL_FLD_ADDR:
-            // Remember that the LclVar node has been cloned. The flag will be set
-            // on 'copy' as well.
-            tree->gtFlags |= GTF_VAR_CLONED;
             copy = new (this, tree->OperGet())
                 GenTreeLclFld(tree->OperGet(), tree->TypeGet(), tree->AsLclFld()->GetLclNum(),
                               tree->AsLclFld()->GetLclOffs());
             copy->AsLclFld()->SetFieldSeq(tree->AsLclFld()->GetFieldSeq());
+            goto FINISH_CLONING_LCL_NODE;
+
+        FINISH_CLONING_LCL_NODE:
+            // Remember that the local node has been cloned. Below the flag will be set on 'copy' too.
+            tree->gtFlags |= GTF_VAR_CLONED;
+            copy->AsLclVarCommon()->SetSsaNum(tree->AsLclVarCommon()->GetSsaNum());
+            assert(!copy->AsLclVarCommon()->HasSsaName() || ((copy->gtFlags & GTF_VAR_DEF) == 0));
             break;
 
         case GT_CLS_VAR:

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7983,7 +7983,6 @@ GenTree* Compiler::gtClone(GenTree* tree, bool complexOK)
             break;
 
         case GT_LCL_VAR:
-        case GT_LCL_VAR_ADDR:
             copy = gtNewLclvNode(tree->AsLclVarCommon()->GetLclNum(),
                                  tree->TypeGet() DEBUGARG(tree->AsLclVar()->gtLclILoffs));
             goto FINISH_CLONING_LCL_NODE;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_68479/Runtime_68479.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_68479/Runtime_68479.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+public class Runtime_68479
+{
+    public static int Main()
+    {
+        return Problem(new Class(), 1, 1) == 1 ? 100 : 101;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Problem(Class a, long b, long c)
+    {
+        c = 17;
+        BlockFwdSub();
+        Use(ref a.Field, a.Field, b % c);
+
+        return a.Field;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void BlockFwdSub() { }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Use(ref int a, long b, long c) { a = 1; }
+
+    class Class
+    {
+        public int Field;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_68479/Runtime_68479.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_68479/Runtime_68479.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The issue was that during early propagation we can call morph, and that can introduce new uses of in-SSA locals. It is safe and desirable to annotate these with the appropriate SSA numbers.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1736241&view=ms.vss-build-web.run-extensions-tab) as expected.

Fixes #68479.