### PR TITLE
[System.Native] (wasm) use a temporary buffer if threading is used

### DIFF
--- a/src/native/libs/System.Native/pal_random.lib.js
+++ b/src/native/libs/System.Native/pal_random.lib.js
@@ -8,23 +8,23 @@ const DotNetEntropyLib = {
         // https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues
         batchedQuotaMax: 65536,
         getBatchedRandomValues: function (buffer, bufferLength) {
-	    // Chrome doesn't want SharedArrayBuffer to be passed to crypto APIs
-	    const needTempBuf = typeof SharedArrayBuffer !== 'undefined' && Module.HEAPU8.buffer instanceof SharedArrayBuffer;
-	    // if we need a temporary buffer, make one that is big enough and write into it from the beginning
-	    // otherwise, use the wasm instance memory and write at the given 'buffer' pointer offset.
-	    const buf = needTempBuf ? new ArrayBuffer(bufferLength) : Module.HEAPU8.buffer;
-	    const offset = needTempBuf ? 0 : buffer;
+            // Chrome doesn't want SharedArrayBuffer to be passed to crypto APIs
+            const needTempBuf = typeof SharedArrayBuffer !== 'undefined' && Module.HEAPU8.buffer instanceof SharedArrayBuffer;
+            // if we need a temporary buffer, make one that is big enough and write into it from the beginning
+            // otherwise, use the wasm instance memory and write at the given 'buffer' pointer offset.
+            const buf = needTempBuf ? new ArrayBuffer(bufferLength) : Module.HEAPU8.buffer;
+            const offset = needTempBuf ? 0 : buffer;
             // for modern web browsers
             // map the work array to the memory buffer passed with the length
             for (let i = 0; i < bufferLength; i += this.batchedQuotaMax) {
                 const view = new Uint8Array(buf, offset + i, Math.min(bufferLength - i, this.batchedQuotaMax));
                 crypto.getRandomValues(view)
             }
-	    if (needTempBuf) {
-		// copy data out of the temporary buffer into the wasm instance memory
-		const heapView = new Uint8Array(Module.HEAPU8.buffer, buffer, bufferLength);
-		heapView.set(new Uint8Array (buf));
-	    }
+            if (needTempBuf) {
+                // copy data out of the temporary buffer into the wasm instance memory
+                const heapView = new Uint8Array(Module.HEAPU8.buffer, buffer, bufferLength);
+                heapView.set(new Uint8Array (buf));
+            }
         }
     },
     dotnet_browser_entropy: function (buffer, bufferLength) {

--- a/src/native/libs/System.Native/pal_random.lib.js
+++ b/src/native/libs/System.Native/pal_random.lib.js
@@ -8,12 +8,23 @@ const DotNetEntropyLib = {
         // https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues
         batchedQuotaMax: 65536,
         getBatchedRandomValues: function (buffer, bufferLength) {
+	    // Chrome doesn't want SharedArrayBuffer to be passed to crypto APIs
+	    const needTempBuf = typeof SharedArrayBuffer !== 'undefined' && Module.HEAPU8.buffer instanceof SharedArrayBuffer;
+	    // if we need a temporary buffer, make one that is big enough and write into it from the beginning
+	    // otherwise, use the wasm instance memory and write at the given 'buffer' pointer offset.
+	    const buf = needTempBuf ? new ArrayBuffer(bufferLength) : Module.HEAPU8.buffer;
+	    const offset = needTempBuf ? 0 : buffer;
             // for modern web browsers
             // map the work array to the memory buffer passed with the length
             for (let i = 0; i < bufferLength; i += this.batchedQuotaMax) {
-                const view = new Uint8Array(Module.HEAPU8.buffer, buffer + i, Math.min(bufferLength - i, this.batchedQuotaMax));
+                const view = new Uint8Array(buf, offset + i, Math.min(bufferLength - i, this.batchedQuotaMax));
                 crypto.getRandomValues(view)
             }
+	    if (needTempBuf) {
+		// copy data out of the temporary buffer into the wasm instance memory
+		const heapView = new Uint8Array(Module.HEAPU8.buffer, buffer, bufferLength);
+		heapView.set(new Uint8Array (buf));
+	    }
         }
     },
     dotnet_browser_entropy: function (buffer, bufferLength) {


### PR DESCRIPTION
Chrome doesn't want a SharedArrayBuffer to be passed to crypto.getRandomValues(), so pass a temporary buffer and then copy the bytes into the wasm instance heap


This gets used on browser-wasm by:

`System.Security.Cryptography.RandomNumberGeneratorImplementation.GetBytes` 
https://github.com/dotnet/runtime/blob/463be3ab8d236cc3d3bf0c663805e6f0562c9f68/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RandomNumberGeneratorImplementation.Browser.cs#L8-L15

and by 
`System.Guid.NewGuid`
https://github.com/dotnet/runtime/blob/463be3ab8d236cc3d3bf0c663805e6f0562c9f68/src/libraries/System.Private.CoreLib/src/System/Guid.Unix.cs#L15-L18
