### PR TITLE
[wasm][debugger] Firefox - remove item from commands_received

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxExecutionContext.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxExecutionContext.cs
@@ -12,6 +12,7 @@ internal sealed class FirefoxExecutionContext : ExecutionContext
     public string? ActorName { get; set; }
     public string? ThreadName { get; set; }
     public string? GlobalName { get; set; }
+    public Result LastDebuggerAgentBufferReceived { get; set; }
 
     public FirefoxExecutionContext(MonoSDBHelper sdbAgent, int id, string actorName) : base(sdbAgent, id, actorName)
     {

--- a/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxMonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxMonoProxy.cs
@@ -660,13 +660,19 @@ internal sealed class FirefoxMonoProxy : MonoProxy
         return false;
     }
 
+    internal override void SaveLastDebuggerAgentBufferReceivedToContext(SessionId sessionId, Result res)
+    {
+        var context = GetContextFixefox(sessionId);
+        context.LastDebuggerAgentBufferReceived = res;
+    }
+
     private async Task<bool> SendPauseToBrowser(SessionId sessionId, JObject args, CancellationToken token)
     {
-        Result res = await SendMonoCommand(sessionId, MonoCommands.GetDebuggerAgentBufferReceived(RuntimeId), token);
+        var context = GetContextFixefox(sessionId);
+        Result res = context.LastDebuggerAgentBufferReceived;
         if (!res.IsOk)
             return false;
 
-        var context = GetContextFixefox(sessionId);
         byte[] newBytes = Convert.FromBase64String(res.Value?["result"]?["value"]?["value"]?.Value<string>());
         using var retDebuggerCmdReader = new MonoBinaryReader(newBytes);
         retDebuggerCmdReader.ReadBytes(11);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -1061,9 +1061,15 @@ namespace Microsoft.WebAssembly.Diagnostics
 
             return true;
         }
+
+        internal virtual void SaveLastDebuggerAgentBufferReceivedToContext(SessionId sessionId, Result res)
+        {
+        }
+
         internal async Task<bool> OnReceiveDebuggerAgentEvent(SessionId sessionId, JObject args, CancellationToken token)
         {
             Result res = await SendMonoCommand(sessionId, MonoCommands.GetDebuggerAgentBufferReceived(RuntimeId), token);
+            SaveLastDebuggerAgentBufferReceivedToContext(sessionId, res);
             if (!res.IsOk)
                 return false;
 

--- a/src/mono/wasm/runtime/debug.ts
+++ b/src/mono/wasm/runtime/debug.ts
@@ -105,7 +105,7 @@ export function mono_wasm_send_dbg_command(id: number, command_set: number, comm
 }
 
 export function mono_wasm_get_dbg_command_info(): CommandResponseResult {
-    const { res_ok, res } = commands_received.get(0);
+    const { res_ok, res } = commands_received.remove(0);
 
     if (!res_ok)
         throw new Error("Failed on mono_wasm_get_dbg_command_info");


### PR DESCRIPTION
Fixing firefox implementation to avoid this warning: Addind an id that already exists in commands_received