### PR TITLE
Fix nullability for IEnumFORMATETC

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -1733,7 +1733,7 @@ namespace System.Runtime.InteropServices.ComTypes
     public partial interface IEnumFORMATETC
     {
         void Clone(out System.Runtime.InteropServices.ComTypes.IEnumFORMATETC newEnum);
-        int Next(int celt, System.Runtime.InteropServices.ComTypes.FORMATETC[] rgelt, int[] pceltFetched);
+        int Next(int celt, System.Runtime.InteropServices.ComTypes.FORMATETC[] rgelt, int[]? pceltFetched);
         int Reset();
         int Skip(int celt);
     }

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/ComTypes/IEnumFormatETC.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/ComTypes/IEnumFormatETC.cs
@@ -24,7 +24,7 @@ namespace System.Runtime.InteropServices.ComTypes
         ///     in NULL for that parameter).
         /// </summary>
         [PreserveSig]
-        int Next(int celt, [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] FORMATETC[] rgelt, [Out, MarshalAs(UnmanagedType.LPArray)] int[] pceltFetched);
+        int Next(int celt, [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] FORMATETC[] rgelt, [Out, MarshalAs(UnmanagedType.LPArray)] int[]? pceltFetched);
 
         /// <summary>
         ///     Skips over the next specified number of elements in the enumeration sequence.


### PR DESCRIPTION
See for justification https://docs.microsoft.com/en-us/windows/win32/api/objidl/nf-objidl-ienumformatetc-next#parameters

I hit this when implement ComWrappers for WinForms where I have to pass null data to `pceltFetched` which was given to me from unmanaged side.