### PR TITLE
Ensure that System.Guid can build successfully

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -5,6 +5,7 @@ using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;


### PR DESCRIPTION
I missed that the test runs were a bit older in https://github.com/dotnet/runtime/pull/66889 and so they didn't catch the build failure related to the removed namespace.