### PR TITLE
Avoid Path.Join(string, ...) allocations for null/empty inputs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
@@ -479,17 +479,44 @@ namespace System.IO
 
         public static string Join(string? path1, string? path2)
         {
-            return Join(path1.AsSpan(), path2.AsSpan());
+            if (string.IsNullOrEmpty(path1))
+                return path2 ?? string.Empty;
+
+            if (string.IsNullOrEmpty(path2))
+                return path1;
+
+            return JoinInternal(path1, path2);
         }
 
         public static string Join(string? path1, string? path2, string? path3)
         {
-            return Join(path1.AsSpan(), path2.AsSpan(), path3.AsSpan());
+            if (string.IsNullOrEmpty(path1))
+                return Join(path2, path3);
+
+            if (string.IsNullOrEmpty(path2))
+                return Join(path1, path3);
+
+            if (string.IsNullOrEmpty(path3))
+                return Join(path1, path2);
+
+            return JoinInternal(path1, path2, path3);
         }
 
         public static string Join(string? path1, string? path2, string? path3, string? path4)
         {
-            return Join(path1.AsSpan(), path2.AsSpan(), path3.AsSpan(), path4.AsSpan());
+            if (string.IsNullOrEmpty(path1))
+                return Join(path2, path3, path4);
+
+            if (string.IsNullOrEmpty(path2))
+                return Join(path1, path3, path4);
+
+            if (string.IsNullOrEmpty(path3))
+                return Join(path1, path2, path4);
+
+            if (string.IsNullOrEmpty(path4))
+                return Join(path1, path2, path3);
+
+            return JoinInternal(path1, path2, path3, path4);
         }
 
         public static string Join(params string?[] paths)


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/68582#discussion_r861002249