### PR TITLE
Disable win-arm64 runtime tests on PRs for CoreCLR

### DIFF
--- a/eng/pipelines/coreclr/crossgen2-composite.yml
+++ b/eng/pipelines/coreclr/crossgen2-composite.yml
@@ -22,7 +22,8 @@ jobs:
     - OSX_x64
     - windows_x86
     - windows_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: innerloop
@@ -49,7 +50,8 @@ jobs:
     - OSX_x64
     - windows_x86
     - windows_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     jobParameters:
       testGroup: innerloop
       readyToRun: true

--- a/eng/pipelines/coreclr/crossgen2-outerloop.yml
+++ b/eng/pipelines/coreclr/crossgen2-outerloop.yml
@@ -22,7 +22,8 @@ jobs:
     - OSX_x64
     - windows_x86
     - windows_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: outerloop
@@ -53,7 +54,8 @@ jobs:
     - OSX_x64
     - windows_x86
     - windows_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       isOfficialBuild: false

--- a/eng/pipelines/coreclr/crossgen2.yml
+++ b/eng/pipelines/coreclr/crossgen2.yml
@@ -20,7 +20,8 @@ jobs:
     - OSX_arm64
     - OSX_x64
     - windows_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: innerloop
@@ -45,7 +46,8 @@ jobs:
     - OSX_arm64
     - OSX_x64
     - windows_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     jobParameters:
       testGroup: innerloop
       readyToRun: true

--- a/eng/pipelines/coreclr/exploratory.yml
+++ b/eng/pipelines/coreclr/exploratory.yml
@@ -27,7 +27,8 @@ jobs:
     - Linux_x64
     - windows_x64
     - windows_x86
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - OSX_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
@@ -44,7 +45,8 @@ jobs:
     - Linux_x64
     - windows_x64
     - windows_x86
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - OSX_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml

--- a/eng/pipelines/coreclr/gc-longrunning.yml
+++ b/eng/pipelines/coreclr/gc-longrunning.yml
@@ -18,7 +18,8 @@ jobs:
     - Linux_x64
     - Linux_arm64
     - windows_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - OSX_x64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
@@ -41,7 +42,8 @@ jobs:
     - Linux_x64
     - Linux_arm64
     - windows_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/gc-simulator.yml
+++ b/eng/pipelines/coreclr/gc-simulator.yml
@@ -19,7 +19,8 @@ jobs:
     # - Linux_x64
     - Linux_arm64
     - windows_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - OSX_x64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
@@ -43,7 +44,8 @@ jobs:
     # - Linux_x64
     - Linux_arm64
     - windows_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/jit-cfg.yml
+++ b/eng/pipelines/coreclr/jit-cfg.yml
@@ -17,7 +17,8 @@ jobs:
     platforms:
     - Linux_arm64
     - Linux_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - windows_x64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
@@ -39,7 +40,8 @@ jobs:
     platforms:
     - Linux_arm64
     - Linux_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - windows_x64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml

--- a/eng/pipelines/coreclr/jit-experimental.yml
+++ b/eng/pipelines/coreclr/jit-experimental.yml
@@ -19,7 +19,8 @@ jobs:
     - OSX_x64
     - Linux_arm64
     - Linux_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - windows_x64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
@@ -43,7 +44,8 @@ jobs:
     - OSX_x64
     - Linux_arm64
     - Linux_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - windows_x64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml

--- a/eng/pipelines/coreclr/jitstress-isas-arm.yml
+++ b/eng/pipelines/coreclr/jitstress-isas-arm.yml
@@ -17,7 +17,8 @@ jobs:
     platforms:
     - Linux_arm64
     - OSX_arm64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: jitstress-isas-arm
@@ -38,7 +39,8 @@ jobs:
     platforms:
     - Linux_arm64
     - OSX_arm64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/jitstress.yml
+++ b/eng/pipelines/coreclr/jitstress.yml
@@ -22,7 +22,8 @@ jobs:
     - Linux_x64
     - windows_x64
     - windows_x86
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: jitstress
@@ -48,7 +49,8 @@ jobs:
     - Linux_x64
     - windows_x64
     - windows_x86
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/jitstress2-jitstressregs.yml
+++ b/eng/pipelines/coreclr/jitstress2-jitstressregs.yml
@@ -22,7 +22,8 @@ jobs:
     - Linux_x64
     - windows_x64
     - windows_x86
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: jitstress2-jitstressregs
@@ -48,7 +49,8 @@ jobs:
     - Linux_x64
     - windows_x64
     - windows_x86
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/libraries-jitstress.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress.yml
@@ -23,7 +23,8 @@ jobs:
     - Linux_arm64
     - windows_x86
     - windows_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     jobParameters:
       # libraries test build platforms
       testBuildPlatforms:
@@ -41,7 +42,8 @@ jobs:
     - Linux_arm
     - Linux_arm64
     - Linux_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - windows_x64
     - windows_x86
     helixQueueGroup: libraries

--- a/eng/pipelines/coreclr/libraries-jitstress2-jitstressregs.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress2-jitstressregs.yml
@@ -23,7 +23,8 @@ jobs:
     - Linux_arm64
     - windows_x86
     - windows_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     jobParameters:
       # libraries test build platforms
       testBuildPlatforms:
@@ -41,7 +42,8 @@ jobs:
     - Linux_arm
     - Linux_arm64
     - Linux_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - windows_x64
     - windows_x86
     helixQueueGroup: libraries

--- a/eng/pipelines/coreclr/libraries-jitstressregs.yml
+++ b/eng/pipelines/coreclr/libraries-jitstressregs.yml
@@ -23,7 +23,8 @@ jobs:
     - Linux_arm64
     - windows_x86
     - windows_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     jobParameters:
       # libraries test build platforms
       testBuildPlatforms:
@@ -41,7 +42,8 @@ jobs:
     - Linux_arm
     - Linux_arm64
     - Linux_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - windows_x64
     - windows_x86
     helixQueueGroup: libraries

--- a/eng/pipelines/coreclr/libraries-pgo.yml
+++ b/eng/pipelines/coreclr/libraries-pgo.yml
@@ -23,7 +23,8 @@ jobs:
     - Linux_arm64
     - windows_x86
     - windows_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     jobParameters:
       # libraries test build platforms
       testBuildPlatforms:
@@ -41,7 +42,8 @@ jobs:
     - Linux_arm
     - Linux_arm64
     - Linux_x64
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - windows_x64
     - windows_x86
     helixQueueGroup: libraries

--- a/eng/pipelines/coreclr/pgo.yml
+++ b/eng/pipelines/coreclr/pgo.yml
@@ -20,7 +20,8 @@ jobs:
     - Linux_x64
     - OSX_arm64
     - windows_arm
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - windows_x64
     - windows_x86
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
@@ -46,7 +47,8 @@ jobs:
     - Linux_x64
     - OSX_arm64
     - windows_arm
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - windows_x64
     - windows_x86
     helixQueueGroup: ci

--- a/eng/pipelines/coreclr/r2r.yml
+++ b/eng/pipelines/coreclr/r2r.yml
@@ -20,7 +20,8 @@ jobs:
     - Linux_x64
     - OSX_arm64
     - windows_arm
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - windows_x64
     - windows_x86
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
@@ -46,7 +47,8 @@ jobs:
     - Linux_x64
     - OSX_arm64
     - windows_arm
-    - windows_arm64
+    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
+    # - windows_arm64
     - windows_x64
     - windows_x86
     helixQueueGroup: ci

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -858,7 +858,6 @@ jobs:
     platforms:
     - Linux_arm
     - windows_x86
-    - windows_arm64
     helixQueueGroup: pr
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:
@@ -869,6 +868,23 @@ jobs:
           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
+          
+#
+# CoreCLR Test execution on Windows ARM64 using live libraries for rolling.
+# TODO: move to PR testing in the bracket above once https://github.com/dotnet/runtime/issues/68626 is closed
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+    buildConfig: checked
+    platforms:
+    - windows_arm64
+    helixQueueGroup: pr
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: innerloop
+      liveLibrariesBuildConfig: Release
+      condition: eq(variables['isRollingBuild'], true)
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/68626

Disable tests in PR builds for CoreCLR windows arm64 while we have decreased capacity. 