### PR TITLE
[mono][eventpipe] Implementing MethodDetails and BulkType events

### DIFF
--- a/src/coreclr/scripts/genEventPipe.py
+++ b/src/coreclr/scripts/genEventPipe.py
@@ -278,7 +278,7 @@ def generateWriteEventBody(template, providerName, eventName, runtimeFlavor):
                 emittedWriteToBuffer = True
         elif paramName in template.arrays:
             size = "sizeof(%s) * (int)%s" % (
-                lttngDataTypeMapping[parameter.winType],
+                getLttngDataTypeMapping(runtimeFlavor)[parameter.winType],
                 parameter.prop)
             if template.name in specialCaseSizes and paramName in specialCaseSizes[template.name]:
                 size = "(int)(%s)" % specialCaseSizes[template.name][paramName]
@@ -1041,7 +1041,7 @@ def generateEventPipeImplFiles(
                 )
 
                 eventpipeImpl.write(
-                    "EventPipeProvider *EventPipeProvider" + providerPrettyName + 
+                    "EventPipeProvider *EventPipeProvider" + providerPrettyName +
                     (" = nullptr;\n" if target_cpp else " = NULL;\n")
                 )
                 templateNodes = providerNode.getElementsByTagName('template')

--- a/src/coreclr/scripts/genEventPipe.py
+++ b/src/coreclr/scripts/genEventPipe.py
@@ -53,7 +53,7 @@ def generateMethodSignatureWrite(eventName, template, extern, runtimeFlavor):
 
             if paramName in template.structs:
                 sig_pieces.append(
-                    "%sint %s_ElementSize,\n" %
+                    "%ssize_t %s_ElementSize,\n" %
                     (lindent, paramName))
 
             sig_pieces.append(lindent)
@@ -262,10 +262,10 @@ def generateWriteEventBody(template, providerName, eventName, runtimeFlavor):
         parameter = fnSig.getParam(paramName)
 
         if paramName in template.structs:
-            size = "(int)%s_ElementSize * (int)%s" % (
+            size = "(size_t)%s_ElementSize * (size_t)%s" % (
                 paramName, parameter.prop)
             if template.name in specialCaseSizes and paramName in specialCaseSizes[template.name]:
-                size = "(int)(%s)" % specialCaseSizes[template.name][paramName]
+                size = "(size_t)(%s)" % specialCaseSizes[template.name][paramName]
             if runtimeFlavor.mono:
                 pack_list.append(
                     "    success &= write_buffer((const uint8_t *)%s, %s, &buffer, &offset, &size, &fixedBuffer);" %
@@ -277,11 +277,11 @@ def generateWriteEventBody(template, providerName, eventName, runtimeFlavor):
                     (paramName, size))
                 emittedWriteToBuffer = True
         elif paramName in template.arrays:
-            size = "sizeof(%s) * (int)%s" % (
+            size = "sizeof(%s) * (size_t)%s" % (
                 getLttngDataTypeMapping(runtimeFlavor)[parameter.winType],
                 parameter.prop)
             if template.name in specialCaseSizes and paramName in specialCaseSizes[template.name]:
-                size = "(int)(%s)" % specialCaseSizes[template.name][paramName]
+                size = "(size_t)(%s)" % specialCaseSizes[template.name][paramName]
             if runtimeFlavor.mono:
                 pack_list.append(
                     "    success &= write_buffer((const uint8_t *)%s, %s, &buffer, &offset, &size, &fixedBuffer);" %

--- a/src/coreclr/scripts/genEventPipe.py
+++ b/src/coreclr/scripts/genEventPipe.py
@@ -53,7 +53,7 @@ def generateMethodSignatureWrite(eventName, template, extern, runtimeFlavor):
 
             if paramName in template.structs:
                 sig_pieces.append(
-                    "%ssize_t %s_ElementSize,\n" %
+                    "%sint %s_ElementSize,\n" %
                     (lindent, paramName))
 
             sig_pieces.append(lindent)
@@ -262,10 +262,10 @@ def generateWriteEventBody(template, providerName, eventName, runtimeFlavor):
         parameter = fnSig.getParam(paramName)
 
         if paramName in template.structs:
-            size = "(size_t)%s_ElementSize * (size_t)%s" % (
+            size = "(int)%s_ElementSize * (int)%s" % (
                 paramName, parameter.prop)
             if template.name in specialCaseSizes and paramName in specialCaseSizes[template.name]:
-                size = "(size_t)(%s)" % specialCaseSizes[template.name][paramName]
+                size = "(int)(%s)" % specialCaseSizes[template.name][paramName]
             if runtimeFlavor.mono:
                 pack_list.append(
                     "    success &= write_buffer((const uint8_t *)%s, %s, &buffer, &offset, &size, &fixedBuffer);" %
@@ -277,11 +277,11 @@ def generateWriteEventBody(template, providerName, eventName, runtimeFlavor):
                     (paramName, size))
                 emittedWriteToBuffer = True
         elif paramName in template.arrays:
-            size = "sizeof(%s) * (size_t)%s" % (
+            size = "sizeof(%s) * (int)%s" % (
                 getLttngDataTypeMapping(runtimeFlavor)[parameter.winType],
                 parameter.prop)
             if template.name in specialCaseSizes and paramName in specialCaseSizes[template.name]:
-                size = "(size_t)(%s)" % specialCaseSizes[template.name][paramName]
+                size = "(int)(%s)" % specialCaseSizes[template.name][paramName]
             if runtimeFlavor.mono:
                 pack_list.append(
                     "    success &= write_buffer((const uint8_t *)%s, %s, &buffer, &offset, &size, &fixedBuffer);" %

--- a/src/coreclr/scripts/genEventing.py
+++ b/src/coreclr/scripts/genEventing.py
@@ -533,7 +533,7 @@ def generateClrEventPipeWriteEvents(eventNodes, allTemplates, extern, target_cpp
                 countw      = getPalDataTypeMapping(runtimeFlavor)[winCount]
 
                 if params in template.structs:
-                    fnptypeline.append("%ssize_t %s_ElementSize,\n" % (lindent, params))
+                    fnptypeline.append("%sint %s_ElementSize,\n" % (lindent, params))
 
                 fnptypeline.append(lindent)
                 fnptypeline.append(typewName)

--- a/src/coreclr/scripts/genEventing.py
+++ b/src/coreclr/scripts/genEventing.py
@@ -533,7 +533,7 @@ def generateClrEventPipeWriteEvents(eventNodes, allTemplates, extern, target_cpp
                 countw      = getPalDataTypeMapping(runtimeFlavor)[winCount]
 
                 if params in template.structs:
-                    fnptypeline.append("%sint %s_ElementSize,\n" % (lindent, params))
+                    fnptypeline.append("%ssize_t %s_ElementSize,\n" % (lindent, params))
 
                 fnptypeline.append(lindent)
                 fnptypeline.append(typewName)

--- a/src/coreclr/scripts/genLttngProvider.py
+++ b/src/coreclr/scripts/genLttngProvider.py
@@ -66,7 +66,7 @@ This file is generated using the logic from <root>/src/scripts/genLttngProvider.
 
 specialCaseSizes = { "BulkType" : { "Values" : "Values_ElementSize" }, "GCBulkRootCCW" : { "Values" : "Values_ElementSize" }, "GCBulkRCW" : { "Values" : "Values_ElementSize" }, "GCBulkRootStaticVar" : { "Values" : "Values_ElementSize" } }
 
-lttngDataTypeMapping ={
+coreCLRLttngDataTypeMapping ={
         #constructed types
         "win:null"          :" ",
         "win:Int64"         :"const __int64",
@@ -87,6 +87,34 @@ lttngDataTypeMapping ={
         "win:Pointer"       :"const size_t",
         "win:Binary"        :"const BYTE"
         }
+
+monoLttngDataTypeMapping ={
+        #constructed types
+        "win:null"          :" ",
+        "win:Int64"         :"const int64_t",
+        "win:ULong"         :"const uint32_t",
+        "win:count"         :"*",
+        "win:Struct"        :"const uint8_t *",
+        #actual spec
+        "win:GUID"          :"const int32_t",
+        "win:AnsiString"    :"const uint8_t*",
+        "win:UnicodeString" :"const uint8_t*",
+        "win:Double"        :"const double",
+        "win:Int32"         :"const int32_t",
+        "win:Boolean"       :"const bool",
+        "win:UInt64"        :"const uint64_t",
+        "win:UInt32"        :"const uint32_t",
+        "win:UInt16"        :"const uint16_t",
+        "win:UInt8"         :"const uint8_t",
+        "win:Pointer"       :"const size_t",
+        "win:Binary"        :"const BYTE"
+        }
+
+def getLttngDataTypeMapping(runtimeFlavor):
+    if runtimeFlavor.coreclr:
+        return coreCLRLttngDataTypeMapping
+    elif runtimeFlavor.mono:
+        return monoLttngDataTypeMapping
 
 ctfDataTypeMapping ={
         #constructed types
@@ -114,7 +142,7 @@ MAX_LTTNG_ARGS = 9
 def shouldPackTemplate(template):
     return template.num_params > MAX_LTTNG_ARGS or len(template.structs) > 0 or len(template.arrays) > 0
 
-def generateArgList(template):
+def generateArgList(template, runtimeFlavor):
     header = "TP_ARGS( \\\n"
     footer = ")\n"
 
@@ -131,9 +159,9 @@ def generateArgList(template):
         for params in fnSig.paramlist:
             fnparam     = fnSig.getParam(params)
             wintypeName = fnparam.winType
-            typewName   = lttngDataTypeMapping[wintypeName]
+            typewName   = getLttngDataTypeMapping(runtimeFlavor)[wintypeName]
             winCount    = fnparam.count
-            countw      = lttngDataTypeMapping[winCount]
+            countw      = getLttngDataTypeMapping(runtimeFlavor)[winCount]
 
             arg = "        " + typewName
             if countw != " ":
@@ -145,7 +173,7 @@ def generateArgList(template):
     return header + args + footer
 
 
-def generateFieldList(template):
+def generateFieldList(template, runtimeFlavor):
     header = "    " + " TP_FIELDS(\n"
     footer = "\n    )\n)\n"
 
@@ -160,8 +188,8 @@ def generateFieldList(template):
             fnparam     = fnSig.getParam(params)
             wintypeName = fnparam.winType
             winCount    = fnparam.count
-            countw      = lttngDataTypeMapping[winCount]
-            typewName   = lttngDataTypeMapping[wintypeName].replace("const ","")
+            countw      = getLttngDataTypeMapping(runtimeFlavor)[winCount]
+            typewName   = getLttngDataTypeMapping(runtimeFlavor)[wintypeName].replace("const ","")
 
             field_body  = None
             ctf_type    = None
@@ -193,7 +221,7 @@ def generateFieldList(template):
 
     return header + field_list + footer
 
-def generateLttngHeader(providerName, allTemplates, eventNodes):
+def generateLttngHeader(providerName, allTemplates, eventNodes, runtimeFlavor):
     lTTngHdr = []
     for templateName in allTemplates:
         template = allTemplates[templateName]
@@ -202,7 +230,7 @@ def generateLttngHeader(providerName, allTemplates, eventNodes):
         lTTngHdr.append("\n#define " + templateName + "_TRACEPOINT_ARGS \\\n")
 
 #TP_ARGS
-        tp_args = generateArgList(template)
+        tp_args = generateArgList(template, runtimeFlavor)
         lTTngHdr.append(tp_args)
 
 #TP_EVENT_CLASS
@@ -212,7 +240,7 @@ def generateLttngHeader(providerName, allTemplates, eventNodes):
         lTTngHdr.append("    " + templateName + "_TRACEPOINT_ARGS,\n")
 
 #TP_FIELDS
-        tp_fields = generateFieldList(template)
+        tp_fields = generateFieldList(template, runtimeFlavor)
         lTTngHdr.append(tp_fields)
 
 # Macro for defining event instance
@@ -270,7 +298,7 @@ TRACEPOINT_EVENT_INSTANCE(\\
     return ''.join(lTTngHdr)
 
 
-def generateMethodBody(template, providerName, eventName):
+def generateMethodBody(template, providerName, eventName, runtimeFlavor):
     #emit code to init variables convert unicode to ansi string
     result = []
 
@@ -331,9 +359,9 @@ def generateMethodBody(template, providerName, eventName):
                 continue
 
             elif ctf_type == "ctf_sequence" or wintypeName == "win:Pointer":
-                line += "(" + lttngDataTypeMapping[wintypeName]
-                if not lttngDataTypeMapping[winCount] == " ":
-                    line += lttngDataTypeMapping[winCount]
+                line += "(" + getLttngDataTypeMapping(runtimeFlavor)[wintypeName]
+                if not getLttngDataTypeMapping(runtimeFlavor)[winCount] == " ":
+                    line += getLttngDataTypeMapping(runtimeFlavor)[winCount]
 
                 line += ") "
                 linefnbody.append(line + paramname)
@@ -358,7 +386,7 @@ def generateMethodBody(template, providerName, eventName):
                 pack_list.append("    success &= WriteToBuffer((const BYTE *)%s, %s, buffer, offset, size, fixedBuffer);" % (paramName, size))
                 emittedWriteToBuffer = True
             elif paramName in template.arrays:
-                size = "sizeof(%s) * (int)%s" % (lttngDataTypeMapping[parameter.winType], parameter.prop)
+                size = "sizeof(%s) * (int)%s" % (getLttngDataTypeMapping(runtimeFlavor)[parameter.winType], parameter.prop)
                 if template.name in specialCaseSizes and paramName in specialCaseSizes[template.name]:
                     size = "(int)(%s)" % specialCaseSizes[template.name][paramName]
                 pack_list.append("    success &= WriteToBuffer((const BYTE *)%s, %s, buffer, offset, size, fixedBuffer);" % (paramName, size))
@@ -451,7 +479,7 @@ def generateLttngTpProvider(providerName, eventNodes, allTemplates, runtimeFlavo
         lTTngImpl.append("    if (!EventXplatEnabled%s())\n" % (eventName,))
         lTTngImpl.append("        return ERROR_SUCCESS;\n")
 
-        result = generateMethodBody(template, providerName, eventName)
+        result = generateMethodBody(template, providerName, eventName, runtimeFlavor)
         lTTngImpl.append(result)
 
         lTTngImpl.append("\n    return ERROR_SUCCESS;\n}\n\n")
@@ -529,7 +557,7 @@ def generateLttngFiles(etwmanifest, eventprovider_directory, runtimeFlavor, dryR
 
                 lttnghdr_file.write("\n#include <lttng/tracepoint.h>\n\n")
 
-                lttnghdr_file.write(generateLttngHeader(providerName,allTemplates,eventNodes) + "\n")
+                lttnghdr_file.write(generateLttngHeader(providerName,allTemplates,eventNodes,runtimeFlavor) + "\n")
 
             with open_for_update(lttngevntprov) as lttngimpl_file:
                 lttngimpl_file.write(stdprolog + "\n")

--- a/src/coreclr/scripts/genLttngProvider.py
+++ b/src/coreclr/scripts/genLttngProvider.py
@@ -97,8 +97,8 @@ monoLttngDataTypeMapping ={
         "win:Struct"        :"const uint8_t *",
         #actual spec
         "win:GUID"          :"const int32_t",
-        "win:AnsiString"    :"const uint8_t*",
-        "win:UnicodeString" :"const uint8_t*",
+        "win:AnsiString"    :"const char*",
+        "win:UnicodeString" :"const ep_char8_t*",
         "win:Double"        :"const double",
         "win:Int32"         :"const int32_t",
         "win:Boolean"       :"const bool",
@@ -106,8 +106,8 @@ monoLttngDataTypeMapping ={
         "win:UInt32"        :"const uint32_t",
         "win:UInt16"        :"const uint16_t",
         "win:UInt8"         :"const uint8_t",
-        "win:Pointer"       :"const size_t",
-        "win:Binary"        :"const BYTE"
+        "win:Pointer"       :"const void*",
+        "win:Binary"        :"const uint8_t"
         }
 
 def getLttngDataTypeMapping(runtimeFlavor):

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -1443,7 +1443,7 @@ eventpipe_fire_method_events (
 
 		if (verbose) {
 			method_name = method->name;
-			method_signature = mono_signature_full_name (method->signature);
+			method_signature = mono_signature_full_name (mono_method_signature_internal (method));
 			if (method->klass)
 				method_namespace = mono_type_get_name_full (m_class_get_byval_arg (method->klass), MONO_TYPE_NAME_FORMAT_IL);
 		}
@@ -2959,7 +2959,7 @@ ep_rt_mono_write_event_jit_start (MonoMethod *method)
 		}
 
 		method_name = method->name;
-		method_signature = mono_signature_full_name (method->signature);
+		method_signature = mono_signature_full_name (mono_method_signature_internal (method));
 
 		if (method->klass) {
 			module_id = (uint64_t)m_class_get_image (method->klass);
@@ -3114,7 +3114,7 @@ ep_rt_mono_write_event_method_load (
 
 		if (verbose) {
 			method_name = method->name;
-			method_signature = mono_signature_full_name (method->signature);
+			method_signature = mono_signature_full_name (mono_method_signature_internal (method));
 
 			if (method->klass)
 				method_namespace = mono_type_get_name_full (m_class_get_byval_arg (method->klass), MONO_TYPE_NAME_FORMAT_IL);
@@ -5376,7 +5376,7 @@ mono_profiler_jit_done (
 	if (verbose) {
 		//TODO: Optimize string formatting into functions accepting GString to reduce heap alloc.
 		method_name = method->name;
-		method_signature = mono_signature_full_name (method->signature);
+		method_signature = mono_signature_full_name (mono_method_signature_internal (method));
 		if (method->klass)
 			method_namespace = mono_type_get_name_full (m_class_get_byval_arg (method->klass), MONO_TYPE_NAME_FORMAT_IL);
 	}

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -2862,6 +2862,9 @@ ep_rt_mono_write_event_ee_startup_start (void)
 // !!!!!!! NOTE !!!!!!!!
 
 typedef enum {
+	K_ETW_TYPE_FLAGS_DELEGATE = 0x1,
+	K_ETW_TYPE_FLAGS_FINALIZABLE = 0x2,
+	K_ETW_TYPE_FLAGS_EXTERNALLY_IMPLEMENTED_COM_OBJECT = 0x4,
 	K_ETW_TYPE_FLAGS_ARRAY = 0x8,
 
 	K_ETW_TYPE_FLAGS_ARRAY_RANK_MASK = 0x3F00,
@@ -3089,6 +3092,15 @@ ep_rt_mono_log_single_type (MonoType *mono_type, intptr_t type_id)
 			p_val->rg_type_parameters[i] = get_typeid_for_type (class_inst->type_argv[i]);
 		}
 	}
+
+	if (mono_class_has_finalizer (klass))
+		p_val->fixed_sized_data.flags |= K_ETW_TYPE_FLAGS_FINALIZABLE;
+
+	if (m_class_is_delegate (klass))
+		p_val->fixed_sized_data.flags |= K_ETW_TYPE_FLAGS_DELEGATE;
+
+	if (mono_class_is_com_object (klass))
+		p_val->fixed_sized_data.flags |= K_ETW_TYPE_FLAGS_EXTERNALLY_IMPLEMENTED_COM_OBJECT;
 
     // Now that we know the full size of this type's data, see if it fits in our
     // batch or whether we need to flush

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -2970,6 +2970,7 @@ ep_rt_mono_fire_bulk_type_event (void)
 		}
 	}
 
+	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_DIAGNOSTICS, "Firing BulkTypeEvent!");
 	FireEtwBulkType(m_n_bulk_type_value_count,
 					n_clr_instance_id,
 					i_size,
@@ -3091,6 +3092,11 @@ ep_rt_mono_log_single_type (intptr_t type_id)
         // call itself again.
 		ep_rt_mono_fire_bulk_type_event();
 		return ep_rt_mono_log_single_type(type_id);
+	}
+	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_DIAGNOSTICS, "p_val added at index: %d\ntype_id: %d\nmodule_id: %d\ntype_name_id: %d\ntype: %d\nc_type_parameters: %d", m_n_bulk_type_value_count, p_val->fixed_sized_data.type_id, p_val->fixed_sized_data.module_id, p_val->fixed_sized_data.type_name_id, mono_type->type, p_val->c_type_parameters);
+	for (int i = 0; i < p_val->c_type_parameters; i++)
+	{
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_DIAGNOSTICS, "type: %d\n", ((MonoType*)p_val->rg_type_parameters[i])->type);
 	}
 
     // The type fits into the batch, so update our state
@@ -3217,6 +3223,7 @@ ep_rt_mono_send_method_details_event (MonoMethod *method)
 
 	ep_rt_mono_fire_bulk_type_event();
 
+	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_DIAGNOSTICS, "Firing Method:\n%s[%d]\ntype ID [%d]\nToken %d -> %d\nNumParam %d\nmodule %d\n", method->name, (uint64_t)method, method_type_id, method->token, method_token, method_inst_parameter_types_count, loader_module_id);
 	FireEtwMethodDetails((uint64_t)method,
 						 (uint64_t)method_type_id,
 						 method_token,

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -2863,6 +2863,10 @@ ep_rt_mono_write_event_ee_startup_start (void)
 
 typedef enum {
 	K_ETW_TYPE_FLAGS_ARRAY = 0x8,
+
+	K_ETW_TYPE_FLAGS_ARRAY_RANK_MASK = 0x3F00,
+	K_ETW_TYPE_FLAGS_ARRAY_RANK_SHIFT = 8,
+	K_ETW_TYPE_FLAGS_ARRAY_RANK_MAX = K_ETW_TYPE_FLAGS_ARRAY_RANK_MASK >> K_ETW_TYPE_FLAGS_ARRAY_RANK_SHIFT
 } EtwTypeFlags;
 
 // This only contains the fixed-size data at the top of each struct in
@@ -3063,7 +3067,7 @@ ep_rt_mono_log_single_type (MonoType *mono_type, intptr_t type_id)
 			// Fortunately kEtwTypeFlagsArrayRankMax should be greater than the
 			// number of ranks the type loader will support
 			uint32_t rank = mono_array_type->rank;
-			if (rank < (0x3700 >> 8))
+			if (rank < K_ETW_TYPE_FLAGS_ARRAY_RANK_MAX)
 			{
 				rank <<= 8;
 				p_val->fixed_sized_data.flags |= rank;

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -2896,7 +2896,7 @@ ep_rt_mono_get_byte_count_in_event(BulkTypeValue *bulk_type_value)
 	return
 		sizeof(bulk_type_value->fixed_sized_data) +
 		sizeof(bulk_type_value->c_type_parameters) +
-		(sizeof(bulk_type_value->s_name) + 1) * sizeof(char) +  // Size of name, including null terminator
+		(strlen(bulk_type_value->s_name) + 1) * sizeof(char) +  // Size of name, including null terminator
 		bulk_type_value->c_type_parameters * sizeof(uint64_t);	// Type parameters
 }
 

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -2880,7 +2880,7 @@ typedef struct _EventStructBulkTypeFixedSizedData {
 typedef struct _BultTypeValue {
 	EventStructBulkTypeFixedSizedData fixed_sized_data;
 	uint32_t c_type_parameters;
-	intptr_t rg_type_parameters[100]; // Should be variable length to save space
+	intptr_t rg_type_parameters[32];
 	char *s_name;
 } BulkTypeValue;
 
@@ -3013,7 +3013,7 @@ ep_rt_mono_log_single_type (intptr_t type_id)
 
     // Clear out p_val before filling it out (array elements can get reused if there
     // are enough types that we need to flush to multiple events).
-	memset(p_val->rg_type_parameters, 0, 100);
+	memset(p_val->rg_type_parameters, 0, 32);
 	if (p_val->s_name)
 		p_val->s_name[0] = '\0';
 	p_val->c_type_parameters = 0;

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -2870,9 +2870,9 @@ typedef enum {
 // fields of the struct described in the manifest.
 typedef struct _EventStructBulkTypeFixedSizedData {
 	uint64_t type_id;
-    uint64_t module_id;
-    uint32_t type_name_id;
-    uint32_t flags;
+	uint64_t module_id;
+	uint32_t type_name_id;
+	uint32_t flags;
 	uint8_t cor_element_type;
 } EventStructBulkTypeFixedSizedData;
 

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -2896,10 +2896,14 @@ static
 uint32_t
 ep_rt_mono_get_byte_count_in_event(BulkTypeValue *bulk_type_value)
 {
+	uint32_t s_name_len = 0;
+	if (bulk_type_value->s_name)
+		s_name_len = strlen(bulk_type_value->s_name);
+
 	return
 		sizeof(bulk_type_value->fixed_sized_data) +
 		sizeof(bulk_type_value->c_type_parameters) +
-		(strlen(bulk_type_value->s_name) + 1) * sizeof(char) +  // Size of name, including null terminator
+		(s_name_len + 1) * sizeof(char) +  // Size of name, including null terminator
 		bulk_type_value->c_type_parameters * sizeof(uint64_t);	// Type parameters
 }
 
@@ -2957,7 +2961,7 @@ ep_rt_mono_fire_bulk_type_event (BulkTypeEventLogger *p_type_logger)
 		i_size += sizeof(target->fixed_sized_data);
 
 		char *wsz_name = target->s_name;
-		if (!wsz_name)
+		if (!wsz_name || strlen(wsz_name) == 0)
 		{
 			p_type_logger->m_p_bulk_type_event_buffer[i_size++] = 0;
 			p_type_logger->m_p_bulk_type_event_buffer[i_size++] = 0;
@@ -3050,7 +3054,7 @@ ep_rt_mono_log_single_type (BulkTypeEventLogger *p_type_logger, MonoType *mono_t
 	memset(p_val->rg_type_parameters, 0, 32);
 	memset(p_val->rg_mono_type_parameters, 0, 32);
 	if (p_val->s_name)
-		p_val->s_name[0] = '\0';
+		p_val->s_name = '\0';
 	p_val->c_type_parameters = 0;
 
 	// Initialize p_val fixed_sized_data

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -2903,7 +2903,7 @@ void
 ep_rt_bulk_type_value_clear (BulkTypeValue *bulk_type_value);
 
 static
-uint32_t
+int
 ep_rt_mono_get_byte_count_in_event (BulkTypeValue *bulk_type_value);
 
 static
@@ -2976,10 +2976,10 @@ ep_rt_bulk_type_value_clear (BulkTypeValue *bulk_type_value)
 }
 
 static
-uint32_t
+int
 ep_rt_mono_get_byte_count_in_event (BulkTypeValue *bulk_type_value)
 {
-	size_t s_name_len = 0;
+	int s_name_len = 0;
 
 	return sizeof (bulk_type_value->fixed_sized_data.type_id) + 	// Fixed Sized Data
 		sizeof (bulk_type_value->fixed_sized_data.module_id) +
@@ -2987,22 +2987,22 @@ ep_rt_mono_get_byte_count_in_event (BulkTypeValue *bulk_type_value)
 		sizeof (bulk_type_value->fixed_sized_data.flags) +
 		sizeof (bulk_type_value->fixed_sized_data.cor_element_type) +
 		sizeof (bulk_type_value->c_type_parameters) +		// Type parameters
-		 (s_name_len + 1) * sizeof (ep_char8_t) +		// Size of name, including null terminator
+		(s_name_len + 1) * sizeof (ep_char8_t) +		// Size of name, including null terminator
 		bulk_type_value->c_type_parameters * sizeof (uint64_t);	// Type parameters
 }
 
 // ETW has a limitation of 64K for TOTAL event Size, however there is overhead associated with
 // the event headers.   It is unclear exactly how much that is, but 1K should be sufficiently
 // far away to avoid problems without sacrificing the perf of bulk processing.
-static const uint32_t CB_MAX_ETW_EVENT = 63 * 1024;
+#define CB_MAX_ETW_EVENT (63 * 1024)
 
 // The maximum event size, and the size of the buffer that we allocate to hold the event contents.
-static const size_t K_SIZE_OF_EVENT_BUFFER = 65536;
+#define K_SIZE_OF_EVENT_BUFFER 65536
 
 // Estimate of how many bytes we can squeeze in the event data for the value struct
 // array. (Intentionally overestimate the size of the non-array parts to keep it safe.)
 // This follows CoreCLR's kMaxBytesTypeValues.
-static const uint32_t K_MAX_BYTES_TYPE_VALUES = (CB_MAX_ETW_EVENT - 0x30);
+#define K_MAX_BYTES_TYPE_VALUES (CB_MAX_ETW_EVENT - 0x30)
 
 // Estimate of how many type value elements we can put into the struct array, while
 // staying under the ETW event size limit. Note that this is impossible to calculate
@@ -3429,7 +3429,7 @@ ep_rt_mono_send_method_details_event (MonoMethod *method)
 	if (method_inst)
 		method_inst_parameter_types_count = method_inst->type_argc;
 
-	intptr_t method_inst_parameters_type_ids [method_inst_parameter_types_count];
+	intptr_t method_inst_parameters_type_ids [K_MAX_METHOD_TYPE_ARGUMENT_COUNT];
 	for (int i = 0; i < method_inst_parameter_types_count; i++) {
 		method_inst_parameters_type_ids [i] = get_typeid_for_type (method_inst->type_argv [i]);
 

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -2914,7 +2914,7 @@ void
 ep_rt_bulk_type_event_logger_free (BulkTypeEventLogger *type_logger);
 
 static
-size_t
+int
 write_event_buffer (
 	const uint8_t *val,
 	size_t size,
@@ -2922,28 +2922,28 @@ write_event_buffer (
 	char **buf_next);
 
 static
-size_t
+int
 write_event_buffer_int8 (
 	int8_t val,
 	char *buf_start,
 	char **buf_next);
 
 static
-size_t
+int
 write_event_buffer_int16 (
 	int16_t val,
 	char *buf_start,
 	char **buf_next);
 
 static
-size_t
+int
 write_event_buffer_int32 (
 	int32_t val,
 	char *buf_start,
 	char **buf_next);
 
 static
-size_t
+int
 write_event_buffer_int64 (
 	int64_t val,
 	char *buf_start,
@@ -3031,7 +3031,7 @@ ep_rt_bulk_type_event_logger_free (BulkTypeEventLogger *type_logger)
 }
 
 static
-size_t
+int
 write_event_buffer (
 	const uint8_t *val,
 	size_t size,
@@ -3044,7 +3044,7 @@ write_event_buffer (
 }
 
 static
-size_t
+int
 write_event_buffer_int8 (
 	int8_t val,
 	char *buf_start,
@@ -3054,7 +3054,7 @@ write_event_buffer_int8 (
 }
 
 static
-size_t
+int
 write_event_buffer_int16 (
 	int16_t val,
 	char *buf_start,
@@ -3064,7 +3064,7 @@ write_event_buffer_int16 (
 }
 
 static
-size_t
+int
 write_event_buffer_int32 (
 	int32_t val,
 	char *buf_start,
@@ -3074,7 +3074,7 @@ write_event_buffer_int32 (
 }
 
 static
-size_t
+int
 write_event_buffer_int64 (
 	int64_t val,
 	char *buf_start,
@@ -3099,7 +3099,7 @@ ep_rt_mono_fire_bulk_type_event (BulkTypeEventLogger *type_logger)
 
 	uint16_t clr_instance_id = clr_instance_get_id ();
 
-	size_t values_element_size = 0;
+	uint32_t values_element_size = 0;
 
 	char *ptr = (char *)type_logger->bulk_type_event_buffer;
 

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -2915,7 +2915,7 @@ void
 ep_rt_bulk_type_event_logger_free (BulkTypeEventLogger *type_logger);
 
 static
-int
+size_t
 write_event_buffer (
 	const uint8_t *val,
 	size_t size,
@@ -2923,28 +2923,28 @@ write_event_buffer (
 	char **buf_next);
 
 static
-int
+size_t
 write_event_buffer_int8 (
 	int8_t val,
 	char *buf_start,
 	char **buf_next);
 
 static
-int
+size_t
 write_event_buffer_int16 (
 	int16_t val,
 	char *buf_start,
 	char **buf_next);
 
 static
-int
+size_t
 write_event_buffer_int32 (
 	int32_t val,
 	char *buf_start,
 	char **buf_next);
 
 static
-int
+size_t
 write_event_buffer_int64 (
 	int64_t val,
 	char *buf_start,
@@ -3032,7 +3032,7 @@ ep_rt_bulk_type_event_logger_free (BulkTypeEventLogger *type_logger)
 }
 
 static
-int
+size_t
 write_event_buffer (
 	const uint8_t *val,
 	size_t size,
@@ -3045,7 +3045,7 @@ write_event_buffer (
 }
 
 static
-int
+size_t
 write_event_buffer_int8 (
 	int8_t val,
 	char *buf_start,
@@ -3055,7 +3055,7 @@ write_event_buffer_int8 (
 }
 
 static
-int
+size_t
 write_event_buffer_int16 (
 	int16_t val,
 	char *buf_start,
@@ -3065,7 +3065,7 @@ write_event_buffer_int16 (
 }
 
 static
-int
+size_t
 write_event_buffer_int32 (
 	int32_t val,
 	char *buf_start,
@@ -3075,7 +3075,7 @@ write_event_buffer_int32 (
 }
 
 static
-int
+size_t
 write_event_buffer_int64 (
 	int64_t val,
 	char *buf_start,
@@ -3100,7 +3100,7 @@ ep_rt_mono_fire_bulk_type_event (BulkTypeEventLogger *type_logger)
 
 	uint16_t clr_instance_id = clr_instance_get_id ();
 
-	uint32_t values_element_size = 0;
+	size_t values_element_size = 0;
 
 	char *ptr = (char *)type_logger->bulk_type_event_buffer;
 

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -2917,7 +2917,7 @@ static
 int
 write_event_buffer (
 	const uint8_t *val,
-	size_t size,
+	int size,
 	char *buf_start,
 	char **buf_next);
 
@@ -3034,7 +3034,7 @@ static
 int
 write_event_buffer (
 	const uint8_t *val,
-	size_t size,
+	int size,
 	char *buf_start,
 	char **buf_next)
 {

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2179,6 +2179,9 @@ ep_rt_volatile_store_ptr_without_barrier (
 bool
 ep_rt_mono_write_event_ee_startup_start (void);
 
+void
+ep_rt_mono_send_method_details_events (MonoMethod *method);
+
 bool
 ep_rt_mono_write_event_jit_start (MonoMethod *method);
 

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2180,6 +2180,18 @@ bool
 ep_rt_mono_write_event_ee_startup_start (void);
 
 void
+ep_rt_mono_fire_bulk_type_event (void);
+
+uint32_t
+ep_rt_mono_log_single_type (intptr_t type_id);
+
+void
+ep_rt_mono_log_type_and_parameters (intptr_t type_id);
+
+void
+ep_rt_mono_log_type_and_parameters_if_necessary (intptr_t type_id);
+
+void
 ep_rt_mono_send_method_details_events (MonoMethod *method);
 
 bool

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2183,13 +2183,13 @@ void
 ep_rt_mono_fire_bulk_type_event (void);
 
 uint32_t
-ep_rt_mono_log_single_type (intptr_t type_id);
+ep_rt_mono_log_single_type (MonoType *mono_type, intptr_t type_id);
 
 void
-ep_rt_mono_log_type_and_parameters (intptr_t type_id);
+ep_rt_mono_log_type_and_parameters (MonoType *mono_type, intptr_t type_id);
 
 void
-ep_rt_mono_log_type_and_parameters_if_necessary (intptr_t type_id);
+ep_rt_mono_log_type_and_parameters_if_necessary (MonoType *mono_type, intptr_t type_id);
 
 void
 ep_rt_mono_send_method_details_events (MonoMethod *method);

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2179,17 +2179,19 @@ ep_rt_volatile_store_ptr_without_barrier (
 bool
 ep_rt_mono_write_event_ee_startup_start (void);
 
+typedef struct _BulkTypeEventLogger BulkTypeEventLogger;
+
 void
-ep_rt_mono_fire_bulk_type_event (void);
+ep_rt_mono_fire_bulk_type_event (BulkTypeEventLogger *p_type_logger);
 
 uint32_t
-ep_rt_mono_log_single_type (MonoType *mono_type, intptr_t type_id);
+ep_rt_mono_log_single_type (BulkTypeEventLogger *p_type_logger, MonoType *mono_type, intptr_t type_id);
 
 void
-ep_rt_mono_log_type_and_parameters (MonoType *mono_type, intptr_t type_id);
+ep_rt_mono_log_type_and_parameters (BulkTypeEventLogger *p_type_logger, MonoType *mono_type, intptr_t type_id);
 
 void
-ep_rt_mono_log_type_and_parameters_if_necessary (MonoType *mono_type, intptr_t type_id);
+ep_rt_mono_log_type_and_parameters_if_necessary (BulkTypeEventLogger *p_type_logger, MonoType *mono_type, intptr_t type_id);
 
 void
 ep_rt_mono_send_method_details_events (MonoMethod *method);

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2187,16 +2187,19 @@ ep_rt_mono_fire_bulk_type_event (BulkTypeEventLogger *p_type_logger);
 int
 ep_rt_mono_log_single_type (
 	BulkTypeEventLogger *p_type_logger,
+	MonoMemPool *mem_pool,
 	MonoType *mono_type);
 
 void
 ep_rt_mono_log_type_and_parameters (
 	BulkTypeEventLogger *p_type_logger,
+	MonoMemPool *mem_pool,
 	MonoType *mono_type);
 
 void
 ep_rt_mono_log_type_and_parameters_if_necessary (
 	BulkTypeEventLogger *p_type_logger,
+	MonoMemPool *mem_pool,
 	MonoType *mono_type);
 
 void

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2187,20 +2187,17 @@ ep_rt_mono_fire_bulk_type_event (BulkTypeEventLogger *p_type_logger);
 int
 ep_rt_mono_log_single_type (
 	BulkTypeEventLogger *p_type_logger,
-	MonoType *mono_type,
-	intptr_t type_id);
+	MonoType *mono_type);
 
 void
 ep_rt_mono_log_type_and_parameters (
 	BulkTypeEventLogger *p_type_logger,
-	MonoType *mono_type,
-	intptr_t type_id);
+	MonoType *mono_type);
 
 void
 ep_rt_mono_log_type_and_parameters_if_necessary (
 	BulkTypeEventLogger *p_type_logger,
-	MonoType *mono_type,
-	intptr_t type_id);
+	MonoType *mono_type);
 
 void
 ep_rt_mono_send_method_details_event (MonoMethod *method);

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2185,13 +2185,22 @@ void
 ep_rt_mono_fire_bulk_type_event (BulkTypeEventLogger *p_type_logger);
 
 int
-ep_rt_mono_log_single_type (BulkTypeEventLogger *p_type_logger, MonoType *mono_type, intptr_t type_id);
+ep_rt_mono_log_single_type (
+	BulkTypeEventLogger *p_type_logger,
+	MonoType *mono_type,
+	intptr_t type_id);
 
 void
-ep_rt_mono_log_type_and_parameters (BulkTypeEventLogger *p_type_logger, MonoType *mono_type, intptr_t type_id);
+ep_rt_mono_log_type_and_parameters (
+	BulkTypeEventLogger *p_type_logger,
+	MonoType *mono_type,
+	intptr_t type_id);
 
 void
-ep_rt_mono_log_type_and_parameters_if_necessary (BulkTypeEventLogger *p_type_logger, MonoType *mono_type, intptr_t type_id);
+ep_rt_mono_log_type_and_parameters_if_necessary (
+	BulkTypeEventLogger *p_type_logger,
+	MonoType *mono_type,
+	intptr_t type_id);
 
 void
 ep_rt_mono_send_method_details_event (MonoMethod *method);

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2187,19 +2187,16 @@ ep_rt_mono_fire_bulk_type_event (BulkTypeEventLogger *p_type_logger);
 int
 ep_rt_mono_log_single_type (
 	BulkTypeEventLogger *p_type_logger,
-	MonoMemPool *mem_pool,
 	MonoType *mono_type);
 
 void
 ep_rt_mono_log_type_and_parameters (
 	BulkTypeEventLogger *p_type_logger,
-	MonoMemPool *mem_pool,
 	MonoType *mono_type);
 
 void
 ep_rt_mono_log_type_and_parameters_if_necessary (
 	BulkTypeEventLogger *p_type_logger,
-	MonoMemPool *mem_pool,
 	MonoType *mono_type);
 
 void

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2184,7 +2184,7 @@ typedef struct _BulkTypeEventLogger BulkTypeEventLogger;
 void
 ep_rt_mono_fire_bulk_type_event (BulkTypeEventLogger *p_type_logger);
 
-uint32_t
+int
 ep_rt_mono_log_single_type (BulkTypeEventLogger *p_type_logger, MonoType *mono_type, intptr_t type_id);
 
 void
@@ -2194,7 +2194,7 @@ void
 ep_rt_mono_log_type_and_parameters_if_necessary (BulkTypeEventLogger *p_type_logger, MonoType *mono_type, intptr_t type_id);
 
 void
-ep_rt_mono_send_method_details_events (MonoMethod *method);
+ep_rt_mono_send_method_details_event (MonoMethod *method);
 
 bool
 ep_rt_mono_write_event_jit_start (MonoMethod *method);

--- a/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
+++ b/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
@@ -28,6 +28,7 @@ MethodJitMemoryAllocatedForCode
 MethodJittingStarted_V1
 MethodLoad_V1
 MethodLoadVerbose_V1
+MethodDetails
 ModuleDCEnd_V2
 ModuleLoad_V2
 ModuleUnload_V2

--- a/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
+++ b/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
@@ -4,6 +4,7 @@ AppDomainDCEnd_V1
 AssemblyDCEnd_V1
 AssemblyLoad_V1
 AssemblyUnload_V1
+BulkType
 ContentionStart_V1
 ContentionStop
 DCEndComplete_V1

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -1226,7 +1226,7 @@ mono_class_get_fields_lazy (MonoClass* klass, gpointer *iter);
 gboolean
 mono_class_check_vtable_constraints (MonoClass *klass, GList *in_setup);
 
-gboolean
+MONO_COMPONENT_API gboolean
 mono_class_has_finalizer (MonoClass *klass);
 
 void


### PR DESCRIPTION
This PR looks to implement MethodDetails and BulkType trace events on mono, closely following the implementation of src/coreclr/vm/eventtrace.cpp's [SendMethodDetailsEvent](https://github.com/dotnet/runtime/blob/e4163ea55ebb3673c29e1c2a850a6a790029d278/src/coreclr/vm/eventtrace.cpp#L6413) and [FireBulkTypeEvent](https://github.com/dotnet/runtime/blob/e4163ea55ebb3673c29e1c2a850a6a790029d278/src/coreclr/vm/eventtrace.cpp#L1641). In doing so, apps running on mono can be traced following steps from https://github.com/dotnet/runtime/blob/main/docs/design/mono/diagnostics-tracing.md and produce a `.nettrace` file with relevant MethodDetails and BulkType events. This `.nettrace` containing `MethodDetails` and `BulkType` events is necessary to leverage the dotnet-pgo tool to generate a corresponding .mibc file for future consumption in the mono AOT compiler.

This PR makes the following changes:
- Implements MethodDetails events in ep_rt_mono_send_method_details_event (2nd commit)
- Implements BulkType events in ep_rt_mono_fire_bulk_type_event (4th commit)
- Extends LttngDataTypeMapping to have a mono friendly mapping (1st commit)
- Utilizes mono method signature getter to avoid accessing method signatures prior to creation (3rd commit)

----------------
### Creating a `.mibc` on mono from the [HelloWorld sample](https://github.com/dotnet/runtime/blob/main/src/mono/sample/HelloWorld/Program.cs)

1. Building mono+libs
2. Building the HelloWorld sample with `make run`
3. Generating a trace
   3a. `DOTNET_DiagnosticPorts="/Users/mdhwang/myport,suspend" <path to app executable>`
   3b. `dotnet-trace collect --providers Microsoft-Windows-DotNETRuntime:0x1F000080018:5 --diagnostic-port ~/myport`
4. `dotnet-pgo create-mibc --trace <path-to-trace>` <s>(built with a dotnet-pgo tool with [AddAssembliesAssociatedWithType](https://github.com/dotnet/runtime/blob/e4163ea55ebb3673c29e1c2a850a6a790029d278/src/coreclr/tools/dotnet-pgo/MibcEmitter.cs#L170) modified to skip generic parameters)
```
if (type.IsGenericParameter)
  return;
```
</s> Modification no longer needed.

--------------
Implementation Details
-----
For the most part, the implementation of the relevant functions are similar to CoreCLR. Below are some key differences

### `ep_rt_mono_send_method_details_event`
Utilizes a helper `get_typeid_for_type` in order to obtain a unique type ID, to fulfill the niche of CoreCLR's type handle 

### `ep_rt_mono_log_type_and_parameters_if_necessary`
Decided to not implement the hash table until it will actually be used, which seems to be when `ep_rt_mono_log_type_and_parameters_if_necessary` is used outside of `ep_rt_mono_send_method_details_event`

### `ep_rt_mono_log_type_and_parameters`
In line with `LogTypeAndParameters` except for the absence of `typeLogBehavior`, for currently this is only called following `ep_rt_mono_send_method_details_event` which always logs.

### `ep_rt_mono_log_single_type`
Fills in `rg_type_parameters` and `c_type_parameters` by three categories of MonoType  1) `MONO_TYPE_ARRAY` `MONO_TYPE_SZARRAY  2) `MONO_TYPE_GENERICINST`  3) `MONO_TYPE_CLASS` `MONO_TYPE_VALUETYPE` `MONO_TYPE_PTR` `MONO_TYPE_BYREF`  for any embedded type parameters.
Does not set `s_name` and keeps it as `NULL` until the data will actually be used in mono, which GC Heap Dumps are a likely candidate for.

### `ep_rt_mono_fire_bulk_type_event`
Copies to the BulkTypeEvent buffer through helper functions.

Various helper functions and `static const` variables have been added in addition to `BulkTypeValue` and `BulkTypeEventLogger` structs with respective memory management `init/fini/clear` functions.

--------------
TODO/Questions
-----
<s>Does sName in eventtrace.cpp need to be carried over? </s> 
We have opted to keep `s_name` as `NULL` until it is actually used in mono, which GC Heap Dumps are a likely candidate for.

<s> Variable size array for rg_type_parameters in BulkTypeValue struct that already has variable size field s_name </s> 
Figured out that `StackSArray<ULONGLONG>` has a fixed size that evaluates to `32`

Where else to emit ep_rt_mono_send_method_details_event?

<s> How necessary are the 0x06 method token mask and 0x02 type token masks, should dotnet-pgo be tweaked instead? </s> 
Found the equivalent for mono using `mono_metadata_make_token` and `mono_metadata_token_index`

<s> How to implement `if_necessary` portion of LogTypeAndParametersIfNecessary (th.IsRestored and what exactly is client usage of LogTypeAndParametersIfNecessary) </s> 
Decided to not implement the hash table until it will actually be used, which seems to be when `ep_rt_mono_log_type_and_parameters_if_necessary` is used outside of `ep_rt_mono_send_method_details_event`
