### PR TITLE
Merge several version of MsQuicStream SendAsync code

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicBuffers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicBuffers.cs
@@ -119,7 +119,6 @@ internal unsafe struct MsQuicBuffers : IDisposable
     {
         int count = buffers.Length;
         Reserve(count);
-        _count = count;
 
         ReadOnlySpan<ReadOnlyMemory<byte>> span = buffers.Span;
         for (int i = 0; i < span.Length; i++)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicBuffers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicBuffers.cs
@@ -39,8 +39,27 @@ internal unsafe struct MsQuicBuffers : IDisposable
         NativeMemory.Free(buffers);
     }
 
+    private void Reserve(int count)
+    {
+        if (_handles.Length < count)
+        {
+            _handles = new MemoryHandle[count];
+            FreeNativeMemory();
+            _buffers = (QUIC_BUFFER*)NativeMemory.Alloc((nuint)count, (nuint)sizeof(QUIC_BUFFER));
+        }
+    }
+
+    private void SetBuffer(int index, ReadOnlyMemory<byte> buffer)
+    {
+        MemoryHandle handle = buffer.Pin();
+
+        _handles[index] = handle;
+        _buffers[index].Buffer = (byte*)handle.Pointer;
+        _buffers[index].Length = (uint)buffer.Length;
+    }
+
     /// <summary>
-    /// The method initializes QUIC_BUFFER* with data from inputs, converted via toBuffer.
+    /// Initializes QUIC_BUFFER* with data from inputs, converted via toBuffer.
     /// Note that the struct either needs to be freshly created via new or previously cleaned up with Reset.
     /// </summary>
     /// <param name="inputs">Inputs to get their byte array, pin them and pepare them to be passed to MsQuic as QUIC_BUFFER*.</param>
@@ -48,26 +67,66 @@ internal unsafe struct MsQuicBuffers : IDisposable
     /// <typeparam name="T">The type of the inputs.</typeparam>
     public void Initialize<T>(IList<T> inputs, Func<T, ReadOnlyMemory<byte>> toBuffer)
     {
-        if (_handles.Length < inputs.Count)
-        {
-            _handles = new MemoryHandle[inputs.Count];
-        }
-        if (_count < inputs.Count)
-        {
-            FreeNativeMemory();
-            _buffers = (QUIC_BUFFER*)NativeMemory.Alloc((nuint)sizeof(QUIC_BUFFER), (nuint)inputs.Count);
-        }
-
+        Reserve(inputs.Count);
         _count = inputs.Count;
 
         for (int i = 0; i < inputs.Count; ++i)
         {
             ReadOnlyMemory<byte> buffer = toBuffer(inputs[i]);
-            MemoryHandle handle = buffer.Pin();
+            SetBuffer(i, buffer);
+        }
+    }
 
-            _handles[i] = handle;
-            _buffers[i].Buffer = (byte*)handle.Pointer;
-            _buffers[i].Length = (uint)buffer.Length;
+    /// <summary>
+    /// Initializes QUIC_BUFFER* with the provided buffer.
+    /// Note that the struct either needs to be freshly created via new or previously cleaned up with Reset.
+    /// </summary>
+    /// <param name="buffer">Buffer to be passed to MsQuic as QUIC_BUFFER*.</param>
+    public void Initialize(ReadOnlyMemory<byte> buffer)
+    {
+        Reserve(1);
+        _count = 1;
+        SetBuffer(0, buffer);
+    }
+
+    /// <summary>
+    /// Initializes QUIC_BUFFER* with the provided buffers.
+    /// Note that the struct either needs to be freshly created via new or previously cleaned up with Reset.
+    /// </summary>
+    /// <param name="buffers">Buffers to be passed to MsQuic as QUIC_BUFFER*.</param>
+    public void Initialize(ReadOnlySequence<byte> buffers)
+    {
+        int count = 0;
+        foreach (ReadOnlyMemory<byte> _ in buffers)
+        {
+            ++count;
+        }
+
+        Reserve(count);
+        _count = count;
+        count = 0;
+
+        foreach (ReadOnlyMemory<byte> buffer in buffers)
+        {
+            SetBuffer(count, buffer);
+            ++count;
+        }
+    }
+
+    /// <summary>
+    /// Initializes QUIC_BUFFER* with the provided buffers.
+    /// Note that the struct either needs to be freshly created via new or previously cleaned up with Reset.
+    /// </summary>
+    /// <param name="buffers">Buffers to be passed to MsQuic as QUIC_BUFFER*.</param>
+    public void Initialize(ReadOnlyMemory<ReadOnlyMemory<byte>> buffers)
+    {
+        int count = buffers.Length;
+        Reserve(count);
+        _count = count;
+
+        for (int i = 0; i < buffers.Length; i++)
+        {
+            SetBuffer(i, buffers.Span[i]);
         }
     }
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicBuffers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicBuffers.cs
@@ -47,6 +47,8 @@ internal unsafe struct MsQuicBuffers : IDisposable
             FreeNativeMemory();
             _buffers = (QUIC_BUFFER*)NativeMemory.Alloc((nuint)count, (nuint)sizeof(QUIC_BUFFER));
         }
+
+        _count = count;
     }
 
     private void SetBuffer(int index, ReadOnlyMemory<byte> buffer)
@@ -68,7 +70,6 @@ internal unsafe struct MsQuicBuffers : IDisposable
     public void Initialize<T>(IList<T> inputs, Func<T, ReadOnlyMemory<byte>> toBuffer)
     {
         Reserve(inputs.Count);
-        _count = inputs.Count;
 
         for (int i = 0; i < inputs.Count; ++i)
         {
@@ -85,7 +86,6 @@ internal unsafe struct MsQuicBuffers : IDisposable
     public void Initialize(ReadOnlyMemory<byte> buffer)
     {
         Reserve(1);
-        _count = 1;
         SetBuffer(0, buffer);
     }
 
@@ -103,13 +103,10 @@ internal unsafe struct MsQuicBuffers : IDisposable
         }
 
         Reserve(count);
-        _count = count;
-        count = 0;
-
+        int i = 0;
         foreach (ReadOnlyMemory<byte> buffer in buffers)
         {
-            SetBuffer(count, buffer);
-            ++count;
+            SetBuffer(i++, buffer);
         }
     }
 
@@ -124,9 +121,10 @@ internal unsafe struct MsQuicBuffers : IDisposable
         Reserve(count);
         _count = count;
 
-        for (int i = 0; i < buffers.Length; i++)
+        ReadOnlySpan<ReadOnlyMemory<byte>> span = buffers.Span;
+        for (int i = 0; i < span.Length; i++)
         {
-            SetBuffer(i, buffers.Span[i]);
+            SetBuffer(i, span[i]);
         }
     }
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -328,19 +328,18 @@ namespace System.Net.Quic.Implementations.MsQuic
                 _state.SendBuffers.Buffers,
                 (uint)_state.SendBuffers.Count,
                 flags,
-                IntPtr.Zero);
+                (void*)IntPtr.Zero);
 
-            if (!MsQuicStatusHelper.SuccessfulStatusCode(status))
+            if (StatusFailed(status))
             {
                 CleanupWriteFailedState();
                 CleanupSendState(_state);
 
-                if (status == MsQuicStatusCodes.Aborted)
+                if (status == QUIC_STATUS_ABORTED)
                 {
                     throw ThrowHelper.GetConnectionAbortedException(_state.ConnectionState.AbortErrorCode);
                 }
-                QuicExceptionHelpers.ThrowIfFailed(status,
-                    "Could not send data to peer.");
+                ThrowIfFailure(status, "Could not send data to peer.");
             }
 
             return _state.SendResettableCompletionSource.GetTypelessValueTask();

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -1706,50 +1706,31 @@ namespace System.Net.Quic.Implementations.MsQuic
         private interface ISendBufferAdapter
         {
             void SetupSendState(State state);
-
             bool IsEmpty { get; }
         }
 
         private struct WriteMemoryAdapter : ISendBufferAdapter
         {
             private readonly ReadOnlyMemory<byte> _buffer;
-
             public WriteMemoryAdapter(ReadOnlyMemory<byte> buffer) => _buffer = buffer;
-
             public bool IsEmpty => _buffer.IsEmpty;
-
-            public void SetupSendState(State state)
-            {
-                state.SendBuffers.Initialize(_buffer);
-            }
+            public void SetupSendState(State state) => state.SendBuffers.Initialize(_buffer);
         }
 
         private struct WriteSequenceAdapter : ISendBufferAdapter
         {
             private readonly ReadOnlySequence<byte> _buffers;
-
             public WriteSequenceAdapter(ReadOnlySequence<byte> buffers) => _buffers = buffers;
-
             public bool IsEmpty => _buffers.IsEmpty;
-
-            public void SetupSendState(State state)
-            {
-                state.SendBuffers.Initialize(_buffers);
-            }
+            public void SetupSendState(State state) => state.SendBuffers.Initialize(_buffers);
         }
 
         private struct WriteMemoryOfMemoryAdapter : ISendBufferAdapter
         {
             private readonly ReadOnlyMemory<ReadOnlyMemory<byte>> _buffers;
-
             public WriteMemoryOfMemoryAdapter(ReadOnlyMemory<ReadOnlyMemory<byte>> buffers) => _buffers = buffers;
-
             public bool IsEmpty => _buffers.IsEmpty;
-
-            public void SetupSendState(State state)
-            {
-                state.SendBuffers.Initialize(_buffers);
-            }
+            public void SetupSendState(State state) => state.SendBuffers.Initialize(_buffers);
         }
     }
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -303,12 +303,12 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             using CancellationTokenRegistration registration = SetupWriteStartState(adapter.IsEmpty, cancellationToken);
 
-            await WriteAsyncInternal<TAdapter>(adapter, flags).ConfigureAwait(false);
+            await WriteAsyncCore<TAdapter>(adapter, flags).ConfigureAwait(false);
 
             CleanupWriteCompletedState();
         }
 
-        private unsafe ValueTask WriteAsyncInternal<TAdapter>(TAdapter adapter, QUIC_SEND_FLAGS flags) where TAdapter : ISendBufferAdapter
+        private unsafe ValueTask WriteAsyncCore<TAdapter>(TAdapter adapter, QUIC_SEND_FLAGS flags) where TAdapter : ISendBufferAdapter
         {
             if (adapter.IsEmpty)
             {


### PR DESCRIPTION
Fixes #55818.

This PR extracts common code from several `Send*Async` methods used to implement `WriteAsync` into a single `WriteAsyncInternal` method.