### PR TITLE
Fix some incorrect SpecialFolder entries for Unix

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/System.Native/Interop.SearchPath.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Native/Interop.SearchPath.cs
@@ -19,6 +19,7 @@ internal static partial class Interop
             NSDocumentDirectory = 9,
             NSDesktopDirectory = 12,
             NSCachesDirectory = 13,
+            NSApplicationSupportDirectory = 14,
             NSMoviesDirectory = 17,
             NSMusicDirectory = 18,
             NSPicturesDirectory = 19

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -2292,7 +2292,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileStatus.SetTimes.OSX.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(IsiOSLike)' == 'true'">
+  <ItemGroup Condition="'$(IsiOSLike)' == 'true' or '$(IsOSXLike)' == 'true'">
     <Compile Include="$(CommonPath)Interop\OSX\System.Native\Interop.SearchPath.cs">
       <Link>Common\Interop\OSX\Interop.SearchPath.cs</Link>
     </Compile>

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.GetFolderPathCore.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.GetFolderPathCore.Unix.cs
@@ -20,7 +20,7 @@ namespace System
         private static string GetFolderPathCore(SpecialFolder folder, SpecialFolderOption option)
         {
             // Get the path for the SpecialFolder
-            string? path = GetFolderPathCoreWithoutValidation(folder);
+            string path = GetFolderPathCoreWithoutValidation(folder) ?? string.Empty;
             Debug.Assert(path != null);
 
             // If we didn't get one, or if we got one but we're not supposed to verify it,

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.GetFolderPathCore.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.GetFolderPathCore.Unix.cs
@@ -93,9 +93,8 @@ namespace System
                     return ReadXdgDirectory(home, "XDG_TEMPLATES_DIR", "Templates");
 #if TARGET_OSX
                 case SpecialFolder.ApplicationData:
-                    return Path.Combine(home, "Library", "Application Support");
                 case SpecialFolder.LocalApplicationData:
-                    return Path.Combine(home, "Library");
+                    return Path.Combine(home, "Library", "Application Support");
                 case SpecialFolder.MyDocuments: // same value as Personal
                     return Path.Combine(home, "Documents");
                 case SpecialFolder.MyMusic:

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.GetFolderPathCore.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.GetFolderPathCore.Unix.cs
@@ -85,8 +85,32 @@ namespace System
             switch (folder)
             {
                 case SpecialFolder.UserProfile:
-                case SpecialFolder.MyDocuments: // same value as Personal
                     return home;
+                case SpecialFolder.Desktop:
+                case SpecialFolder.DesktopDirectory:
+                    return ReadXdgDirectory(home, "XDG_DESKTOP_DIR", "Desktop");
+                case SpecialFolder.Templates:
+                    return ReadXdgDirectory(home, "XDG_TEMPLATES_DIR", "Templates");
+#if TARGET_OSX
+                case SpecialFolder.ApplicationData:
+                    return Path.Combine(home, "Library", "Application Support");
+                case SpecialFolder.LocalApplicationData:
+                    return Path.Combine(home, "Library");
+                case SpecialFolder.MyDocuments: // same value as Personal
+                    return Path.Combine(home, "Documents");
+                case SpecialFolder.MyMusic:
+                    return Path.Combine(home, "Music");
+                case SpecialFolder.MyVideos:
+                    return Path.Combine(home, "Movies");
+                case SpecialFolder.MyPictures:
+                    return Path.Combine(home, "Pictures");
+                case SpecialFolder.Fonts:
+                    return Path.Combine(home, "Library", "Fonts");
+                case SpecialFolder.Favorites:
+                    return Path.Combine(home, "Library", "Favorites");
+                case SpecialFolder.InternetCache:
+                    return Path.Combine(home, "Library", "Caches");
+#else
                 case SpecialFolder.ApplicationData:
                     return GetXdgConfig(home);
                 case SpecialFolder.LocalApplicationData:
@@ -98,29 +122,12 @@ namespace System
                         data = Path.Combine(home, ".local", "share");
                     }
                     return data;
-
-                case SpecialFolder.Desktop:
-                case SpecialFolder.DesktopDirectory:
-                    return ReadXdgDirectory(home, "XDG_DESKTOP_DIR", "Desktop");
-                case SpecialFolder.Templates:
-                    return ReadXdgDirectory(home, "XDG_TEMPLATES_DIR", "Templates");
-                case SpecialFolder.MyVideos:
-                    return ReadXdgDirectory(home, "XDG_VIDEOS_DIR", "Videos");
-
-#if TARGET_OSX
-                case SpecialFolder.MyMusic:
-                    return Path.Combine(home, "Music");
-                case SpecialFolder.MyPictures:
-                    return Path.Combine(home, "Pictures");
-                case SpecialFolder.Fonts:
-                    return Path.Combine(home, "Library", "Fonts");
-                case SpecialFolder.Favorites:
-                    return Path.Combine(home, "Library", "Favorites");
-                case SpecialFolder.InternetCache:
-                    return Path.Combine(home, "Library", "Caches");
-#else
+                case SpecialFolder.MyDocuments: // same value as Personal
+                    return ReadXdgDirectory(home, "XDG_DOCUMENTS_DIR", "Documents");
                 case SpecialFolder.MyMusic:
                     return ReadXdgDirectory(home, "XDG_MUSIC_DIR", "Music");
+                case SpecialFolder.MyVideos:
+                    return ReadXdgDirectory(home, "XDG_VIDEOS_DIR", "Videos");
                 case SpecialFolder.MyPictures:
                     return ReadXdgDirectory(home, "XDG_PICTURES_DIR", "Pictures");
                 case SpecialFolder.Fonts:

--- a/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -332,19 +332,21 @@ namespace System.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.AnyUnix | TestPlatforms.Browser)]
-        public void GetFolderPath_Unix_PersonalExists()
+        public void GetFolderPath_Unix_UserProfileExists()
         {
-            Assert.True(Directory.Exists(Environment.GetFolderPath(Environment.SpecialFolder.Personal)));
+            Assert.True(Directory.Exists(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)));
         }
 
         [Fact]
         [PlatformSpecific(TestPlatforms.AnyUnix | TestPlatforms.Browser)]  // Tests OS-specific environment
-        public void GetFolderPath_Unix_PersonalIsHomeAndUserProfile()
+        public void GetFolderPath_Unix_PersonalIsDocumentsAndUserProfile()
         {
             if (!PlatformDetection.IsiOS && !PlatformDetection.IstvOS && !PlatformDetection.IsMacCatalyst)
             {
-                Assert.Equal(Environment.GetEnvironmentVariable("HOME"), Environment.GetFolderPath(Environment.SpecialFolder.Personal));
-                Assert.Equal(Environment.GetEnvironmentVariable("HOME"), Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
+                Assert.Equal(Path.Combine(Environment.GetEnvironmentVariable("HOME"), "Documents"),
+                             Environment.GetFolderPath(Environment.SpecialFolder.Personal,  Environment.SpecialFolderOption.DoNotVerify));
+                Assert.Equal(Path.Combine(Environment.GetEnvironmentVariable("HOME"), "Documents"),
+                             Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments,  Environment.SpecialFolderOption.DoNotVerify));
             }
 
             Assert.Equal(Environment.GetEnvironmentVariable("HOME"), Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
@@ -357,6 +359,7 @@ namespace System.Tests
         [InlineData(Environment.SpecialFolder.Desktop)]
         [InlineData(Environment.SpecialFolder.DesktopDirectory)]
         [InlineData(Environment.SpecialFolder.Fonts)]
+        [InlineData(Environment.SpecialFolder.MyDocuments)]
         [InlineData(Environment.SpecialFolder.MyMusic)]
         [InlineData(Environment.SpecialFolder.MyPictures)]
         [InlineData(Environment.SpecialFolder.MyVideos)]
@@ -391,7 +394,7 @@ namespace System.Tests
         [Theory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Tests OS-specific environment
         [InlineData(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.None)]
-        [InlineData(Environment.SpecialFolder.MyDocuments, Environment.SpecialFolderOption.None)] // MyDocuments == Personal
+        [InlineData(Environment.SpecialFolder.MyDocuments, Environment.SpecialFolderOption.DoNotVerify)] // MyDocuments == Personal
         [InlineData(Environment.SpecialFolder.CommonApplicationData, Environment.SpecialFolderOption.None)]
         [InlineData(Environment.SpecialFolder.CommonTemplates, Environment.SpecialFolderOption.DoNotVerify)]
         [InlineData(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.DoNotVerify)]

--- a/src/native/libs/System.Native/CMakeLists.txt
+++ b/src/native/libs/System.Native/CMakeLists.txt
@@ -59,6 +59,11 @@ if (CLR_CMAKE_TARGET_MACCATALYST OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVO
     set(NATIVE_SOURCES ${NATIVE_SOURCES}
         pal_log.m
         pal_searchpath.m)
+elseif (CLR_CMAKE_TARGET_OSX)
+    list (APPEND NATIVE_SOURCES
+        pal_searchpath.m
+        pal_console.c
+        pal_log.c)
 else ()
     list (APPEND NATIVE_SOURCES
         pal_searchpath.c


### PR DESCRIPTION
This PR:
- fixes an incorrect Documents/Personal entry for Linux+Mac (from `HOME` to `XDG_DOCUMENTS_DIR`/`HOME/Documents` for Linux and Mac respectively)
- fixes an incorrect Videos entry for Mac (from `HOME/Videos` to `HOME/Movies`)
- fixes an incorrect (Local) ApplicationData entry for Mac (from `XDG_CONFIG_HOME` and `XDG_DATA_HOME` to `HOME/Library/Application Support` for both ApplicationData and LocalApplicationData)

- Changes the Unix tests to check that `SpecialFolder.Personal` and `SpecialFolder.MyDocuments` are the Documents directory instead of `HOME`.

Fixes #63214, 
Fixes #68323, 
Fixes #40353