### PR TITLE
Ensure decimal.TryWriteSignificandLittleEndian correctly takes endianness into account

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
@@ -1189,10 +1189,19 @@ namespace System
         {
             if (destination.Length >= (sizeof(ulong) + sizeof(uint)))
             {
+                var lo64 = _lo64;
+                var hi32 = _hi32;
+
+                if (!BitConverter.IsLittleEndian)
+                {
+                    lo64 = BinaryPrimitives.ReverseEndianness(lo64);
+                    hi32 = BinaryPrimitives.ReverseEndianness(hi32);
+                }
+
                 ref byte address = ref MemoryMarshal.GetReference(destination);
 
-                Unsafe.WriteUnaligned(ref address, _lo64);
-                Unsafe.WriteUnaligned(ref Unsafe.AddByteOffset(ref address, sizeof(ulong)), _hi32);
+                Unsafe.WriteUnaligned(ref address, lo64);
+                Unsafe.WriteUnaligned(ref Unsafe.AddByteOffset(ref address, sizeof(ulong)), hi32);
 
                 bytesWritten = sizeof(ulong) + sizeof(uint);
                 return true;


### PR DESCRIPTION
Discovered by @uweigand in https://github.com/dotnet/runtime/pull/68141#issuecomment-1105272469

`decimal` wasn't covered by https://github.com/dotnet/runtime/pull/68331