### PR TITLE
Do not fold relocatable constants into displacements

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1215,15 +1215,18 @@ AGAIN:
                 break;
             }
 
-            if (op1->AsOp()->gtOp2->IsIntCnsFitsInI32() &&
-                FitsIn<INT32>(cns + op1->AsOp()->gtOp2->AsIntCon()->gtIconVal))
+            if (op1->AsOp()->gtOp2->IsIntCnsFitsInI32())
             {
-                cns += op1->AsOp()->gtOp2->AsIntCon()->gtIconVal;
-                op1 = op1->AsOp()->gtOp1;
+                GenTreeIntCon* addConst = op1->AsOp()->gtOp2->AsIntCon();
 
-                goto AGAIN;
+                if (addConst->ImmedValCanBeFolded(compiler, GT_ADD) && FitsIn<INT32>(cns + addConst->IconValue()))
+                {
+                    cns += addConst->IconValue();
+                    op1 = op1->AsOp()->gtOp1;
+
+                    goto AGAIN;
+                }
             }
-
             break;
 
         case GT_MUL:
@@ -1295,15 +1298,18 @@ AGAIN:
                 break;
             }
 
-            if (op2->AsOp()->gtOp2->IsIntCnsFitsInI32() &&
-                FitsIn<INT32>(cns + op2->AsOp()->gtOp2->AsIntCon()->gtIconVal))
+            if (op2->AsOp()->gtOp2->IsIntCnsFitsInI32())
             {
-                cns += op2->AsOp()->gtOp2->AsIntCon()->gtIconVal;
-                op2 = op2->AsOp()->gtOp1;
+                GenTreeIntCon* addConst = op2->AsOp()->gtOp2->AsIntCon();
+
+                if (addConst->ImmedValCanBeFolded(compiler, GT_ADD) && FitsIn<INT32>(cns + addConst->IconValue()))
+                {
+                    cns += addConst->IconValue();
+                    op2 = op2->AsOp()->gtOp1;
+                }
 
                 goto AGAIN;
             }
-
             break;
 
         case GT_MUL:

--- a/src/tests/JIT/Directed/ConstantFolding/HandlesInAddrModes.il
+++ b/src/tests/JIT/Directed/ConstantFolding/HandlesInAddrModes.il
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly HandlesInAddrModes { }
+.assembly extern System.Runtime { }
+
+.class HandlesInAddrModes
+{
+  .method public static int32 Main()
+  {
+    .entrypoint
+
+    ldc.i4 0
+    conv.i
+    call char .this::Problem(native int)
+    ldc.i4 120 // 'x'
+    ceq
+    ldc.i4 100
+    mul
+    ret
+  }
+
+  .method private static char Problem(native int idx) noinlining
+  {
+    ldstr "xyz"
+    call instance char& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) string::GetPinnableReference()
+    ldarg idx
+    ldc.i4 2
+    conv.i
+    mul
+    add
+    ldind.u2
+    ret
+  }
+}

--- a/src/tests/JIT/Directed/ConstantFolding/HandlesInAddrModes.ilproj
+++ b/src/tests/JIT/Directed/ConstantFolding/HandlesInAddrModes.ilproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Directed/ConstantFolding/folding_extends_int32_on_64_bit_hosts.cs
+++ b/src/tests/JIT/Directed/ConstantFolding/folding_extends_int32_on_64_bit_hosts.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 public class FoldingExtendsInt32On64BitHostsTest
 {
     // On 64 bit hosts, 32 bit constants are stored as 64 bit signed values.


### PR DESCRIPTION
When creating address modes, we try to look through cascading `ADD`s with constants that could contribute to the final displacement (`LEA`s "offset"). In doing so, we were failing to take into account the possibility that said constants could be relocatable handles, such as `[000016]` in the following tree:
```scala
N009 (  9, 11) [000009] ---XG------                         *  RETURN    int
N008 (  8, 10) [000008] ---XG------                         \--*  IND       ushort
N007 (  5,  8) [000007] -------N---                            \--*  ADD       byref
N003 (  3,  6) [000015] -----------                               +--*  ADD       byref
N001 (  1,  1) [000014] -----------                               |  +--*  CNS_INT   long   12 field offset Fseq[_firstChar]
N002 (  1,  4) [000016] H----------                               |  \--*  CNS_INT(h) ref    0x420068 [ICON_STR_HDL]
N006 (  2,  2) [000006] -------N---                               \--*  LSH       long
N004 (  1,  1) [000003] -----------                                  +--*  LCL_VAR   long   V00 arg0         u:1 (last use)
N005 (  1,  1) [000005] -----------                                  \--*  CNS_INT   long   1
```
We cannot fold such "constants" into `LEA`s, this change makes the address mode forming logic respect that.

Should fix the crashes seen in #68739.

No diffs are expected.