### PR TITLE
Fix Typo in Manual Console Testing

### DIFF
--- a/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
@@ -318,7 +318,7 @@ namespace System
         {
             Console.WriteLine(Console.OutputEncoding);
             Console.WriteLine("'\u03A0\u03A3'.");
-            AssertUserExpectedResults("Pi and Segma or question marks");
+            AssertUserExpectedResults("Pi and Sigma or question marks");
         }
 
         private static void AssertUserExpectedResults(string expected)


### PR DESCRIPTION
Fix a typo in the Manual test of System.Console to correct "Segma" to "Sigma".