### PR TITLE
Avoid byte[] allocation for IPAddressUtil.IsMulticast

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPAddressUtil.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPAddressUtil.cs
@@ -20,7 +20,9 @@ namespace System.Net.NetworkInformation
             }
             else
             {
-                byte firstByte = address.GetAddressBytes()[0];
+#pragma warning disable CS0618 // using Obsolete Address API because it's the more efficient option in this case
+                byte firstByte = (byte)address.Address;
+#pragma warning restore CS0618
                 return firstByte >= 224 && firstByte <= 239;
             }
         }


### PR DESCRIPTION
Ping.RawSocket his its own inline implementaion of this, maybe this
should be consolidated somewhere?
[src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
L101](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs#L101)