### PR TITLE
Revert "Set SocketsHttpHandler's default connect timeout to 15s (#66607)"

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/libraries/Common/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -27,6 +27,6 @@ namespace System.Net.Http
         public static readonly TimeSpan DefaultPooledConnectionLifetime = Timeout.InfiniteTimeSpan;
         public static readonly TimeSpan DefaultPooledConnectionIdleTimeout = TimeSpan.FromMinutes(1);
         public static readonly TimeSpan DefaultExpect100ContinueTimeout = TimeSpan.FromSeconds(1);
-        public static readonly TimeSpan DefaultConnectTimeout = TimeSpan.FromSeconds(15);
+        public static readonly TimeSpan DefaultConnectTimeout = Timeout.InfiniteTimeSpan;
     }
 }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1054,7 +1054,7 @@ namespace System.Net.Http.Functional.Tests
         {
             using (var handler = new SocketsHttpHandler())
             {
-                Assert.Equal(TimeSpan.FromSeconds(15), handler.ConnectTimeout);
+                Assert.Equal(Timeout.InfiniteTimeSpan, handler.ConnectTimeout);
             }
         }
 


### PR DESCRIPTION
This reverts commit 436b97cc809a3db1d1a25faedbc64aa97875bae3.

The change proved to be problematic as-is, because

1) There is a high chance that the user code has a retry logic that does retry when `SocketException` is caught but does not retry in case of `OperationCanceledException`. This can lead to a spike of (unretried) exceptions which weren't there before. Example:
https://github.com/NuGet/NuGet.Client/blob/93bb3921490e9d499be1fb48d6cb9dcaff734db1/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs#L212-L263

2) The workaround with setting the `ConnectTimeout` back to infinity may not be available -- if `HttpClientHandler` is used instead of `SocketsHttpHandler` (e.g. due to reusing code between .NET Framework and .NET Core/.NET 5+), or if the code that executes the requests is hidden inside a library.

I will reopen #66297 for further considerations.