### PR TITLE
[release/6.0] Unloadability bugs fixes

### DIFF
--- a/src/coreclr/binder/assemblybinder.cpp
+++ b/src/coreclr/binder/assemblybinder.cpp
@@ -33,6 +33,7 @@
 extern HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToBindWithin,
                                                  BINDER_SPACE::AssemblyName *pAssemblyName,
                                                  CLRPrivBinderCoreCLR *pTPABinder,
+                                                 AssemblyLoadContext *pBinder,
                                                  ICLRPrivAssembly **ppLoadedAssembly);
 
 #endif // !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
@@ -1408,6 +1409,7 @@ namespace BINDER_SPACE
 HRESULT AssemblyBinder::BindUsingHostAssemblyResolver(/* in */ INT_PTR pManagedAssemblyLoadContextToBindWithin,
                                                       /* in */ AssemblyName       *pAssemblyName,
                                                       /* in */ CLRPrivBinderCoreCLR *pTPABinder,
+                                                      /* in */ AssemblyLoadContext *pBinder,
                                                       /* out */ Assembly           **ppAssembly)
 {
     HRESULT hr = E_FAIL;
@@ -1417,7 +1419,7 @@ HRESULT AssemblyBinder::BindUsingHostAssemblyResolver(/* in */ INT_PTR pManagedA
     // RuntimeInvokeHostAssemblyResolver will perform steps 2-4 of CLRPrivBinderAssemblyLoadContext::BindAssemblyByName.
     ICLRPrivAssembly *pLoadedAssembly = NULL;
     hr = RuntimeInvokeHostAssemblyResolver(pManagedAssemblyLoadContextToBindWithin,
-                                           pAssemblyName, pTPABinder, &pLoadedAssembly);
+                                           pAssemblyName, pTPABinder, pBinder, &pLoadedAssembly);
     if (SUCCEEDED(hr))
     {
         _ASSERTE(pLoadedAssembly != NULL);

--- a/src/coreclr/binder/clrprivbindercoreclr.cpp
+++ b/src/coreclr/binder/clrprivbindercoreclr.cpp
@@ -107,7 +107,7 @@ HRESULT CLRPrivBinderCoreCLR::BindUsingAssemblyName(BINDER_SPACE::AssemblyName *
         if (pManagedAssemblyLoadContext != NULL)
         {
             hr = AssemblyBinder::BindUsingHostAssemblyResolver(pManagedAssemblyLoadContext, pAssemblyName,
-                                                                NULL, &pCoreCLRFoundAssembly);
+                                                                NULL, this, &pCoreCLRFoundAssembly);
             if (SUCCEEDED(hr))
             {
                 // We maybe returned an assembly that was bound to a different AssemblyLoadContext instance.

--- a/src/coreclr/binder/inc/assemblybinder.hpp
+++ b/src/coreclr/binder/inc/assemblybinder.hpp
@@ -21,6 +21,7 @@
 class CLRPrivBinderCoreCLR;
 class PEAssembly;
 class PEImage;
+class AssemblyLoadContext;
 
 namespace BINDER_SPACE
 {
@@ -59,6 +60,7 @@ namespace BINDER_SPACE
         static HRESULT BindUsingHostAssemblyResolver (/* in */ INT_PTR pManagedAssemblyLoadContextToBindWithin,
                                                       /* in */ AssemblyName       *pAssemblyName,
                                                       /* in */ CLRPrivBinderCoreCLR *pTPABinder,
+                                                      /* in */ AssemblyLoadContext *pBinder,
                                                       /* out */ Assembly           **ppAssembly);
 
         static HRESULT BindUsingPEImage(/* in */  ApplicationContext *pApplicationContext,

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -5460,15 +5460,12 @@ HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToB
                 LoaderAllocator *pResultAssemblyLoaderAllocator = pDomainAssembly->GetLoaderAllocator();
                 LoaderAllocator *pParentLoaderAllocator = NULL;
                 hr = pBinder->GetLoaderAllocator((LPVOID*)&pParentLoaderAllocator);
-                if (!SUCCEEDED(hr))
+                if (SUCCEEDED(hr))
                 {
-                    // The AssemblyLoadContext for which we are resolving the the Assembly is not collectible.
-                    COMPlusThrow(kNotSupportedException, W("NotSupported_CollectibleBoundNonCollectible")); 
+                    _ASSERTE(pParentLoaderAllocator);
+                    _ASSERTE(pResultAssemblyLoaderAllocator);
+                    pParentLoaderAllocator->EnsureReference(pResultAssemblyLoaderAllocator);
                 }
-
-                _ASSERTE(pParentLoaderAllocator);
-                _ASSERTE(pResultAssemblyLoaderAllocator);
-                pParentLoaderAllocator->EnsureReference(pResultAssemblyLoaderAllocator);
             }
 
             pResolvedAssembly = pLoadedPEAssembly->GetHostAssembly();

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -5275,7 +5275,7 @@ AppDomain::AssemblyIterator::Next_Unlocked(
 #if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
 
 // Returns S_OK if the assembly was successfully loaded
-HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToBindWithin, BINDER_SPACE::AssemblyName *pAssemblyName, CLRPrivBinderCoreCLR *pTPABinder, ICLRPrivAssembly **ppLoadedAssembly)
+HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToBindWithin, BINDER_SPACE::AssemblyName *pAssemblyName, CLRPrivBinderCoreCLR *pTPABinder, AssemblyLoadContext *pBinder, ICLRPrivAssembly **ppLoadedAssembly)
 {
     CONTRACTL
     {
@@ -5451,6 +5451,24 @@ HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToB
                 PathString name;
                 pAssemblyName->GetDisplayName(name, BINDER_SPACE::AssemblyName::INCLUDE_ALL);
                 COMPlusThrowHR(COR_E_INVALIDOPERATION, IDS_HOST_ASSEMBLY_RESOLVER_DYNAMICALLY_EMITTED_ASSEMBLIES_UNSUPPORTED, name);
+            }
+
+            // For collectible assemblies, ensure that the parent loader allocator keeps the assembly's loader allocator
+            // alive for all its lifetime.
+            if (pDomainAssembly->IsCollectible())
+            {
+                LoaderAllocator *pResultAssemblyLoaderAllocator = pDomainAssembly->GetLoaderAllocator();
+                LoaderAllocator *pParentLoaderAllocator = NULL;
+                hr = pBinder->GetLoaderAllocator((LPVOID*)&pParentLoaderAllocator);
+                if (!SUCCEEDED(hr))
+                {
+                    // The AssemblyLoadContext for which we are resolving the the Assembly is not collectible.
+                    COMPlusThrow(kNotSupportedException, W("NotSupported_CollectibleBoundNonCollectible")); 
+                }
+
+                _ASSERTE(pParentLoaderAllocator);
+                _ASSERTE(pResultAssemblyLoaderAllocator);
+                pParentLoaderAllocator->EnsureReference(pResultAssemblyLoaderAllocator);
             }
 
             pResolvedAssembly = pLoadedPEAssembly->GetHostAssembly();

--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -401,8 +401,9 @@ LoaderAllocator * LoaderAllocator::GCLoaderAllocators_RemoveAssemblies(AppDomain
 #endif //0
 
     AppDomain::AssemblyIterator i;
-    // Iterate through every loader allocator, marking as we go
     {
+        // Iterate through every loader allocator, marking as we go
+        CrstHolder chLoaderAllocatorReferencesLock(pAppDomain->GetLoaderAllocatorReferencesLock());
         CrstHolder chAssemblyListLock(pAppDomain->GetAssemblyListLock());
 
         i = pAppDomain->IterateAssembliesEx((AssemblyIterationFlags)(
@@ -424,17 +425,11 @@ LoaderAllocator * LoaderAllocator::GCLoaderAllocators_RemoveAssemblies(AppDomain
                 }
             }
         }
-    }
 
-    // Iterate through every loader allocator, unmarking marked loaderallocators, and
-    // build a free list of unmarked ones
-    {
-        CrstHolder chLoaderAllocatorReferencesLock(pAppDomain->GetLoaderAllocatorReferencesLock());
-        CrstHolder chAssemblyListLock(pAppDomain->GetAssemblyListLock());
-
+        // Iterate through every loader allocator, unmarking marked loaderallocators, and
+        // build a free list of unmarked ones
         i = pAppDomain->IterateAssembliesEx((AssemblyIterationFlags)(
             kIncludeExecution | kIncludeLoaded | kIncludeCollected));
-        CollectibleAssemblyHolder<DomainAssembly *> pDomainAssembly;
 
         while (i.Next_Unlocked(pDomainAssembly.This()))
         {


### PR DESCRIPTION
This change ports two unloadability fixes for issues found by a customer.
* #68550 that adds reference between native
  `LoaderAllocator`s of two collectible `AssemblyLoadContexts` when one of
   them is used to resolve assembly using the other one. This reference
   ensures that the one that provides the resolved `Assembly` isn't
   collected before the one that uses it. This port was done manually as some of
   the related code was cleaned up in the main and data structures are slightly
   different in 6.0.
* #68336 that adds a missing lock around `m_LoaderAllocatorReferences`
  iteration during assembly load context destruction.

There is one part of #68550 that was intentionally not ported. The change 
in main has added an exception in case a collectible
`Assembly` is resolved into a non-collectible `AssemblyLoadContext`.
Although that is incorrect, there are cases when it would work. So the
added exception is a breaking change that I think we likely don't want
to get into 6.0.
In case we decide to port that breaking change too, we can just remove the 2nd
commit in this PR.

## Customer Impact
Without this change, .NET 6 apps that return collectible `Assembly` from the `AssemblyLoadContext.Load` override or the `AssemblyLoadContext.Resolving` event will likely crash intermittently when operating on the loaded `Assembly`.

## Testing
coreclr and libraries tests locally also with GC stress 3 and with runincontext mode. The customer that has reported this issue is testing a patched coreclr.dll with this fix in their environment.

## Risk
Low, it affects only collectible assemblies resolved by one collectible `AssemblyLoadContext` from another collectible one.