### PR TITLE
[release/6.0] Use x64 directory if running x64 process on arm64 apphost

### DIFF
--- a/src/native/corehost/hostmisc/pal.h
+++ b/src/native/corehost/hostmisc/pal.h
@@ -310,6 +310,7 @@ namespace pal
     void unload_library(dll_t library);
 
     bool is_running_in_wow64();
+    bool is_emulating_x64();
 
     bool are_paths_equal_with_normalized_casing(const string_t& path1, const string_t& path2);
 }

--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -789,39 +789,43 @@ bool pal::is_running_in_wow64()
 }
 
 typedef BOOL (WINAPI* is_wow64_process2)(
-  HANDLE hProcess,
-  USHORT *pProcessMachine,
-  USHORT *pNativeMachine
+    HANDLE hProcess,
+    USHORT *pProcessMachine,
+    USHORT *pNativeMachine
 );
 
 bool pal::is_emulating_x64()
 {
-    USHORT pProcessMachine, pNativeMachine;
+#if defined(TARGET_AMD64)
     auto kernel32 = LoadLibraryExW(L"kernel32.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
-    if (kernel32)
+    if (kernel32 == nullptr)
     {
-        is_wow64_process2 isWow64Process2Func = (is_wow64_process2)GetProcAddress(kernel32, "IsWow64Process2");
-        if (!isWow64Process2Func)
-        {
-            // Could not find IsWow64Process2.
-            return false;
-        }
-
-        if (!isWow64Process2Func(GetCurrentProcess(), &pProcessMachine, &pNativeMachine))
-        {
-            // IsWow64Process2 failed. Log the error and continue.
-            trace::info(_X("Call to IsWow64Process2 failed: %s"), GetLastError());
-            return false;
-        }
-
-        // Check if we are running an x64 process on a non-x64 windows machine.
-        return pProcessMachine != pNativeMachine && pProcessMachine == IMAGE_FILE_MACHINE_AMD64;
+        // Loading kernel32.dll failed, log the error and continue.
+        trace::info(_X("Could not load 'kernel32.dll': %u"), GetLastError());
+        return false;
     }
 
-    // Loading kernel32.dll failed, log the error and continue.
-    trace::info(_X("Could not load 'kernel32.dll': %s"), GetLastError());
+    is_wow64_process2 is_wow64_process2_func = (is_wow64_process2)::GetProcAddress(kernel32, "IsWow64Process2");
+    if (is_wow64_process2_func == nullptr)
+    {
+        // Could not find IsWow64Process2.
+        return false;
+    }
 
+    USHORT process_machine;
+    USHORT native_machine;
+    if (!is_wow64_process2_func(GetCurrentProcess(), &process_machine, &native_machine))
+    {
+        // IsWow64Process2 failed. Log the error and continue.
+        trace::info(_X("Call to IsWow64Process2 failed: %u"), GetLastError());
+        return false;
+    }
+
+    // If we are running targeting x64 on a non-x64 machine, we are emulating
+    return native_machine != IMAGE_FILE_MACHINE_AMD64;
+#else
     return false;
+#endif
 }
 
 bool pal::are_paths_equal_with_normalized_casing(const string_t& path1, const string_t& path2)

--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -292,6 +292,11 @@ bool pal::get_default_installation_dir(pal::string_t* recv)
     }
 
     append_path(recv, _X("dotnet"));
+    if (pal::is_emulating_x64())
+    {
+        // Install location for emulated x64 should be %ProgramFiles%\dotnet\x64.
+        append_path(recv, _X("x64"));
+    }
 
     return true;
 }
@@ -781,6 +786,42 @@ bool pal::is_running_in_wow64()
         return false;
     }
     return (fWow64Process != FALSE);
+}
+
+typedef BOOL (WINAPI* is_wow64_process2)(
+  HANDLE hProcess,
+  USHORT *pProcessMachine,
+  USHORT *pNativeMachine
+);
+
+bool pal::is_emulating_x64()
+{
+    USHORT pProcessMachine, pNativeMachine;
+    auto kernel32 = LoadLibraryExW(L"kernel32.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (kernel32)
+    {
+        is_wow64_process2 isWow64Process2Func = (is_wow64_process2)GetProcAddress(kernel32, "IsWow64Process2");
+        if (!isWow64Process2Func)
+        {
+            // Could not find IsWow64Process2.
+            return false;
+        }
+
+        if (!isWow64Process2Func(GetCurrentProcess(), &pProcessMachine, &pNativeMachine))
+        {
+            // IsWow64Process2 failed. Log the error and continue.
+            trace::info(_X("Call to IsWow64Process2 failed: %s"), GetLastError());
+            return false;
+        }
+
+        // Check if we are running an x64 process on a non-x64 windows machine.
+        return pProcessMachine != pNativeMachine && pProcessMachine == IMAGE_FILE_MACHINE_AMD64;
+    }
+
+    // Loading kernel32.dll failed, log the error and continue.
+    trace::info(_X("Could not load 'kernel32.dll': %s"), GetLastError());
+
+    return false;
 }
 
 bool pal::are_paths_equal_with_normalized_casing(const string_t& path1, const string_t& path2)


### PR DESCRIPTION
Backport of #59890 and #68671

Issues:
- https://github.com/dotnet/runtime/issues/65263
- https://github.com/dotnet/runtime/issues/67316

## Customer Impact

When running an x64 application via `apphost` on arm64 (Windows or macOS), the application looks for a .NET install at a default path corresponding to an arm64 install rather than an x64 install. This means that:
1. If only arm64 is installed, the application will try and fail to load the arm64 `hostfxr`
2. If both arm64 and x64 are installed and the arm64 runtime version is a better match for the application (for example, a higher patch version), the application will try and fail to load the arm64 `hostpolicy` if multi-level lookup is enabled (default on Windows)

On Windows, (2) also occurs when running via the x64 `dotnet`. This includes running SDK commands. For example, running `\Program Files\dotnet\x64\dotnet.exe build` (or even `--info`) will fail to load the arm64 `hostpolicy`.

In every case, the result is a confusing error about failing to load one of our hosting components.

## Testing

Manual validation
- arm64 installed, x64 not installed
  - we report that no runtime is installed (instead of trying to load the arm64 `hostfxr`)
- arm64 installed, x64 installed, arm64 is a better version match
  - we use the x64 runtime (instead of trying to load the arm64 `hostpolicy` on Windows)
- arm64 installed, x64 at the default location, but not registered
  - we can find the x64 runtime (instead of trying to load the arm64 `hostfxr`)
- arm64 not installed, x64 at the default location, but not registered
  - we can find the x64 runtime (instead of reporting that no runtime is installed)

## Risk

The fix for macOS has been in main for about 6 months. The fix for Windows is targeted to only affect x64 hosting binaries running on non-x64 systems.