### PR TITLE
Fix nullable reference type warnings in RegexGenerator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
@@ -238,7 +238,7 @@ namespace System.Text.RegularExpressions.Generator
         /// <summary>A regex method.</summary>
         internal sealed record RegexMethod(RegexType DeclaringType, MethodDeclarationSyntax MethodSyntax, string MethodName, string Modifiers, string Pattern, RegexOptions Options, int? MatchTimeout, RegexTree Tree, AnalysisResults Analysis)
         {
-            public string GeneratedName { get; set; }
+            public string? GeneratedName { get; set; }
             public bool IsDuplicate { get; set; }
         }
 

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
@@ -47,7 +47,7 @@ namespace System.Text.RegularExpressions.Generator
             // - Diagnostic in the case of a failure that should end the compilation
             // - (RegexMethod regexMethod, string runnerFactoryImplementation, Dictionary<string, string[]> requiredHelpers) in the case of valid regex
             // - (RegexMethod regexMethod, string reason, Diagnostic diagnostic) in the case of a limited-support regex
-            IncrementalValueProvider<ImmutableArray<object?>> codeOrDiagnostics =
+            IncrementalValueProvider<ImmutableArray<object>> codeOrDiagnostics =
                 context.SyntaxProvider
 
                 // Find all MethodDeclarationSyntax nodes attributed with RegexGenerator and gather the required information.
@@ -94,11 +94,11 @@ namespace System.Text.RegularExpressions.Generator
             // and raise all of the created diagnostics.
             context.RegisterSourceOutput(codeOrDiagnostics.Combine(compilationDataProvider), static (context, compilationDataAndResults) =>
             {
-                ImmutableArray<object?> results = compilationDataAndResults.Left;
+                ImmutableArray<object> results = compilationDataAndResults.Left;
 
                 // Report any top-level diagnostics.
                 bool allFailures = true;
-                foreach (object? result in results)
+                foreach (object result in results)
                 {
                     if (result is Diagnostic d)
                     {


### PR DESCRIPTION
In response to https://github.com/dotnet/runtime/pull/68490#discussion_r857909668

I temporarily changed the TargetFramework to net7.0 and got it compiling without warning, but am not including the TargetFramework change here.