### PR TITLE
Allow empty directory values in FileSystemEventArgs/RenamedEventArgs ctors

### DIFF
--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
@@ -17,14 +17,18 @@ namespace System.IO
         /// </devdoc>
         public FileSystemEventArgs(WatcherChangeTypes changeType, string directory, string? name)
         {
+            ArgumentNullException.ThrowIfNull(directory);
+
             _changeType = changeType;
             _name = name;
-            _fullPath = Path.Join(Path.GetFullPath(directory), name);
 
-            if (string.IsNullOrWhiteSpace(name))
+            _fullPath = Path.GetFullPath((string.IsNullOrWhiteSpace(directory), string.IsNullOrWhiteSpace(name)) switch
             {
-                _fullPath = PathInternal.EnsureTrailingSeparator(_fullPath);
-            }
+                (true, true) => "." + PathInternal.DirectorySeparatorCharAsString,
+                (true, false) => name!,
+                (false, true) => PathInternal.EnsureTrailingSeparator(directory),
+                (false, false) => Path.Join(directory, name),
+            });
         }
 
         /// <devdoc>

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
@@ -22,13 +22,17 @@ namespace System.IO
             _changeType = changeType;
             _name = name;
 
-            _fullPath = Path.GetFullPath((string.IsNullOrWhiteSpace(directory), string.IsNullOrWhiteSpace(name)) switch
+            if (string.IsNullOrEmpty(directory)) // empty directory means current working dir
             {
-                (true, true) => "." + PathInternal.DirectorySeparatorCharAsString,
-                (true, false) => name!,
-                (false, true) => PathInternal.EnsureTrailingSeparator(directory),
-                (false, false) => Path.Join(directory, name),
-            });
+                directory = ".";
+            }
+
+            _fullPath = Path.Join(Path.GetFullPath(directory), name);
+
+            if (string.IsNullOrEmpty(name))
+            {
+                _fullPath = PathInternal.EnsureTrailingSeparator(_fullPath);
+            }
         }
 
         /// <devdoc>

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
@@ -22,17 +22,13 @@ namespace System.IO
             _changeType = changeType;
             _name = name;
 
-            if (string.IsNullOrEmpty(directory)) // empty directory means current working dir
+            if (directory.Length == 0) // empty directory means current working dir
             {
                 directory = ".";
             }
 
-            _fullPath = Path.Join(Path.GetFullPath(directory), name);
-
-            if (string.IsNullOrEmpty(name))
-            {
-                _fullPath = PathInternal.EnsureTrailingSeparator(_fullPath);
-            }
+            string fullDirectoryPath = Path.GetFullPath(directory);
+            _fullPath = string.IsNullOrEmpty(name) ? PathInternal.EnsureTrailingSeparator(fullDirectoryPath) : Path.Join(fullDirectoryPath, name);
         }
 
         /// <devdoc>

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/RenamedEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/RenamedEventArgs.cs
@@ -19,17 +19,13 @@ namespace System.IO
         {
             _oldName = oldName;
 
-            if (string.IsNullOrEmpty(directory)) // empty directory means current working dir
+            if (directory.Length == 0) // empty directory means current working dir
             {
                 directory = ".";
             }
 
-            _oldFullPath = Path.Join(Path.GetFullPath(directory), oldName);
-
-            if (string.IsNullOrEmpty(oldName))
-            {
-                _oldFullPath = PathInternal.EnsureTrailingSeparator(_oldFullPath);
-            }
+            string fullDirectoryPath = Path.GetFullPath(directory);
+            _oldFullPath = string.IsNullOrEmpty(oldName) ? PathInternal.EnsureTrailingSeparator(fullDirectoryPath) : Path.Join(fullDirectoryPath, oldName);
         }
 
         /// <devdoc>

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/RenamedEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/RenamedEventArgs.cs
@@ -18,12 +18,14 @@ namespace System.IO
             : base(changeType, directory, name)
         {
             _oldName = oldName;
-            _oldFullPath = Path.Join(Path.GetFullPath(directory), oldName);
 
-            if (string.IsNullOrWhiteSpace(oldName))
+            _oldFullPath = Path.GetFullPath((string.IsNullOrWhiteSpace(directory), string.IsNullOrWhiteSpace(oldName)) switch
             {
-                _oldFullPath = PathInternal.EnsureTrailingSeparator(_oldFullPath);
-            }
+                (true, true) => "." + PathInternal.DirectorySeparatorCharAsString,
+                (true, false) => oldName!,
+                (false, true) => PathInternal.EnsureTrailingSeparator(directory),
+                (false, false) => Path.Join(directory, oldName),
+            });
         }
 
         /// <devdoc>

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/RenamedEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/RenamedEventArgs.cs
@@ -19,13 +19,17 @@ namespace System.IO
         {
             _oldName = oldName;
 
-            _oldFullPath = Path.GetFullPath((string.IsNullOrWhiteSpace(directory), string.IsNullOrWhiteSpace(oldName)) switch
+            if (string.IsNullOrEmpty(directory)) // empty directory means current working dir
             {
-                (true, true) => "." + PathInternal.DirectorySeparatorCharAsString,
-                (true, false) => oldName!,
-                (false, true) => PathInternal.EnsureTrailingSeparator(directory),
-                (false, false) => Path.Join(directory, oldName),
-            });
+                directory = ".";
+            }
+
+            _oldFullPath = Path.Join(Path.GetFullPath(directory), oldName);
+
+            if (string.IsNullOrEmpty(oldName))
+            {
+                _oldFullPath = PathInternal.EnsureTrailingSeparator(_oldFullPath);
+            }
         }
 
         /// <devdoc>

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Args.FileSystemEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Args.FileSystemEventArgs.cs
@@ -42,6 +42,7 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         [InlineData("/", null, "/")]
         [InlineData("/", "", "/")]
+        [InlineData("/", "   ", "/   ")]
         [InlineData("/", "foo.txt", "/foo.txt")]
         [InlineData("/bar", null, "/bar/")]
         [InlineData("/bar", "", "/bar/")]
@@ -74,6 +75,8 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         [InlineData("", "")]
         [InlineData("", "foo.txt")]
+        [InlineData("   ", "    ")]
+        [InlineData("   ", "foo.txt")]
         [InlineData("bar", "foo.txt")]
         [InlineData("bar/baz", "foo.txt")]
         public static void FileSystemEventArgs_ctor_DirectoryIsRelativePath_Unix(string directory, string name)

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Args.FileSystemEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Args.FileSystemEventArgs.cs
@@ -22,8 +22,15 @@ namespace System.IO.Tests
 
         [Theory]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [InlineData("D:\\", null, "D:\\")]
+        [InlineData("D:\\", "", "D:\\")]
         [InlineData("D:\\", "foo.txt", "D:\\foo.txt")]
+        [InlineData("E:\\bar", null, "E:\\bar\\")]
+        [InlineData("E:\\bar", "", "E:\\bar\\")]
         [InlineData("E:\\bar", "foo.txt", "E:\\bar\\foo.txt")]
+        [InlineData("E:\\bar\\", null, "E:\\bar\\")]
+        [InlineData("E:\\bar\\", "", "E:\\bar\\")]
+        [InlineData("E:\\bar\\", "foo.txt", "E:\\bar\\foo.txt")]
         public static void FileSystemEventArgs_ctor_DirectoryIsAbsolutePath_Windows(string directory, string name, string expectedFullPath)
         {
             FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
@@ -33,8 +40,15 @@ namespace System.IO.Tests
 
         [Theory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [InlineData("/", null, "/")]
+        [InlineData("/", "", "/")]
         [InlineData("/", "foo.txt", "/foo.txt")]
+        [InlineData("/bar", null, "/bar/")]
+        [InlineData("/bar", "", "/bar/")]
         [InlineData("/bar", "foo.txt", "/bar/foo.txt")]
+        [InlineData("/bar/", null, "/bar/")]
+        [InlineData("/bar/", "", "/bar/")]
+        [InlineData("/bar/", "foo.txt", "/bar/foo.txt")]
         public static void FileSystemEventArgs_ctor_DirectoryIsAbsolutePath_Unix(string directory, string name, string expectedFullPath)
         {
             FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
@@ -44,24 +58,30 @@ namespace System.IO.Tests
 
         [Theory]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [InlineData("", "")]
+        [InlineData("", "foo.txt")]
         [InlineData("bar", "foo.txt")]
         [InlineData("bar\\baz", "foo.txt")]
         public static void FileSystemEventArgs_ctor_DirectoryIsRelativePath_Windows(string directory, string name)
         {
             FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
 
-            Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), directory, name), args.FullPath);
+            var expectedDirectory = PathInternal.EnsureTrailingSeparator(Path.Combine(Directory.GetCurrentDirectory(), directory));
+            Assert.Equal(Path.Combine(expectedDirectory, name), args.FullPath);
         }
 
         [Theory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [InlineData("", "")]
+        [InlineData("", "foo.txt")]
         [InlineData("bar", "foo.txt")]
         [InlineData("bar/baz", "foo.txt")]
         public static void FileSystemEventArgs_ctor_DirectoryIsRelativePath_Unix(string directory, string name)
         {
             FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
 
-            Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), directory, name), args.FullPath);
+            var expectedDirectory = PathInternal.EnsureTrailingSeparator(Path.Combine(Directory.GetCurrentDirectory(), directory));
+            Assert.Equal(Path.Combine(expectedDirectory, name), args.FullPath);
         }
 
         [Theory]
@@ -80,7 +100,6 @@ namespace System.IO.Tests
         public static void FileSystemEventArgs_ctor_Invalid()
         {
             Assert.Throws<ArgumentNullException>(() => new FileSystemEventArgs((WatcherChangeTypes)0, null, "foo.txt"));
-            Assert.Throws<ArgumentException>(() => new FileSystemEventArgs((WatcherChangeTypes)0, "", "foo.txt"));
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Args.RenamedEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Args.RenamedEventArgs.cs
@@ -47,24 +47,30 @@ namespace System.IO.Tests
 
         [Theory]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [InlineData("", "", "")]
+        [InlineData("", "foo.txt", "bar.txt")]
         [InlineData("bar", "foo.txt", "bar.txt")]
         [InlineData("bar\\baz", "foo.txt", "bar.txt")]
         public static void RenamedEventArgs_ctor_OldFullPath_DirectoryIsRelativePath_Windows(string directory, string name, string oldName)
         {
             RenamedEventArgs args = new RenamedEventArgs(WatcherChangeTypes.All, directory, name, oldName);
 
-            Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), directory, oldName), args.OldFullPath);
+            var expectedDirectory = PathInternal.EnsureTrailingSeparator(Path.Combine(Directory.GetCurrentDirectory(), directory));
+            Assert.Equal(Path.Combine(expectedDirectory, oldName), args.OldFullPath);
         }
 
         [Theory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [InlineData("", "", "")]
+        [InlineData("", "foo.txt", "bar.txt")]
         [InlineData("bar", "foo.txt", "bar.txt")]
         [InlineData("bar/baz", "foo.txt", "bar.txt")]
         public static void RenamedEventArgs_ctor_OldFullPath_DirectoryIsRelativePath_Unix(string directory, string name, string oldName)
         {
             RenamedEventArgs args = new RenamedEventArgs(WatcherChangeTypes.All, directory, name, oldName);
 
-            Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), directory, oldName), args.OldFullPath);
+            var expectedDirectory = PathInternal.EnsureTrailingSeparator(Path.Combine(Directory.GetCurrentDirectory(), directory));
+            Assert.Equal(Path.Combine(expectedDirectory, oldName), args.OldFullPath);
         }
 
         [Theory]
@@ -83,7 +89,6 @@ namespace System.IO.Tests
         [Fact]
         public static void RenamedEventArgs_ctor_Invalid()
         {
-            Assert.Throws<ArgumentException>(() => new RenamedEventArgs((WatcherChangeTypes)0, "", "foo.txt", "bar.txt"));
             Assert.Throws<ArgumentNullException>(() => new RenamedEventArgs((WatcherChangeTypes)0, null, "foo.txt", "bar.txt"));
         }
     }


### PR DESCRIPTION
Fixes #68566.

A regression was introduced by #63051. That PR introduced an intentional breaking change where `FileSystemEventArgs.FullPath` would become a fully-qualified path, but the change also included an unintentional breaking change that prevented `FileSystemEventArgs` and `RenamedEventArgs` from accepting a directory value that is null or whitespace. That PR added asserts for the empty directory case, ensuring exceptions were thrown, but in .NET 6, the behavior of the event args types was to infer a relative directory in that scenario.

This change allows empty directory values while still resulting in fully-qualified paths for `FullPath` and `OldFullPath`.