### PR TITLE
Use switch over a span in a few more places

### DIFF
--- a/src/libraries/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.TryReadStatusFile.cs
+++ b/src/libraries/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.TryReadStatusFile.cs
@@ -60,46 +60,45 @@ internal static partial class Interop
                     break;
                 }
 
-                ReadOnlySpan<char> name = line.Slice(0, startIndex);
                 ReadOnlySpan<char> value = line.Slice(startIndex + 1);
                 bool valueParsed = true;
 
+                switch (line.Slice(0, startIndex)) // name
+                {
 #if DEBUG
-                if (name.SequenceEqual("Pid"))
-                {
-                    valueParsed = int.TryParse(value, out results.Pid);
-                }
-                else
+                    case "Pid":
+                        valueParsed = int.TryParse(value, out results.Pid);
+                        break;
 #endif
-                if (name.SequenceEqual("VmHWM"))
-                {
-                    valueParsed = ulong.TryParse(value[..^3], out results.VmHWM);
-                }
-                else if (name.SequenceEqual("VmRSS"))
-                {
-                    valueParsed = ulong.TryParse(value[..^3], out results.VmRSS);
-                }
-                else if (name.SequenceEqual("VmData"))
-                {
-                    valueParsed = ulong.TryParse(value[..^3], out ulong vmData);
-                    results.VmData += vmData;
-                }
-                else if (name.SequenceEqual("VmSwap"))
-                {
-                    valueParsed = ulong.TryParse(value[..^3], out results.VmSwap);
-                }
-                else if (name.SequenceEqual("VmSize"))
-                {
-                    valueParsed = ulong.TryParse(value[..^3], out results.VmSize);
-                }
-                else if (name.SequenceEqual("VmPeak"))
-                {
-                    valueParsed = ulong.TryParse(value[..^3], out results.VmPeak);
-                }
-                else if (name.SequenceEqual("VmStk"))
-                {
-                    valueParsed = ulong.TryParse(value[..^3], out ulong vmStack);
-                    results.VmData += vmStack;
+                    case "VmHWM":
+                        valueParsed = ulong.TryParse(value[..^3], out results.VmHWM);
+                        break;
+
+                    case "VmRSS":
+                        valueParsed = ulong.TryParse(value[..^3], out results.VmRSS);
+                        break;
+
+                    case "VmData":
+                        valueParsed = ulong.TryParse(value[..^3], out ulong vmData);
+                        results.VmData += vmData;
+                        break;
+
+                    case "VmSwap":
+                        valueParsed = ulong.TryParse(value[..^3], out results.VmSwap);
+                        break;
+
+                    case "VmSize":
+                        valueParsed = ulong.TryParse(value[..^3], out results.VmSize);
+                        break;
+
+                    case "VmPeak":
+                        valueParsed = ulong.TryParse(value[..^3], out results.VmPeak);
+                        break;
+
+                    case "VmStk":
+                        valueParsed = ulong.TryParse(value[..^3], out ulong vmStack);
+                        results.VmData += vmStack;
+                        break;
                 }
 
                 Debug.Assert(valueParsed);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AsymmetricAlgorithm.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AsymmetricAlgorithm.cs
@@ -362,20 +362,12 @@ namespace System.Security.Cryptography
         public virtual void ImportFromPem(ReadOnlySpan<char> input)
         {
             PemKeyHelpers.ImportPem(input, label =>
-            {
-                if (label.SequenceEqual(PemLabels.Pkcs8PrivateKey))
+                label switch
                 {
-                    return ImportPkcs8PrivateKey;
-                }
-                else if (label.SequenceEqual(PemLabels.SpkiPublicKey))
-                {
-                    return ImportSubjectPublicKeyInfo;
-                }
-                else
-                {
-                    return null;
-                }
-            });
+                    PemLabels.Pkcs8PrivateKey => ImportPkcs8PrivateKey,
+                    PemLabels.SpkiPublicKey => ImportSubjectPublicKeyInfo,
+                    _ => null,
+                });
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECAlgorithm.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECAlgorithm.cs
@@ -698,24 +698,14 @@ namespace System.Security.Cryptography
         /// </remarks>
         public override void ImportFromPem(ReadOnlySpan<char> input)
         {
-            PemKeyHelpers.ImportPem(input, label => {
-                if (label.SequenceEqual(PemLabels.Pkcs8PrivateKey))
+            PemKeyHelpers.ImportPem(input, label =>
+                label switch
                 {
-                    return ImportPkcs8PrivateKey;
-                }
-                else if (label.SequenceEqual(PemLabels.SpkiPublicKey))
-                {
-                    return ImportSubjectPublicKeyInfo;
-                }
-                else if (label.SequenceEqual(PemLabels.EcPrivateKey))
-                {
-                    return ImportECPrivateKey;
-                }
-                else
-                {
-                    return null;
-                }
-            });
+                    PemLabels.Pkcs8PrivateKey => ImportPkcs8PrivateKey,
+                    PemLabels.SpkiPublicKey => ImportSubjectPublicKeyInfo,
+                    PemLabels.EcPrivateKey => ImportECPrivateKey,
+                    _ => null,
+                });
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSA.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSA.cs
@@ -662,28 +662,15 @@ namespace System.Security.Cryptography
         /// </remarks>
         public override void ImportFromPem(ReadOnlySpan<char> input)
         {
-            PemKeyHelpers.ImportPem(input, label => {
-                if (label.SequenceEqual(PemLabels.RsaPrivateKey))
+            PemKeyHelpers.ImportPem(input, label =>
+                label switch
                 {
-                    return ImportRSAPrivateKey;
-                }
-                else if (label.SequenceEqual(PemLabels.Pkcs8PrivateKey))
-                {
-                    return ImportPkcs8PrivateKey;
-                }
-                else if (label.SequenceEqual(PemLabels.RsaPublicKey))
-                {
-                    return ImportRSAPublicKey;
-                }
-                else if (label.SequenceEqual(PemLabels.SpkiPublicKey))
-                {
-                    return ImportSubjectPublicKeyInfo;
-                }
-                else
-                {
-                    return null;
-                }
-            });
+                    PemLabels.RsaPrivateKey => ImportRSAPrivateKey,
+                    PemLabels.Pkcs8PrivateKey => ImportPkcs8PrivateKey,
+                    PemLabels.RsaPublicKey => ImportRSAPublicKey,
+                    PemLabels.SpkiPublicKey => ImportSubjectPublicKeyInfo,
+                    _ => null,
+                });
         }
 
         /// <summary>


### PR DESCRIPTION
C# has added the ability to `switch` on a `ReadOnlySpan<char>`, using cascading `SequenceEquals` calls when there are only a few cases, and using the same hash-based jump table when there are enough cases.  Use it in a few more places.