### PR TITLE
Tweak Rune.DecodeFromUtf8

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
@@ -395,46 +395,38 @@ namespace System.Text
             // it tries to consume as many code units as possible as long as those code
             // units constitute the beginning of a longer well-formed subsequence per Table 3-7.
 
+            // Try reading source[0].
+
             int index = 0;
-
-            // Try reading input[0].
-
-            if ((uint)index >= (uint)source.Length)
+            if (source.IsEmpty)
             {
                 goto NeedsMoreData;
             }
 
-            uint tempValue = source[index];
-            if (!UnicodeUtility.IsAsciiCodePoint(tempValue))
+            uint tempValue = source[0];
+            if (UnicodeUtility.IsAsciiCodePoint(tempValue))
             {
-                goto NotAscii;
+                bytesConsumed = 1;
+                result = UnsafeCreate(tempValue);
+                return OperationStatus.Done;
             }
-
-        Finish:
-
-            bytesConsumed = index + 1;
-            Debug.Assert(1 <= bytesConsumed && bytesConsumed <= 4); // Valid subsequences are always length [1..4]
-            result = UnsafeCreate(tempValue);
-            return OperationStatus.Done;
-
-        NotAscii:
 
             // Per Table 3-7, the beginning of a multibyte sequence must be a code unit in
             // the range [C2..F4]. If it's outside of that range, it's either a standalone
             // continuation byte, or it's an overlong two-byte sequence, or it's an out-of-range
             // four-byte sequence.
 
+            // Try reading source[1].
+
+            index = 1;
             if (!UnicodeUtility.IsInRangeInclusive(tempValue, 0xC2, 0xF4))
             {
-                goto FirstByteInvalid;
+                goto Invalid;
             }
 
             tempValue = (tempValue - 0xC2) << 6;
 
-            // Try reading input[1].
-
-            index++;
-            if ((uint)index >= (uint)source.Length)
+            if (1 >= (uint)source.Length)
             {
                 goto NeedsMoreData;
             }
@@ -443,7 +435,7 @@ namespace System.Text
             // complement representation is in the range [-65..-128]. This allows us to
             // perform a single comparison to see if a byte is a continuation byte.
 
-            int thisByteSignExtended = (sbyte)source[index];
+            int thisByteSignExtended = (sbyte)source[1];
             if (thisByteSignExtended >= -64)
             {
                 goto Invalid;
@@ -485,15 +477,15 @@ namespace System.Text
             // The first two bytes were just fine. We don't need to perform any other checks
             // on the remaining bytes other than to see that they're valid continuation bytes.
 
-            // Try reading input[2].
+            // Try reading source[2].
 
-            index++;
-            if ((uint)index >= (uint)source.Length)
+            index = 2;
+            if (2 >= (uint)source.Length)
             {
                 goto NeedsMoreData;
             }
 
-            thisByteSignExtended = (sbyte)source[index];
+            thisByteSignExtended = (sbyte)source[2];
             if (thisByteSignExtended >= -64)
             {
                 goto Invalid; // this byte is not a UTF-8 continuation byte
@@ -510,15 +502,15 @@ namespace System.Text
                 goto Finish; // this is a valid 3-byte sequence
             }
 
-            // Try reading input[3].
+            // Try reading source[3].
 
-            index++;
-            if ((uint)index >= (uint)source.Length)
+            index = 3;
+            if (3 >= (uint)source.Length)
             {
                 goto NeedsMoreData;
             }
 
-            thisByteSignExtended = (sbyte)source[index];
+            thisByteSignExtended = (sbyte)source[3];
             if (thisByteSignExtended >= -64)
             {
                 goto Invalid; // this byte is not a UTF-8 continuation byte
@@ -529,19 +521,15 @@ namespace System.Text
             tempValue += 0x80; // remove the continuation byte marker
             tempValue -= (0xF0 - 0xE0) << 18; // remove the leading byte marker
 
+            // Valid 4-byte sequence
             UnicodeDebug.AssertIsValidSupplementaryPlaneScalar(tempValue);
-            goto Finish; // this is a valid 4-byte sequence
 
-        FirstByteInvalid:
+        Finish:
 
-            index = 1; // Invalid subsequences are always at least length 1.
-
-        Invalid:
-
-            Debug.Assert(1 <= index && index <= 3); // Invalid subsequences are always length 1..3
-            bytesConsumed = index;
-            result = ReplacementChar;
-            return OperationStatus.InvalidData;
+            bytesConsumed = index + 1;
+            Debug.Assert(1 <= bytesConsumed && bytesConsumed <= 4); // Valid subsequences are always length [1..4]
+            result = UnsafeCreate(tempValue);
+            return OperationStatus.Done;
 
         NeedsMoreData:
 
@@ -549,6 +537,13 @@ namespace System.Text
             bytesConsumed = index;
             result = ReplacementChar;
             return OperationStatus.NeedMoreData;
+
+        Invalid:
+
+            Debug.Assert(1 <= index && index <= 3); // Invalid subsequences are always length 1..3
+            bytesConsumed = index;
+            result = ReplacementChar;
+            return OperationStatus.InvalidData;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
@@ -426,7 +426,7 @@ namespace System.Text
 
             tempValue = (tempValue - 0xC2) << 6;
 
-            if (1 >= (uint)source.Length)
+            if (source.Length <= 1)
             {
                 goto NeedsMoreData;
             }
@@ -480,7 +480,7 @@ namespace System.Text
             // Try reading source[2].
 
             index = 2;
-            if (2 >= (uint)source.Length)
+            if (source.Length <= 2)
             {
                 goto NeedsMoreData;
             }
@@ -505,7 +505,7 @@ namespace System.Text
             // Try reading source[3].
 
             index = 3;
-            if (3 >= (uint)source.Length)
+            if (source.Length <= 3)
             {
                 goto NeedsMoreData;
             }


### PR DESCRIPTION
It's quite possible this isn't the right test or that other inputs would fare worse; @GrabYourPitchforks, please do let me know if I should be running something different (or if my machine may not be representative).

|          Method |         Toolchain | Text |       Mean |    Error |   StdDev | Ratio |
|---------------- |------------------ |----- |-----------:|---------:|---------:|------:|
| IterateFromUTF8 | \main\corerun.exe |    0 | 1,356.2 ns |  4.52 ns |  4.00 ns |  1.00 |
| IterateFromUTF8 |   \pr\corerun.exe |    0 | 1,177.9 ns |  5.01 ns |  4.69 ns |  0.87 |
|                 |                   |      |            |          |          |       |
| IterateFromUTF8 | \main\corerun.exe |    1 |   514.8 ns |  0.64 ns |  0.56 ns |  1.00 |
| IterateFromUTF8 |   \pr\corerun.exe |    1 |   440.3 ns |  1.52 ns |  1.27 ns |  0.86 |
|                 |                   |      |            |          |          |       |
| IterateFromUTF8 | \main\corerun.exe |    2 | 1,148.7 ns | 14.39 ns | 13.46 ns |  1.00 |
| IterateFromUTF8 |   \pr\corerun.exe |    2 |   998.1 ns |  7.98 ns |  6.66 ns |  0.87 |
|                 |                   |      |            |          |          |       |
| IterateFromUTF8 | \main\corerun.exe |    3 | 2,881.7 ns | 13.30 ns | 11.79 ns |  1.00 |
| IterateFromUTF8 |   \pr\corerun.exe |    3 | 2,407.5 ns | 14.55 ns | 12.90 ns |  0.84 |
|                 |                   |      |            |          |          |       |
| IterateFromUTF8 | \main\corerun.exe |    4 |   751.2 ns |  3.40 ns |  3.02 ns |  1.00 |
| IterateFromUTF8 |   \pr\corerun.exe |    4 |   680.7 ns |  3.87 ns |  3.43 ns |  0.91 |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System;
using System.Text;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    private byte[] _bytes;

    [Params(0, 1, 2, 3, 4)]
    public int Text { get; set; }

    [GlobalSetup]
    public void Setup()
    {
        string text = Text switch
        {
            // From https://lipsum.com/
            0 => "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
            // Below text generated with https://generator.lorem-ipsum.info/
            // Standard Lorem Ipsum
            1 => "In laoreet petentium hendrerit mel, posse perpetua id vim. Te vis esse pertinax. Sed ad laboramus intellegat. Esse nostro ceteros per ut, no idque solet melius usu, amet utinam populo vel no. No omnis moderatius vim.",
            // Cyrillic
            2 => "Лорем ипсум долор сит амет, хис адхуц дицта ат. Ест омнес партем нострум ан, нец цивибус денияуе перципитур ет. Ут анимал праесент цонтентионес вис, сеа хинц минимум ут, симул виртуте хендрерит дуо цу. Ех алияуид денияуе диссентиунт вел. Амет цонсецтетуер ид вел.",
            // Greek
            3 => "Λορεμ ιπσθμ δολορ σιτ αμετ, vελ ατ θνθμ θλλθμ λιβεραvισσε, vιξ σθασ γλοριατθρ αβηορρεαντ αν, σεδ ει ιθvαρετ ιντελλεγεβατ. Εα εστ ιδqθε ιντελλεγατ φορενσιβθσ, ειθσ φαστιδιι δισπθτανδο νε ηασ. Νεc αν αccομμοδαρε cονcλθδατθρqθε, ιγνοτα ριδενσ ινcιδεριντ θσθ αδ, θτ αλτερα αππελλαντθρ θσθ. Vισ θτ διcιτ qθοδσι δεβιτισ. Vελ εα ορατιο περσιθσ, ιδ οπορτεατ cονcλθσιονεμqθε ηασ, qθο ιν τραcτατοσ μνεσαρcηθμ. Πρι εqθιδεμ σθσcιπιτ ιμπερδιετ εα, ναμ vιδιτ λθδθσ νεγλεγεντθρ αν, qθι φαcετε qθαεqθε μεντιτθμ νε. Ηισ qθοτ εροσ νομιναvι ιδ, σθμο μαγνα νο σιτ, vενιαμ αντιοπαμ θτ vιξ.",
            // Chinese Simplified
            _ => "望敗必総減論元進東前世氏謙大。爆秋答染作構天団経処解室速物察書切。失医龍軽係府食君権題半感体。西標活街予女模行改円芸敷流比査岡海。歩読稿京慶王徳提陸情更典安要央汚。題羽次仲抜電伸華識表足前資通者撮存工局。安稿報会市芸喰職細療越変。報横必応設来向現菌米終半獲合代所泄写。右残保奏建週況将連部的際前済次質毎。",
        };
        _bytes = Encoding.UTF8.GetBytes(text);
    }

    [Benchmark]
    public int IterateFromUTF8()
    {
        int aggregate = 0;
        ReadOnlySpan<byte> bytes = _bytes;
        while (!bytes.IsEmpty)
        {
            Rune.DecodeFromUtf8(bytes, out Rune result, out int bytesConsumed);
            aggregate += result.Value;
            bytes = bytes.Slice(bytesConsumed);
        }
        return aggregate;
    }
}
```