### PR TITLE
[HTTP/3] Build latest msquic locally in docker image

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -55,7 +55,7 @@ jobs:
       export CLIENT_DUMPS_SHARE="$(Build.ArtifactStagingDirectory)/dumps/client/3.0"
       export SERVER_DUMPS_SHARE="$(Build.ArtifactStagingDirectory)/dumps/server/3.0"
       export HTTPSTRESS_CLIENT_ARGS="$HTTPSTRESS_CLIENT_ARGS -http 3.0"
-      export HTTPSTRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 3.0"
+      export HTTPSTRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 3.0 -aspnetlog"
       docker-compose up --abort-on-container-exit --no-color
     timeoutInMinutes: 35 # In case the HTTP/3.0 run hangs, we timeout shortly after the expected 30 minute run
     displayName: Run HttpStress - HTTP 3.0

--- a/src/libraries/System.Net.Http/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http/src/Resources/Strings.resx
@@ -544,7 +544,7 @@
     <value>HTTP request version upgrade is not enabled for synchronous '{0}'. Do not use '{1}' version policy for synchronous HTTP methods.</value>
   </data>
   <data name="net_http_requested_version_cannot_establish" xml:space="preserve">
-    <value>Requesting HTTP version {0} with version policy {1} while unable to establish HTTP/{2} connection.</value>
+    <value>Requesting HTTP version {0} with version policy {1} while unable to establish HTTP/{2} connection (QuicEnabled={3}).</value>
   </data>
   <data name="net_http_requested_version_server_refused" xml:space="preserve">
     <value>Requesting HTTP version {0} with version policy {1} while server offers only version fallback.</value>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -419,11 +419,12 @@ namespace System.Net.Http
         // If not, then it must be unavailable at the moment; we will detect this and ensure it is not added back to the available pool.
 
         [DoesNotReturn]
-        private static void ThrowGetVersionException(HttpRequestMessage request, int desiredVersion)
+        private void ThrowGetVersionException(HttpRequestMessage request, int desiredVersion)
         {
             Debug.Assert(desiredVersion == 2 || desiredVersion == 3);
-
-            throw new HttpRequestException(SR.Format(SR.net_http_requested_version_cannot_establish, request.Version, request.VersionPolicy, desiredVersion));
+#pragma warning disable CA1416
+            throw new HttpRequestException(SR.Format(SR.net_http_requested_version_cannot_establish, request.Version, request.VersionPolicy, desiredVersion, (_poolManager.Settings._quicImplementationProvider ?? QuicImplementationProviders.Default).IsSupported));
+#pragma warning restore CA1416
         }
 
         private bool CheckExpirationOnGet(HttpConnectionBase connection)

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -4,14 +4,24 @@ FROM $SDK_BASE_IMAGE
 WORKDIR /app
 COPY . .
 
-# Pulling the msquic Debian package from packages.microsoft.com
+# Build latest msquic locally
 RUN apt-get update -y
-RUN apt-get install -y gnupg2 software-properties-common
-RUN curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-RUN apt-add-repository https://packages.microsoft.com/debian/11/prod
-RUN apt-get update -y
-RUN apt-get install -y libmsquic
 RUN apt-get upgrade -y
+RUN apt-get install -y cmake clang ruby-dev gem lttng-tools libssl-dev && \
+    gem install fpm
+RUN git clone --recursive https://github.com/dotnet/msquic
+RUN cd msquic/src/msquic && \
+    mkdir build && \
+    options="-DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off" && \
+    cmake -B build -DCMAKE_BUILD_TYPE=Release -DQUIC_ENABLE_LOGGING=false -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off && \
+    cd build && \
+    cmake --build . --config Release
+RUN cd msquic/src/msquic/build/bin/Release && \
+    rm libmsquic.so && \
+    fpm -f -s dir -t deb -n libmsquic -v $( find -type f | cut -d "." -f 4- ) \
+      --license MIT --url https://github.com/microsoft/msquic --log error \
+      $( ls ./* | cut -d "/" -f 2 | sed -r "s/(.*)/\1=\/usr\/lib\/\1/g" ) && \
+      dpkg -i libmsquic_*.deb
 
 ARG VERSION=7.0
 ARG CONFIGURATION=Release

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -1,8 +1,7 @@
 ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:6.0-bullseye-slim
 FROM $SDK_BASE_IMAGE
 
-WORKDIR /app
-COPY . .
+WORKDIR /msquic
 
 # Build latest msquic locally
 RUN apt-get update -y
@@ -22,6 +21,9 @@ RUN cd msquic/src/msquic/build/bin/Release && \
       --license MIT --url https://github.com/microsoft/msquic --log error \
       $( ls ./* | cut -d "/" -f 2 | sed -r "s/(.*)/\1=\/usr\/lib\/\1/g" ) && \
       dpkg -i libmsquic_*.deb
+
+WORKDIR /app
+COPY . .
 
 ARG VERSION=7.0
 ARG CONFIGURATION=Release


### PR DESCRIPTION
We don't have libmsquic 2.0+ in packages yet so build it locally.

Fixes #67442