### PR TITLE
Fix expected number of RequestLeftQueue events in telemetry test.

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
@@ -646,7 +646,7 @@ namespace System.Net.Http.Functional.Tests
                             socketsHttpHandler.MaxConnectionsPerServer = 1;
                             socketsHttpHandler.SslOptions.RemoteCertificateValidationCallback = delegate { return true; };
 
-                            // Dummy request to ensure that the MaxConcurrentStreams setting has been acknowledged
+                            // Dummy request to establish connection and ensure that the MaxConcurrentStreams setting has been acknowledged
                             await client.GetStringAsync(uri);
 
                             Task firstRequest = client.GetStringAsync(uri);
@@ -706,7 +706,14 @@ namespace System.Net.Http.Functional.Tests
                 ValidateConnectionEstablishedClosed(events, version);
 
                 var requestLeftQueueEvents = events.Where(e => e.Event.EventName == "RequestLeftQueue");
-                Assert.InRange(requestLeftQueueEvents.Count(), 2, version.Major == 3 ? 3 : 2);
+                var (minCount, maxCount) = version.Major switch
+                {
+                    1 => (2, 2),
+                    2 => (2, 3), // race condition: if a connection hits its stream limit, it will be removed from the list and re-added on a separate thread
+                    3 => (3, 3),
+                    _ => throw new ArgumentOutOfRangeException()
+                };
+                Assert.InRange(requestLeftQueueEvents.Count(), minCount, maxCount);
 
                 foreach (var (e, _) in requestLeftQueueEvents)
                 {


### PR DESCRIPTION
The `System.Net.Http.Functional.Tests.TelemetryTest_Http20.EventSource_ConnectionPoolAtMaxConnections_LogsRequestLeftQueue` Test frequently passes only on reruns because more than expected number of events was logged. 

If an H2 connection hits its stream limit, it will be removed from the list of available connections and then re-added on a separate thread.
The test may have sent the second request before the ThreadPool managed to re-add the connection

This PR adjusts the assert to accomodate the data race above.

cc: @MihaZupan (who found the explanation for the observed data race)

Fixes #67273.