### PR TITLE
JIT: update `NO_WAY` assert, fix issue it was hiding

### DIFF
--- a/src/coreclr/jit/error.h
+++ b/src/coreclr/jit/error.h
@@ -100,9 +100,6 @@ extern void RecordNowayAssertGlobal(const char* filename, unsigned line, const c
 
 #ifdef DEBUG
 
-#define NO_WAY(msg) (debugError(msg, __FILE__, __LINE__), noWay())
-// Used for fallback stress mode
-#define NO_WAY_NOASSERT(msg) noWay()
 #define BADCODE(msg) (debugError(msg, __FILE__, __LINE__), badCode())
 #define BADCODE3(msg, msg2, arg) badCode3(msg, msg2, arg, __FILE__, __LINE__)
 // Used for an assert that we want to convert into BADCODE to force minopts, or in minopts to force codegen.
@@ -116,7 +113,9 @@ extern void RecordNowayAssertGlobal(const char* filename, unsigned line, const c
         }                                                                                                              \
     } while (0)
 #define unreached() noWayAssertBody("unreached", __FILE__, __LINE__)
-
+#define NO_WAY(msg) noWayAssertBody(msg, __FILE__, __LINE__)
+// Used for fallback stress mode
+#define NO_WAY_NOASSERT(msg) noWay()
 #define NOWAY_MSG(msg) noWayAssertBodyConditional(msg, __FILE__, __LINE__)
 #define NOWAY_MSG_FILE_AND_LINE(msg, file, line) noWayAssertBodyConditional(msg, file, line)
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -4005,7 +4005,7 @@ bool Compiler::fgOptimizeBranch(BasicBlock* bJump)
 
     /* Visit all the statements in bDest */
 
-    for (Statement* const curStmt : bDest->Statements())
+    for (Statement* const curStmt : bDest->NonPhiStatements())
     {
         // Clone/substitute the expression.
         Statement* stmt = gtCloneStmt(curStmt);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -17959,7 +17959,7 @@ SPILLSTACK:
             case BBJ_EHFINALLYRET:
             case BBJ_EHFILTERRET:
             case BBJ_THROW:
-                NO_WAY("can't have 'unreached' end of BB with non-empty stack");
+                BADCODE("can't have 'unreached' end of BB with non-empty stack");
                 break;
 
             default:


### PR DESCRIPTION
`NO_WAY` asserts differed from `noway_assert` for no good reason I could see,
and the former would silently suppress jit problems, including one that
came up recently in the SPMI aspnet replay.

Update so these macros do the same thing (by default they will cause checked
jits to assert, since `COMPlus_JitEnableNoWayAssert` is on by default for
checked.

Work around the one issue this uncovered: we can do late flow opts (triggered
by GC poll insertion) that try and clone block IR, and cloning of PHIs is not
supported. SSA is dead by this point anyways, but we haven't yet removed the
related IR.

Closes #68781.