### PR TITLE
[wasm] Migrate rest of the JS interop functions to out params

### DIFF
--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
@@ -56,7 +56,7 @@ internal static partial class Interop
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern void WebSocketCloseRef(IntPtr webSocketJSHandle, int code, in string? reason, bool waitForCloseReceived, out IntPtr promiseJSHandle, out int exceptionalResult, out object result);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern string CancelPromise(IntPtr promiseJSHandle, out int exceptionalResult);
+        internal static extern void CancelPromise(IntPtr promiseJSHandle, out int exceptionalResult, out string result);
 
         // / <summary>
         // / Execute the provided string in the JavaScript context

--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern string InvokeJS(string str, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern object CompileFunction(string str, out int exceptionalResult);
+        internal static extern void CompileFunction(string str, out int exceptionalResult, out object result);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern void InvokeJSWithArgs(IntPtr jsHandle, string method, object?[] parms, out int exceptionalResult, out object result);
         // FIXME: All of these signatures need to be object? in various places and not object, but the nullability
@@ -73,7 +73,7 @@ internal static partial class Interop
 
         public static System.Runtime.InteropServices.JavaScript.Function? CompileFunction(string snippet)
         {
-            object res = CompileFunction(snippet, out int exception);
+            CompileFunction(snippet, out int exception, out object res);
             if (exception != 0)
                 throw new JSException((string)res);
             ReleaseInFlight(res);

--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
@@ -15,9 +15,9 @@ internal static partial class Interop
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern string InvokeJS(string str, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern void CompileFunction(string str, out int exceptionalResult, out object result);
+        internal static extern void CompileFunctionRef(string str, out int exceptionalResult, out object result);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern void InvokeJSWithArgs(IntPtr jsHandle, string method, object?[] parms, out int exceptionalResult, out object result);
+        internal static extern void InvokeJSWithArgsRef(IntPtr jsHandle, string method, object?[] parms, out int exceptionalResult, out object result);
         // FIXME: All of these signatures need to be object? in various places and not object, but the nullability
         //  warnings will take me hours and hours to fix so I'm not doing that right now since they're already broken
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
@@ -56,7 +56,7 @@ internal static partial class Interop
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern void WebSocketCloseRef(IntPtr webSocketJSHandle, int code, in string? reason, bool waitForCloseReceived, out IntPtr promiseJSHandle, out int exceptionalResult, out object result);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern void CancelPromise(IntPtr promiseJSHandle, out int exceptionalResult, out string result);
+        internal static extern void CancelPromiseRef(IntPtr promiseJSHandle, out int exceptionalResult, out string result);
 
         // / <summary>
         // / Execute the provided string in the JavaScript context
@@ -73,7 +73,7 @@ internal static partial class Interop
 
         public static System.Runtime.InteropServices.JavaScript.Function? CompileFunction(string snippet)
         {
-            CompileFunction(snippet, out int exception, out object res);
+            CompileFunctionRef(snippet, out int exception, out object res);
             if (exception != 0)
                 throw new JSException((string)res);
             ReleaseInFlight(res);

--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern string InvokeJS(string str, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern void CompileFunctionRef(string str, out int exceptionalResult, out object result);
+        internal static extern void CompileFunctionRef(in string str, out int exceptionalResult, out object result);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern void InvokeJSWithArgsRef(IntPtr jsHandle, in string method, in object?[] parms, out int exceptionalResult, out object result);
         // FIXME: All of these signatures need to be object? in various places and not object, but the nullability

--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
@@ -17,7 +17,7 @@ internal static partial class Interop
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern void CompileFunctionRef(string str, out int exceptionalResult, out object result);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern void InvokeJSWithArgsRef(IntPtr jsHandle, string method, object?[] parms, out int exceptionalResult, out object result);
+        internal static extern void InvokeJSWithArgsRef(IntPtr jsHandle, in string method, in object?[] parms, out int exceptionalResult, out object result);
         // FIXME: All of these signatures need to be object? in various places and not object, but the nullability
         //  warnings will take me hours and hours to fix so I'm not doing that right now since they're already broken
         [MethodImplAttribute(MethodImplOptions.InternalCall)]

--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
@@ -17,7 +17,7 @@ internal static partial class Interop
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern object CompileFunction(string str, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern object InvokeJSWithArgs(IntPtr jsHandle, string method, object?[] parms, out int exceptionalResult);
+        internal static extern void InvokeJSWithArgs(IntPtr jsHandle, string method, object?[] parms, out int exceptionalResult, out object result);
         // FIXME: All of these signatures need to be object? in various places and not object, but the nullability
         //  warnings will take me hours and hours to fix so I'm not doing that right now since they're already broken
         [MethodImplAttribute(MethodImplOptions.InternalCall)]

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
@@ -32,7 +32,7 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             AssertNotDisposed();
 
-            Interop.Runtime.InvokeJSWithArgs(JSHandle, method, args, out int exception, out object res);
+            Interop.Runtime.InvokeJSWithArgsRef(JSHandle, method, args, out int exception, out object res);
             if (exception != 0)
                 throw new JSException((string)res);
             Interop.Runtime.ReleaseInFlight(res);

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
@@ -32,7 +32,7 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             AssertNotDisposed();
 
-            object res = Interop.Runtime.InvokeJSWithArgs(JSHandle, method, args, out int exception);
+            Interop.Runtime.InvokeJSWithArgs(JSHandle, method, args, out int exception, out object res);
             if (exception != 0)
                 throw new JSException((string)res);
             Interop.Runtime.ReleaseInFlight(res);

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.JS.Owned.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.JS.Owned.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Diagnostics;
 
 namespace System.Runtime.InteropServices.JavaScript
 {
@@ -66,7 +65,6 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             GCHandle handle = (GCHandle)(IntPtr)tcsGCHandle;
             // this is JS owned Normal handle. We always have a Target
-            Debug.Assert(handle.Target != null, "TaskCompletionSource should not be null.");
             TaskCompletionSource<object> tcs = (TaskCompletionSource<object>)handle.Target!;
             tcs.SetResult(result);
         }
@@ -75,7 +73,6 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             GCHandle handle = (GCHandle)(IntPtr)tcsGCHandle;
             // this is JS owned Normal handle. We always have a Target
-            Debug.Assert(handle.Target != null, "TaskCompletionSource should not be null.");
             TaskCompletionSource<object> tcs = (TaskCompletionSource<object>)handle.Target!;
             tcs.SetException(new JSException(reason));
         }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.JS.Owned.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.JS.Owned.cs
@@ -81,7 +81,6 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             GCHandle handle = (GCHandle)(IntPtr)tcsGCHandle;
             // this is JS owned Normal handle. We always have a Target
-            Debug.Assert(handle.Target != null, "TaskCompletionSource should not be null.");
             TaskCompletionSource<object> tcs = (TaskCompletionSource<object>)handle.Target!;
             result = tcs.Task;
         }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.JS.Owned.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.JS.Owned.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Diagnostics;
 
 namespace System.Runtime.InteropServices.JavaScript
 {
@@ -65,6 +66,7 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             GCHandle handle = (GCHandle)(IntPtr)tcsGCHandle;
             // this is JS owned Normal handle. We always have a Target
+            Debug.Assert(handle.Target != null, "TaskCompletionSource should not be null.");
             TaskCompletionSource<object> tcs = (TaskCompletionSource<object>)handle.Target!;
             tcs.SetResult(result);
         }
@@ -73,6 +75,7 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             GCHandle handle = (GCHandle)(IntPtr)tcsGCHandle;
             // this is JS owned Normal handle. We always have a Target
+            Debug.Assert(handle.Target != null, "TaskCompletionSource should not be null.");
             TaskCompletionSource<object> tcs = (TaskCompletionSource<object>)handle.Target!;
             tcs.SetException(new JSException(reason));
         }
@@ -81,6 +84,7 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             GCHandle handle = (GCHandle)(IntPtr)tcsGCHandle;
             // this is JS owned Normal handle. We always have a Target
+            Debug.Assert(handle.Target != null, "TaskCompletionSource should not be null.");
             TaskCompletionSource<object> tcs = (TaskCompletionSource<object>)handle.Target!;
             result = tcs.Task;
         }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -329,7 +329,7 @@ namespace System.Runtime.InteropServices.JavaScript
 
         public static void CancelPromise(IntPtr promiseJSHandle)
         {
-            var res = Interop.Runtime.CancelPromise(promiseJSHandle, out int exception);
+            Interop.Runtime.CancelPromise(promiseJSHandle, out int exception, out string res);
             if (exception != 0)
                 throw new JSException(res);
         }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -329,7 +329,7 @@ namespace System.Runtime.InteropServices.JavaScript
 
         public static void CancelPromise(IntPtr promiseJSHandle)
         {
-            Interop.Runtime.CancelPromise(promiseJSHandle, out int exception, out string res);
+            Interop.Runtime.CancelPromiseRef(promiseJSHandle, out int exception, out string res);
             if (exception != 0)
                 throw new JSException(res);
         }

--- a/src/mono/wasm/runtime/cancelable-promise.ts
+++ b/src/mono/wasm/runtime/cancelable-promise.ts
@@ -18,7 +18,7 @@ export function isThenable(js_obj: any): boolean {
         ((typeof js_obj === "object" || typeof js_obj === "function") && typeof js_obj.then === "function");
 }
 
-export function mono_wasm_cancel_promise(thenable_js_handle: JSHandle, is_exception: Int32Ptr, result_address: MonoObjectRef): void | MonoString {
+export function mono_wasm_cancel_promise_ref(thenable_js_handle: JSHandle, is_exception: Int32Ptr, result_address: MonoObjectRef): void | MonoString {
     const resultRoot = mono_wasm_new_external_root<MonoObject>(result_address);
     try {
         const promise = mono_wasm_get_jsobj_from_js_handle(thenable_js_handle);

--- a/src/mono/wasm/runtime/cancelable-promise.ts
+++ b/src/mono/wasm/runtime/cancelable-promise.ts
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { mono_wasm_get_jsobj_from_js_handle } from "./gc-handles";
-import { wrap_error } from "./method-calls";
-import { JSHandle, MonoString } from "./types";
+import { wrap_error_root } from "./method-calls";
+import { mono_wasm_new_external_root } from "./roots";
+import { JSHandle, MonoObject, MonoObjectRef, MonoString } from "./types";
 import { Int32Ptr } from "./types/emscripten";
 
 export const _are_promises_supported = ((typeof Promise === "object") || (typeof Promise === "function")) && (typeof Promise.resolve === "function");
@@ -17,14 +18,19 @@ export function isThenable(js_obj: any): boolean {
         ((typeof js_obj === "object" || typeof js_obj === "function") && typeof js_obj.then === "function");
 }
 
-export function mono_wasm_cancel_promise(thenable_js_handle: JSHandle, is_exception: Int32Ptr): void | MonoString {
+export function mono_wasm_cancel_promise(thenable_js_handle: JSHandle, is_exception: Int32Ptr, result_address: MonoObjectRef): void | MonoString {
+    const resultRoot = mono_wasm_new_external_root<MonoObject>(result_address);
     try {
         const promise = mono_wasm_get_jsobj_from_js_handle(thenable_js_handle);
         const promise_control = promise[promise_control_symbol];
         promise_control.reject("OperationCanceledException");
     }
     catch (ex) {
-        return wrap_error(is_exception, ex);
+        wrap_error_root(is_exception, ex, resultRoot);
+        return;
+    }
+    finally {
+        resultRoot.release();
     }
 }
 

--- a/src/mono/wasm/runtime/cjs/dotnet.cjs.lib.js
+++ b/src/mono/wasm/runtime/cjs/dotnet.cjs.lib.js
@@ -43,7 +43,7 @@ const linked_functions = [
     "mono_wasm_trace_logger",
 
     // corebindings.c
-    "mono_wasm_invoke_js_with_args",
+    "mono_wasm_invoke_js_with_args_ref",
     "mono_wasm_get_object_property_ref",
     "mono_wasm_set_object_property_ref",
     "mono_wasm_get_by_index_ref",
@@ -55,13 +55,13 @@ const linked_functions = [
     "mono_wasm_typed_array_copy_to_ref",
     "mono_wasm_typed_array_from_ref",
     "mono_wasm_typed_array_copy_from_ref",
-    "mono_wasm_cancel_promise",
+    "mono_wasm_cancel_promise_ref",
     "mono_wasm_web_socket_open_ref",
     "mono_wasm_web_socket_send",
     "mono_wasm_web_socket_receive",
     "mono_wasm_web_socket_close_ref",
     "mono_wasm_web_socket_abort",
-    "mono_wasm_compile_function",
+    "mono_wasm_compile_function_ref",
 
     // pal_icushim_static.c
     "mono_wasm_load_icu_data",

--- a/src/mono/wasm/runtime/corebindings.c
+++ b/src/mono/wasm/runtime/corebindings.c
@@ -28,7 +28,7 @@ extern void mono_wasm_typed_array_to_array_ref (int js_handle, int *is_exception
 extern void mono_wasm_typed_array_copy_to_ref (int js_handle, int ptr, int begin, int end, int bytes_per_element, int *is_exception, MonoObject** result);
 extern void mono_wasm_typed_array_from_ref (int ptr, int begin, int end, int bytes_per_element, int type, int *is_exception, MonoObject** result);
 extern void mono_wasm_typed_array_copy_from_ref (int js_handle, int ptr, int begin, int end, int bytes_per_element, int *is_exception, MonoObject** result);
-extern MonoString* mono_wasm_cancel_promise (int thenable_js_handle, int *is_exception);
+extern void mono_wasm_cancel_promise (int thenable_js_handle, int *is_exception, MonoString** result);
 extern void mono_wasm_web_socket_open_ref (MonoString **uri, MonoArray **subProtocols, MonoDelegate **on_close, int *web_socket_js_handle, int *thenable_js_handle, int *is_exception, MonoObject **result);
 extern void mono_wasm_web_socket_send (int webSocket_js_handle, void* buffer_ptr, int offset, int length, int message_type, int end_of_message, int *thenable_js_handle, int *is_exception, MonoObject **result);
 extern void mono_wasm_web_socket_receive (int webSocket_js_handle, void* buffer_ptr, int offset, int length, void* response_ptr, int *thenable_js_handle, int *is_exception, MonoObject **result);

--- a/src/mono/wasm/runtime/corebindings.c
+++ b/src/mono/wasm/runtime/corebindings.c
@@ -16,7 +16,7 @@
 #include "gc-common.h"
 
 //JS funcs
-extern void mono_wasm_invoke_js_with_args (int js_handle, MonoString *method, MonoArray *args, int *is_exception, MonoObject **result);
+extern void mono_wasm_invoke_js_with_args_ref (int js_handle, MonoString *method, MonoArray *args, int *is_exception, MonoObject **result);
 extern void mono_wasm_get_object_property_ref (int js_handle, MonoString **propertyName, int *is_exception, MonoObject **result);
 extern void mono_wasm_get_by_index_ref (int js_handle, int property_index, int *is_exception, MonoObject **result);
 extern void mono_wasm_set_object_property_ref (int js_handle, MonoString **propertyName, MonoObject **value, int createIfNotExist, int hasOwnProperty, int *is_exception, MonoObject **result);
@@ -28,17 +28,17 @@ extern void mono_wasm_typed_array_to_array_ref (int js_handle, int *is_exception
 extern void mono_wasm_typed_array_copy_to_ref (int js_handle, int ptr, int begin, int end, int bytes_per_element, int *is_exception, MonoObject** result);
 extern void mono_wasm_typed_array_from_ref (int ptr, int begin, int end, int bytes_per_element, int type, int *is_exception, MonoObject** result);
 extern void mono_wasm_typed_array_copy_from_ref (int js_handle, int ptr, int begin, int end, int bytes_per_element, int *is_exception, MonoObject** result);
-extern void mono_wasm_cancel_promise (int thenable_js_handle, int *is_exception, MonoString** result);
+extern void mono_wasm_cancel_promise_ref (int thenable_js_handle, int *is_exception, MonoString** result);
 extern void mono_wasm_web_socket_open_ref (MonoString **uri, MonoArray **subProtocols, MonoDelegate **on_close, int *web_socket_js_handle, int *thenable_js_handle, int *is_exception, MonoObject **result);
 extern void mono_wasm_web_socket_send (int webSocket_js_handle, void* buffer_ptr, int offset, int length, int message_type, int end_of_message, int *thenable_js_handle, int *is_exception, MonoObject **result);
 extern void mono_wasm_web_socket_receive (int webSocket_js_handle, void* buffer_ptr, int offset, int length, void* response_ptr, int *thenable_js_handle, int *is_exception, MonoObject **result);
 extern void mono_wasm_web_socket_close_ref (int webSocket_js_handle, int code, MonoString **reason, int wait_for_close_received, int *thenable_js_handle, int *is_exception, MonoObject **result);
 extern void mono_wasm_web_socket_abort (int webSocket_js_handle, int *is_exception, MonoString **result);
-extern void mono_wasm_compile_function (MonoString *str, int *is_exception, MonoObject **result);
+extern void mono_wasm_compile_function_ref (MonoString *str, int *is_exception, MonoObject **result);
 
 void core_initialize_internals ()
 {
-	mono_add_internal_call ("Interop/Runtime::InvokeJSWithArgs", mono_wasm_invoke_js_with_args);
+	mono_add_internal_call ("Interop/Runtime::InvokeJSWithArgsRef", mono_wasm_invoke_js_with_args_ref);
 	mono_add_internal_call ("Interop/Runtime::GetObjectPropertyRef", mono_wasm_get_object_property_ref);
 	mono_add_internal_call ("Interop/Runtime::GetByIndexRef", mono_wasm_get_by_index_ref);
 	mono_add_internal_call ("Interop/Runtime::SetObjectPropertyRef", mono_wasm_set_object_property_ref);
@@ -50,13 +50,13 @@ void core_initialize_internals ()
 	mono_add_internal_call ("Interop/Runtime::TypedArrayCopyToRef", mono_wasm_typed_array_copy_to_ref);
 	mono_add_internal_call ("Interop/Runtime::TypedArrayFromRef", mono_wasm_typed_array_from_ref);
 	mono_add_internal_call ("Interop/Runtime::TypedArrayCopyFromRef", mono_wasm_typed_array_copy_from_ref);
-	mono_add_internal_call ("Interop/Runtime::CompileFunction", mono_wasm_compile_function);
+	mono_add_internal_call ("Interop/Runtime::CompileFunctionRef", mono_wasm_compile_function_ref);
 	mono_add_internal_call ("Interop/Runtime::WebSocketOpenRef", mono_wasm_web_socket_open_ref);
 	mono_add_internal_call ("Interop/Runtime::WebSocketSend", mono_wasm_web_socket_send);
 	mono_add_internal_call ("Interop/Runtime::WebSocketReceive", mono_wasm_web_socket_receive);
 	mono_add_internal_call ("Interop/Runtime::WebSocketCloseRef", mono_wasm_web_socket_close_ref);
 	mono_add_internal_call ("Interop/Runtime::WebSocketAbort", mono_wasm_web_socket_abort);
-	mono_add_internal_call ("Interop/Runtime::CancelPromise", mono_wasm_cancel_promise);
+	mono_add_internal_call ("Interop/Runtime::CancelPromiseRef", mono_wasm_cancel_promise_ref);
 }
 
 // Int8Array 		| int8_t	| byte or SByte (signed byte)

--- a/src/mono/wasm/runtime/corebindings.c
+++ b/src/mono/wasm/runtime/corebindings.c
@@ -34,7 +34,7 @@ extern void mono_wasm_web_socket_send (int webSocket_js_handle, void* buffer_ptr
 extern void mono_wasm_web_socket_receive (int webSocket_js_handle, void* buffer_ptr, int offset, int length, void* response_ptr, int *thenable_js_handle, int *is_exception, MonoObject **result);
 extern void mono_wasm_web_socket_close_ref (int webSocket_js_handle, int code, MonoString **reason, int wait_for_close_received, int *thenable_js_handle, int *is_exception, MonoObject **result);
 extern void mono_wasm_web_socket_abort (int webSocket_js_handle, int *is_exception, MonoString **result);
-extern MonoObject* mono_wasm_compile_function (MonoString *str, int *is_exception);
+extern void mono_wasm_compile_function (MonoString *str, int *is_exception, MonoObject **result);
 
 void core_initialize_internals ()
 {

--- a/src/mono/wasm/runtime/corebindings.c
+++ b/src/mono/wasm/runtime/corebindings.c
@@ -16,7 +16,7 @@
 #include "gc-common.h"
 
 //JS funcs
-extern MonoObject* mono_wasm_invoke_js_with_args (int js_handle, MonoString *method, MonoArray *args, int *is_exception);
+extern void mono_wasm_invoke_js_with_args (int js_handle, MonoString *method, MonoArray *args, int *is_exception, MonoObject **result);
 extern void mono_wasm_get_object_property_ref (int js_handle, MonoString **propertyName, int *is_exception, MonoObject **result);
 extern void mono_wasm_get_by_index_ref (int js_handle, int property_index, int *is_exception, MonoObject **result);
 extern void mono_wasm_set_object_property_ref (int js_handle, MonoString **propertyName, MonoObject **value, int createIfNotExist, int hasOwnProperty, int *is_exception, MonoObject **result);

--- a/src/mono/wasm/runtime/corebindings.c
+++ b/src/mono/wasm/runtime/corebindings.c
@@ -16,7 +16,7 @@
 #include "gc-common.h"
 
 //JS funcs
-extern void mono_wasm_invoke_js_with_args_ref (int js_handle, MonoString *method, MonoArray *args, int *is_exception, MonoObject **result);
+extern void mono_wasm_invoke_js_with_args_ref (int js_handle, MonoString **method, MonoArray **args, int *is_exception, MonoObject **result);
 extern void mono_wasm_get_object_property_ref (int js_handle, MonoString **propertyName, int *is_exception, MonoObject **result);
 extern void mono_wasm_get_by_index_ref (int js_handle, int property_index, int *is_exception, MonoObject **result);
 extern void mono_wasm_set_object_property_ref (int js_handle, MonoString **propertyName, MonoObject **value, int createIfNotExist, int hasOwnProperty, int *is_exception, MonoObject **result);

--- a/src/mono/wasm/runtime/es6/dotnet.es6.lib.js
+++ b/src/mono/wasm/runtime/es6/dotnet.es6.lib.js
@@ -80,7 +80,7 @@ const linked_functions = [
     "mono_wasm_trace_logger",
 
     // corebindings.c
-    "mono_wasm_invoke_js_with_args",
+    "mono_wasm_invoke_js_with_args_ref",
     "mono_wasm_get_object_property_ref",
     "mono_wasm_set_object_property_ref",
     "mono_wasm_get_by_index_ref",
@@ -92,13 +92,13 @@ const linked_functions = [
     "mono_wasm_typed_array_copy_to_ref",
     "mono_wasm_typed_array_from_ref",
     "mono_wasm_typed_array_copy_from_ref",
-    "mono_wasm_cancel_promise",
+    "mono_wasm_cancel_promise_ref",
     "mono_wasm_web_socket_open_ref",
     "mono_wasm_web_socket_send",
     "mono_wasm_web_socket_receive",
     "mono_wasm_web_socket_close_ref",
     "mono_wasm_web_socket_abort",
-    "mono_wasm_compile_function",
+    "mono_wasm_compile_function_ref",
 
     // pal_icushim_static.c
     "mono_wasm_load_icu_data",

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -46,14 +46,14 @@ import {
 import {
     call_static_method, mono_bind_static_method, mono_call_assembly_entry_point,
     mono_method_resolve,
-    mono_wasm_compile_function,
+    mono_wasm_compile_function_ref,
     mono_wasm_get_by_index_ref, mono_wasm_get_global_object_ref, mono_wasm_get_object_property_ref,
     mono_wasm_invoke_js,
     mono_wasm_invoke_js_blazor,
-    mono_wasm_invoke_js_with_args, mono_wasm_set_by_index_ref, mono_wasm_set_object_property_ref
+    mono_wasm_invoke_js_with_args_ref, mono_wasm_set_by_index_ref, mono_wasm_set_object_property_ref
 } from "./method-calls";
 import { mono_wasm_typed_array_copy_to_ref, mono_wasm_typed_array_from_ref, mono_wasm_typed_array_copy_from_ref, mono_wasm_load_bytes_into_heap } from "./buffers";
-import { mono_wasm_cancel_promise } from "./cancelable-promise";
+import { mono_wasm_cancel_promise_ref } from "./cancelable-promise";
 import { mono_wasm_release_cs_owned_object } from "./gc-handles";
 import { mono_wasm_web_socket_open_ref, mono_wasm_web_socket_send, mono_wasm_web_socket_receive, mono_wasm_web_socket_close_ref, mono_wasm_web_socket_abort } from "./web-socket";
 import cwraps from "./cwraps";
@@ -319,7 +319,7 @@ export const __linker_exports: any = {
     mono_wasm_trace_logger,
 
     // also keep in sync with corebindings.c
-    mono_wasm_invoke_js_with_args,
+    mono_wasm_invoke_js_with_args_ref,
     mono_wasm_get_object_property_ref,
     mono_wasm_set_object_property_ref,
     mono_wasm_get_by_index_ref,
@@ -331,13 +331,13 @@ export const __linker_exports: any = {
     mono_wasm_typed_array_copy_to_ref,
     mono_wasm_typed_array_from_ref,
     mono_wasm_typed_array_copy_from_ref,
-    mono_wasm_cancel_promise,
+    mono_wasm_cancel_promise_ref,
     mono_wasm_web_socket_open_ref,
     mono_wasm_web_socket_send,
     mono_wasm_web_socket_receive,
     mono_wasm_web_socket_close_ref,
     mono_wasm_web_socket_abort,
-    mono_wasm_compile_function,
+    mono_wasm_compile_function_ref,
 
     //  also keep in sync with pal_icushim_static.c
     mono_wasm_load_icu_data,

--- a/src/mono/wasm/runtime/method-calls.ts
+++ b/src/mono/wasm/runtime/method-calls.ts
@@ -301,9 +301,9 @@ export function mono_call_assembly_entry_point(assembly: string, args?: any[], s
     return mono_bind_assembly_entry_point(assembly, signature)(...args);
 }
 
-export function mono_wasm_invoke_js_with_args_ref(js_handle: JSHandle, method_name: MonoString, args: MonoArray, is_exception: Int32Ptr, result_address: MonoObjectRef): any {
-    const argsRoot = mono_wasm_new_root(args), 
-        nameRoot = mono_wasm_new_root(method_name),
+export function mono_wasm_invoke_js_with_args_ref(js_handle: JSHandle, method_name: MonoStringRef, args: MonoObjectRef, is_exception: Int32Ptr, result_address: MonoObjectRef): any {
+    const argsRoot = mono_wasm_new_external_root<MonoArray>(args), 
+        nameRoot = mono_wasm_new_external_root<MonoString>(method_name),
         resultRoot = mono_wasm_new_external_root<MonoObject>(result_address);
     try {
         const js_name = conv_string_root(nameRoot);

--- a/src/mono/wasm/runtime/method-calls.ts
+++ b/src/mono/wasm/runtime/method-calls.ts
@@ -620,15 +620,15 @@ export function mono_wasm_invoke_js(code: MonoString, is_exception: Int32Ptr): M
 // Compiles a JavaScript function from the function data passed.
 // Note: code snippet is not a function definition. Instead it must create and return a function instance.
 // code like `return function() { App.call_test_method(); };`
-export function mono_wasm_compile_function_ref(code: MonoString, is_exception: Int32Ptr, result_address: MonoObjectRef): void {
-    const resultRoot = mono_wasm_new_external_root<MonoObject>(result_address);
+export function mono_wasm_compile_function_ref(code: MonoStringRef, is_exception: Int32Ptr, result_address: MonoObjectRef): void {
+    const codeRoot = mono_wasm_new_external_root<MonoString>(code),
+        resultRoot = mono_wasm_new_external_root<MonoObject>(result_address);
 
-    if (code === MonoStringNull) {
+    const js_code = conv_string_root(codeRoot);
+    if (!js_code) {
         js_to_mono_obj_root(MonoStringNull, resultRoot, true);
         return;
     }
-
-    const js_code = conv_string(code);
 
     try {
         const closure = {

--- a/src/mono/wasm/runtime/method-calls.ts
+++ b/src/mono/wasm/runtime/method-calls.ts
@@ -301,7 +301,7 @@ export function mono_call_assembly_entry_point(assembly: string, args?: any[], s
     return mono_bind_assembly_entry_point(assembly, signature)(...args);
 }
 
-export function mono_wasm_invoke_js_with_args(js_handle: JSHandle, method_name: MonoString, args: MonoArray, is_exception: Int32Ptr, result_address: MonoObjectRef): any {
+export function mono_wasm_invoke_js_with_args_ref(js_handle: JSHandle, method_name: MonoString, args: MonoArray, is_exception: Int32Ptr, result_address: MonoObjectRef): any {
     const argsRoot = mono_wasm_new_root(args), 
         nameRoot = mono_wasm_new_root(method_name),
         resultRoot = mono_wasm_new_external_root<MonoObject>(result_address);
@@ -620,7 +620,7 @@ export function mono_wasm_invoke_js(code: MonoString, is_exception: Int32Ptr): M
 // Compiles a JavaScript function from the function data passed.
 // Note: code snippet is not a function definition. Instead it must create and return a function instance.
 // code like `return function() { App.call_test_method(); };`
-export function mono_wasm_compile_function(code: MonoString, is_exception: Int32Ptr, result_address: MonoObjectRef): void {
+export function mono_wasm_compile_function_ref(code: MonoString, is_exception: Int32Ptr, result_address: MonoObjectRef): void {
     const resultRoot = mono_wasm_new_external_root<MonoObject>(result_address);
 
     if (code === MonoStringNull) {


### PR DESCRIPTION
A follow up on the https://github.com/dotnet/runtime/pull/65994.

Migrate rest of the JS interop functions to out params instead of return.
- `mono_wasm_invoke_js_with_args`
- `mono_wasm_cancel_promise`
- `mono_wasm_compile_function`