### PR TITLE
Remove gtSetCallArgsOrder quirk

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -3401,24 +3401,7 @@ unsigned Compiler::gtSetCallArgsOrder(CallArgs* args, bool lateArgs, int* callCo
         {
             GenTree* node  = arg.GetEarlyNode();
             unsigned level = gtSetEvalOrder(node);
-
-            if (arg.GetWellKnownArg() == WellKnownArg::ThisPointer)
-            {
-                // TODO-ARGS: Quirk to match old costs assigned to 'this'
-                costEx += node->GetCostEx();
-                costSz += node->GetCostSz() + 1;
-            }
-            else
-            {
-                update(node, level);
-            }
-        }
-
-        // TODO-ARGS: Quirk to match old costs assigned to 'this'
-        CallArg* thisArg = args->GetThisArg();
-        if ((thisArg != nullptr) && (thisArg->GetEarlyNode() == nullptr))
-        {
-            costSz++;
+            update(node, level);
         }
     }
 


### PR DESCRIPTION
This quirk was added during the call args refactoring because the 'this'
argument had special handling before that.

The quirked code assigns the 'this' arg in the early list 1 higher "size" cost than other early args. We use that cost in loop inversion to decide whether to duplicate the guard condition or not, so I expect we will see some size-wise regressions because we duplicate the loop condition more often now when the condition involves a call.