### PR TITLE
Copy propagate on `LCL_FLD`s

### DIFF
--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -205,15 +205,18 @@ void Compiler::optCopyProp(Statement* stmt, GenTreeLclVarCommon* tree, unsigned 
             continue;
         }
 
-        var_types newLclType = newLclVarDsc->TypeGet();
-        if (!newLclVarDsc->lvNormalizeOnLoad())
+        if (tree->OperIs(GT_LCL_VAR))
         {
-            newLclType = genActualType(newLclType);
-        }
+            var_types newLclType = newLclVarDsc->TypeGet();
+            if (!newLclVarDsc->lvNormalizeOnLoad())
+            {
+                newLclType = genActualType(newLclType);
+            }
 
-        if (newLclType != tree->TypeGet())
-        {
-            continue;
+            if (newLclType != tree->TypeGet())
+            {
+                continue;
+            }
         }
 
 #ifdef DEBUG
@@ -388,8 +391,7 @@ void Compiler::optBlockCopyProp(BasicBlock* block, LclNumToLiveDefsMap* curSsaNa
 
                 optCopyPropPushDef(tree, lclDefNode, lclNum, curSsaName);
             }
-            // TODO-CQ: propagate on LCL_FLDs too.
-            else if (tree->OperIs(GT_LCL_VAR) && ((tree->gtFlags & GTF_VAR_DEF) == 0))
+            else if (tree->OperIs(GT_LCL_VAR, GT_LCL_FLD) && ((tree->gtFlags & GTF_VAR_DEF) == 0))
             {
                 const unsigned lclNum = optIsSsaLocal(tree->AsLclVarCommon());
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -8136,7 +8136,7 @@ GenTree* Compiler::gtCloneExpr(
                         new (this, GT_LCL_FLD) GenTreeLclFld(GT_LCL_FLD, tree->TypeGet(), tree->AsLclFld()->GetLclNum(),
                                                              tree->AsLclFld()->GetLclOffs());
                     copy->AsLclFld()->SetFieldSeq(tree->AsLclFld()->GetFieldSeq());
-                    copy->gtFlags = tree->gtFlags;
+                    copy->AsLclFld()->SetSsaNum(tree->AsLclFld()->GetSsaNum());
                 }
                 goto DONE;
 


### PR DESCRIPTION
Now that we check propagation legality using values of the underlying locations (as opposed to the nodes themselves), we can enable this small and simple CQ improvement.

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1740481&view=ms.vss-build-web.run-extensions-tab).