### PR TITLE
Fix superpmi.py overridden build_type arg

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -341,11 +341,7 @@ asm_diff_parser.add_argument("-retainOnlyTopFiles", action="store_true", help="R
 asm_diff_parser.add_argument("--diff_with_release", action="store_true", help="Specify if this is asmdiff using release binaries.")
 
 # subparser for throughput
-throughput_parser = subparsers.add_parser("tpdiff",
-                                          description=throughput_description, parents=[target_parser, superpmi_common_parser, replay_common_parser, base_diff_parser],
-                                          # Allow overriding build_type with new default
-                                          conflict_handler='resolve')
-
+throughput_parser = subparsers.add_parser("tpdiff", description=throughput_description, parents=[target_parser, superpmi_common_parser, replay_common_parser, base_diff_parser])
 add_core_root_arguments(throughput_parser, "Release", throughput_build_type_help)
 
 # subparser for upload

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -242,16 +242,18 @@ subparsers.required = True
 # You normally use the default host OS, but for Azure Storage upload and other
 # operations, it can be useful to allow it to be specified.
 
-core_root_parser = argparse.ArgumentParser(add_help=False)
+def add_core_root_arguments(parser, build_type_default, build_type_help):
+    parser.add_argument("-arch", help=arch_help)
+    parser.add_argument("-build_type", default=build_type_default, help=build_type_help)
+    parser.add_argument("-host_os", help=host_os_help)
+    parser.add_argument("-core_root", help=core_root_help)
+    parser.add_argument("-log_level", help=log_level_help)
+    parser.add_argument("-log_file", help=log_file_help)
+    parser.add_argument("-spmi_location", help=spmi_location_help)
+    parser.add_argument("--no_progress", action="store_true", help=download_no_progress_help)
 
-core_root_parser.add_argument("-arch", help=arch_help)
-core_root_parser.add_argument("-build_type", default="Checked", help=build_type_help)
-core_root_parser.add_argument("-host_os", help=host_os_help)
-core_root_parser.add_argument("-core_root", help=core_root_help)
-core_root_parser.add_argument("-log_level", help=log_level_help)
-core_root_parser.add_argument("-log_file", help=log_file_help)
-core_root_parser.add_argument("-spmi_location", help=spmi_location_help)
-core_root_parser.add_argument("--no_progress", action="store_true", help=download_no_progress_help)
+core_root_parser = argparse.ArgumentParser(add_help=False)
+add_core_root_arguments(core_root_parser, "Checked", build_type_help)
 
 # Create a set of arguments common to target specification. Used for collect, replay, asmdiffs, upload, upload-private, download, list-collections.
 
@@ -340,12 +342,11 @@ asm_diff_parser.add_argument("--diff_with_release", action="store_true", help="S
 
 # subparser for throughput
 throughput_parser = subparsers.add_parser("tpdiff",
-                                          description=throughput_description, parents=[core_root_parser, target_parser, superpmi_common_parser, replay_common_parser, base_diff_parser],
+                                          description=throughput_description, parents=[target_parser, superpmi_common_parser, replay_common_parser, base_diff_parser],
                                           # Allow overriding build_type with new default
                                           conflict_handler='resolve')
 
-# Override build type
-throughput_parser.add_argument("-build_type", default="Release", help=throughput_build_type_help)
+add_core_root_arguments(throughput_parser, "Release", throughput_build_type_help)
 
 # subparser for upload
 upload_parser = subparsers.add_parser("upload", description=upload_description, parents=[core_root_parser, target_parser])


### PR DESCRIPTION
Looks like the build_type arg of the parent parser gets corrupted when
adding a similar named one to throughput_diff_parser ([Python bug](https://bugs.python.org/issue22401)).
This breaks specifying build_type for other arguments. The fix is to just use a function to add the common arguments.

We could do it this way consistently instead of using the `parents` mechanism, but I just went for the small diff fix. If you think it would be better to do it this way consistently I can make the change.