### PR TITLE
Fix leaks after unsuccessful assembly load (another try)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2153,6 +2153,9 @@
   <data name="FileNotFound_ResolveAssembly" xml:space="preserve">
     <value>Could not resolve assembly '{0}'.</value>
   </data>
+  <data name="FileNotFound_LoadFile" xml:space="preserve">
+    <value>Could not load file or assembly '{0}'. The system cannot find the file specified.</value>
+  </data>
   <data name="Format_AttributeUsage" xml:space="preserve">
     <value>Duplicate AttributeUsageAttribute found on attribute type {0}.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
@@ -263,6 +263,9 @@ namespace System.Reflection
                 if (s_loadfile.TryGetValue(normalizedPath, out result))
                     return result;
 
+                if (!File.Exists(normalizedPath))
+                    throw new FileNotFoundException(SR.Format(SR.FileNotFound_LoadFile, normalizedPath), normalizedPath);
+
                 AssemblyLoadContext alc = new IndividualAssemblyLoadContext($"Assembly.LoadFile({normalizedPath})");
                 result = alc.LoadFromAssemblyPath(normalizedPath);
                 s_loadfile.Add(normalizedPath, result);

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
@@ -263,8 +263,8 @@ namespace System.Reflection
                 if (s_loadfile.TryGetValue(normalizedPath, out result))
                     return result;
 
-// we cannot check for file presence on WASM. The files could be embedded and not physically present.
-#if !TARGET_WASM
+                // we cannot check for file presence on BROWSER. The files could be embedded and not physically present.
+#if !TARGET_BROWSER
                 string assemblyPath = normalizedPath;
 #if MONO
                 assemblyPath?.Replace('\\', Path.DirectorySeparatorChar);
@@ -272,7 +272,7 @@ namespace System.Reflection
 
                 if (!File.Exists(assemblyPath))
                     throw new FileNotFoundException(SR.Format(SR.FileNotFound_LoadFile, assemblyPath), assemblyPath);
-#endif // !TARGET_WASM
+#endif // !TARGET_BROWSER
 
                 AssemblyLoadContext alc = new IndividualAssemblyLoadContext($"Assembly.LoadFile({normalizedPath})");
                 result = alc.LoadFromAssemblyPath(normalizedPath);

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
@@ -272,7 +272,7 @@ namespace System.Reflection
 
                 if (!File.Exists(assemblyPath))
                     throw new FileNotFoundException(SR.Format(SR.FileNotFound_LoadFile, assemblyPath), assemblyPath);
-#endif
+#endif // !TARGET_WASM
 
                 AssemblyLoadContext alc = new IndividualAssemblyLoadContext($"Assembly.LoadFile({normalizedPath})");
                 result = alc.LoadFromAssemblyPath(normalizedPath);

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
@@ -265,13 +265,8 @@ namespace System.Reflection
 
                 // we cannot check for file presence on BROWSER. The files could be embedded and not physically present.
 #if !TARGET_BROWSER
-                string assemblyPath = normalizedPath;
-#if MONO
-                assemblyPath?.Replace('\\', Path.DirectorySeparatorChar);
-#endif
-
-                if (!File.Exists(assemblyPath))
-                    throw new FileNotFoundException(SR.Format(SR.FileNotFound_LoadFile, assemblyPath), assemblyPath);
+                if (!File.Exists(normalizedPath))
+                    throw new FileNotFoundException(SR.Format(SR.FileNotFound_LoadFile, normalizedPath), normalizedPath);
 #endif // !TARGET_BROWSER
 
                 AssemblyLoadContext alc = new IndividualAssemblyLoadContext($"Assembly.LoadFile({normalizedPath})");

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
@@ -263,8 +263,16 @@ namespace System.Reflection
                 if (s_loadfile.TryGetValue(normalizedPath, out result))
                     return result;
 
-                if (!File.Exists(normalizedPath))
-                    throw new FileNotFoundException(SR.Format(SR.FileNotFound_LoadFile, normalizedPath), normalizedPath);
+// we cannot check for file presence on WASM. The files could be embedded and not physically present.
+#if !TARGET_WASM
+                string assemblyPath = normalizedPath;
+#if MONO
+                assemblyPath?.Replace('\\', Path.DirectorySeparatorChar);
+#endif
+
+                if (!File.Exists(assemblyPath))
+                    throw new FileNotFoundException(SR.Format(SR.FileNotFound_LoadFile, assemblyPath), assemblyPath);
+#endif
 
                 AssemblyLoadContext alc = new IndividualAssemblyLoadContext($"Assembly.LoadFile({normalizedPath})");
                 result = alc.LoadFromAssemblyPath(normalizedPath);


### PR DESCRIPTION
Same as https://github.com/dotnet/runtime/pull/68203, but excluding WASM/BROWSER, since the scenario may use embedded files.

Fixes:#58093