### PR TITLE
Add SlidingWindow and FixedWindow to RateLimitPartition

### DIFF
--- a/src/libraries/System.Threading.RateLimiting/ref/System.Threading.RateLimiting.cs
+++ b/src/libraries/System.Threading.RateLimiting/ref/System.Threading.RateLimiting.cs
@@ -23,6 +23,28 @@ namespace System.Threading.RateLimiting
         public int QueueLimit { get { throw null; } }
         public System.Threading.RateLimiting.QueueProcessingOrder QueueProcessingOrder { get { throw null; } }
     }
+    public sealed partial class FixedWindowRateLimiter : System.Threading.RateLimiting.ReplenishingRateLimiter
+    {
+        public FixedWindowRateLimiter(System.Threading.RateLimiting.FixedWindowRateLimiterOptions options) { }
+        public override System.TimeSpan? IdleDuration { get { throw null; } }
+        public override bool IsAutoReplenishing { get { throw null; } }
+        public override System.TimeSpan ReplenishmentPeriod { get { throw null; } }
+        protected override System.Threading.RateLimiting.RateLimitLease AcquireCore(int requestCount) { throw null; }
+        protected override void Dispose(bool disposing) { }
+        protected override System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
+        public override int GetAvailablePermits() { throw null; }
+        public override bool TryReplenish() { throw null; }
+        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAsyncCore(int requestCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+    public sealed partial class FixedWindowRateLimiterOptions
+    {
+        public FixedWindowRateLimiterOptions(int permitLimit, System.Threading.RateLimiting.QueueProcessingOrder queueProcessingOrder, int queueLimit, System.TimeSpan window, bool autoReplenishment = true) { }
+        public bool AutoReplenishment { get { throw null; } }
+        public int PermitLimit { get { throw null; } }
+        public int QueueLimit { get { throw null; } }
+        public System.Threading.RateLimiting.QueueProcessingOrder QueueProcessingOrder { get { throw null; } }
+        public System.TimeSpan Window { get { throw null; } }
+    }
     public static partial class MetadataName
     {
         public static System.Threading.RateLimiting.MetadataName<string> ReasonPhrase { get { throw null; } }
@@ -90,7 +112,9 @@ namespace System.Threading.RateLimiting
     public static partial class RateLimitPartition
     {
         public static System.Threading.RateLimiting.RateLimitPartition<TKey> CreateConcurrencyLimiter<TKey>(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.ConcurrencyLimiterOptions> factory) { throw null; }
+        public static System.Threading.RateLimiting.RateLimitPartition<TKey> CreateFixedWindowLimiter<TKey>(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.FixedWindowRateLimiterOptions> factory) { throw null; }
         public static System.Threading.RateLimiting.RateLimitPartition<TKey> CreateNoLimiter<TKey>(TKey partitionKey) { throw null; }
+        public static System.Threading.RateLimiting.RateLimitPartition<TKey> CreateSlidingWindowLimiter<TKey>(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.SlidingWindowRateLimiterOptions> factory) { throw null; }
         public static System.Threading.RateLimiting.RateLimitPartition<TKey> CreateTokenBucketLimiter<TKey>(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.TokenBucketRateLimiterOptions> factory) { throw null; }
         public static System.Threading.RateLimiting.RateLimitPartition<TKey> Create<TKey>(TKey partitionKey, System.Func<TKey, System.Threading.RateLimiting.RateLimiter> factory) { throw null; }
     }
@@ -108,6 +132,29 @@ namespace System.Threading.RateLimiting
         public abstract bool IsAutoReplenishing { get; }
         public abstract System.TimeSpan ReplenishmentPeriod { get; }
         public abstract bool TryReplenish();
+    }
+    public sealed partial class SlidingWindowRateLimiter : System.Threading.RateLimiting.ReplenishingRateLimiter
+    {
+        public SlidingWindowRateLimiter(System.Threading.RateLimiting.SlidingWindowRateLimiterOptions options) { }
+        public override System.TimeSpan? IdleDuration { get { throw null; } }
+        public override bool IsAutoReplenishing { get { throw null; } }
+        public override System.TimeSpan ReplenishmentPeriod { get { throw null; } }
+        protected override System.Threading.RateLimiting.RateLimitLease AcquireCore(int requestCount) { throw null; }
+        protected override void Dispose(bool disposing) { }
+        protected override System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
+        public override int GetAvailablePermits() { throw null; }
+        public override bool TryReplenish() { throw null; }
+        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAsyncCore(int requestCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+    public sealed partial class SlidingWindowRateLimiterOptions
+    {
+        public SlidingWindowRateLimiterOptions(int permitLimit, System.Threading.RateLimiting.QueueProcessingOrder queueProcessingOrder, int queueLimit, System.TimeSpan window, int segmentsPerWindow, bool autoReplenishment = true) { }
+        public bool AutoReplenishment { get { throw null; } }
+        public int PermitLimit { get { throw null; } }
+        public int QueueLimit { get { throw null; } }
+        public System.Threading.RateLimiting.QueueProcessingOrder QueueProcessingOrder { get { throw null; } }
+        public int SegmentsPerWindow { get { throw null; } }
+        public System.TimeSpan Window { get { throw null; } }
     }
     public sealed partial class TokenBucketRateLimiter : System.Threading.RateLimiting.ReplenishingRateLimiter
     {
@@ -131,50 +178,5 @@ namespace System.Threading.RateLimiting
         public System.TimeSpan ReplenishmentPeriod { get { throw null; } }
         public int TokenLimit { get { throw null; } }
         public int TokensPerPeriod { get { throw null; } }
-    }
-    public sealed partial class SlidingWindowRateLimiter : System.Threading.RateLimiting.ReplenishingRateLimiter
-    {
-        public SlidingWindowRateLimiter(System.Threading.RateLimiting.SlidingWindowRateLimiterOptions options) { }
-        public override System.TimeSpan? IdleDuration { get { throw null; } }
-        public override bool IsAutoReplenishing { get { throw null; } }
-        public override System.TimeSpan ReplenishmentPeriod { get { throw null; } }
-        protected override System.Threading.RateLimiting.RateLimitLease AcquireCore(int requestCount) { throw null; }
-        protected override void Dispose(bool disposing) { }
-        protected override System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
-        public override int GetAvailablePermits() { throw null; }
-        public override bool TryReplenish() { throw null; }
-        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAsyncCore(int requestCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-    }
-    public sealed partial class SlidingWindowRateLimiterOptions
-    {
-        public SlidingWindowRateLimiterOptions(int permitLimit, System.Threading.RateLimiting.QueueProcessingOrder queueProcessingOrder, int queueLimit, System.TimeSpan window, int segmentsPerWindow, bool autoReplenishment = true) { }
-        public bool AutoReplenishment { get { throw null; } }
-        public int QueueLimit { get { throw null; } }
-        public System.Threading.RateLimiting.QueueProcessingOrder QueueProcessingOrder { get { throw null; } }
-        public System.TimeSpan Window { get { throw null; } }
-        public int PermitLimit { get { throw null; } }
-        public int SegmentsPerWindow { get { throw null; } }
-    }
-    public sealed partial class FixedWindowRateLimiter : System.Threading.RateLimiting.ReplenishingRateLimiter
-    {
-        public FixedWindowRateLimiter(System.Threading.RateLimiting.FixedWindowRateLimiterOptions options) { }
-        public override System.TimeSpan? IdleDuration { get { throw null; } }
-        public override bool IsAutoReplenishing { get { throw null; } }
-        public override System.TimeSpan ReplenishmentPeriod { get { throw null; } }
-        protected override System.Threading.RateLimiting.RateLimitLease AcquireCore(int requestCount) { throw null; }
-        protected override void Dispose(bool disposing) { }
-        protected override System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
-        public override int GetAvailablePermits() { throw null; }
-        public override bool TryReplenish() { throw null; }
-        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAsyncCore(int requestCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-    }
-    public sealed partial class FixedWindowRateLimiterOptions
-    {
-        public FixedWindowRateLimiterOptions(int permitLimit, System.Threading.RateLimiting.QueueProcessingOrder queueProcessingOrder, int queueLimit, System.TimeSpan window, bool autoReplenishment = true) { }
-        public bool AutoReplenishment { get { throw null; } }
-        public int QueueLimit { get { throw null; } }
-        public System.Threading.RateLimiting.QueueProcessingOrder QueueProcessingOrder { get { throw null; } }
-        public System.TimeSpan Window { get { throw null; } }
-        public int PermitLimit { get { throw null; } }
     }
 }


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/65400

Because of the order and time window the sliding/fixed window PR and PartionedRateLimiter PR came in, these APIs weren't added to either PR. So adding them now.