### PR TITLE
Always set `IND_NONFAULTING` for not-null addresses

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -9705,15 +9705,9 @@ void GenTree::SetIndirExceptionFlags(Compiler* comp)
         addr = AsArrLen()->ArrRef();
     }
 
-    if ((addr->gtFlags & GTF_EXCEPT) != 0)
-    {
-        gtFlags |= GTF_EXCEPT;
-    }
-    else
-    {
-        gtFlags &= ~GTF_EXCEPT;
-        gtFlags |= GTF_IND_NONFAULTING;
-    }
+    gtFlags |= GTF_IND_NONFAULTING;
+    gtFlags &= ~GTF_EXCEPT;
+    gtFlags |= addr->gtFlags & GTF_EXCEPT;
 }
 
 #ifdef DEBUG

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5603,8 +5603,6 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
         tree->SetOper(GT_IND);
         tree->AsOp()->gtOp1 = addr;
 
-        tree->SetIndirExceptionFlags(this);
-
         if (addExplicitNullCheck)
         {
             //


### PR DESCRIPTION
Previously, that was only done if the address was itself side-effect-free, but that is an unnecessary (with the fix to `fgMorphField` in this PR) pessimization. A canonical example of a non-null address that can still throw is an `INDEX_ADDR` (which I am in the process of transitioning `INDEX` to, and so this change is meant to avoid diffs for that change).

A small number of positive [diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1737220&view=ms.vss-build-web.run-extensions-tab) (mostly due to containment).