### PR TITLE
Reset the bbNatLoopNum of block for removed loop

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -9599,15 +9599,15 @@ void Compiler::optMarkLoopRemoved(unsigned loopNum)
     // be live if parent is getting removed, but until we fix it, this will
     // at least guarantee that the loopTable is somewhat accurate and up to
     // date.
-    for (BasicBlock::loopNumber l = optLoopTable[loopNum].lpChild; //
-         l != BasicBlock::NOT_IN_LOOP;                             //
+    for (BasicBlock::loopNumber l = loop.lpChild; //
+         l != BasicBlock::NOT_IN_LOOP;            //
          l = optLoopTable[l].lpSibling)
     {
         if ((optLoopTable[l].lpFlags & LPFLG_REMOVED) == 0)
         {
             JITDUMP("Resetting parent of loop number " FMT_LP " from " FMT_LP " to " FMT_LP ".\n", l,
-                    optLoopTable[l].lpParent, optLoopTable[loopNum].lpParent);
-            optLoopTable[l].lpParent = optLoopTable[loopNum].lpParent;
+                    optLoopTable[l].lpParent, loop.lpParent);
+            optLoopTable[l].lpParent = loop.lpParent;
         }
     }
 

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -9582,22 +9582,21 @@ void Compiler::optMarkLoopRemoved(unsigned loopNum)
 
     assert(loopNum < optLoopCount);
     LoopDsc& loop = optLoopTable[loopNum];
+
+    for (BasicBlock* const auxBlock : loop.LoopBlocks())
+    {
+        assert(auxBlock->bbNatLoopNum == loopNum);
+        JITDUMP("Resetting loop number for " FMT_BB " from " FMT_LP " to " FMT_LP ".\n", auxBlock->bbNum, loopNum,
+                loop.lpParent);
+        auxBlock->bbNatLoopNum = loop.lpParent;
+    }
+
     loop.lpFlags |= LPFLG_REMOVED;
 
 #ifdef DEBUG
     if (optAnyChildNotRemoved(loopNum))
     {
         JITDUMP("Removed loop " FMT_LP " has one or more live children\n", loopNum);
-    }
-
-    for (BasicBlock* const auxBlock : Blocks())
-    {
-        if (auxBlock->bbNatLoopNum == loopNum)
-        {
-            JITDUMP("Resetting loop number for " FMT_BB " from " FMT_LP " to " FMT_LP ".\n", auxBlock->bbNum, loopNum,
-                    loop.lpParent);
-            auxBlock->bbNatLoopNum = loop.lpParent;
-        }
     }
 
 // Note: we can't call `fgDebugCheckLoopTable()` here because if there are live children, it will assert.

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -9571,7 +9571,8 @@ bool Compiler::optAnyChildNotRemoved(unsigned loopNum)
 // optMarkLoopRemoved: Mark the specified loop as removed (some optimization, such as unrolling, has made the
 // loop no longer exist). Note that only the given loop is marked as being removed; if it has any children,
 // they are not touched (but a warning message is output to the JitDump).
-// This method also resets the `bbNatLoopNum` field to point to either parent's loop number or NOT_IN_LOOP.
+// This method resets the `bbNatLoopNum` field to point to either parent's loop number or NOT_IN_LOOP.
+// For consistency, it also updates the child loop's `lpParent` field to have its parent
 //
 // Arguments:
 //      loopNum - the loop number to remove
@@ -9585,13 +9586,36 @@ void Compiler::optMarkLoopRemoved(unsigned loopNum)
 
     for (BasicBlock* const auxBlock : loop.LoopBlocks())
     {
-        assert(auxBlock->bbNatLoopNum == loopNum);
-        JITDUMP("Resetting loop number for " FMT_BB " from " FMT_LP " to " FMT_LP ".\n", auxBlock->bbNum, loopNum,
-                loop.lpParent);
-        auxBlock->bbNatLoopNum = loop.lpParent;
+        // auxBlock should be either part of this loop or one of the child loop.
+        assert(auxBlock->bbNatLoopNum >= loopNum);
+
+        if (auxBlock->bbNatLoopNum == loopNum)
+        {
+            JITDUMP("Resetting loop number for " FMT_BB " from " FMT_LP " to " FMT_LP ".\n", auxBlock->bbNum,
+                    auxBlock->bbNatLoopNum, loop.lpParent);
+            auxBlock->bbNatLoopNum = loop.lpParent;
+        }
+    }
+
+    // Stop referring this loop as a parent of child loops
+    // TODO: As `optAnyChildNotRemoved()` points out, child loops should
+    // be live if parent is getting removed, but until we fix it, this will
+    // at least guarantee that the loopTable is somewhat accurate and up to
+    // date.
+    for (BasicBlock::loopNumber l = optLoopTable[loopNum].lpChild; //
+         l != BasicBlock::NOT_IN_LOOP;                             //
+         l = optLoopTable[l].lpSibling)
+    {
+        if ((optLoopTable[l].lpFlags & LPFLG_REMOVED) == 0)
+        {
+            JITDUMP("Resetting parent of loop number " FMT_LP " from " FMT_LP " to " FMT_LP ".\n", l,
+                    optLoopTable[l].lpParent, optLoopTable[loopNum].lpParent);
+            optLoopTable[l].lpParent = optLoopTable[loopNum].lpParent;
+        }
     }
 
     loop.lpFlags |= LPFLG_REMOVED;
+
 
 #ifdef DEBUG
     if (optAnyChildNotRemoved(loopNum))

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -9586,9 +9586,6 @@ void Compiler::optMarkLoopRemoved(unsigned loopNum)
 
     for (BasicBlock* const auxBlock : loop.LoopBlocks())
     {
-        // auxBlock should be either part of this loop or one of the child loop.
-        assert(auxBlock->bbNatLoopNum >= loopNum);
-
         if (auxBlock->bbNatLoopNum == loopNum)
         {
             JITDUMP("Resetting loop number for " FMT_BB " from " FMT_LP " to " FMT_LP ".\n", auxBlock->bbNum,
@@ -9615,7 +9612,6 @@ void Compiler::optMarkLoopRemoved(unsigned loopNum)
     }
 
     loop.lpFlags |= LPFLG_REMOVED;
-
 
 #ifdef DEBUG
     if (optAnyChildNotRemoved(loopNum))

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -9571,6 +9571,7 @@ bool Compiler::optAnyChildNotRemoved(unsigned loopNum)
 // optMarkLoopRemoved: Mark the specified loop as removed (some optimization, such as unrolling, has made the
 // loop no longer exist). Note that only the given loop is marked as being removed; if it has any children,
 // they are not touched (but a warning message is output to the JitDump).
+// This method also resets the `bbNatLoopNum` field to point to either parent's loop number or NOT_IN_LOOP.
 //
 // Arguments:
 //      loopNum - the loop number to remove
@@ -9587,6 +9588,16 @@ void Compiler::optMarkLoopRemoved(unsigned loopNum)
     if (optAnyChildNotRemoved(loopNum))
     {
         JITDUMP("Removed loop " FMT_LP " has one or more live children\n", loopNum);
+    }
+
+    for (BasicBlock* const auxBlock : Blocks())
+    {
+        if (auxBlock->bbNatLoopNum == loopNum)
+        {
+            JITDUMP("Resetting loop number for " FMT_BB " from " FMT_LP " to " FMT_LP ".\n", auxBlock->bbNum, loopNum,
+                    loop.lpParent);
+            auxBlock->bbNatLoopNum = loop.lpParent;
+        }
     }
 
 // Note: we can't call `fgDebugCheckLoopTable()` here because if there are live children, it will assert.


### PR DESCRIPTION
When a loop is removed, we should also reset the `bbNatLoopNum` present at the blocks to reflect the updated information.

Fixes: https://github.com/dotnet/runtime/issues/68769