### PR TITLE
Reduce leaked test files

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
@@ -69,9 +69,24 @@ namespace System.IO
         protected virtual void Dispose(bool disposing)
         {
             // No managed resources to clean up, so disposing is ignored.
+            try
+            {
+                try
+                {
+                    Directory.Delete(TestDirectory, recursive: true);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    DirectoryInfo di = new DirectoryInfo(TestDirectory);
+                    foreach (FileInfo file in di.GetFiles("*", SearchOption.AllDirectories))
+                    {
+                        file.IsReadOnly = false;
+                    }
 
-            try { Directory.Delete(TestDirectory, recursive: true); }
-            catch { } // avoid exceptions escaping Dispose
+                    Directory.Delete(TestDirectory, recursive: true);
+                }
+            }
+            catch {  } // avoid exceptions escaping Dispose
         }
 
         /// <summary>

--- a/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
@@ -36,7 +36,8 @@ namespace System.IO
             string failure = string.Empty;
             for (int i = 0; i <= 2; i++)
             {
-                TestDirectory = Path.Combine(tempDirectory, GetType().Name + "_" + Path.GetRandomFileName());
+                // Prefix with "#" to help spot leaked files
+                TestDirectory = Path.Combine(tempDirectory, "#" + GetType().Name + "_" + Path.GetRandomFileName());
                 try
                 {
                     Directory.CreateDirectory(TestDirectory);

--- a/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
@@ -69,7 +69,6 @@ namespace System.IO
         /// <summary>Delete the associated test directory.</summary>
         protected virtual void Dispose(bool disposing)
         {
-            // No managed resources to clean up, so disposing is ignored.
             try
             {
                 try

--- a/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
@@ -80,13 +80,13 @@ namespace System.IO
         /// </summary>
         protected string TestDirectory { get; }
 
-        protected string GetRandomFileName() => GetTestFileName() + ".txt";
-        protected string GetRandomLinkName() => GetTestFileName() + ".link";
-        protected string GetRandomDirName()  => GetTestFileName() + "_dir";
+        protected string GetRandomFileName([CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0) => GetTestFileName(index: null, memberName, lineNumber) + ".txt";
+        protected string GetRandomLinkName([CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0) => GetTestFileName(index: null, memberName, lineNumber) + ".link";
+        protected string GetRandomDirName([CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0) => GetTestFileName(index: null, memberName, lineNumber) + "_dir";
 
-        protected string GetRandomFilePath() => Path.Combine(TestDirectoryActualCasing, GetRandomFileName());
-        protected string GetRandomLinkPath() => Path.Combine(TestDirectoryActualCasing, GetRandomLinkName());
-        protected string GetRandomDirPath()  => Path.Combine(TestDirectoryActualCasing, GetRandomDirName());
+        protected string GetRandomFilePath([CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0) => Path.Combine(TestDirectoryActualCasing, GetRandomFileName(memberName, lineNumber));
+        protected string GetRandomLinkPath([CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0) => Path.Combine(TestDirectoryActualCasing, GetRandomLinkName(memberName, lineNumber));
+        protected string GetRandomDirPath([CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)  => Path.Combine(TestDirectoryActualCasing, GetRandomDirName(memberName, lineNumber));
 
         private string _testDirectoryActualCasing;
         private string TestDirectoryActualCasing => _testDirectoryActualCasing ??= GetTestDirectoryActualCasing();

--- a/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
@@ -79,9 +79,9 @@ namespace System.IO
                 catch (UnauthorizedAccessException)
                 {
                     DirectoryInfo di = new DirectoryInfo(TestDirectory);
-                    foreach (FileInfo file in di.GetFiles("*", SearchOption.AllDirectories))
+                    foreach (FileSystemInfo fsi in di.EnumerateFileSystemInfos("*", SearchOption.AllDirectories))
                     {
-                        file.IsReadOnly = false;
+                        fsi.Attributes = FileAttributes.Normal;
                     }
 
                     Directory.Delete(TestDirectory, recursive: true);

--- a/src/libraries/Common/tests/TestUtilities/System/IO/PathGenerator.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/IO/PathGenerator.cs
@@ -24,7 +24,7 @@ namespace System.IO
         private static string GenerateRandomFileSafeString(int length)
         {
             // A little more entropy than Guid.NewGuid().ToString("N").Substring(0, length))
-            const string alphanum = "abcdefghijklmnopqrstuvwxyz0123456789";
+            const string AlphaNumeric = "abcdefghijklmnopqrstuvwxyz0123456789";
 
             byte[] bytes = new byte[length];
             lock (_rand)
@@ -36,7 +36,7 @@ namespace System.IO
 
             for (int i = 0; i < length; i++)
             {
-                chars[i] = alphanum[bytes[i] % alphanum.Length];
+                chars[i] = AlphaNumeric[bytes[i] % AlphaNumeric.Length];
             }
 
             return new String(chars);

--- a/src/libraries/Common/tests/TestUtilities/System/IO/PathGenerator.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/IO/PathGenerator.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace System.IO
@@ -17,6 +18,22 @@ namespace System.IO
                 memberName ?? "TestBase",
                 lineNumber,
                 index.GetValueOrDefault(),
-                Guid.NewGuid().ToString("N").Substring(0, 8)); // randomness to avoid collisions between derived test classes using same base method concurrently
+                GenerateRandomFileSafeString(8)); // randomness to avoid collisions between derived test classes using same base method concurrently
+
+        private static string GenerateRandomFileSafeString(int length)
+        {
+            // A little more entropy than Guid.NewGuid().ToString("N").Substring(0, length))
+            const string alphanum = "abcdefghijklmnopqrstuvwxyz0123456789";
+
+            byte[] rand = RandomNumberGenerator.GetBytes(length);
+            char[] chars = new char[length];
+
+            for (int i = 0; i < length; i++)
+            {
+                chars[i] = alphanum[rand[i] % alphanum.Length];
+            }
+
+            return new String(chars);
+        }
     }
 }

--- a/src/libraries/Common/tests/TestUtilities/System/IO/PathGenerator.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/IO/PathGenerator.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
-using System.Security.Cryptography;
 using System.Text;
 
 namespace System.IO
 {
     public static class PathGenerator
     {
+        private static Random _rand = new Random();
+
         public static string GenerateTestFileName([CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)
             => GenerateTestFileName(null, memberName, lineNumber);
 
@@ -25,12 +26,17 @@ namespace System.IO
             // A little more entropy than Guid.NewGuid().ToString("N").Substring(0, length))
             const string alphanum = "abcdefghijklmnopqrstuvwxyz0123456789";
 
-            byte[] rand = RandomNumberGenerator.GetBytes(length);
+            byte[] bytes = new byte[length];
+            lock (_rand)
+            {
+                _rand.NextBytes(bytes);
+            }
+
             char[] chars = new char[length];
 
             for (int i = 0; i < length; i++)
             {
-                chars[i] = alphanum[rand[i] % alphanum.Length];
+                chars[i] = alphanum[bytes[i] % alphanum.Length];
             }
 
             return new String(chars);

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -53,7 +53,7 @@ namespace System
 
         public static bool IsSuperUser => IsBrowser || IsWindows ? false : libc.geteuid() == 0;
 
-        public static bool IsUnixAndElevated => !IsWindows && IsSuperUser;
+        public static bool IsUnixAndSuperUser => !IsWindows && IsSuperUser;
 
         public static Version OpenSslVersion => !IsOSXLike && !IsWindows && !IsAndroid ?
             GetOpenSslVersion() :

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -53,6 +53,8 @@ namespace System
 
         public static bool IsSuperUser => IsBrowser || IsWindows ? false : libc.geteuid() == 0;
 
+        public static bool IsUnixAndElevated => !IsWindows && IsSuperUser;
+
         public static Version OpenSslVersion => !IsOSXLike && !IsWindows && !IsAndroid ?
             GetOpenSslVersion() :
             throw new PlatformNotSupportedException();

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/ConfigurationPathTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/ConfigurationPathTests.cs
@@ -44,6 +44,7 @@ namespace System.ConfigurationTests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Fails when path contains #")]
         public void CustomAppConfigIsUsedWhenSpecifiedAsAbsoluteUri()
         {
             const string SettingName = "test_CustomAppConfigIsUsedWhenSpecified";

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -20,7 +20,7 @@ namespace System.Diagnostics.Tests
 {
     public partial class ProcessTests : ProcessTestBase
     {
-        private static bool IsRemoteExecutorSupportedAndOnUnixAndElevated => RemoteExecutor.IsSupported && PlatformDetection.IsUnixAndElevated;
+        private static bool IsRemoteExecutorSupportedAndOnUnixAndSuperUser => RemoteExecutor.IsSupported && PlatformDetection.IsUnixAndSuperUser;
 
         [Fact]
         private void TestWindowApisUnix()
@@ -455,7 +455,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(IsUnixAndElevated))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(IsUnixAndSuperUser))]
         public void TestPriorityClassUnix()
         {
             CreateDefaultProcess();
@@ -481,7 +481,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(IsUnixAndElevated))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(IsUnixAndSuperUser))]
         public void TestBasePriorityOnUnix()
         {
             CreateDefaultProcess();
@@ -594,7 +594,7 @@ namespace System.Diagnostics.Tests
         /// Tests when running as root and starting a new process as a normal user,
         /// the new process doesn't have elevated privileges.
         /// </summary>
-        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndElevated))]
+        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndSuperUser))]
         [OuterLoop("Needs sudo access")]
         [InlineData(true)]
         [InlineData(false)]

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -20,6 +20,8 @@ namespace System.Diagnostics.Tests
 {
     public partial class ProcessTests : ProcessTestBase
     {
+        private static bool IsRemoteExecutorSupportedAndOnUnixAndElevated => RemoteExecutor.IsSupported && PlatformDetection.IsUnixAndElevated;
+
         [Fact]
         private void TestWindowApisUnix()
         {
@@ -453,8 +455,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(IsUnixAndElevated))]
         public void TestPriorityClassUnix()
         {
             CreateDefaultProcess();
@@ -480,8 +481,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(IsUnixAndElevated))]
         public void TestBasePriorityOnUnix()
         {
             CreateDefaultProcess();
@@ -594,9 +594,8 @@ namespace System.Diagnostics.Tests
         /// Tests when running as root and starting a new process as a normal user,
         /// the new process doesn't have elevated privileges.
         /// </summary>
-        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndElevated))]
         [OuterLoop("Needs sudo access")]
-        [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
         [InlineData(true)]
         [InlineData(false)]
         public unsafe void TestCheckChildProcessUserAndGroupIdsElevated(bool useRootGroups)

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -455,7 +455,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(IsUnixAndSuperUser))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsUnixAndSuperUser))]
         public void TestPriorityClassUnix()
         {
             CreateDefaultProcess();
@@ -481,7 +481,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(IsUnixAndSuperUser))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsUnixAndSuperUser))]
         public void TestBasePriorityOnUnix()
         {
             CreateDefaultProcess();

--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/tests/TextWriterTraceListener_WriteTests.cs
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/tests/TextWriterTraceListener_WriteTests.cs
@@ -17,11 +17,6 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
         {
             return new TextWriterTraceListener(_fileName);
         }
-
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-        }
     }
 
     public class TextWriterTraceListener_WriteTestsCtorStream : TextWriterTraceListener_WriteTestsBase
@@ -39,13 +34,13 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
         }
 
         [Fact]
-        public void TestWriterPropery()
+        public void TestWriterProperty()
         {
             var testWriter = new StreamWriter(_stream);
             using (var target = new TextWriterTraceListener())
             {
                 Assert.Null(target.Writer);
-                target.Writer = testWriter;
+                target.Writer = testWriter; // disposed by TextWriterTraceListener
                 Assert.NotNull(target.Writer);
                 Assert.Same(testWriter, target.Writer);
             }
@@ -112,11 +107,9 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
             target.WriteLine(TestMessage);
             target.Write(TestMessage);
             target.Flush();
-        }
 
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
+            // Write created a new StreamWriter around the file, so re-Dispose
+            target.Dispose();
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.Unix.cs
@@ -9,7 +9,9 @@ namespace System.Formats.Tar.Tests
 {
     public partial class TarWriter_WriteEntry_File_Tests : TarTestsBase
     {
-        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        private static bool IsRemoteExecutorSupportedAndOnUnixAndElevated => RemoteExecutor.IsSupported && PlatformDetection.IsUnixAndElevated;
+
+        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndElevated))]
         [InlineData(TarFormat.Ustar)]
         [InlineData(TarFormat.Pax)]
         [InlineData(TarFormat.Gnu)]
@@ -52,7 +54,7 @@ namespace System.Formats.Tar.Tests
             }, format.ToString(), new RemoteInvokeOptions { RunAsSudo = true }).Dispose();
         }
 
-        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndElevated))]
         [InlineData(TarFormat.Ustar)]
         [InlineData(TarFormat.Pax)]
         [InlineData(TarFormat.Gnu)]
@@ -100,7 +102,7 @@ namespace System.Formats.Tar.Tests
             }, format.ToString(), new RemoteInvokeOptions { RunAsSudo = true }).Dispose();
         }
 
-        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndElevated))]
         [InlineData(TarFormat.Ustar)]
         [InlineData(TarFormat.Pax)]
         [InlineData(TarFormat.Gnu)]

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.Unix.cs
@@ -9,9 +9,9 @@ namespace System.Formats.Tar.Tests
 {
     public partial class TarWriter_WriteEntry_File_Tests : TarTestsBase
     {
-        private static bool IsRemoteExecutorSupportedAndOnUnixAndElevated => RemoteExecutor.IsSupported && PlatformDetection.IsUnixAndElevated;
+        private static bool IsRemoteExecutorSupportedAndOnUnixAndSuperUser => RemoteExecutor.IsSupported && PlatformDetection.IsUnixAndSuperUser;
 
-        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndElevated))]
+        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndSuperUser))]
         [InlineData(TarFormat.Ustar)]
         [InlineData(TarFormat.Pax)]
         [InlineData(TarFormat.Gnu)]
@@ -54,7 +54,7 @@ namespace System.Formats.Tar.Tests
             }, format.ToString(), new RemoteInvokeOptions { RunAsSudo = true }).Dispose();
         }
 
-        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndElevated))]
+        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndSuperUser))]
         [InlineData(TarFormat.Ustar)]
         [InlineData(TarFormat.Pax)]
         [InlineData(TarFormat.Gnu)]
@@ -102,7 +102,7 @@ namespace System.Formats.Tar.Tests
             }, format.ToString(), new RemoteInvokeOptions { RunAsSudo = true }).Dispose();
         }
 
-        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndElevated))]
+        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndSuperUser))]
         [InlineData(TarFormat.Ustar)]
         [InlineData(TarFormat.Pax)]
         [InlineData(TarFormat.Gnu)]

--- a/src/libraries/System.IO.FileSystem/tests/Base/FileGetSetAttributes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/FileGetSetAttributes.cs
@@ -99,7 +99,7 @@ namespace System.IO.Tests
         {
             string path = CreateItem();
             streamName = path + streamName;
-            File.Create(streamName);
+            File.Create(streamName).Dispose();
 
             FileAttributes attributes = GetAttributes(streamName);
             Assert.NotEqual((FileAttributes)0, attributes);

--- a/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.FileSystem.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.FileSystem.cs
@@ -469,7 +469,6 @@ namespace System.IO.Tests
             Assert.False(targetInfo.Exists);
             Assert.Equal(Path.GetDirectoryName(linkInfo.FullName), Path.GetDirectoryName(targetInfo.FullName));
 
-            linkInfo.Delete();
             Directory.SetCurrentDirectory(Path.GetTempPath());
         }
 

--- a/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.FileSystem.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.FileSystem.cs
@@ -468,6 +468,9 @@ namespace System.IO.Tests
             // Verify that Target is resolved and is relative to Link's directory and not to the cwd.
             Assert.False(targetInfo.Exists);
             Assert.Equal(Path.GetDirectoryName(linkInfo.FullName), Path.GetDirectoryName(targetInfo.FullName));
+
+            linkInfo.Delete();
+            Directory.SetCurrentDirectory(Path.GetTempPath());
         }
 
         protected static string? GetAppExecLinkPath()

--- a/src/libraries/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -34,6 +34,7 @@ namespace System.IO.Tests
                 string subdir = Path.GetRandomFileName();
                 DirectoryInfo info = Create(subdir);
                 Assert.Equal(subdir, info.ToString());
+                Environment.CurrentDirectory = Path.GetTempPath();
             }).Dispose();
         }
 
@@ -85,7 +86,6 @@ namespace System.IO.Tests
         public void PathAlreadyExistsAsDirectory(FileAttributes attributes)
         {
             DirectoryInfo testDir = Create(GetTestFilePath());
-            FileAttributes original = testDir.Attributes;
 
             try
             {
@@ -94,7 +94,7 @@ namespace System.IO.Tests
             }
             finally
             {
-                testDir.Attributes = original;
+                testDir.Attributes = FileAttributes.Normal;
             }
         }
 

--- a/src/libraries/System.IO.FileSystem/tests/Directory/Delete.Windows.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Delete.Windows.cs
@@ -18,13 +18,18 @@ namespace System.IO.Tests
             string parentPath = GetTestFilePath();
             var parent = Directory.CreateDirectory(parentPath);
             var ac = parent.GetAccessControl();
-            ac.SetAccessRule(new FileSystemAccessRule(WindowsIdentity.GetCurrent().User, FileSystemRights.ListDirectory, AccessControlType.Deny));
+            var rule = new FileSystemAccessRule(WindowsIdentity.GetCurrent().User, FileSystemRights.ListDirectory, AccessControlType.Deny);
+            ac.SetAccessRule(rule);
             parent.SetAccessControl(ac);
 
             var subDir = parent.CreateSubdirectory("subdir");
             File.Create(Path.Combine(subDir.FullName, GetTestFileName())).Dispose();
             Delete(subDir.FullName, recursive: true);
             Assert.False(subDir.Exists);
+
+            // Cleanup
+            ac.RemoveAccessRule(rule);
+            parent.SetAccessControl(ac);
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -11,7 +11,7 @@ namespace System.IO.Tests
     {
         static bool IsBindMountSupported => OperatingSystem.IsLinux() && !PlatformDetection.IsInContainer;
 
-        static bool IsBindMountSupportedAndOnUnixAndElevated => IsBindMountSupported && PlatformDetection.IsUnixAndElevated;
+        static bool IsBindMountSupportedAndOnUnixAndSuperUser => IsBindMountSupported && PlatformDetection.IsUnixAndSuperUser;
 
         #region Utilities
 
@@ -207,7 +207,7 @@ namespace System.IO.Tests
             Assert.False(Directory.Exists(testDir));
         }
 
-        [ConditionalFact(nameof(IsBindMountSupportedAndOnUnixAndElevated))]
+        [ConditionalFact(nameof(IsBindMountSupportedAndOnUnixAndSuperUser))]
         [OuterLoop("Needs sudo access")]
         [PlatformSpecific(TestPlatforms.Linux)]
         public void Unix_NotFoundDirectory_ReadOnlyVolume()

--- a/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -11,6 +11,8 @@ namespace System.IO.Tests
     {
         static bool IsBindMountSupported => OperatingSystem.IsLinux() && !PlatformDetection.IsInContainer;
 
+        static bool IsBindMountSupportedAndOnUnixAndElevated => IsBindMountSupported && PlatformDetection.IsUnixAndElevated;
+
         #region Utilities
 
         protected virtual void Delete(string path)
@@ -205,10 +207,9 @@ namespace System.IO.Tests
             Assert.False(Directory.Exists(testDir));
         }
 
-        [ConditionalFact(nameof(IsBindMountSupported))]
+        [ConditionalFact(nameof(IsBindMountSupportedAndOnUnixAndElevated))]
         [OuterLoop("Needs sudo access")]
         [PlatformSpecific(TestPlatforms.Linux)]
-        [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
         public void Unix_NotFoundDirectory_ReadOnlyVolume()
         {
             ReadOnly_FileSystemHelper(readOnlyDirectory =>

--- a/src/libraries/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -711,11 +711,11 @@ namespace System.IO.Tests
 
             if (TestDirectories)
             {
-                Assert.Equal(2, GetEntries(testDir.FullName, "*BBBBBBBBBB*").Length);
+                Assert.Equal(2, GetEntries(testDir.FullName, "*BBBBBBBB*").Length);
             }
             if (TestFiles)
             {
-                Assert.Equal(2, GetEntries(testDir.FullName, "*AAAAAAAAAA*").Length);
+                Assert.Equal(2, GetEntries(testDir.FullName, "*AAAAAAAA*").Length);
             }
         }
 

--- a/src/libraries/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -703,19 +703,19 @@ namespace System.IO.Tests
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
             string testBase = GetTestFileName();
-            testDir.CreateSubdirectory(testBase + "aBBb");
-            testDir.CreateSubdirectory(testBase + "aBBB");
+            testDir.CreateSubdirectory(testBase + "aBBBBBBBBBBb");
+            testDir.CreateSubdirectory(testBase + "aBBBBBBBBBBB");
 
-            File.Create(Path.Combine(testDir.FullName, testBase + "AAAA")).Dispose();
-            File.Create(Path.Combine(testDir.FullName, testBase + "aAAa")).Dispose();
+            File.Create(Path.Combine(testDir.FullName, testBase + "AAAAAAAAAA")).Dispose();
+            File.Create(Path.Combine(testDir.FullName, testBase + "aAAAAAAAAa")).Dispose();
 
             if (TestDirectories)
             {
-                Assert.Equal(2, GetEntries(testDir.FullName, "*BB*").Length);
+                Assert.Equal(2, GetEntries(testDir.FullName, "*BBBBBBBBBB*").Length);
             }
             if (TestFiles)
             {
-                Assert.Equal(2, GetEntries(testDir.FullName, "*AA*").Length);
+                Assert.Equal(2, GetEntries(testDir.FullName, "*AAAAAAAAAA*").Length);
             }
         }
 
@@ -724,19 +724,19 @@ namespace System.IO.Tests
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
             string testBase = GetTestFileName();
-            testDir.CreateSubdirectory(testBase + "yZZz");
-            testDir.CreateSubdirectory(testBase + "yZZZ");
+            testDir.CreateSubdirectory(testBase + "yZZZZZZZZZZz");
+            testDir.CreateSubdirectory(testBase + "yZZZZZZZZZZZ");
 
-            File.Create(Path.Combine(testDir.FullName, testBase + "YYYY")).Dispose();
-            File.Create(Path.Combine(testDir.FullName, testBase + "yYYy")).Dispose();
+            File.Create(Path.Combine(testDir.FullName, testBase + "YYYYYYYYYYYY")).Dispose();
+            File.Create(Path.Combine(testDir.FullName, testBase + "yYYYYYYYYYYy")).Dispose();
 
             if (TestDirectories)
             {
-                Assert.Equal(1, GetEntries(testDir.FullName, "*ZZ*").Length);
+                Assert.Equal(1, GetEntries(testDir.FullName, "*ZZZZZZZZZZ*").Length);
             }
             if (TestFiles)
             {
-                Assert.Equal(1, GetEntries(testDir.FullName, "*YY*").Length);
+                Assert.Equal(1, GetEntries(testDir.FullName, "*YYYYYYYYYY*").Length);
             }
         }
 

--- a/src/libraries/System.IO.FileSystem/tests/Directory/SetCurrentDirectory.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/SetCurrentDirectory.cs
@@ -40,6 +40,8 @@ namespace System.IO.Tests
                 {
                     Assert.Equal(TestDirectory, Directory.GetCurrentDirectory());
                 }
+
+                Directory.SetCurrentDirectory(Path.GetTempPath());
             }).Dispose();
         }
 
@@ -76,6 +78,8 @@ namespace System.IO.Tests
                     {
                         Assert.Equal(path, Directory.GetCurrentDirectory());
                     }
+
+                    Directory.SetCurrentDirectory(Path.GetTempPath());
                 }).Dispose();
             }
         }

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
@@ -263,6 +263,8 @@ namespace System.IO.Tests.Enumeration
             };
 
             Assert.Equal(new string[] { fileTwo.FullName }, enumerable);
+
+            fileTwo.Attributes &= ~FileAttributes.ReadOnly;
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
@@ -264,6 +264,7 @@ namespace System.IO.Tests.Enumeration
 
             Assert.Equal(new string[] { fileTwo.FullName }, enumerable);
 
+            // Cleanup
             fileTwo.Attributes &= ~FileAttributes.ReadOnly;
         }
     }

--- a/src/libraries/System.IO.FileSystem/tests/File/Delete.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Delete.cs
@@ -10,6 +10,8 @@ namespace System.IO.Tests
     {
         static bool IsBindMountSupported => OperatingSystem.IsLinux() && !PlatformDetection.IsInContainer;
 
+        private static bool IsBindMountSupportedAndOnUnixAndElevated => IsBindMountSupported && PlatformDetection.IsUnixAndElevated;
+
         protected virtual void Delete(string path)
         {
             File.Delete(path);
@@ -114,10 +116,9 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [ConditionalFact(nameof(IsBindMountSupported))]
+        [ConditionalFact(nameof(IsBindMountSupportedAndOnUnixAndElevated))]
         [OuterLoop("Needs sudo access")]
         [PlatformSpecific(TestPlatforms.Linux)]
-        [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
         public void Unix_NonExistentPath_ReadOnlyVolume()
         {
             ReadOnly_FileSystemHelper(readOnlyDirectory =>
@@ -126,10 +127,9 @@ namespace System.IO.Tests
             });
         }
 
-        [ConditionalFact(nameof(IsBindMountSupported))]
+        [ConditionalFact(nameof(IsBindMountSupportedAndOnUnixAndElevated))]
         [OuterLoop("Needs sudo access")]
         [PlatformSpecific(TestPlatforms.Linux)]
-        [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
         public void Unix_ExistingDirectory_ReadOnlyVolume()
         {
             ReadOnly_FileSystemHelper(readOnlyDirectory =>

--- a/src/libraries/System.IO.FileSystem/tests/File/Delete.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Delete.cs
@@ -10,7 +10,7 @@ namespace System.IO.Tests
     {
         static bool IsBindMountSupported => OperatingSystem.IsLinux() && !PlatformDetection.IsInContainer;
 
-        private static bool IsBindMountSupportedAndOnUnixAndElevated => IsBindMountSupported && PlatformDetection.IsUnixAndElevated;
+        private static bool IsBindMountSupportedAndOnUnixAndSuperUser => IsBindMountSupported && PlatformDetection.IsUnixAndSuperUser;
 
         protected virtual void Delete(string path)
         {
@@ -116,7 +116,7 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [ConditionalFact(nameof(IsBindMountSupportedAndOnUnixAndElevated))]
+        [ConditionalFact(nameof(IsBindMountSupportedAndOnUnixAndSuperUser))]
         [OuterLoop("Needs sudo access")]
         [PlatformSpecific(TestPlatforms.Linux)]
         public void Unix_NonExistentPath_ReadOnlyVolume()
@@ -127,7 +127,7 @@ namespace System.IO.Tests
             });
         }
 
-        [ConditionalFact(nameof(IsBindMountSupportedAndOnUnixAndElevated))]
+        [ConditionalFact(nameof(IsBindMountSupportedAndOnUnixAndSuperUser))]
         [OuterLoop("Needs sudo access")]
         [PlatformSpecific(TestPlatforms.Linux)]
         public void Unix_ExistingDirectory_ReadOnlyVolume()

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Unix.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Unix.cs
@@ -23,9 +23,10 @@ namespace System.IO.Pipes.Tests
             _output = output;
         }
 
-        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        private static bool IsRemoteExecutorSupportedAndOnUnixAndElevated => RemoteExecutor.IsSupported && PlatformDetection.IsUnixAndElevated;
+
+        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndElevated))]
         [OuterLoop("Needs sudo access")]
-        [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
         [InlineData(PipeOptions.None, PipeOptions.None)]
         [InlineData(PipeOptions.None, PipeOptions.CurrentUserOnly)]
         [InlineData(PipeOptions.CurrentUserOnly, PipeOptions.None)]

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Unix.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Unix.cs
@@ -23,9 +23,9 @@ namespace System.IO.Pipes.Tests
             _output = output;
         }
 
-        private static bool IsRemoteExecutorSupportedAndOnUnixAndElevated => RemoteExecutor.IsSupported && PlatformDetection.IsUnixAndElevated;
+        private static bool IsRemoteExecutorSupportedAndOnUnixAndSuperUser => RemoteExecutor.IsSupported && PlatformDetection.IsUnixAndSuperUser;
 
-        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndElevated))]
+        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndSuperUser))]
         [OuterLoop("Needs sudo access")]
         [InlineData(PipeOptions.None, PipeOptions.None)]
         [InlineData(PipeOptions.None, PipeOptions.CurrentUserOnly)]

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -744,10 +744,10 @@ namespace System.Net.NetworkInformation.Tests
             Assert.Equal(IPStatus.TimedOut, reply.Status);
         }
 
-        private static bool IsRemoteExecutorSupportedAndOnUnixAndElevated => RemoteExecutor.IsSupported && PlatformDetection.IsUnixAndElevated;
+        private static bool IsRemoteExecutorSupportedAndOnUnixAndSuperUser => RemoteExecutor.IsSupported && PlatformDetection.IsUnixAndSuperUser;
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndElevated))]
+        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndSuperUser))]
         [InlineData(AddressFamily.InterNetwork)]
         [InlineData(AddressFamily.InterNetworkV6)]
         [OuterLoop] // Depends on sudo

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -744,9 +744,10 @@ namespace System.Net.NetworkInformation.Tests
             Assert.Equal(IPStatus.TimedOut, reply.Status);
         }
 
+        private static bool IsRemoteExecutorSupportedAndOnUnixAndElevated => RemoteExecutor.IsSupported && PlatformDetection.IsUnixAndElevated;
+
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
+        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndOnUnixAndElevated))]
         [InlineData(AddressFamily.InterNetwork)]
         [InlineData(AddressFamily.InterNetworkV6)]
         [OuterLoop] // Depends on sudo


### PR DESCRIPTION
Replaces https://github.com/dotnet/runtime/pull/68456
Fix https://github.com/dotnet/runtime/issues/68454 (?)
Fix https://github.com/dotnet/runtime/issues/62756

Increase entropy in randomly generated file names
Pass through caller method name and line number in more cases to improve test file name forensics
Add # prefix to test folders to make it easier to find leaks in today's crowded temp folders
Remove any read-only attributes on files within the test folder to ensure it can be deleted
Fix several test issues causing leaked files
Improve file-matching test to ensure it doesn't accidentally match a randomly generated name
Fixup sudo conditions
In some cases, a test was leaking its temp directory when it remote-exec'd code that changed the current directory to the temp directory. The fix was to set the current directory back at the end of the remote-exec'd code. This is a puzzle as the test directory gets deleted when the test method completes, which happens after the remote-exec process has already quit, and the current-directory of the remote-exec process ought to be irrelevant. It's as if Windows holds on to it a little longer.

This fixes almost all leaked files when running the FileSystem test cases.