### PR TITLE
Fix a few TODOs in regex

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1732,6 +1732,7 @@ namespace System.Text.RegularExpressions
             int categoryLength = set[CategoryLengthIndex];
             int endPosition = SetStartIndex + setLength + categoryLength;
             bool negated = IsNegated(set);
+            Span<char> scratch = stackalloc char[32];
 
             // Special-case of set of a single character to output that character.
             if (!negated && // no negation
@@ -1782,38 +1783,41 @@ namespace System.Text.RegularExpressions
                 ch1 = set[index];
                 if (ch1 == 0)
                 {
-                    bool found = false;
-
-                    const char GroupChar = (char)0;
+                    const char GroupChar = '\0';
                     int lastindex = set.IndexOf(GroupChar, index + 1);
                     if (lastindex != -1)
                     {
-                        string group = set.Substring(index, lastindex - index + 1);
-
-                        foreach (KeyValuePair<string, string> kvp in s_definedCategories)
+                        ReadOnlySpan<char> group = set.AsSpan(index, lastindex - index + 1);
+                        switch (group)
                         {
-                            if (group.Equals(kvp.Value))
-                            {
-                                desc.Append((short)set[index + 1] > 0 ? "\\p{" : "\\P{").Append(kvp.Key).Append('}');
-                                found = true;
+                            case WordCategories:
+                                desc.Append(@"\w");
                                 break;
-                            }
-                        }
 
-                        if (!found)
-                        {
-                            if (group.Equals(WordCategories))
-                            {
-                                desc.Append("\\w");
-                            }
-                            else if (group.Equals(NotWordCategories))
-                            {
-                                desc.Append("\\W");
-                            }
-                            else
-                            {
-                                // TODO: The code is incorrectly handling pretty-printing groups like \P{P}.
-                            }
+                            case NotWordCategories:
+                                desc.Append(@"\W");
+                                break;
+
+                            default:
+                                // The inverse of a group as created by AddCategoryFromName simply negates every character as a 16-bit value.
+                                Span<char> invertedGroup = group.Length <= scratch.Length ? scratch.Slice(0, group.Length) : new char[group.Length];
+                                for (int i = 0; i < group.Length; i++)
+                                {
+                                    invertedGroup[i] = (char)-(short)group[i];
+                                }
+
+                                // Determine whether the group is a known Unicode category, e.g. \p{Mc}, or group of categories, e.g. \p{L},
+                                // or the inverse of those.
+                                foreach (KeyValuePair<string, string> kvp in s_definedCategories)
+                                {
+                                    bool equalsGroup = group.SequenceEqual(kvp.Value.AsSpan());
+                                    if (equalsGroup || invertedGroup.SequenceEqual(kvp.Value.AsSpan()))
+                                    {
+                                        desc.Append(equalsGroup ? @"\p{" : @"\P{").Append(kvp.Key).Append('}');
+                                        break;
+                                    }
+                                }
+                                break;
                         }
 
                         index = lastindex;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFindOptimizations.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFindOptimizations.cs
@@ -686,10 +686,8 @@ namespace System.Text.RegularExpressions
                             }
 
                             // We have a winner.  The starting position is just after the last position that failed to match the loop.
-                            // TODO: It'd be nice to be able to communicate literalPos as a place the matching engine can start matching
-                            // after the loop, so that it doesn't need to re-match the loop.  This might only be feasible for RegexCompiler
-                            // and the source generator after we refactor them to generate a single Scan method rather than separate
-                            // FindFirstChar / Go methods.
+                            // RegexCompiler and the source generator also communicate the location of the found literal via a member of RegexRunner
+                            // they don't use, but that's not viable here.
                             pos = startingPos + prev + 1;
                             return true;
                         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicNFA.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicNFA.cs
@@ -161,11 +161,6 @@ namespace System.Text.RegularExpressions.Symbolic
         public IEnumerable<(TSet, SymbolicRegexNode<TSet>?, int)> EnumeratePaths(int sourceState) =>
             _transitionFunction[sourceState].EnumeratePaths(_solver, _solver.Full);
 
-        /// <summary>
-        /// TODO: Explore an unexplored state on transition further.
-        /// </summary>
-        public static void ExploreState(int state) => new NotImplementedException();
-
         public static SymbolicNFA<TSet> Explore(SymbolicRegexNode<TSet> root, int bound)
         {
             (Dictionary<TransitionRegex<TSet>, Transition> cache,


### PR DESCRIPTION
- Fix RegexCharClass.DescribeSet to properly handle negated Unicode category pretty-printing (used by the source generator)
- Fix a stale TODO comment in RegexFindOptimizations
- Delete an unused, unimplemented method in the debug-only SymbolicNFA