### PR TITLE
Detect the default locale name during startup on Apple platforms

### DIFF
--- a/src/coreclr/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/coreclr/dlls/mscoree/coreclr/CMakeLists.txt
@@ -166,10 +166,15 @@ if(FEATURE_MERGE_JIT_AND_ENGINE)
     set(CLRJIT_STATIC clrjit_static)
 endif(FEATURE_MERGE_JIT_AND_ENGINE)
 
+if (CLR_CMAKE_TARGET_OSX OR CLR_CMAKE_TARGET_MACCATALYST)
+    include(CMakeFindFrameworks)
+    find_library(FOUNDATION Foundation REQUIRED)
+endif()
+
 target_sources(coreclr PUBLIC $<TARGET_OBJECTS:cee_wks_core>)
-target_link_libraries(coreclr PUBLIC ${CORECLR_LIBRARIES} ${CLRJIT_STATIC} cee_wks)
+target_link_libraries(coreclr PUBLIC ${CORECLR_LIBRARIES} ${CLRJIT_STATIC} cee_wks ${FOUNDATION})
 target_sources(coreclr_static PUBLIC $<TARGET_OBJECTS:cee_wks_core>)
-target_link_libraries(coreclr_static PUBLIC ${CORECLR_LIBRARIES} clrjit_static cee_wks_mergeable)
+target_link_libraries(coreclr_static PUBLIC ${CORECLR_LIBRARIES} clrjit_static cee_wks_mergeable ${FOUNDATION})
 target_compile_definitions(coreclr_static PUBLIC CORECLR_EMBEDDED)
 
 if(CLR_CMAKE_TARGET_WIN32)

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
@@ -37,6 +37,9 @@ namespace System.Globalization.Tests
         [PlatformSpecific(TestPlatforms.OSX | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS)]
         public void CurrentCulture_Default_Not_Invariant()
         {
+            // On OSX-like platforms, it should default to what the default system culture is 
+            // set to.  Since we shouldn't assume en-US, we just test if it's not the invariant
+            // culture.
             Assert.NotEqual(CultureInfo.CurrentCulture, CultureInfo.InvariantCulture);
             Assert.NotEqual(CultureInfo.CurrentUICulture, CultureInfo.InvariantCulture);
         }
@@ -133,7 +136,7 @@ namespace System.Globalization.Tests
             }, expectedCultureName, new RemoteInvokeOptions { StartInfo = psi }).Dispose();
         }
 
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // When LANG is empty or unset, should default to the invariant culture on Unix.
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
         [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         [InlineData("")]
         [InlineData(null)]
@@ -149,13 +152,28 @@ namespace System.Globalization.Tests
                psi.Environment["LANG"] = langEnvVar;
             }
 
+            // When LANG is empty or unset, on Unix it should default to the invariant culture.
+            // On OSX-like platforms, it should default to what the default system culture is 
+            // set to.  Since we shouldn't assume en-US, we just test if it's not the invariant
+            // culture.
             RemoteExecutor.Invoke(() =>
             {
                 Assert.NotNull(CultureInfo.CurrentCulture);
                 Assert.NotNull(CultureInfo.CurrentUICulture);
 
-                Assert.Equal("", CultureInfo.CurrentCulture.Name);
-                Assert.Equal("", CultureInfo.CurrentUICulture.Name);
+                if (PlatformDetection.IsOSXLike)
+                {
+                    Assert.NotEqual("", CultureInfo.CurrentCulture.Name);
+                    Assert.NotEqual("", CultureInfo.CurrentUICulture.Name);
+
+                    Assert.NotEqual(CultureInfo.CurrentCulture, CultureInfo.InvariantCulture);
+                    Assert.NotEqual(CultureInfo.CurrentUICulture, CultureInfo.InvariantCulture);
+                }
+                else
+                {
+                    Assert.Equal("", CultureInfo.CurrentCulture.Name);
+                    Assert.Equal("", CultureInfo.CurrentUICulture.Name);
+                }
             }, new RemoteInvokeOptions { StartInfo = psi }).Dispose();
         }
 

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
@@ -34,6 +34,14 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.OSX | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS)]
+        public void CurrentCulture_Default_Not_Invariant()
+        {
+            Assert.NotEqual(CultureInfo.CurrentCulture, CultureInfo.InvariantCulture);
+            Assert.NotEqual(CultureInfo.CurrentUICulture, CultureInfo.InvariantCulture);
+        }
+
+        [Fact]
         public void CurrentCulture_Set_Null_ThrowsArgumentNullException()
         {
             AssertExtensions.Throws<ArgumentNullException>("value", () => CultureInfo.CurrentCulture = null);

--- a/src/mono/mono/mini/CMakeLists.txt
+++ b/src/mono/mono/mini/CMakeLists.txt
@@ -68,6 +68,13 @@ if(HAVE_SYS_ICU AND NOT HOST_WASI)
       pal_timeZoneInfo.c
       entrypoints.c
       ${pal_icushim_sources_base})
+
+  if (TARGET_DARWIN)
+    set(icu_shim_sources_base
+        ${icu_shim_sources_base}
+        pal_locale.m)
+  endif()
+
   addprefix(icu_shim_sources "${ICU_SHIM_PATH}" "${icu_shim_sources_base}")
   set_source_files_properties(${icu_shim_sources} PROPERTIES COMPILE_DEFINITIONS OSX_ICU_LIBRARY_PATH="${OSX_ICU_LIBRARY_PATH}")
   set_source_files_properties(${icu_shim_sources} PROPERTIES COMPILE_FLAGS "-I\"${ICU_INCLUDEDIR}\" -I\"${CLR_SRC_NATIVE_DIR}/libs/System.Globalization.Native/\" -I\"${CLR_SRC_NATIVE_DIR}/libs/Common/\" ${ICU_FLAGS}")

--- a/src/native/libs/System.Globalization.Native/CMakeLists.txt
+++ b/src/native/libs/System.Globalization.Native/CMakeLists.txt
@@ -80,6 +80,11 @@ endif()
 include_directories("../Common")
 
 if (GEN_SHARED_LIB)
+    if (CLR_CMAKE_TARGET_OSX OR CLR_CMAKE_TARGET_MACCATALYST OR  CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS)
+        include(CMakeFindFrameworks)
+        find_library(FOUNDATION Foundation REQUIRED)
+    endif()
+
     add_library(System.Globalization.Native
         SHARED
         ${NATIVEGLOBALIZATION_SOURCES}
@@ -88,11 +93,11 @@ if (GEN_SHARED_LIB)
 
     target_link_libraries(System.Globalization.Native
         dl
+        ${FOUNDATION}
     )
 
     install_with_stripped_symbols (System.Globalization.Native PROGRAMS .)
 endif()
-
 
 add_library(System.Globalization.Native-Static
     STATIC

--- a/src/native/libs/System.Globalization.Native/CMakeLists.txt
+++ b/src/native/libs/System.Globalization.Native/CMakeLists.txt
@@ -60,6 +60,10 @@ set(NATIVEGLOBALIZATION_SOURCES
     pal_icushim.c
 )
 
+if (CLR_CMAKE_TARGET_OSX OR CLR_CMAKE_TARGET_MACCATALYST OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS)
+    set(NATIVEGLOBALIZATION_SOURCES ${NATIVEGLOBALIZATION_SOURCES} pal_locale.m)
+endif()
+
 # time zone names are filtered out of icu data for the browser and associated functionality is disabled
 if (NOT CLR_CMAKE_TARGET_BROWSER)
     set(NATIVEGLOBALIZATION_SOURCES ${NATIVEGLOBALIZATION_SOURCES} pal_timeZoneInfo.c)

--- a/src/native/libs/System.Globalization.Native/pal_locale.c
+++ b/src/native/libs/System.Globalization.Native/pal_locale.c
@@ -135,15 +135,16 @@ int32_t FixupLocaleName(UChar* value, int32_t valueLength)
 const char* DetectDefaultLocaleName()
 {
     const char* icuLocale;
-#ifdef __APPLE__
-    icuLocale = DetectDefaultAppleLocaleName();
-if (icuLocale == NULL || icuLocale[0] == 0)
-#endif
+
     icuLocale = uloc_getDefault();
 
     if (strcmp(icuLocale, "en_US_POSIX") == 0)
     {
+#if TARGET_OS_MAC
+        icuLocale = DetectDefaultAppleLocaleName();
+#else
         return "";
+#endif
     }
 
     return icuLocale;

--- a/src/native/libs/System.Globalization.Native/pal_locale.c
+++ b/src/native/libs/System.Globalization.Native/pal_locale.c
@@ -134,7 +134,11 @@ int32_t FixupLocaleName(UChar* value, int32_t valueLength)
 // is not desirable at all because it doesn't support case insensitive string comparisons.
 const char* DetectDefaultLocaleName()
 {
+#ifndef __APPLE__
     const char* icuLocale = uloc_getDefault();
+#else
+    const char* icuLocale = DetectDefaultAppleLocaleName();
+#endif
     if (strcmp(icuLocale, "en_US_POSIX") == 0)
     {
         return "";

--- a/src/native/libs/System.Globalization.Native/pal_locale.c
+++ b/src/native/libs/System.Globalization.Native/pal_locale.c
@@ -134,11 +134,13 @@ int32_t FixupLocaleName(UChar* value, int32_t valueLength)
 // is not desirable at all because it doesn't support case insensitive string comparisons.
 const char* DetectDefaultLocaleName()
 {
-#ifndef __APPLE__
-    const char* icuLocale = uloc_getDefault();
-#else
-    const char* icuLocale = DetectDefaultAppleLocaleName();
+    const char* icuLocale;
+#ifdef __APPLE__
+    icuLocale = DetectDefaultAppleLocaleName();
+if (icuLocale == NULL || icuLocale[0] == 0)
 #endif
+    icuLocale = uloc_getDefault();
+
     if (strcmp(icuLocale, "en_US_POSIX") == 0)
     {
         return "";

--- a/src/native/libs/System.Globalization.Native/pal_locale.c
+++ b/src/native/libs/System.Globalization.Native/pal_locale.c
@@ -140,7 +140,7 @@ const char* DetectDefaultLocaleName()
 
     if (strcmp(icuLocale, "en_US_POSIX") == 0)
     {
-#if TARGET_OS_MAC
+#ifdef TARGET_OS_MAC
         icuLocale = DetectDefaultAppleLocaleName();
 #else
         return "";

--- a/src/native/libs/System.Globalization.Native/pal_locale.c
+++ b/src/native/libs/System.Globalization.Native/pal_locale.c
@@ -136,9 +136,7 @@ int32_t FixupLocaleName(UChar* value, int32_t valueLength)
 // The reason is POSIX locale collation behavior is not desirable at all because it doesn't support case insensitive string comparisons.
 const char* DetectDefaultLocaleName()
 {
-    const char* icuLocale;
-
-    icuLocale = uloc_getDefault();
+    const char* icuLocale = uloc_getDefault();
 
     if (strcmp(icuLocale, "en_US_POSIX") == 0)
     {

--- a/src/native/libs/System.Globalization.Native/pal_locale.c
+++ b/src/native/libs/System.Globalization.Native/pal_locale.c
@@ -129,9 +129,11 @@ int32_t FixupLocaleName(UChar* value, int32_t valueLength)
     return i;
 }
 
-// We use whatever ICU give us as the default locale except if it is en_US_POSIX. We'll map
-// this POSIX locale to Invariant instead. The reason is POSIX locale collation behavior
-// is not desirable at all because it doesn't support case insensitive string comparisons.
+// We use whatever ICU give us as the default locale except if it is en_US_POSIX. 
+//
+// On Apple related platforms (OSX, iOS, tvOS, MacCatalyst), we'll take what the system locale is.  
+// On all other platforms we'll map this POSIX locale to Invariant instead. 
+// The reason is POSIX locale collation behavior is not desirable at all because it doesn't support case insensitive string comparisons.
 const char* DetectDefaultLocaleName()
 {
     const char* icuLocale;
@@ -140,11 +142,7 @@ const char* DetectDefaultLocaleName()
 
     if (strcmp(icuLocale, "en_US_POSIX") == 0)
     {
-#ifdef TARGET_OS_MAC
-        icuLocale = DetectDefaultAppleLocaleName();
-#else
         return "";
-#endif
     }
 
     return icuLocale;
@@ -223,6 +221,16 @@ int32_t GlobalizationNative_GetDefaultLocaleName(UChar* value, int32_t valueLeng
 
     const char* defaultLocale = DetectDefaultLocaleName();
 
+#ifdef __APPLE__
+    char* appleLocale = NULL;
+    
+    if (strcmp(defaultLocale, "") == 0)
+    {
+        appleLocale = DetectDefaultAppleLocaleName();
+        defaultLocale = appleLocale;
+    }
+#endif
+
     uloc_getBaseName(defaultLocale, localeNameBuffer, ULOC_FULLNAME_CAPACITY, &status);
     u_charsToUChars_safe(localeNameBuffer, value, valueLength, &status);
 
@@ -242,6 +250,11 @@ int32_t GlobalizationNative_GetDefaultLocaleName(UChar* value, int32_t valueLeng
             u_charsToUChars_safe(collationValueTemp, &value[localeNameLen + 1], valueLength - localeNameLen - 1, &status);
         }
     }
+
+#ifdef __APPLE__
+    if (appleLocale)
+        free(appleLocale);
+#endif
 
     return UErrorCodeToBool(status);
 }

--- a/src/native/libs/System.Globalization.Native/pal_locale.m
+++ b/src/native/libs/System.Globalization.Native/pal_locale.m
@@ -1,19 +1,31 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#include <stdlib.h>
 #include "pal_locale_internal.h"
+
 #import <Foundation/Foundation.h>
 
 const char* DetectDefaultAppleLocaleName()
 {
     NSLocale *currentLocale = [NSLocale currentLocale];
     NSString *localeName = @"";
+    const char* envLocaleName;
+    
+    // Match the ICU behavior where the default locale can be overriden by 
+    // and env variable.
+    envLocaleName = getenv("LANG");
+
+    if (envLocaleName != NULL)
+    {
+        return envLocaleName;
+    }
     
     if (!currentLocale)
     {
         return strdup([localeName UTF8String]);
     }
-    
+
     if ([currentLocale.languageCode length] > 0 && [currentLocale.countryCode length] > 0)
     {
         localeName = [NSString stringWithFormat:@"%@-%@", currentLocale.languageCode, currentLocale.countryCode];
@@ -25,3 +37,4 @@ const char* DetectDefaultAppleLocaleName()
     
     return strdup([localeName UTF8String]);
 }
+

--- a/src/native/libs/System.Globalization.Native/pal_locale.m
+++ b/src/native/libs/System.Globalization.Native/pal_locale.m
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "pal_locale_internal.h"
+#import <Foundation/Foundation.h>
+
+const char* DetectDefaultAppleLocaleName()
+{
+    NSLocale *currentLocale = [NSLocale currentLocale];
+    NSString *localeName = @"";
+    
+    if (!currentLocale)
+    {
+        return strdup([localeName UTF8String]);
+    }
+    
+    if ([currentLocale.languageCode length] > 0 && [currentLocale.countryCode length] > 0)
+    {
+        localeName = [NSString stringWithFormat:@"%@-%@", currentLocale.languageCode, currentLocale.countryCode];
+    }
+    else
+    {
+        localeName = [currentLocale.localeIdentifier stringByReplacingOccurrencesOfString:@"_" withString:@"-"];
+    }
+    
+    return strdup([localeName UTF8String]);
+}

--- a/src/native/libs/System.Globalization.Native/pal_locale.m
+++ b/src/native/libs/System.Globalization.Native/pal_locale.m
@@ -10,16 +10,6 @@ const char* DetectDefaultAppleLocaleName()
 {
     NSLocale *currentLocale = [NSLocale currentLocale];
     NSString *localeName = @"";
-    const char* envLocaleName;
-    
-    // Match the ICU behavior where the default locale can be overriden by 
-    // and env variable.
-    envLocaleName = getenv("LANG");
-
-    if (envLocaleName != NULL)
-    {
-        return envLocaleName;
-    }
     
     if (!currentLocale)
     {

--- a/src/native/libs/System.Globalization.Native/pal_locale.m
+++ b/src/native/libs/System.Globalization.Native/pal_locale.m
@@ -6,7 +6,7 @@
 
 #import <Foundation/Foundation.h>
 
-const char* DetectDefaultAppleLocaleName()
+char* DetectDefaultAppleLocaleName()
 {
     NSLocale *currentLocale = [NSLocale currentLocale];
     NSString *localeName = @"";

--- a/src/native/libs/System.Globalization.Native/pal_locale.m
+++ b/src/native/libs/System.Globalization.Native/pal_locale.m
@@ -22,7 +22,7 @@ char* DetectDefaultAppleLocaleName()
     }
     else
     {
-        localeName = [currentLocale.localeIdentifier stringByReplacingOccurrencesOfString:@"_" withString:@"-"];
+        localeName = currentLocale.localeIdentifier;
     }
     
     return strdup([localeName UTF8String]);

--- a/src/native/libs/System.Globalization.Native/pal_locale_internal.h
+++ b/src/native/libs/System.Globalization.Native/pal_locale_internal.h
@@ -51,3 +51,13 @@ Detect the default locale for the machine, defaulting to Invaraint if
 we can't compute one (different from uloc_getDefault()) would do.
 */
 const char* DetectDefaultLocaleName(void);
+
+#ifdef __APPLE__
+/*
+Function:
+DetectDefaultSystemLocaleName
+
+Detects the default locale string for Apple platforms
+*/
+const char* DetectDefaultAppleLocaleName(void);
+#endif

--- a/src/native/libs/System.Globalization.Native/pal_locale_internal.h
+++ b/src/native/libs/System.Globalization.Native/pal_locale_internal.h
@@ -59,5 +59,5 @@ DetectDefaultSystemLocaleName
 
 Detects the default locale string for Apple platforms
 */
-const char* DetectDefaultAppleLocaleName(void);
+char* DetectDefaultAppleLocaleName(void);
 #endif


### PR DESCRIPTION
This change adds a function to lookup the current `NSLocale` and extract the language + country code to load into ICU by default.  Previously, we would defer to uloc_getDefault in ICU, which would return a value we would ignore (en_US_POSIX) and result in falling back to invariant mode.

Fixes https://github.com/dotnet/runtime/issues/68321