### PR TITLE
Add DI spec tests for scope factory singleton, hierarchical scopes

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/Autofac.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/Autofac.cs
@@ -7,11 +7,17 @@ using Autofac.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.DependencyInjection.Specification
 {
-    public class AutofacDependencyInjectionSpecificationTests : DependencyInjectionSpecificationTests
+    public class AutofacDependencyInjectionSpecificationTests : SkippableDependencyInjectionSpecificationTests
     {
         public override bool SupportsIServiceProviderIsService => false;
 
-        protected override IServiceProvider CreateServiceProvider(IServiceCollection serviceCollection)
+        public override string[] SkippedTests => new[]
+        {
+            "ScopesAreFlatNotHierarchical",
+            "ServiceScopeFactoryIsSingleton"
+        };
+
+        protected override IServiceProvider CreateServiceProviderImpl(IServiceCollection serviceCollection)
         {
             var builder = new ContainerBuilder();
             builder.Populate(serviceCollection);

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/Autofac.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/Autofac.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
 {
     public class AutofacDependencyInjectionSpecificationTests : SkippableDependencyInjectionSpecificationTests
     {
-        public override bool SupportsIServiceProviderIsService => true;
+        public override bool SupportsIServiceProviderIsService => false;
 
         public override string[] SkippedTests => new[]
         {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/Autofac.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/Autofac.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
 {
     public class AutofacDependencyInjectionSpecificationTests : SkippableDependencyInjectionSpecificationTests
     {
-        public override bool SupportsIServiceProviderIsService => false;
+        public override bool SupportsIServiceProviderIsService => true;
 
         public override string[] SkippedTests => new[]
         {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/DryIoc.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/DryIoc.cs
@@ -7,11 +7,16 @@ using DryIoc.Microsoft.DependencyInjection;
 
 namespace Microsoft.Extensions.DependencyInjection.Specification
 {
-    public class DryIocDependencyInjectionSpecificationTests : DependencyInjectionSpecificationTests
+    public class DryIocDependencyInjectionSpecificationTests : SkippableDependencyInjectionSpecificationTests
     {
         public override bool SupportsIServiceProviderIsService => false;
 
-        protected override IServiceProvider CreateServiceProvider(IServiceCollection serviceCollection)
+        public override string[] SkippedTests => new[]
+        {
+            "ServiceScopeFactoryIsSingleton"
+        };
+
+        protected override IServiceProvider CreateServiceProviderImpl(IServiceCollection serviceCollection)
         {
             return new Container()
                 .WithDependencyInjectionAdapter(serviceCollection)

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/Grace.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/Grace.cs
@@ -7,13 +7,14 @@ using Grace.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection.Specification
 {
-    public class GraceDependencyInjectionSpecificationTests: SkippableDependencyInjectionSpecificationTests
+    public class GraceDependencyInjectionSpecificationTests : SkippableDependencyInjectionSpecificationTests
     {
         public override bool SupportsIServiceProviderIsService => false;
 
         public override string[] SkippedTests => new[]
         {
             "ResolvesMixedOpenClosedGenericsAsEnumerable",
+            "ServiceScopeFactoryIsSingleton",
             "TypeActivatorWorksWithCtorWithOptionalArgs_WithStructDefaults"
         };
 


### PR DESCRIPTION
Fix #67391

Adds Microsoft.Extensions.DependencyInjection.Specification.Tests for ensuring:

- `IServiceScopeFactory` is a singleton.
- Dependency injection scopes are flat, not  hierarchical structure.

Autofac, Grace, and DryIoc all fail one or both of these tests. Changes include adding explicit skip for the failing tests on those external containers.

Also switched the `IServiceProviderIsService` tests on for Autofac since that is supported. All of those tests pass.