### PR TITLE
Improving the 64-bit number formatting to better match the 32-bit algorithm

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -1524,7 +1524,7 @@ namespace System
             charsWritten = bufferLength;
             fixed (char* buffer = &MemoryMarshal.GetReference(destination))
             {
-                char* p = UInt64ToDecChars(buffer + bufferLength, (uint)(-value), digits);
+                char* p = UInt64ToDecChars(buffer + bufferLength, (ulong)(-value), digits);
                 Debug.Assert(p == buffer + sNegative.Length);
 
                 for (int i = sNegative.Length - 1; i >= 0; i--)

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -360,7 +360,7 @@ namespace System
             {
                 p = UInt32ToDecChars(p, decimal.DecDivMod1E9(ref d), 9);
             }
-            p = UInt32ToDecChars(p, d.Low, 0);
+            p = UInt32ToDecChars(p, d.Low);
 
             int i = (int)((buffer + DecimalPrecision) - p);
 
@@ -1171,7 +1171,7 @@ namespace System
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] // called from only one location
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe void Int32ToNumber(int value, ref NumberBuffer number)
         {
             number.DigitsCount = Int32Precision;
@@ -1187,7 +1187,7 @@ namespace System
             }
 
             byte* buffer = number.GetDigitsPointer();
-            byte* p = UInt32ToDecChars(buffer + Int32Precision, (uint)value, 0);
+            byte* p = UInt32ToDecChars(buffer + Int32Precision, (uint)value);
 
             int i = (int)(buffer + Int32Precision - p);
 
@@ -1297,6 +1297,7 @@ namespace System
             return true;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe char* Int32ToHexChars(char* buffer, uint value, int hexBase, int digits)
         {
             while (--digits >= 0 || value != 0)
@@ -1308,14 +1309,14 @@ namespace System
             return buffer;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] // called from only one location
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe void UInt32ToNumber(uint value, ref NumberBuffer number)
         {
             number.DigitsCount = UInt32Precision;
             number.IsNegative = false;
 
             byte* buffer = number.GetDigitsPointer();
-            byte* p = UInt32ToDecChars(buffer + UInt32Precision, value, 0);
+            byte* p = UInt32ToDecChars(buffer + UInt32Precision, value);
 
             int i = (int)(buffer + UInt32Precision - p);
 
@@ -1330,6 +1331,21 @@ namespace System
             number.CheckConsistency();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe byte* UInt32ToDecChars(byte* bufferEnd, uint value)
+        {
+            do
+            {
+                uint remainder;
+                (value, remainder) = Math.DivRem(value, 10);
+                *(--bufferEnd) = (byte)(remainder + '0');
+            }
+            while (value != 0);
+
+            return bufferEnd;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe byte* UInt32ToDecChars(byte* bufferEnd, uint value, int digits)
         {
             while (--digits >= 0 || value != 0)
@@ -1341,6 +1357,21 @@ namespace System
             return bufferEnd;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe char* UInt32ToDecChars(char* bufferEnd, uint value)
+        {
+            do
+            {
+                uint remainder;
+                (value, remainder) = Math.DivRem(value, 10);
+                *(--bufferEnd) = (char)(remainder + '0');
+            }
+            while (value != 0);
+
+            return bufferEnd;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe char* UInt32ToDecChars(char* bufferEnd, uint value, int digits)
         {
             while (--digits >= 0 || value != 0)
@@ -1367,13 +1398,7 @@ namespace System
             fixed (char* buffer = result)
             {
                 char* p = buffer + bufferLength;
-                do
-                {
-                    uint remainder;
-                    (value, remainder) = Math.DivRem(value, 10);
-                    *(--p) = (char)(remainder + '0');
-                }
-                while (value != 0);
+                p = UInt32ToDecChars(p, value);
                 Debug.Assert(p == buffer);
             }
             return result;
@@ -1410,13 +1435,7 @@ namespace System
                 char* p = buffer + bufferLength;
                 if (digits <= 1)
                 {
-                    do
-                    {
-                        uint remainder;
-                        (value, remainder) = Math.DivRem(value, 10);
-                        *(--p) = (char)(remainder + '0');
-                    }
-                    while (value != 0);
+                    p = UInt32ToDecChars(p, value);
                 }
                 else
                 {
@@ -1427,21 +1446,23 @@ namespace System
             return true;
         }
 
-        private static unsafe void Int64ToNumber(long input, ref NumberBuffer number)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe void Int64ToNumber(long value, ref NumberBuffer number)
         {
-            ulong value = (ulong)input;
-            number.IsNegative = input < 0;
             number.DigitsCount = Int64Precision;
-            if (number.IsNegative)
+
+            if (value >= 0)
             {
-                value = (ulong)(-input);
+                number.IsNegative = false;
+            }
+            else
+            {
+                number.IsNegative = true;
+                value = -value;
             }
 
             byte* buffer = number.GetDigitsPointer();
-            byte* p = buffer + Int64Precision;
-            while (High32(value) != 0)
-                p = UInt32ToDecChars(p, Int64DivMod1E9(ref value), 9);
-            p = UInt32ToDecChars(p, Low32(value), 0);
+            byte* p = UInt64ToDecChars(buffer + Int64Precision, (ulong)value);
 
             int i = (int)(buffer + Int64Precision - p);
 
@@ -1459,32 +1480,22 @@ namespace System
         public static string Int64ToDecStr(long value)
         {
             return value >= 0 ?
-                UInt64ToDecStr((ulong)value, -1) :
+                UInt64ToDecStr((ulong)value) :
                 NegativeInt64ToDecStr(value, -1, NumberFormatInfo.CurrentInfo.NegativeSign);
         }
 
-        private static unsafe string NegativeInt64ToDecStr(long input, int digits, string sNegative)
+        private static unsafe string NegativeInt64ToDecStr(long value, int digits, string sNegative)
         {
-            Debug.Assert(input < 0);
+            Debug.Assert(value < 0);
 
             if (digits < 1)
-            {
                 digits = 1;
-            }
 
-            ulong value = (ulong)(-input);
-
-            int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits(value)) + sNegative.Length;
+            int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits((ulong)(-value))) + sNegative.Length;
             string result = string.FastAllocateString(bufferLength);
             fixed (char* buffer = result)
             {
-                char* p = buffer + bufferLength;
-                while (High32(value) != 0)
-                {
-                    p = UInt32ToDecChars(p, Int64DivMod1E9(ref value), 9);
-                    digits -= 9;
-                }
-                p = UInt32ToDecChars(p, Low32(value), digits);
+                char* p = UInt64ToDecChars(buffer + bufferLength, (ulong)(-value), digits);
                 Debug.Assert(p == buffer + sNegative.Length);
 
                 for (int i = sNegative.Length - 1; i >= 0; i--)
@@ -1496,18 +1507,14 @@ namespace System
             return result;
         }
 
-        private static unsafe bool TryNegativeInt64ToDecStr(long input, int digits, string sNegative, Span<char> destination, out int charsWritten)
+        private static unsafe bool TryNegativeInt64ToDecStr(long value, int digits, string sNegative, Span<char> destination, out int charsWritten)
         {
-            Debug.Assert(input < 0);
+            Debug.Assert(value < 0);
 
             if (digits < 1)
-            {
                 digits = 1;
-            }
 
-            ulong value = (ulong)(-input);
-
-            int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits((ulong)(-input))) + sNegative.Length;
+            int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits((ulong)(-value))) + sNegative.Length;
             if (bufferLength > destination.Length)
             {
                 charsWritten = 0;
@@ -1517,13 +1524,7 @@ namespace System
             charsWritten = bufferLength;
             fixed (char* buffer = &MemoryMarshal.GetReference(destination))
             {
-                char* p = buffer + bufferLength;
-                while (High32(value) != 0)
-                {
-                    p = UInt32ToDecChars(p, Int64DivMod1E9(ref value), 9);
-                    digits -= 9;
-                }
-                p = UInt32ToDecChars(p, Low32(value), digits);
+                char* p = UInt64ToDecChars(buffer + bufferLength, (uint)(-value), digits);
                 Debug.Assert(p == buffer + sNegative.Length);
 
                 for (int i = sNegative.Length - 1; i >= 0; i--)
@@ -1537,20 +1538,14 @@ namespace System
 
         private static unsafe string Int64ToHexStr(long value, char hexBase, int digits)
         {
+            if (digits < 1)
+                digits = 1;
+
             int bufferLength = Math.Max(digits, FormattingHelpers.CountHexDigits((ulong)value));
             string result = string.FastAllocateString(bufferLength);
             fixed (char* buffer = result)
             {
-                char* p = buffer + bufferLength;
-                if (High32((ulong)value) != 0)
-                {
-                    p = Int32ToHexChars(p, Low32((ulong)value), hexBase, 8);
-                    p = Int32ToHexChars(p, High32((ulong)value), hexBase, digits - 8);
-                }
-                else
-                {
-                    p = Int32ToHexChars(p, Low32((ulong)value), hexBase, Math.Max(digits, 1));
-                }
+                char* p = Int64ToHexChars(buffer + bufferLength, (ulong)value, hexBase, digits);
                 Debug.Assert(p == buffer);
             }
             return result;
@@ -1558,6 +1553,9 @@ namespace System
 
         private static unsafe bool TryInt64ToHexStr(long value, char hexBase, int digits, Span<char> destination, out int charsWritten)
         {
+            if (digits < 1)
+                digits = 1;
+
             int bufferLength = Math.Max(digits, FormattingHelpers.CountHexDigits((ulong)value));
             if (bufferLength > destination.Length)
             {
@@ -1568,32 +1566,49 @@ namespace System
             charsWritten = bufferLength;
             fixed (char* buffer = &MemoryMarshal.GetReference(destination))
             {
-                char* p = buffer + bufferLength;
-                if (High32((ulong)value) != 0)
-                {
-                    p = Int32ToHexChars(p, Low32((ulong)value), hexBase, 8);
-                    p = Int32ToHexChars(p, High32((ulong)value), hexBase, digits - 8);
-                }
-                else
-                {
-                    p = Int32ToHexChars(p, Low32((ulong)value), hexBase, Math.Max(digits, 1));
-                }
+                char* p = Int64ToHexChars(buffer + bufferLength, (ulong)value, hexBase, digits);
                 Debug.Assert(p == buffer);
             }
             return true;
         }
 
+#if TARGET_64BIT
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        private static unsafe char* Int64ToHexChars(char* buffer, ulong value, int hexBase, int digits)
+        {
+#if TARGET_32BIT
+            uint lower = (uint)value;
+            uint upper = (uint)(value >> 32);
+
+            if (upper != 0)
+            {
+                buffer = Int32ToHexChars(buffer, lower, hexBase, 8);
+                return Int32ToHexChars(buffer, upper, hexBase, digits - 8);
+            }
+            else
+            {
+                return Int32ToHexChars(buffer, lower, hexBase, Math.Max(digits, 1));
+            }
+#else
+            while (--digits >= 0 || value != 0)
+            {
+                byte digit = (byte)(value & 0xF);
+                *(--buffer) = (char)(digit + (digit < 10 ? (byte)'0' : hexBase));
+                value >>= 4;
+            }
+            return buffer;
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe void UInt64ToNumber(ulong value, ref NumberBuffer number)
         {
             number.DigitsCount = UInt64Precision;
             number.IsNegative = false;
 
             byte* buffer = number.GetDigitsPointer();
-            byte* p = buffer + UInt64Precision;
-
-            while (High32(value) != 0)
-                p = UInt32ToDecChars(p, Int64DivMod1E9(ref value), 9);
-            p = UInt32ToDecChars(p, Low32(value), 0);
+            byte* p = UInt64ToDecChars(buffer + UInt64Precision, value, 0);
 
             int i = (int)(buffer + UInt64Precision - p);
 
@@ -1608,12 +1623,112 @@ namespace System
             number.CheckConsistency();
         }
 
-        internal static unsafe string UInt64ToDecStr(ulong value, int digits)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint Int64DivMod1E9(ref ulong value)
         {
-            if (digits < 1)
-                digits = 1;
+            uint rem = (uint)(value % 1_000_000_000);
+            value /= 1_000_000_000;
+            return rem;
+        }
 
-            int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits(value));
+#if TARGET_64BIT
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        internal static unsafe byte* UInt64ToDecChars(byte* bufferEnd, ulong value)
+        {
+#if TARGET_32BIT
+            while ((uint)(value >> 32) != 0)
+            {
+                bufferEnd = UInt32ToDecChars(bufferEnd, Int64DivMod1E9(ref value), 9);
+            }
+            return UInt32ToDecChars(bufferEnd, (uint)value);
+#else
+            do
+            {
+                ulong remainder;
+                (value, remainder) = Math.DivRem(value, 10);
+                *(--bufferEnd) = (byte)(remainder + '0');
+            }
+            while (value != 0);
+
+            return bufferEnd;
+#endif
+        }
+
+#if TARGET_64BIT
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        internal static unsafe byte* UInt64ToDecChars(byte* bufferEnd, ulong value, int digits)
+        {
+#if TARGET_32BIT
+            while ((uint)(value >> 32) != 0)
+            {
+                bufferEnd = UInt32ToDecChars(bufferEnd, Int64DivMod1E9(ref value), 9);
+                digits -= 9;
+            }
+            return UInt32ToDecChars(bufferEnd, (uint)value, digits);
+#else
+            while (--digits >= 0 || value != 0)
+            {
+                ulong remainder;
+                (value, remainder) = Math.DivRem(value, 10);
+                *(--bufferEnd) = (byte)(remainder + '0');
+            }
+            return bufferEnd;
+#endif
+        }
+
+#if TARGET_64BIT
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        internal static unsafe char* UInt64ToDecChars(char* bufferEnd, ulong value)
+        {
+#if TARGET_32BIT
+            while ((uint)(value >> 32) != 0)
+            {
+                bufferEnd = UInt32ToDecChars(bufferEnd, Int64DivMod1E9(ref value), 9);
+            }
+            return UInt32ToDecChars(bufferEnd, (uint)value);
+#else
+            do
+            {
+                ulong remainder;
+                (value, remainder) = Math.DivRem(value, 10);
+                *(--bufferEnd) = (char)(remainder + '0');
+            }
+            while (value != 0);
+
+            return bufferEnd;
+#endif
+        }
+
+#if TARGET_64BIT
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        internal static unsafe char* UInt64ToDecChars(char* bufferEnd, ulong value, int digits)
+        {
+#if TARGET_32BIT
+            while ((uint)(value >> 32) != 0)
+            {
+                bufferEnd = UInt32ToDecChars(bufferEnd, Int64DivMod1E9(ref value), 9);
+                digits -= 9;
+            }
+            return UInt32ToDecChars(bufferEnd, (uint)value, digits);
+#else
+            while (--digits >= 0 || value != 0)
+            {
+                ulong remainder;
+                (value, remainder) = Math.DivRem(value, 10);
+                *(--bufferEnd) = (char)(remainder + '0');
+            }
+            return bufferEnd;
+#endif
+        }
+
+        internal static unsafe string UInt64ToDecStr(ulong value)
+        {
+            // Intrinsified in mono interpreter
+            int bufferLength = FormattingHelpers.CountDigits(value);
 
             // For single-digit values that are very common, especially 0 and 1, just return cached strings.
             if (bufferLength == 1)
@@ -1625,12 +1740,23 @@ namespace System
             fixed (char* buffer = result)
             {
                 char* p = buffer + bufferLength;
-                while (High32(value) != 0)
-                {
-                    p = UInt32ToDecChars(p, Int64DivMod1E9(ref value), 9);
-                    digits -= 9;
-                }
-                p = UInt32ToDecChars(p, Low32(value), digits);
+                p = UInt64ToDecChars(p, value);
+                Debug.Assert(p == buffer);
+            }
+            return result;
+        }
+
+        internal static unsafe string UInt64ToDecStr(ulong value, int digits)
+        {
+            if (digits <= 1)
+                return UInt64ToDecStr(value);
+
+            int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits(value));
+            string result = string.FastAllocateString(bufferLength);
+            fixed (char* buffer = result)
+            {
+                char* p = buffer + bufferLength;
+                p = UInt64ToDecChars(p, value, digits);
                 Debug.Assert(p == buffer);
             }
             return result;
@@ -1638,9 +1764,6 @@ namespace System
 
         private static unsafe bool TryUInt64ToDecStr(ulong value, int digits, Span<char> destination, out int charsWritten)
         {
-            if (digits < 1)
-                digits = 1;
-
             int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits(value));
             if (bufferLength > destination.Length)
             {
@@ -1652,12 +1775,14 @@ namespace System
             fixed (char* buffer = &MemoryMarshal.GetReference(destination))
             {
                 char* p = buffer + bufferLength;
-                while (High32(value) != 0)
+                if (digits <= 1)
                 {
-                    p = UInt32ToDecChars(p, Int64DivMod1E9(ref value), 9);
-                    digits -= 9;
+                    p = UInt64ToDecChars(p, value);
                 }
-                p = UInt32ToDecChars(p, Low32(value), digits);
+                else
+                {
+                    p = UInt64ToDecChars(p, value, digits);
+                }
                 Debug.Assert(p == buffer);
             }
             return true;
@@ -2609,17 +2734,6 @@ namespace System
                     }
                 }
             }
-        }
-
-        private static uint Low32(ulong value) => (uint)value;
-
-        private static uint High32(ulong value) => (uint)((value & 0xFFFFFFFF00000000) >> 32);
-
-        private static uint Int64DivMod1E9(ref ulong value)
-        {
-            uint rem = (uint)(value % 1000000000);
-            value /= 1000000000;
-            return rem;
         }
 
         private static ulong ExtractFractionAndBiasedExponent(double value, out int exponent)

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -360,7 +360,7 @@ namespace System
             {
                 p = UInt32ToDecChars(p, decimal.DecDivMod1E9(ref d), 9);
             }
-            p = UInt32ToDecChars(p, d.Low);
+            p = UInt32ToDecChars(p, d.Low, 0);
 
             int i = (int)((buffer + DecimalPrecision) - p);
 
@@ -1187,7 +1187,7 @@ namespace System
             }
 
             byte* buffer = number.GetDigitsPointer();
-            byte* p = UInt32ToDecChars(buffer + Int32Precision, (uint)value);
+            byte* p = UInt32ToDecChars(buffer + Int32Precision, (uint)value, 0);
 
             int i = (int)(buffer + Int32Precision - p);
 
@@ -1316,7 +1316,7 @@ namespace System
             number.IsNegative = false;
 
             byte* buffer = number.GetDigitsPointer();
-            byte* p = UInt32ToDecChars(buffer + UInt32Precision, value);
+            byte* p = UInt32ToDecChars(buffer + UInt32Precision, value, 0);
 
             int i = (int)(buffer + UInt32Precision - p);
 
@@ -1462,7 +1462,7 @@ namespace System
             }
 
             byte* buffer = number.GetDigitsPointer();
-            byte* p = UInt64ToDecChars(buffer + Int64Precision, (ulong)value);
+            byte* p = UInt64ToDecChars(buffer + Int64Precision, (ulong)value, 0);
 
             int i = (int)(buffer + Int64Precision - p);
 


### PR DESCRIPTION
Found that the implementation was less efficient than expected when working on `Int128` and `UInt128`. This updates the 64-bit paths to be closer to what the 32-bit paths do, but with keeping the "decomposed" operation on 32-bit platforms.