### PR TITLE
Use `TempFile` in a test instead of `Path.GetTempFileName()`

### DIFF
--- a/src/libraries/System.Threading.ThreadPool/tests/System.Threading.ThreadPool.Tests.csproj
+++ b/src/libraries/System.Threading.ThreadPool/tests/System.Threading.ThreadPool.Tests.csproj
@@ -9,6 +9,8 @@
     <Compile Include="RegisteredWaitTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs"
+             Link="CommonTest\System\IO\TempFile.cs" />
     <Compile Include="$(CommonTestPath)System\Threading\ThreadTestHelpers.cs"
              Link="CommonTest\System\Threading\ThreadTestHelpers.cs" />
   </ItemGroup>

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -1032,49 +1032,31 @@ namespace System.Threading.ThreadPools.Tests
                 const int FourKibibytes = OneKibibyte << 2;
                 const int FileSize = 1024;
 
-                string destinationFilePath = null;
-                try
+                using var destinationTempFile = TempFile.Create(CreateArray(FileSize));
+
+                static byte[] CreateArray(int count)
                 {
-                    destinationFilePath = CreateFileWithRandomContent(FileSize);
-
-                    static string CreateFileWithRandomContent(int fileSize)
-                    {
-                        string filePath = Path.GetTempFileName();
-                        File.WriteAllBytes(filePath, CreateArray(fileSize));
-                        return filePath;
-                    }
-
-                    static byte[] CreateArray(int count)
-                    {
-                        var result = new byte[count];
-                        const int Seed = 12345;
-                        var random = new Random(Seed);
-                        random.NextBytes(result);
-                        return result;
-                    }
-
-                    for (int j = 0; j < 100; j++)
-                    {
-                        using var fileStream =
-                            new FileStream(
-                                destinationFilePath,
-                                FileMode.Create,
-                                FileAccess.Write,
-                                FileShare.Read,
-                                FourKibibytes,
-                                FileOptions.None);
-                        for (int i = 0; i < FileSize; i++)
-                        {
-                            fileStream.WriteByte(default);
-                            await fileStream.FlushAsync();
-                        }
-                    }
+                    var result = new byte[count];
+                    const int Seed = 12345;
+                    var random = new Random(Seed);
+                    random.NextBytes(result);
+                    return result;
                 }
-                finally
+
+                for (int j = 0; j < 100; j++)
                 {
-                    if (!string.IsNullOrEmpty(destinationFilePath) && File.Exists(destinationFilePath))
+                    using var fileStream =
+                        new FileStream(
+                            destinationTempFile.Path,
+                            FileMode.Create,
+                            FileAccess.Write,
+                            FileShare.Read,
+                            FourKibibytes,
+                            FileOptions.None);
+                    for (int i = 0; i < FileSize; i++)
                     {
-                        File.Delete(destinationFilePath);
+                        fileStream.WriteByte(default);
+                        await fileStream.FlushAsync();
                     }
                 }
             }).Dispose();


### PR DESCRIPTION
Addresses https://github.com/dotnet/runtime/pull/68171#discussion_r853528453