### PR TITLE
Tweak RegexGenerator scan loop

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -387,37 +387,34 @@ namespace System.Text.RegularExpressions.Generator
                     writer.WriteLine($"base.runtextpos = {(!rtl ? "inputSpan.Length" : "0")};");
                 }
             }
-            else if (rm.MatchTimeout == Timeout.Infinite)
+            else
             {
-                // Emit the general purpose scan loop, without timeouts.
-                needsTryFind = needsTryMatch = true;
-                writer.WriteLine($"// Search until we can't find a valid starting position, we find a match, or we reach the end of the input.");
-                writer.WriteLine($"while (TryFindNextPossibleStartingPosition(inputSpan) &&");
-                writer.WriteLine($"       !TryMatchAtCurrentPosition(inputSpan) &&");
+                // Emit the general purpose scan loop. At this point, we always need TryMatchAtCurrentPosition.  If we have any
+                // information that will enable TryFindNextPossibleStartingPosition to help narrow down the search, we need it,
+                // too, but otherwise it can be skipped.
+                needsTryMatch = true;
+                needsTryFind =
+                    rm.Tree.FindOptimizations.FindMode != FindNextStartingPositionMode.NoSearch ||
+                    rm.Tree.FindOptimizations.MinRequiredLength != 0 ||
+                    rm.Tree.FindOptimizations.LeadingAnchor != RegexNodeKind.Unknown ||
+                    rm.Tree.FindOptimizations.TrailingAnchor != RegexNodeKind.Unknown;
+
+                writer.WriteLine("// Search until we can't find a valid starting position, we find a match, or we reach the end of the input.");
+                writer.Write("while (");
+                if (needsTryFind)
+                {
+                    writer.WriteLine("TryFindNextPossibleStartingPosition(inputSpan) &&");
+                    writer.Write("       ");
+                }
+                writer.WriteLine("!TryMatchAtCurrentPosition(inputSpan) &&");
                 writer.WriteLine($"       base.runtextpos != {(!rtl ? "inputSpan.Length" : "0")})");
                 using (EmitBlock(writer, null))
                 {
                     writer.WriteLine($"base.runtextpos{(!rtl ? "++" : "--")};");
-                }
-            }
-            else
-            {
-                // Emit the general purpose scan loop, with (possible) timeouts.
-                needsTryFind = needsTryMatch = true;
-                writer.WriteLine("// Search until we can't find a valid starting position, we find a match, or we reach the end of the input.");
-                using (EmitBlock(writer, "while (TryFindNextPossibleStartingPosition(inputSpan))"))
-                {
-                    // Check the timeout every time we run the whole match logic at a new starting location, as each such
-                    // operation could do work at least linear in the length of the input.
-                    EmitTimeoutCheckIfNeeded(writer, rm);
 
-                    using (EmitBlock(writer, $"if (TryMatchAtCurrentPosition(inputSpan) || base.runtextpos == {(!rtl ? "inputSpan.Length" : "0")})"))
-                    {
-                        writer.WriteLine("return;");
-                    }
-                    writer.WriteLine();
-
-                    writer.WriteLine($"base.runtextpos{(!rtl ? "++" : "--")};");
+                    // Check the timeout at least once per failed starting location, as finding the next location and
+                    // attempting a match at that location could do work at least linear in the length of the input.
+                    EmitTimeoutCheckIfNeeded(writer, rm, appendNewLineIfTimeoutEmitted: false);
                 }
             }
 
@@ -444,6 +441,7 @@ namespace System.Text.RegularExpressions.Generator
             writer.WriteLine();
 
             const string NoMatchFound = "NoMatchFound";
+            bool findEndsInAlwaysReturningTrue = false;
             bool noMatchFoundLabelNeeded = false;
 
             // Generate length check.  If the input isn't long enough to possibly match, fail quickly.
@@ -451,21 +449,21 @@ namespace System.Text.RegularExpressions.Generator
             // especially since we want the "return false" code regardless.
             int minRequiredLength = rm.Tree.FindOptimizations.MinRequiredLength;
             Debug.Assert(minRequiredLength >= 0);
-            writer.WriteLine("// Validate that enough room remains in the input to match.");
+            FinishEmitBlock clause = default;
             if (minRequiredLength > 0)
             {
-                writer.WriteLine($"// Any possible match is at least {minRequiredLength} characters.");
+                writer.WriteLine(minRequiredLength == 1 ?
+                    "// Empty matches aren't possible." :
+                    $"// Any possible match is at least {minRequiredLength} characters.");
+                clause = EmitBlock(writer, (minRequiredLength, rtl) switch
+                {
+                    (1, false) => "if ((uint)pos < (uint)inputSpan.Length)",
+                    (_, false) => $"if (pos <= inputSpan.Length - {minRequiredLength})",
+                    (1, true) => "if (pos > 0)",
+                    (_, true) => $"if (pos >= {minRequiredLength})",
+                });
             }
-            string clause = (minRequiredLength, rtl) switch
-                            {
-                                (0, false) => "if ((uint)pos <= (uint)inputSpan.Length)",
-                                (1, false) => "if ((uint)pos < (uint)inputSpan.Length)",
-                                (_, false) => $"if (pos <= inputSpan.Length - {minRequiredLength})",
-                                (0, true) => "if (pos >= 0)",
-                                (1, true) => "if (pos > 0)",
-                                (_, true) => $"if (pos >= {minRequiredLength})",
-                            };
-            using (EmitBlock(writer, clause))
+            using (clause)
             {
                 // Emit any anchors.
                 if (!EmitAnchors())
@@ -503,19 +501,25 @@ namespace System.Text.RegularExpressions.Generator
 
                         case FindNextStartingPositionMode.NoSearch:
                             writer.WriteLine("return true;");
+                            findEndsInAlwaysReturningTrue = true;
                             break;
                     }
                 }
             }
-            writer.WriteLine();
 
-            writer.WriteLine("// No match found.");
-            if (noMatchFoundLabelNeeded)
+            // If the main path is guaranteed to end in a "return true;" and nothing is going to
+            // jump past it, we don't need a "return false;" path.
+            if (minRequiredLength > 0 || !findEndsInAlwaysReturningTrue || noMatchFoundLabelNeeded)
             {
-                writer.WriteLine($"{NoMatchFound}:");
+                writer.WriteLine();
+                writer.WriteLine("// No match found.");
+                if (noMatchFoundLabelNeeded)
+                {
+                    writer.WriteLine($"{NoMatchFound}:");
+                }
+                writer.WriteLine($"base.runtextpos = {(!rtl ? "inputSpan.Length" : "0")};");
+                writer.WriteLine("return false;");
             }
-            writer.WriteLine($"base.runtextpos = {(!rtl ? "inputSpan.Length" : "0")};");
-            writer.WriteLine("return false;");
 
             // We're done.  Patch up any additional declarations.
             ReplaceAdditionalDeclarations(writer, additionalDeclarations, additionalDeclarationsPosition, additionalDeclarationsIndent);
@@ -567,6 +571,7 @@ namespace System.Text.RegularExpressions.Generator
                             writer.WriteLine("base.runtextpos = inputSpan.Length - 1;");
                         }
                         writer.WriteLine("return true;");
+                        findEndsInAlwaysReturningTrue = true;
                         return true;
 
                     case FindNextStartingPositionMode.LeadingAnchor_LeftToRight_End:
@@ -578,6 +583,7 @@ namespace System.Text.RegularExpressions.Generator
                             writer.WriteLine("base.runtextpos = inputSpan.Length;");
                         }
                         writer.WriteLine("return true;");
+                        findEndsInAlwaysReturningTrue = true;
                         return true;
 
                     case FindNextStartingPositionMode.LeadingAnchor_RightToLeft_Beginning:
@@ -590,6 +596,7 @@ namespace System.Text.RegularExpressions.Generator
                             writer.WriteLine("base.runtextpos = 0;");
                         }
                         writer.WriteLine("return true;");
+                        findEndsInAlwaysReturningTrue = true;
                         return true;
 
                     case FindNextStartingPositionMode.LeadingAnchor_RightToLeft_EndZ:
@@ -620,6 +627,7 @@ namespace System.Text.RegularExpressions.Generator
                             writer.WriteLine($"base.runtextpos = inputSpan.Length - {regexTree.FindOptimizations.MinRequiredLength + 1};");
                         }
                         writer.WriteLine("return true;");
+                        findEndsInAlwaysReturningTrue = true;
                         return true;
 
                     case FindNextStartingPositionMode.TrailingAnchor_FixedLength_LeftToRight_End:
@@ -630,6 +638,7 @@ namespace System.Text.RegularExpressions.Generator
                             writer.WriteLine($"base.runtextpos = inputSpan.Length - {regexTree.FindOptimizations.MinRequiredLength};");
                         }
                         writer.WriteLine("return true;");
+                        findEndsInAlwaysReturningTrue = true;
                         return true;
                 }
 
@@ -651,7 +660,8 @@ namespace System.Text.RegularExpressions.Generator
                                 noMatchFoundLabelNeeded = true;
                                 Goto(NoMatchFound);
                             }
-                            writer.WriteLine("pos = newlinePos + pos + 1;");
+                            writer.WriteLine("pos += newlinePos + 1;");
+                            writer.WriteLine();
 
                             // We've updated the position.  Make sure there's still enough room in the input for a possible match.
                             using (EmitBlock(writer, minRequiredLength switch
@@ -4185,7 +4195,7 @@ namespace System.Text.RegularExpressions.Generator
         /// routed to the correct child, but such constructs aren't actually introducing backtracking and thus don't need to be
         /// instrumented for timeouts.
         /// </remarks>
-        private static void EmitTimeoutCheckIfNeeded(IndentedTextWriter writer, RegexMethod rm)
+        private static void EmitTimeoutCheckIfNeeded(IndentedTextWriter writer, RegexMethod rm, bool appendNewLineIfTimeoutEmitted = true)
         {
             // If the match timeout was explicitly set to infinite, then no timeout code needs to be emitted.
             if (rm.MatchTimeout != Timeout.Infinite)
@@ -4199,7 +4209,11 @@ namespace System.Text.RegularExpressions.Generator
                 {
                     writer.WriteLine("base.CheckTimeout();");
                 }
-                writer.WriteLine();
+
+                if (appendNewLineIfTimeoutEmitted)
+                {
+                    writer.WriteLine();
+                }
             }
         }
 


### PR DESCRIPTION
Cleans up the generated code a bit, removing some unnecessary code:
- If TryFindNextPossibleStartingPosition has no information to use to do something helpful, there's no point in emitting it.
- Simplify the Scan loop structure
- Avoid emitting a minimum length required check if the minimum is 0, as we'll never have a position that fails that check.
- Avoid a `return false;` code path in TryFindNextPossibleStartingPosition if it'll never be used.