### PR TITLE
Ensure TestHandleCollector has enough memory pressure to trigger

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/HandleCollectorTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/HandleCollectorTests.cs
@@ -9,7 +9,7 @@ namespace System.Runtime.InteropServices
     public class HandleCollectorTests
     {
         private const int LowLimitSize = 20;
-        private const int HighLimitSize = 100000;
+        private const int HighLimitSize = 100_000;
 
         [Theory]
         [InlineData(null, 0)]
@@ -128,6 +128,7 @@ namespace System.Runtime.InteropServices
             for (int i = 0; i < LowLimitSize + 1; ++i)
             {
                 HandleLimitTester hlt = new HandleLimitTester(lowLimitCollector);
+                Assert.True(lowLimitCollector.Count <= i + 1);
             }
 
             // HandleLimitTester does the decrement on the HandleCollector during finalization, so we wait for pending finalizers.
@@ -142,6 +143,7 @@ namespace System.Runtime.InteropServices
             for (int i = 0; i < HighLimitSize + 10; ++i)
             {
                 HandleLimitTester hlt = new HandleLimitTester(highLimitCollector);
+                Assert.True(highLimitCollector.Count <= i + 1);
             }
 
             // HandleLimitTester does the decrement on the HandleCollector during finalization, so we wait for pending finalizers.
@@ -155,11 +157,13 @@ namespace System.Runtime.InteropServices
 
         private sealed class HandleLimitTester
         {
-            private HandleCollector _collector;
+            private readonly HandleCollector _collector;
+            private readonly int[] _pressure;
 
             internal HandleLimitTester(HandleCollector collector)
             {
                 _collector = collector;
+                _pressure = new int[collector.InitialThreshold];
                 _collector.Add();
                 GC.KeepAlive(this);
             }

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/HandleCollectorTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/HandleCollectorTests.cs
@@ -163,7 +163,7 @@ namespace System.Runtime.InteropServices
             internal HandleLimitTester(HandleCollector collector)
             {
                 _collector = collector;
-                _pressure = new int[collector.InitialThreshold];
+                _pressure = new int[1_000];
                 _collector.Add();
                 GC.KeepAlive(this);
             }

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/HandleCollectorTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/HandleCollectorTests.cs
@@ -163,6 +163,8 @@ namespace System.Runtime.InteropServices
             internal HandleLimitTester(HandleCollector collector)
             {
                 _collector = collector;
+                // Adding an allocation to ensure memory pressure exists so the call to
+                // GC.Collect() in the Add() method below will have something to do.
                 _pressure = new int[1_000];
                 _collector.Add();
                 GC.KeepAlive(this);


### PR DESCRIPTION
Fixes #66571 

/cc @elinor-fung 