### PR TITLE
improve TlsFrameHelper

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsFrameHelper.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsFrameHelper.cs
@@ -179,27 +179,51 @@ namespace System.Net.Security
             {
                 header.Type = (TlsContentType)frame[0];
 
-                if (frame.Length >= 3)
+                if (frame.Length > 4)
                 {
                     // SSLv3, TLS or later
                     if (frame[1] == 3)
                     {
-                        if (frame.Length > 4)
+                        header.Length = ((frame[3] << 8) | frame[4]);
+                        header.Version = TlsMinorVersionToProtocol(frame[2]);
+                        return true;
+                    }
+                    else if (frame[2] == (byte)TlsHandshakeType.ClientHello &&
+                       frame[3] == 3) // SSL3 or above
+                    {
+                        int length;
+                        if ((frame[0] & 0x80) != 0)
                         {
-                            header.Length = ((frame[3] << 8) | frame[4]);
+                            // Two bytes
+                            length = (((frame[0] & 0x7f) << 8) | frame[1]) + 2;
+                        }
+                        else
+                        {
+                            // Three bytes
+                            length = (((frame[0] & 0x3f) << 8) | frame[1]) + 3;
                         }
 
-                        header.Version = TlsMinorVersionToProtocol(frame[2]);
-                    }
-                    else
-                    {
-                        header.Length = -1;
-                        header.Version = SslProtocols.None;
+                        // max frame for SSLv2 is 32767.
+                        // However, we expect something reasonable for initial HELLO
+                        // We don't have enough logic to verify full validity,
+                        // the limits bellow are queses.
+                        if (length > 20 && length < 1000)
+                        {
+#pragma warning disable CS0618 // Ssl2 and Ssl3 are obsolete
+                            header.Version = SslProtocols.Ssl2;
+#pragma warning restore CS0618
+                            header.Length = length;
+                            header.Type = TlsContentType.Handshake;
+                            return true;
+                        }
                     }
                 }
             }
 
-            return result;
+            header.Length = -1;
+            header.Version = SslProtocols.None;
+
+                return result;
         }
 
         // Returns frame size e.g. header + content
@@ -252,6 +276,18 @@ namespace System.Net.Security
             }
 
             info.HandshakeType = (TlsHandshakeType)frame[HandshakeTypeOffset];
+#pragma warning disable CS0618 // Ssl2 and Ssl3 are obsolete
+            if (info.Header.Version == SslProtocols.Ssl2)
+            {
+                // This is safe. We would not get here if the length is too small.
+                info.SupportedVersions |= TlsMinorVersionToProtocol(frame[4]);
+                // We only recognize Unified ClientHello at the moment.
+                // This is needed to trigger certificate selection callback in SslStream.
+                info.HandshakeType = TlsHandshakeType.ClientHello;
+                // There is no more parsing for old protocols.
+                return true;
+            }
+#pragma warning restore CS0618
 
             // Check if we have full frame.
             bool isComplete = frame.Length >= HeaderSize + info.Header.Length;
@@ -412,10 +448,10 @@ namespace System.Net.Security
             // Skip compression methods (max size 2^8-1 => size fits in 1 byte)
             p = SkipOpaqueType1(p);
 
-            // is invalid structure or no extensions?
+            // no extensions
             if (p.IsEmpty)
             {
-                return false;
+                return true;
             }
 
             // client_hello_extension_list (max size 2^16-1 => size fits in 2 bytes)

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TlsFrameHelperTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TlsFrameHelperTests.cs
@@ -88,6 +88,34 @@ namespace System.Net.Security.Tests
             Assert.Equal(TlsFrameHelper.ApplicationProtocolInfo.Http2, info.ApplicationProtocols);
         }
 
+        [Fact]
+        public void TlsFrameHelper_UnifiedClientHello_Ok()
+        {
+            TlsFrameHelper.TlsFrameInfo info = default;
+            Assert.True(TlsFrameHelper.TryGetFrameInfo(s_UnifiedHello, ref info));
+#pragma warning disable CS0618 // Ssl2 and Ssl3 are obsolete
+#pragma warning disable SYSLIB0039 // Tls 1.0 is obsolete as well
+            Assert.Equal(SslProtocols.Ssl2, info.Header.Version);
+            Assert.Equal(SslProtocols.Ssl2 | SslProtocols.Tls, info.SupportedVersions);
+#pragma warning restore SYSLIB0039
+#pragma warning restore CS0618
+            Assert.Equal(TlsContentType.Handshake, info.Header.Type);
+            Assert.Equal(TlsFrameHelper.ApplicationProtocolInfo.None, info.ApplicationProtocols);
+            Assert.Equal(TlsHandshakeType.ClientHello, info.HandshakeType);
+        }
+
+        [Fact]
+        public void TlsFrameHelper_TlsClientHelloNoExtensions_Ok()
+        {
+            TlsFrameHelper.TlsFrameInfo info = default;
+            Assert.True(TlsFrameHelper.TryGetFrameInfo(s_TlsClientHelloNoExtensions, ref info));
+            Assert.Equal(SslProtocols.Tls12, info.Header.Version);
+            Assert.Equal(SslProtocols.Tls12, info.SupportedVersions);
+            Assert.Equal(TlsContentType.Handshake, info.Header.Type);
+            Assert.Equal(TlsFrameHelper.ApplicationProtocolInfo.None, info.ApplicationProtocols);
+            Assert.Equal(TlsHandshakeType.ClientHello, info.HandshakeType);
+        }
+
         public static IEnumerable<object[]> InvalidClientHelloData()
         {
             int id = 0;
@@ -379,6 +407,36 @@ namespace System.Net.Security.Tests
             0x00, 0x0B, 0x00, 0x02, 0x01, 0x00,
             // Extension.extension_type (application_level_Protocol)
             0x00, 0x10, 0x00, 0x05, 0x00, 0x03, 0x02, 0x68, 0x32,
+        };
+
+        private static byte[] s_UnifiedHello = new byte[]
+        {
+            // Length
+            0x80, 0x49,
+            // ClientHello
+            0x01,
+            // Version
+            0x03, 0x01,
+            0x00, 0x30, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00,
+            0x2F, 0x00, 0x00, 0x35, 0x00, 0x00, 0x04, 0x00,
+            0x00, 0x05, 0x00, 0x00, 0x0A, 0x01, 0x00, 0x80,
+            0x07, 0x00, 0xC0, 0x03, 0x00, 0x80, 0x00, 0x00,
+            0x09, 0x06, 0x00, 0x40, 0x00, 0x00, 0x64, 0x00,
+            0x00, 0x62, 0x00, 0x00, 0x03, 0x00, 0x00, 0x06,
+            0x02, 0x00, 0x80, 0x04, 0x00, 0x80, 0x5B, 0x0B,
+            0xA1, 0xEB, 0xBF, 0x2D, 0x57, 0xF5, 0xD1, 0x0F,
+            0x52, 0x3B, 0x12, 0x9C, 0xF8, 0xD4,
+        };
+
+        private static byte[] s_TlsClientHelloNoExtensions = new byte[] {
+            0x16, 0x03, 0x03, 0x00, 0x39, 0x01, 0x00, 0x00,
+            0x35, 0x03, 0x03, 0x62, 0x5d, 0x50, 0x2a, 0x41,
+            0x2f, 0xd8, 0xc3, 0x65, 0x35, 0xea, 0x01, 0x70,
+            0x03, 0x7e, 0x7e, 0x2d, 0xd4, 0xfe, 0x93, 0x39,
+            0xa4, 0x04, 0x66, 0xbb, 0x46, 0x91, 0x41, 0xc3,
+            0x48, 0x87, 0x3d, 0x00, 0x00, 0x0e, 0x00, 0x3d,
+            0x00, 0x3c, 0x00, 0x0a, 0x00, 0x35, 0x00, 0x2f,
+            0x00, 0x05, 0x00, 0x04, 0x01, 0x00
         };
 
         private static IEnumerable<byte[]> InvalidClientHello()


### PR DESCRIPTION
This is essentially port of https://github.com/microsoft/reverse-proxy/pull/1656 to recognize Unified hello.

Note that unlike 6.0 the unified frames cannot be processed because of #64322.
That may need some more work if we want to bring back some functionality. 
