### PR TITLE
Ensure the generic math APIs are publicly exposed on nint/nuint where relevant

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
@@ -288,72 +288,22 @@ namespace System
         //
 
         /// <inheritdoc cref="IBinaryInteger{TSelf}.DivRem(TSelf, TSelf)" />
-        static (nint Quotient, nint Remainder) IBinaryInteger<nint>.DivRem(nint left, nint right) => Math.DivRem(left, right);
+        public static (nint Quotient, nint Remainder) DivRem(nint left, nint right) => Math.DivRem(left, right);
 
         /// <inheritdoc cref="IBinaryInteger{TSelf}.LeadingZeroCount(TSelf)" />
-        static nint IBinaryInteger<nint>.LeadingZeroCount(nint value)
-        {
-            if (Environment.Is64BitProcess)
-            {
-                return BitOperations.LeadingZeroCount((ulong)value);
-            }
-            else
-            {
-                return BitOperations.LeadingZeroCount((uint)value);
-            }
-        }
+        public static nint LeadingZeroCount(nint value) => BitOperations.LeadingZeroCount((nuint)value);
 
         /// <inheritdoc cref="IBinaryInteger{TSelf}.PopCount(TSelf)" />
-        static nint IBinaryInteger<nint>.PopCount(nint value)
-        {
-            if (Environment.Is64BitProcess)
-            {
-                return BitOperations.PopCount((ulong)value);
-            }
-            else
-            {
-                return BitOperations.PopCount((uint)value);
-            }
-        }
+        public static nint PopCount(nint value) => BitOperations.PopCount((nuint)value);
 
         /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateLeft(TSelf, int)" />
-        static nint IBinaryInteger<nint>.RotateLeft(nint value, int rotateAmount)
-        {
-            if (Environment.Is64BitProcess)
-            {
-                return (nint)BitOperations.RotateLeft((ulong)value, rotateAmount);
-            }
-            else
-            {
-                return (nint)BitOperations.RotateLeft((uint)value, rotateAmount);
-            }
-        }
+        public static nint RotateLeft(nint value, int rotateAmount) => (nint)BitOperations.RotateLeft((nuint)value, rotateAmount);
 
         /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateRight(TSelf, int)" />
-        static nint IBinaryInteger<nint>.RotateRight(nint value, int rotateAmount)
-        {
-            if (Environment.Is64BitProcess)
-            {
-                return (nint)BitOperations.RotateRight((ulong)value, rotateAmount);
-            }
-            else
-            {
-                return (nint)BitOperations.RotateRight((uint)value, rotateAmount);
-            }
-        }
+        public static nint RotateRight(nint value, int rotateAmount) => (nint)BitOperations.RotateRight((nuint)value, rotateAmount);
 
         /// <inheritdoc cref="IBinaryInteger{TSelf}.TrailingZeroCount(TSelf)" />
-        static nint IBinaryInteger<nint>.TrailingZeroCount(nint value)
-        {
-            if (Environment.Is64BitProcess)
-            {
-                return BitOperations.TrailingZeroCount((ulong)value);
-            }
-            else
-            {
-                return BitOperations.TrailingZeroCount((uint)value);
-            }
-        }
+        public static nint TrailingZeroCount(nint value) => BitOperations.TrailingZeroCount(value);
 
         /// <inheritdoc cref="IBinaryInteger{TSelf}.GetShortestBitLength()" />
         unsafe long IBinaryInteger<nint>.GetShortestBitLength()
@@ -396,24 +346,16 @@ namespace System
         //
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
-        static bool IBinaryNumber<nint>.IsPow2(nint value) => BitOperations.IsPow2(value);
+        public static bool IsPow2(nint value) => BitOperations.IsPow2(value);
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />
-        static nint IBinaryNumber<nint>.Log2(nint value)
+        public static nint Log2(nint value)
         {
             if (value < 0)
             {
                 ThrowHelper.ThrowValueArgumentOutOfRange_NeedNonNegNumException();
             }
-
-            if (Environment.Is64BitProcess)
-            {
-                return BitOperations.Log2((ulong)value);
-            }
-            else
-            {
-                return BitOperations.Log2((uint)value);
-            }
+            return BitOperations.Log2((nuint)value);
         }
 
         //
@@ -517,13 +459,13 @@ namespace System
         //
 
         /// <inheritdoc cref="INumber{TSelf}.Abs(TSelf)" />
-        static nint INumber<nint>.Abs(nint value) => Math.Abs(value);
+        public static nint Abs(nint value) => Math.Abs(value);
 
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
-        static nint INumber<nint>.Clamp(nint value, nint min, nint max) => Math.Clamp(value, min, max);
+        public static nint Clamp(nint value, nint min, nint max) => Math.Clamp(value, min, max);
 
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
-        static nint INumber<nint>.CopySign(nint value, nint sign)
+        public static nint CopySign(nint value, nint sign)
         {
             nint absValue = value;
 
@@ -547,7 +489,8 @@ namespace System
 
         /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static nint INumber<nint>.CreateChecked<TOther>(TOther value)
+        public static nint CreateChecked<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -614,7 +557,8 @@ namespace System
 
         /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static nint INumber<nint>.CreateSaturating<TOther>(TOther value)
+        public static nint CreateSaturating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -692,7 +636,8 @@ namespace System
 
         /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static nint INumber<nint>.CreateTruncating<TOther>(TOther value)
+        public static nint CreateTruncating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -758,13 +703,13 @@ namespace System
         }
 
         /// <inheritdoc cref="INumber{TSelf}.IsNegative(TSelf)" />
-        static bool INumber<nint>.IsNegative(nint value) => value < 0;
+        public static bool IsNegative(nint value) => value < 0;
 
         /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
-        static nint INumber<nint>.Max(nint x, nint y) => Math.Max(x, y);
+        public static nint Max(nint x, nint y) => Math.Max(x, y);
 
         /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
-        static nint INumber<nint>.MaxMagnitude(nint x, nint y)
+        public static nint MaxMagnitude(nint x, nint y)
         {
             nint absX = x;
 
@@ -794,10 +739,10 @@ namespace System
         }
 
         /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
-        static nint INumber<nint>.Min(nint x, nint y) => Math.Min(x, y);
+        public static nint Min(nint x, nint y) => Math.Min(x, y);
 
         /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
-        static nint INumber<nint>.MinMagnitude(nint x, nint y)
+        public static nint MinMagnitude(nint x, nint y)
         {
             nint absX = x;
 
@@ -827,11 +772,12 @@ namespace System
         }
 
         /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        static int INumber<nint>.Sign(nint value) => Math.Sign(value);
+        public static int Sign(nint value) => Math.Sign(value);
 
         /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool INumber<nint>.TryCreate<TOther>(TOther value, out nint result)
+        public static bool TryCreate<TOther>(TOther value, out nint result)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
@@ -280,72 +280,22 @@ namespace System
         //
 
         /// <inheritdoc cref="IBinaryInteger{TSelf}.DivRem(TSelf, TSelf)" />
-        static (nuint Quotient, nuint Remainder) IBinaryInteger<nuint>.DivRem(nuint left, nuint right) => Math.DivRem(left, right);
+        public static (nuint Quotient, nuint Remainder) DivRem(nuint left, nuint right) => Math.DivRem(left, right);
 
         /// <inheritdoc cref="IBinaryInteger{TSelf}.LeadingZeroCount(TSelf)" />
-        static nuint IBinaryInteger<nuint>.LeadingZeroCount(nuint value)
-        {
-            if (Environment.Is64BitProcess)
-            {
-                return (nuint)BitOperations.LeadingZeroCount((ulong)value);
-            }
-            else
-            {
-                return (nuint)BitOperations.LeadingZeroCount((uint)value);
-            }
-        }
+        public static nuint LeadingZeroCount(nuint value) => (nuint)BitOperations.LeadingZeroCount(value);
 
         /// <inheritdoc cref="IBinaryInteger{TSelf}.PopCount(TSelf)" />
-        static nuint IBinaryInteger<nuint>.PopCount(nuint value)
-        {
-            if (Environment.Is64BitProcess)
-            {
-                return (nuint)BitOperations.PopCount((ulong)value);
-            }
-            else
-            {
-                return (nuint)BitOperations.PopCount((uint)value);
-            }
-        }
+        public static nuint PopCount(nuint value) => (nuint)BitOperations.PopCount(value);
 
         /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateLeft(TSelf, int)" />
-        static nuint IBinaryInteger<nuint>.RotateLeft(nuint value, int rotateAmount)
-        {
-            if (Environment.Is64BitProcess)
-            {
-                return (nuint)BitOperations.RotateLeft((ulong)value, rotateAmount);
-            }
-            else
-            {
-                return (nuint)BitOperations.RotateLeft((uint)value, rotateAmount);
-            }
-        }
+        public static nuint RotateLeft(nuint value, int rotateAmount) => BitOperations.RotateLeft(value, rotateAmount);
 
         /// <inheritdoc cref="IBinaryInteger{TSelf}.RotateRight(TSelf, int)" />
-        static nuint IBinaryInteger<nuint>.RotateRight(nuint value, int rotateAmount)
-        {
-            if (Environment.Is64BitProcess)
-            {
-                return (nuint)BitOperations.RotateRight((ulong)value, rotateAmount);
-            }
-            else
-            {
-                return (nuint)BitOperations.RotateRight((uint)value, rotateAmount);
-            }
-        }
+        public static nuint RotateRight(nuint value, int rotateAmount) => BitOperations.RotateRight(value, rotateAmount);
 
         /// <inheritdoc cref="IBinaryInteger{TSelf}.TrailingZeroCount(TSelf)" />
-        static nuint IBinaryInteger<nuint>.TrailingZeroCount(nuint value)
-        {
-            if (Environment.Is64BitProcess)
-            {
-                return (nuint)BitOperations.TrailingZeroCount((ulong)value);
-            }
-            else
-            {
-                return (nuint)BitOperations.TrailingZeroCount((uint)value);
-            }
-        }
+        public static nuint TrailingZeroCount(nuint value) => (nuint)BitOperations.TrailingZeroCount(value);
 
         /// <inheritdoc cref="IBinaryInteger{TSelf}.GetShortestBitLength()" />
         unsafe long IBinaryInteger<nuint>.GetShortestBitLength() => (sizeof(nuint) * 8) - BitOperations.LeadingZeroCount((nuint)_value);
@@ -376,30 +326,10 @@ namespace System
         //
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.IsPow2(TSelf)" />
-        static bool IBinaryNumber<nuint>.IsPow2(nuint value)
-        {
-            if (Environment.Is64BitProcess)
-            {
-                return BitOperations.IsPow2((ulong)value);
-            }
-            else
-            {
-                return BitOperations.IsPow2((uint)value);
-            }
-        }
+        public static bool IsPow2(nuint value) => BitOperations.IsPow2(value);
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />
-        static nuint IBinaryNumber<nuint>.Log2(nuint value)
-        {
-            if (Environment.Is64BitProcess)
-            {
-                return (nuint)BitOperations.Log2((ulong)value);
-            }
-            else
-            {
-                return (nuint)BitOperations.Log2((uint)value);
-            }
-        }
+        public static nuint Log2(nuint value) => (nuint)BitOperations.Log2(value);
 
         //
         // IBitwiseOperators
@@ -505,14 +435,15 @@ namespace System
         static nuint INumber<nuint>.Abs(nuint value) => value;
 
         /// <inheritdoc cref="INumber{TSelf}.Clamp(TSelf, TSelf, TSelf)" />
-        static nuint INumber<nuint>.Clamp(nuint value, nuint min, nuint max) => Math.Clamp(value, min, max);
+        public static nuint Clamp(nuint value, nuint min, nuint max) => Math.Clamp(value, min, max);
 
         /// <inheritdoc cref="INumber{TSelf}.CopySign(TSelf, TSelf)" />
         static nuint INumber<nuint>.CopySign(nuint value, nuint sign) => value;
 
         /// <inheritdoc cref="INumber{TSelf}.CreateChecked{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static nuint INumber<nuint>.CreateChecked<TOther>(TOther value)
+        public static nuint CreateChecked<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -579,7 +510,8 @@ namespace System
 
         /// <inheritdoc cref="INumber{TSelf}.CreateSaturating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static nuint INumber<nuint>.CreateSaturating<TOther>(TOther value)
+        public static nuint CreateSaturating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -660,7 +592,8 @@ namespace System
 
         /// <inheritdoc cref="INumber{TSelf}.CreateTruncating{TOther}(TOther)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static nuint INumber<nuint>.CreateTruncating<TOther>(TOther value)
+        public static nuint CreateTruncating<TOther>(TOther value)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {
@@ -729,23 +662,24 @@ namespace System
         static bool INumber<nuint>.IsNegative(nuint value) => false;
 
         /// <inheritdoc cref="INumber{TSelf}.Max(TSelf, TSelf)" />
-        static nuint INumber<nuint>.Max(nuint x, nuint y) => Math.Max(x, y);
+        public static nuint Max(nuint x, nuint y) => Math.Max(x, y);
 
         /// <inheritdoc cref="INumber{TSelf}.MaxMagnitude(TSelf, TSelf)" />
-        static nuint INumber<nuint>.MaxMagnitude(nuint x, nuint y) => Math.Max(x, y);
+        public static nuint MaxMagnitude(nuint x, nuint y) => Max(x, y);
 
         /// <inheritdoc cref="INumber{TSelf}.Min(TSelf, TSelf)" />
-        static nuint INumber<nuint>.Min(nuint x, nuint y) => Math.Min(x, y);
+        public static nuint Min(nuint x, nuint y) => Math.Min(x, y);
 
         /// <inheritdoc cref="INumber{TSelf}.MinMagnitude(TSelf, TSelf)" />
-        static nuint INumber<nuint>.MinMagnitude(nuint x, nuint y) => Math.Min(x, y);
+        public static nuint MinMagnitude(nuint x, nuint y) => Min(x, y);
 
         /// <inheritdoc cref="INumber{TSelf}.Sign(TSelf)" />
-        static int INumber<nuint>.Sign(nuint value) => (value == 0) ? 0 : 1;
+        public static int Sign(nuint value) => (value == 0) ? 0 : 1;
 
         /// <inheritdoc cref="INumber{TSelf}.TryCreate{TOther}(TOther, out TSelf)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool INumber<nuint>.TryCreate<TOther>(TOther value, out nuint result)
+        public static bool TryCreate<TOther>(TOther value, out nuint result)
+            where TOther : INumber<TOther>
         {
             if (typeof(TOther) == typeof(byte))
             {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -3239,12 +3239,27 @@ namespace System
         static nint System.Numerics.INumberBase<nint>.One { get { throw null; } }
         static nint System.Numerics.INumberBase<nint>.Zero { get { throw null; } }
         static nint System.Numerics.ISignedNumber<nint>.NegativeOne { get { throw null; } }
+        public static nint Abs(nint value) { throw null; }
         public static System.IntPtr Add(System.IntPtr pointer, int offset) { throw null; }
+        public static nint Clamp(nint value, nint min, nint max) { throw null; }
         public int CompareTo(System.IntPtr value) { throw null; }
         public int CompareTo(object? value) { throw null; }
+        public static nint CopySign(nint value, nint sign) { throw null; }
+        public static nint CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static nint CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static nint CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static (nint Quotient, nint Remainder) DivRem(nint left, nint right) { throw null; }
         public bool Equals(System.IntPtr other) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
+        public static bool IsNegative(nint value) { throw null; }
+        public static bool IsPow2(nint value) { throw null; }
+        public static nint LeadingZeroCount(nint value) { throw null; }
+        public static nint Log2(nint value) { throw null; }
+        public static nint Max(nint x, nint y) { throw null; }
+        public static nint MaxMagnitude(nint x, nint y) { throw null; }
+        public static nint Min(nint x, nint y) { throw null; }
+        public static nint MinMagnitude(nint x, nint y) { throw null; }
         public static System.IntPtr operator +(System.IntPtr pointer, int offset) { throw null; }
         public static bool operator ==(System.IntPtr value1, System.IntPtr value2) { throw null; }
         public static explicit operator System.IntPtr (int value) { throw null; }
@@ -3263,20 +3278,16 @@ namespace System
         public static System.IntPtr Parse(string s, System.Globalization.NumberStyles style) { throw null; }
         public static System.IntPtr Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
         public static System.IntPtr Parse(string s, System.IFormatProvider? provider) { throw null; }
+        public static nint PopCount(nint value) { throw null; }
+        public static nint RotateLeft(nint value, int rotateAmount) { throw null; }
+        public static nint RotateRight(nint value, int rotateAmount) { throw null; }
+        public static int Sign(nint value) { throw null; }
         public static System.IntPtr Subtract(System.IntPtr pointer, int offset) { throw null; }
         static nint System.Numerics.IAdditionOperators<nint, nint, nint>.operator +(nint left, nint right) { throw null; }
         static nint System.Numerics.IAdditionOperators<nint, nint, nint>.operator checked +(nint left, nint right) { throw null; }
-        static (nint Quotient, nint Remainder) System.Numerics.IBinaryInteger<nint>.DivRem(nint left, nint right) { throw null; }
         int System.Numerics.IBinaryInteger<nint>.GetByteCount() { throw null; }
         long System.Numerics.IBinaryInteger<nint>.GetShortestBitLength() { throw null; }
-        static nint System.Numerics.IBinaryInteger<nint>.LeadingZeroCount(nint value) { throw null; }
-        static nint System.Numerics.IBinaryInteger<nint>.PopCount(nint value) { throw null; }
-        static nint System.Numerics.IBinaryInteger<nint>.RotateLeft(nint value, int rotateAmount) { throw null; }
-        static nint System.Numerics.IBinaryInteger<nint>.RotateRight(nint value, int rotateAmount) { throw null; }
-        static nint System.Numerics.IBinaryInteger<nint>.TrailingZeroCount(nint value) { throw null; }
         bool System.Numerics.IBinaryInteger<nint>.TryWriteLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
-        static bool System.Numerics.IBinaryNumber<nint>.IsPow2(nint value) { throw null; }
-        static nint System.Numerics.IBinaryNumber<nint>.Log2(nint value) { throw null; }
         static nint System.Numerics.IBitwiseOperators<nint, nint, nint>.operator &(nint left, nint right) { throw null; }
         static nint System.Numerics.IBitwiseOperators<nint, nint, nint>.operator |(nint left, nint right) { throw null; }
         static nint System.Numerics.IBitwiseOperators<nint, nint, nint>.operator ^(nint left, nint right) { throw null; }
@@ -3294,19 +3305,6 @@ namespace System
         static nint System.Numerics.IModulusOperators<nint, nint, nint>.operator %(nint left, nint right) { throw null; }
         static nint System.Numerics.IMultiplyOperators<nint, nint, nint>.operator checked *(nint left, nint right) { throw null; }
         static nint System.Numerics.IMultiplyOperators<nint, nint, nint>.operator *(nint left, nint right) { throw null; }
-        static nint System.Numerics.INumber<nint>.Abs(nint value) { throw null; }
-        static nint System.Numerics.INumber<nint>.Clamp(nint value, nint min, nint max) { throw null; }
-        static nint System.Numerics.INumber<nint>.CopySign(nint value, nint sign) { throw null; }
-        static nint System.Numerics.INumber<nint>.CreateChecked<TOther>(TOther value) { throw null; }
-        static nint System.Numerics.INumber<nint>.CreateSaturating<TOther>(TOther value) { throw null; }
-        static nint System.Numerics.INumber<nint>.CreateTruncating<TOther>(TOther value) { throw null; }
-        static bool System.Numerics.INumber<nint>.IsNegative(nint value) { throw null; }
-        static nint System.Numerics.INumber<nint>.Max(nint x, nint y) { throw null; }
-        static nint System.Numerics.INumber<nint>.MaxMagnitude(nint x, nint y) { throw null; }
-        static nint System.Numerics.INumber<nint>.Min(nint x, nint y) { throw null; }
-        static nint System.Numerics.INumber<nint>.MinMagnitude(nint x, nint y) { throw null; }
-        static int System.Numerics.INumber<nint>.Sign(nint value) { throw null; }
-        static bool System.Numerics.INumber<nint>.TryCreate<TOther>(TOther value, out nint result) { throw null; }
         static nint System.Numerics.IShiftOperators<nint, nint>.operator <<(nint value, int shiftAmount) { throw null; }
         static nint System.Numerics.IShiftOperators<nint, nint>.operator >>(nint value, int shiftAmount) { throw null; }
         static nint System.Numerics.IShiftOperators<nint, nint>.operator >>>(nint value, int shiftAmount) { throw null; }
@@ -3324,6 +3322,8 @@ namespace System
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
+        public static nint TrailingZeroCount(nint value) { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out nint result) where TOther : System.Numerics.INumber<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.IntPtr result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.IntPtr result) { throw null; }
@@ -5917,11 +5917,23 @@ namespace System
         static nuint System.Numerics.INumberBase<nuint>.One { get { throw null; } }
         static nuint System.Numerics.INumberBase<nuint>.Zero { get { throw null; } }
         public static System.UIntPtr Add(System.UIntPtr pointer, int offset) { throw null; }
+        public static nuint Clamp(nuint value, nuint min, nuint max) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public int CompareTo(System.UIntPtr value) { throw null; }
+        public static nuint CreateChecked<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static nuint CreateSaturating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static nuint CreateTruncating<TOther>(TOther value) where TOther : System.Numerics.INumber<TOther> { throw null; }
+        public static (nuint Quotient, nuint Remainder) DivRem(nuint left, nuint right) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public bool Equals(System.UIntPtr other) { throw null; }
         public override int GetHashCode() { throw null; }
+        public static bool IsPow2(nuint value) { throw null; }
+        public static nuint LeadingZeroCount(nuint value) { throw null; }
+        public static nuint Log2(nuint value) { throw null; }
+        public static nuint Max(nuint x, nuint y) { throw null; }
+        public static nuint MaxMagnitude(nuint x, nuint y) { throw null; }
+        public static nuint Min(nuint x, nuint y) { throw null; }
+        public static nuint MinMagnitude(nuint x, nuint y) { throw null; }
         public static System.UIntPtr operator +(System.UIntPtr pointer, int offset) { throw null; }
         public static bool operator ==(System.UIntPtr value1, System.UIntPtr value2) { throw null; }
         public static explicit operator System.UIntPtr (uint value) { throw null; }
@@ -5938,20 +5950,16 @@ namespace System
         public static System.UIntPtr Parse(string s, System.Globalization.NumberStyles style) { throw null; }
         public static System.UIntPtr Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
         public static System.UIntPtr Parse(string s, System.IFormatProvider? provider) { throw null; }
+        public static nuint PopCount(nuint value) { throw null; }
+        public static nuint RotateLeft(nuint value, int rotateAmount) { throw null; }
+        public static nuint RotateRight(nuint value, int rotateAmount) { throw null; }
+        public static int Sign(nuint value) { throw null; }
         public static System.UIntPtr Subtract(System.UIntPtr pointer, int offset) { throw null; }
         static nuint System.Numerics.IAdditionOperators<nuint, nuint, nuint>.operator +(nuint left, nuint right) { throw null; }
         static nuint System.Numerics.IAdditionOperators<nuint, nuint, nuint>.operator checked +(nuint left, nuint right) { throw null; }
-        static (nuint Quotient, nuint Remainder) System.Numerics.IBinaryInteger<nuint>.DivRem(nuint left, nuint right) { throw null; }
         int System.Numerics.IBinaryInteger<nuint>.GetByteCount() { throw null; }
         long System.Numerics.IBinaryInteger<nuint>.GetShortestBitLength() { throw null; }
-        static nuint System.Numerics.IBinaryInteger<nuint>.LeadingZeroCount(nuint value) { throw null; }
-        static nuint System.Numerics.IBinaryInteger<nuint>.PopCount(nuint value) { throw null; }
-        static nuint System.Numerics.IBinaryInteger<nuint>.RotateLeft(nuint value, int rotateAmount) { throw null; }
-        static nuint System.Numerics.IBinaryInteger<nuint>.RotateRight(nuint value, int rotateAmount) { throw null; }
-        static nuint System.Numerics.IBinaryInteger<nuint>.TrailingZeroCount(nuint value) { throw null; }
         bool System.Numerics.IBinaryInteger<nuint>.TryWriteLittleEndian(System.Span<byte> destination, out int bytesWritten) { throw null; }
-        static bool System.Numerics.IBinaryNumber<nuint>.IsPow2(nuint value) { throw null; }
-        static nuint System.Numerics.IBinaryNumber<nuint>.Log2(nuint value) { throw null; }
         static nuint System.Numerics.IBitwiseOperators<nuint, nuint, nuint>.operator &(nuint left, nuint right) { throw null; }
         static nuint System.Numerics.IBitwiseOperators<nuint, nuint, nuint>.operator |(nuint left, nuint right) { throw null; }
         static nuint System.Numerics.IBitwiseOperators<nuint, nuint, nuint>.operator ^(nuint left, nuint right) { throw null; }
@@ -5970,18 +5978,8 @@ namespace System
         static nuint System.Numerics.IMultiplyOperators<nuint, nuint, nuint>.operator checked *(nuint left, nuint right) { throw null; }
         static nuint System.Numerics.IMultiplyOperators<nuint, nuint, nuint>.operator *(nuint left, nuint right) { throw null; }
         static nuint System.Numerics.INumber<nuint>.Abs(nuint value) { throw null; }
-        static nuint System.Numerics.INumber<nuint>.Clamp(nuint value, nuint min, nuint max) { throw null; }
         static nuint System.Numerics.INumber<nuint>.CopySign(nuint value, nuint sign) { throw null; }
-        static nuint System.Numerics.INumber<nuint>.CreateChecked<TOther>(TOther value) { throw null; }
-        static nuint System.Numerics.INumber<nuint>.CreateSaturating<TOther>(TOther value) { throw null; }
-        static nuint System.Numerics.INumber<nuint>.CreateTruncating<TOther>(TOther value) { throw null; }
         static bool System.Numerics.INumber<nuint>.IsNegative(nuint value) { throw null; }
-        static nuint System.Numerics.INumber<nuint>.Max(nuint x, nuint y) { throw null; }
-        static nuint System.Numerics.INumber<nuint>.MaxMagnitude(nuint x, nuint y) { throw null; }
-        static nuint System.Numerics.INumber<nuint>.Min(nuint x, nuint y) { throw null; }
-        static nuint System.Numerics.INumber<nuint>.MinMagnitude(nuint x, nuint y) { throw null; }
-        static int System.Numerics.INumber<nuint>.Sign(nuint value) { throw null; }
-        static bool System.Numerics.INumber<nuint>.TryCreate<TOther>(TOther value, out nuint result) { throw null; }
         static nuint System.Numerics.IShiftOperators<nuint, nuint>.operator <<(nuint value, int shiftAmount) { throw null; }
         static nuint System.Numerics.IShiftOperators<nuint, nuint>.operator >>(nuint value, int shiftAmount) { throw null; }
         static nuint System.Numerics.IShiftOperators<nuint, nuint>.operator >>>(nuint value, int shiftAmount) { throw null; }
@@ -5998,6 +5996,8 @@ namespace System
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format, System.IFormatProvider? provider) { throw null; }
         public uint ToUInt32() { throw null; }
         public ulong ToUInt64() { throw null; }
+        public static nuint TrailingZeroCount(nuint value) { throw null; }
+        public static bool TryCreate<TOther>(TOther value, out nuint result) where TOther : System.Numerics.INumber<TOther> { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, [System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UIntPtr result) { throw null; }
         public static bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.UIntPtr result) { throw null; }


### PR DESCRIPTION
Based on the last API review and changes that will be coming to C# 11, we want to expose these members publicly on nint/nuint.

This will also make the APIs visible on `IntPtr/UIntPtr` before C# has unified them, but this should be acceptable and will unblock other work.