### PR TITLE
Avoid delegate allocation in NamedPipeClientStream.ConnectAsync

### DIFF
--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs
@@ -194,7 +194,12 @@ namespace System.IO.Pipes
             }
 
             int startTime = Environment.TickCount; // We need to measure time here, not in the lambda
-            return Task.Run(() => ConnectInternal(timeout, cancellationToken, startTime), cancellationToken);
+
+            return Task.Factory.StartNew(static state =>
+            {
+                var tuple = ((NamedPipeClientStream stream, int timeout, CancellationToken cancellationToken, int startTime))state!;
+                tuple.stream.ConnectInternal(tuple.timeout, tuple.cancellationToken, tuple.startTime);
+            }, (this, timeout, cancellationToken, startTime), cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
         }
 
         public Task ConnectAsync(TimeSpan timeout, CancellationToken cancellationToken = default) =>


### PR DESCRIPTION
We still need to allocate an object for the closed-over state, but we can avoid the per-call delegate allocation.