### PR TITLE
Improve impPopCallArgs

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3906,7 +3906,6 @@ private:
 
     bool impCheckImplicitArgumentCoercion(var_types sigType, var_types nodeType) const;
 
-private:
     void impPopReverseCallArgs(CORINFO_SIG_INFO* sig, GenTreeCall* call, unsigned skipReverseCount);
 
     //---------------- Spilling the importer stack ----------------------------

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3543,8 +3543,9 @@ protected:
     void impResolveToken(const BYTE* addr, CORINFO_RESOLVED_TOKEN* pResolvedToken, CorInfoTokenKind kind);
 
     void impPushOnStack(GenTree* tree, typeInfo ti);
-    void        impPushNullObjRefOnStack();
-    StackEntry  impPopStack();
+    void       impPushNullObjRefOnStack();
+    StackEntry impPopStack();
+    void impPopStack(unsigned n);
     StackEntry& impStackTop(unsigned n = 0);
     unsigned impStackHeight();
 
@@ -3901,11 +3902,12 @@ private:
                 ((opcode >= CEE_STLOC_0) && (opcode <= CEE_STLOC_3)));
     }
 
-    void impPopCallArgs(unsigned count, CORINFO_SIG_INFO* sig, GenTreeCall* call);
+    void impPopCallArgs(CORINFO_SIG_INFO* sig, GenTreeCall* call);
 
     bool impCheckImplicitArgumentCoercion(var_types sigType, var_types nodeType) const;
 
-    void impPopReverseCallArgs(unsigned count, CORINFO_SIG_INFO* sig, GenTreeCall* call, unsigned skipReverseCount = 0);
+private:
+    void impPopReverseCallArgs(CORINFO_SIG_INFO* sig, GenTreeCall* call, unsigned skipReverseCount);
 
     //---------------- Spilling the importer stack ----------------------------
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1675,7 +1675,7 @@ CallArg* CallArgs::InsertAfter(Compiler* comp, CallArg* after, GenTree* node, We
     assert(found && "Could not find arg to insert after in argument list");
 #endif
 
-    InsertAfterUnchecked(comp, after, node, wellKnownArg);
+    return InsertAfterUnchecked(comp, after, node, wellKnownArg);
 }
 
 //---------------------------------------------------------------

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1675,6 +1675,23 @@ CallArg* CallArgs::InsertAfter(Compiler* comp, CallArg* after, GenTree* node, We
     assert(found && "Could not find arg to insert after in argument list");
 #endif
 
+    InsertAfterUnchecked(comp, after, node, wellKnownArg);
+}
+
+//---------------------------------------------------------------
+// InsertAfterUnchecked: Create a new argument after another argument, without debug checks.
+//
+// Parameters:
+//   comp         - The compiler.
+//   after        - The existing argument to insert the new argument after.
+//   node         - The IR node for the argument.
+//   wellKnownArg - The kind of argument, if special.
+//
+// Returns:
+//   The created representative for the argument.
+//
+CallArg* CallArgs::InsertAfterUnchecked(Compiler* comp, CallArg* after, GenTree* node, WellKnownArg wellKnownArg)
+{
     CallArg* newArg = new (comp, CMK_CallArgs) CallArg(wellKnownArg);
     newArg->SetEarlyNode(node);
     newArg->SetNext(after->GetNext());

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4332,6 +4332,7 @@ public:
     CallArg* PushFront(Compiler* comp, GenTree* node, WellKnownArg wellKnownArg = WellKnownArg::None);
     CallArg* PushBack(Compiler* comp, GenTree* node, WellKnownArg wellKnownArg = WellKnownArg::None);
     CallArg* InsertAfter(Compiler* comp, CallArg* after, GenTree* node, WellKnownArg wellKnownArg = WellKnownArg::None);
+    CallArg* InsertAfterUnchecked(Compiler* comp, CallArg* after, GenTree* node, WellKnownArg wellKnownArg = WellKnownArg::None);
     CallArg* InsertInstParam(Compiler* comp, GenTree* node);
     CallArg* InsertAfterThisOrFirst(Compiler* comp, GenTree* node, WellKnownArg wellKnownArg = WellKnownArg::None);
     void PushLateBack(CallArg* arg);

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4332,7 +4332,10 @@ public:
     CallArg* PushFront(Compiler* comp, GenTree* node, WellKnownArg wellKnownArg = WellKnownArg::None);
     CallArg* PushBack(Compiler* comp, GenTree* node, WellKnownArg wellKnownArg = WellKnownArg::None);
     CallArg* InsertAfter(Compiler* comp, CallArg* after, GenTree* node, WellKnownArg wellKnownArg = WellKnownArg::None);
-    CallArg* InsertAfterUnchecked(Compiler* comp, CallArg* after, GenTree* node, WellKnownArg wellKnownArg = WellKnownArg::None);
+    CallArg* InsertAfterUnchecked(Compiler*    comp,
+                                  CallArg*     after,
+                                  GenTree*     node,
+                                  WellKnownArg wellKnownArg = WellKnownArg::None);
     CallArg* InsertInstParam(Compiler* comp, GenTree* node);
     CallArg* InsertAfterThisOrFirst(Compiler* comp, GenTree* node, WellKnownArg wellKnownArg = WellKnownArg::None);
     void PushLateBack(CallArg* arg);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -842,7 +842,7 @@ void Compiler::impPopCallArgs(CORINFO_SIG_INFO* sig, GenTreeCall* call)
     // actual order so that we can walk the signature at the same time.
     for (unsigned stackIndex = sig->numArgs; stackIndex > 0; stackIndex--)
     {
-        const StackEntry& se           = impStackTop(stackIndex - 1);
+        const StackEntry& se = impStackTop(stackIndex - 1);
 
         typeInfo ti      = se.seTypeInfo;
         GenTree* argNode = se.val;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -224,11 +224,12 @@ void Compiler::impResolveToken(const BYTE* addr, CORINFO_RESOLVED_TOKEN* pResolv
     info.compCompHnd->resolveToken(pResolvedToken);
 }
 
-/*****************************************************************************
- *
- *  Pop one tree from the stack.
- */
-
+//------------------------------------------------------------------------
+// impPopStack: Pop one tree from the stack.
+//
+// Returns:
+//   The stack entry for the popped tree.
+//
 StackEntry Compiler::impPopStack()
 {
     if (verCurrentState.esStackDepth == 0)
@@ -239,6 +240,12 @@ StackEntry Compiler::impPopStack()
     return verCurrentState.esStack[--verCurrentState.esStackDepth];
 }
 
+//------------------------------------------------------------------------
+// impPopStack: Pop a variable number of trees from the stack.
+//
+// Arguments:
+//   n - The number of trees to pop.
+//
 void Compiler::impPopStack(unsigned n)
 {
     if (verCurrentState.esStackDepth < n)
@@ -813,11 +820,9 @@ void Compiler::impAssignTempGen(unsigned             tmpNum,
 //   their values.
 //
 // Parameters:
-//   count   - The number of arguments to pop
 //   sig     - Signature used to figure out classes the runtime must load, and
 //             also to record exact receiving argument types that may be needed for ABI
 //             purposes later.
-//             Can be nullptr for certain helpers.
 //   call    - The call to pop arguments into.
 //
 void Compiler::impPopCallArgs(CORINFO_SIG_INFO* sig, GenTreeCall* call)

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -842,8 +842,7 @@ void Compiler::impPopCallArgs(CORINFO_SIG_INFO* sig, GenTreeCall* call)
     // actual order so that we can walk the signature at the same time.
     for (unsigned stackIndex = sig->numArgs; stackIndex > 0; stackIndex--)
     {
-        unsigned          fromTopIndex = stackIndex - 1;
-        const StackEntry& se           = impStackTop(fromTopIndex);
+        const StackEntry& se           = impStackTop(stackIndex - 1);
 
         typeInfo ti      = se.seTypeInfo;
         GenTree* argNode = se.val;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -937,7 +937,7 @@ void Compiler::impPopCallArgs(CORINFO_SIG_INFO* sig, GenTreeCall* call)
         }
         else
         {
-            lastArg = call->gtArgs.InsertAfter(this, lastArg, argNode);
+            lastArg = call->gtArgs.InsertAfterUnchecked(this, lastArg, argNode);
         }
 
         call->gtFlags |= argNode->gtFlags & GTF_GLOB_EFFECT;


### PR DESCRIPTION
Today `impPopCallArgs` works in the following way:
1. We first loop for the number of args to pop, popping each arg from the top of the stack
2. As part of this loop we call `impNormStructVal` with `CHECK_SPILL_ALL`, which is necessary because we are normalizing the arguments in reverse order
3. We finally insert the argument at the front of the arg list and then proceed to the next arg

When this is done, we loop through the arg list in order and walk the signature at the same time. We check that the implicit type coercions between the arg types and signature types are ok, and we insert some implicit casts and `GT_PUTARG_TYPE`.

This PR changes the loop to always walk the arguments on the stack in order. That means instead of popping arguments from the top of the stack and thus walking the arguments backwards, we start from the beginning. The benefit is that we can then walk the signature at the same time. Furthermore, when calling `impNormStructVal` we now only check interference with the stack entries that are not arguments since we now know that arguments will be normalized and kept in order.

While the fewer interference checks result in only small [diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1745902&view=ms.vss-build-web.run-extensions-tab), the main benefit of this change is that it will help the logic for an upcoming change where I want to consistently store signature types and class handles in `CallArg`. Having access to the signature when we create the args in the first place simplifies things.

Furthermore, I have cleaned things up a little bit by removing the possibility of `sig` being null. There was only one caller passing this, for a helper, and it can simply pop the arguments on its own.