### PR TITLE
Fix declaration hiding in host

### DIFF
--- a/src/native/corehost/CMakeLists.txt
+++ b/src/native/corehost/CMakeLists.txt
@@ -12,6 +12,12 @@ include(${CLR_ENG_NATIVE_DIR}/configurecompiler.cmake)
 if (MSVC)
     # Host components don't try to handle asynchronous exceptions
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/EHsc>)
+
+    # Explicitly re-enable warnings about declation hiding (currently disabled by configurecompiler.cmake)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/we4456>) # declaration of 'identifier' hides previous local declaration
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/we4457>) # declaration of 'identifier' hides function parameter
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/we4458>) # declaration of 'identifier' hides class member
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/we4459>) # declaration of 'identifier' hides global declaration
 elseif (CMAKE_CXX_COMPILER_ID MATCHES GNU)
     # Prevents libc from calling pthread_cond_destroy on static objects in
     # dlopen()'ed library which we dlclose() in pal::unload_library.

--- a/src/native/corehost/fxr/framework_info.cpp
+++ b/src/native/corehost/fxr/framework_info.cpp
@@ -62,10 +62,10 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
                 pal::readdir_onlydirectories(fx_shared_dir, &fx_names);
             }
 
-            for (pal::string_t fx_name : fx_names)
+            for (pal::string_t fx_name_local : fx_names)
             {
                 auto fx_dir = fx_shared_dir;
-                append_path(&fx_dir, fx_name.c_str());
+                append_path(&fx_dir, fx_name_local.c_str());
 
                 if (pal::directory_exists(fx_dir))
                 {
@@ -81,7 +81,7 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
                         {
                             trace::verbose(_X("Found FX version [%s]"), ver.c_str());
 
-                            framework_info info(fx_name, fx_dir, parsed, hive_depth);
+                            framework_info info(fx_name_local, fx_dir, parsed, hive_depth);
                             framework_infos->push_back(info);
                         }
                     }

--- a/src/native/corehost/fxr/fx_resolver.cpp
+++ b/src/native/corehost/fxr/fx_resolver.cpp
@@ -268,10 +268,7 @@ namespace
                     if (selected_ver != fx_ver_t())
                     {
                         // Compare the previous hive_dir selection with the current hive_dir to see which one is the better match
-                        std::vector<fx_ver_t> version_list;
-                        version_list.push_back(resolved_ver);
-                        version_list.push_back(selected_ver);
-                        resolved_ver = resolve_framework_reference_from_version_list(version_list, fx_ref);
+                        resolved_ver = resolve_framework_reference_from_version_list({ resolved_ver, selected_ver }, fx_ref);
                     }
 
                     if (resolved_ver != selected_ver)


### PR DESCRIPTION
Fix local declarations hiding previous declarations in host. This also enables warnings about declaration hiding for the host build. Other parts of the repo have a bunch of these, so I left it disabled in the shared configuration.

Pointed out in https://github.com/dotnet/runtime/pull/68355#discussion_r855886109