### PR TITLE
[wasm] Add legs to build wasm with internal threads only and full threading enabled

### DIFF
--- a/eng/pipelines/common/templates/wasm-build-only.yml
+++ b/eng/pipelines/common/templates/wasm-build-only.yml
@@ -1,0 +1,45 @@
+parameters:
+  alwaysRun: false
+  extraBuildArgs: ''
+  isExtraPlatformsBuild: false
+  nameSuffix: ''
+  platforms: []
+
+jobs:
+
+#
+# Build for Browser/wasm and test it
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/global-build-job.yml
+    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+    buildConfig: Release
+    runtimeFlavor: mono
+    platforms: ${{ parameters.platforms }}
+    variables:
+      # map dependencies variables to local variables
+      - name: librariesContainsChange
+        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+      - name: monoContainsChange
+        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
+      - name: alwaysRunVar
+        value: ${{ parameters.alwaysRun }}
+      - name: allWasmContainsChange
+        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_allwasm.containsChange'] ]
+    jobParameters:
+      isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
+      testGroup: innerloop
+      nameSuffix: LibraryTests${{ parameters.nameSuffix }}_BuildOnly
+      buildArgs: -s mono+libs+host -c $(_BuildConfig) /p:ArchiveTests=true /p:BrowserHost=$(_hostedOs) ${{ parameters.extraBuildArgs }}
+      timeoutInMinutes: 240
+      # always run for runtime-wasm builds (triggered manually)
+      # Always run for rolling builds
+      # Else run on path changes
+      condition: >-
+        or(
+          eq(variables['alwaysRunVar'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_allwasm.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true))
+

--- a/eng/pipelines/common/templates/wasm-build-only.yml
+++ b/eng/pipelines/common/templates/wasm-build-only.yml
@@ -30,7 +30,7 @@ jobs:
     jobParameters:
       isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
       testGroup: innerloop
-      nameSuffix: LibraryTests${{ parameters.nameSuffix }}_BuildOnly
+      nameSuffix: ${{ parameters.nameSuffix }}_BuildOnly
       buildArgs: -s mono+libs+host -c $(_BuildConfig) /p:ArchiveTests=true /p:BrowserHost=$(_hostedOs) ${{ parameters.extraBuildArgs }}
       timeoutInMinutes: 240
       # always run for runtime-wasm builds (triggered manually)

--- a/eng/pipelines/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/runtime-extra-platforms-wasm.yml
@@ -65,6 +65,36 @@ jobs:
         - WasmTestOnBrowser
         - WasmTestOnNodeJs
 
+  # Library tests with full threading 
+  - template: /eng/pipelines/common/templates/wasm-library-tests.yml
+    parameters:
+      platforms:
+        - Browser_wasm
+        #- Browser_wasm_win
+      nameSuffix: _Threading
+      extraBuildArgs: /p:WasmEnableThreads=true
+      # Don't run for rolling builds, as this is covered
+      alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      scenarios:
+        - normal
+        - WasmTestOnBrowser
+        - WasmTestOnNodeJs
+
+  # Library tests with internal threads only
+  - template: /eng/pipelines/common/templates/wasm-library-tests.yml
+    parameters:
+      platforms:
+        - Browser_wasm
+        #- Browser_wasm_win
+      nameSuffix: _Threading_PerfTracing
+      extraBuildArgs: /p:WasmEnablePerfTracing=true
+      # Don't run for rolling builds, as this is covered
+      alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      scenarios:
+        - normal
+        - WasmTestOnBrowser
+        - WasmTestOnNodeJs
+
   # EAT Library tests - only run on linux
   - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
     parameters:

--- a/eng/pipelines/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/runtime-extra-platforms-wasm.yml
@@ -75,6 +75,8 @@ jobs:
       extraBuildArgs: /p:WasmEnableThreads=true
       # Don't run for rolling builds, as this is covered
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      # NOTE - Since threading is experimental, we don't want to block mainline work
+      shouldContinueOnError: true
       scenarios:
         - normal
         - WasmTestOnBrowser
@@ -90,6 +92,8 @@ jobs:
       extraBuildArgs: /p:WasmEnablePerfTracing=true
       # Don't run for rolling builds, as this is covered
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      # NOTE - Since threading is experimental, we don't want to block mainline work
+      shouldContinueOnError: true
       scenarios:
         - normal
         - WasmTestOnBrowser

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -394,6 +394,23 @@ jobs:
       - Browser_wasm
     alwaysRun: ${{ variables.isRollingBuild }}
 
+# BUILD ONLY - Wasm Threading Legs
+- template: /eng/pipelines/common/templates/wasm-build-only.yml
+  parameters:
+    platforms:
+      - Browser_wasm
+    nameSuffix: _Threading
+    extraBuildArgs: /p:WasmEnableThreads=true
+    alwaysRun: ${{ variables.isRollingBuild }}
+
+- template: /eng/pipelines/common/templates/wasm-build-only.yml
+  parameters:
+    platforms:
+      - Browser_wasm
+    nameSuffix: _Threading_PerfTracing
+    extraBuildArgs: /p:WasmEnablePerfTracing=true
+    alwaysRun: ${{ variables.isRollingBuild }}
+
 #
 # iOS/tvOS devices - Full AOT + AggressiveTrimming to reduce size
 # Build the whole product using Mono and run libraries tests

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -395,6 +395,28 @@ jobs:
     alwaysRun: ${{ variables.isRollingBuild }}
 
 #
+# Temporarily add a leg that makes sure the wasm runtime with threading enabled
+# builds. We are working on making this a normal part of the wasm build.
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/global-build-job.yml
+    buildConfig: release
+    runtimeFlavor: mono
+    platforms:
+      - Browser_wasm
+    jobParameters:
+      buildArgs: -s mono+libs -c $(_BuildConfig) /p:WasmEnableThreads=true
+      nameSuffix: Threading_AllSubsets_Mono
+      timeoutInMinutes: 180
+      condition: >-
+        or(
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+          eq(variables['isRollingBuild'], true))
+
+#
 # iOS/tvOS devices - Full AOT + AggressiveTrimming to reduce size
 # Build the whole product using Mono and run libraries tests
 #

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -395,28 +395,6 @@ jobs:
     alwaysRun: ${{ variables.isRollingBuild }}
 
 #
-# Temporarily add a leg that makes sure the wasm runtime with threading enabled
-# builds. We are working on making this a normal part of the wasm build.
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: release
-    runtimeFlavor: mono
-    platforms:
-      - Browser_wasm
-    jobParameters:
-      buildArgs: -s mono+libs -c $(_BuildConfig) /p:WasmEnableThreads=true
-      nameSuffix: Threading_AllSubsets_Mono
-      timeoutInMinutes: 180
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['isRollingBuild'], true))
-
-#
 # iOS/tvOS devices - Full AOT + AggressiveTrimming to reduce size
 # Build the whole product using Mono and run libraries tests
 #

--- a/eng/testing/tests.wasm.targets
+++ b/eng/testing/tests.wasm.targets
@@ -73,6 +73,7 @@
 
     <_XHarnessArgs Condition="'$(IsFunctionalTest)' == 'true'"     >$(_XHarnessArgs) --expected-exit-code=$(ExpectedExitCode)</_XHarnessArgs>
     <_XHarnessArgs Condition="'$(WasmXHarnessArgs)' != ''"         >$(_XHarnessArgs) $(WasmXHarnessArgs)</_XHarnessArgs>
+    <_XHarnessArgs Condition="('$(WasmEnableThreads)' == 'true' or '$(WasmEnablePerfTracing)' == 'true') and '$(_XHarnessArs.Contains(&quot;--web-server-use-cop&quot;)' != 'true'">$(_XHarnessArgs) --web-server-use-cop</_XHarnessArgs>
     <_XHarnessArgs                                                 >$(_XHarnessArgs) -s dotnet.js.symbols</_XHarnessArgs>
     <_XHarnessArgs Condition="'$(_UseWasmSymbolicator)' == 'true'" >$(_XHarnessArgs) --symbol-patterns wasm-symbol-patterns.txt</_XHarnessArgs>
     <_XHarnessArgs Condition="'$(_UseWasmSymbolicator)' == 'true'" >$(_XHarnessArgs) --symbolicator WasmSymbolicator.dll,Microsoft.WebAssembly.Internal.SymbolicatorWrapperForXHarness</_XHarnessArgs>

--- a/src/mono/mono/utils/mono-threads-wasm.c
+++ b/src/mono/mono/utils/mono-threads-wasm.c
@@ -229,13 +229,14 @@ mono_thread_platform_create_thread (MonoThreadStart thread_fn, gpointer thread_d
 	pthread_attr_t attr;
 	pthread_t thread;
 	gint res;
-	gsize set_stack_size;
 
 	res = pthread_attr_init (&attr);
 	if (res != 0)
 		g_error ("%s: pthread_attr_init failed, error: \"%s\" (%d)", __func__, g_strerror (res), res);
 
 #if 0
+	gsize set_stack_size;
+
 	if (stack_size)
 		set_stack_size = *stack_size;
 	else

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -428,12 +428,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <!-- WasmOptConfigurationFlags property is set by reading from emcc-props.json -->
-        <WasmOptConfigurationFlags Condition="'$(WasmOptConfigurationFlags)' != ''" Include="$(WasmOptConfigurationFlags)" />
+      <!-- WasmOptConfigurationFlags property is set by reading from emcc-props.json -->
+      <WasmOptConfigurationFlags Condition="'$(WasmOptConfigurationFlags)' != ''" Include="$(WasmOptConfigurationFlags)" />
     </ItemGroup>
 
     <Message Text="Stripping symbols from dotnet.wasm ..." Importance="High" Condition="'$(WasmNativeStrip)' == 'true'" />
-    <Exec Command='wasm-opt$(_ExeExt) --enable-exception-handling @(WasmOptConfigurationFlags->'%(Identity)', ' ') --strip-dwarf "$(_WasmIntermediateOutputPath)dotnet.wasm" -o "$(_WasmIntermediateOutputPath)dotnet.wasm"'
+    <Exec Command='wasm-opt$(_ExeExt) --enable-exception-handling @(WasmOptConfigurationFlags, ' ') --strip-dwarf "$(_WasmIntermediateOutputPath)dotnet.wasm" -o "$(_WasmIntermediateOutputPath)dotnet.wasm"'
           Condition="'$(WasmNativeStrip)' == 'true'"
           IgnoreStandardErrorWarningFormat="true"
           EnvironmentVariables="@(EmscriptenEnvVars)" />

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -433,7 +433,7 @@
     </ItemGroup>
 
     <Message Text="Stripping symbols from dotnet.wasm ..." Importance="High" Condition="'$(WasmNativeStrip)' == 'true'" />
-    <Exec Command='wasm-opt$(_ExeExt) --enable-exception-handling @(WasmOptConfigurationFlags, ' ') --strip-dwarf "$(_WasmIntermediateOutputPath)dotnet.wasm" -o "$(_WasmIntermediateOutputPath)dotnet.wasm"'
+    <Exec Command="wasm-opt$(_ExeExt) --enable-exception-handling @(WasmOptConfigurationFlags, ' ') --strip-dwarf &quot;$(_WasmIntermediateOutputPath)dotnet.wasm&quot; -o &quot;$(_WasmIntermediateOutputPath)dotnet.wasm&quot;"
           Condition="'$(WasmNativeStrip)' == 'true'"
           IgnoreStandardErrorWarningFormat="true"
           EnvironmentVariables="@(EmscriptenEnvVars)" />

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -427,6 +427,11 @@
       <FileWrites Include="$(_WasmIntermediateOutputPath)dotnet.js.symbols" Condition="'$(WasmEmitSymbolMap)' == 'true'" />
     </ItemGroup>
 
+    <ItemGroup>
+        <!-- WasmOptConfigurationFlags property is set by reading from emcc-props.json -->
+        <WasmOptConfigurationFlags Condition="'$(WasmOptConfigurationFlags)' != ''" Include="$(WasmOptConfigurationFlags)" />
+    </ItemGroup>
+
     <Message Text="Stripping symbols from dotnet.wasm ..." Importance="High" Condition="'$(WasmNativeStrip)' == 'true'" />
     <Exec Command='wasm-opt$(_ExeExt) --enable-exception-handling @(WasmOptConfigurationFlags->'%(Identity)', ' ') --strip-dwarf "$(_WasmIntermediateOutputPath)dotnet.wasm" -o "$(_WasmIntermediateOutputPath)dotnet.wasm"'
           Condition="'$(WasmNativeStrip)' == 'true'"
@@ -452,7 +457,7 @@
 
     <ReadEmccProps JsonFilePath="$(_WasmRuntimePackSrcDir)emcc-props.json">
       <Output TaskParameter="EmccProperties" ItemName="_EmccPropItems" />
-      <Output TaskParameter="WasmOptConfigurationFlags" = "_WasmOptConfigurationFlagsItems" />
+      <Output TaskParameter="WasmOptConfigurationFlags" ItemName= "_WasmOptConfigurationFlagsItems" />
     </ReadEmccProps>
 
     <CreateProperty Value="%(_EmccPropItems.Value)">

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -640,6 +640,7 @@
              TaskFactory="JsonToItemsTaskFactory.JsonToItemsTaskFactory">
     <ParameterGroup>
       <EmccProperties ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
+      <WasmOptConfigurationFlags ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
     </ParameterGroup>
   </UsingTask>
 </Project>

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -428,7 +428,7 @@
     </ItemGroup>
 
     <Message Text="Stripping symbols from dotnet.wasm ..." Importance="High" Condition="'$(WasmNativeStrip)' == 'true'" />
-    <Exec Command='wasm-opt$(_ExeExt) --enable-simd --enable-exception-handling --strip-dwarf "$(_WasmIntermediateOutputPath)dotnet.wasm" -o "$(_WasmIntermediateOutputPath)dotnet.wasm"'
+    <Exec Command='wasm-opt$(_ExeExt) --enable-exception-handling @(WasmOptConfigurationFlags->'%(Identity)', ' ') --strip-dwarf "$(_WasmIntermediateOutputPath)dotnet.wasm" -o "$(_WasmIntermediateOutputPath)dotnet.wasm"'
           Condition="'$(WasmNativeStrip)' == 'true'"
           IgnoreStandardErrorWarningFormat="true"
           EnvironmentVariables="@(EmscriptenEnvVars)" />
@@ -452,10 +452,15 @@
 
     <ReadEmccProps JsonFilePath="$(_WasmRuntimePackSrcDir)emcc-props.json">
       <Output TaskParameter="EmccProperties" ItemName="_EmccPropItems" />
+      <Output TaskParameter="WasmOptConfigurationFlags" = "_WasmOptConfigurationFlagsItems" />
     </ReadEmccProps>
 
     <CreateProperty Value="%(_EmccPropItems.Value)">
       <Output TaskParameter="Value" PropertyName="%(_EmccPropItems.Identity)" />
+    </CreateProperty>
+
+    <CreateProperty Value="%(_WasmOptConfigurationFlagsItems.Value)">
+      <Output TaskParameter="Value" PropertyName="%(_WasmOptConfigurationFlagsItems.Identity)" />
     </CreateProperty>
 
     <Error Condition="'$(RuntimeEmccVersionRaw)' == ''"

--- a/src/mono/wasm/runtime/CMakeLists.txt
+++ b/src/mono/wasm/runtime/CMakeLists.txt
@@ -35,7 +35,9 @@ set_target_properties(dotnet PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${NATIVE_BIN_DIR}")
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
-    add_custom_command(TARGET dotnet POST_BUILD COMMAND ${EMSDK_PATH}/upstream/bin/wasm-opt ${WASM_OPT_ADDITIONAL_FLAGS} --enable-exception-handling --strip-dwarf ${NATIVE_BIN_DIR}/dotnet.wasm -o ${NATIVE_BIN_DIR}/dotnet.wasm)
+    add_custom_command(TARGET dotnet
+                        POST_BUILD COMMAND ${EMSDK_PATH}/upstream/bin/wasm-opt --enable-exception-handling ${CONFIGURATION_WASM_OPT_FLAGS} --strip-dwarf ${NATIVE_BIN_DIR}/dotnet.wasm -o ${NATIVE_BIN_DIR}/dotnet.wasm
+                        COMMENT "Stripping debug symbols from dotnet.wasm using wasm-opt")
 endif()
 
 configure_file(wasm-config.h.in include/wasm/wasm-config.h)

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -153,7 +153,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <_WasmOptConfigurationFlags>@(WasmOptConfigurationFlags->'%(Identity)', '%3B ') </_WasmOptConfigurationFlags>
+      <_WasmOptConfigurationFlags>@(WasmOptConfigurationFlags, '%3B ') </_WasmOptConfigurationFlags>
       <_EmccPropsJson>
 <![CDATA[
 {
@@ -218,7 +218,7 @@
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DCMAKE_BUILD_TYPE=$(Configuration)</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DCONFIGURATION_EMCC_FLAGS=&quot;$(CMakeConfigurationEmccFlags)&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DCONFIGURATION_LINK_FLAGS=&quot;$(CMakeConfigurationLinkFlags)&quot;</CMakeBuildRuntimeConfigureCmd>
-      <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DCONFIGURATION_WASM_OPT_FLAGS=&quot;@(WasmOptConfigurationFlags->'%(Identity)', ';')&quot;</CMakeBuildRuntimeConfigureCmd>
+      <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DCONFIGURATION_WASM_OPT_FLAGS=&quot;@(WasmOptConfigurationFlags, ';')&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DMONO_INCLUDES=&quot;$(MonoArtifactsPath)include/mono-2.0&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DMONO_OBJ_INCLUDES=&quot;$(MonoObjDir.TrimEnd('\/'))&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DICU_LIB_DIR=&quot;$(ICULibDir.TrimEnd('\/'))&quot;</CMakeBuildRuntimeConfigureCmd>

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -49,7 +49,7 @@
       InputDirectory="$([MSBuild]::NormalizePath('$(PkgSystem_Runtime_TimeZoneData)', 'contentFiles', 'any', 'any', 'data'))"
       OutputFileName="$(TimeZonesDataPath)" />
   </Target>
-  
+
   <UsingTask TaskName="ManagedToNativeGenerator" AssemblyFile="$(WasmAppBuilderTasksAssemblyPath)" />
   <Target Name="GenerateManagedToNative" DependsOnTargets="CheckEnv;ResolveLibrariesFromLocalBuild">
     <PropertyGroup>
@@ -72,7 +72,7 @@
     </MSBuild>
 
     <MakeDir Directories="$(WasmObjDir)" Condition="!Exists('$(WasmObjDir)')" />
-    
+
     <ManagedToNativeGenerator
       Assemblies="@(WasmPInvokeAssembly)"
       PInvokeModules="@(WasmPInvokeModule)"
@@ -106,29 +106,12 @@
       <_EmccVersionHash>$([System.Text.RegularExpressions.Regex]::Match($(_EmccVersionRaw), $(_EmccVersionRegexPattern)).Groups[2].Value)</_EmccVersionHash>
     </PropertyGroup>
 
-    <Error Text="Failed to parse emcc version, and hash from the full version string: '$(_EmccVersionRaw)'"
-           Condition="'$(_EmccVersion)' == '' or '$(_EmccVersionHash)' == ''" />
-
     <PropertyGroup>
-      <_EmccPropsJson>
-<![CDATA[
-{
-  "items": {
-    "EmccProperties": [
-      { "identity": "RuntimeEmccVersion",     "value": "$(_EmccVersion)" },
-      { "identity": "RuntimeEmccVersionRaw",  "value": "$(_EmccVersionRaw)" },
-      { "identity": "RuntimeEmccVersionHash", "value": "$(_EmccVersionHash)" }
-    ]
-  }
-}
-]]>
-      </_EmccPropsJson>
+        <_WasmOptConfigurationFlags>@(WasmOptConfigurationFlags)</_WasmOptConfigurationFlags>
     </PropertyGroup>
 
-    <WriteLinesToFile File="$(NativeBinDir)src\emcc-props.json"
-                      Lines="$(_EmccPropsJson)"
-                      Overwrite="true"
-                      WriteOnlyWhenDifferent="true" />
+    <Error Text="Failed to parse emcc version, and hash from the full version string: '$(_EmccVersionRaw)'"
+           Condition="'$(_EmccVersion)' == '' or '$(_EmccVersionHash)' == ''" />
 
     <PropertyGroup>
       <_DefaultExportedFunctions Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))"
@@ -160,6 +143,10 @@
       <_EmccLinkFlags Include="-s ENVIRONMENT=&quot;web,webview,worker,node,shell&quot;" />
     </ItemGroup>
 
+    <ItemGroup Condition="'$(MonoWasmThreads)' == 'true'">
+      <WasmOptConfigurationFlags Include="--enable-threads;--enable-bulk-memory;--enable-sign-ext" />
+    </ItemGroup>
+
     <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
       <_EmccLinkFlags Include="--profiling-funcs" />
       <_EmccFlags Include="@(_EmccCommonFlags)" />
@@ -168,6 +155,30 @@
     <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
       <_EmccFlags Include="@(_EmccCommonFlags)" />
     </ItemGroup>
+
+    <PropertyGroup>
+      <_EmccPropsJson>
+<![CDATA[
+{
+  "items": {
+    "EmccProperties": [
+      { "identity": "RuntimeEmccVersion",     "value": "$(_EmccVersion)" },
+      { "identity": "RuntimeEmccVersionRaw",  "value": "$(_EmccVersionRaw)" },
+      { "identity": "RuntimeEmccVersionHash", "value": "$(_EmccVersionHash)" }
+    ],
+    "WasmOptConfigurationFlags": [
+      { "identity": "WasmOptConfigurationFlags", "value": "@(WasmOptConfigurationFlags->'%(Identity)', ';')" }
+    ]
+  }
+}
+]]>
+      </_EmccPropsJson>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="$(NativeBinDir)src\emcc-props.json"
+                      Lines="$(_EmccPropsJson)"
+                      Overwrite="true"
+                      WriteOnlyWhenDifferent="true" />
 
     <WriteLinesToFile File="$(_EmccDefaultsRspPath)"
                       Lines="@(_EmccFlags)"
@@ -210,6 +221,7 @@
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DCMAKE_BUILD_TYPE=$(Configuration)</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DCONFIGURATION_EMCC_FLAGS=&quot;$(CMakeConfigurationEmccFlags)&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DCONFIGURATION_LINK_FLAGS=&quot;$(CMakeConfigurationLinkFlags)&quot;</CMakeBuildRuntimeConfigureCmd>
+      <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DCONFIGURATION_WASM_OPT_FLAGS=&quot;@(WasmOptConfigurationFlags->'%(Identity)', ';')&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DMONO_INCLUDES=&quot;$(MonoArtifactsPath)include/mono-2.0&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DMONO_OBJ_INCLUDES=&quot;$(MonoObjDir.TrimEnd('\/'))&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DICU_LIB_DIR=&quot;$(ICULibDir.TrimEnd('\/'))&quot;</CMakeBuildRuntimeConfigureCmd>

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -153,7 +153,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <_WasmOptConfigurationFlags>@(WasmOptConfigurationFlags->'%(Identity)', '; ') </_WasmOptConfigurationFlags>
+      <_WasmOptConfigurationFlags>@(WasmOptConfigurationFlags->'%(Identity)', '%3B ') </_WasmOptConfigurationFlags>
       <_EmccPropsJson>
 <![CDATA[
 {

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -106,10 +106,6 @@
       <_EmccVersionHash>$([System.Text.RegularExpressions.Regex]::Match($(_EmccVersionRaw), $(_EmccVersionRegexPattern)).Groups[2].Value)</_EmccVersionHash>
     </PropertyGroup>
 
-    <PropertyGroup>
-        <_WasmOptConfigurationFlags>@(WasmOptConfigurationFlags)</_WasmOptConfigurationFlags>
-    </PropertyGroup>
-
     <Error Text="Failed to parse emcc version, and hash from the full version string: '$(_EmccVersionRaw)'"
            Condition="'$(_EmccVersion)' == '' or '$(_EmccVersionHash)' == ''" />
 
@@ -157,6 +153,7 @@
     </ItemGroup>
 
     <PropertyGroup>
+      <_WasmOptConfigurationFlags>@(WasmOptConfigurationFlags->'%(Identity)', '; ') </_WasmOptConfigurationFlags>
       <_EmccPropsJson>
 <![CDATA[
 {
@@ -167,7 +164,7 @@
       { "identity": "RuntimeEmccVersionHash", "value": "$(_EmccVersionHash)" }
     ],
     "WasmOptConfigurationFlags": [
-      { "identity": "WasmOptConfigurationFlags", "value": "@(WasmOptConfigurationFlags->'%(Identity)', ';')" }
+      { "identity": "WasmOptConfigurationFlags", "value": "$(_WasmOptConfigurationFlags)" }
     ]
   }
 }


### PR DESCRIPTION
This change adds two build-only lanes to `runtime` and two full build+test lanes to `runtime-wasm` that builds wasm with internal threads only (`WasmEnablePerfTracing`) and full threading (`WasmEnableThreads`).

The `runtime-wasm` additions can only be manually triggered.