### PR TITLE
Remove assert from LibraryImportGenerator

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
@@ -671,10 +671,13 @@ namespace Microsoft.Interop
                 // Attribute data may be null when using runtime-provided marshallers by default for certain types (strings, for example)
                 // without the user explicitly putting an attribute on the type or parameter. The marshallers should have the correct shape
                 // already in thoses cases, so the diagnostic here is not so interesting.
-                Debug.Assert(bufferElementType is not null || attrData is not null);
-                if (bufferElementType is null && attrData is not null)
+                if (bufferElementType is null)
                 {
-                    _diagnostics.ReportInvalidMarshallingAttributeInfo(attrData, nameof(SR.ValueInCallerAllocatedBufferRequiresSpanConstructorMessage), nativeType.ToDisplayString(), type.ToDisplayString());
+                    if (attrData is not null)
+                    {
+                        _diagnostics.ReportInvalidMarshallingAttributeInfo(attrData, nameof(SR.ValueInCallerAllocatedBufferRequiresSpanConstructorMessage), nativeType.ToDisplayString(), type.ToDisplayString());
+                    }
+
                     return NoMarshallingInfo.Instance;
                 }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/68572

I'm not actually sure why this is happening. Somehow in VS design-time, we can't find the buffer element type of one of the string marshaller implementations. Actually building to generate the code seems fine - verified that we are still correctly using the string marshaller implementations.

This change removes the assert to unblock the SPCL in VS experience and we can look into why we get into this case separately.

cc @stephentoub 