### PR TITLE
Update arm/arm64 Linux cross build images

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -39,7 +39,7 @@ jobs:
       targetRid: linux-arm
       platform: Linux_arm
       container:
-        image: ubuntu-16.04-cross-20210719121212-8a8d3be
+        image: ubuntu-18.04-cross-arm-20220426130400-6e40d49
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
@@ -91,7 +91,7 @@ jobs:
       platform: Linux_arm64
       container:
         ${{ if eq(parameters.container, '') }}:
-          image: ubuntu-16.04-cross-arm64-20210719121212-8a8d3be
+          image: ubuntu-18.04-cross-arm64-20220426130400-6e40d49
         ${{ if ne(parameters.container, '') }}:
           image: ${{ parameters.container }}
         registry: mcr

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -41,7 +41,7 @@ jobs:
       - ${{ if or(eq(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
         - (Ubuntu.2110.Arm64.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-21.10-helix-arm64v8-20211116135000-0f8d97e
       - ${{ if or(ne(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
-        - (Ubuntu.1804.ArmArch.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-helix-arm64v8-20210106155927-56c6673
+        - (Ubuntu.1804.ArmArch.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-20220426125905-97d8652
 
     # Linux musl x64
     - ${{ if eq(parameters.platform, 'Linux_musl_x64') }}:

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -603,7 +603,7 @@
       <MonoUseCrossTool>true</MonoUseCrossTool>
       <MonoAotAbi>aarch64-linux-gnu</MonoAotAbi>
       <MonoAotOffsetsFile>$(MonoObjCrossDir)offsets-aarch-linux-gnu.h</MonoAotOffsetsFile>
-      <MonoAotOffsetsPrefix>$(MonoCrossDir)/usr/lib/gcc/aarch64-linux-gnu/5</MonoAotOffsetsPrefix>
+      <MonoAotOffsetsPrefix>$(MonoCrossDir)/usr/lib/gcc/aarch64-linux-gnu/7</MonoAotOffsetsPrefix>
     </PropertyGroup>
 
     <!-- macOS host specific options -->


### PR DESCRIPTION
The images are updated to the latest ones as a preparation for enabling
native PGO for Linux arm64 and potentially Linux arm.

We are moving to targeting glibc 2.27 (the one from Ubuntu 18.04).
Before, we were targeting obsolete Ubuntu 16.04.