### PR TITLE
Lock EnsureConfigured to prevent initialization issues in JsonTypeInfo

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -201,9 +201,15 @@ namespace System.Text.Json.Serialization.Metadata
             if (_isConfigured)
                 return;
 
-            Configure();
+            lock (this)
+            {
+                if (_isConfigured)
+                    return;
 
-            _isConfigured = true;
+                Configure();
+
+                _isConfigured = true;
+            }
         }
 
         internal virtual void Configure()

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -195,13 +195,14 @@ namespace System.Text.Json.Serialization.Metadata
         }
 
         private bool _isConfigured;
+        private object _configureLock = new object();
 
         internal void EnsureConfigured()
         {
             if (_isConfigured)
                 return;
 
-            lock (this)
+            lock (_configureLock)
             {
                 if (_isConfigured)
                     return;
@@ -214,6 +215,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         internal virtual void Configure()
         {
+            Debug.Assert(Monitor.IsEntered(_configureLock), "Configure called directly, use EnsureConfigured which locks this method");
             JsonConverter converter = PropertyInfoForTypeInfo.ConverterBase;
             Debug.Assert(PropertyInfoForTypeInfo.ConverterStrategy == PropertyInfoForTypeInfo.ConverterBase.ConverterStrategy,
                 $"ConverterStrategy from PropertyInfoForTypeInfo.ConverterStrategy ({PropertyInfoForTypeInfo.ConverterStrategy}) does not match converter's ({PropertyInfoForTypeInfo.ConverterBase.ConverterStrategy})");


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/67816
Fixes: https://github.com/dotnet/runtime/issues/68584
Contributes to: https://github.com/dotnet/runtime/issues/67761

Replaces: https://github.com/dotnet/runtime/pull/68480

It's theoretically possible to achieve this without having to use locks (which I've tried in the replaced PR) but:
- this is affecting many PRs 
- most likely there are more initialization issues than just the one I addressed in the replaced PR
- lock-less behavior will make this code very prone to re-introducing initialization issues
- this lock will only happen once per initialization of JsonTypeInfo which is supposedly happening only once per type per options so it's single time cost (minus multiple threads trying to do the same initialization)