### PR TITLE
Hoist the nullchecks for 'this' object

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1739,6 +1739,7 @@ void CodeGen::genGenerateMachineCode()
     {
         compiler->opts.disAsm = true;
     }
+    compiler->compCurBB = compiler->fgFirstBB;
 
     if (compiler->opts.disAsm)
     {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5624,7 +5624,11 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
             GenTree* lclVar = gtNewLclvNode(lclNum, objRefType);
             nullchk         = gtNewNullCheck(lclVar, compCurBB);
 
-            nullchk->gtFlags |= GTF_DONT_CSE; // Don't try to create a CSE for these TYP_BYTE indirections
+            if (lclNum != info.compThisArg)
+            {
+                // Don't try to create a CSE for these TYP_BYTE indirections unless it was a "this" pointer.
+                nullchk->gtFlags |= GTF_DONT_CSE;
+            }
 
             if (asg)
             {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5624,12 +5624,6 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
             GenTree* lclVar = gtNewLclvNode(lclNum, objRefType);
             nullchk         = gtNewNullCheck(lclVar, compCurBB);
 
-            if (lclNum != info.compThisArg)
-            {
-                // Don't try to create a CSE for these TYP_BYTE indirections unless it was a "this" pointer.
-                nullchk->gtFlags |= GTF_DONT_CSE;
-            }
-
             if (asg)
             {
                 // Create the "comma" node.

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -3684,14 +3684,6 @@ bool Compiler::optIsCSEcandidate(GenTree* tree)
         case GT_RETURN:
             return false; // Currently the only special nodes that we hit
                           // that we know that we don't want to CSE
-        case GT_NULLCHECK:
-            GenTreeLclVar* lclVar;
-            if (tree->AsUnOp()->gtGetOp1()->OperIs(GT_LCL_VAR))
-            {
-                lclVar = tree->AsUnOp()->gtGetOp1()->AsLclVar();
-                return lclVar->GetLclNum() == info.compThisArg;
-            }
-            return false;
 
         default:
             break; // Any new nodes that we might add later...

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -3684,6 +3684,14 @@ bool Compiler::optIsCSEcandidate(GenTree* tree)
         case GT_RETURN:
             return false; // Currently the only special nodes that we hit
                           // that we know that we don't want to CSE
+        case GT_NULLCHECK:
+            GenTreeLclVar* lclVar;
+            if (tree->AsUnOp()->gtGetOp1()->OperIs(GT_LCL_VAR))
+            {
+                lclVar = tree->AsUnOp()->gtGetOp1()->AsLclVar();
+                return lclVar->GetLclNum() == info.compThisArg;
+            }
+            return false;
 
         default:
             break; // Any new nodes that we might add later...

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -6523,18 +6523,12 @@ void Compiler::optHoistLoopBlocks(unsigned loopNum, ArrayStack<BasicBlock*>* blo
             }
             else if (node->OperIs(GT_NULLCHECK))
             {
-                GenTreeLclVar* lclVar;
-                if (node->AsUnOp()->gtGetOp1()->OperIs(GT_LCL_VAR))
-                {
-                    // If a null-check is for `this` object, it is safe to
-                    // hoist it out of the loop.
-                    //
-                    // TODO-CQ: Identify more scenarios where we can hoist
-                    // the null-checks
-                    lclVar = node->AsUnOp()->gtGetOp1()->AsLclVar();
-                    return lclVar->GetLclNum() == m_compiler->info.compThisArg;
-                }
-                return false;
+                // If a null-check is for `this` object, it is safe to
+                // hoist it out of the loop. Assrtionprop will get rid
+                // of left over nullchecks present inside the loop. Also,
+                // since NULLCHECK has no value, it will never be CSE,
+                // hence this check is not present in optIsCSEcandidate().
+                return true;
             }
 
             // Tree must be a suitable CSE candidate for us to be able to hoist it.

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -6521,6 +6521,21 @@ void Compiler::optHoistLoopBlocks(unsigned loopNum, ArrayStack<BasicBlock*>* blo
             {
                 return false;
             }
+            else if (node->OperIs(GT_NULLCHECK))
+            {
+                GenTreeLclVar* lclVar;
+                if (node->AsUnOp()->gtGetOp1()->OperIs(GT_LCL_VAR))
+                {
+                    // If a null-check is for `this` object, it is safe to
+                    // hoist it out of the loop.
+                    //
+                    // TODO-CQ: Identify more scenarios where we can hoist
+                    // the null-checks
+                    lclVar = node->AsUnOp()->gtGetOp1()->AsLclVar();
+                    return lclVar->GetLclNum() == m_compiler->info.compThisArg;
+                }
+                return false;
+            }
 
             // Tree must be a suitable CSE candidate for us to be able to hoist it.
             return m_compiler->optIsCSEcandidate(node);


### PR DESCRIPTION
Marking `nullcheck` around `this` as hoistable-candidate should be safe IMO. 

![image](https://user-images.githubusercontent.com/12488060/165470988-fe4a00f2-fed0-4643-8ab1-6e00b6f7ded6.png)
