### PR TITLE
[LibraryImportGenerator] Update diagnostic titles to use localized strings

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeMarshallingAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeMarshallingAttribute.cs
@@ -16,7 +16,7 @@ namespace System.Runtime.InteropServices
     public sealed class NativeMarshallingAttribute : Attribute
     {
         /// <summary>
-        /// Create a <see cref="MarshalUsingAttribute" /> that provides a native marshalling type.
+        /// Create a <see cref="NativeMarshallingAttribute" /> that provides a native marshalling type.
         /// </summary>
         /// <param name="nativeType">The marshaller type used to convert the attributed type from managed to native code. This type must be attributed with <see cref="CustomTypeMarshallerAttribute" /></param>
         public NativeMarshallingAttribute(Type nativeType)

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/AnalyzerDiagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/AnalyzerDiagnostics.cs
@@ -18,18 +18,14 @@ namespace Microsoft.Interop.Analyzers
             // Migration from DllImport to LibraryImport
             public const string ConvertToLibraryImport = Prefix + "001";
 
-            // ManualTypeMarshalling
-            public const string MarshallerTypeMustSpecifyManagedType = Prefix + "002";
-            public const string CustomTypeMarshallerAttributeMustBeValid = Prefix + "003";
-            public const string InvalidNativeType = Prefix + "004";
-            public const string GetPinnableReferenceReturnTypeBlittable = Prefix + "005";
-            public const string CustomMarshallerTypeMustHaveRequiredShape = Prefix + "006";
-            public const string CustomMarshallerTypeMustSupportDirection = Prefix + "007";
-            public const string ProvidedMethodsNotSpecifiedInShape = Prefix + "008";
-            public const string MissingAllocatingMarshallingFallback = Prefix + "009";
-            public const string CallerAllocConstructorMustHaveBufferSize = Prefix + "010";
-            public const string InvalidSignaturesInMarshallerShape = Prefix + "011";
-            public const string MarshallerGetPinnableReferenceRequiresTwoStageMarshalling = Prefix + "012";
+            // CustomTypeMarshaller
+            public const string InvalidCustomTypeMarshallerAttributeUsage = Prefix + "002";
+            public const string InvalidNativeType = Prefix + "003";
+            public const string CustomMarshallerTypeMustHaveRequiredShape = Prefix + "004";
+            public const string ProvidedMethodsNotSpecifiedInFeatures = Prefix + "005";
+            public const string MissingAllocatingMarshallingFallback = Prefix + "006";
+            public const string CallerAllocConstructorMustHaveBufferSize = Prefix + "007";
+            public const string InvalidSignaturesInMarshallerShape = Prefix + "008";
         }
 
         internal static LocalizableResourceString GetResourceString(string resourceName)

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomTypeMarshallerAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomTypeMarshallerAnalyzer.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor MarshallerTypeMustSpecifyManagedTypeRule =
             new DiagnosticDescriptor(
                 Ids.InvalidCustomTypeMarshallerAttributeUsage,
-                "InvalidCustomTypeMarshallerAttributeUsage",
+                GetResourceString(nameof(SR.InvalidCustomTypeMarshallerAttributeUsageTitle)),
                 GetResourceString(nameof(SR.MarshallerTypeMustSpecifyManagedTypeMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -45,7 +45,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor CustomTypeMarshallerAttributeMustBeValidRule =
             new DiagnosticDescriptor(
                 Ids.InvalidCustomTypeMarshallerAttributeUsage,
-                "InvalidCustomTypeMarshallerAttributeUsage",
+                GetResourceString(nameof(SR.InvalidCustomTypeMarshallerAttributeUsageTitle)),
                 GetResourceString(nameof(SR.CustomTypeMarshallerAttributeMustBeValidMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -55,7 +55,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor MarshallerKindMustBeValidRule =
             new DiagnosticDescriptor(
                 Ids.InvalidCustomTypeMarshallerAttributeUsage,
-                "InvalidCustomTypeMarshallerAttributeUsage",
+                GetResourceString(nameof(SR.InvalidCustomTypeMarshallerAttributeUsageTitle)),
                 GetResourceString(nameof(SR.MarshallerKindMustBeValidMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -65,7 +65,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor MarshallerDirectionMustBeValidRule =
             new DiagnosticDescriptor(
                 Ids.InvalidCustomTypeMarshallerAttributeUsage,
-                "InvalidCustomTypeMarshallerAttributeUsage",
+                GetResourceString(nameof(SR.InvalidCustomTypeMarshallerAttributeUsageTitle)),
                 GetResourceString(nameof(SR.MarshallerDirectionMustBeValidMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -75,7 +75,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor NativeTypeMustHaveCustomTypeMarshallerAttributeRule =
             new DiagnosticDescriptor(
                 Ids.InvalidNativeType,
-                "InvalidNativeType",
+                GetResourceString(nameof(SR.InvalidNativeTypeTitle)),
                 GetResourceString(nameof(SR.NativeTypeMustHaveCustomTypeMarshallerAttributeMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -85,7 +85,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor NativeTypeMustBeBlittableRule =
             new DiagnosticDescriptor(
                 Ids.InvalidNativeType,
-                "InvalidNativeType",
+                GetResourceString(nameof(SR.InvalidNativeTypeTitle)),
                 GetResourceString(nameof(SR.NativeTypeMustBeBlittableMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -95,7 +95,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor GetPinnableReferenceReturnTypeBlittableRule =
             new DiagnosticDescriptor(
                 Ids.InvalidSignaturesInMarshallerShape,
-                "InvalidSignaturesInMarshallerShape",
+                GetResourceString(nameof(SR.InvalidSignaturesInMarshallerShapeTitle)),
                 GetResourceString(nameof(SR.GetPinnableReferenceReturnTypeBlittableMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -105,7 +105,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor NativeTypeMustBePointerSizedRule =
             new DiagnosticDescriptor(
                 Ids.InvalidNativeType,
-                "InvalidNativeType",
+                GetResourceString(nameof(SR.InvalidNativeTypeTitle)),
                 GetResourceString(nameof(SR.NativeTypeMustBePointerSizedMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -115,7 +115,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor CustomMarshallerTypeMustSupportDirectionRule =
             new DiagnosticDescriptor(
                 Ids.InvalidCustomTypeMarshallerAttributeUsage,
-                "InvalidCustomTypeMarshallerAttributeUsage",
+                GetResourceString(nameof(SR.InvalidCustomTypeMarshallerAttributeUsageTitle)),
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustSupportDirectionMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -125,7 +125,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor ValueInRequiresOneParameterConstructorRule =
             new DiagnosticDescriptor(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
-                "CustomMarshallerTypeMustHaveRequiredShape",
+                GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.ValueInRequiresOneParameterConstructorMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -135,7 +135,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor LinearCollectionInRequiresTwoParameterConstructorRule =
             new DiagnosticDescriptor(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
-                "CustomMarshallerTypeMustHaveRequiredShape",
+                GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.LinearCollectionInRequiresTwoParameterConstructorMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -145,7 +145,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor ValueInCallerAllocatedBufferRequiresSpanConstructorRule =
             new DiagnosticDescriptor(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
-                "CustomMarshallerTypeMustHaveRequiredShape",
+                GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.ValueInCallerAllocatedBufferRequiresSpanConstructorMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -155,7 +155,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor LinearCollectionInCallerAllocatedBufferRequiresSpanConstructorRule =
             new DiagnosticDescriptor(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
-                "CustomMarshallerTypeMustHaveRequiredShape",
+                GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.LinearCollectionInCallerAllocatedBufferRequiresSpanConstructorMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -165,7 +165,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor OutRequiresToManagedRule =
             new DiagnosticDescriptor(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
-                "CustomMarshallerTypeMustHaveRequiredShape",
+                GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.OutRequiresToManagedMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -175,7 +175,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor LinearCollectionInRequiresCollectionMethodsRule =
             new DiagnosticDescriptor(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
-                "CustomMarshallerTypeMustHaveRequiredShape",
+                GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.LinearCollectionInRequiresCollectionMethodsMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -185,7 +185,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor LinearCollectionOutRequiresCollectionMethodsRule =
             new DiagnosticDescriptor(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
-                "CustomMarshallerTypeMustHaveRequiredShape",
+                GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.LinearCollectionOutRequiresCollectionMethodsMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -195,7 +195,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor LinearCollectionOutRequiresIntConstructorRule =
             new DiagnosticDescriptor(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
-                "CustomMarshallerTypeMustHaveRequiredShape",
+                GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.LinearCollectionOutRequiresIntConstructorMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -205,7 +205,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor UnmanagedResourcesRequiresFreeNativeRule =
             new DiagnosticDescriptor(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
-                "CustomMarshallerTypeMustHaveRequiredShape",
+                GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.UnmanagedResourcesRequiresFreeNativeMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -215,7 +215,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor OutTwoStageMarshallingRequiresFromNativeValueRule =
             new DiagnosticDescriptor(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
-                "CustomMarshallerTypeMustHaveRequiredShape",
+                GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.OutTwoStageMarshallingRequiresFromNativeValueMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -225,7 +225,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor InTwoStageMarshallingRequiresToNativeValueRule =
             new DiagnosticDescriptor(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
-                "CustomMarshallerTypeMustHaveRequiredShape",
+                GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.InTwoStageMarshallingRequiresToNativeValueMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -235,7 +235,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor GetPinnableReferenceShouldSupportAllocatingMarshallingFallbackRule =
             new DiagnosticDescriptor(
                 Ids.MissingAllocatingMarshallingFallback,
-                "GetPinnableReferenceShouldSupportAllocatingMarshallingFallback",
+                GetResourceString(nameof(SR.MissingAllocatingMarshallingFallbackTitle)),
                 GetResourceString(nameof(SR.GetPinnableReferenceShouldSupportAllocatingMarshallingFallbackMessage)),
                 Category,
                 DiagnosticSeverity.Warning,
@@ -245,7 +245,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackRule =
             new DiagnosticDescriptor(
                 Ids.MissingAllocatingMarshallingFallback,
-                "CallerAllocMarshallingShouldSupportAllocatingMarshallingFallback",
+                GetResourceString(nameof(SR.MissingAllocatingMarshallingFallbackTitle)),
                 GetResourceString(nameof(SR.CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackMessage)),
                 Category,
                 DiagnosticSeverity.Warning,
@@ -255,7 +255,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor CallerAllocConstructorMustHaveBufferSizeRule =
             new DiagnosticDescriptor(
                 Ids.CallerAllocConstructorMustHaveBufferSize,
-                "CallerAllocConstructorMustHaveBufferSize",
+                GetResourceString(nameof(SR.CallerAllocConstructorMustHaveBufferSizeTitle)),
                 GetResourceString(nameof(SR.CallerAllocConstructorMustHaveBufferSizeMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -265,7 +265,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor RefNativeValueUnsupportedRule =
             new DiagnosticDescriptor(
                 Ids.InvalidSignaturesInMarshallerShape,
-                "InvalidSignaturesInMarshallerShape",
+                GetResourceString(nameof(SR.InvalidSignaturesInMarshallerShapeTitle)),
                 GetResourceString(nameof(SR.RefNativeValueUnsupportedMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -275,7 +275,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor NativeGenericTypeMustBeClosedOrMatchArityRule =
             new DiagnosticDescriptor(
                 Ids.InvalidNativeType,
-                "NativeGenericTypeMustBeClosedOrMatchArity",
+                GetResourceString(nameof(SR.InvalidNativeTypeTitle)),
                 GetResourceString(nameof(SR.NativeGenericTypeMustBeClosedOrMatchArityMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -285,7 +285,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor MarshallerGetPinnableReferenceRequiresTwoStageMarshallingRule =
             new DiagnosticDescriptor(
                 Ids.ProvidedMethodsNotSpecifiedInFeatures,
-                "ProvidedMethodsNotSpecifiedInFeatures",
+                GetResourceString(nameof(SR.ProvidedMethodsNotSpecifiedInFeaturesTitle)),
                 GetResourceString(nameof(SR.MarshallerGetPinnableReferenceRequiresTwoStageMarshallingMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -295,7 +295,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor FreeNativeMethodProvidedShouldSpecifyUnmanagedResourcesFeatureRule =
             new DiagnosticDescriptor(
                 Ids.ProvidedMethodsNotSpecifiedInFeatures,
-                "ProvidedMethodsNotSpecifiedInFeatures",
+                GetResourceString(nameof(SR.ProvidedMethodsNotSpecifiedInFeaturesTitle)),
                 GetResourceString(nameof(SR.FreeNativeMethodProvidedShouldSpecifyUnmanagedResourcesFeatureMessage)),
                 Category,
                 DiagnosticSeverity.Warning,
@@ -305,7 +305,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor ToNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureRule =
             new DiagnosticDescriptor(
                 Ids.ProvidedMethodsNotSpecifiedInFeatures,
-                "ProvidedMethodsNotSpecifiedInFeatures",
+                GetResourceString(nameof(SR.ProvidedMethodsNotSpecifiedInFeaturesTitle)),
                 GetResourceString(nameof(SR.ToNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureMessage)),
                 Category,
                 DiagnosticSeverity.Warning,
@@ -315,7 +315,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor FromNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureRule =
             new DiagnosticDescriptor(
                 Ids.ProvidedMethodsNotSpecifiedInFeatures,
-                "ProvidedMethodsNotSpecifiedInFeatures",
+                GetResourceString(nameof(SR.ProvidedMethodsNotSpecifiedInFeaturesTitle)),
                 GetResourceString(nameof(SR.FromNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureMessage)),
                 Category,
                 DiagnosticSeverity.Warning,
@@ -325,7 +325,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor CallerAllocatedBufferConstructorProvidedShouldSpecifyFeatureRule =
             new DiagnosticDescriptor(
                 Ids.ProvidedMethodsNotSpecifiedInFeatures,
-                "ProvidedMethodsNotSpecifiedInFeatures",
+                GetResourceString(nameof(SR.ProvidedMethodsNotSpecifiedInFeaturesTitle)),
                 GetResourceString(nameof(SR.CallerAllocatedBufferConstructorProvidedShouldSpecifyFeatureMessage)),
                 Category,
                 DiagnosticSeverity.Warning,
@@ -335,7 +335,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor TwoStageMarshallingNativeTypesMustMatchRule =
             new DiagnosticDescriptor(
                 Ids.InvalidSignaturesInMarshallerShape,
-                "InvalidSignaturesInMarshallerShape",
+                GetResourceString(nameof(SR.InvalidSignaturesInMarshallerShapeTitle)),
                 GetResourceString(nameof(SR.TwoStageMarshallingNativeTypesMustMatchMessage)),
                 Category,
                 DiagnosticSeverity.Warning,
@@ -345,7 +345,7 @@ namespace Microsoft.Interop.Analyzers
         public static readonly DiagnosticDescriptor LinearCollectionElementTypesMustMatchRule =
             new DiagnosticDescriptor(
                 Ids.InvalidSignaturesInMarshallerShape,
-                "InvalidSignaturesInMarshallerShape",
+                GetResourceString(nameof(SR.InvalidSignaturesInMarshallerShapeTitle)),
                 GetResourceString(nameof(SR.LinearCollectionElementTypesMustMatchMessage)),
                 Category,
                 DiagnosticSeverity.Warning,

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomTypeMarshallerAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomTypeMarshallerAnalyzer.cs
@@ -34,8 +34,8 @@ namespace Microsoft.Interop.Analyzers
 
         public static readonly DiagnosticDescriptor MarshallerTypeMustSpecifyManagedTypeRule =
             new DiagnosticDescriptor(
-                Ids.MarshallerTypeMustSpecifyManagedType,
-                "MarshallerTypeMustSpecifyManagedType",
+                Ids.InvalidCustomTypeMarshallerAttributeUsage,
+                "InvalidCustomTypeMarshallerAttributeUsage",
                 GetResourceString(nameof(SR.MarshallerTypeMustSpecifyManagedTypeMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -44,8 +44,8 @@ namespace Microsoft.Interop.Analyzers
 
         public static readonly DiagnosticDescriptor CustomTypeMarshallerAttributeMustBeValidRule =
             new DiagnosticDescriptor(
-                Ids.CustomTypeMarshallerAttributeMustBeValid,
-                "CustomTypeMarshallerAttributeMustBeValid",
+                Ids.InvalidCustomTypeMarshallerAttributeUsage,
+                "InvalidCustomTypeMarshallerAttributeUsage",
                 GetResourceString(nameof(SR.CustomTypeMarshallerAttributeMustBeValidMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -54,8 +54,8 @@ namespace Microsoft.Interop.Analyzers
 
         public static readonly DiagnosticDescriptor MarshallerKindMustBeValidRule =
             new DiagnosticDescriptor(
-                Ids.CustomTypeMarshallerAttributeMustBeValid,
-                "CustomTypeMarshallerAttributeMustBeValid",
+                Ids.InvalidCustomTypeMarshallerAttributeUsage,
+                "InvalidCustomTypeMarshallerAttributeUsage",
                 GetResourceString(nameof(SR.MarshallerKindMustBeValidMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -64,8 +64,8 @@ namespace Microsoft.Interop.Analyzers
 
         public static readonly DiagnosticDescriptor MarshallerDirectionMustBeValidRule =
             new DiagnosticDescriptor(
-                Ids.CustomTypeMarshallerAttributeMustBeValid,
-                "CustomTypeMarshallerAttributeMustBeValid",
+                Ids.InvalidCustomTypeMarshallerAttributeUsage,
+                "InvalidCustomTypeMarshallerAttributeUsage",
                 GetResourceString(nameof(SR.MarshallerDirectionMustBeValidMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -94,8 +94,8 @@ namespace Microsoft.Interop.Analyzers
 
         public static readonly DiagnosticDescriptor GetPinnableReferenceReturnTypeBlittableRule =
             new DiagnosticDescriptor(
-                Ids.GetPinnableReferenceReturnTypeBlittable,
-                "GetPinnableReferenceReturnTypeBlittable",
+                Ids.InvalidSignaturesInMarshallerShape,
+                "InvalidSignaturesInMarshallerShape",
                 GetResourceString(nameof(SR.GetPinnableReferenceReturnTypeBlittableMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -114,8 +114,8 @@ namespace Microsoft.Interop.Analyzers
 
         public static readonly DiagnosticDescriptor CustomMarshallerTypeMustSupportDirectionRule =
             new DiagnosticDescriptor(
-                Ids.CustomMarshallerTypeMustSupportDirection,
-                "CustomMarshallerTypeMustSupportDirection",
+                Ids.InvalidCustomTypeMarshallerAttributeUsage,
+                "InvalidCustomTypeMarshallerAttributeUsage",
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustSupportDirectionMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -284,8 +284,8 @@ namespace Microsoft.Interop.Analyzers
 
         public static readonly DiagnosticDescriptor MarshallerGetPinnableReferenceRequiresTwoStageMarshallingRule =
             new DiagnosticDescriptor(
-                Ids.MarshallerGetPinnableReferenceRequiresTwoStageMarshalling,
-                "MarshallerGetPinnableReferenceRequiresTwoStageMarshalling",
+                Ids.ProvidedMethodsNotSpecifiedInFeatures,
+                "ProvidedMethodsNotSpecifiedInFeatures",
                 GetResourceString(nameof(SR.MarshallerGetPinnableReferenceRequiresTwoStageMarshallingMessage)),
                 Category,
                 DiagnosticSeverity.Error,
@@ -294,8 +294,8 @@ namespace Microsoft.Interop.Analyzers
 
         public static readonly DiagnosticDescriptor FreeNativeMethodProvidedShouldSpecifyUnmanagedResourcesFeatureRule =
             new DiagnosticDescriptor(
-                Ids.ProvidedMethodsNotSpecifiedInShape,
-                "ProvidedMethodsNotSpecifiedInShape",
+                Ids.ProvidedMethodsNotSpecifiedInFeatures,
+                "ProvidedMethodsNotSpecifiedInFeatures",
                 GetResourceString(nameof(SR.FreeNativeMethodProvidedShouldSpecifyUnmanagedResourcesFeatureMessage)),
                 Category,
                 DiagnosticSeverity.Warning,
@@ -304,8 +304,8 @@ namespace Microsoft.Interop.Analyzers
 
         public static readonly DiagnosticDescriptor ToNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureRule =
             new DiagnosticDescriptor(
-                Ids.ProvidedMethodsNotSpecifiedInShape,
-                "ProvidedMethodsNotSpecifiedInShape",
+                Ids.ProvidedMethodsNotSpecifiedInFeatures,
+                "ProvidedMethodsNotSpecifiedInFeatures",
                 GetResourceString(nameof(SR.ToNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureMessage)),
                 Category,
                 DiagnosticSeverity.Warning,
@@ -314,8 +314,8 @@ namespace Microsoft.Interop.Analyzers
 
         public static readonly DiagnosticDescriptor FromNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureRule =
             new DiagnosticDescriptor(
-                Ids.ProvidedMethodsNotSpecifiedInShape,
-                "ProvidedMethodsNotSpecifiedInShape",
+                Ids.ProvidedMethodsNotSpecifiedInFeatures,
+                "ProvidedMethodsNotSpecifiedInFeatures",
                 GetResourceString(nameof(SR.FromNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureMessage)),
                 Category,
                 DiagnosticSeverity.Warning,
@@ -324,8 +324,8 @@ namespace Microsoft.Interop.Analyzers
 
         public static readonly DiagnosticDescriptor CallerAllocatedBufferConstructorProvidedShouldSpecifyFeatureRule =
             new DiagnosticDescriptor(
-                Ids.ProvidedMethodsNotSpecifiedInShape,
-                "ProvidedMethodsNotSpecifiedInShape",
+                Ids.ProvidedMethodsNotSpecifiedInFeatures,
+                "ProvidedMethodsNotSpecifiedInFeatures",
                 GetResourceString(nameof(SR.CallerAllocatedBufferConstructorProvidedShouldSpecifyFeatureMessage)),
                 Category,
                 DiagnosticSeverity.Warning,

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomTypeMarshallerFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomTypeMarshallerFixer.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Interop.Analyzers
             ImmutableArray.Create(
                 AnalyzerDiagnostics.Ids.CustomMarshallerTypeMustHaveRequiredShape,
                 AnalyzerDiagnostics.Ids.MissingAllocatingMarshallingFallback,
-                AnalyzerDiagnostics.Ids.ProvidedMethodsNotSpecifiedInShape);
+                AnalyzerDiagnostics.Ids.ProvidedMethodsNotSpecifiedInFeatures);
 
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
@@ -158,7 +158,7 @@ namespace Microsoft.Interop.Analyzers
             CustomTypeMarshallerFeatures featuresToAdd = CustomTypeMarshallerFeatures.None;
             foreach (var diagnostic in diagnostics)
             {
-                if (diagnostic.Id == AnalyzerDiagnostics.Ids.ProvidedMethodsNotSpecifiedInShape)
+                if (diagnostic.Id == AnalyzerDiagnostics.Ids.ProvidedMethodsNotSpecifiedInFeatures)
                 {
                     featuresToAddDiagnostics.Add(diagnostic);
                     if (diagnostic.Properties.TryGetValue(CustomTypeMarshallerAnalyzer.MissingFeaturesKey, out string missingFeatures)

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/Strings.resx
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -436,5 +436,26 @@
   </data>
   <data name="TwoStageMarshallingNativeTypesMustMatchMessage" xml:space="preserve">
     <value>The return type of 'ToNativeValue' and the parameter type of 'FromNativeValue' must be the same</value>
+  </data>
+  <data name="CallerAllocConstructorMustHaveBufferSizeTitle" xml:space="preserve">
+    <value>'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</value>
+  </data>
+  <data name="CustomMarshallerTypeMustHaveRequiredShapeTitle" xml:space="preserve">
+    <value>Marshaller type does not have the required shape</value>
+  </data>
+  <data name="InvalidCustomTypeMarshallerAttributeUsageTitle" xml:space="preserve">
+    <value>Invalid `CustomTypeMarshallerAttribute` usage</value>
+  </data>
+  <data name="InvalidNativeTypeTitle" xml:space="preserve">
+    <value>Specified native type is invalid</value>
+  </data>
+  <data name="InvalidSignaturesInMarshallerShapeTitle" xml:space="preserve">
+    <value>Marshaller type has incompatible method signatures</value>
+  </data>
+  <data name="MissingAllocatingMarshallingFallbackTitle" xml:space="preserve">
+    <value>Marshaller type does not support allocating constructor</value>
+  </data>
+  <data name="ProvidedMethodsNotSpecifiedInFeaturesTitle" xml:space="preserve">
+    <value>Marshaller type defines a well-known method without specifying support for the corresponding feature</value>
   </data>
 </root>

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.cs.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Nativní typ {0} musí nastavit pole BufferSize u použitého atributu System.Runtime.InteropServices.CustomTypeMarshallerAttribute, aby se určila velikost vyrovnávací paměť přidělené volajícímu, protože má konstruktor přebírající „Span&lt;byte&gt;“ přidělený volajícímu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallerAllocConstructorMustHaveBufferSizeTitle">
+        <source>'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</source>
+        <target state="new">'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackDescription">
         <source>A type that supports marshalling from managed to native using a caller-allocated buffer should also support marshalling from managed to native where using a caller-allocated buffer is impossible.</source>
         <target state="translated">Typ, který podporuje zařazování ze spravovaného na nativní prostřednictvím vyrovnávací paměť přidělené volajícím, by měl zároveň podporovat zařazování ze spravovaného na nativní v případech, kdy není vyrovnávací paměť přidělená volajícím možná.</target>
@@ -132,6 +137,11 @@
         <target state="translated">Převést na LibraryImport s příponou {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CustomMarshallerTypeMustHaveRequiredShapeTitle">
+        <source>Marshaller type does not have the required shape</source>
+        <target state="new">Marshaller type does not have the required shape</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CustomMarshallerTypeMustSupportDirectionDescription">
         <source>A native must set the 'Direction' property on the 'CustomTypeMarshallerAttribute' to a value that sets at least one known flag value on the 'CustomTypeMarshallerDirection' enum</source>
         <target state="translated">Nativní musí nastavit vlastnost „Direction“ u atributu CustomTypeMarshallerAttribute na hodnotu, která nastavuje alespoň jednu hodnotu příznaku na výčtu CustomTypeMarshallerDirection</target>
@@ -227,9 +237,24 @@
         <target state="translated">Metoda {0} by měla mít vlastnost „static“, „partial“ a non-generic, když je označena atributem LibraryImportAttribute. Generování zdroje voláním P/Invoke bude metodu {0} ignorovat.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidCustomTypeMarshallerAttributeUsageTitle">
+        <source>Invalid `CustomTypeMarshallerAttribute` usage</source>
+        <target state="new">Invalid `CustomTypeMarshallerAttribute` usage</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidLibraryImportAttributeUsageTitle">
         <source>Invalid 'LibraryImportAttribute' usage</source>
         <target state="translated">Neplatné použití LibraryImportAttribute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNativeTypeTitle">
+        <source>Specified native type is invalid</source>
+        <target state="new">Specified native type is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidSignaturesInMarshallerShapeTitle">
+        <source>Marshaller type has incompatible method signatures</source>
+        <target state="new">Marshaller type has incompatible method signatures</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidStringMarshallingConfigurationDescription">
@@ -352,6 +377,11 @@
         <target state="translated">Typ {0} neurčuje spravovaný typ v atributu System.Runtime.InteropServices.CustomTypeMarshallerAttribute použitém na typ</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingAllocatingMarshallingFallbackTitle">
+        <source>Marshaller type does not support allocating constructor</source>
+        <target state="new">Marshaller type does not support allocating constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NativeGenericTypeMustBeClosedOrMatchArityDescription">
         <source>The native type '{0}' must be a closed generic or have the same number of generic parameters as the managed type so the emitted code can use a specific instantiation.</source>
         <target state="translated">Nativní typ {0} musí být uzavřený obecný typ nebo musí mít stejný počet obecných parametrů jako spravovaný typ, aby mohl vygenerovaný kód použít konkrétní vytvoření instance.</target>
@@ -410,6 +440,11 @@
       <trans-unit id="OutTwoStageMarshallingRequiresFromNativeValueMessage">
         <source>The marshaller type '{0}' supports marshalling in the 'Out' direction with the 'TwoStageMarshalling' feature, but it does not provide a 'FromNativeValue' instance method that returns 'void' and takes one parameter.</source>
         <target state="translated">Typ zařazování {0} podporuje zařazování ve směru „Out“ s funkcí TwoStageMarshalling, ale neposkytuje instanční metodu FromNativeValue, která vrací „void“ a přebírá jeden parametr.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvidedMethodsNotSpecifiedInFeaturesTitle">
+        <source>Marshaller type defines a well-known method without specifying support for the corresponding feature</source>
+        <target state="new">Marshaller type defines a well-known method without specifying support for the corresponding feature</target>
         <note />
       </trans-unit>
       <trans-unit id="RefNativeValueUnsupportedDescription">

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.de.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Der native Typ \"{0}\" muss das Feld \"BufferSize\" für das angewendete \"System.Runtime.InteropServices.CustomTypeMarshallerAttribute\" festlegen, um die Größe des vom Aufrufer zugewiesenen Puffers anzugeben, da er über einen Konstruktor verfügt, der ein vom Aufrufer zugewiesenes \"Span&lt;byte&gt;\" akzeptiert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallerAllocConstructorMustHaveBufferSizeTitle">
+        <source>'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</source>
+        <target state="new">'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackDescription">
         <source>A type that supports marshalling from managed to native using a caller-allocated buffer should also support marshalling from managed to native where using a caller-allocated buffer is impossible.</source>
         <target state="translated">Ein Typ, der das Marshalling von verwaltet zu nativ mithilfe eines vom Aufrufer zugewiesenen Puffers unterstützt, sollte auch Marshalling von verwaltet zu nativ unterstützen, wobei die Verwendung eines vom Aufrufer zugeordneten Puffers unmöglich ist.</target>
@@ -132,6 +137,11 @@
         <target state="translated">In \"LibraryImport\" mit Suffix \"{0}\" konvertieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="CustomMarshallerTypeMustHaveRequiredShapeTitle">
+        <source>Marshaller type does not have the required shape</source>
+        <target state="new">Marshaller type does not have the required shape</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CustomMarshallerTypeMustSupportDirectionDescription">
         <source>A native must set the 'Direction' property on the 'CustomTypeMarshallerAttribute' to a value that sets at least one known flag value on the 'CustomTypeMarshallerDirection' enum</source>
         <target state="translated">Ein natives Element muss die Direction-Eigenschaft für \"CustomTypeMarshallerAttribute\" auf einen Wert festlegen, der mindestens einen bekannten Flagwert für die Enumeration \"CustomTypeMarshallerDirection\" festlegt.</target>
@@ -227,9 +237,24 @@
         <target state="translated">Die Methode \"{0}\" muss \"statisch\", \"partiell\" und nicht generisch sein, wenn sie mit \"LibraryImportAttribute\" markiert ist. Die P/Invoke-Quellgenerierung ignoriert die Methode \"{0}\".</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidCustomTypeMarshallerAttributeUsageTitle">
+        <source>Invalid `CustomTypeMarshallerAttribute` usage</source>
+        <target state="new">Invalid `CustomTypeMarshallerAttribute` usage</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidLibraryImportAttributeUsageTitle">
         <source>Invalid 'LibraryImportAttribute' usage</source>
         <target state="translated">Ungültige Verwendung von \"LibraryImportAttribute\"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNativeTypeTitle">
+        <source>Specified native type is invalid</source>
+        <target state="new">Specified native type is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidSignaturesInMarshallerShapeTitle">
+        <source>Marshaller type has incompatible method signatures</source>
+        <target state="new">Marshaller type has incompatible method signatures</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidStringMarshallingConfigurationDescription">
@@ -352,6 +377,11 @@
         <target state="translated">Der Typ \"{0}\" gibt keinen verwalteten Typ in \"System.Runtime.InteropServices.CustomTypeMarshallerAttribute\" an, der auf den Typ angewendet wird.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingAllocatingMarshallingFallbackTitle">
+        <source>Marshaller type does not support allocating constructor</source>
+        <target state="new">Marshaller type does not support allocating constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NativeGenericTypeMustBeClosedOrMatchArityDescription">
         <source>The native type '{0}' must be a closed generic or have the same number of generic parameters as the managed type so the emitted code can use a specific instantiation.</source>
         <target state="translated">Der native Typ \"{0}\" muss ein geschlossener generischer Typ sein oder dieselbe Anzahl generischer Parameter wie der verwaltete Typ aufweisen, damit der ausgegebene Code eine bestimmte Instanziierung verwenden kann.</target>
@@ -410,6 +440,11 @@
       <trans-unit id="OutTwoStageMarshallingRequiresFromNativeValueMessage">
         <source>The marshaller type '{0}' supports marshalling in the 'Out' direction with the 'TwoStageMarshalling' feature, but it does not provide a 'FromNativeValue' instance method that returns 'void' and takes one parameter.</source>
         <target state="translated">Der Marshallertyp \"{0}\" unterstützt das Marshalling in der Out-Richtung mit der Funktion \"TwoStageMarshalling\", stellt jedoch keine FromNativeValue-Instanzmethode bereit, die \"void\" zurückgibt und einen Parameter akzeptiert.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvidedMethodsNotSpecifiedInFeaturesTitle">
+        <source>Marshaller type defines a well-known method without specifying support for the corresponding feature</source>
+        <target state="new">Marshaller type defines a well-known method without specifying support for the corresponding feature</target>
         <note />
       </trans-unit>
       <trans-unit id="RefNativeValueUnsupportedDescription">

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.es.xlf
@@ -22,6 +22,11 @@
         <target state="translated">El tipo nativo “{0}” debe establecer el campo “BufferSize” en el “System.Runtime.InteropServices.CustomTypeMarshallerAttribute” aplicado para especificar el tamaño del búfer asignado por el autor de la llamada porque tiene un constructor que toma un “Span&lt;byte&gt;” asignado por el autor de la llamada</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallerAllocConstructorMustHaveBufferSizeTitle">
+        <source>'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</source>
+        <target state="new">'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackDescription">
         <source>A type that supports marshalling from managed to native using a caller-allocated buffer should also support marshalling from managed to native where using a caller-allocated buffer is impossible.</source>
         <target state="translated">Un tipo que admita serializar desde administrado a nativo usando un búfer asignado por el autor de la llamada debe también admitir la serialización de administrado a nativo cuando no sea posible usar un búfer asignado por el autor de la llamada.</target>
@@ -132,6 +137,11 @@
         <target state="translated">Convertir a “LibraryImport” con sufijo “{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="CustomMarshallerTypeMustHaveRequiredShapeTitle">
+        <source>Marshaller type does not have the required shape</source>
+        <target state="new">Marshaller type does not have the required shape</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CustomMarshallerTypeMustSupportDirectionDescription">
         <source>A native must set the 'Direction' property on the 'CustomTypeMarshallerAttribute' to a value that sets at least one known flag value on the 'CustomTypeMarshallerDirection' enum</source>
         <target state="translated">Un tipo nativo debe establecer la propiedad “Direction” en el “CustomTypeMarshallerAttribute” en un valor que establezca al menos un valor de marca conocido en la enumeración “CustomTypeMarshallerDirection”</target>
@@ -227,9 +237,24 @@
         <target state="translated">El método “{0}” debe ser “static”, “partial”, y no genérico cuando está marcado con “LibraryImportAttribute”. La generación del código fuente P/Invoke omitirá el método “{0}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidCustomTypeMarshallerAttributeUsageTitle">
+        <source>Invalid `CustomTypeMarshallerAttribute` usage</source>
+        <target state="new">Invalid `CustomTypeMarshallerAttribute` usage</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidLibraryImportAttributeUsageTitle">
         <source>Invalid 'LibraryImportAttribute' usage</source>
         <target state="translated">Uso de “LibraryImportAttribute” no válido</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNativeTypeTitle">
+        <source>Specified native type is invalid</source>
+        <target state="new">Specified native type is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidSignaturesInMarshallerShapeTitle">
+        <source>Marshaller type has incompatible method signatures</source>
+        <target state="new">Marshaller type has incompatible method signatures</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidStringMarshallingConfigurationDescription">
@@ -352,6 +377,11 @@
         <target state="translated">El tipo “{0}” no especifica un tipo administrado en el “System.Runtime.InteropServices.CustomTypeMarshallerAttribute” aplicado al tipo</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingAllocatingMarshallingFallbackTitle">
+        <source>Marshaller type does not support allocating constructor</source>
+        <target state="new">Marshaller type does not support allocating constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NativeGenericTypeMustBeClosedOrMatchArityDescription">
         <source>The native type '{0}' must be a closed generic or have the same number of generic parameters as the managed type so the emitted code can use a specific instantiation.</source>
         <target state="translated">El tipo nativo “{0}” debe ser un genérico cerrado o tener el mismo número de parámetros genéricos que el tipo administrado para que el código emitido pueda usar una creación de instancia específica.</target>
@@ -410,6 +440,11 @@
       <trans-unit id="OutTwoStageMarshallingRequiresFromNativeValueMessage">
         <source>The marshaller type '{0}' supports marshalling in the 'Out' direction with the 'TwoStageMarshalling' feature, but it does not provide a 'FromNativeValue' instance method that returns 'void' and takes one parameter.</source>
         <target state="translated">El tipo de serializador “{0}” admite la serialización en la dirección “Out” con la característica “TwoStageMarshalling”, pero no proporciona un método de instancia “FromNativeValue” que devuelva “void” y toma un parámetro.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvidedMethodsNotSpecifiedInFeaturesTitle">
+        <source>Marshaller type defines a well-known method without specifying support for the corresponding feature</source>
+        <target state="new">Marshaller type defines a well-known method without specifying support for the corresponding feature</target>
         <note />
       </trans-unit>
       <trans-unit id="RefNativeValueUnsupportedDescription">

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.fr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Le type natif «{0}» doit définir le champ «BufferSize» sur le «System.Runtime.InteropServices.CustomTypeMarshallerAttribute» appliqué pour spécifier la taille de la mémoire tampon allouée par l’appelant, car il a un constructeur qui accepte un «Span&lt;byte&gt;» alloué par l’appelant</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallerAllocConstructorMustHaveBufferSizeTitle">
+        <source>'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</source>
+        <target state="new">'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackDescription">
         <source>A type that supports marshalling from managed to native using a caller-allocated buffer should also support marshalling from managed to native where using a caller-allocated buffer is impossible.</source>
         <target state="translated">Un type qui prend en charge le marshaling de managé à natif à l’aide d’une mémoire tampon allouée par l’appelant doit également prendre en charge le marshaling entre managé et natif, où l’utilisation d’un tampon alloué par l’appelant est impossible.</target>
@@ -132,6 +137,11 @@
         <target state="translated">Convertir en « LibraryImport » avec suffixe « {0} »</target>
         <note />
       </trans-unit>
+      <trans-unit id="CustomMarshallerTypeMustHaveRequiredShapeTitle">
+        <source>Marshaller type does not have the required shape</source>
+        <target state="new">Marshaller type does not have the required shape</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CustomMarshallerTypeMustSupportDirectionDescription">
         <source>A native must set the 'Direction' property on the 'CustomTypeMarshallerAttribute' to a value that sets at least one known flag value on the 'CustomTypeMarshallerDirection' enum</source>
         <target state="translated">Un natif doit définir la propriété « Direction » de « CustomTypeMarshallerAttribute » sur une valeur qui définit au moins une valeur d’indicateur connue sur l’énumération « CustomTypeMarshallerDirection »</target>
@@ -227,9 +237,24 @@
         <target state="translated">La méthode « {0} » doit être « static », « partial » et non générique quand elle est marquée avec « LibraryImportAttribute ». La génération source P/Invoke ignore la méthode « {0} ».</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidCustomTypeMarshallerAttributeUsageTitle">
+        <source>Invalid `CustomTypeMarshallerAttribute` usage</source>
+        <target state="new">Invalid `CustomTypeMarshallerAttribute` usage</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidLibraryImportAttributeUsageTitle">
         <source>Invalid 'LibraryImportAttribute' usage</source>
         <target state="translated">Utilisation de « LibraryImportAttribute » non valide</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNativeTypeTitle">
+        <source>Specified native type is invalid</source>
+        <target state="new">Specified native type is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidSignaturesInMarshallerShapeTitle">
+        <source>Marshaller type has incompatible method signatures</source>
+        <target state="new">Marshaller type has incompatible method signatures</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidStringMarshallingConfigurationDescription">
@@ -352,6 +377,11 @@
         <target state="translated">Le type « {0} » ne spécifie pas de type managé dans « System.Runtime.InteropServices.CustomTypeMarshallerAttribute » appliqué au type</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingAllocatingMarshallingFallbackTitle">
+        <source>Marshaller type does not support allocating constructor</source>
+        <target state="new">Marshaller type does not support allocating constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NativeGenericTypeMustBeClosedOrMatchArityDescription">
         <source>The native type '{0}' must be a closed generic or have the same number of generic parameters as the managed type so the emitted code can use a specific instantiation.</source>
         <target state="translated">Le type natif « {0} » doit être un générique fermé ou avoir le même nombre de paramètres génériques que le type managé pour que le code émis puisse utiliser une instanciation spécifique.</target>
@@ -410,6 +440,11 @@
       <trans-unit id="OutTwoStageMarshallingRequiresFromNativeValueMessage">
         <source>The marshaller type '{0}' supports marshalling in the 'Out' direction with the 'TwoStageMarshalling' feature, but it does not provide a 'FromNativeValue' instance method that returns 'void' and takes one parameter.</source>
         <target state="translated">Le type de marshaleur « {0} » prend en charge le marshaling dans la direction « Out » avec la fonctionnalité « TwoStageMarshalling », mais il ne fournit pas de méthode d’instance « FromNativeValue » qui retourne « void » et accepte un paramètre.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvidedMethodsNotSpecifiedInFeaturesTitle">
+        <source>Marshaller type defines a well-known method without specifying support for the corresponding feature</source>
+        <target state="new">Marshaller type defines a well-known method without specifying support for the corresponding feature</target>
         <note />
       </trans-unit>
       <trans-unit id="RefNativeValueUnsupportedDescription">

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.it.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Il tipo nativo '{0}' deve impostare il campo 'BufferSize' nell'elemento 'System.Runtime.InteropServices.CustomTypeMarshallerAttribute' applicato per specificare le dimensioni del buffer allocato dal chiamante, perché contiene un costruttore che accetta un elemento 'Span&lt;byte&gt;' allocato dal chiamante</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallerAllocConstructorMustHaveBufferSizeTitle">
+        <source>'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</source>
+        <target state="new">'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackDescription">
         <source>A type that supports marshalling from managed to native using a caller-allocated buffer should also support marshalling from managed to native where using a caller-allocated buffer is impossible.</source>
         <target state="translated">Un tipo che supporta il marshalling da gestito a nativo tramite un buffer allocato dal chiamante deve supportare anche il marshalling da gestito a nativo in cui non è possibile usare un buffer allocato dal chiamante.</target>
@@ -132,6 +137,11 @@
         <target state="translated">Converti in 'LibraryImport' con il suffisso '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="CustomMarshallerTypeMustHaveRequiredShapeTitle">
+        <source>Marshaller type does not have the required shape</source>
+        <target state="new">Marshaller type does not have the required shape</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CustomMarshallerTypeMustSupportDirectionDescription">
         <source>A native must set the 'Direction' property on the 'CustomTypeMarshallerAttribute' to a value that sets at least one known flag value on the 'CustomTypeMarshallerDirection' enum</source>
         <target state="translated">Un tipo nativo deve impostare la proprietà 'Direction' in 'CustomTypeMarshallerAttribute' su un valore che imposta almeno un valore di flag noto nell'enumerazione 'CustomTypeMarshallerDirection'</target>
@@ -227,9 +237,24 @@
         <target state="translated">Il metodo '{0}' deve essere 'static', 'partial' e non generico quando è contrassegnato con 'LibraryImportAttribute'. Durante la generazione dell'origine P/Invoke il metodo '{0}' verrà ignorato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidCustomTypeMarshallerAttributeUsageTitle">
+        <source>Invalid `CustomTypeMarshallerAttribute` usage</source>
+        <target state="new">Invalid `CustomTypeMarshallerAttribute` usage</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidLibraryImportAttributeUsageTitle">
         <source>Invalid 'LibraryImportAttribute' usage</source>
         <target state="translated">Utilizzo di 'LibraryImportAttribute' non valido</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNativeTypeTitle">
+        <source>Specified native type is invalid</source>
+        <target state="new">Specified native type is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidSignaturesInMarshallerShapeTitle">
+        <source>Marshaller type has incompatible method signatures</source>
+        <target state="new">Marshaller type has incompatible method signatures</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidStringMarshallingConfigurationDescription">
@@ -352,6 +377,11 @@
         <target state="translated">Il tipo '{0}' non specifica un tipo gestito nell'elemento 'System.Runtime.InteropServices.CustomTypeMarshallerAttribute' applicato al tipo</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingAllocatingMarshallingFallbackTitle">
+        <source>Marshaller type does not support allocating constructor</source>
+        <target state="new">Marshaller type does not support allocating constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NativeGenericTypeMustBeClosedOrMatchArityDescription">
         <source>The native type '{0}' must be a closed generic or have the same number of generic parameters as the managed type so the emitted code can use a specific instantiation.</source>
         <target state="translated">Il tipo nativo '{0}' deve essere un generico chiuso o avere lo stesso numero di parametri generici del tipo gestito in modo che il codice emesso possa usare una creazione di istanza specifica.</target>
@@ -410,6 +440,11 @@
       <trans-unit id="OutTwoStageMarshallingRequiresFromNativeValueMessage">
         <source>The marshaller type '{0}' supports marshalling in the 'Out' direction with the 'TwoStageMarshalling' feature, but it does not provide a 'FromNativeValue' instance method that returns 'void' and takes one parameter.</source>
         <target state="translated">Il tipo di gestore del marshalling '{0}' supporta il marshalling nella direzione 'Out' con la funzionalità 'TwoStageMarshalling', ma non fornisce un metodo di istanza 'FromNativeValue' che restituisce 'void' e accetta un solo parametro.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvidedMethodsNotSpecifiedInFeaturesTitle">
+        <source>Marshaller type defines a well-known method without specifying support for the corresponding feature</source>
+        <target state="new">Marshaller type defines a well-known method without specifying support for the corresponding feature</target>
         <note />
       </trans-unit>
       <trans-unit id="RefNativeValueUnsupportedDescription">

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.ja.xlf
@@ -22,6 +22,11 @@
         <target state="translated">ネイティブ型 '{0}' は、呼び出し元が割り当てた 'Span&lt;byte&gt;' を受け取るコンストラクターを持つため、その型は 'System.Runtime.InteropServices.CustomTypeMarshallerAttribute' に BufferSize フィールドを設定して呼び出し元に割り当てられた 'BufferSize' フィールドを指定する必要があります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallerAllocConstructorMustHaveBufferSizeTitle">
+        <source>'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</source>
+        <target state="new">'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackDescription">
         <source>A type that supports marshalling from managed to native using a caller-allocated buffer should also support marshalling from managed to native where using a caller-allocated buffer is impossible.</source>
         <target state="translated">呼び出し元に割り当てられたバッファーを使用してマネージドからネイティブへのマーシャリングをサポートする型は、呼び出し元に割り当てられたバッファーを使用できない場合に、マネージドからネイティブへのマーシャリングもサポートする必要があります。</target>
@@ -132,6 +137,11 @@
         <target state="translated">'{0}' サフィックスを持つ 'LibraryImport' への変換</target>
         <note />
       </trans-unit>
+      <trans-unit id="CustomMarshallerTypeMustHaveRequiredShapeTitle">
+        <source>Marshaller type does not have the required shape</source>
+        <target state="new">Marshaller type does not have the required shape</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CustomMarshallerTypeMustSupportDirectionDescription">
         <source>A native must set the 'Direction' property on the 'CustomTypeMarshallerAttribute' to a value that sets at least one known flag value on the 'CustomTypeMarshallerDirection' enum</source>
         <target state="translated">ネイティブは、'CustomTypeMarshallerAttribute' の 'Direction' プロパティを、'CustomTypeMarshallerDirection' 列挙型に少なくとも 1 つの既知のフラグ値を設定した値に設定する必要があります</target>
@@ -227,9 +237,24 @@
         <target state="translated">'LibraryImportAttribute' でマークされている場合、メソッド '{0}'は 'static'、'partial'、非ジェネリックである必要があります。P/Invoke ソース生成では、メソッド '{0}' は無視されます。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidCustomTypeMarshallerAttributeUsageTitle">
+        <source>Invalid `CustomTypeMarshallerAttribute` usage</source>
+        <target state="new">Invalid `CustomTypeMarshallerAttribute` usage</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidLibraryImportAttributeUsageTitle">
         <source>Invalid 'LibraryImportAttribute' usage</source>
         <target state="translated">'LibraryImportAttribute' の使用状況が無効です</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNativeTypeTitle">
+        <source>Specified native type is invalid</source>
+        <target state="new">Specified native type is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidSignaturesInMarshallerShapeTitle">
+        <source>Marshaller type has incompatible method signatures</source>
+        <target state="new">Marshaller type has incompatible method signatures</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidStringMarshallingConfigurationDescription">
@@ -352,6 +377,11 @@
         <target state="translated">型 '{0}' は、型に適用される 'System.Runtime.InteropServices.CustomTypeMarshallerAttribute' でマネージド型を指定しません</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingAllocatingMarshallingFallbackTitle">
+        <source>Marshaller type does not support allocating constructor</source>
+        <target state="new">Marshaller type does not support allocating constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NativeGenericTypeMustBeClosedOrMatchArityDescription">
         <source>The native type '{0}' must be a closed generic or have the same number of generic parameters as the managed type so the emitted code can use a specific instantiation.</source>
         <target state="translated">ネイティブ型 '{0}' は、マネージド型と同じ数のジェネリック パラメーターであるか、またはマネージド型と同じ数のジェネリック パラメーターを持つ必要があります。生成されたコードは特定のインスタンス化を使用できます。</target>
@@ -410,6 +440,11 @@
       <trans-unit id="OutTwoStageMarshallingRequiresFromNativeValueMessage">
         <source>The marshaller type '{0}' supports marshalling in the 'Out' direction with the 'TwoStageMarshalling' feature, but it does not provide a 'FromNativeValue' instance method that returns 'void' and takes one parameter.</source>
         <target state="translated">マーシャラー型 '{0}' は、'TwoStageMarshalling' 機能を使用して 'Out' 方向のマーシャリングをサポートしますが、'void' を返し、1 つのパラメーターを受け取る 'FromNativeValue' インスタンス メソッドは指定されません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvidedMethodsNotSpecifiedInFeaturesTitle">
+        <source>Marshaller type defines a well-known method without specifying support for the corresponding feature</source>
+        <target state="new">Marshaller type defines a well-known method without specifying support for the corresponding feature</target>
         <note />
       </trans-unit>
       <trans-unit id="RefNativeValueUnsupportedDescription">

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.ko.xlf
@@ -22,6 +22,11 @@
         <target state="translated">네이티브 형식 '{0}'에는 호출자 할당 'Span&lt;byte&gt;'을 사용하는 생성자가 있으므로 호출자 할당 버퍼의 크기를 지정하려면 적용된 'System.Runtime.InteropServices.CustomTypeMarshallerAttribute'에 'BufferSize' 필드를 설정해야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallerAllocConstructorMustHaveBufferSizeTitle">
+        <source>'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</source>
+        <target state="new">'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackDescription">
         <source>A type that supports marshalling from managed to native using a caller-allocated buffer should also support marshalling from managed to native where using a caller-allocated buffer is impossible.</source>
         <target state="translated">호출자 할당 버퍼를 사용하여 관리 형식에서 네이티브 형식으로의 마샬링을 지원하는 형식은 호출자 할당된 버퍼를 사용할 수 없는 경우 관리 형식에서 네이티브 형식으로의 마샬링도 지원해야 합니다.</target>
@@ -132,6 +137,11 @@
         <target state="translated">'{0}' 접미사가 있는 'LibraryImport'로 변환</target>
         <note />
       </trans-unit>
+      <trans-unit id="CustomMarshallerTypeMustHaveRequiredShapeTitle">
+        <source>Marshaller type does not have the required shape</source>
+        <target state="new">Marshaller type does not have the required shape</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CustomMarshallerTypeMustSupportDirectionDescription">
         <source>A native must set the 'Direction' property on the 'CustomTypeMarshallerAttribute' to a value that sets at least one known flag value on the 'CustomTypeMarshallerDirection' enum</source>
         <target state="translated">네이티브는 'CustomTypeMarshallerDirection' 열거형에서 알려진 플래그 값을 하나 이상 설정하는 값으로 'CustomTypeMarshallerAttribute'의 'Direction' 속성을 설정해야 합니다.</target>
@@ -227,9 +237,24 @@
         <target state="translated">'{0}' 메서드는 'LibraryImportAttribute'로 표시된 경우 '정적', '부분적'이어야 하며 일반이 아니어야 합니다. P/Invoke 소스 생성은 '{0}' 메서드를 무시합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidCustomTypeMarshallerAttributeUsageTitle">
+        <source>Invalid `CustomTypeMarshallerAttribute` usage</source>
+        <target state="new">Invalid `CustomTypeMarshallerAttribute` usage</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidLibraryImportAttributeUsageTitle">
         <source>Invalid 'LibraryImportAttribute' usage</source>
         <target state="translated">잘못된 'LibraryImportAttribute' 사용</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNativeTypeTitle">
+        <source>Specified native type is invalid</source>
+        <target state="new">Specified native type is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidSignaturesInMarshallerShapeTitle">
+        <source>Marshaller type has incompatible method signatures</source>
+        <target state="new">Marshaller type has incompatible method signatures</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidStringMarshallingConfigurationDescription">
@@ -352,6 +377,11 @@
         <target state="translated">형식 '{0}'은(는) 해당 형식에 적용된 'System.Runtime.InteropServices.CustomTypeMarshallerAttribute'의 관리 형식을 지정하지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingAllocatingMarshallingFallbackTitle">
+        <source>Marshaller type does not support allocating constructor</source>
+        <target state="new">Marshaller type does not support allocating constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NativeGenericTypeMustBeClosedOrMatchArityDescription">
         <source>The native type '{0}' must be a closed generic or have the same number of generic parameters as the managed type so the emitted code can use a specific instantiation.</source>
         <target state="translated">네이티브 형식 '{0}'은(는) 닫힌 제네릭이거나 내보낸 코드에서 특정 인스턴스화를 사용할 수 있도록 관리되는 형식과 동일한 수의 제네릭 매개 변수를 가져야 합니다.</target>
@@ -410,6 +440,11 @@
       <trans-unit id="OutTwoStageMarshallingRequiresFromNativeValueMessage">
         <source>The marshaller type '{0}' supports marshalling in the 'Out' direction with the 'TwoStageMarshalling' feature, but it does not provide a 'FromNativeValue' instance method that returns 'void' and takes one parameter.</source>
         <target state="translated">마샬러 형식 '{0}'은(는) 'TwoStageMarshalling' 기능을 사용하여 'Out' 방향으로 마샬링을 지원하지만 'void'를 반환하고 하나의 매개 변수를 사용하는 'FromNativeValue' 인스턴스 메서드를 제공하지 않습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvidedMethodsNotSpecifiedInFeaturesTitle">
+        <source>Marshaller type defines a well-known method without specifying support for the corresponding feature</source>
+        <target state="new">Marshaller type defines a well-known method without specifying support for the corresponding feature</target>
         <note />
       </trans-unit>
       <trans-unit id="RefNativeValueUnsupportedDescription">

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.pl.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Typ natywny „{0}” musi ustawić pole „BufferSize” w zastosowanym atrybucie „System.Runtime.InteropServices.CustomTypeMarshallerAttribute”, aby określić rozmiar buforu przydzielonego przez funkcję wywołującą, ponieważ ma on konstruktora, który przyjmuje przydzieloną funkcję wywołującą o wartości „Span&lt;byte&gt;”</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallerAllocConstructorMustHaveBufferSizeTitle">
+        <source>'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</source>
+        <target state="new">'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackDescription">
         <source>A type that supports marshalling from managed to native using a caller-allocated buffer should also support marshalling from managed to native where using a caller-allocated buffer is impossible.</source>
         <target state="translated">Typ, który obsługuje skierowanie z parametru zarządzanego do natywnego przy użyciu bufora przydzielonego przez funkcję wywołującą, powinien również obsługiwać skierowanie z parametru zarządzanego do natywnego, gdy użycie bufora przydzielonego przez funkcję wywołującą jest niemożliwe.</target>
@@ -132,6 +137,11 @@
         <target state="translated">Konwertuj na element „LibraryImport” z sufiksem „{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="CustomMarshallerTypeMustHaveRequiredShapeTitle">
+        <source>Marshaller type does not have the required shape</source>
+        <target state="new">Marshaller type does not have the required shape</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CustomMarshallerTypeMustSupportDirectionDescription">
         <source>A native must set the 'Direction' property on the 'CustomTypeMarshallerAttribute' to a value that sets at least one known flag value on the 'CustomTypeMarshallerDirection' enum</source>
         <target state="translated">Typ natywny musi ustawić właściwość „Direction” w atrybucie „CustomTypeMarshallerAttribute” na wartość, która ustawia co najmniej jedną znaną wartość flagi w wyliczeniu „CustomTypeMarshallerDirection”</target>
@@ -227,9 +237,24 @@
         <target state="translated">Metoda „{0}” powinna być „statyczna”, „częściowa” i nieogólna, gdy jest oznaczona za pomocą atrybutu „LibraryImportAttribute”. Generowanie źródła funkcji P/Invoke zignoruje metodę „{0}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidCustomTypeMarshallerAttributeUsageTitle">
+        <source>Invalid `CustomTypeMarshallerAttribute` usage</source>
+        <target state="new">Invalid `CustomTypeMarshallerAttribute` usage</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidLibraryImportAttributeUsageTitle">
         <source>Invalid 'LibraryImportAttribute' usage</source>
         <target state="translated">Nieprawidłowe użycie parametru „LibraryImportAttribute”</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNativeTypeTitle">
+        <source>Specified native type is invalid</source>
+        <target state="new">Specified native type is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidSignaturesInMarshallerShapeTitle">
+        <source>Marshaller type has incompatible method signatures</source>
+        <target state="new">Marshaller type has incompatible method signatures</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidStringMarshallingConfigurationDescription">
@@ -352,6 +377,11 @@
         <target state="translated">Typ „{0}” nie określa typu zarządzanego w atrybucie „System.Runtime.InteropServices.CustomTypeMarshallerAttribute” zastosowanym do typu</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingAllocatingMarshallingFallbackTitle">
+        <source>Marshaller type does not support allocating constructor</source>
+        <target state="new">Marshaller type does not support allocating constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NativeGenericTypeMustBeClosedOrMatchArityDescription">
         <source>The native type '{0}' must be a closed generic or have the same number of generic parameters as the managed type so the emitted code can use a specific instantiation.</source>
         <target state="translated">Typ natywny „{0}” musi być zamkniętym typem ogólnym lub mieć taką samą liczbę parametrów ogólnych jak typ zarządzany, aby emitowany kod mógł używać określonego tworzenia wystąpienia.</target>
@@ -410,6 +440,11 @@
       <trans-unit id="OutTwoStageMarshallingRequiresFromNativeValueMessage">
         <source>The marshaller type '{0}' supports marshalling in the 'Out' direction with the 'TwoStageMarshalling' feature, but it does not provide a 'FromNativeValue' instance method that returns 'void' and takes one parameter.</source>
         <target state="translated">Typ elementu przeprowadzającego marshalling „{0}” obsługuje skierowanie w kierunku „na zewnątrz” z funkcją „TwoStageMarshalling”, ale nie zapewnia metody wystąpienia „FromNativeValue”, która zwraca wartość „void” i przyjmuje jeden parametr.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvidedMethodsNotSpecifiedInFeaturesTitle">
+        <source>Marshaller type defines a well-known method without specifying support for the corresponding feature</source>
+        <target state="new">Marshaller type defines a well-known method without specifying support for the corresponding feature</target>
         <note />
       </trans-unit>
       <trans-unit id="RefNativeValueUnsupportedDescription">

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.pt-BR.xlf
@@ -22,6 +22,11 @@
         <target state="translated">O tipo nativo '{0}' deve definir o campo 'BufferSize' no 'System.Runtime.InteropServices.CustomTypeMarshallerAttribute' aplicado para especificar o tamanho do buffer alocado pelo chamador porque ele tem um construtor que recebe um 'Span&lt;byte&gt;' alocado pelo chamador</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallerAllocConstructorMustHaveBufferSizeTitle">
+        <source>'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</source>
+        <target state="new">'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackDescription">
         <source>A type that supports marshalling from managed to native using a caller-allocated buffer should also support marshalling from managed to native where using a caller-allocated buffer is impossible.</source>
         <target state="translated">Um tipo que dá suporte ao marshaling de gerenciado para nativo usando um buffer alocado por chamador também deve dar suporte ao marshalling de gerenciado para nativo, em que usar um buffer alocado por chamador é impossível.</target>
@@ -132,6 +137,11 @@
         <target state="translated">Converter em 'LibraryImport' com '{0}' sufixo</target>
         <note />
       </trans-unit>
+      <trans-unit id="CustomMarshallerTypeMustHaveRequiredShapeTitle">
+        <source>Marshaller type does not have the required shape</source>
+        <target state="new">Marshaller type does not have the required shape</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CustomMarshallerTypeMustSupportDirectionDescription">
         <source>A native must set the 'Direction' property on the 'CustomTypeMarshallerAttribute' to a value that sets at least one known flag value on the 'CustomTypeMarshallerDirection' enum</source>
         <target state="translated">Um nativo deve definir a propriedade 'Direction' em 'CustomTypeMarshallerAttribute' como um valor que define pelo menos um valor de sinalizador conhecido na enumeração 'CustomTypeMarshallerDirection'</target>
@@ -227,9 +237,24 @@
         <target state="translated">O método '{0}' deve ser 'static', 'partial' e não genérico quando marcado com 'LibraryImportAttribute'. A geração de origem P/Invoke ignorará o método '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidCustomTypeMarshallerAttributeUsageTitle">
+        <source>Invalid `CustomTypeMarshallerAttribute` usage</source>
+        <target state="new">Invalid `CustomTypeMarshallerAttribute` usage</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidLibraryImportAttributeUsageTitle">
         <source>Invalid 'LibraryImportAttribute' usage</source>
         <target state="translated">Uso 'LibraryImportAttribute' inválido</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNativeTypeTitle">
+        <source>Specified native type is invalid</source>
+        <target state="new">Specified native type is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidSignaturesInMarshallerShapeTitle">
+        <source>Marshaller type has incompatible method signatures</source>
+        <target state="new">Marshaller type has incompatible method signatures</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidStringMarshallingConfigurationDescription">
@@ -352,6 +377,11 @@
         <target state="translated">O tipo '{0}' não especifica um tipo gerenciado em 'System.Runtime.InteropServices.CustomTypeMarshallerAttribute' aplicado ao tipo</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingAllocatingMarshallingFallbackTitle">
+        <source>Marshaller type does not support allocating constructor</source>
+        <target state="new">Marshaller type does not support allocating constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NativeGenericTypeMustBeClosedOrMatchArityDescription">
         <source>The native type '{0}' must be a closed generic or have the same number of generic parameters as the managed type so the emitted code can use a specific instantiation.</source>
         <target state="translated">O tipo nativo '{0}' deve ser um genérico fechado ou ter o mesmo número de parâmetros genéricos que o tipo gerenciado para que o código emitido possa usar uma instanciação específica.</target>
@@ -410,6 +440,11 @@
       <trans-unit id="OutTwoStageMarshallingRequiresFromNativeValueMessage">
         <source>The marshaller type '{0}' supports marshalling in the 'Out' direction with the 'TwoStageMarshalling' feature, but it does not provide a 'FromNativeValue' instance method that returns 'void' and takes one parameter.</source>
         <target state="translated">O tipo de marshaller '{0}' dá suporte ao marshalling na direção 'Out' com o recurso 'TwoStageMarshalling', mas não fornece um método de instância 'FromNativeValue' que retorna 'void' e recebe um parâmetro.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvidedMethodsNotSpecifiedInFeaturesTitle">
+        <source>Marshaller type defines a well-known method without specifying support for the corresponding feature</source>
+        <target state="new">Marshaller type defines a well-known method without specifying support for the corresponding feature</target>
         <note />
       </trans-unit>
       <trans-unit id="RefNativeValueUnsupportedDescription">

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.ru.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Собственный тип \"{0}\" должен задавать в поле \"BufferSize\" примененного атрибута \"System.Runtime.InteropServices.CustomTypeMarshallerAttribute\" размер выделенного вызывающим объектом буфера, так как он содержит конструктор, который принимает выделенный вызывающим объектом \"Span&lt;byte&gt;\".</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallerAllocConstructorMustHaveBufferSizeTitle">
+        <source>'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</source>
+        <target state="new">'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackDescription">
         <source>A type that supports marshalling from managed to native using a caller-allocated buffer should also support marshalling from managed to native where using a caller-allocated buffer is impossible.</source>
         <target state="translated">Тип, который поддерживает маршализацию из управляемого кода в собственный с использованием буфера, выделенного вызывающим объектом, также должен поддерживать маршализацию из управляемого кода в собственный, когда использование буфера, выделенного вызывающим объектом, невозможно.</target>
@@ -132,6 +137,11 @@
         <target state="translated">Преобразовать в \"LibraryImport\" с суффиксом \"{0}\"</target>
         <note />
       </trans-unit>
+      <trans-unit id="CustomMarshallerTypeMustHaveRequiredShapeTitle">
+        <source>Marshaller type does not have the required shape</source>
+        <target state="new">Marshaller type does not have the required shape</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CustomMarshallerTypeMustSupportDirectionDescription">
         <source>A native must set the 'Direction' property on the 'CustomTypeMarshallerAttribute' to a value that sets at least one known flag value on the 'CustomTypeMarshallerDirection' enum</source>
         <target state="translated">В собственном коде свойство \"Direction\" атрибута \"CustomTypeMarshallerAttribute\" должно иметь значение, которое задает по крайней мере одно известное значение флага в перечислении \"CustomTypeMarshallerDirection\"</target>
@@ -227,9 +237,24 @@
         <target state="translated">Метод \"{0}\" должен быть \"static\", \"partial\" и неуниверсальным, если он имеет атрибут \"LibraryImportAttribute\". При создании источника в P/Invoke метод \"{0}\" игнорируется.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidCustomTypeMarshallerAttributeUsageTitle">
+        <source>Invalid `CustomTypeMarshallerAttribute` usage</source>
+        <target state="new">Invalid `CustomTypeMarshallerAttribute` usage</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidLibraryImportAttributeUsageTitle">
         <source>Invalid 'LibraryImportAttribute' usage</source>
         <target state="translated">Недопустимое использование \"LibraryImportAttribute\"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNativeTypeTitle">
+        <source>Specified native type is invalid</source>
+        <target state="new">Specified native type is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidSignaturesInMarshallerShapeTitle">
+        <source>Marshaller type has incompatible method signatures</source>
+        <target state="new">Marshaller type has incompatible method signatures</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidStringMarshallingConfigurationDescription">
@@ -352,6 +377,11 @@
         <target state="translated">Тип \"{0}\" не указывает управляемый тип в примененном к нему атрибуте \"System.Runtime.InteropServices.CustomTypeMarshallerAttribute\"</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingAllocatingMarshallingFallbackTitle">
+        <source>Marshaller type does not support allocating constructor</source>
+        <target state="new">Marshaller type does not support allocating constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NativeGenericTypeMustBeClosedOrMatchArityDescription">
         <source>The native type '{0}' must be a closed generic or have the same number of generic parameters as the managed type so the emitted code can use a specific instantiation.</source>
         <target state="translated">Собственный тип \"{0}\" должен быть закрытым универсальным или иметь то же количество универсальных параметров, что и управляемый тип, чтобы генерируемый код мог использовать конкретный экземпляр.</target>
@@ -410,6 +440,11 @@
       <trans-unit id="OutTwoStageMarshallingRequiresFromNativeValueMessage">
         <source>The marshaller type '{0}' supports marshalling in the 'Out' direction with the 'TwoStageMarshalling' feature, but it does not provide a 'FromNativeValue' instance method that returns 'void' and takes one parameter.</source>
         <target state="translated">Тип маршалатора \"{0}\" поддерживает маршализацию в направлении \"наружу\" с помощью функции \"TwoStageMarshalling\", но не предоставляет метод экземпляра \"FromNativeValue\", который возвращает \"void\" и принимает один параметр.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvidedMethodsNotSpecifiedInFeaturesTitle">
+        <source>Marshaller type defines a well-known method without specifying support for the corresponding feature</source>
+        <target state="new">Marshaller type defines a well-known method without specifying support for the corresponding feature</target>
         <note />
       </trans-unit>
       <trans-unit id="RefNativeValueUnsupportedDescription">

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.tr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Çağıran tarafından ayrılan 'Span&lt;byte&gt;' alan bir oluşturucuya sahip olduğu için '{0}' yerel türünün, çağıran tarafından ayrılan arabelleğin boyutunu belirtmek için, geçerli 'System.Runtime.InteropServices.CustomTypeMarshallerAttribute' üzerindeki 'BufferSize' alanını ayarlaması gerekir</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallerAllocConstructorMustHaveBufferSizeTitle">
+        <source>'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</source>
+        <target state="new">'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackDescription">
         <source>A type that supports marshalling from managed to native using a caller-allocated buffer should also support marshalling from managed to native where using a caller-allocated buffer is impossible.</source>
         <target state="translated">Çağıran tarafından ayrılan arabelleği kullanarak yönetilenden yerele sıralamayı destekleyen bir tür ayrıca, çağıran tarafından ayrılan arabellek kullanımının olanaksız olduğu durumlarda da yönetilenden yerele sıralamayı desteklemelidir.</target>
@@ -132,6 +137,11 @@
         <target state="translated">'{0}' soneki ile 'LibraryImport' olarak dönüştür</target>
         <note />
       </trans-unit>
+      <trans-unit id="CustomMarshallerTypeMustHaveRequiredShapeTitle">
+        <source>Marshaller type does not have the required shape</source>
+        <target state="new">Marshaller type does not have the required shape</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CustomMarshallerTypeMustSupportDirectionDescription">
         <source>A native must set the 'Direction' property on the 'CustomTypeMarshallerAttribute' to a value that sets at least one known flag value on the 'CustomTypeMarshallerDirection' enum</source>
         <target state="translated">Yerel türün, 'CustomTypeMarshallerAttribute' üzerindeki 'Direction' özelliğini, 'CustomTypeMarshallerDirection' sabit listesi üzerinde en az bir bilinen bayrak değeri ayarlayacak bir değere ayarlaması gerekir</target>
@@ -227,9 +237,24 @@
         <target state="translated">'LibraryImportAttribute' ile işaretlendiğinde '{0}' metodu 'static', 'partial' ve genel olmayan özellikte olmalıdır. P/Invoke kaynak oluşturma '{0}' metodunu yok sayar.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidCustomTypeMarshallerAttributeUsageTitle">
+        <source>Invalid `CustomTypeMarshallerAttribute` usage</source>
+        <target state="new">Invalid `CustomTypeMarshallerAttribute` usage</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidLibraryImportAttributeUsageTitle">
         <source>Invalid 'LibraryImportAttribute' usage</source>
         <target state="translated">Geçersiz 'LibraryImportAttribute' kullanımı</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNativeTypeTitle">
+        <source>Specified native type is invalid</source>
+        <target state="new">Specified native type is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidSignaturesInMarshallerShapeTitle">
+        <source>Marshaller type has incompatible method signatures</source>
+        <target state="new">Marshaller type has incompatible method signatures</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidStringMarshallingConfigurationDescription">
@@ -352,6 +377,11 @@
         <target state="translated">'{0}' türünde, bu türe uygulanan 'System.Runtime.InteropServices.CustomTypeMarshallerAttribute' değerinde herhangi bir yönetilen tür belirtilmiyor</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingAllocatingMarshallingFallbackTitle">
+        <source>Marshaller type does not support allocating constructor</source>
+        <target state="new">Marshaller type does not support allocating constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NativeGenericTypeMustBeClosedOrMatchArityDescription">
         <source>The native type '{0}' must be a closed generic or have the same number of generic parameters as the managed type so the emitted code can use a specific instantiation.</source>
         <target state="translated">'{0}' yerel türü kapalı bir genel tür olmalıdır veya yayınlanan kodun belirli bir örnek oluşturma kullanabilmesi için yönetilen türle aynı sayıda genel parametreye sahip olmalıdır.</target>
@@ -410,6 +440,11 @@
       <trans-unit id="OutTwoStageMarshallingRequiresFromNativeValueMessage">
         <source>The marshaller type '{0}' supports marshalling in the 'Out' direction with the 'TwoStageMarshalling' feature, but it does not provide a 'FromNativeValue' instance method that returns 'void' and takes one parameter.</source>
         <target state="translated">'{0}' sıralayıcı türü 'TwoStageMarshalling' özelliğiyle 'Out' yönünde sıralamayı destekliyor, ancak 'void' döndüren ve bir parametre alan bir 'FromNativeValue' örnek metodu sağlamaz.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvidedMethodsNotSpecifiedInFeaturesTitle">
+        <source>Marshaller type defines a well-known method without specifying support for the corresponding feature</source>
+        <target state="new">Marshaller type defines a well-known method without specifying support for the corresponding feature</target>
         <note />
       </trans-unit>
       <trans-unit id="RefNativeValueUnsupportedDescription">

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.zh-Hans.xlf
@@ -22,6 +22,11 @@
         <target state="translated">本机类型“{0}”必须在应用的 “System.Runtime.InteropServices.CustomTypeMarshallerAttribute” 上设置 “BufferSize” 字段以指定调用方分配的缓冲区的大小，因为它具有采用调用方分配的 “Span&lt;byte&gt;” 的构造函数</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallerAllocConstructorMustHaveBufferSizeTitle">
+        <source>'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</source>
+        <target state="new">'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackDescription">
         <source>A type that supports marshalling from managed to native using a caller-allocated buffer should also support marshalling from managed to native where using a caller-allocated buffer is impossible.</source>
         <target state="translated">支持使用调用方分配的缓冲区从托管到本机封送的类型还应该支持在不可能使用调用方分配的缓冲区情况下从托管到本机封送。</target>
@@ -132,6 +137,11 @@
         <target state="translated">转换为带“{0}”后缀的 “LibraryImport”</target>
         <note />
       </trans-unit>
+      <trans-unit id="CustomMarshallerTypeMustHaveRequiredShapeTitle">
+        <source>Marshaller type does not have the required shape</source>
+        <target state="new">Marshaller type does not have the required shape</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CustomMarshallerTypeMustSupportDirectionDescription">
         <source>A native must set the 'Direction' property on the 'CustomTypeMarshallerAttribute' to a value that sets at least one known flag value on the 'CustomTypeMarshallerDirection' enum</source>
         <target state="translated">本机必须将 “CustomTypeMarshallerAttribute” 上的 “Direction” 属性设置为在 “CustomTypeMarshallerDirection” 枚举上至少设置一个已知标志值的值</target>
@@ -227,9 +237,24 @@
         <target state="translated">在标记为 “LibraryImportAttribute” 时，方法“{0}”应为 “static”、“partial” 和非泛型。P/Invoke 源生成将忽略方法“{0}”。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidCustomTypeMarshallerAttributeUsageTitle">
+        <source>Invalid `CustomTypeMarshallerAttribute` usage</source>
+        <target state="new">Invalid `CustomTypeMarshallerAttribute` usage</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidLibraryImportAttributeUsageTitle">
         <source>Invalid 'LibraryImportAttribute' usage</source>
         <target state="translated">“LibraryImportAttribute” 用法无效</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNativeTypeTitle">
+        <source>Specified native type is invalid</source>
+        <target state="new">Specified native type is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidSignaturesInMarshallerShapeTitle">
+        <source>Marshaller type has incompatible method signatures</source>
+        <target state="new">Marshaller type has incompatible method signatures</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidStringMarshallingConfigurationDescription">
@@ -352,6 +377,11 @@
         <target state="translated">类型“{0}”未在应用于该类型的 “System.Runtime.InteropServices.CustomTypeMarshallerAttribute” 中指定托管类型</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingAllocatingMarshallingFallbackTitle">
+        <source>Marshaller type does not support allocating constructor</source>
+        <target state="new">Marshaller type does not support allocating constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NativeGenericTypeMustBeClosedOrMatchArityDescription">
         <source>The native type '{0}' must be a closed generic or have the same number of generic parameters as the managed type so the emitted code can use a specific instantiation.</source>
         <target state="translated">本机类型“{0}”必须是封闭泛型或具有与托管类型相同数目的泛型参数，以便发出的代码可以使用特定实例化。</target>
@@ -410,6 +440,11 @@
       <trans-unit id="OutTwoStageMarshallingRequiresFromNativeValueMessage">
         <source>The marshaller type '{0}' supports marshalling in the 'Out' direction with the 'TwoStageMarshalling' feature, but it does not provide a 'FromNativeValue' instance method that returns 'void' and takes one parameter.</source>
         <target state="translated">封送处理程序类型“{0}”支持使用 “TwoStageMarshalling” 功能在 “Out” 方向进行封送，但它不提供返回 “void” 并采用一个参数的 “FromNativeValue” 实例方法。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvidedMethodsNotSpecifiedInFeaturesTitle">
+        <source>Marshaller type defines a well-known method without specifying support for the corresponding feature</source>
+        <target state="new">Marshaller type defines a well-known method without specifying support for the corresponding feature</target>
         <note />
       </trans-unit>
       <trans-unit id="RefNativeValueUnsupportedDescription">

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.zh-Hant.xlf
@@ -22,6 +22,11 @@
         <target state="translated">原生類型'{0}'必須在套用的 'System.Runtime.InteropServices.CustomTypeMarshallerAttribute' 上設定 'BufferSize' 字段，以指定通話者設定的緩衝區大小，因为它的建構函式採用通話者設定的 'Span&lt;byte&gt;'</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallerAllocConstructorMustHaveBufferSizeTitle">
+        <source>'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</source>
+        <target state="new">'BufferSize' should be set on 'CustomTypeMarshallerAttribute'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackDescription">
         <source>A type that supports marshalling from managed to native using a caller-allocated buffer should also support marshalling from managed to native where using a caller-allocated buffer is impossible.</source>
         <target state="translated">支援使用通話者設定緩衝區從 Managed 到 native 的類型，也應支援從售管理到原生排列，因為無法使用通話者設定的緩衝區。</target>
@@ -132,6 +137,11 @@
         <target state="translated">轉換為具有 '{0}'後綴的 'LibraryImport'</target>
         <note />
       </trans-unit>
+      <trans-unit id="CustomMarshallerTypeMustHaveRequiredShapeTitle">
+        <source>Marshaller type does not have the required shape</source>
+        <target state="new">Marshaller type does not have the required shape</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CustomMarshallerTypeMustSupportDirectionDescription">
         <source>A native must set the 'Direction' property on the 'CustomTypeMarshallerAttribute' to a value that sets at least one known flag value on the 'CustomTypeMarshallerDirection' enum</source>
         <target state="translated">原生必須將 'CustomTypeMarshallerAttribute' 上的 'Direction' 屬性設定為在 'CustomTypeMarshallerDirection' 列舉上設定至少一個已知旗標值的值</target>
@@ -227,9 +237,24 @@
         <target state="translated">以 'LibraryImportAttribute' 標示時，方法'{0}'應為 'static'、'partial' 和非泛型。產生 P/Invoke 来源會忽略方法'{0}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidCustomTypeMarshallerAttributeUsageTitle">
+        <source>Invalid `CustomTypeMarshallerAttribute` usage</source>
+        <target state="new">Invalid `CustomTypeMarshallerAttribute` usage</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidLibraryImportAttributeUsageTitle">
         <source>Invalid 'LibraryImportAttribute' usage</source>
         <target state="translated">'LibraryImportAttribute' 使用方式無效</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNativeTypeTitle">
+        <source>Specified native type is invalid</source>
+        <target state="new">Specified native type is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidSignaturesInMarshallerShapeTitle">
+        <source>Marshaller type has incompatible method signatures</source>
+        <target state="new">Marshaller type has incompatible method signatures</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidStringMarshallingConfigurationDescription">
@@ -352,6 +377,11 @@
         <target state="translated">類型 '{0}' 未在套用至類型的 'System.Runtime.InteropServices.CustomTypeMarshallerAttribute' 中指定受管理類型</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingAllocatingMarshallingFallbackTitle">
+        <source>Marshaller type does not support allocating constructor</source>
+        <target state="new">Marshaller type does not support allocating constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NativeGenericTypeMustBeClosedOrMatchArityDescription">
         <source>The native type '{0}' must be a closed generic or have the same number of generic parameters as the managed type so the emitted code can use a specific instantiation.</source>
         <target state="translated">原生類型 '{0}' 必須是封閉式泛型或具有與受管理類型相同的泛型參數數目，因此發出的程式碼可以使用特定的具現化。</target>
@@ -410,6 +440,11 @@
       <trans-unit id="OutTwoStageMarshallingRequiresFromNativeValueMessage">
         <source>The marshaller type '{0}' supports marshalling in the 'Out' direction with the 'TwoStageMarshalling' feature, but it does not provide a 'FromNativeValue' instance method that returns 'void' and takes one parameter.</source>
         <target state="translated">封送處理器類型 '{0}'支援以 'Out' 方向使用 'TwoStageMarshalling' 功能進行排列，但未提供傳回 'void' 並接受一個參數的 'FromNativeValue' 實例方法。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvidedMethodsNotSpecifiedInFeaturesTitle">
+        <source>Marshaller type defines a well-known method without specifying support for the corresponding feature</source>
+        <target state="new">Marshaller type defines a well-known method without specifying support for the corresponding feature</target>
         <note />
       </trans-unit>
       <trans-unit id="RefNativeValueUnsupportedDescription">


### PR DESCRIPTION
The analyzer diagnostics were using localized strings for the message and description, but not the title.

Also collapses a few of the more specific IDs into existing ones.