### PR TITLE
Remove unnecessary/erroneous initialization to base.Crawlpos()

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -1453,7 +1453,7 @@ namespace System.Text.RegularExpressions.Generator
                         startingCapturePos = ReserveName("alternation_starting_capturepos");
                         if (canUseLocalsForAllState)
                         {
-                            additionalDeclarations.Add($"int {startingCapturePos} = base.Crawlpos();");
+                            additionalDeclarations.Add($"int {startingCapturePos} = 0;");
                             writer.WriteLine($"{startingCapturePos} = base.Crawlpos();");
                         }
                         else


### PR DESCRIPTION
We use this `additionalDeclarations.Add` mechanism in the source generator when we can't declare the local exactly where it's needed due to branching structure and the compiler not always being able to see that the local is definitely assigned.  In such cases, we instead emit the local at the beginning of the method, default initialized, and then later assign it where we need to.  In this particular case, we should be default assigning it but are accidentally calling base.Crawlpos().  This isn't functionally wrong, but it's unnecessary.