### PR TITLE
Switched to "index < length - 1" in BitConverter.ToBoolean for performance reasons

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -742,7 +742,7 @@ namespace System
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
             if (startIndex < 0)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_IndexMustBeLess);
-            if (startIndex >= value.Length)
+            if (startIndex > value.Length - 1)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_IndexMustBeLess); // differs from other overloads, which throw base ArgumentException
 
             return value[startIndex] != 0;


### PR DESCRIPTION
Possible fix of these:

1. https://github.com/dotnet/perf-autofiling-issues/issues/4727
2. https://github.com/dotnet/runtime/issues/68338
3. https://github.com/dotnet/perf-autofiling-issues/issues/4738
4. https://github.com/dotnet/perf-autofiling-issues/issues/4706
5. https://github.com/dotnet/perf-autofiling-issues/issues/4870

Introduced by me in this PR: #67696.
See  [this](https://github.com/dotnet/runtime/pull/67696#discussion_r857702227) comment for explanation. And other comments there related to regression.