### PR TITLE
[eventpipe] Fix environment variable parser for multiple configurations

### DIFF
--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -792,12 +792,17 @@ get_next_config_value (const ep_char8_t *data, const ep_char8_t **start, const e
 	EP_ASSERT (end != NULL);
 
 	*start = data;
-	while (*data != '\0' && *data != ':')
+	while (*data != '\0' && *data != ',' && *data != ':')
 		data++;
 
 	*end = data;
 
-	return *data != '\0' ? ++data : NULL;
+	if (*data == '\0')
+		return NULL;
+	else if (*data == ',')
+		return data;
+	else
+		return ++data;
 }
 
 static


### PR DESCRIPTION
Running

```
DOTNET_EnableEventPipe=1 DOTNET_EventPipeConfig='Microsoft-DotNETCore-SampleProfiler:f00000000000:4,Microsoft-Windows-DotNETRuntime:4c14fccbd:4' dotnet run
```

leads to a null-pointer dereference while comparing two strings where one is a null pointer:

```
Thread 1 "dotnet" received signal SIGSEGV, Segmentation fault.
__strcmp_avx2 () at ../sysdeps/x86_64/multiarch/strcmp-avx2.S:102
(gdb) bt
#0  __strcmp_avx2 () at ../sysdeps/x86_64/multiarch/strcmp-avx2.S:102
#1  0x00007ffff77de16d in ep_rt_utf8_string_compare (str1=0x7ffff781a1db "*", str2=0x0)
...
#6  0x00007ffff77c4f5a in ep_enable_2
```

Multiple provider configurations are seperated by commata as implemented in `ep_enable_2`. However, commata are ignored in `get_next_config_value` while parsing the actual environment variable. For the example above this leads to a configuration [here](https://github.com/dotnet/runtime/blob/8006e6a89bc02e410331e6323e3f6321b224b327/src/native/eventpipe/ep.c#L1066) where

```
provider_name = "Microsoft-DotNETCore-SampleProfiler"
keywords = 0xf00000000000
logging_level = EP_EVENT_LEVEL_INFORMATIONAL
filter_data = "4c14fccbd"
```

and leaving the second provider uninitialized (note the wrong `filter_data`). Similar for

```
DOTNET_EnableEventPipe=1 DOTNET_EventPipeConfig='Microsoft-DotNETCore-SampleProfiler:f00000000000:4:foo=bar,Microsoft-Windows-DotNETRuntime:4c14fccbd:4' dotnet run
```

we have

```
provider_name = "Microsoft-DotNETCore-SampleProfiler"
keywords = 0xf00000000000
logging_level = EP_EVENT_LEVEL_INFORMATIONAL
filter_data = "foo=bar,Microsoft-Windows-DotNETRuntime"
```

where `filter_data` is wrong, too.

I couldn't find any documentation for a filter so I assumed that commata are not contained in filter rules and only adjusted `get_next_config_value` which fixes the issue for me.