### PR TITLE
add architecture enum PPC64le

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Architecture.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Architecture.cs
@@ -13,5 +13,6 @@ namespace System.Runtime.InteropServices
         S390x,
         LoongArch64,
         Armv6,
+        PPC64le,
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Architecture.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Architecture.cs
@@ -13,6 +13,6 @@ namespace System.Runtime.InteropServices
         S390x,
         LoongArch64,
         Armv6,
-        PPC64le,
+        Ppc64le,
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.cs
@@ -69,7 +69,7 @@ namespace System.Runtime.InteropServices
 #elif TARGET_LOONGARCH64
             => Architecture.LoongArch64;
 #elif TARGET_POWERPC64
-            => Architecture.PPC64le;
+            => Architecture.Ppc64le;
 #else
 #error Unknown Architecture
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.cs
@@ -68,6 +68,8 @@ namespace System.Runtime.InteropServices
             => Architecture.S390x;
 #elif TARGET_LOONGARCH64
             => Architecture.LoongArch64;
+#elif TARGET_POWERPC64
+            => Architecture.PPC64le;
 #else
 #error Unknown Architecture
 #endif

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/CheckArchitectureTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/CheckArchitectureTests.cs
@@ -48,8 +48,8 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
                     Assert.Equal(Architecture.Armv6, processArch);
                     break;
 
-                case Architecture.PPC64le:
-                    Assert.Equal(Architecture.PPC64le, processArch);
+                case Architecture.Ppc64le:
+                    Assert.Equal(Architecture.Ppc64le, processArch);
                     break;
 
                 default:

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/CheckArchitectureTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/CheckArchitectureTests.cs
@@ -48,6 +48,10 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
                     Assert.Equal(Architecture.Armv6, processArch);
                     break;
 
+                case Architecture.PPC64le:
+                    Assert.Equal(Architecture.PPC64le, processArch);
+                    break;
+
                 default:
                     Assert.False(true, "Unexpected Architecture.");
                     break;

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -12861,6 +12861,7 @@ namespace System.Runtime.InteropServices
         S390x = 5,
         LoongArch64 = 6,
         Armv6 = 7,
+        PPC64le = 8,
     }
     public enum CharSet
     {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -12861,7 +12861,7 @@ namespace System.Runtime.InteropServices
         S390x = 5,
         LoongArch64 = 6,
         Armv6 = 7,
-        PPC64le = 8,
+        Ppc64le = 8,
     }
     public enum CharSet
     {


### PR DESCRIPTION
Add architecture enum for PPC64le. API proposal request raised [here ](https://github.com/dotnet/runtime/issues/67428)

Fixes https://github.com/dotnet/runtime/issues/67428