### PR TITLE
Convert RsaPaddingProcessor to statics

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
@@ -78,7 +78,7 @@ namespace System.Security.Cryptography
                 ArgumentNullException.ThrowIfNull(data);
                 ArgumentNullException.ThrowIfNull(padding);
 
-                Interop.AndroidCrypto.RsaPadding rsaPadding = GetInteropPadding(padding, out RsaPaddingProcessor? oaepProcessor);
+                Interop.AndroidCrypto.RsaPadding rsaPadding = GetInteropPadding(padding, out HashAlgorithmName? oaepHashAlgorithmName);
                 SafeRsaHandle key = GetKey();
 
                 int rsaSize = Interop.AndroidCrypto.RsaSize(key);
@@ -89,7 +89,7 @@ namespace System.Security.Cryptography
                 {
                     destination = new Span<byte>(buf, 0, rsaSize);
 
-                    if (!TryDecrypt(key, data, destination, rsaPadding, oaepProcessor, out int bytesWritten))
+                    if (!TryDecrypt(key, data, destination, rsaPadding, oaepHashAlgorithmName, out int bytesWritten))
                     {
                         Debug.Fail($"{nameof(TryDecrypt)} should not return false for RSA_size buffer");
                         throw new CryptographicException();
@@ -112,7 +112,7 @@ namespace System.Security.Cryptography
             {
                 ArgumentNullException.ThrowIfNull(padding);
 
-                Interop.AndroidCrypto.RsaPadding rsaPadding = GetInteropPadding(padding, out RsaPaddingProcessor? oaepProcessor);
+                Interop.AndroidCrypto.RsaPadding rsaPadding = GetInteropPadding(padding, out HashAlgorithmName? oaepHashAlgorithmName);
                 SafeRsaHandle key = GetKey();
 
                 int keySizeBytes = Interop.AndroidCrypto.RsaSize(key);
@@ -135,7 +135,7 @@ namespace System.Security.Cryptography
                         tmp = rent;
                     }
 
-                    bool ret = TryDecrypt(key, data, tmp, rsaPadding, oaepProcessor, out bytesWritten);
+                    bool ret = TryDecrypt(key, data, tmp, rsaPadding, oaepHashAlgorithmName, out bytesWritten);
 
                     if (ret)
                     {
@@ -163,7 +163,7 @@ namespace System.Security.Cryptography
                     return ret;
                 }
 
-                return TryDecrypt(key, data, destination, rsaPadding, oaepProcessor, out bytesWritten);
+                return TryDecrypt(key, data, destination, rsaPadding, oaepHashAlgorithmName, out bytesWritten);
             }
 
             private static bool TryDecrypt(
@@ -171,14 +171,14 @@ namespace System.Security.Cryptography
                 ReadOnlySpan<byte> data,
                 Span<byte> destination,
                 Interop.AndroidCrypto.RsaPadding rsaPadding,
-                RsaPaddingProcessor? rsaPaddingProcessor,
+                HashAlgorithmName? oaepHashAlgorithmName,
                 out int bytesWritten)
             {
                 // If rsaPadding is PKCS1 or OAEP-SHA1 then no depadding method should be present.
                 // If rsaPadding is NoPadding then a depadding method should be present.
                 Debug.Assert(
                     (rsaPadding == Interop.AndroidCrypto.RsaPadding.NoPadding) ==
-                    (rsaPaddingProcessor != null));
+                    (oaepHashAlgorithmName != null));
 
                 // Caller should have already checked this.
                 Debug.Assert(!key.IsInvalid);
@@ -199,7 +199,7 @@ namespace System.Security.Cryptography
                 Span<byte> decryptBuf = destination;
                 byte[]? paddingBuf = null;
 
-                if (rsaPaddingProcessor != null)
+                if (oaepHashAlgorithmName != null)
                 {
                     paddingBuf = CryptoPool.Rent(rsaSize);
                     decryptBuf = paddingBuf;
@@ -210,9 +210,9 @@ namespace System.Security.Cryptography
                     int returnValue = Interop.AndroidCrypto.RsaPrivateDecrypt(data.Length, data, decryptBuf, key, rsaPadding);
                     CheckReturn(returnValue);
 
-                    if (rsaPaddingProcessor != null)
+                    if (oaepHashAlgorithmName != null)
                     {
-                        return rsaPaddingProcessor.DepadOaep(paddingBuf, destination, out bytesWritten);
+                        return RsaPaddingProcessor.DepadOaep(oaepHashAlgorithmName.Value, paddingBuf, destination, out bytesWritten);
                     }
                     else
                     {
@@ -243,7 +243,7 @@ namespace System.Security.Cryptography
                 ArgumentNullException.ThrowIfNull(data);
                 ArgumentNullException.ThrowIfNull(padding);
 
-                Interop.AndroidCrypto.RsaPadding rsaPadding = GetInteropPadding(padding, out RsaPaddingProcessor? oaepProcessor);
+                Interop.AndroidCrypto.RsaPadding rsaPadding = GetInteropPadding(padding, out HashAlgorithmName? oaepHashAlgorithmName);
                 SafeRsaHandle key = GetKey();
 
                 byte[] buf = new byte[Interop.AndroidCrypto.RsaSize(key)];
@@ -253,7 +253,7 @@ namespace System.Security.Cryptography
                     data,
                     buf,
                     rsaPadding,
-                    oaepProcessor,
+                    oaepHashAlgorithmName,
                     out int bytesWritten);
 
                 if (!encrypted || bytesWritten != buf.Length)
@@ -269,10 +269,10 @@ namespace System.Security.Cryptography
             {
                 ArgumentNullException.ThrowIfNull(padding);
 
-                Interop.AndroidCrypto.RsaPadding rsaPadding = GetInteropPadding(padding, out RsaPaddingProcessor? oaepProcessor);
+                Interop.AndroidCrypto.RsaPadding rsaPadding = GetInteropPadding(padding, out HashAlgorithmName? oaepHashAlgorithmName);
                 SafeRsaHandle key = GetKey();
 
-                return TryEncrypt(key, data, destination, rsaPadding, oaepProcessor, out bytesWritten);
+                return TryEncrypt(key, data, destination, rsaPadding, oaepHashAlgorithmName, out bytesWritten);
             }
 
             private static bool TryEncrypt(
@@ -280,7 +280,7 @@ namespace System.Security.Cryptography
                 ReadOnlySpan<byte> data,
                 Span<byte> destination,
                 Interop.AndroidCrypto.RsaPadding rsaPadding,
-                RsaPaddingProcessor? rsaPaddingProcessor,
+                HashAlgorithmName? oaepHashAlgorithmName,
                 out int bytesWritten)
             {
                 int rsaSize = Interop.AndroidCrypto.RsaSize(key);
@@ -293,7 +293,7 @@ namespace System.Security.Cryptography
 
                 int returnValue;
 
-                if (rsaPaddingProcessor != null)
+                if (oaepHashAlgorithmName != null)
                 {
                     Debug.Assert(rsaPadding == Interop.AndroidCrypto.RsaPadding.NoPadding);
                     byte[] rented = CryptoPool.Rent(rsaSize);
@@ -301,7 +301,7 @@ namespace System.Security.Cryptography
 
                     try
                     {
-                        rsaPaddingProcessor.PadOaep(data, tmp);
+                        RsaPaddingProcessor.PadOaep(oaepHashAlgorithmName.Value, data, tmp);
                         returnValue = Interop.AndroidCrypto.RsaPublicEncrypt(tmp.Length, tmp, destination, key, rsaPadding);
                     }
                     finally
@@ -327,23 +327,23 @@ namespace System.Security.Cryptography
 
             private static Interop.AndroidCrypto.RsaPadding GetInteropPadding(
                 RSAEncryptionPadding padding,
-                out RsaPaddingProcessor? rsaPaddingProcessor)
+                out HashAlgorithmName? oaepHashAlgorithmName)
             {
                 if (padding == RSAEncryptionPadding.Pkcs1)
                 {
-                    rsaPaddingProcessor = null;
+                    oaepHashAlgorithmName = null;
                     return Interop.AndroidCrypto.RsaPadding.Pkcs1;
                 }
 
                 if (padding == RSAEncryptionPadding.OaepSHA1)
                 {
-                    rsaPaddingProcessor = null;
+                    oaepHashAlgorithmName = null;
                     return Interop.AndroidCrypto.RsaPadding.OaepSHA1;
                 }
 
                 if (padding.Mode == RSAEncryptionPaddingMode.Oaep)
                 {
-                    rsaPaddingProcessor = RsaPaddingProcessor.OpenProcessor(padding.OaepHashAlgorithm);
+                    oaepHashAlgorithmName = padding.OaepHashAlgorithm;
                     return Interop.AndroidCrypto.RsaPadding.NoPadding;
                 }
 
@@ -720,7 +720,6 @@ namespace System.Security.Cryptography
                     throw PaddingModeNotSupported();
                 }
 
-                RsaPaddingProcessor processor = RsaPaddingProcessor.OpenProcessor(hashAlgorithm);
                 SafeRsaHandle rsa = GetKey();
 
                 int bytesRequired = Interop.AndroidCrypto.RsaSize(rsa);
@@ -743,11 +742,11 @@ namespace System.Security.Cryptography
 
                 if (padding.Mode == RSASignaturePaddingMode.Pkcs1)
                 {
-                    processor.PadPkcs1Signature(hash, encodedBytes);
+                    RsaPaddingProcessor.PadPkcs1Signature(hashAlgorithm, hash, encodedBytes);
                 }
                 else if (padding.Mode == RSASignaturePaddingMode.Pss)
                 {
-                    processor.EncodePss(hash, encodedBytes, KeySize);
+                    RsaPaddingProcessor.EncodePss(hashAlgorithm, hash, encodedBytes, KeySize);
                 }
                 else
                 {
@@ -790,7 +789,6 @@ namespace System.Security.Cryptography
                     throw PaddingModeNotSupported();
                 }
 
-                RsaPaddingProcessor processor = RsaPaddingProcessor.OpenProcessor(hashAlgorithm);
                 SafeRsaHandle rsa = GetKey();
 
                 int requiredBytes = Interop.AndroidCrypto.RsaSize(rsa);
@@ -800,7 +798,7 @@ namespace System.Security.Cryptography
                     return false;
                 }
 
-                if (hash.Length != processor.HashLength)
+                if (hash.Length != RsaPaddingProcessor.HashLength(hashAlgorithm))
                 {
                     return false;
                 }
@@ -827,14 +825,14 @@ namespace System.Security.Cryptography
                     {
                         byte[] repadRent = CryptoPool.Rent(unwrapped.Length);
                         Span<byte> repadded = repadRent.AsSpan(0, requiredBytes);
-                        processor.PadPkcs1Signature(hash, repadded);
+                        RsaPaddingProcessor.PadPkcs1Signature(hashAlgorithm, hash, repadded);
                         bool valid = CryptographicOperations.FixedTimeEquals(repadded, unwrapped);
                         CryptoPool.Return(repadRent, requiredBytes);
                         return valid;
                     }
                     else if (padding == RSASignaturePadding.Pss)
                     {
-                        return processor.VerifyPss(hash, unwrapped, KeySize);
+                        return RsaPaddingProcessor.VerifyPss(hashAlgorithm, hash, unwrapped, KeySize);
                     }
                     else
                     {

--- a/src/libraries/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
@@ -69,10 +69,7 @@ namespace System.Security.Cryptography
                         }
                         else if (padding.Mode == RSAEncryptionPaddingMode.Oaep)
                         {
-                            RsaPaddingProcessor processor =
-                                RsaPaddingProcessor.OpenProcessor(padding.OaepHashAlgorithm);
-
-                            processor.PadOaep(data, paddedMessage);
+                            RsaPaddingProcessor.PadOaep(padding.OaepHashAlgorithm, data, paddedMessage);
                         }
                         else
                         {
@@ -154,10 +151,7 @@ namespace System.Security.Cryptography
                         }
                         else if (padding.Mode == RSAEncryptionPaddingMode.Oaep)
                         {
-                            RsaPaddingProcessor processor =
-                                RsaPaddingProcessor.OpenProcessor(padding.OaepHashAlgorithm);
-
-                            processor.PadOaep(data, paddedMessage);
+                            RsaPaddingProcessor.PadOaep(padding.OaepHashAlgorithm, data, paddedMessage);
                         }
                         else
                         {

--- a/src/libraries/Common/src/System/Security/Cryptography/RsaPaddingProcessor.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RsaPaddingProcessor.cs
@@ -7,58 +7,81 @@ using System.Diagnostics;
 
 namespace System.Security.Cryptography
 {
-    internal sealed class RsaPaddingProcessor
+    internal static class RsaPaddingProcessor
     {
         // DigestInfo header values taken from https://tools.ietf.org/html/rfc3447#section-9.2, Note 1.
-        private static readonly byte[] s_digestInfoMD5 =
+        private static ReadOnlySpan<byte> DigestInfoMD5 => new byte[]
             {
                 0x30, 0x20, 0x30, 0x0C, 0x06, 0x08, 0x2A, 0x86,
                 0x48, 0x86, 0xF7, 0x0D, 0x02, 0x05, 0x05, 0x00,
                 0x04, 0x10,
             };
 
-        private static readonly byte[] s_digestInfoSha1 =
+        private static ReadOnlySpan<byte> DigestInfoSha1 => new byte[]
             {
                 0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2B, 0x0E, 0x03,
                 0x02, 0x1A, 0x05, 0x00, 0x04, 0x14,
             };
 
-        private static readonly byte[] s_digestInfoSha256 =
+        private static ReadOnlySpan<byte> DigestInfoSha256 => new byte[]
             {
                 0x30, 0x31, 0x30, 0x0D, 0x06, 0x09, 0x60, 0x86, 0x48,
                 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04,
                 0x20,
             };
 
-        private static readonly byte[] s_digestInfoSha384 =
+        private static ReadOnlySpan<byte> DigestInfoSha384 => new byte[]
             {
                 0x30, 0x41, 0x30, 0x0D, 0x06, 0x09, 0x60, 0x86, 0x48,
                 0x01, 0x65, 0x03, 0x04, 0x02, 0x02, 0x05, 0x00, 0x04,
                 0x30,
             };
 
-        private static readonly byte[] s_digestInfoSha512 =
+        private static ReadOnlySpan<byte> DigestInfoSha512 => new byte[]
             {
                 0x30, 0x51, 0x30, 0x0D, 0x06, 0x09, 0x60, 0x86, 0x48,
                 0x01, 0x65, 0x03, 0x04, 0x02, 0x03, 0x05, 0x00, 0x04,
                 0x40,
             };
 
-        private static readonly ConcurrentDictionary<HashAlgorithmName, RsaPaddingProcessor> s_lookup =
-            new ConcurrentDictionary<HashAlgorithmName, RsaPaddingProcessor>();
+        private static ReadOnlySpan<byte> EightZeros => new byte[8];
 
-        private readonly HashAlgorithmName _hashAlgorithmName;
-        private readonly int _hLen;
-        private readonly ReadOnlyMemory<byte> _digestInfoPrefix;
-
-        private RsaPaddingProcessor(
+        private static ReadOnlySpan<byte> GetDigestInfoForAlgorithm(
             HashAlgorithmName hashAlgorithmName,
-            int hLen,
-            ReadOnlyMemory<byte> digestInfoPrefix)
+            out int digestLengthInBytes)
         {
-            _hashAlgorithmName = hashAlgorithmName;
-            _hLen = hLen;
-            _digestInfoPrefix = digestInfoPrefix;
+            if (hashAlgorithmName == HashAlgorithmName.MD5)
+            {
+#pragma warning disable CA1416 // Unsupported on Browser. We just want the const here.
+                digestLengthInBytes = MD5.HashSizeInBytes;
+                return DigestInfoMD5;
+#pragma warning restore CA1416
+            }
+            else if (hashAlgorithmName == HashAlgorithmName.SHA1)
+            {
+                digestLengthInBytes = SHA1.HashSizeInBytes;
+                return DigestInfoSha1;
+            }
+            else if (hashAlgorithmName == HashAlgorithmName.SHA256)
+            {
+                digestLengthInBytes = SHA256.HashSizeInBytes;
+                return DigestInfoSha256;
+            }
+            else if (hashAlgorithmName == HashAlgorithmName.SHA384)
+            {
+                digestLengthInBytes = SHA384.HashSizeInBytes;
+                return DigestInfoSha384;
+            }
+            else if (hashAlgorithmName == HashAlgorithmName.SHA512)
+            {
+                digestLengthInBytes = SHA512.HashSizeInBytes;
+                return DigestInfoSha512;
+            }
+            else
+            {
+                Debug.Fail("Unknown digest algorithm");
+                throw new CryptographicException();
+            }
         }
 
         internal static int BytesRequiredForBitCount(int keySizeInBits)
@@ -66,54 +89,10 @@ namespace System.Security.Cryptography
             return (int)(((uint)keySizeInBits + 7) / 8);
         }
 
-        private static ReadOnlySpan<byte> EightZeros => new byte[8]; // rely on C# compiler optimization to eliminate allocation
-
-        internal int HashLength => _hLen;
-
-        internal static RsaPaddingProcessor OpenProcessor(HashAlgorithmName hashAlgorithmName)
+        internal static int HashLength(HashAlgorithmName hashAlgorithmName)
         {
-            return s_lookup.GetOrAdd(
-                hashAlgorithmName,
-                static hashAlgorithmName =>
-                {
-                    ReadOnlyMemory<byte> digestInfoPrefix;
-                    int digestLength;
-
-                    if (hashAlgorithmName == HashAlgorithmName.MD5)
-                    {
-                        digestInfoPrefix = s_digestInfoMD5;
-#pragma warning disable CA1416 // Unsupported on Browser. We just want the const here.
-                        digestLength = MD5.HashSizeInBytes;
-#pragma warning restore CA1416
-                    }
-                    else if (hashAlgorithmName == HashAlgorithmName.SHA1)
-                    {
-                        digestInfoPrefix = s_digestInfoSha1;
-                        digestLength = SHA1.HashSizeInBytes;
-                    }
-                    else if (hashAlgorithmName == HashAlgorithmName.SHA256)
-                    {
-                        digestInfoPrefix = s_digestInfoSha256;
-                        digestLength = SHA256.HashSizeInBytes;
-                    }
-                    else if (hashAlgorithmName == HashAlgorithmName.SHA384)
-                    {
-                        digestInfoPrefix = s_digestInfoSha384;
-                        digestLength = SHA384.HashSizeInBytes;
-                    }
-                    else if (hashAlgorithmName == HashAlgorithmName.SHA512)
-                    {
-                        digestInfoPrefix = s_digestInfoSha512;
-                        digestLength = SHA512.HashSizeInBytes;
-                    }
-                    else
-                    {
-                        Debug.Fail("Unknown digest algorithm");
-                        throw new CryptographicException();
-                    }
-
-                    return new RsaPaddingProcessor(hashAlgorithmName, digestLength, digestInfoPrefix);
-                });
+            GetDigestInfoForAlgorithm(hashAlgorithmName, out int hLen);
+            return hLen;
         }
 
         internal static void PadPkcs1Encryption(
@@ -144,17 +123,19 @@ namespace System.Security.Cryptography
             source.CopyTo(mInEM);
         }
 
-        internal void PadPkcs1Signature(
+        internal static void PadPkcs1Signature(
+            HashAlgorithmName hashAlgorithmName,
             ReadOnlySpan<byte> source,
             Span<byte> destination)
         {
+            ReadOnlySpan<byte> digestInfoPrefix = GetDigestInfoForAlgorithm(hashAlgorithmName, out _);
+
             // https://tools.ietf.org/html/rfc3447#section-9.2
 
             // 1. H = Hash(M)
             // Done by the caller.
 
             // 2. Encode the DigestInfo value
-            ReadOnlySpan<byte> digestInfoPrefix = _digestInfoPrefix.Span;
             int expectedLength = digestInfoPrefix[^1];
 
             if (source.Length != expectedLength)
@@ -182,12 +163,14 @@ namespace System.Security.Cryptography
             source.CopyTo(destination.Slice(paddingLength + 3 + digestInfoPrefix.Length));
         }
 
-        internal void PadOaep(
+        internal static void PadOaep(
+            HashAlgorithmName hashAlgorithmName,
             ReadOnlySpan<byte> source,
             Span<byte> destination)
         {
             // https://tools.ietf.org/html/rfc3447#section-7.1.1
 
+            GetDigestInfoForAlgorithm(hashAlgorithmName, out int hLen);
             byte[]? dbMask = null;
             Span<byte> dbMaskSpan = Span<byte>.Empty;
 
@@ -195,7 +178,7 @@ namespace System.Security.Cryptography
             {
                 // Since the biggest known _hLen is 512/8 (64) and destination.Length is 0 or more,
                 // this shouldn't underflow without something having severely gone wrong.
-                int maxInput = checked(destination.Length - _hLen - _hLen - 2);
+                int maxInput = checked(destination.Length - hLen - hLen - 2);
 
                 // 1(a) does not apply, we do not allow custom label values.
 
@@ -208,19 +191,21 @@ namespace System.Security.Cryptography
 
                 // The final message (step 2(i)) will be
                 // 0x00 || maskedSeed (hLen long) || maskedDB (rest of the buffer)
-                Span<byte> seed = destination.Slice(1, _hLen);
-                Span<byte> db = destination.Slice(1 + _hLen);
+                Span<byte> seed = destination.Slice(1, hLen);
+                Span<byte> db = destination.Slice(1 + hLen);
 
-                using (IncrementalHash hasher = IncrementalHash.CreateHash(_hashAlgorithmName))
+                using (IncrementalHash hasher = IncrementalHash.CreateHash(hashAlgorithmName))
                 {
+                    Debug.Assert(hasher.HashLengthInBytes == hLen);
+
                     // DB = lHash || PS || 0x01 || M
-                    Span<byte> lHash = db.Slice(0, _hLen);
+                    Span<byte> lHash = db.Slice(0, hLen);
                     Span<byte> mDest = db.Slice(db.Length - source.Length);
-                    Span<byte> ps = db.Slice(_hLen, db.Length - _hLen - 1 - mDest.Length);
-                    Span<byte> psEnd = db.Slice(_hLen + ps.Length, 1);
+                    Span<byte> ps = db.Slice(hLen, db.Length - hLen - 1 - mDest.Length);
+                    Span<byte> psEnd = db.Slice(hLen + ps.Length, 1);
 
                     // 2(a) lHash = Hash(L), where L is the empty string.
-                    if (!hasher.TryGetHashAndReset(lHash, out int hLen2) || hLen2 != _hLen)
+                    if (!hasher.TryGetHashAndReset(lHash, out int hLen2) || hLen2 != hLen)
                     {
                         Debug.Fail("TryGetHashAndReset failed with exact-size destination");
                         throw new CryptographicException();
@@ -247,7 +232,7 @@ namespace System.Security.Cryptography
                     Xor(db, dbMaskSpan);
 
                     // 2(g)
-                    Span<byte> seedMask = stackalloc byte[_hLen];
+                    Span<byte> seedMask = stackalloc byte[hLen];
                     Mgf1(hasher, db, seedMask);
 
                     // 2(h)
@@ -272,27 +257,32 @@ namespace System.Security.Cryptography
             }
         }
 
-        internal bool DepadOaep(
+        internal static bool DepadOaep(
+            HashAlgorithmName hashAlgorithmName,
             ReadOnlySpan<byte> source,
             Span<byte> destination,
             out int bytesWritten)
         {
-            // https://tools.ietf.org/html/rfc3447#section-7.1.2
-            using (IncrementalHash hasher = IncrementalHash.CreateHash(_hashAlgorithmName))
-            {
-                Span<byte> lHash = stackalloc byte[_hLen];
+            GetDigestInfoForAlgorithm(hashAlgorithmName, out int hLen);
 
-                if (!hasher.TryGetHashAndReset(lHash, out int hLen2) || hLen2 != _hLen)
+            // https://tools.ietf.org/html/rfc3447#section-7.1.2
+            using (IncrementalHash hasher = IncrementalHash.CreateHash(hashAlgorithmName))
+            {
+                Debug.Assert(hasher.HashLengthInBytes == hLen);
+
+                Span<byte> lHash = stackalloc byte[hLen];
+
+                if (!hasher.TryGetHashAndReset(lHash, out int hLen2) || hLen2 != hLen)
                 {
                     Debug.Fail("TryGetHashAndReset failed with exact-size destination");
                     throw new CryptographicException();
                 }
 
                 int y = source[0];
-                ReadOnlySpan<byte> maskedSeed = source.Slice(1, _hLen);
-                ReadOnlySpan<byte> maskedDB = source.Slice(1 + _hLen);
+                ReadOnlySpan<byte> maskedSeed = source.Slice(1, hLen);
+                ReadOnlySpan<byte> maskedDB = source.Slice(1 + hLen);
 
-                Span<byte> seed = stackalloc byte[_hLen];
+                Span<byte> seed = stackalloc byte[hLen];
                 // seedMask = MGF(maskedDB, hLen)
                 Mgf1(hasher, maskedDB, seed);
 
@@ -310,11 +300,11 @@ namespace System.Security.Cryptography
                     // DB = dbMask XOR maskedDB
                     Xor(dbMask, maskedDB);
 
-                    ReadOnlySpan<byte> lHashPrime = dbMask.Slice(0, _hLen);
+                    ReadOnlySpan<byte> lHashPrime = dbMask.Slice(0, hLen);
 
                     int separatorPos = int.MaxValue;
 
-                    for (int i = dbMask.Length - 1; i >= _hLen; i--)
+                    for (int i = dbMask.Length - 1; i >= hLen; i--)
                     {
                         // if dbMask[i] is 1, val is 0. otherwise val is [01,FF]
                         byte dbMinus1 = (byte)(dbMask[i] - 1);
@@ -366,25 +356,27 @@ namespace System.Security.Cryptography
             }
         }
 
-        internal void EncodePss(ReadOnlySpan<byte> mHash, Span<byte> destination, int keySize)
+        internal static void EncodePss(HashAlgorithmName hashAlgorithmName, ReadOnlySpan<byte> mHash, Span<byte> destination, int keySize)
         {
+            GetDigestInfoForAlgorithm(hashAlgorithmName, out int hLen);
+
             // https://tools.ietf.org/html/rfc3447#section-9.1.1
             int emBits = keySize - 1;
             int emLen = BytesRequiredForBitCount(emBits);
 
-            if (mHash.Length != _hLen)
+            if (mHash.Length != hLen)
             {
                 throw new CryptographicException(SR.Cryptography_SignHash_WrongSize);
             }
 
             // In this implementation, sLen is restricted to the length of the input hash.
-            int sLen = _hLen;
+            int sLen = hLen;
 
             // 3.  if emLen < hLen + sLen + 2, encoding error.
             //
             // sLen = hLen in this implementation.
 
-            if (emLen < 2 + _hLen + sLen)
+            if (emLen < 2 + hLen + sLen)
             {
                 throw new CryptographicException(SR.Cryptography_KeyTooSmall);
             }
@@ -396,17 +388,18 @@ namespace System.Security.Cryptography
             // 12. Let EM = maskedDB || H || 0xbc (H has length hLen)
             Span<byte> em = destination.Slice(destination.Length - emLen, emLen);
 
-            int dbLen = emLen - _hLen - 1;
+            int dbLen = emLen - hLen - 1;
 
             Span<byte> db = em.Slice(0, dbLen);
-            Span<byte> hDest = em.Slice(dbLen, _hLen);
+            Span<byte> hDest = em.Slice(dbLen, hLen);
             em[emLen - 1] = 0xBC;
 
             byte[] dbMaskRented = CryptoPool.Rent(dbLen);
             Span<byte> dbMask = new Span<byte>(dbMaskRented, 0, dbLen);
 
-            using (IncrementalHash hasher = IncrementalHash.CreateHash(_hashAlgorithmName))
+            using (IncrementalHash hasher = IncrementalHash.CreateHash(hashAlgorithmName))
             {
+                Debug.Assert(hasher.HashLengthInBytes == hLen);
                 // 4. Generate a random salt of length sLen
                 Span<byte> salt = stackalloc byte[sLen];
                 RandomNumberGenerator.Fill(salt);
@@ -418,7 +411,7 @@ namespace System.Security.Cryptography
                 hasher.AppendData(mHash);
                 hasher.AppendData(salt);
 
-                if (!hasher.TryGetHashAndReset(hDest, out int hLen2) || hLen2 != _hLen)
+                if (!hasher.TryGetHashAndReset(hDest, out int hLen2) || hLen2 != hLen)
                 {
                     Debug.Fail("TryGetHashAndReset failed with exact-size destination");
                     throw new CryptographicException();
@@ -426,7 +419,7 @@ namespace System.Security.Cryptography
 
                 // 7. Generate PS as zero-valued bytes of length emLen - sLen - hLen - 2.
                 // 8. Let DB = PS || 0x01 || salt
-                int psLen = emLen - sLen - _hLen - 2;
+                int psLen = emLen - sLen - hLen - 2;
                 db.Slice(0, psLen).Clear();
                 db[psLen] = 0x01;
                 salt.CopyTo(db.Slice(psLen + 1));
@@ -451,14 +444,16 @@ namespace System.Security.Cryptography
             CryptoPool.Return(dbMaskRented, clearSize: 0);
         }
 
-        internal bool VerifyPss(ReadOnlySpan<byte> mHash, ReadOnlySpan<byte> em, int keySize)
+        internal static bool VerifyPss(HashAlgorithmName hashAlgorithmName, ReadOnlySpan<byte> mHash, ReadOnlySpan<byte> em, int keySize)
         {
+            GetDigestInfoForAlgorithm(hashAlgorithmName, out int hLen);
+
             // https://tools.ietf.org/html/rfc3447#section-9.1.2
 
             int emBits = keySize - 1;
             int emLen = BytesRequiredForBitCount(emBits);
 
-            if (mHash.Length != _hLen)
+            if (mHash.Length != hLen)
             {
                 return false;
             }
@@ -466,10 +461,10 @@ namespace System.Security.Cryptography
             Debug.Assert(em.Length >= emLen);
 
             // In this implementation, sLen is restricted to hLen.
-            int sLen = _hLen;
+            int sLen = hLen;
 
             // 3. If emLen < hLen + sLen + 2, output "inconsistent" and stop.
-            if (emLen < _hLen + sLen + 2)
+            if (emLen < hLen + sLen + 2)
             {
                 return false;
             }
@@ -481,10 +476,10 @@ namespace System.Security.Cryptography
             }
 
             // 5. maskedDB is the leftmost emLen - hLen -1 bytes, H is the next hLen bytes.
-            int dbLen = emLen - _hLen - 1;
+            int dbLen = emLen - hLen - 1;
 
             ReadOnlySpan<byte> maskedDb = em.Slice(0, dbLen);
-            ReadOnlySpan<byte> h = em.Slice(dbLen, _hLen);
+            ReadOnlySpan<byte> h = em.Slice(dbLen, hLen);
 
             // 6. If the unused bits aren't zero, output "inconsistent" and stop.
             int unusedBits = 8 * emLen - emBits;
@@ -501,8 +496,10 @@ namespace System.Security.Cryptography
 
             try
             {
-                using (IncrementalHash hasher = IncrementalHash.CreateHash(_hashAlgorithmName))
+                using (IncrementalHash hasher = IncrementalHash.CreateHash(hashAlgorithmName))
                 {
+                    Debug.Assert(hasher.HashLengthInBytes == hLen);
+
                     Mgf1(hasher, h, dbMask);
 
                     // 8. DB = maskedDB XOR dbMask
@@ -516,7 +513,7 @@ namespace System.Security.Cryptography
                     //
                     // Since signature verification is a public key operation there's no need to
                     // use fixed time equality checking here.
-                    for (int i = emLen - _hLen - sLen - 2 - 1; i >= 0; --i)
+                    for (int i = emLen - hLen - sLen - 2 - 1; i >= 0; --i)
                     {
                         if (dbMask[i] != 0)
                         {
@@ -526,7 +523,7 @@ namespace System.Security.Cryptography
 
                     // 10 ("b") If the octet at position emLen - hLen - sLen - 1 (under a 1-indexed scheme)
                     // is not 0x01, output "inconsistent" and stop.
-                    if (dbMask[emLen - _hLen - sLen - 2] != 0x01)
+                    if (dbMask[emLen - hLen - sLen - 2] != 0x01)
                     {
                         return false;
                     }
@@ -539,9 +536,9 @@ namespace System.Security.Cryptography
                     hasher.AppendData(mHash);
                     hasher.AppendData(salt);
 
-                    Span<byte> hPrime = stackalloc byte[_hLen];
+                    Span<byte> hPrime = stackalloc byte[hLen];
 
-                    if (!hasher.TryGetHashAndReset(hPrime, out int hLen2) || hLen2 != _hLen)
+                    if (!hasher.TryGetHashAndReset(hPrime, out int hLen2) || hLen2 != hLen)
                     {
                         Debug.Fail("TryGetHashAndReset failed with exact-size destination");
                         throw new CryptographicException();
@@ -562,8 +559,9 @@ namespace System.Security.Cryptography
         }
 
         // https://tools.ietf.org/html/rfc3447#appendix-B.2.1
-        private void Mgf1(IncrementalHash hasher, ReadOnlySpan<byte> mgfSeed, Span<byte> mask)
+        private static void Mgf1(IncrementalHash hasher, ReadOnlySpan<byte> mgfSeed, Span<byte> mask)
         {
+            int hLen = hasher.HashLengthInBytes;
             Span<byte> writePtr = mask;
             int count = 0;
             Span<byte> bigEndianCount = stackalloc byte[sizeof(int)];
@@ -574,7 +572,7 @@ namespace System.Security.Cryptography
                 BinaryPrimitives.WriteInt32BigEndian(bigEndianCount, count);
                 hasher.AppendData(bigEndianCount);
 
-                if (writePtr.Length >= _hLen)
+                if (writePtr.Length >= hLen)
                 {
                     if (!hasher.TryGetHashAndReset(writePtr, out int bytesWritten))
                     {
@@ -582,12 +580,12 @@ namespace System.Security.Cryptography
                         throw new CryptographicException();
                     }
 
-                    Debug.Assert(bytesWritten == _hLen);
+                    Debug.Assert(bytesWritten == hLen);
                     writePtr = writePtr.Slice(bytesWritten);
                 }
                 else
                 {
-                    Span<byte> tmp = stackalloc byte[_hLen];
+                    Span<byte> tmp = stackalloc byte[hLen];
 
                     if (!hasher.TryGetHashAndReset(tmp, out int bytesWritten))
                     {
@@ -595,7 +593,7 @@ namespace System.Security.Cryptography
                         throw new CryptographicException();
                     }
 
-                    Debug.Assert(bytesWritten == _hLen);
+                    Debug.Assert(bytesWritten == hLen);
                     tmp.Slice(0, writePtr.Length).CopyTo(writePtr);
                     break;
                 }

--- a/src/libraries/Common/src/System/Security/Cryptography/RsaPaddingProcessor.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RsaPaddingProcessor.cs
@@ -128,14 +128,13 @@ namespace System.Security.Cryptography
             ReadOnlySpan<byte> source,
             Span<byte> destination)
         {
-            ReadOnlySpan<byte> digestInfoPrefix = GetDigestInfoForAlgorithm(hashAlgorithmName, out _);
-
             // https://tools.ietf.org/html/rfc3447#section-9.2
 
             // 1. H = Hash(M)
             // Done by the caller.
 
             // 2. Encode the DigestInfo value
+            ReadOnlySpan<byte> digestInfoPrefix = GetDigestInfoForAlgorithm(hashAlgorithmName, out _);
             int expectedLength = digestInfoPrefix[^1];
 
             if (source.Length != expectedLength)
@@ -170,7 +169,7 @@ namespace System.Security.Cryptography
         {
             // https://tools.ietf.org/html/rfc3447#section-7.1.1
 
-            GetDigestInfoForAlgorithm(hashAlgorithmName, out int hLen);
+            int hLen = HashLength(hashAlgorithmName);
             byte[]? dbMask = null;
             Span<byte> dbMaskSpan = Span<byte>.Empty;
 
@@ -263,7 +262,7 @@ namespace System.Security.Cryptography
             Span<byte> destination,
             out int bytesWritten)
         {
-            GetDigestInfoForAlgorithm(hashAlgorithmName, out int hLen);
+            int hLen = HashLength(hashAlgorithmName);
 
             // https://tools.ietf.org/html/rfc3447#section-7.1.2
             using (IncrementalHash hasher = IncrementalHash.CreateHash(hashAlgorithmName))
@@ -358,7 +357,7 @@ namespace System.Security.Cryptography
 
         internal static void EncodePss(HashAlgorithmName hashAlgorithmName, ReadOnlySpan<byte> mHash, Span<byte> destination, int keySize)
         {
-            GetDigestInfoForAlgorithm(hashAlgorithmName, out int hLen);
+            int hLen = HashLength(hashAlgorithmName);
 
             // https://tools.ietf.org/html/rfc3447#section-9.1.1
             int emBits = keySize - 1;
@@ -446,7 +445,7 @@ namespace System.Security.Cryptography
 
         internal static bool VerifyPss(HashAlgorithmName hashAlgorithmName, ReadOnlySpan<byte> mHash, ReadOnlySpan<byte> em, int keySize)
         {
-            GetDigestInfoForAlgorithm(hashAlgorithmName, out int hLen);
+            int hLen = HashLength(hashAlgorithmName);
 
             // https://tools.ietf.org/html/rfc3447#section-9.1.2
 


### PR DESCRIPTION
This is a follow up to #68553. This changes `RsaPaddingProcessor` to be entirely static.

* Instances are no longer cached as statics
* The DigestInfos can now use the `ReadOnlySpan<byte>` C# compiler optimization for arrays.

This has no material impact on benchmarks, in wall time nor per-invocation allocations, but makes the code a little more reasonable, and probably slightly reduces the amount of memory since the statics are no longer around indefinitely.


<details>
<summary>RSA Encrypt Benchmarks (click to expand)</summary>

|      Method |        Job | Toolchain | EncryptionPadding |        Mean |    Error |   StdDev | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |----------- |---------- |------------------ |------------:|---------:|---------:|------:|------:|------:|------:|----------:|
| EncryptData | Job-BWYKBU |    branch |        OaepSHA256 |    56.60 us | 0.078 us | 0.069 us |  1.00 |     - |     - |     - |     160 B |
| EncryptData | Job-JLGOQC |      main |        OaepSHA256 |    56.55 us | 0.064 us | 0.054 us |  1.00 |     - |     - |     - |     160 B |
|             |            |           |                   |             |          |          |       |       |       |       |           |
| DecryptData | Job-BWYKBU |    branch |        OaepSHA256 | 1,366.78 us | 0.584 us | 0.487 us |  1.00 |     - |     - |     - |     162 B |
| DecryptData | Job-JLGOQC |      main |        OaepSHA256 | 1,367.31 us | 1.072 us | 0.895 us |  1.00 |     - |     - |     - |     162 B |
|             |            |           |                   |             |          |          |       |       |       |       |           |
| EncryptData | Job-BWYKBU |    branch |             Pkcs1 |    55.84 us | 0.116 us | 0.108 us |  1.00 |     - |     - |     - |     160 B |
| EncryptData | Job-JLGOQC |      main |             Pkcs1 |    56.00 us | 0.165 us | 0.154 us |  1.00 |     - |     - |     - |     160 B |
|             |            |           |                   |             |          |          |       |       |       |       |           |
| DecryptData | Job-BWYKBU |    branch |             Pkcs1 | 1,365.71 us | 0.477 us | 0.398 us |  1.00 |     - |     - |     - |     162 B |
| DecryptData | Job-JLGOQC |      main |             Pkcs1 | 1,365.54 us | 0.818 us | 0.766 us |  1.00 |     - |     - |     - |     162 B |

</details>

<details>
<summary>RSA Sign Benchmarks (click to expand)</summary>

|     Method |        Job | Toolchain | SignaturePadding |        Mean |    Error |   StdDev | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------- |----------- |---------- |----------------- |------------:|---------:|---------:|------:|------:|------:|------:|----------:|
|   SignHash | Job-ENFCWV |    branch |            Pkcs1 | 1,371.64 μs | 0.529 μs | 0.442 μs |  1.00 |     - |     - |     - |      66 B |
|   SignHash | Job-UJMZPE |      main |            Pkcs1 | 1,372.17 μs | 0.783 μs | 0.694 μs |  1.00 |     - |     - |     - |      66 B |
|            |            |           |                  |             |          |          |       |       |       |       |           |
| VerifyHash | Job-ENFCWV |    branch |            Pkcs1 |    55.63 μs | 0.106 μs | 0.089 μs |  1.00 |     - |     - |     - |      32 B |
| VerifyHash | Job-UJMZPE |      main |            Pkcs1 |    55.63 μs | 0.135 μs | 0.113 μs |  1.00 |     - |     - |     - |      32 B |
|            |            |           |                  |             |          |          |       |       |       |       |           |
|   SignHash | Job-ENFCWV |    branch |              Pss | 1,367.65 μs | 0.474 μs | 0.396 μs |  1.00 |     - |     - |     - |     218 B |
|   SignHash | Job-UJMZPE |      main |              Pss | 1,368.40 μs | 0.984 μs | 0.872 μs |  1.00 |     - |     - |     - |     218 B |
|            |            |           |                  |             |          |          |       |       |       |       |           |
| VerifyHash | Job-ENFCWV |    branch |              Pss |    57.73 μs | 0.082 μs | 0.072 μs |  1.00 |     - |     - |     - |     216 B |
| VerifyHash | Job-UJMZPE |      main |              Pss |    57.70 μs | 0.133 μs | 0.125 μs |  1.00 |     - |     - |     - |     216 B |

</details>