### PR TITLE
JIT: fix bad arm64 move peephole

### DIFF
--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -15724,8 +15724,7 @@ bool emitter::IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regN
         // Sometimes emitLastIns can be a mov with single register e.g. "mov reg, #imm". So ensure to
         // optimize formats that does vector-to-vector or scalar-to-scalar register movs.
         //
-        const bool isValidLastInsFormats =
-            ((lastInsfmt == IF_DV_3C) || (lastInsfmt == IF_DR_2G) || (lastInsfmt == IF_DR_2E));
+        const bool isValidLastInsFormats = ((lastInsfmt == IF_DV_3C) || (lastInsfmt == IF_DR_2E));
 
         if (isValidLastInsFormats && (prevDst == dst) && (prevSrc == src))
         {


### PR DESCRIPTION
`IF_DR_2G` `(mov sp/reg, reg/sp)` has an implicit reg2, so an unwary peephole opt
might mistakenly think it is `mov reg, x0`. If the opt is unlucky and the next
instruction is a real `mov reg, x0` the peephole opt might suppress the second
instruction, leaving the wrong value in `reg`.

Fix is to just disallow `IF_DR_2G` in the peephole.

Fixes #68527.