### PR TITLE
Throw from MsQuicImplementationProvider if not supported.

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicImplementationProvider.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicImplementationProvider.cs
@@ -11,11 +11,21 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         internal override QuicListenerProvider CreateListener(QuicListenerOptions options)
         {
+            if (!IsSupported)
+            {
+                throw new PlatformNotSupportedException(SR.SystemNetQuic_PlatformNotSupported);
+            }
+
             return new MsQuicListener(options);
         }
 
         internal override QuicConnectionProvider CreateConnection(QuicClientConnectionOptions options)
         {
+            if (!IsSupported)
+            {
+                throw new PlatformNotSupportedException(SR.SystemNetQuic_PlatformNotSupported);
+            }
+
             return new MsQuicConnection(options);
         }
     }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicPlatformDetectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicPlatformDetectionTests.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Net.Quic.Implementations;
+using System.Net.Security;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Quic.Tests
+{
+    public class MsQuicPlatformDetectionTests : QuicTestBase<MsQuicProviderFactory>
+    {
+        public MsQuicPlatformDetectionTests(ITestOutputHelper output) : base(output) { }
+
+        public static bool IsQuicUnsupported => !IsSupported;
+
+        [ConditionalFact(nameof(IsQuicUnsupported))]
+        public void UnsupportedPlatforms_ThrowsPlatformNotSupportedException()
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => CreateQuicListener());
+            Assert.Throws<PlatformNotSupportedException>(() => CreateQuicConnection(new IPEndPoint(IPAddress.Loopback, 0)));
+        }
+    }
+}


### PR DESCRIPTION
Contributes to #56005.

#67039 added code to throw on truly unsupported platforms (like browser). This PR makes sure we throw on supported platforms (Windows/Linux) when MsQuic library could not be loaded.