### PR TITLE
Remove unwrapping of OCTET STRING wrapping in EnvelopedCms.

### DIFF
--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decrypt.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decrypt.cs
@@ -112,23 +112,7 @@ namespace Internal.Cryptography.Pal.AnyOS
                     return null;
                 }
 
-                // Compat: Previous versions of the managed PAL encryptor would wrap the contents in an octet stream
-                // which is not correct and is incompatible with other CMS readers. To maintain compatibility with
-                // existing CMS that have the incorrect wrapping, we attempt to remove it.
-                if (contentType == Oids.Pkcs7Data)
-                {
-                    if (decrypted?.Length > 0 && decrypted[0] == 0x04)
-                    {
-                        try
-                        {
-                            decrypted = AsnDecoder.ReadOctetString(decrypted, AsnEncodingRules.BER, out _);
-                        }
-                        catch (AsnContentException)
-                        {
-                        }
-                    }
-                }
-                else
+                if (contentType != Oids.Pkcs7Data)
                 {
                     decrypted = GetAsnSequenceWithContentNoValidation(decrypted);
                 }

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/GeneralTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/GeneralTests.cs
@@ -378,37 +378,6 @@ KoZIhvcNAwcECJ01qtX2EKx6oIAEEM7op+R2U3GQbYwlEj5X+h0AAAAAAAAAAAAA
             Assert.Equal(expectedSize, reDecoded.ContentInfo.Content.Length);
         }
 
-        [Fact]
-        [OuterLoop(/* Leaks key on disk if interrupted */)]
-        [SkipOnPlatform(TestPlatforms.Windows, "Applies to managed PAL only.")]
-        public static void FromManagedPal_CompatWithOctetStringWrappedContents_Decrypt()
-        {
-            byte[] expectedContent = new byte[] { 1, 2, 3 };
-            byte[] encodedMessage =
-                ("3082010C06092A864886F70D010703A081FE3081FB0201003181C83081C5020100302" +
-                 "E301A311830160603550403130F5253414B65795472616E7366657231021031D935FB" +
-                 "63E8CFAB48A0BF7B397B67C0300D06092A864886F70D0101010500048180586BCA530" +
-                 "9A74A211859714715D90B8E13A7712838746877DF7D68B0BCF36DE3F77854276C8EAD" +
-                 "389ADD8402697E4FFF215143E0E63676349592CB3A86FF556230D5F4AC4A9A6758219" +
-                 "9E65281A8B63DFBCFB7180E6B54C6E38BECAF09624C6B6D2B3058F280FE8F0BF8EBA3" +
-                 "57AECC1B9B177E98671A9659B034501AE3D58789302B06092A864886F70D010701301" +
-                 "406082A864886F70D0307040810B222648FDC0DE38008036BB59C8B6A784B").HexToByteArray();
-            EnvelopedCms ecms = new EnvelopedCms();
-            ecms.Decode(encodedMessage);
-
-            using (X509Certificate2 privateCert = Certificates.RSAKeyTransfer1.TryGetCertificateWithPrivateKey())
-            {
-                if (privateCert == null)
-                {
-                    return; //Private key not available.
-                }
-
-                ecms.Decrypt(new X509Certificate2Collection(privateCert));
-            }
-
-            Assert.Equal(expectedContent, ecms.ContentInfo.Content);
-        }
-
         private static void Assert_Certificate_Roundtrip(CertLoader certificateLoader)
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });


### PR DESCRIPTION
Prior to .NET Core 3.0, EnvelopedCms would pack and unpack PKCS7 data in an
OCTET STRING when encrypted and decrypted. This turned out to be incorrect.
Other implementations do not do the OCTET STRING wrapping, so when a different
CMS implementation processed a PKCS7 data encrypted by .NET, it would contain
the raw OCTET STRING. So the data would appear to be appended by the byte 0x04,
and then a length indicator.

We removed the wrapping in OCTET STRING. However, we left in the unwrapping of
the OCTET STRING because previously encrypted data by .NET would now contain
the raw data, thus appearing prefixed by 0x04 and a length indicator.

This however still has a problem where if the data to be encrypted started with
0x04 and a reasonable length, it would mistakenly be treated as an OCTET STRING.

This change removes the compatibility and is thus a breaking change. If customers
have CMS data that was encrypted by .NET Core prior to 3.0, they will experience
decrypted data that starts with the byte 0x04 and at least one length byte.

Customers can work around this with AsnDecoder.ReadOctetString to remove the extra
bytes, and optionally re-encrypting it and storing that so the work around is no
longer necessary.

Closes #68554.