### PR TITLE
Update RegexGenerator message for LimitedSourceGenerationMessage

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/Strings.resx
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/Strings.resx
@@ -141,7 +141,7 @@
     <value>RegexGenerator limitation reached.</value>
   </data>
   <data name="LimitedSourceGenerationMessage" xml:space="preserve">
-    <value>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression, due to an unsupported option or too complex a regular expression.  The implementation will interpret the regular expression at run-time.</value>
+    <value>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</value>
   </data>
   <data name="Generic" xml:space="preserve">
     <value>Regular expression parser error '{0}' at offset {1}.</value>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.cs.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression, due to an unsupported option or too complex a regular expression.  The implementation will interpret the regular expression at run-time.</source>
-        <target state="translated">RegexGenerator nemohl vygenerovat úplnou zdrojovou implementaci zadaného regulárního výrazu, protože možnost není podporovaná nebo je regulární výraz příliš složitý.  Implementace bude regulární výraz interpretovat za běhu.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
+        <target state="needs-review-translation">RegexGenerator nemohl vygenerovat úplnou zdrojovou implementaci zadaného regulárního výrazu, protože možnost není podporovaná nebo je regulární výraz příliš složitý.  Implementace bude regulární výraz interpretovat za běhu.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.de.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression, due to an unsupported option or too complex a regular expression.  The implementation will interpret the regular expression at run-time.</source>
-        <target state="translated">Der RegexGenerator konnte aufgrund einer nicht unterstützten Option oder eines zu komplexen regulären Ausdrucks keine vollständige Quellimplementierung für den angegebenen regulären Ausdruck generieren.  Die Implementierung wird den regulären Ausdruck zur Laufzeit interpretieren.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
+        <target state="needs-review-translation">Der RegexGenerator konnte aufgrund einer nicht unterstützten Option oder eines zu komplexen regulären Ausdrucks keine vollständige Quellimplementierung für den angegebenen regulären Ausdruck generieren.  Die Implementierung wird den regulären Ausdruck zur Laufzeit interpretieren.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.es.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression, due to an unsupported option or too complex a regular expression.  The implementation will interpret the regular expression at run-time.</source>
-        <target state="translated">RegexGenerator no pudo generar una implementación de origen completa para la expresión regular especificada debido a una opción no admitida o a una expresión regular demasiado compleja.  La implementación interpretará la expresión regular en tiempo de ejecución.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
+        <target state="needs-review-translation">RegexGenerator no pudo generar una implementación de origen completa para la expresión regular especificada debido a una opción no admitida o a una expresión regular demasiado compleja.  La implementación interpretará la expresión regular en tiempo de ejecución.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.fr.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression, due to an unsupported option or too complex a regular expression.  The implementation will interpret the regular expression at run-time.</source>
-        <target state="translated">RegexGenerator n’a pas pu générer d’implémentation source complète pour l’expression régulière spécifiée en raison d’une option non prise en charge ou d’une expression régulière trop complexe.  L’implémentation interprète l’expression régulière au moment de l’exécution.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
+        <target state="needs-review-translation">RegexGenerator n’a pas pu générer d’implémentation source complète pour l’expression régulière spécifiée en raison d’une option non prise en charge ou d’une expression régulière trop complexe.  L’implémentation interprète l’expression régulière au moment de l’exécution.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.it.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression, due to an unsupported option or too complex a regular expression.  The implementation will interpret the regular expression at run-time.</source>
-        <target state="translated">RegexGenerator non è riuscito a generare un'implementazione di origine completa per l'espressione regolare specificata a causa di un'opzione non supportata o di un'espressione regolare troppo complessa.  L'implementazione interpreterà l'espressione regolare in fase di esecuzione.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
+        <target state="needs-review-translation">RegexGenerator non è riuscito a generare un'implementazione di origine completa per l'espressione regolare specificata a causa di un'opzione non supportata o di un'espressione regolare troppo complessa.  L'implementazione interpreterà l'espressione regolare in fase di esecuzione.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ja.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression, due to an unsupported option or too complex a regular expression.  The implementation will interpret the regular expression at run-time.</source>
-        <target state="translated">オプションがサポートされていないか、または正規表現が複雑すぎるため、RegexGenerator は指定された正規表現の完全なソース実装を生成できませんでした。 実装では、実行時に正規表現が解釈されます。</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
+        <target state="needs-review-translation">オプションがサポートされていないか、または正規表現が複雑すぎるため、RegexGenerator は指定された正規表現の完全なソース実装を生成できませんでした。 実装では、実行時に正規表現が解釈されます。</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ko.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression, due to an unsupported option or too complex a regular expression.  The implementation will interpret the regular expression at run-time.</source>
-        <target state="translated">지원되지 않는 옵션 또는 너무 복잡한 정규식으로 인해 RegexGenerator가 지정한 정규식에 대한 전체 소스 구현을 생성할 수 없습니다. 구현에서는 런타임에 정규식을 해석합니다.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
+        <target state="needs-review-translation">지원되지 않는 옵션 또는 너무 복잡한 정규식으로 인해 RegexGenerator가 지정한 정규식에 대한 전체 소스 구현을 생성할 수 없습니다. 구현에서는 런타임에 정규식을 해석합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pl.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression, due to an unsupported option or too complex a regular expression.  The implementation will interpret the regular expression at run-time.</source>
-        <target state="translated">Obiekt RegexGenerator nie może wygenerować pełnej implementacji źródła dla określonego wyrażenia regularnego z powodu nieobsługiwanych opcji lub zbyt złożonego wyrażenia regularnego.  Implementacja będzie interpretować wyrażenie regularne w czasie wykonywania.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
+        <target state="needs-review-translation">Obiekt RegexGenerator nie może wygenerować pełnej implementacji źródła dla określonego wyrażenia regularnego z powodu nieobsługiwanych opcji lub zbyt złożonego wyrażenia regularnego.  Implementacja będzie interpretować wyrażenie regularne w czasie wykonywania.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression, due to an unsupported option or too complex a regular expression.  The implementation will interpret the regular expression at run-time.</source>
-        <target state="translated">O RegexGenerator não pôde gerar uma implementação de origem completa para a expressão regular especificada, devido a uma opção sem suporte ou a uma expressão regular muito complexa.  A implementação interpretará a expressão regular em tempo de execução.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
+        <target state="needs-review-translation">O RegexGenerator não pôde gerar uma implementação de origem completa para a expressão regular especificada, devido a uma opção sem suporte ou a uma expressão regular muito complexa.  A implementação interpretará a expressão regular em tempo de execução.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ru.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression, due to an unsupported option or too complex a regular expression.  The implementation will interpret the regular expression at run-time.</source>
-        <target state="translated">Средству RegexGenerator не удалось создать полную реализацию источника для указанного регулярного выражения, так как параметр не поддерживается или регулярное выражение является слишком сложным. Реализация будет интерпретировать регулярное выражение во время выполнения.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
+        <target state="needs-review-translation">Средству RegexGenerator не удалось создать полную реализацию источника для указанного регулярного выражения, так как параметр не поддерживается или регулярное выражение является слишком сложным. Реализация будет интерпретировать регулярное выражение во время выполнения.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.tr.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression, due to an unsupported option or too complex a regular expression.  The implementation will interpret the regular expression at run-time.</source>
-        <target state="translated">RegexGenerator, desteklenmeyen bir seçenek veya çok karmaşık bir normal ifade nedeniyle belirtilen normal ifade için tam kaynak uygulaması oluşturamadı. Uygulama, normal ifadeyi çalışma zamanında yorumlar.</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
+        <target state="needs-review-translation">RegexGenerator, desteklenmeyen bir seçenek veya çok karmaşık bir normal ifade nedeniyle belirtilen normal ifade için tam kaynak uygulaması oluşturamadı. Uygulama, normal ifadeyi çalışma zamanında yorumlar.</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression, due to an unsupported option or too complex a regular expression.  The implementation will interpret the regular expression at run-time.</source>
-        <target state="translated">由于不支持的选项或正则表达式过于复杂，RegexGenerator 无法为指定正则表达式生成完整的源实现。实现将在运行时解释正则表达式。</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
+        <target state="needs-review-translation">由于不支持的选项或正则表达式过于复杂，RegexGenerator 无法为指定正则表达式生成完整的源实现。实现将在运行时解释正则表达式。</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationMessage">
-        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression, due to an unsupported option or too complex a regular expression.  The implementation will interpret the regular expression at run-time.</source>
-        <target state="translated">RegexGenerator 無法為指定的規則運算式產生完整的來源實作，因為不支援的選項或規則運算式太複雜。實作會在執行時間解譯規則運算式。</target>
+        <source>The RegexGenerator couldn't generate a complete source implementation for the specified regular expression due to an internal limitation.</source>
+        <target state="needs-review-translation">RegexGenerator 無法為指定的規則運算式產生完整的來源實作，因為不支援的選項或規則運算式太複雜。實作會在執行時間解譯規則運算式。</target>
         <note />
       </trans-unit>
       <trans-unit id="LimitedSourceGenerationTitle">


### PR DESCRIPTION
It won't necessarily fall back to interpretation, and there are reasons now beyond complexity and options (e.g. case-insensitive backreferences).  Just simplify the message.