### PR TITLE
[wasm-mt] fix build config logic error, and pthread_getschedparam initialization

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -163,7 +163,8 @@ namespace System.Threading
 #endif
 #endif
 
-        internal static void ThrowIfNoThreadStart() {
+        internal static void ThrowIfNoThreadStart()
+        {
             if (!IsThreadStartSupported)
                 throw new PlatformNotSupportedException();
         }

--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -684,8 +684,8 @@ mono_thread_internal_set_priority (MonoInternalThread *internal, MonoThreadPrior
 	return;
 #else /* !HOST_WIN32 and not HOST_FUCHSIA */
 	pthread_t tid;
-	int policy;
-	struct sched_param param;
+	int policy = SCHED_OTHER;
+	struct sched_param param = {0,};
 	gint res;
 
 	tid = thread_get_tid (internal);

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -204,7 +204,7 @@
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DICU_LIB_DIR=&quot;$(ICULibDir.TrimEnd('\/'))&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DMONO_ARTIFACTS_DIR=&quot;$(MonoArtifactsPath.TrimEnd('\/'))&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DNATIVE_BIN_DIR=&quot;$(NativeBinDir.TrimEnd('\/'))&quot;</CMakeBuildRuntimeConfigureCmd>
-      <CMakeBuildRuntimeConfigureCmd Condition="'$(MonoWasmThreads)' != 'true'">$(CMakeBuildRuntimeConfigureCmd) -DDISABLE_THREADS=1</CMakeBuildRuntimeConfigureCmd>
+      <CMakeBuildRuntimeConfigureCmd Condition="'$(MonoWasmThreads)' == 'true'">$(CMakeBuildRuntimeConfigureCmd) -DDISABLE_THREADS=0</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd Condition="'$(MonoWasmThreadsNoUser)' == 'true'">$(CMakeBuildRuntimeConfigureCmd) -DDISABLE_WASM_USER_THREADS=1</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) $(CMakeConfigurationEmsdkPath)</CMakeBuildRuntimeConfigureCmd>
 


### PR DESCRIPTION
Two followups for the initial merge PR.

1. On Emscripten, `pthread_getschedparam` doesn't write to its output variables, so set them to good initial values
2. The wasm CMakeLists.txt defaults DISABLE_THREADS to ON, so instead set it to _off_ when MonoWasmThreads is true, and leave it at the default value (ie off) otherwise.