### PR TITLE
Fix PeriodicTimer_ActiveOperations_TimerRooted test

### DIFF
--- a/src/libraries/System.Runtime/tests/System/Threading/PeriodicTimerTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Threading/PeriodicTimerTests.cs
@@ -146,6 +146,8 @@ namespace System.Threading.Tests
                         return (new WeakReference<PeriodicTimer>(timer), task);
                     }
 
+                    task.GetAwaiter().GetResult();
+
                     waitMs *= 2;
                 }
 

--- a/src/libraries/System.Runtime/tests/System/Threading/PeriodicTimerTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Threading/PeriodicTimerTests.cs
@@ -112,20 +112,44 @@ namespace System.Threading.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public async Task PeriodicTimer_ActiveOperations_TimerRooted()
         {
-            (WeakReference<PeriodicTimer> timer, ValueTask<bool> task) = Create();
+            // Step 1: Verify that if we have an active wait the timer does not get collected.
+            WeakReference<PeriodicTimer> timer = await CreateAndVerifyRooted();
 
-            WaitForTimerToBeCollected(timer, expected: false);
-
-            Assert.True(await task);
-
+            // Step 2: Verify that now the timer does get collected
             WaitForTimerToBeCollected(timer, expected: true);
 
+            // It is important that we do these two thing sin NoInlining
+            // methods. We are only guaranteed that references inside these
+            // methods are not live anymore when the functions return.
             [MethodImpl(MethodImplOptions.NoInlining)]
-            static (WeakReference<PeriodicTimer>, ValueTask<bool>) Create()
+            static async ValueTask<WeakReference<PeriodicTimer>> CreateAndVerifyRooted()
             {
-                var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(1));
-                ValueTask<bool> task = timer.WaitForNextTickAsync();
-                return (new WeakReference<PeriodicTimer>(timer), task);
+                (WeakReference<PeriodicTimer> timer, ValueTask<bool> task) = CreateActive();
+
+                WaitForTimerToBeCollected(timer, expected: false);
+
+                Assert.True(await task);
+
+                return timer;
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static (WeakReference<PeriodicTimer>, ValueTask<bool>) CreateActive()
+            {
+                int waitMs = 1;
+                for (int i = 0; i < 10; i++)
+                {
+                    var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(waitMs));
+                    ValueTask<bool> task = timer.WaitForNextTickAsync();
+                    if (!task.IsCompleted)
+                    {
+                        return (new WeakReference<PeriodicTimer>(timer), task);
+                    }
+
+                    waitMs *= 2;
+                }
+
+                throw new Exception("Expected to be able to create an active wait for a timer");
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System/Threading/PeriodicTimerTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Threading/PeriodicTimerTests.cs
@@ -118,7 +118,7 @@ namespace System.Threading.Tests
             // Step 2: Verify that now the timer does get collected
             WaitForTimerToBeCollected(timer, expected: true);
 
-            // It is important that we do these two thing sin NoInlining
+            // It is important that we do these two things in NoInlining
             // methods. We are only guaranteed that references inside these
             // methods are not live anymore when the functions return.
             [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
There are two problems with this test
1. `WaitForNextTickAsync` may return a synchronously completed task, in
   which case it does not root the timer, causing our first
   `WaitForTimerToBeCollected` to fail because the timer was collected.
   This problem is easily reproduced by adding a small sleep after
   constructing the `PeriodicTimer` in `Create`, and I believe it is the
   cause of #59542.
2. There is no guarantee that the timer is not still rooted after the
   wait finishes because the returned `ValueTask<bool>` may be keeping
   it alive (although, it seems unlikely Roslyn will extend the lifetime across the `await` like this).
   Fixed by wrapping in another NoInlining method.

Fix #59542