### PR TITLE
`PUTARG_STK`/x86: mark `push [mem]` candidates reg optional

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -647,11 +647,17 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
         MakeSrcContained(putArgStk, src);
     }
 #ifdef TARGET_X86
-    else if ((genTypeSize(src) == TARGET_POINTER_SIZE) && IsContainableMemoryOp(src) &&
-             IsSafeToContainMem(putArgStk, src))
+    else if ((genTypeSize(src) == TARGET_POINTER_SIZE) && IsSafeToContainMem(putArgStk, src))
     {
-        // Contain for "push [mem]".
-        MakeSrcContained(putArgStk, src);
+        // We can use "src" directly from memory with "push [mem]".
+        if (IsContainableMemoryOp(src))
+        {
+            MakeSrcContained(putArgStk, src);
+        }
+        else
+        {
+            src->SetRegOptional();
+        }
     }
 #endif // TARGET_X86
 }


### PR DESCRIPTION
In #67400 I enabled containment for `PUTARG_STK` sources coming from memory on x86. This change completes that change by also enabling the "reg optional" setting, for yet [more CQ](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-68641/win-x86.md):

```
benchmarks.run.windows.x86:      -9.6K
coreclr_tests.pmi.windows.x86:   -37K
libraries.crossgen2.windows.x86: -81K
libraries.pmi.windows.x86:       -77K
libraries_tests.pmi.windows.x86: -114K
```
(All regressions are due to different allocation)