### PR TITLE
Fix the TypeConverter when enabling UseSystemResourceKeys

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ArrayConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ArrayConverter.cs
@@ -19,7 +19,7 @@ namespace System.ComponentModel
         {
             if (destinationType == typeof(string) && value is Array)
             {
-                return SR.Format(SR.Array, value.GetType().Name);
+                return string.Format(SR.GetResourceString(nameof(SR.Array), "{0} Array"), value.GetType().Name);
             }
 
             return base.ConvertTo(context, culture, value, destinationType);

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/CollectionConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/CollectionConverter.cs
@@ -20,7 +20,7 @@ namespace System.ComponentModel
         {
             if (destinationType == typeof(string) && value is ICollection)
             {
-                return SR.Collection;
+                return SR.GetResourceString(nameof(SR.Collection), "(Collection)");
             }
 
             return base.ConvertTo(context, culture, value, destinationType);

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
@@ -22,7 +22,7 @@ namespace System.ComponentModel
         /// <summary>
         /// Retrieves the "default" name for our culture.
         /// </summary>
-        private static string DefaultCultureString => SR.CultureInfoConverterDefaultCultureString;
+        private static string DefaultCultureString => SR.GetResourceString(nameof(SR.CultureInfoConverterDefaultCultureString), "(Default)");
 
         private const string DefaultInvariantCultureString = "(Default)";
 

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
@@ -467,7 +467,7 @@ namespace System.ComponentModel.Design
             {
                 if (destinationType == typeof(string))
                 {
-                    return SR.CollectionConverterText;
+                    return SR.GetResourceString(nameof(SR.CollectionConverterText), "(Collection)");
                 }
                 return base.ConvertTo(cxt, culture, value, destinationType);
             }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtendedPropertyDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtendedPropertyDescriptor.cs
@@ -99,7 +99,7 @@ namespace System.ComponentModel
                     string? providerName = site?.Name;
                     if (providerName != null && providerName.Length > 0)
                     {
-                        name = SR.Format(SR.MetaExtenderName, name, providerName);
+                        name = string.Format(SR.GetResourceString(nameof(SR.MetaExtenderName), "{0} on {1}"), name, providerName);
                     }
                 }
                 return name;

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/InstanceCreationEditor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/InstanceCreationEditor.cs
@@ -11,7 +11,7 @@ namespace System.ComponentModel
     /// </summary>
     public abstract class InstanceCreationEditor
     {
-        public virtual string Text => SR.InstanceCreationEditorDefaultText;
+        public virtual string Text => SR.GetResourceString(nameof(SR.InstanceCreationEditorDefaultText), "(New...)");
 
         /// <summary>
         /// This method is invoked when you user chooses the link displayed by the PropertyGrid for the InstanceCreationEditor.

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/MultilineStringConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/MultilineStringConverter.cs
@@ -20,7 +20,7 @@ namespace System.ComponentModel
 
             if (destinationType == typeof(string) && value is string)
             {
-                return SR.Text;
+                return SR.GetResourceString(nameof(SR.Text), "(Text)");
             }
 
             return base.ConvertTo(context, culture, value, destinationType);

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReferenceConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReferenceConverter.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel
     /// </summary>
     public class ReferenceConverter : TypeConverter
     {
-        private static readonly string s_none = SR.toStringNone;
+        private static readonly string s_none = SR.GetResourceString(nameof(SR.toStringNone), "(none)");
         private readonly Type _type;
 
         /// <summary>

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeConverter.cs
@@ -191,7 +191,7 @@ namespace System.ComponentModel
         /// </summary>
         protected Exception GetConvertFromException(object? value)
         {
-            string? valueTypeName = value == null ? SR.Null : value.GetType().FullName;
+            string? valueTypeName = value == null ? SR.GetResourceString(nameof(SR.Null), "(null)") : value.GetType().FullName;
             throw new NotSupportedException(SR.Format(SR.ConvertFromException, GetType().Name, valueTypeName));
         }
 
@@ -201,7 +201,7 @@ namespace System.ComponentModel
         /// </summary>
         protected Exception GetConvertToException(object? value, Type destinationType)
         {
-            string? valueTypeName = value == null ? SR.Null : value.GetType().FullName;
+            string? valueTypeName = value == null ? SR.GetResourceString(nameof(SR.Null), "(null)") : value.GetType().FullName;
             throw new NotSupportedException(SR.Format(SR.ConvertToException, GetType().Name, valueTypeName, destinationType.FullName));
         }
 

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeListConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeListConverter.cs
@@ -73,7 +73,7 @@ namespace System.ComponentModel
             {
                 if (value == null)
                 {
-                    return SR.none;
+                    return SR.GetResourceString(nameof(SR.none), "(none)");
                 }
                 else
                 {

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Timers/TimersDescriptionAttribute.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Timers/TimersDescriptionAttribute.cs
@@ -40,7 +40,7 @@ namespace System.Timers
                 if (!_replaced)
                 {
                     _replaced = true;
-                    DescriptionValue = SR.Format(base.Description);
+                    DescriptionValue = string.Format(base.Description);
                 }
                 return base.Description;
             }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Timers/TimersDescriptionAttribute.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Timers/TimersDescriptionAttribute.cs
@@ -40,7 +40,10 @@ namespace System.Timers
                 if (!_replaced)
                 {
                     _replaced = true;
-                    DescriptionValue = base.Description;
+
+                    // We call string.Format here only to keep the original behavior which throws when having null description.
+                    // That will keep the exception is thrown from same original place with the exact parameters.
+                    DescriptionValue = string.Format(base.Description);
                 }
                 return base.Description;
             }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Timers/TimersDescriptionAttribute.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Timers/TimersDescriptionAttribute.cs
@@ -40,7 +40,7 @@ namespace System.Timers
                 if (!_replaced)
                 {
                     _replaced = true;
-                    DescriptionValue = string.Format(base.Description);
+                    DescriptionValue = base.Description;
                 }
                 return base.Description;
             }

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/ContainerTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/ContainerTests.cs
@@ -322,7 +322,7 @@ namespace System.ComponentModel.Tests
             Assert.Equal(typeof(ArgumentException), ex.GetType());
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            Assert.True(ex.Message.IndexOf("'dup'") != -1);
+            Assert.True(ex.Message.IndexOf("'dup'") != -1 || ex.Message.IndexOf(" dup") != -1);
             Assert.Null(ex.ParamName);
             Assert.Equal(1, container.Components.Count);
 
@@ -334,7 +334,7 @@ namespace System.ComponentModel.Tests
             Assert.Equal(typeof(ArgumentException), ex.GetType());
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            Assert.True(ex.Message.IndexOf("'duP'") != -1);
+            Assert.True(ex.Message.IndexOf("'duP'") != -1 || ex.Message.IndexOf(" duP") != -1);
             Assert.Null(ex.ParamName);
             Assert.Equal(1, container.Components.Count);
 
@@ -356,7 +356,7 @@ namespace System.ComponentModel.Tests
             Assert.Equal(typeof(ArgumentException), ex.GetType());
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            Assert.True(ex.Message.IndexOf("'dup'") != -1);
+            Assert.True(ex.Message.IndexOf("'dup'") != -1 || ex.Message.IndexOf(" dup") != -1);
             Assert.Null(ex.ParamName);
             Assert.Equal(2, container.Components.Count);
             Assert.Equal(1, container2.Components.Count);
@@ -729,7 +729,7 @@ namespace System.ComponentModel.Tests
             Assert.Equal(typeof(ArgumentException), ex.GetType());
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            Assert.True(ex.Message.IndexOf("'dup'") != -1);
+            Assert.True(ex.Message.IndexOf("'dup'") != -1 || ex.Message.IndexOf(" dup") != -1);
             Assert.Null(ex.ParamName);
             Assert.Equal(2, _container.Components.Count);
             _container.InvokeValidateName(compB, "whatever");
@@ -742,7 +742,7 @@ namespace System.ComponentModel.Tests
             Assert.Equal(typeof(ArgumentException), ex.GetType());
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            Assert.True(ex.Message.IndexOf("'dup'") != -1);
+            Assert.True(ex.Message.IndexOf("'dup'") != -1 || ex.Message.IndexOf(" dup") != -1);
             Assert.Null(ex.ParamName);
             Assert.Equal(2, _container.Components.Count);
             _container.InvokeValidateName(compC, "whatever");
@@ -757,7 +757,7 @@ namespace System.ComponentModel.Tests
             Assert.Equal(typeof(ArgumentException), ex.GetType());
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            Assert.True(ex.Message.IndexOf("'dup'") != -1);
+            Assert.True(ex.Message.IndexOf("'dup'") != -1 || ex.Message.IndexOf(" dup") != -1);
             Assert.Null(ex.ParamName);
             Assert.Equal(2, _container.Components.Count);
             _container.InvokeValidateName(compD, "whatever");

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/CultureInfoConverterTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/CultureInfoConverterTests.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Design.Serialization;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Tests;
 using Xunit;
 
 namespace System.ComponentModel.Tests
@@ -150,6 +151,15 @@ namespace System.ComponentModel.Tests
             };
             Assert.Equal("(Default)", converter.ConvertTo(CultureInfo.InvariantCulture, typeof(string)));
             Assert.Equal("Fixed", converter.ConvertTo(new CultureInfo("en-US"), typeof(string)));
+        }
+
+        [Fact]
+        public void CultureInfoConverterForDefaultValue()
+        {
+            using (new ThreadCultureChange(null, CultureInfo.InvariantCulture))
+            {
+                Assert.Equal("", ((CultureInfo)TypeDescriptor.GetConverter(typeof(System.Globalization.CultureInfo)).ConvertFrom(null, null, "(Default)")).Name);
+            }
         }
 
         private class SubCultureInfoConverter : CultureInfoConverter


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/68651

When enabling `UseSystemResourceKeys` msbuild property, the build will strip out all string resources and any resource lookup will report the resource key instead of the resource value. This is mainly used when reducing the size of the built binaries. In TypeConverter, this will cause a problem because there are some resources that have values with special meaning. Reporting the resource key in such cases will make the requested conversion operation fail as the converter will not recognize the value picked up from the resources. 

The fix is to apply @jkotas suggestion mentioned in the comment https://github.com/dotnet/runtime/issues/68651#issuecomment-1112641957.