### PR TITLE
Ensure that Arm64 always sets the VectorTableLookup type for shuffle to be `byte` or `sbyte`

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -21658,6 +21658,9 @@ GenTree* Compiler::gtNewSimdShuffleNode(var_types   type,
         nodeBuilder.AddOperand(i, gtNewIconNode(vecCns[i]));
     }
 
+    // VectorTableLookup is only valid on byte/sbyte
+    simdBaseJitType = varTypeIsUnsigned(simdBaseType) ? CORINFO_TYPE_UBYTE : CORINFO_TYPE_BYTE;
+
     op2 = gtNewSimdHWIntrinsicNode(type, std::move(nodeBuilder), createIntrinsic, simdBaseJitType, simdSize,
                                    isSimdAsHWIntrinsic);
 


### PR DESCRIPTION
This resolves #68815.

I'm doing some additional testing locally to see if I can determine why CI didn't fail despite running the library tests on Arm64.