### PR TITLE
JIT ARM32: Fix wrong emitAttr passed for loads/stores in PUTARG_STK

### DIFF
--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -1128,9 +1128,9 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
                         type = TYP_UINT;
                     }
                 }
-                const emitAttr attr     = emitTypeSize(type);
+
+                const emitAttr attr     = emitActualTypeSize(type);
                 const unsigned moveSize = genTypeSize(type);
-                assert(EA_SIZE_IN_BYTES(attr) == moveSize);
 
                 remainingSize -= moveSize;
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_60827/Runtime_60827.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_60827/Runtime_60827.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+public struct S0
+{
+    public ushort F1;
+    public ushort F2;
+    public byte F3;
+
+    public void M21()
+    {
+        M25(0, 1, 2, 3, this);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void M25(int r0, int r1, int r2, int r3, S0 stkArg)
+    {
+    }
+}
+
+public class Runtime_60827
+{
+    public static int Main()
+    {
+        new S0().M21();
+
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_60827/Runtime_60827.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_60827/Runtime_60827.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
On arm architectures the small load/store instructions all work larger
registers and for loads the instruction automatically normalizes the
result. Due to this we always expect to pass the normalized size for
loads/stores when generating these instructions, but in this particular
place we did not do so, resulting in asserts on arm32.

On arm64 the function ignores the size so nothing happens.

I assume this is the right fix based on `genCodeForIndir` and `genCodeForStoreInd` that both use `emitActualTypeSize` when emitting these same instructions.

cc @dotnet/jit-contrib PTAL @BruceForstall 

Fix #60827