### PR TITLE
Mitigate stress hangs by marking GC-sensitive tests as out-of-proc

### DIFF
--- a/src/tests/JIT/Methodical/Arrays/misc/arrres_d.csproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/arrres_d.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/Arrays/misc/arrres_do.csproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/arrres_do.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/Arrays/misc/arrres_il_r.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/arrres_il_r.ilproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/Arrays/misc/arrres_r.csproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/arrres_r.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/Arrays/misc/arrres_ro.csproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/arrres_ro.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/Arrays/misc/gcarr_d.csproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/gcarr_d.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/Arrays/misc/gcarr_do.csproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/gcarr_do.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/Arrays/misc/gcarr_il_d.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/gcarr_il_d.ilproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/Arrays/misc/gcarr_il_r.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/gcarr_il_r.ilproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/Arrays/misc/gcarr_r.csproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/gcarr_r.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/Arrays/misc/gcarr_ro.csproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/gcarr_ro.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/Boxing/boxunbox/KeepAliveBoxOpt.csproj
+++ b/src/tests/JIT/Methodical/Boxing/boxunbox/KeepAliveBoxOpt.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Methodical/Coverage/copy_prop_byref_to_native_int.ilproj
+++ b/src/tests/JIT/Methodical/Coverage/copy_prop_byref_to_native_int.ilproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />

--- a/src/tests/JIT/Methodical/eh/interactions/gcincatch_d.csproj
+++ b/src/tests/JIT/Methodical/eh/interactions/gcincatch_d.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/eh/interactions/gcincatch_do.csproj
+++ b/src/tests/JIT/Methodical/eh/interactions/gcincatch_do.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/eh/interactions/gcincatch_r.csproj
+++ b/src/tests/JIT/Methodical/eh/interactions/gcincatch_r.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/eh/interactions/gcincatch_ro.csproj
+++ b/src/tests/JIT/Methodical/eh/interactions/gcincatch_ro.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_c_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_c_d.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_c_do.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_c_do.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_c_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_c_il_d.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_c_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_c_il_r.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_c_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_c_r.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_c_ro.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_c_ro.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_f4_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_f4_d.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_f4_do.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_f4_do.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_f4_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_f4_il_d.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_f4_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_f4_il_r.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_f4_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_f4_r.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_f4_ro.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_f4_ro.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_f8_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_f8_d.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_f8_do.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_f8_do.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_f8_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_f8_il_d.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_f8_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_f8_il_r.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_f8_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_f8_r.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_f8_ro.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_f8_ro.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i1_do.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i1_do.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i1_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i1_il_d.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i1_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i1_il_r.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i1_ro.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i1_ro.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i2_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i2_d.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i2_do.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i2_do.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i2_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i2_il_d.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i2_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i2_il_r.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i2_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i2_r.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i2_ro.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i2_ro.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i4_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i4_d.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i4_do.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i4_do.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i4_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i4_il_d.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i4_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i4_il_r.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i4_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i4_r.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_i4_ro.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_i4_ro.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_o_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_o_d.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_o_do.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_o_do.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_o_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_o_il_d.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_o_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_o_il_r.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_o_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_o_r.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_o_ro.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_o_ro.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_s_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_s_d.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_s_do.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_s_do.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_s_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_s_il_d.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_s_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_s_il_r.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_s_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_s_r.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refarg_s_ro.csproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refarg_s_ro.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_c_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_c_il_d.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_c_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_c_il_r.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_i1_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_i1_il_d.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_i1_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_i1_il_r.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_i2_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_i2_il_d.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_i2_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_i2_il_r.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_i4_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_i4_il_d.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_i4_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_i4_il_r.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_o2_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_o2_il_d.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_o2_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_o2_il_r.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_o_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_o_il_d.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_o_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_o_il_r.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_r4_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_r4_il_d.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_r4_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_r4_il_r.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_r8_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_r8_il_d.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_r8_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_r8_il_r.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_u2_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_u2_il_d.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/basic/refloc_u2_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/basic/refloc_u2_il_r.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/misc/refarg_box_f8_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/misc/refarg_box_f8_il_d.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/misc/refarg_box_f8_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/misc/refarg_box_f8_il_r.ilproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/misc/refarg_box_val_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/misc/refarg_box_val_il_d.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/misc/refarg_box_val_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/misc/refarg_box_val_il_r.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/rotate/rotate_i4_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/rotate/rotate_i4_il_d.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/rotate/rotate_i4_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/rotate/rotate_i4_il_r.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/explicit/rotate/rotate_u2_il_d.ilproj
+++ b/src/tests/JIT/Methodical/explicit/rotate/rotate_u2_il_d.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/explicit/rotate/rotate_u2_il_r.ilproj
+++ b/src/tests/JIT/Methodical/explicit/rotate/rotate_u2_il_r.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- https://github.com/dotnet/runtime/issues/68060 -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>


### PR DESCRIPTION
According to Andrew Au's findings in the issue

https://github.com/dotnet/runtime/issues/68060

a few tests explicitly manipulate the GC finalizer queue in a way
that is prone to hangs due to entering an infinite finalization
loop under GC stress. While the primary issue tracks the problem
in its entirety, the fix is non-trivial as it's not yet fully
understood whether we should fix the runtime, the GC stress mode
behavior or the tests themselves; after all, quite a few other
tests use explicit finalization too. To mitigate the problem in
the short term and help cleaning up the pending failures in GC
stress runs I propose marking the two tests that are known to
regularly cause these issues - arrres and
copy_prop_byref_to_native_int - as requiring process isolation
to run out-of-process as they used to before the test merging.

Thanks

Tomas

/cc @dotnet/jit-contrib 