### PR TITLE
Physical value numbering

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4737,6 +4737,15 @@ public:
                                  ValueNumPair         value,
                                  bool                 normalize = true);
 
+    void fgValueNumberFieldLoad(GenTree* loadTree, GenTree* baseAddr, FieldSeqNode* fieldSeq, ssize_t offset);
+
+    void fgValueNumberFieldStore(GenTree*      storeNode,
+                                 GenTree*      baseAddr,
+                                 FieldSeqNode* fieldSeq,
+                                 ssize_t       offset,
+                                 unsigned      storeSize,
+                                 ValueNum      value);
+
     unsigned fgVNPassesCompleted; // Number of times fgValueNumber has been run.
 
     // Utility functions for fgValueNumber.

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4730,6 +4730,13 @@ public:
     // Compute the value number for a byref-exposed load of the given type via the given pointerVN.
     ValueNum fgValueNumberByrefExposedLoad(var_types type, ValueNum pointerVN);
 
+    void fgValueNumberLocalStore(GenTree*             storeNode,
+                                 GenTreeLclVarCommon* lclDefNode,
+                                 unsigned             storeSize,
+                                 ssize_t              storeOffset,
+                                 ValueNumPair         value,
+                                 bool                 normalize = true);
+
     unsigned fgVNPassesCompleted; // Number of times fgValueNumber has been run.
 
     // Utility functions for fgValueNumber.

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4692,43 +4692,9 @@ public:
     // tree node).
     void fgValueNumber();
 
-    // Computes new GcHeap VN via the assignment H[elemTypeEq][arrVN][inx][fldSeq] = rhsVN.
-    // Assumes that "elemTypeEq" is the (equivalence class rep) of the array element type.
-    // The 'indType' is the indirection type of the lhs of the assignment and will typically
-    // match the element type of the array or fldSeq.  When this type doesn't match
-    // or if the fldSeq is 'NotAField' we invalidate the array contents H[elemTypeEq][arrVN]
-    //
-    ValueNum fgValueNumberArrIndexAssign(CORINFO_CLASS_HANDLE elemTypeEq,
-                                         ValueNum             arrVN,
-                                         ValueNum             inxVN,
-                                         FieldSeqNode*        fldSeq,
-                                         ValueNum             rhsVN,
-                                         var_types            indType);
+    void fgValueNumberArrayElemLoad(GenTree* loadTree, VNFuncApp* addrFunc);
 
-    // Requires that "tree" is a GT_IND marked as an array index, and that its address argument
-    // has been parsed to yield the other input arguments.  If evaluation of the address
-    // can raise exceptions, those should be captured in the exception set "addrXvnp".
-    // Assumes that "elemTypeEq" is the (equivalence class rep) of the array element type.
-    // Marks "tree" with the VN for H[elemTypeEq][arrVN][inx][fldSeq] (for the liberal VN; a new unique
-    // VN for the conservative VN.)  Also marks the tree's argument as the address of an array element.
-    // The type tree->TypeGet() will typically match the element type of the array or fldSeq.
-    // When this type doesn't match or if the fldSeq is 'NotAField' we return a new unique VN
-    //
-    ValueNum fgValueNumberArrIndexVal(GenTree*             tree,
-                                      CORINFO_CLASS_HANDLE elemTypeEq,
-                                      ValueNum             arrVN,
-                                      ValueNum             inxVN,
-                                      ValueNumPair         addrXvnp,
-                                      FieldSeqNode*        fldSeq);
-
-    // Requires "funcApp" to be a VNF_PtrToArrElem, and "addrXvnp" to represent the exception set thrown
-    // by evaluating the array index expression "tree".  Returns the value number resulting from
-    // dereferencing the array in the current GcHeap state.  If "tree" is non-null, it must be the
-    // "GT_IND" that does the dereference, and it is given the returned value number.
-    ValueNum fgValueNumberArrIndexVal(GenTree* tree, VNFuncApp* funcApp, ValueNumPair addrXvnp);
-
-    // Compute the value number for a byref-exposed load of the given type via the given pointerVN.
-    ValueNum fgValueNumberByrefExposedLoad(var_types type, ValueNum pointerVN);
+    void fgValueNumberArrayElemStore(GenTree* storeNode, VNFuncApp* addrFunc, unsigned storeSize, ValueNum value);
 
     void fgValueNumberLocalStore(GenTree*             storeNode,
                                  GenTreeLclVarCommon* lclDefNode,
@@ -4745,6 +4711,9 @@ public:
                                  ssize_t       offset,
                                  unsigned      storeSize,
                                  ValueNum      value);
+
+    // Compute the value number for a byref-exposed load of the given type via the given pointerVN.
+    ValueNum fgValueNumberByrefExposedLoad(var_types type, ValueNum pointerVN);
 
     unsigned fgVNPassesCompleted; // Number of times fgValueNumber has been run.
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4692,16 +4692,16 @@ public:
     // tree node).
     void fgValueNumber();
 
+    void fgValueNumberLocalStore(GenTree*             storeNode,
+                                 GenTreeLclVarCommon* lclDefNode,
+                                 ssize_t              offset,
+                                 unsigned             storeSize,
+                                 ValueNumPair         value,
+                                 bool                 normalize = true);
+
     void fgValueNumberArrayElemLoad(GenTree* loadTree, VNFuncApp* addrFunc);
 
     void fgValueNumberArrayElemStore(GenTree* storeNode, VNFuncApp* addrFunc, unsigned storeSize, ValueNum value);
-
-    void fgValueNumberLocalStore(GenTree*             storeNode,
-                                 GenTreeLclVarCommon* lclDefNode,
-                                 unsigned             storeSize,
-                                 ssize_t              storeOffset,
-                                 ValueNumPair         value,
-                                 bool                 normalize = true);
 
     void fgValueNumberFieldLoad(GenTree* loadTree, GenTree* baseAddr, FieldSeqNode* fieldSeq, ssize_t offset);
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -16026,7 +16026,8 @@ bool GenTree::DefinesLocal(Compiler* comp, GenTreeLclVarCommon** pLclVarTree, bo
         else if (AsOp()->gtOp1->OperGet() == GT_IND)
         {
             GenTree* indArg = AsOp()->gtOp1->AsOp()->gtOp1;
-            return indArg->DefinesLocalAddr(comp, genTypeSize(AsOp()->gtOp1->TypeGet()), pLclVarTree, pIsEntire, pOffset);
+            return indArg->DefinesLocalAddr(comp, genTypeSize(AsOp()->gtOp1->TypeGet()), pLclVarTree, pIsEntire,
+                                            pOffset);
         }
         else if (AsOp()->gtOp1->OperIsBlk())
         {
@@ -16074,11 +16075,8 @@ bool GenTree::DefinesLocal(Compiler* comp, GenTreeLclVarCommon** pLclVarTree, bo
     return false;
 }
 
-bool GenTree::DefinesLocalAddr(Compiler*             comp,
-                               unsigned              width,
-                               GenTreeLclVarCommon** pLclVarTree,
-                               bool*                 pIsEntire,
-                               ssize_t*              pOffset)
+bool GenTree::DefinesLocalAddr(
+    Compiler* comp, unsigned width, GenTreeLclVarCommon** pLclVarTree, bool* pIsEntire, ssize_t* pOffset)
 {
     if (OperIs(GT_ADDR, GT_LCL_VAR_ADDR, GT_LCL_FLD_ADDR))
     {
@@ -16811,9 +16809,9 @@ bool GenTree::IsFieldAddr(Compiler* comp, GenTree** pBaseAddr, FieldSeqNode** pF
     else if (IsCnsIntOrI() && IsIconHandle(GTF_ICON_STATIC_HDL))
     {
         assert(!comp->GetZeroOffsetFieldMap()->Lookup(this) && (AsIntCon()->gtFieldSeq != nullptr));
-        baseAddr   = this;
-        fldSeq     = AsIntCon()->gtFieldSeq;
-        offset     = AsIntCon()->IconValue();
+        baseAddr = this;
+        fldSeq   = AsIntCon()->gtFieldSeq;
+        offset   = AsIntCon()->IconValue();
     }
     else if (comp->GetZeroOffsetFieldMap()->Lookup(this, &fldSeq))
     {
@@ -18136,8 +18134,9 @@ FieldSeqStore::FieldSeqStore(CompAllocator alloc) : m_alloc(alloc), m_canonMap(n
 {
 }
 
-FieldSeqNode* FieldSeqStore::CreateSingleton(
-    CORINFO_FIELD_HANDLE fieldHnd, size_t offset, FieldSeqNode::FieldKind fieldKind)
+FieldSeqNode* FieldSeqStore::CreateSingleton(CORINFO_FIELD_HANDLE    fieldHnd,
+                                             size_t                  offset,
+                                             FieldSeqNode::FieldKind fieldKind)
 {
     FieldSeqNode  fsn(fieldHnd, nullptr, offset, fieldKind);
     FieldSeqNode* res = nullptr;
@@ -18195,8 +18194,7 @@ FieldSeqNode* FieldSeqStore::Append(FieldSeqNode* a, FieldSeqNode* b)
 }
 
 FieldSeqNode::FieldSeqNode(CORINFO_FIELD_HANDLE fieldHnd, FieldSeqNode* next, size_t offset, FieldKind fieldKind)
-    : m_next(next)
-    , m_offset(offset)
+    : m_next(next), m_offset(offset)
 {
     uintptr_t handleValue = reinterpret_cast<uintptr_t>(fieldHnd);
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1915,8 +1915,10 @@ public:
     // tree for the local that is defined, and, if "pIsEntire" is non-null, sets "*pIsEntire" to
     // true or false, depending on whether the assignment writes to the entirety of the local
     // variable, or just a portion of it.
-    bool DefinesLocal(
-        Compiler* comp, GenTreeLclVarCommon** pLclVarTree, bool* pIsEntire = nullptr, ssize_t* pOffset = nullptr);
+    bool DefinesLocal(Compiler*             comp,
+                      GenTreeLclVarCommon** pLclVarTree,
+                      bool*                 pIsEntire = nullptr,
+                      ssize_t*              pOffset   = nullptr);
 
     bool IsLocalAddrExpr(Compiler*             comp,
                          GenTreeLclVarCommon** pLclVarTree,
@@ -1955,11 +1957,8 @@ public:
     // operation.  Returns "true" if "this" is an address of (or within)
     // a local variable; sets "*pLclVarTree" to that local variable instance; and, if "pIsEntire" is non-null,
     // sets "*pIsEntire" to true if this assignment writes the full width of the local.
-    bool DefinesLocalAddr(Compiler*             comp,
-                          unsigned              width,
-                          GenTreeLclVarCommon** pLclVarTree,
-                          bool*                 pIsEntire,
-                          ssize_t*              pOffset = nullptr);
+    bool DefinesLocalAddr(
+        Compiler* comp, unsigned width, GenTreeLclVarCommon** pLclVarTree, bool* pIsEntire, ssize_t* pOffset = nullptr);
 
     // These are only used for dumping.
     // The GetRegNum() is only valid in LIR, but the dumping methods are not easily

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1900,7 +1900,8 @@ public:
     // tree for the local that is defined, and, if "pIsEntire" is non-null, sets "*pIsEntire" to
     // true or false, depending on whether the assignment writes to the entirety of the local
     // variable, or just a portion of it.
-    bool DefinesLocal(Compiler* comp, GenTreeLclVarCommon** pLclVarTree, bool* pIsEntire = nullptr);
+    bool DefinesLocal(
+        Compiler* comp, GenTreeLclVarCommon** pLclVarTree, bool* pIsEntire = nullptr, ssize_t* pOffset = nullptr);
 
     bool IsLocalAddrExpr(Compiler*             comp,
                          GenTreeLclVarCommon** pLclVarTree,
@@ -1939,7 +1940,11 @@ public:
     // operation.  Returns "true" if "this" is an address of (or within)
     // a local variable; sets "*pLclVarTree" to that local variable instance; and, if "pIsEntire" is non-null,
     // sets "*pIsEntire" to true if this assignment writes the full width of the local.
-    bool DefinesLocalAddr(Compiler* comp, unsigned width, GenTreeLclVarCommon** pLclVarTree, bool* pIsEntire);
+    bool DefinesLocalAddr(Compiler*             comp,
+                          unsigned              width,
+                          GenTreeLclVarCommon** pLclVarTree,
+                          bool*                 pIsEntire,
+                          ssize_t*              pOffset = nullptr);
 
     // These are only used for dumping.
     // The GetRegNum() is only valid in LIR, but the dumping methods are not easily
@@ -3519,6 +3524,8 @@ public:
     {
         m_fieldSeq = fieldSeq;
     }
+
+    unsigned GetSize() const;
 
 #ifdef TARGET_ARM
     bool IsOffsetMisaligned() const;
@@ -6521,6 +6528,8 @@ struct GenTreeIndir : public GenTreeOp
     GenTree* Index();
     unsigned Scale();
     ssize_t  Offset();
+
+    unsigned Size() const;
 
     GenTreeIndir(genTreeOps oper, var_types type, GenTree* addr, GenTree* data) : GenTreeOp(oper, type, addr, data)
     {

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -1416,8 +1416,8 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
 
         GenTree*       ptrSlot         = gtNewOperNode(GT_IND, TYP_I_IMPL, destAddr);
         GenTreeIntCon* typeFieldOffset = gtNewIconNode(OFFSETOF__CORINFO_TypedReference__type, TYP_I_IMPL);
-        typeFieldOffset->gtFieldSeq    = GetFieldSeqStore()->CreateSingleton(GetRefanyTypeField(),
-                                                                             OFFSETOF__CORINFO_TypedReference__type);
+        typeFieldOffset->gtFieldSeq =
+            GetFieldSeqStore()->CreateSingleton(GetRefanyTypeField(), OFFSETOF__CORINFO_TypedReference__type);
         GenTree* typeSlot =
             gtNewOperNode(GT_IND, TYP_I_IMPL, gtNewOperNode(GT_ADD, destAddr->gtType, destAddrClone, typeFieldOffset));
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -1410,11 +1410,14 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
 
         assert(OFFSETOF__CORINFO_TypedReference__dataPtr == 0);
         assert(destAddr->gtType == TYP_I_IMPL || destAddr->gtType == TYP_BYREF);
-        fgAddFieldSeqForZeroOffset(destAddr, GetFieldSeqStore()->CreateSingleton(GetRefanyDataField()));
+        fgAddFieldSeqForZeroOffset(destAddr,
+                                   GetFieldSeqStore()->CreateSingleton(GetRefanyDataField(),
+                                                                       OFFSETOF__CORINFO_TypedReference__dataPtr));
 
         GenTree*       ptrSlot         = gtNewOperNode(GT_IND, TYP_I_IMPL, destAddr);
         GenTreeIntCon* typeFieldOffset = gtNewIconNode(OFFSETOF__CORINFO_TypedReference__type, TYP_I_IMPL);
-        typeFieldOffset->gtFieldSeq    = GetFieldSeqStore()->CreateSingleton(GetRefanyTypeField());
+        typeFieldOffset->gtFieldSeq    = GetFieldSeqStore()->CreateSingleton(GetRefanyTypeField(),
+                                                                             OFFSETOF__CORINFO_TypedReference__type);
         GenTree* typeSlot =
             gtNewOperNode(GT_IND, TYP_I_IMPL, gtNewOperNode(GT_ADD, destAddr->gtType, destAddrClone, typeFieldOffset));
 
@@ -3635,11 +3638,11 @@ GenTree* Compiler::impCreateSpanIntrinsic(CORINFO_SIG_INFO* sig)
     CORINFO_FIELD_HANDLE lengthFieldHnd  = info.compCompHnd->getFieldInClass(spanHnd, 1);
 
     GenTreeLclFld* pointerField = gtNewLclFldNode(spanTempNum, TYP_BYREF, 0);
-    pointerField->SetFieldSeq(GetFieldSeqStore()->CreateSingleton(pointerFieldHnd));
+    pointerField->SetFieldSeq(GetFieldSeqStore()->CreateSingleton(pointerFieldHnd, 0));
     GenTree* pointerFieldAsg = gtNewAssignNode(pointerField, pointerValue);
 
     GenTreeLclFld* lengthField = gtNewLclFldNode(spanTempNum, TYP_INT, TARGET_POINTER_SIZE);
-    lengthField->SetFieldSeq(GetFieldSeqStore()->CreateSingleton(lengthFieldHnd));
+    lengthField->SetFieldSeq(GetFieldSeqStore()->CreateSingleton(lengthFieldHnd, TARGET_POINTER_SIZE));
     GenTree* lengthFieldAsg = gtNewAssignNode(lengthField, lengthValue);
 
     // Now append a few statements the initialize the span
@@ -8164,11 +8167,35 @@ GenTree* Compiler::impImportStaticFieldAccess(CORINFO_RESOLVED_TOKEN* pResolvedT
                           (pFieldInfo->fieldAccessor == CORINFO_FIELD_STATIC_READYTORUN_HELPER);
     FieldSeqNode::FieldKind fieldKind =
         isSharedStatic ? FieldSeqNode::FieldKind::SharedStatic : FieldSeqNode::FieldKind::SimpleStatic;
-    FieldSeqNode* innerFldSeq = !isBoxedStatic ? GetFieldSeqStore()->CreateSingleton(pResolvedToken->hField, fieldKind)
-                                               : FieldSeqStore::NotAField();
+
+    FieldSeqNode* innerFldSeq = nullptr;
+    FieldSeqNode* outerFldSeq = nullptr;
+    if (isBoxedStatic)
+    {
+        innerFldSeq = FieldSeqStore::NotAField();
+        outerFldSeq = GetFieldSeqStore()->CreateSingleton(pResolvedToken->hField, TARGET_POINTER_SIZE, fieldKind);
+    }
+    else
+    {
+        bool hasConstAddr = (pFieldInfo->fieldAccessor == CORINFO_FIELD_STATIC_ADDRESS) ||
+                            (pFieldInfo->fieldAccessor == CORINFO_FIELD_STATIC_RVA_ADDRESS);
+
+        size_t offset;
+        if (hasConstAddr)
+        {
+            offset = reinterpret_cast<size_t>(info.compCompHnd->getFieldAddress(pResolvedToken->hField));
+            assert(offset != 0);
+        }
+        else
+        {
+            offset = pFieldInfo->offset;
+        }
+
+        innerFldSeq = GetFieldSeqStore()->CreateSingleton(pResolvedToken->hField, offset, fieldKind);
+        outerFldSeq = FieldSeqStore::NotAField();
+    }
 
     GenTree* op1;
-
     switch (pFieldInfo->fieldAccessor)
     {
         case CORINFO_FIELD_STATIC_GENERICS_STATIC_HELPER:
@@ -8294,8 +8321,6 @@ GenTree* Compiler::impImportStaticFieldAccess(CORINFO_RESOLVED_TOKEN* pResolvedT
 
                 if (isBoxedStatic)
                 {
-                    FieldSeqNode* outerFldSeq = GetFieldSeqStore()->CreateSingleton(pResolvedToken->hField, fieldKind);
-
                     op1->ChangeType(TYP_REF); // points at boxed object
                     op1 = gtNewOperNode(GT_ADD, TYP_BYREF, op1, gtNewIconNode(TARGET_POINTER_SIZE, outerFldSeq));
 
@@ -8319,8 +8344,6 @@ GenTree* Compiler::impImportStaticFieldAccess(CORINFO_RESOLVED_TOKEN* pResolvedT
 
     if (isBoxedStatic)
     {
-        FieldSeqNode* outerFldSeq = GetFieldSeqStore()->CreateSingleton(pResolvedToken->hField, fieldKind);
-
         op1 = gtNewOperNode(GT_IND, TYP_REF, op1);
         op1->gtFlags |= (GTF_IND_INVARIANT | GTF_IND_NONFAULTING | GTF_IND_NONNULL);
 

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -308,7 +308,8 @@ class LocalAddressVisitor final : public GenTreeVisitor<LocalAddressVisitor>
                 if (haveCorrectFieldForVN)
                 {
                     FieldSeqStore* fieldSeqStore = compiler->GetFieldSeqStore();
-                    m_fieldSeq = fieldSeqStore->Append(val.m_fieldSeq, fieldSeqStore->CreateSingleton(field->gtFldHnd));
+                    FieldSeqNode*  fieldSeqNode  = fieldSeqStore->CreateSingleton(field->gtFldHnd, field->gtFldOffset);
+                    m_fieldSeq = fieldSeqStore->Append(val.m_fieldSeq, fieldSeqNode);
                 }
                 else
                 {

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -309,7 +309,7 @@ class LocalAddressVisitor final : public GenTreeVisitor<LocalAddressVisitor>
                 {
                     FieldSeqStore* fieldSeqStore = compiler->GetFieldSeqStore();
                     FieldSeqNode*  fieldSeqNode  = fieldSeqStore->CreateSingleton(field->gtFldHnd, field->gtFldOffset);
-                    m_fieldSeq = fieldSeqStore->Append(val.m_fieldSeq, fieldSeqNode);
+                    m_fieldSeq                   = fieldSeqStore->Append(val.m_fieldSeq, fieldSeqNode);
                 }
                 else
                 {

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -3309,7 +3309,7 @@ void Compiler::lvaUpdateClass(unsigned varNum, GenTree* tree, CORINFO_CLASS_HAND
 //
 // Returns:
 //    Number of bytes needed on the frame for such a local.
-
+//
 unsigned Compiler::lvaLclSize(unsigned varNum)
 {
     assert(varNum < lvaCount);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9872,10 +9872,8 @@ GenTree* Compiler::fgMorphBlockOperand(GenTree* tree, var_types asgType, unsigne
         }
         if (needsIndirection)
         {
-            if (indirTree != nullptr)
+            if ((indirTree != nullptr) && (indirTree->OperIsBlk() || !isBlkReqd))
             {
-                // If we have an indirection and a block is required, it should already be a block.
-                assert(indirTree->OperIsBlk() || !isBlkReqd);
                 effectiveVal->gtType = asgType;
             }
             else
@@ -9894,11 +9892,14 @@ GenTree* Compiler::fgMorphBlockOperand(GenTree* tree, var_types asgType, unsigne
                         newTree = gtNewObjNode(clsHnd, addr);
                         gtSetObjGcInfo(newTree->AsObj());
                     }
+
+                    gtUpdateNodeSideEffects(newTree);
                 }
                 else
                 {
                     newTree = gtNewIndir(asgType, addr);
                 }
+
                 effectiveVal = newTree;
             }
         }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3465,11 +3465,11 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
             // (tmp.ptr=argx),(tmp.type=handle)
             GenTreeLclFld* destPtrSlot  = gtNewLclFldNode(tmp, TYP_I_IMPL, OFFSETOF__CORINFO_TypedReference__dataPtr);
             GenTreeLclFld* destTypeSlot = gtNewLclFldNode(tmp, TYP_I_IMPL, OFFSETOF__CORINFO_TypedReference__type);
-            destPtrSlot->SetFieldSeq(GetFieldSeqStore()->CreateSingleton(GetRefanyDataField(),
-                                                                         OFFSETOF__CORINFO_TypedReference__dataPtr));
+            destPtrSlot->SetFieldSeq(
+                GetFieldSeqStore()->CreateSingleton(GetRefanyDataField(), OFFSETOF__CORINFO_TypedReference__dataPtr));
             destPtrSlot->gtFlags |= GTF_VAR_DEF;
-            destTypeSlot->SetFieldSeq(GetFieldSeqStore()->CreateSingleton(GetRefanyTypeField(),
-                                                                          OFFSETOF__CORINFO_TypedReference__type));
+            destTypeSlot->SetFieldSeq(
+                GetFieldSeqStore()->CreateSingleton(GetRefanyTypeField(), OFFSETOF__CORINFO_TypedReference__type));
             destTypeSlot->gtFlags |= GTF_VAR_DEF;
 
             GenTree* asgPtrSlot  = gtNewAssignNode(destPtrSlot, argx->AsOp()->gtOp1);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3465,9 +3465,11 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
             // (tmp.ptr=argx),(tmp.type=handle)
             GenTreeLclFld* destPtrSlot  = gtNewLclFldNode(tmp, TYP_I_IMPL, OFFSETOF__CORINFO_TypedReference__dataPtr);
             GenTreeLclFld* destTypeSlot = gtNewLclFldNode(tmp, TYP_I_IMPL, OFFSETOF__CORINFO_TypedReference__type);
-            destPtrSlot->SetFieldSeq(GetFieldSeqStore()->CreateSingleton(GetRefanyDataField()));
+            destPtrSlot->SetFieldSeq(GetFieldSeqStore()->CreateSingleton(GetRefanyDataField(),
+                                                                         OFFSETOF__CORINFO_TypedReference__dataPtr));
             destPtrSlot->gtFlags |= GTF_VAR_DEF;
-            destTypeSlot->SetFieldSeq(GetFieldSeqStore()->CreateSingleton(GetRefanyTypeField()));
+            destTypeSlot->SetFieldSeq(GetFieldSeqStore()->CreateSingleton(GetRefanyTypeField(),
+                                                                          OFFSETOF__CORINFO_TypedReference__type));
             destTypeSlot->gtFlags |= GTF_VAR_DEF;
 
             GenTree* asgPtrSlot  = gtNewAssignNode(destPtrSlot, argx->AsOp()->gtOp1);
@@ -5290,24 +5292,12 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
 {
     assert(tree->gtOper == GT_FIELD);
 
-    CORINFO_FIELD_HANDLE symHnd     = tree->AsField()->gtFldHnd;
-    unsigned             fldOffset  = tree->AsField()->gtFldOffset;
-    GenTree*             objRef     = tree->AsField()->GetFldObj();
-    bool                 objIsLocal = false;
-
-    FieldSeqNode* fieldSeq = FieldSeqStore::NotAField();
-    if (!tree->AsField()->gtFldMayOverlap)
-    {
-        if (objRef != nullptr)
-        {
-            fieldSeq = GetFieldSeqStore()->CreateSingleton(symHnd, FieldSeqNode::FieldKind::Instance);
-        }
-        else
-        {
-            // Only simple statics get imported as GT_FIELDs.
-            fieldSeq = GetFieldSeqStore()->CreateSingleton(symHnd, FieldSeqNode::FieldKind::SimpleStatic);
-        }
-    }
+    CORINFO_FIELD_HANDLE symHnd        = tree->AsField()->gtFldHnd;
+    unsigned             fldOffset     = tree->AsField()->gtFldOffset;
+    GenTree*             objRef        = tree->AsField()->GetFldObj();
+    bool                 objIsLocal    = false;
+    bool                 fldMayOverlap = tree->AsField()->gtFldMayOverlap;
+    FieldSeqNode*        fieldSeq      = FieldSeqStore::NotAField();
 
     // Reset the flag because we may reuse the node.
     tree->AsField()->gtFldMayOverlap = false;
@@ -5573,6 +5563,12 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
             addr              = gtNewOperNode(GT_ADD, addType, addr, offsetNode);
         }
 #endif
+
+        if (!fldMayOverlap)
+        {
+            fieldSeq = GetFieldSeqStore()->CreateSingleton(symHnd, fldOffset, FieldSeqNode::FieldKind::Instance);
+        }
+
         if (fldOffset != 0)
         {
             // Generate the "addr" node.
@@ -5687,6 +5683,9 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
             /* indirect to have tlsRef point at the base of the DLLs Thread Local Storage */
             tlsRef = gtNewOperNode(GT_IND, TYP_I_IMPL, tlsRef);
 
+            assert(!fldMayOverlap);
+            fieldSeq = GetFieldSeqStore()->CreateSingleton(symHnd, fldOffset, FieldSeqNode::FieldKind::SimpleStatic);
+
             if (fldOffset != 0)
             {
                 GenTree* fldOffsetNode = new (this, GT_CNS_INT) GenTreeIntCon(TYP_INT, fldOffset, fieldSeq);
@@ -5721,9 +5720,11 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
             // For boxed statics, this direct address will be for the box. We have already added
             // the indirection for the field itself and attached the sequence, in importation.
             bool isBoxedStatic = gtIsStaticFieldPtrToBoxedStruct(tree->TypeGet(), symHnd);
-            if (isBoxedStatic)
+            if (!isBoxedStatic)
             {
-                fieldSeq = FieldSeqStore::NotAField();
+                // Only simple statics get importred as GT_FIELDs.
+                fieldSeq = GetFieldSeqStore()->CreateSingleton(symHnd, reinterpret_cast<size_t>(fldAddr),
+                                                               FieldSeqNode::FieldKind::SimpleStatic);
             }
 
             // TODO-CQ: enable this optimization for 32 bit targets.

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9922,8 +9922,7 @@ GenTree* Compiler::fgMorphBlockOperand(GenTree* tree, var_types asgType, unsigne
 //    false otherwise.
 //
 // Notes:
-//   This check is needed to avoid accessing LCL_VARs with incorrect
-//   CORINFO_FIELD_HANDLE that would confuse VN optimizations.
+//   TODO-PhysicalVN: with the physical VN scheme, this method is no longer needed.
 //
 bool Compiler::fgMorphCanUseLclFldForCopy(unsigned lclNum1, unsigned lclNum2)
 {

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -1218,10 +1218,10 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
                 CORINFO_CLASS_HANDLE classHnd = srcVarDsc->GetStructHnd();
                 CORINFO_FIELD_HANDLE fieldHnd =
                     m_comp->info.compCompHnd->getFieldInClass(classHnd, srcFieldVarDsc->lvFldOrdinal);
-                FieldSeqNode* curFieldSeq = m_comp->GetFieldSeqStore()->CreateSingleton(fieldHnd);
 
-                unsigned  srcFieldOffset = m_comp->lvaGetDesc(srcFieldLclNum)->lvFldOffset;
-                var_types srcType        = srcFieldVarDsc->TypeGet();
+                unsigned      srcFieldOffset = m_comp->lvaGetDesc(srcFieldLclNum)->lvFldOffset;
+                var_types     srcType        = srcFieldVarDsc->TypeGet();
+                FieldSeqNode* curFieldSeq    = m_comp->GetFieldSeqStore()->CreateSingleton(fieldHnd, srcFieldOffset);
 
                 if (!m_dstUseLclFld)
                 {
@@ -1317,11 +1317,13 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
                 CORINFO_FIELD_HANDLE fieldHnd =
                     m_comp->info.compCompHnd->getFieldInClass(classHnd,
                                                               m_comp->lvaGetDesc(dstFieldLclNum)->lvFldOrdinal);
-                FieldSeqNode* curFieldSeq = m_comp->GetFieldSeqStore()->CreateSingleton(fieldHnd);
+
+                unsigned      fldOffset   = m_comp->lvaGetDesc(dstFieldLclNum)->lvFldOffset;
                 var_types     destType    = m_comp->lvaGetDesc(dstFieldLclNum)->lvType;
+                FieldSeqNode* curFieldSeq = m_comp->GetFieldSeqStore()->CreateSingleton(fieldHnd, fldOffset);
 
                 bool done = false;
-                if (m_comp->lvaGetDesc(dstFieldLclNum)->lvFldOffset == 0)
+                if (fldOffset == 0)
                 {
                     // If this is a full-width use of the src via a different type, we need to create a
                     // GT_LCL_FLD.
@@ -1348,7 +1350,6 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
                 }
                 if (!done)
                 {
-                    unsigned fldOffset = m_comp->lvaGetDesc(dstFieldLclNum)->lvFldOffset;
                     if (!m_srcUseLclFld)
                     {
                         assert(srcAddrClone != nullptr);

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -926,11 +926,12 @@ void MorphCopyBlockHelper::MorphStructCases()
         m_dst                     = m_comp->fgMorphBlockOperand(m_dst, asgType, m_blockSize, isBlkReqd);
         m_dst->gtFlags |= GTF_DONT_CSE;
         m_asg->gtOp1 = m_dst;
-        m_asg->gtFlags |= (m_dst->gtFlags & GTF_ALL_EFFECT);
 
-        // Eliminate the "OBJ or BLK" node on the src.
-        m_src        = m_comp->fgMorphBlockOperand(m_src, asgType, m_blockSize, false /*!isBlkReqd*/);
+        m_src        = m_comp->fgMorphBlockOperand(m_src, asgType, m_blockSize, isBlkReqd);
         m_asg->gtOp2 = m_src;
+
+        m_asg->SetAllEffectsFlags(m_dst, m_src);
+        m_asg->gtFlags |= GTF_ASG;
 
         m_result                 = m_asg;
         m_transformationDecision = BlockTransformation::StructBlock;

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -7854,6 +7854,7 @@ bool Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
                         GenTreeArrAddr* arrAddr  = nullptr;
                         GenTree*        baseAddr = nullptr;
                         FieldSeqNode*   fldSeq   = nullptr;
+                        ssize_t         offset   = 0;
 
                         if (arg->IsArrayAddr(&arrAddr))
                         {
@@ -7865,7 +7866,7 @@ bool Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
                             // Conservatively assume byrefs may alias this array element
                             memoryHavoc |= memoryKindSet(ByrefExposed);
                         }
-                        else if (arg->IsFieldAddr(this, &baseAddr, &fldSeq))
+                        else if (arg->IsFieldAddr(this, &baseAddr, &fldSeq, &offset))
                         {
                             assert((fldSeq != nullptr) && (fldSeq != FieldSeqStore::NotAField()));
 

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -1782,7 +1782,7 @@ ValueNum ValueNumStore::VNForIntPtrCon(ssize_t cnsVal)
 {
 #ifdef HOST_64BIT
     return VNForLongCon(cnsVal);
-#else // !HOST_64BIT
+#else  // !HOST_64BIT
     return VNForIntCon(cnsVal);
 #endif // !HOST_64BIT
 }
@@ -2380,7 +2380,8 @@ ValueNum ValueNumStore::VNForMapSelect(ValueNumKind vnk, var_types type, ValueNu
 //    number returned can be of a type different from "type", as physical maps
 //    do not have canonical types, only sizes.
 //
-ValueNum ValueNumStore::VNForMapPhysicalSelect(ValueNumKind vnk, var_types type, ValueNum map, unsigned offset, unsigned size)
+ValueNum ValueNumStore::VNForMapPhysicalSelect(
+    ValueNumKind vnk, var_types type, ValueNum map, unsigned offset, unsigned size)
 {
     assert(MapIsPhysical(map));
 
@@ -2428,7 +2429,7 @@ TailCall:
     // This label allows us to directly implement a tail call by setting up the arguments, and doing a goto to here.
 
     assert(map != NoVN && index != NoVN);
-    assert(map   == VNNormalValue(map));   // Arguments carry no exceptions.
+    assert(map == VNNormalValue(map));     // Arguments carry no exceptions.
     assert(index == VNNormalValue(index)); // Arguments carry no exceptions.
 
     *pUsedRecursiveVN = false;
@@ -2492,7 +2493,8 @@ TailCall:
                                 funcApp.m_args[0], map, funcApp.m_args[1], funcApp.m_args[2], index, funcApp.m_args[2]);
 #endif
 
-                        m_pComp->optRecordLoopMemoryDependence(m_pComp->compCurTree, m_pComp->compCurBB, funcApp.m_args[0]);
+                        m_pComp->optRecordLoopMemoryDependence(m_pComp->compCurTree, m_pComp->compCurBB,
+                                                               funcApp.m_args[0]);
                         return funcApp.m_args[2];
                     }
                     // i # j ==> select(store(m, i, v), j) == select(m, j)
@@ -2502,7 +2504,8 @@ TailCall:
                         assert(funcApp.m_args[1] != index); // we already checked this above.
 #if FEATURE_VN_TRACE_APPLY_SELECTORS
                         JITDUMP("      AX2: " FMT_VN " != " FMT_VN " ==> select([" FMT_VN "]store(" FMT_VN ", " FMT_VN
-                                ", " FMT_VN "), " FMT_VN ") ==> select(" FMT_VN ", " FMT_VN ") remaining budget is %d.\n",
+                                ", " FMT_VN "), " FMT_VN ") ==> select(" FMT_VN ", " FMT_VN
+                                ") remaining budget is %d.\n",
                                 index, funcApp.m_args[1], map, funcApp.m_args[0], funcApp.m_args[1], funcApp.m_args[2],
                                 index, funcApp.m_args[0], index, *pBudget);
 #endif
@@ -2697,8 +2700,10 @@ TailCall:
                                 m_fixedPointMapSels.Pop();
 
                                 // To avoid exponential searches, we make sure that this result is memo-ized.
-                                // The result is always valid for memoization if we didn't rely on RecursiveVN to get it.
-                                // If RecursiveVN was used, we are processing a loop and we can't memo-ize this intermediate
+                                // The result is always valid for memoization if we didn't rely on RecursiveVN to get
+                                // it.
+                                // If RecursiveVN was used, we are processing a loop and we can't memo-ize this
+                                // intermediate
                                 // result if, e.g., this block is in a multi-entry loop.
                                 if (!*pUsedRecursiveVN)
                                 {
@@ -4216,8 +4221,8 @@ ValueNumPair ValueNumStore::VNPairForLoad(
     ValueNumPair locationValue, unsigned locationSize, var_types loadType, ssize_t offset, unsigned loadSize)
 {
     ValueNum liberalVN = VNForLoad(VNK_Liberal, locationValue.GetLiberal(), locationSize, loadType, offset, loadSize);
-    ValueNum conservVN = VNForLoad(VNK_Conservative, locationValue.GetConservative(), locationSize, loadType, offset,
-                                   loadSize);
+    ValueNum conservVN =
+        VNForLoad(VNK_Conservative, locationValue.GetConservative(), locationSize, loadType, offset, loadSize);
 
     return ValueNumPair(liberalVN, conservVN);
 }
@@ -4240,11 +4245,8 @@ ValueNumPair ValueNumStore::VNPairForLoad(
 // Notes:
 //    Does not handle "entire" (whole/identity) stores.
 //
-ValueNum ValueNumStore::VNForStore(ValueNum locationValue,
-                                   unsigned locationSize,
-                                   ssize_t  offset,
-                                   unsigned storeSize,
-                                   ValueNum value)
+ValueNum ValueNumStore::VNForStore(
+    ValueNum locationValue, unsigned locationSize, ssize_t offset, unsigned storeSize, ValueNum value)
 {
     assert(storeSize > 0);
 
@@ -4269,11 +4271,8 @@ ValueNum ValueNumStore::VNForStore(ValueNum locationValue,
 //------------------------------------------------------------------------
 // VNPairForStore: VNForStore applied to a ValueNumPair.
 //
-ValueNumPair ValueNumStore::VNPairForStore(ValueNumPair locationValue,
-                                           unsigned     locationSize,
-                                           ssize_t      offset,
-                                           unsigned     storeSize,
-                                           ValueNumPair value)
+ValueNumPair ValueNumStore::VNPairForStore(
+    ValueNumPair locationValue, unsigned locationSize, ssize_t offset, unsigned storeSize, ValueNumPair value)
 {
     ValueNum liberalVN = VNForStore(locationValue.GetLiberal(), locationSize, offset, storeSize, value.GetLiberal());
     ValueNum conservVN;
@@ -4283,8 +4282,8 @@ ValueNumPair ValueNumStore::VNPairForStore(ValueNumPair locationValue,
     }
     else
     {
-        conservVN = VNForStore(locationValue.GetConservative(), locationSize, offset, storeSize,
-                               value.GetConservative());
+        conservVN =
+            VNForStore(locationValue.GetConservative(), locationSize, offset, storeSize, value.GetConservative());
     }
 
     return ValueNumPair(liberalVN, conservVN);
@@ -4663,9 +4662,9 @@ void Compiler::fgValueNumberArrayElemLoad(GenTree* loadTree, VNFuncApp* addrFunc
     ValueNum wholeElem = vnStore->VNForMapSelect(VNK_Liberal, elemType, hAtArrTypeAtArr, inxVN);
     JITDUMP("  GcHeap[elemTypeEq][array][index: " FMT_VN "] is " FMT_VN "\n", inxVN, wholeElem);
 
-    unsigned  elemSize    = (elemType == TYP_STRUCT) ? info.compCompHnd->getClassSize(elemTypeEq) : genTypeSize(elemType);
-    var_types loadType    = loadTree->TypeGet();
-    unsigned  loadSize    = loadTree->AsIndir()->Size();
+    unsigned  elemSize = (elemType == TYP_STRUCT) ? info.compCompHnd->getClassSize(elemTypeEq) : genTypeSize(elemType);
+    var_types loadType = loadTree->TypeGet();
+    unsigned  loadSize = loadTree->AsIndir()->Size();
     ValueNum  loadValueVN = vnStore->VNForLoad(VNK_Liberal, wholeElem, elemSize, loadType, offset, loadSize);
 
     loadTree->gtVNPair.SetLiberal(loadValueVN);
@@ -4694,9 +4693,9 @@ void Compiler::fgValueNumberArrayElemStore(GenTree* storeNode, VNFuncApp* addrFu
     FieldSeqNode* fldSeq = vnStore->FieldSeqVNToFieldSeq(offsFunc.m_args[0]);
     ssize_t       offset = vnStore->ConstantValue<ssize_t>(offsFunc.m_args[1]);
 
-    bool      invalidateArray      = false;
-    var_types elemType             = DecodeElemType(elemTypeEq);
-    ValueNum  elemTypeEqVN         = vnStore->VNForHandle(ssize_t(elemTypeEq), GTF_ICON_CLASS_HDL);
+    bool      invalidateArray = false;
+    var_types elemType        = DecodeElemType(elemTypeEq);
+    ValueNum  elemTypeEqVN    = vnStore->VNForHandle(ssize_t(elemTypeEq), GTF_ICON_CLASS_HDL);
     JITDUMP("  Array element store: elemTypeEq is " FMT_VN " for %s[]\n", elemTypeEqVN,
             (elemType == TYP_STRUCT) ? eeGetClassName(elemTypeEq) : varTypeName(elemType));
 
@@ -4740,8 +4739,7 @@ void Compiler::fgValueNumberArrayElemStore(GenTree* storeNode, VNFuncApp* addrFu
         }
 
         // TODO-PhysicalVN: with the physical VN scheme, we no longer need the type check below.
-        var_types arrElemFldType =
-            (fldSeq != nullptr) ? eeGetFieldType(fldSeq->GetTail()->GetFieldHandle()) : elemType;
+        var_types arrElemFldType = (fldSeq != nullptr) ? eeGetFieldType(fldSeq->GetTail()->GetFieldHandle()) : elemType;
 
         if ((storeNode->gtGetOp1()->TypeGet() != arrElemFldType) || (newWholeElem == ValueNumStore::NoVN))
         {
@@ -4798,15 +4796,13 @@ void Compiler::fgValueNumberFieldLoad(GenTree* loadTree, GenTree* baseAddr, Fiel
     //
     var_types fieldType;
     unsigned  fieldSize;
-    ValueNum  fieldSelectorVN =
-        vnStore->VNForFieldSelector(fieldSeq->GetFieldHandle(), &fieldType, &fieldSize);
+    ValueNum  fieldSelectorVN = vnStore->VNForFieldSelector(fieldSeq->GetFieldHandle(), &fieldType, &fieldSize);
 
     ValueNum fieldMapVN           = ValueNumStore::NoVN;
     ValueNum fieldValueSelectorVN = ValueNumStore::NoVN;
     if (baseAddr != nullptr)
     {
-        fieldMapVN =
-            vnStore->VNForMapSelect(VNK_Liberal, TYP_MEM, fgCurMemoryVN[GcHeap], fieldSelectorVN);
+        fieldMapVN           = vnStore->VNForMapSelect(VNK_Liberal, TYP_MEM, fgCurMemoryVN[GcHeap], fieldSelectorVN);
         fieldValueSelectorVN = vnStore->VNLiberalNormalValue(baseAddr->gtVNPair);
     }
     else
@@ -4815,8 +4811,7 @@ void Compiler::fgValueNumberFieldLoad(GenTree* loadTree, GenTree* baseAddr, Fiel
         fieldValueSelectorVN = fieldSelectorVN;
     }
 
-    ValueNum fieldValueVN =
-        vnStore->VNForMapSelect(VNK_Liberal, fieldType, fieldMapVN, fieldValueSelectorVN);
+    ValueNum fieldValueVN = vnStore->VNForMapSelect(VNK_Liberal, fieldType, fieldMapVN, fieldValueSelectorVN);
 
     // Finally, account for the struct fields and type mismatches.
     var_types loadType    = loadTree->TypeGet();
@@ -4839,12 +4834,8 @@ void Compiler::fgValueNumberFieldLoad(GenTree* loadTree, GenTree* baseAddr, Fiel
 //    storeSize - The number of bytes being stored
 //    value     - The value being stored
 //
-void Compiler::fgValueNumberFieldStore(GenTree*      storeNode,
-                                       GenTree*      baseAddr,
-                                       FieldSeqNode* fieldSeq,
-                                       ssize_t       offset,
-                                       unsigned      storeSize,
-                                       ValueNum      value)
+void Compiler::fgValueNumberFieldStore(
+    GenTree* storeNode, GenTree* baseAddr, FieldSeqNode* fieldSeq, ssize_t offset, unsigned storeSize, ValueNum value)
 {
     assert(fieldSeq != nullptr);
 
@@ -4868,7 +4859,7 @@ void Compiler::fgValueNumberFieldStore(GenTree*      storeNode,
     {
         // Construct the "field map" VN. It represents memory state of the first field of all objects
         // on the heap. This is our primary map.
-        fieldMapVN = vnStore->VNForMapSelect(VNK_Liberal, TYP_MEM, fgCurMemoryVN[GcHeap], fieldSelectorVN);
+        fieldMapVN           = vnStore->VNForMapSelect(VNK_Liberal, TYP_MEM, fgCurMemoryVN[GcHeap], fieldSelectorVN);
         fieldValueSelectorVN = vnStore->VNLiberalNormalValue(baseAddr->gtVNPair);
     }
     else
@@ -4886,7 +4877,7 @@ void Compiler::fgValueNumberFieldStore(GenTree*      storeNode,
     else
     {
         ValueNum oldFieldValueVN = vnStore->VNForMapSelect(VNK_Liberal, fieldType, fieldMapVN, fieldValueSelectorVN);
-        newFieldValueVN = vnStore->VNForStore(oldFieldValueVN, fieldSize, offset, storeSize, value);
+        newFieldValueVN          = vnStore->VNForStore(oldFieldValueVN, fieldSize, offset, storeSize, value);
     }
 
     if (newFieldValueVN != ValueNumStore::NoVN)
@@ -6921,11 +6912,11 @@ const char* ValueNumStore::VNFuncNameArr[] = {
 }
 
 static const char* s_reservedNameArr[] = {
-    "$VN.Recursive",    // -2  RecursiveVN
-    "$VN.No",           // -1  NoVN
-    "$VN.Null",         //  0  VNForNull()
-    "$VN.Void",         //  1  VNForVoid()
-    "$VN.EmptyExcSet"   //  2  VNForEmptyExcSet()
+    "$VN.Recursive",  // -2  RecursiveVN
+    "$VN.No",         // -1  NoVN
+    "$VN.Null",       //  0  VNForNull()
+    "$VN.Void",       //  1  VNForVoid()
+    "$VN.EmptyExcSet" //  2  VNForEmptyExcSet()
 };
 
 // Returns the string name of "vn" when it is a reserved value number, nullptr otherwise
@@ -8160,7 +8151,7 @@ void Compiler::fgValueNumberAssignment(GenTreeOp* tree)
                 if ((fldSeq == FieldSeqStore::NotAField()) || ((fldSeq == nullptr) && !isEntire))
                 {
                     rhsVNPair.SetBoth(vnStore->VNForExpr(compCurBB, lclVarTree->TypeGet()));
-                    offset  = 0;
+                    offset    = 0;
                     storeSize = lvaLclExactSize(lclVarTree->GetLclNum());
                 }
 
@@ -8238,8 +8229,8 @@ void Compiler::fgValueNumberBlockAssignment(GenTree* tree)
             }
             else if (lhs->OperIs(GT_LCL_FLD))
             {
-                storeSize   = lhs->AsLclFld()->GetSize();
-                lhsFldSeq   = lhs->AsLclFld()->GetFieldSeq();
+                storeSize = lhs->AsLclFld()->GetSize();
+                lhsFldSeq = lhs->AsLclFld()->GetFieldSeq();
             }
             else
             {
@@ -8267,7 +8258,7 @@ void Compiler::fgValueNumberBlockAssignment(GenTree* tree)
                 else
                 {
                     // Non-zero block init is very rare so we'll use a simple, unique VN here.
-                    initObjVN  = vnStore->VNForExpr(compCurBB, lhsVarDsc->TypeGet());
+                    initObjVN = vnStore->VNForExpr(compCurBB, lhsVarDsc->TypeGet());
 
                     // TODO-PhysicalVN: remove this pessimization, it was added to avoid diffs.
                     // There is no need to invalidate the whole local.
@@ -8534,9 +8525,9 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                     {
                         LclVarDsc*   varDsc      = lvaGetDesc(lclNum);
                         ValueNumPair lclVarValue = varDsc->GetPerSsaData(lclFld->GetSsaNum())->m_vnPair;
-                        lclFld->gtVNPair         = vnStore->VNPairForLoad(lclVarValue, lvaLclExactSize(lclNum),
-                                                                          lclFld->TypeGet(), lclFld->GetLclOffs(),
-                                                                          lclFld->GetSize());
+                        lclFld->gtVNPair =
+                            vnStore->VNPairForLoad(lclVarValue, lvaLclExactSize(lclNum), lclFld->TypeGet(),
+                                                   lclFld->GetLclOffs(), lclFld->GetSize());
 
                         // If we have byref field, we may have a zero-offset sequence to add.
                         FieldSeqNode* zeroOffsetFldSeq = nullptr;
@@ -8795,9 +8786,9 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                     }
                     else
                     {
-                        ValueNumPair lclVNPair  = varDsc->GetPerSsaData(ssaNum)->m_vnPair;
-                        unsigned     lclSize    = lvaLclExactSize(lclVarTree->GetLclNum());
-                        offset                  = offset + lclVarTree->GetLclOffs();
+                        ValueNumPair lclVNPair = varDsc->GetPerSsaData(ssaNum)->m_vnPair;
+                        unsigned     lclSize   = lvaLclExactSize(lclVarTree->GetLclNum());
+                        offset                 = offset + lclVarTree->GetLclOffs();
 
                         tree->gtVNPair = vnStore->VNPairForLoad(lclVNPair, lclSize, tree->TypeGet(), offset, loadSize);
                     }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9709,6 +9709,12 @@ ValueNum ValueNumStore::VNForBitCast(ValueNum srcVN, var_types castToType)
 
     assert((castToType != TYP_STRUCT) || (TypeOfVN(srcVN) != TYP_STRUCT));
 
+    // TODO-CQ: implement constant folding for BitCast.
+    if (srcVNFunc.m_func == VNF_ZeroObj)
+    {
+        return VNZeroForType(castToType);
+    }
+
     return VNForFunc(castToType, VNF_BitCast, srcVN, VNForIntCon(castToType));
 }
 

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -4249,19 +4249,6 @@ ValueNumPair ValueNumStore::VNPairForLoadStoreBitcast(ValueNumPair value, var_ty
     return ValueNumPair(liberalVN, conservVN);
 }
 
-ValueNum ValueNumStore::VNForEmptyMap(var_types type)
-{
-    // TODO-PhysicalVN: use one single VN here instead of allocating new ones.
-    return VNForExpr(nullptr, type);
-}
-
-ValueNumPair ValueNumStore::VNPairForEmptyMap(var_types type)
-{
-    ValueNum map = VNForEmptyMap(type);
-
-    return ValueNumPair(map, map);
-}
-
 //------------------------------------------------------------------------
 // IsVNNotAField: Is the value number a "NotAField" field sequence?
 //

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -679,10 +679,6 @@ public:
 
     ValueNumPair VNPairForLoadStoreBitcast(ValueNumPair value, var_types indType, unsigned indSize);
 
-    ValueNum VNForEmptyMap(var_types type);
-
-    ValueNumPair VNPairForEmptyMap(var_types type);
-
     // Compute the ValueNumber for a cast
     ValueNum VNForCast(ValueNum  srcVN,
                        var_types castToType,

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -645,20 +645,6 @@ public:
 // This controls extra tracing of the "evaluation" of "VNF_MapSelect" functions.
 #define FEATURE_VN_TRACE_APPLY_SELECTORS 1
 
-    ValueNum VNApplySelectors(ValueNumKind  vnk,
-                              ValueNum      map,
-                              FieldSeqNode* fieldSeq,
-                              size_t*       wbFinalStructSize = nullptr);
-
-    ValueNum VNApplySelectorsTypeCheck(ValueNum value, var_types indType, size_t valueStructSize);
-
-    ValueNum VNApplySelectorsAssign(
-        ValueNumKind vnk, ValueNum map, FieldSeqNode* fieldSeq, ValueNum value, var_types dstIndType);
-
-    ValueNum VNApplySelectorsAssignTypeCoerce(ValueNum value, var_types dstIndType);
-
-    ValueNumPair VNPairApplySelectors(ValueNumPair map, FieldSeqNode* fieldSeq, var_types indType);
-
     ValueNum VNForLoad(ValueNumKind vnk,
                        ValueNum     locationValue,
                        unsigned     locationSize,
@@ -696,17 +682,6 @@ public:
     ValueNum VNForEmptyMap(var_types type);
 
     ValueNumPair VNPairForEmptyMap(var_types type);
-
-    ValueNumPair VNPairApplySelectorsAssign(ValueNumPair  map,
-                                            FieldSeqNode* fieldSeq,
-                                            ValueNumPair  value,
-                                            var_types     dstIndType)
-    {
-        return ValueNumPair(VNApplySelectorsAssign(VNK_Liberal, map.GetLiberal(), fieldSeq, value.GetLiberal(),
-                                                   dstIndType),
-                            VNApplySelectorsAssign(VNK_Conservative, map.GetConservative(), fieldSeq,
-                                                   value.GetConservative(), dstIndType));
-    }
 
     // Compute the ValueNumber for a cast
     ValueNum VNForCast(ValueNum  srcVN,

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -587,12 +587,20 @@ public:
 
     ValueNum VNForMapSelect(ValueNumKind vnk, var_types type, ValueNum map, ValueNum index);
 
+    ValueNum VNForMapPhysicalSelect(ValueNumKind vnk, var_types type, ValueNum map, unsigned offset, unsigned size);
+
     // A method that does the work for VNForMapSelect and may call itself recursively.
     ValueNum VNForMapSelectWork(
         ValueNumKind vnk, var_types type, ValueNum map, ValueNum index, int* pBudget, bool* pUsedRecursiveVN);
 
     // A specialized version of VNForFunc that is used for VNF_MapStore and provides some logging when verbose is set
     ValueNum VNForMapStore(ValueNum map, ValueNum index, ValueNum value);
+
+    ValueNum VNForMapPhysicalStore(ValueNum map, unsigned offset, unsigned size, ValueNum value);
+
+    ValueNum EncodePhysicalSelector(unsigned offset, unsigned size);
+
+    unsigned DecodePhysicalSelector(ValueNum selector, unsigned* pSize);
 
     ValueNum VNForFieldSelector(CORINFO_FIELD_HANDLE fieldHnd, var_types* pFieldType, size_t* pStructSize = nullptr);
 
@@ -649,6 +657,39 @@ public:
     ValueNum VNApplySelectorsAssignTypeCoerce(ValueNum value, var_types dstIndType);
 
     ValueNumPair VNPairApplySelectors(ValueNumPair map, FieldSeqNode* fieldSeq, var_types indType);
+
+    ValueNum VNForLoad(ValueNumKind vnk,
+                       ValueNum     locationValue,
+                       unsigned     locationSize,
+                       var_types    loadType,
+                       ssize_t      offset,
+                       unsigned     loadSize);
+
+    ValueNumPair VNPairForLoad(ValueNumPair locationValue,
+                               unsigned     locationSize,
+                               var_types    loadType,
+                               ssize_t      offset,
+                               unsigned     loadSize);
+
+    ValueNum VNForStore(ValueNum locationValue,
+                        unsigned locationSize,
+                        ssize_t  offset,
+                        unsigned storeSize,
+                        ValueNum value);
+
+    ValueNumPair VNPairForStore(ValueNumPair locationValue,
+                                unsigned     locationSize,
+                                ssize_t      offset,
+                                unsigned     storeSize,
+                                ValueNumPair value);
+
+    ValueNum VNForLoadStoreBitcast(ValueNumKind vnk, ValueNum value, var_types indType, unsigned indSize);
+
+    ValueNumPair VNPairForLoadStoreBitcast(ValueNumPair value, var_types indType, unsigned indSize);
+
+    ValueNum VNForEmptyMap(var_types type);
+
+    ValueNumPair VNPairForEmptyMap(var_types type);
 
     ValueNumPair VNPairApplySelectorsAssign(ValueNumPair  map,
                                             FieldSeqNode* fieldSeq,
@@ -1014,6 +1055,10 @@ public:
     // Requires "mapStore" to be a map store VNFuncApp.
     // Prints a representation of a MapStore operation on standard out.
     void vnDumpMapStore(Compiler* comp, VNFuncApp* mapStore);
+
+    void vnDumpPhysicalSelector(ValueNum selector);
+
+    void vnDumpMapPhysicalStore(Compiler* comp, VNFuncApp* mapPhysicalStore);
 
     // Requires "memOpaque" to be a mem opaque VNFuncApp
     // Prints a representation of a MemOpaque state on standard out.

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -421,25 +421,16 @@ public:
     // And the single constant for an object reference type.
     static ValueNum VNForNull()
     {
-        // We reserve Chunk 0 for "special" VNs.  SRC_Null (== 0) is the VN of "null".
         return ValueNum(SRC_Null);
-    }
-
-    // The ROH map is the map for the "read-only heap".  We assume that this is never mutated, and always
-    // has the same value number.
-    static ValueNum VNForROH()
-    {
-        // We reserve Chunk 0 for "special" VNs.  Let SRC_ReadOnlyHeap (== 3) be the read-only heap.
-        return ValueNum(SRC_ReadOnlyHeap);
     }
 
     // A special value number for "void" -- sometimes a type-void thing is an argument,
     // and we want the args to be non-NoVN.
     static ValueNum VNForVoid()
     {
-        // We reserve Chunk 0 for "special" VNs.  Let SRC_Void (== 4) be the value for "void".
         return ValueNum(SRC_Void);
     }
+
     static ValueNumPair VNPForVoid()
     {
         return ValueNumPair(VNForVoid(), VNForVoid());
@@ -448,10 +439,9 @@ public:
     // A special value number for the empty set of exceptions.
     static ValueNum VNForEmptyExcSet()
     {
-        // We reserve Chunk 0 for "special" VNs.  Let SRC_EmptyExcSet (== 5) be the value for the empty set of
-        // exceptions.
         return ValueNum(SRC_EmptyExcSet);
     }
+
     static ValueNumPair VNPForEmptyExcSet()
     {
         return ValueNumPair(VNForEmptyExcSet(), VNForEmptyExcSet());
@@ -1405,10 +1395,10 @@ private:
         return m_VNFunc4Map;
     }
 
+    // We reserve Chunk 0 for "special" VNs.
     enum SpecialRefConsts
     {
         SRC_Null,
-        SRC_ReadOnlyHeap,
         SRC_Void,
         SRC_EmptyExcSet,
 

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -683,23 +683,14 @@ public:
                        ssize_t      offset,
                        unsigned     loadSize);
 
-    ValueNumPair VNPairForLoad(ValueNumPair locationValue,
-                               unsigned     locationSize,
-                               var_types    loadType,
-                               ssize_t      offset,
-                               unsigned     loadSize);
+    ValueNumPair VNPairForLoad(
+        ValueNumPair locationValue, unsigned locationSize, var_types loadType, ssize_t offset, unsigned loadSize);
 
-    ValueNum VNForStore(ValueNum locationValue,
-                        unsigned locationSize,
-                        ssize_t  offset,
-                        unsigned storeSize,
-                        ValueNum value);
+    ValueNum VNForStore(
+        ValueNum locationValue, unsigned locationSize, ssize_t offset, unsigned storeSize, ValueNum value);
 
-    ValueNumPair VNPairForStore(ValueNumPair locationValue,
-                                unsigned     locationSize,
-                                ssize_t      offset,
-                                unsigned     storeSize,
-                                ValueNumPair value);
+    ValueNumPair VNPairForStore(
+        ValueNumPair locationValue, unsigned locationSize, ssize_t offset, unsigned storeSize, ValueNumPair value);
 
     bool LoadStoreIsEntire(unsigned locationSize, ssize_t offset, unsigned indSize) const
     {

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -599,6 +599,16 @@ public:
 
     ValueNum VNForMapPhysicalStore(ValueNum map, unsigned offset, unsigned size, ValueNum value);
 
+    bool MapIsPrecise(ValueNum map) const
+    {
+        return (TypeOfVN(map) == TYP_HEAP) || (TypeOfVN(map) == TYP_MEM);
+    }
+
+    bool MapIsPhysical(ValueNum map) const
+    {
+        return !MapIsPrecise(map);
+    }
+
     ValueNum EncodePhysicalSelector(unsigned offset, unsigned size);
 
     unsigned DecodePhysicalSelector(ValueNum selector, unsigned* pSize);
@@ -675,9 +685,9 @@ public:
         return (offset == 0) && (locationSize == indSize);
     }
 
-    ValueNum VNForLoadStoreBitcast(ValueNum value, var_types indType, unsigned indSize);
+    ValueNum VNForLoadStoreBitCast(ValueNum value, var_types indType, unsigned indSize);
 
-    ValueNumPair VNPairForLoadStoreBitcast(ValueNumPair value, var_types indType, unsigned indSize);
+    ValueNumPair VNPairForLoadStoreBitCast(ValueNumPair value, var_types indType, unsigned indSize);
 
     // Compute the ValueNumber for a cast
     ValueNum VNForCast(ValueNum  srcVN,
@@ -716,7 +726,7 @@ public:
     // not true.
 
     // Returns TYP_UNKNOWN if the given value number has not been given a type.
-    var_types TypeOfVN(ValueNum vn);
+    var_types TypeOfVN(ValueNum vn) const;
 
     // Returns BasicBlock::MAX_LOOP_NUM if the given value number's loop nest is unknown or ill-defined.
     BasicBlock::loopNumber LoopOfVN(ValueNum vn);

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -104,7 +104,7 @@
 // will be used to mean GcHeap), $Heap.
 //
 // A store to the ScalarField is seen. Now, the value numbering of fields is done in the following pattern for
-// maps that it builds: [$Heap][$FirstField][$Object][offset:offset + size of the load]. It may seem odd that
+// maps that it builds: [$Heap][$FirstField][$Object][offset:offset + size of the store]. It may seem odd that
 // the indexing is done first for the field, and only then for the object, but the reason for that is the fact
 // that it enables MapStores to $Heap to refer to distinct selectors, thus enabling the traversal through the
 // map updates when looking for the values that were stored. Were $Object VNs used for this, the traversal could
@@ -117,7 +117,7 @@
 //
 // Now that we know where to store, the store maps are built:
 //
-//  $ScalarFieldSelector     = PhysicalSelector(offsetof(StructField) + offsetof(ScalarField), sizeof(ScalarField))
+//  $ScalarFieldSelector     = PhysicalSelector(offsetof(ScalarField), sizeof(ScalarField))
 //  $NewStructFieldForObjMap = MapPhysicalStore($StructFieldForObjMap, $ScalarFieldSelector, $ObjVal)
 //  $NewStructFieldMap       = MapStore($StructFieldMap, $Obj, $NewStructFieldForObjMap)
 //  $NewHeap                 = MapStore($Heap, $StructField, $NewStructFieldMap)

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -139,8 +139,9 @@ ValueNumFuncDef(JitReadyToRunNewArr, 3, false, true, false)
 ValueNumFuncDef(Box, 3, false, false, false)
 ValueNumFuncDef(BoxNullable, 3, false, false, false)
 
-ValueNumFuncDef(LazyStrCns, 2, false, true, false)  // lazy-initialized string literal (helper)
-ValueNumFuncDef(NonNullIndirect, 1, false, true, false)  // this indirect is expected to always return a non-null value
+ValueNumFuncDef(LazyStrCns, 2, false, true, false)            // Lazy-initialized string literal (helper)
+ValueNumFuncDef(InvariantLoad, 1, false, false, false)        // Args: 0: (VN of) the address.
+ValueNumFuncDef(InvariantNonNullLoad, 1, false, true, false)  // Args: 0: (VN of) the address.
 ValueNumFuncDef(Unbox, 2, false, true, false)
 
 ValueNumFuncDef(LT_UN, 2, false, false, false)      // unsigned or unordered comparisons

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -6,9 +6,10 @@
 // <is-shared-static>)
 
 // clang-format off
-ValueNumFuncDef(MemOpaque, 1, false, false, false)  // Args: 0: loop num
-ValueNumFuncDef(MapStore, 4, false, false, false)   // Args: 0: map, 1: index (e. g. field handle), 2: value being stored, 3: loop num.
-ValueNumFuncDef(MapSelect, 2, false, false, false)  // Args: 0: map, 1: key.
+ValueNumFuncDef(MemOpaque, 1, false, false, false)          // Args: 0: loop num
+ValueNumFuncDef(MapStore, 4, false, false, false)           // Args: 0: map, 1: index (e. g. field handle), 2: value being stored, 3: loop num.
+ValueNumFuncDef(MapPhysicalStore, 3, false, false, false)   // Args: 0: map, 1: "physical selector": offset and size, 2: value being stored
+ValueNumFuncDef(MapSelect, 2, false, false, false)          // Args: 0: map, 1: key.
 
 ValueNumFuncDef(PtrToLoc, 2, false, true, false)            // Pointer (byref) to a local variable.  Args: VN's of: 0: var num, 1: FieldSeq.
 ValueNumFuncDef(PtrToArrElem, 4, false, false, false)       // Pointer (byref) to an array element.  Args: 0: array elem type eq class var_types value, VN's of: 1: array, 2: index, 3: FieldSeq.

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -9,18 +9,21 @@
 ValueNumFuncDef(MemOpaque, 1, false, false, false)          // Args: 0: loop num
 ValueNumFuncDef(MapStore, 4, false, false, false)           // Args: 0: map, 1: index (e. g. field handle), 2: value being stored, 3: loop num.
 ValueNumFuncDef(MapPhysicalStore, 3, false, false, false)   // Args: 0: map, 1: "physical selector": offset and size, 2: value being stored
+ValueNumFuncDef(BitCast, 2, false, false, false)            // Args: 0: VN of the arg, 1: VN of the target type
+ValueNumFuncDef(ZeroObj, 1, false, false, false)            // Args: 0: VN of the class handle.
 ValueNumFuncDef(MapSelect, 2, false, false, false)          // Args: 0: map, 1: key.
 
 ValueNumFuncDef(PtrToLoc, 2, false, true, false)            // Pointer (byref) to a local variable.  Args: VN's of: 0: var num, 1: FieldSeq.
 ValueNumFuncDef(PtrToArrElem, 4, false, false, false)       // Pointer (byref) to an array element.  Args: 0: array elem type eq class var_types value, VN's of: 1: array, 2: index, 3: FieldSeq.
-ValueNumFuncDef(PtrToStatic, 2, false, true, false)         // Pointer (byref) to a static variable (or possibly a field thereof, if the static variable is a struct).
-                                                            // Args: 0: (VN of) the box's address if the static is "boxed", 1: the field sequence, of which the first element is the static itself.
+ValueNumFuncDef(PtrToStatic, 3, false, true, false)         // Pointer (byref) to a static variable (or possibly a field thereof, if the static variable is a struct).
+                                                            // Args: 0: (VN of) the box's address if the static is "boxed",
+                                                            //       1: (VN of) the field sequence, of which the first element is the static itself.
+                                                            //       2: (VN of) offset for the constituent struct fields
 
 ValueNumFuncDef(Phi, 2, false, false, false)        // A phi function.  Only occurs as arg of PhiDef or PhiMemoryDef.  Arguments are SSA numbers of var being defined.
 ValueNumFuncDef(PhiDef, 3, false, false, false)     // Args: 0: local var # (or -1 for memory), 1: SSA #, 2: VN of definition.
 // Wouldn't need this if I'd made memory a regular local variable...
 ValueNumFuncDef(PhiMemoryDef, 2, false, false, false) // Args: 0: VN for basic block pointer, 1: VN of definition
-ValueNumFuncDef(ZeroObj, 1, false, false, false)    // Zero-initialized struct. Args: 0: VN of the class handle.
 ValueNumFuncDef(InitVal, 1, false, false, false)    // An input arg, or init val of a local Args: 0: a constant VN.
 
 

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -14,7 +14,8 @@ ValueNumFuncDef(ZeroObj, 1, false, false, false)            // Args: 0: VN of th
 ValueNumFuncDef(MapSelect, 2, false, false, false)          // Args: 0: map, 1: key.
 
 ValueNumFuncDef(PtrToLoc, 2, false, true, false)            // Pointer (byref) to a local variable.  Args: VN's of: 0: var num, 1: FieldSeq.
-ValueNumFuncDef(PtrToArrElem, 4, false, false, false)       // Pointer (byref) to an array element.  Args: 0: array elem type eq class var_types value, VN's of: 1: array, 2: index, 3: FieldSeq.
+ValueNumFuncDef(PtrToArrElem, 4, false, false, false)       // Pointer (byref) to an array element.  Args: 0: array elem type eq class var_types value, VN's of: 1: array, 2: index, 3: "ArrElemOffset" VN.
+ValueNumFuncDef(ArrElemOffset, 2, false, false, false)      // Args: 0: (VN of) the field sequence, 1: (VN of) the offset
 ValueNumFuncDef(PtrToStatic, 3, false, true, false)         // Pointer (byref) to a static variable (or possibly a field thereof, if the static variable is a struct).
                                                             // Args: 0: (VN of) the box's address if the static is "boxed",
                                                             //       1: (VN of) the field sequence, of which the first element is the static itself.

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -7,11 +7,14 @@
 
 // clang-format off
 ValueNumFuncDef(MemOpaque, 1, false, false, false)          // Args: 0: loop num
+ValueNumFuncDef(MapSelect, 2, false, false, false)          // Args: 0: map, 1: key.
 ValueNumFuncDef(MapStore, 4, false, false, false)           // Args: 0: map, 1: index (e. g. field handle), 2: value being stored, 3: loop num.
 ValueNumFuncDef(MapPhysicalStore, 3, false, false, false)   // Args: 0: map, 1: "physical selector": offset and size, 2: value being stored
 ValueNumFuncDef(BitCast, 2, false, false, false)            // Args: 0: VN of the arg, 1: VN of the target type
 ValueNumFuncDef(ZeroObj, 1, false, false, false)            // Args: 0: VN of the class handle.
-ValueNumFuncDef(MapSelect, 2, false, false, false)          // Args: 0: map, 1: key.
+ValueNumFuncDef(PhiDef, 3, false, false, false)             // Args: 0: local var # (or -1 for memory), 1: SSA #, 2: VN of definition.
+ValueNumFuncDef(PhiMemoryDef, 2, false, false, false)       // Args: 0: VN for basic block pointer, 1: VN of definition
+ValueNumFuncDef(Phi, 2, false, false, false)                // A phi function.  Only occurs as arg of PhiDef or PhiMemoryDef.  Arguments are SSA numbers of var being defined.
 
 ValueNumFuncDef(PtrToLoc, 2, false, true, false)            // Pointer (byref) to a local variable.  Args: VN's of: 0: var num, 1: FieldSeq.
 ValueNumFuncDef(PtrToArrElem, 4, false, false, false)       // Pointer (byref) to an array element.  Args: 0: array elem type eq class var_types value, VN's of: 1: array, 2: index, 3: "ArrElemOffset" VN.
@@ -21,13 +24,7 @@ ValueNumFuncDef(PtrToStatic, 3, false, true, false)         // Pointer (byref) t
                                                             //       1: (VN of) the field sequence, of which the first element is the static itself.
                                                             //       2: (VN of) offset for the constituent struct fields
 
-ValueNumFuncDef(Phi, 2, false, false, false)        // A phi function.  Only occurs as arg of PhiDef or PhiMemoryDef.  Arguments are SSA numbers of var being defined.
-ValueNumFuncDef(PhiDef, 3, false, false, false)     // Args: 0: local var # (or -1 for memory), 1: SSA #, 2: VN of definition.
-// Wouldn't need this if I'd made memory a regular local variable...
-ValueNumFuncDef(PhiMemoryDef, 2, false, false, false) // Args: 0: VN for basic block pointer, 1: VN of definition
 ValueNumFuncDef(InitVal, 1, false, false, false)    // An input arg, or init val of a local Args: 0: a constant VN.
-
-
 
 ValueNumFuncDef(Cast, 2, false, false, false)           // VNF_Cast: Cast Operation changes the representations size and unsigned-ness.
                                                         //           Args: 0: Source for the cast operation.


### PR DESCRIPTION
### The problem

As we know, value numbering disambiguates loads from and stores to fields using field handles as the selectors, essentially meaning that the aliasing model it has presumes no two field accesses of different handles will refer to the same location.

This assumption simply does not hold for struct fields in modern .NET, with people using methods like `Unsafe.As` more and more. It also does not match the compiler's own internal model well, where precise types are not a unit of type identity (rather, layout compatibility is). Essentially, the field sequence model is too "high level", both for a subset of user code and (in some ways, perhaps more importantly) the IR.

The latter mismatch has caused a good number of bugs, past and present, especially those induced by "zero-offset field sequences", which represent the extreme case of IR-VN mismatch:

#67360
#64805
#64701
#62687
#57282
#32085
https://github.com/dotnet/coreclr/pull/23932
https://github.com/dotnet/coreclr/pull/27108
https://github.com/dotnet/coreclr/pull/20838

### The solution

It is the case that the invalid (fragmented) field sequences can **only** be detected in value numbering itself, no other phase has the information necessary to recognize that this:
```cs
var a = ref array[0];

// Several blocks later

Use(Unsafe.As<A, B>(ref a).Field);
```
is a possibly partial sequence.

Thus, to address the correctness problem we will need to call back into the VM for each field sequence formed, to see if the parent field's type is the owner of the current field (what `LocalAddressVisitor` does now).

This would solve the correctness problems.

Unfortunately, it has two very significant drawbacks:
1) It does not address the CQ issues associated with using symbols for inherently aliasable locations (e. g. zero-field sequences "polluting" VNs of addresses, even the simple cases of unions being completely "given up on" by numbering, and `StructWithOneField.Field` not being equivalent to `*(FieldType*)&StructWithOneField`).
2) It will hide compiler bugs related to bad field sequence maintenance. Consider block morphing as an example: today, it will fail to attach proper sequences for a case like this: `a[0] = *(ArrayElemType*)&promotedStruct;`, where the LHS's type does not match the RHS's.

An alternative approach, implemented in this change, is to "lower" VN to the IR's level and start using physical selectors (offset and size) to select values instead of field handles. It has a good number of advantages:

1) It is naturally very precise - handles unions, etc.
2) It should allow us to delete the zero-offset field sequence map.
3) It will also allow us to delete quite a bit of field sequence maintenance code.
4) It is "correct by construction" when it comes to aliasing, matching the expectations user code can place on the compiler.
5) It will free up one pointer-sized field on `LCL_FLD` nodes, enabling seamless `TYP_STRUCT` `LCL_FLD`.
6) It allows for more equivalences to be discovered for struct values -- today, their VNs are implicitly tied to their precise types (handles), while the IR generally supports equivalence between "compatible" structs, which is a good thing CQ-wise.

Essentially, we get CQ, correctness, and simplify the compiler code outside of VN.

The disadvantages?

1) Risk & review cost.
2) Up to `0.2%` TP degradation according to PIN for this initial implementation - once the field sequence code is removed, some of that will be gotten back.
3) A more complex VN model.

I believe the advantages of this change far outweigh the drawbacks.

### The implementation

We introduce a new kind of map - "the physical map" - to represent "simple" locations: object fields, static fields, array elements, as well as subsections of them. The field sequence will now be used only to get "the first field map" (and completely unused for array elements), the rest of the struct fields will be represented as "physical selectors": offsets relative to the location the map being updated represents plus the load/store size.

Physical loads will be represented as `MapSelect(location, PhysicalSelector)`. Physical stores will be represented via a new function `MapPhysicalStore`, mirroring `MapStore` with the difference being that the selector is always "physical".

At selection time, we will traverse back through `MapPhysicalStore`, same as with the precise maps (the new term for the old map concept to differentiate it from the physical maps), only use more sophisticated logic to detect whether the selector for the value aliases any stores present. As with the precise maps, we will support map nesting, that is, it will be possible to `MapPhysicalStore(parentMap, ..., MapPhysicalStore(...))`.

We will also introduce a special kind of map, `BitCast` that represent the "identity" selection (i. e. that of the whole value), to satisfy our type system that exists outside the physical selection process, where it will be a no-op.

For some more details on the choices made in this design, see the updated comment at the top of `valuenum.h`.

### The diffs

There are some diffs with change. There are two sources (+ a tiny number of diffs for the block morphing workaround).

The first is because we now number cases like below precisely:
```scala
N001 (  3,  4) [000463] ------------                        |  \--*  LCL_FLD   byref  V01 arg1         u:3[+0] Fseq[_reference] $287

N001 (  3,  4) [000330] ------------                        \--*  LCL_FLD   byref  V01 arg1         u:3[+0] Fseq[_reference, _value] $287
```
And so tend to CSE or copy propagate more. On 64 bit platforms that mostly results in better CQ, but on x86 in particular, "not so much". A variation of that is when we "consolidate" what used to be some number of CSEs into one, with a longer lifetime.

I believe it would be prohibitively expensive (in terms of throughput and code clarity) to quirk the behavior to match the old sequence-based one, so the only thing I can propose is to accept the diffs.

The second, a regression, is due to the fact the physical selection scheme does not handle things like `*(int*)&long.MaxValue`, i. e. selecting from a constant. I am not too worried about this because:
1) It only shows up in test code.
2) Support for it could be added easily enough, but I would like to do that separately (if we decide it's worth it at all) as part of adding constant folding to `BitCast`.