### PR TITLE
[wasm] Fix linux/arm64 emscripten provisioning

### DIFF
--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -35,7 +35,6 @@ EMCC=source $(EMSDK_PATH)/emsdk_env.sh 2>/dev/null && emcc
 .stamp-wasm-install-and-select-$(EMSCRIPTEN_VERSION):
 	rm -rf $(EMSDK_LOCAL_PATH)
 	git clone https://github.com/emscripten-core/emsdk.git $(EMSDK_LOCAL_PATH)
-	cd $(EMSDK_LOCAL_PATH) && git checkout $(EMSCRIPTEN_VERSION)
 	cd $(EMSDK_LOCAL_PATH) && ./emsdk install $(EMSCRIPTEN_VERSION)
 	cd $(EMSDK_LOCAL_PATH) && ./emsdk activate $(EMSCRIPTEN_VERSION)
 	python3 ./sanitize.py $(EMSDK_PATH)


### PR DESCRIPTION
Don't checkout particular emscripten version and instead use main.

It is not needed and fixes linux/arm64 build, where precompiled version
is available in emscripten 3.1.7 and later versions.
The `emsdk install|activate <version>` doesn't work correctly for 3.1.7
tag and does with uptodate main.

It will still install and activate the emscripten version we want, like 3.1.7 currently.