### PR TITLE
Use SYSLIB prefix for all LibraryImportGenerator diagnostics

### DIFF
--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -159,17 +159,15 @@ The diagnostic id values reserved for .NET Libraries analyzer warnings are `SYSL
 |  __`SYSLIB1050`__ | Invalid LibraryImportAttribute usage |
 |  __`SYSLIB1051`__ | Specified type is not supported by source-generated P/Invokes |
 |  __`SYSLIB1052`__ | Specified configuration is not supported by source-generated P/Invokes |
-|  __`SYSLIB1053`__ | Current target framework is not supported by source-generated P/Invokes |
-|  __`SYSLIB1054`__ | Specified LibraryImportAttribute arguments cannot be forwarded to DllImportAttribute |
-|  __`SYSLIB1055`__ | *_`SYSLIB1055`-`SYSLIB1066` reserved for Microsoft.Interop.LibraryImportGenerator._* |
-|  __`SYSLIB1056`__ | *_`SYSLIB1055`-`SYSLIB1066` reserved for Microsoft.Interop.LibraryImportGenerator._* |
-|  __`SYSLIB1057`__ | *_`SYSLIB1055`-`SYSLIB1066` reserved for Microsoft.Interop.LibraryImportGenerator._* |
-|  __`SYSLIB1058`__ | *_`SYSLIB1055`-`SYSLIB1066` reserved for Microsoft.Interop.LibraryImportGenerator._* |
-|  __`SYSLIB1059`__ | *_`SYSLIB1055`-`SYSLIB1066` reserved for Microsoft.Interop.LibraryImportGenerator._* |
-|  __`SYSLIB1060`__ | *_`SYSLIB1055`-`SYSLIB1066` reserved for Microsoft.Interop.LibraryImportGenerator._* |
-|  __`SYSLIB1061`__ | *_`SYSLIB1055`-`SYSLIB1066` reserved for Microsoft.Interop.LibraryImportGenerator._* |
-|  __`SYSLIB1062`__ | *_`SYSLIB1055`-`SYSLIB1066` reserved for Microsoft.Interop.LibraryImportGenerator._* |
-|  __`SYSLIB1063`__ | *_`SYSLIB1055`-`SYSLIB1066` reserved for Microsoft.Interop.LibraryImportGenerator._* |
-|  __`SYSLIB1064`__ | *_`SYSLIB1055`-`SYSLIB1066` reserved for Microsoft.Interop.LibraryImportGenerator._* |
-|  __`SYSLIB1065`__ | *_`SYSLIB1055`-`SYSLIB1066` reserved for Microsoft.Interop.LibraryImportGenerator._* |
-|  __`SYSLIB1066`__ | *_`SYSLIB1055`-`SYSLIB1066` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1053`__ | Specified LibraryImportAttribute arguments cannot be forwarded to DllImportAttribute |
+|  __`SYSLIB1054`__ | Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time |
+|  __`SYSLIB1055`__ | Invalid CustomTypeMarshallerAttribute usage |
+|  __`SYSLIB1056`__ | Specified native type is invalid |
+|  __`SYSLIB1057`__ | Marshaller type does not have the required shape |
+|  __`SYSLIB1058`__ | Marshaller type defines a well-known method without specifying support for the corresponding feature |
+|  __`SYSLIB1059`__ | Marshaller type does not support allocating constructor |
+|  __`SYSLIB1060`__ | BufferSize should be set on CustomTypeMarshallerAttribute |
+|  __`SYSLIB1061`__ | Marshaller type has incompatible method signatures |
+|  __`SYSLIB1062`__ | *_`SYSLIB1062`-`SYSLIB1064` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1063`__ | *_`SYSLIB1062`-`SYSLIB1064` reserved for Microsoft.Interop.LibraryImportGenerator._* |
+|  __`SYSLIB1064`__ | *_`SYSLIB1062`-`SYSLIB1064` reserved for Microsoft.Interop.LibraryImportGenerator._* |

--- a/src/libraries/Common/tests/TestUtilities/System/WindowsIdentityFixture.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/WindowsIdentityFixture.cs
@@ -113,11 +113,8 @@ namespace System
         [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool LogonUser(string userName, string domain, string password, int logonType, int logonProvider, out SafeAccessTokenHandle safeAccessTokenHandle);
 
-#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
-        // TODO: [LibraryImportGenerator] Switch to use LibraryImport once we add support for non-blittable struct marshalling.
-        [DllImport("netapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint NetUserAdd([MarshalAs(UnmanagedType.LPWStr)]string servername, uint level, ref USER_INFO_1 buf, out uint parm_err);
-#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        [LibraryImport("netapi32.dll", SetLastError = true)]
+        internal static partial uint NetUserAdd([MarshalAs(UnmanagedType.LPWStr)]string servername, uint level, ref USER_INFO_1 buf, out uint parm_err);
 
         [LibraryImport("netapi32.dll")]
         internal static partial uint NetUserDel([MarshalAs(UnmanagedType.LPWStr)]string servername, [MarshalAs(UnmanagedType.LPWStr)]string username);

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/AnalyzerDiagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/AnalyzerDiagnostics.cs
@@ -13,19 +13,19 @@ namespace Microsoft.Interop.Analyzers
         /// </summary>
         public static class Ids
         {
-            public const string Prefix = "DLLIMPORTGENANALYZER";
+            public const string Prefix = "SYSLIB";
 
             // Migration from DllImport to LibraryImport
-            public const string ConvertToLibraryImport = Prefix + "001";
+            public const string ConvertToLibraryImport = Prefix + "1054";
 
             // CustomTypeMarshaller
-            public const string InvalidCustomTypeMarshallerAttributeUsage = Prefix + "002";
-            public const string InvalidNativeType = Prefix + "003";
-            public const string CustomMarshallerTypeMustHaveRequiredShape = Prefix + "004";
-            public const string ProvidedMethodsNotSpecifiedInFeatures = Prefix + "005";
-            public const string MissingAllocatingMarshallingFallback = Prefix + "006";
-            public const string CallerAllocConstructorMustHaveBufferSize = Prefix + "007";
-            public const string InvalidSignaturesInMarshallerShape = Prefix + "008";
+            public const string InvalidCustomTypeMarshallerAttributeUsage = Prefix + "1055";
+            public const string InvalidNativeType = Prefix + "1056";
+            public const string CustomMarshallerTypeMustHaveRequiredShape = Prefix + "1057";
+            public const string ProvidedMethodsNotSpecifiedInFeatures = Prefix + "1058";
+            public const string MissingAllocatingMarshallingFallback = Prefix + "1059";
+            public const string CallerAllocConstructorMustHaveBufferSize = Prefix + "1060";
+            public const string InvalidSignaturesInMarshallerShape = Prefix + "1061";
         }
 
         internal static LocalizableResourceString GetResourceString(string resourceName)

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/GeneratorDiagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/GeneratorDiagnostics.cs
@@ -22,8 +22,7 @@ namespace Microsoft.Interop
             public const string InvalidLibraryImportAttributeUsage = Prefix + "1050";
             public const string TypeNotSupported = Prefix + "1051";
             public const string ConfigurationNotSupported = Prefix + "1052";
-            public const string TargetFrameworkNotSupported = Prefix + "1053";
-            public const string CannotForwardToDllImport = Prefix + "1054";
+            public const string CannotForwardToDllImport = Prefix + "1053";
         }
 
         private const string Category = "LibraryImportGenerator";
@@ -147,16 +146,6 @@ namespace Microsoft.Interop
                 DiagnosticSeverity.Error,
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(SR.ConfigurationNotSupportedDescription)));
-
-        public static readonly DiagnosticDescriptor TargetFrameworkNotSupported =
-            new DiagnosticDescriptor(
-                Ids.TargetFrameworkNotSupported,
-                GetResourceString(nameof(SR.TargetFrameworkNotSupportedTitle)),
-                GetResourceString(nameof(SR.TargetFrameworkNotSupportedMessage)),
-                Category,
-                DiagnosticSeverity.Error,
-                isEnabledByDefault: true,
-                description: GetResourceString(nameof(SR.TargetFrameworkNotSupportedDescription)));
 
         public static readonly DiagnosticDescriptor CannotForwardToDllImport =
             new DiagnosticDescriptor(
@@ -325,19 +314,6 @@ namespace Microsoft.Interop
                 attributeData.CreateDiagnostic(
                     GeneratorDiagnostics.MarshallingAttributeConfigurationNotSupported,
                     new LocalizableResourceString(reasonResourceName, SR.ResourceManager, typeof(FxResources.Microsoft.Interop.LibraryImportGenerator.SR), reasonArgs)));
-        }
-
-        /// <summary>
-        /// Report diagnostic for targeting a framework that is not supported
-        /// </summary>
-        /// <param name="minimumSupportedVersion">Minimum supported version of .NET</param>
-        public void ReportTargetFrameworkNotSupported(Version minimumSupportedVersion)
-        {
-            _diagnostics.Add(
-                Diagnostic.Create(
-                    TargetFrameworkNotSupported,
-                    Location.None,
-                    minimumSupportedVersion.ToString(2)));
         }
 
         /// <summary>

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
@@ -92,24 +92,6 @@ namespace Microsoft.Interop
                     return (compilation, fmk, targetFrameworkVersion);
                 });
 
-            context.RegisterSourceOutput(
-                compilationAndTargetFramework
-                    .Combine(methodsToGenerate.Collect()),
-                static (context, data) =>
-                {
-                    if (data.Left.targetFramework is TargetFramework.Unknown && data.Right.Any())
-                    {
-                        // We don't block source generation when the TFM is unknown.
-                        // This allows a user to copy generated source and use it as a starting point
-                        // for manual marshalling if desired.
-                        context.ReportDiagnostic(
-                            Diagnostic.Create(
-                                GeneratorDiagnostics.TargetFrameworkNotSupported,
-                                Location.None,
-                                data.Left.targetFrameworkVersion));
-                    }
-                });
-
             IncrementalValueProvider<LibraryImportGeneratorOptions> stubOptions = context.AnalyzerConfigOptionsProvider
                 .Select(static (options, ct) => new LibraryImportGeneratorOptions(options.GlobalOptions));
 

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/Strings.resx
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/Strings.resx
@@ -284,17 +284,6 @@
   <data name="SafeHandleByRefMustBeConcrete" xml:space="preserve">
     <value>An abstract type derived from 'SafeHandle' cannot be marshalled by reference. The provided type must be concrete.</value>
   </data>
-  <data name="TargetFrameworkNotSupportedDescription" xml:space="preserve">
-    <value>P/Invoke source generation is not supported on unknown target framework v{0}. The generated source will not be compatible with other frameworks.</value>
-    <comment>{0} is a version number</comment>
-  </data>
-  <data name="TargetFrameworkNotSupportedMessage" xml:space="preserve">
-    <value>'LibraryImportAttribute' cannot be used for source-generated P/Invokes on an unknown target framework v{0}.</value>
-    <comment>{0} is a version number</comment>
-  </data>
-  <data name="TargetFrameworkNotSupportedTitle" xml:space="preserve">
-    <value>Current target framework is not supported by source-generated P/Invokes</value>
-  </data>
   <data name="TypeNotSupportedDescription" xml:space="preserve">
     <value>For types that are not supported by source-generated P/Invokes, the resulting P/Invoke will rely on the underlying runtime to marshal the specified type.</value>
   </data>

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.cs.xlf
@@ -462,21 +462,6 @@
         <target state="translated">Abstraktní typ odvozený ze SafeHandle nelze zařadit pomocí odkazu. Poskytnutý typ musí být konkrétní.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedDescription">
-        <source>P/Invoke source generation is not supported on unknown target framework v{0}. The generated source will not be compatible with other frameworks.</source>
-        <target state="translated">Generování zdroje voláním P/Invoke se u neznámé cílové architektura v{0} nepodporuje. Generovaný zdroj nebude kompatibilní s ostatními architekturami.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedMessage">
-        <source>'LibraryImportAttribute' cannot be used for source-generated P/Invokes on an unknown target framework v{0}.</source>
-        <target state="translated">LibraryImportAttribute nelze použít pro zdrojem generovaná volání P/Invokes v neznámé cílové architektuře v{0}.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedTitle">
-        <source>Current target framework is not supported by source-generated P/Invokes</source>
-        <target state="translated">Současná cílová architektura není podporována zdrojem generovanými voláními P/Invokes</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ToNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureDescription">
         <source>A marshaller type that provides a 'ToNativeValue' method should specify that it supports the 'TwoStageMarshalling' feature.</source>
         <target state="translated">Typ zařazování, které poskytuje metodu ToNativeValue, by měl určovat, že podporuje funkci TwoStageMarshalling.</target>

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.de.xlf
@@ -462,21 +462,6 @@
         <target state="translated">Ein abstrakter Typ, der von \"SafeHandle\" abgeleitet wird, kann nicht als Verweis gemarshallt werden. Der angegebene Typ muss ein konkretes Element sein.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedDescription">
-        <source>P/Invoke source generation is not supported on unknown target framework v{0}. The generated source will not be compatible with other frameworks.</source>
-        <target state="translated">Die P/Invoke-Quellgenerierung wird auf unbekanntem Zielframework v{0} nicht unterstützt. Die generierte Quelle ist nicht mit anderen Frameworks kompatibel.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedMessage">
-        <source>'LibraryImportAttribute' cannot be used for source-generated P/Invokes on an unknown target framework v{0}.</source>
-        <target state="translated">\"LibraryImportAttribute\" kann nicht für von der Quelle generierte P/Invokes in einem unbekannten Zielframework v{0} verwendet werden.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedTitle">
-        <source>Current target framework is not supported by source-generated P/Invokes</source>
-        <target state="translated">Das aktuelle Zielframework wird von quellgenerierten P/Invokes nicht unterstützt.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ToNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureDescription">
         <source>A marshaller type that provides a 'ToNativeValue' method should specify that it supports the 'TwoStageMarshalling' feature.</source>
         <target state="translated">Ein Marshallertyp, der eine ToNativeValue-Methode bereitstellt, sollte angeben, dass er das Feature \"TwoStageMarshalling\" unterstützt.</target>

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.es.xlf
@@ -462,21 +462,6 @@
         <target state="translated">Un tipo abstracto derivado de “SafeHandle” no se puede serializar por referencia. El tipo proporcionado debe ser concreto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedDescription">
-        <source>P/Invoke source generation is not supported on unknown target framework v{0}. The generated source will not be compatible with other frameworks.</source>
-        <target state="translated">No se admite la generación de código fuente en la plataforma de destino v{0} desconocida. El código fuente generado no será compatible con otras plataformas.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedMessage">
-        <source>'LibraryImportAttribute' cannot be used for source-generated P/Invokes on an unknown target framework v{0}.</source>
-        <target state="translated">“LibraryImportAttribute” no se puede usar para P/Invokes de un generador de código fuente en una plataforma de destino v{0} desconocida.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedTitle">
-        <source>Current target framework is not supported by source-generated P/Invokes</source>
-        <target state="translated">La plataforma de destino actual no está admitida por P/Invokes de un generador de código fuente</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ToNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureDescription">
         <source>A marshaller type that provides a 'ToNativeValue' method should specify that it supports the 'TwoStageMarshalling' feature.</source>
         <target state="translated">Un tipo de serializador que proporciona un método “ToNativeValue” debe especificar que admite la característica “TwoStageMarshalling”.</target>

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.fr.xlf
@@ -462,21 +462,6 @@
         <target state="translated">Un type abstrait dérivé de « SafeHandle » ne peut pas être marshalé par référence. Le type fourni doit être concret.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedDescription">
-        <source>P/Invoke source generation is not supported on unknown target framework v{0}. The generated source will not be compatible with other frameworks.</source>
-        <target state="translated">La génération de source P/Invoke n’est pas prise en charge sur le framework cible inconnu v{0}. La source générée ne sera pas compatible avec d’autres frameworks.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedMessage">
-        <source>'LibraryImportAttribute' cannot be used for source-generated P/Invokes on an unknown target framework v{0}.</source>
-        <target state="translated">« LibraryImportAttribute » ne peut pas être utilisé pour les P/Invok générés par la source sur un framework cible inconnu v{0}.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedTitle">
-        <source>Current target framework is not supported by source-generated P/Invokes</source>
-        <target state="translated">Le framework cible actuel n’est pas pris en charge par les P/Invokes générés par la source</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ToNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureDescription">
         <source>A marshaller type that provides a 'ToNativeValue' method should specify that it supports the 'TwoStageMarshalling' feature.</source>
         <target state="translated">Un type marshaleur qui fournit une méthode « ToNativeValue » doit spécifier qu’il prend en charge la fonctionnalité « TwoStageMarsoboing ».</target>

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.it.xlf
@@ -462,21 +462,6 @@
         <target state="translated">Non è possibile effettuare il marshalling per riferimento di un tipo astratto derivato da 'SafeHandle'. Il tipo specificato deve essere concreto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedDescription">
-        <source>P/Invoke source generation is not supported on unknown target framework v{0}. The generated source will not be compatible with other frameworks.</source>
-        <target state="translated">La generazione dell'origine P/Invoke non è supportata nel framework di destinazione sconosciuto v{0}. L'origine generata non sarà compatibile con altri framework.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedMessage">
-        <source>'LibraryImportAttribute' cannot be used for source-generated P/Invokes on an unknown target framework v{0}.</source>
-        <target state="translated">Non è possibile usare 'LibraryImportAttribute' per P/Invoke generati dall'origine in un framework di destinazione sconosciuto v{0}.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedTitle">
-        <source>Current target framework is not supported by source-generated P/Invokes</source>
-        <target state="translated">Il framework di destinazione corrente non è supportato dai P/Invoke generati dall'origine</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ToNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureDescription">
         <source>A marshaller type that provides a 'ToNativeValue' method should specify that it supports the 'TwoStageMarshalling' feature.</source>
         <target state="translated">Un tipo di gestore del marshalling che fornisce un metodo 'ToNativeValue' deve specificare che supporta la funzionalità 'TwoStageMarshalling'.</target>

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.ja.xlf
@@ -462,21 +462,6 @@
         <target state="translated">'SafeHandle' から派生した抽象型は、参照でマーシャリングできません。指定される型は具象型である必要があります。</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedDescription">
-        <source>P/Invoke source generation is not supported on unknown target framework v{0}. The generated source will not be compatible with other frameworks.</source>
-        <target state="translated">P/Invoke ソース生成は、不明なターゲット フレームワーク v{0} ではサポートされていません。生成されたソースは、他のフレームワークと互換性がありません。</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedMessage">
-        <source>'LibraryImportAttribute' cannot be used for source-generated P/Invokes on an unknown target framework v{0}.</source>
-        <target state="translated">'LibraryImportAttribute' は、不明なターゲット フレームワーク v{0} でソース生成済みの P/Invoke には使用できません。</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedTitle">
-        <source>Current target framework is not supported by source-generated P/Invokes</source>
-        <target state="translated">現在のターゲット フレームワークは、ソースで生成された P/Invoke ではサポートされていません</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ToNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureDescription">
         <source>A marshaller type that provides a 'ToNativeValue' method should specify that it supports the 'TwoStageMarshalling' feature.</source>
         <target state="translated">'ToNativeValue' メソッドを指定するマーシャラー型では、'TwoStageMarshalling' 機能をサポートすることを指定する必要があります。</target>

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.ko.xlf
@@ -462,21 +462,6 @@
         <target state="translated">'SafeHandle'에서 파생된 추상 형식은 참조로 마샬링할 수 없습니다. 제공된 형식은 구체적이어야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedDescription">
-        <source>P/Invoke source generation is not supported on unknown target framework v{0}. The generated source will not be compatible with other frameworks.</source>
-        <target state="translated">알 수 없는 대상 프레임워크 v{0}에서는 P/Invoke 소스 생성이 지원되지 않습니다. 생성된 소스는 다른 프레임워크와 호환되지 않습니다.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedMessage">
-        <source>'LibraryImportAttribute' cannot be used for source-generated P/Invokes on an unknown target framework v{0}.</source>
-        <target state="translated">알 수 없는 대상 프레임워크 v{0}에서 소스 생성 P/Invoke에 'LibraryImportAttribute'를 사용할 수 없습니다.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedTitle">
-        <source>Current target framework is not supported by source-generated P/Invokes</source>
-        <target state="translated">현재 대상 프레임워크는 소스 생성 P/Invoke에서 지원되지 않습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ToNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureDescription">
         <source>A marshaller type that provides a 'ToNativeValue' method should specify that it supports the 'TwoStageMarshalling' feature.</source>
         <target state="translated">'ToNativeValue' 메서드를 제공하는 마샬러 형식은 'TwoStageMarshalling' 기능을 지원하도록 지정해야 합니다.</target>

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.pl.xlf
@@ -462,21 +462,6 @@
         <target state="translated">Typ abstrakcyjny pochodzący od elementu „SafeHandle” nie może być skierowany przez odwołanie. Podany typ musi być konkretny.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedDescription">
-        <source>P/Invoke source generation is not supported on unknown target framework v{0}. The generated source will not be compatible with other frameworks.</source>
-        <target state="translated">Generowanie źródła funkcji P/Invoke nie jest obsługiwane w nieznanej platformie docelowej v{0}. Wygenerowane źródło nie będzie zgodne z innymi platformami.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedMessage">
-        <source>'LibraryImportAttribute' cannot be used for source-generated P/Invokes on an unknown target framework v{0}.</source>
-        <target state="translated">Element „LibraryImportAttribute” nie może być używany w przypadku funkcji P/Invokes generowanej przez źródło w nieznanej platformie docelowej v{0}.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedTitle">
-        <source>Current target framework is not supported by source-generated P/Invokes</source>
-        <target state="translated">Bieżąca platforma docelowa nie jest obsługiwana przez funkcję P/Invokes generowaną przez źródło</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ToNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureDescription">
         <source>A marshaller type that provides a 'ToNativeValue' method should specify that it supports the 'TwoStageMarshalling' feature.</source>
         <target state="translated">Typ elementu przeprowadzającego marshalling, który udostępnia metodę „ToNativeValue”, powinien określać, że obsługuje on funkcję „TwoStageMarshalling”.</target>

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.pt-BR.xlf
@@ -462,21 +462,6 @@
         <target state="translated">Um tipo abstrato derivado de 'SafeHandle' não pode ser marshalled por referência. O tipo fornecido deve ser concreto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedDescription">
-        <source>P/Invoke source generation is not supported on unknown target framework v{0}. The generated source will not be compatible with other frameworks.</source>
-        <target state="translated">Não há suporte para a geração de origem P/Invoke em estrutura de destino v{0}. A origem gerada não será compatível com outras estruturas.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedMessage">
-        <source>'LibraryImportAttribute' cannot be used for source-generated P/Invokes on an unknown target framework v{0}.</source>
-        <target state="translated">'LibraryImportAttribute' não pode ser usado para P/Invokes gerados pela origem em uma estrutura de destino v{0}.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedTitle">
-        <source>Current target framework is not supported by source-generated P/Invokes</source>
-        <target state="translated">A estrutura de destino atual não tem suporte de P/Invokes gerados pela origem</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ToNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureDescription">
         <source>A marshaller type that provides a 'ToNativeValue' method should specify that it supports the 'TwoStageMarshalling' feature.</source>
         <target state="translated">Um tipo de marshaller que fornece um método 'ToNativeValue' deve especificar que ele dá suporte ao recurso 'TwoStageMarshalling'.</target>

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.ru.xlf
@@ -462,21 +462,6 @@
         <target state="translated">Абстрактный тип, производный от \"SafeHandle\", нельзя маршализировать по ссылке. Указанный тип должен быть конкретным.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedDescription">
-        <source>P/Invoke source generation is not supported on unknown target framework v{0}. The generated source will not be compatible with other frameworks.</source>
-        <target state="translated">Создание источника в P/Invoke не поддерживается для неизвестной целевой платформы версии {0}. Созданный источник не будет совместим с другими платформами.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedMessage">
-        <source>'LibraryImportAttribute' cannot be used for source-generated P/Invokes on an unknown target framework v{0}.</source>
-        <target state="translated">\"LibraryImportAttribute\" нельзя использовать для P/Invoke с созданием источника на неизвестной целевой платформе версии {0}.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedTitle">
-        <source>Current target framework is not supported by source-generated P/Invokes</source>
-        <target state="translated">Текущая целевая платформа не поддерживается в P/Invoke с созданием источника</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ToNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureDescription">
         <source>A marshaller type that provides a 'ToNativeValue' method should specify that it supports the 'TwoStageMarshalling' feature.</source>
         <target state="translated">Тип маршалатора, который предоставляет метод \"ToNativeValue\", должен указывать, что он поддерживает функцию \"TwoStageMarshalling\".</target>

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.tr.xlf
@@ -462,21 +462,6 @@
         <target state="translated">'SafeHandle' özelliğinden türetilen soyut türler, başvuruya göre sıralanamaz. Sağlanan tür somut olmalıdır.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedDescription">
-        <source>P/Invoke source generation is not supported on unknown target framework v{0}. The generated source will not be compatible with other frameworks.</source>
-        <target state="translated">P/Invoke kaynak oluşturma işlemi, bilinmeyen hedef çerçeve v{0} üzerinde desteklenmiyor. Oluşturulan kaynak diğer çerçevelerle uyumlu değil.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedMessage">
-        <source>'LibraryImportAttribute' cannot be used for source-generated P/Invokes on an unknown target framework v{0}.</source>
-        <target state="translated">'LibraryImportAttribute', bilinmeyen hedef çerçeve v{0} üzerinde kaynak tarafından oluşturulan P/Invokes için kullanılamaz.</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedTitle">
-        <source>Current target framework is not supported by source-generated P/Invokes</source>
-        <target state="translated">Geçerli hedef çerçeve, kaynak tarafından oluşturulan P/Invokes tarafından desteklenmiyor</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ToNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureDescription">
         <source>A marshaller type that provides a 'ToNativeValue' method should specify that it supports the 'TwoStageMarshalling' feature.</source>
         <target state="translated">Bir 'ToNativeValue' metodunun sağlandığı sıralayıcı türünde türün, 'TwoStageMarshalling' özelliğini desteklediği belirtilmelidir.</target>

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.zh-Hans.xlf
@@ -462,21 +462,6 @@
         <target state="translated">无法通过引用封送派生自 “SafeHandle” 的抽象类型。提供的类型必须是具体的。</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedDescription">
-        <source>P/Invoke source generation is not supported on unknown target framework v{0}. The generated source will not be compatible with other frameworks.</source>
-        <target state="translated">未知目标框架 v{0} 不支持 P/Invoke 源生成。生成的源将与其他框架不兼容。</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedMessage">
-        <source>'LibraryImportAttribute' cannot be used for source-generated P/Invokes on an unknown target framework v{0}.</source>
-        <target state="translated">“LibraryImportAttribute” 无法用于未知目标框架 v{0} 上的源生成的 P/Invoke。</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedTitle">
-        <source>Current target framework is not supported by source-generated P/Invokes</source>
-        <target state="translated">源生成的 P/Invoke 不支持当前目标框架</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ToNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureDescription">
         <source>A marshaller type that provides a 'ToNativeValue' method should specify that it supports the 'TwoStageMarshalling' feature.</source>
         <target state="translated">提供 “ToNativeValue” 方法的封送程序类型应指定它支持 “TwoStageMarshalling” 功能。</target>

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Resources/xlf/Strings.zh-Hant.xlf
@@ -462,21 +462,6 @@
         <target state="translated">衍生自 'SafeHandle' 的抽象類型無法依參考排列。提供的類型必須是實體。</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedDescription">
-        <source>P/Invoke source generation is not supported on unknown target framework v{0}. The generated source will not be compatible with other frameworks.</source>
-        <target state="translated">未知的目标架構 v{0} 不支援產生 P/Invoke 来源。產生的来源將與其他架構不兼容。</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedMessage">
-        <source>'LibraryImportAttribute' cannot be used for source-generated P/Invokes on an unknown target framework v{0}.</source>
-        <target state="translated">'LibraryImportAttribute' 無法用于未知的目標架構 v{0} 上来源產生的 P/Invokes。</target>
-        <note>{0} is a version number</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkNotSupportedTitle">
-        <source>Current target framework is not supported by source-generated P/Invokes</source>
-        <target state="translated">来源產生的 P/Invokes 不支援目前的目標價構</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ToNativeValueMethodProvidedShouldSpecifyTwoStageMarshallingFeatureDescription">
         <source>A marshaller type that provides a 'ToNativeValue' method should specify that it supports the 'TwoStageMarshalling' feature.</source>
         <target state="translated">提供 'ToNativeValue' 方法的封送處理器類型應該指定它支援 'TwoStageMarshalling' 功能。</target>

--- a/src/samples/LibraryImportGeneratorSample/.editorconfig
+++ b/src/samples/LibraryImportGeneratorSample/.editorconfig
@@ -1,4 +1,4 @@
 ﻿[*.cs]
 
-# SYSLIB1054: Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+# SYSLIB1054: Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 dotnet_diagnostic.SYSLIB1054.severity = default

--- a/src/samples/LibraryImportGeneratorSample/.editorconfig
+++ b/src/samples/LibraryImportGeneratorSample/.editorconfig
@@ -1,4 +1,4 @@
 ﻿[*.cs]
 
-# DLLIMPORTGENANALYZER015: Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
-dotnet_diagnostic.DLLIMPORTGENANALYZER015.severity = default
+# SYSLIB1054: Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+dotnet_diagnostic.SYSLIB1054.severity = default


### PR DESCRIPTION
This also removes an old diagnostic about unsupported target frameworks (from before we did the forwarding) - stolen from https://github.com/dotnet/runtime/issues/60595.

This should be the last item in https://github.com/dotnet/runtime/issues/60595. And then it is docs/samples.