### PR TITLE
Single source of truth for System.Diagnostics.Processes annotations and docs

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.FreeBSD.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.FreeBSD.cs
@@ -7,11 +7,6 @@ namespace System.Diagnostics
 {
     public partial class ProcessThread
     {
-        /// <summary>
-        /// Returns or sets the priority level of the associated thread.  The priority level is
-        /// not an absolute level, but instead contributes to the actual thread priority by
-        /// considering the priority class of the process.
-        /// </summary>
         private ThreadPriorityLevel PriorityLevelCore
         {
             get
@@ -29,51 +24,16 @@ namespace System.Diagnostics
         // all threads e.g. reflects process start. This may be re-visited later.
         private static DateTime GetStartTime() => throw new PlatformNotSupportedException();
 
-        /// <summary>
-        /// Returns the amount of time the associated thread has spent utilizing the CPU.
-        /// It is the sum of the System.Diagnostics.ProcessThread.UserProcessorTime and
-        /// System.Diagnostics.ProcessThread.PrivilegedProcessorTime.
-        /// </summary>
-        [UnsupportedOSPlatform("ios")]
-        [UnsupportedOSPlatform("tvos")]
-        [SupportedOSPlatform("maccatalyst")]
-        public TimeSpan TotalProcessorTime
+        private TimeSpan GetTotalProcessorTime()
         {
-            get
-            {
-                Interop.Process.proc_stats stat = Interop.Process.GetThreadInfo(_processId, Id);
-                return Process.TicksToTimeSpan(stat.userTime + stat.systemTime);
-            }
+            Interop.Process.proc_stats stat = Interop.Process.GetThreadInfo(_processId, Id);
+            return Process.TicksToTimeSpan(stat.userTime + stat.systemTime);
         }
 
-        /// <summary>
-        /// Returns the amount of time the associated thread has spent running code
-        /// inside the application (not the operating system core).
-        /// </summary>
-        public TimeSpan UserProcessorTime
-        {
-            get
-            {
-                Interop.Process.proc_stats stat = Interop.Process.GetThreadInfo(_processId, Id);
-                return Process.TicksToTimeSpan(stat.userTime);
-            }
-        }
+        private TimeSpan GetUserProcessorTime()
+            => Process.TicksToTimeSpan(Interop.Process.GetThreadInfo(_processId, Id).userTime);
 
-        /// <summary>
-        /// Returns the amount of time the thread has spent running code inside the operating
-        /// system core.
-        /// </summary>
-        [UnsupportedOSPlatform("ios")]
-        [UnsupportedOSPlatform("tvos")]
-        [SupportedOSPlatform("maccatalyst")]
-        public TimeSpan PrivilegedProcessorTime
-        {
-            get
-            {
-                Interop.Process.proc_stats stat = Interop.Process.GetThreadInfo(_processId, Id);
-                return Process.TicksToTimeSpan(stat.systemTime);
-            }
-
-        }
+        private TimeSpan GetPrivilegedProcessorTime()
+            => Process.TicksToTimeSpan(Interop.Process.GetThreadInfo(_processId, Id).systemTime);
     }
 }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.Linux.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.Linux.cs
@@ -9,11 +9,6 @@ namespace System.Diagnostics
 {
     public partial class ProcessThread
     {
-        /// <summary>
-        /// Returns or sets the priority level of the associated thread.  The priority level is
-        /// not an absolute level, but instead contributes to the actual thread priority by
-        /// considering the priority class of the process.
-        /// </summary>
         private ThreadPriorityLevel PriorityLevelCore
         {
             // This mapping is relatively arbitrary.  0 is normal based on the man page,
@@ -29,56 +24,17 @@ namespace System.Diagnostics
             }
         }
 
-        /// <summary>
-        /// Returns the amount of time the thread has spent running code inside the operating
-        /// system core.
-        /// </summary>
-        [UnsupportedOSPlatform("ios")]
-        [UnsupportedOSPlatform("tvos")]
-        [SupportedOSPlatform("maccatalyst")]
-        public TimeSpan PrivilegedProcessorTime
-        {
-            get
-            {
-                Interop.procfs.ParsedStat stat = GetStat();
-                return Process.TicksToTimeSpan(stat.stime);
-            }
-        }
+        private TimeSpan GetPrivilegedProcessorTime() => Process.TicksToTimeSpan(GetStat().stime);
 
         private DateTime GetStartTime() => Process.BootTimeToDateTime(Process.TicksToTimeSpan(GetStat().starttime));
 
-        /// <summary>
-        /// Returns the amount of time the associated thread has spent utilizing the CPU.
-        /// It is the sum of the System.Diagnostics.ProcessThread.UserProcessorTime and
-        /// System.Diagnostics.ProcessThread.PrivilegedProcessorTime.
-        /// </summary>
-        [UnsupportedOSPlatform("ios")]
-        [UnsupportedOSPlatform("tvos")]
-        [SupportedOSPlatform("maccatalyst")]
-        public TimeSpan TotalProcessorTime
+        private TimeSpan GetTotalProcessorTime()
         {
-            get
-            {
-                Interop.procfs.ParsedStat stat = GetStat();
-                return Process.TicksToTimeSpan(stat.utime + stat.stime);
-            }
+            Interop.procfs.ParsedStat stat = GetStat();
+            return Process.TicksToTimeSpan(stat.utime + stat.stime);
         }
 
-        /// <summary>
-        /// Returns the amount of time the associated thread has spent running code
-        /// inside the application (not the operating system core).
-        /// </summary>
-        [UnsupportedOSPlatform("ios")]
-        [UnsupportedOSPlatform("tvos")]
-        [SupportedOSPlatform("maccatalyst")]
-        public TimeSpan UserProcessorTime
-        {
-            get
-            {
-                Interop.procfs.ParsedStat stat = GetStat();
-                return Process.TicksToTimeSpan(stat.utime);
-            }
-        }
+        private TimeSpan GetUserProcessorTime() => Process.TicksToTimeSpan(GetStat().utime);
 
         private Interop.procfs.ParsedStat GetStat()
         {

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.OSX.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.OSX.cs
@@ -7,11 +7,6 @@ namespace System.Diagnostics
 {
     public partial class ProcessThread
     {
-        /// <summary>
-        /// Returns or sets the priority level of the associated thread.  The priority level is
-        /// not an absolute level, but instead contributes to the actual thread priority by
-        /// considering the priority class of the process.
-        /// </summary>
         private static ThreadPriorityLevel PriorityLevelCore
         {
             // Does not appear to be a POSIX API to do this on macOS.
@@ -21,42 +16,17 @@ namespace System.Diagnostics
             set { throw new PlatformNotSupportedException(SR.ThreadPriorityNotSupported); }
         }
 
-        /// <summary>
-        /// Returns the amount of time the thread has spent running code inside the operating
-        /// system core.
-        /// </summary>
-        [UnsupportedOSPlatform("ios")]
-        [UnsupportedOSPlatform("tvos")]
-        [SupportedOSPlatform("maccatalyst")]
-        public TimeSpan PrivilegedProcessorTime => new TimeSpan((long)GetThreadInfo().pth_system_time);
+        private TimeSpan GetPrivilegedProcessorTime() => new TimeSpan((long)GetThreadInfo().pth_system_time);
 
         private static DateTime GetStartTime() => throw new PlatformNotSupportedException(); // macOS does not provide a way to get this data
 
-        /// <summary>
-        /// Returns the amount of time the associated thread has spent using the CPU.
-        /// It is the sum of the System.Diagnostics.ProcessThread.UserProcessorTime and
-        /// System.Diagnostics.ProcessThread.PrivilegedProcessorTime.
-        /// </summary>
-        [UnsupportedOSPlatform("ios")]
-        [UnsupportedOSPlatform("tvos")]
-        [SupportedOSPlatform("maccatalyst")]
-        public TimeSpan TotalProcessorTime
+        private TimeSpan GetTotalProcessorTime()
         {
-            get
-            {
-                Interop.libproc.proc_threadinfo info = GetThreadInfo();
-                return new TimeSpan((long)(info.pth_user_time + info.pth_system_time));
-            }
+            Interop.libproc.proc_threadinfo info = GetThreadInfo();
+            return new TimeSpan((long)(info.pth_user_time + info.pth_system_time));
         }
 
-        /// <summary>
-        /// Returns the amount of time the associated thread has spent running code
-        /// inside the application (not the operating system core).
-        /// </summary>
-        [UnsupportedOSPlatform("ios")]
-        [UnsupportedOSPlatform("tvos")]
-        [SupportedOSPlatform("maccatalyst")]
-        public TimeSpan UserProcessorTime => new TimeSpan((long)GetThreadInfo().pth_user_time);
+        private TimeSpan GetUserProcessorTime() => new TimeSpan((long)GetThreadInfo().pth_user_time);
 
         private Interop.libproc.proc_threadinfo GetThreadInfo()
         {

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.Unix.cs
@@ -7,44 +7,23 @@ namespace System.Diagnostics
 {
     public partial class ProcessThread
     {
-        /// <summary>Sets the processor that this thread would ideally like to run on.</summary>
-        public int IdealProcessor
+        private static void SetIdealProcessor(int value)
         {
-            set
-            {
-                // Nop.  This is a hint, and there's no good match for the Windows concept.
-            }
+            // Nop. This is a hint, and there's no good match for the Windows concept.
         }
 
-        /// <summary>
-        /// Resets the ideal processor so there is no ideal processor for this thread (e.g.
-        /// any processor is ideal).
-        /// </summary>
-        public void ResetIdealProcessor()
+        private static void ResetIdealProcessorCore()
         {
-            // Nop.  This is a hint, and there's no good match for the Windows concept.
+            // Nop. This is a hint, and there's no good match for the Windows concept.
         }
 
-        /// <summary>
-        /// Returns or sets whether this thread would like a priority boost if the user interacts
-        /// with user interface associated with this thread.
-        /// </summary>
         private static bool PriorityBoostEnabledCore
         {
             get { return false; }
             set { } // Nop
         }
 
-        /// <summary>
-        /// Sets which processors the associated thread is allowed to be scheduled to run on.
-        /// Each processor is represented as a bit: bit 0 is processor one, bit 1 is processor
-        /// two, etc.  For example, the value 1 means run on processor one, 2 means run on
-        /// processor two, 3 means run on processor one or two.
-        /// </summary>
-        [SupportedOSPlatform("windows")]
-        public IntPtr ProcessorAffinity
-        {
-            set { throw new PlatformNotSupportedException(); } // No ability to change the affinity of a thread in an arbitrary process
-        }
+        private static void SetProcessorAffinity(IntPtr value)
+            => throw new PlatformNotSupportedException(); // No ability to change the affinity of a thread in an arbitrary process
     }
 }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.cs
@@ -60,10 +60,10 @@ namespace System.Diagnostics
             get { return unchecked((int)_threadInfo._threadId); }
         }
 
-        /// <devdoc>
-        ///      Returns or sets whether this thread would like a priority boost if the user interacts
-        ///      with user interface associated with this thread.
-        /// </devdoc>
+        /// <summary>
+        /// Returns or sets whether this thread would like a priority boost if the user interacts
+        /// with user interface associated with this thread.
+        /// </summary>
         public bool PriorityBoostEnabled
         {
             get
@@ -81,11 +81,11 @@ namespace System.Diagnostics
             }
         }
 
-        /// <devdoc>
-        ///     Returns or sets the priority level of the associated thread.  The priority level is
-        ///     not an absolute level, but instead contributes to the actual thread priority by
-        ///     considering the priority class of the process.
-        /// </devdoc>
+        /// <summary>
+        /// Returns or sets the priority level of the associated thread.  The priority level is
+        /// not an absolute level, but instead contributes to the actual thread priority by
+        /// considering the priority class of the process.
+        /// </summary>
         public ThreadPriorityLevel PriorityLevel
         {
             [SupportedOSPlatform("windows")]
@@ -147,9 +147,54 @@ namespace System.Diagnostics
             get => GetStartTime();
         }
 
+        /// <summary>Sets the processor that this thread would ideally like to run on.</summary>
+        public int IdealProcessor { set { SetIdealProcessor(value); } }
+
+        /// <summary>
+        /// Resets the ideal processor so there is no ideal processor for this thread (e.g.
+        /// any processor is ideal).
+        /// </summary>
+        public void ResetIdealProcessor() => ResetIdealProcessorCore();
+
+        /// <summary>
+        /// Sets which processors the associated thread is allowed to be scheduled to run on.
+        /// Each processor is represented as a bit: bit 0 is processor one, bit 1 is processor
+        /// two, etc.  For example, the value 1 means run on processor one, 2 means run on
+        /// processor two, 3 means run on processor one or two.
+        /// </summary>
+        [SupportedOSPlatform("windows")]
+        public IntPtr ProcessorAffinity { set { SetProcessorAffinity(value); } }
+
+        /// <summary>
+        /// Returns the amount of time the thread has spent running code inside the operating
+        /// system core.
+        /// </summary>
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [SupportedOSPlatform("maccatalyst")]
+        public TimeSpan PrivilegedProcessorTime => GetPrivilegedProcessorTime();
+
+        /// <summary>
+        /// Returns the amount of time the associated thread has spent utilizing the CPU.
+        /// It is the sum of the System.Diagnostics.ProcessThread.UserProcessorTime and
+        /// System.Diagnostics.ProcessThread.PrivilegedProcessorTime.
+        /// </summary>
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [SupportedOSPlatform("maccatalyst")]
+        public TimeSpan TotalProcessorTime => GetTotalProcessorTime();
+
         /// <devdoc>
         ///     Helper to check preconditions for property access.
         /// </devdoc>
+        /// <summary>
+        /// Returns the amount of time the associated thread has spent running code
+        /// inside the application (not the operating system core).
+        /// </summary>
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [SupportedOSPlatform("maccatalyst")]
+        public TimeSpan UserProcessorTime => GetUserProcessorTime();
         private void EnsureState(State state)
         {
             if (((state & State.IsLocal) != (State)0) && _isRemoteMachine)

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.cs
@@ -6,13 +6,11 @@ using System.Runtime.Versioning;
 
 namespace System.Diagnostics
 {
-    /// <devdoc>
-    ///    <para>
-    ///       Represents a Win32 thread. This can be used to obtain
-    ///       information about the thread, such as it's performance characteristics. This is
-    ///       returned from the System.Diagnostics.Process.ProcessThread property of the System.Diagnostics.Process component.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>
+    /// Represents a Win32 thread. This can be used to obtain
+    /// information about the thread, such as it's performance characteristics. This is
+    /// returned from the System.Diagnostics.Process.ProcessThread property of the System.Diagnostics.Process component.
+    /// </summary>
     [Designer("System.Diagnostics.Design.ProcessThreadDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     public partial class ProcessThread : Component
     {
@@ -22,10 +20,6 @@ namespace System.Diagnostics
         private bool? _priorityBoostEnabled;
         private ThreadPriorityLevel? _priorityLevel;
 
-        /// <devdoc>
-        ///     Internal constructor.
-        /// </devdoc>
-        /// <internalonly/>
         internal ProcessThread(bool isRemoteMachine, int processId, ThreadInfo threadInfo)
         {
             _isRemoteMachine = isRemoteMachine;
@@ -33,28 +27,26 @@ namespace System.Diagnostics
             _threadInfo = threadInfo;
         }
 
-        /// <devdoc>
-        ///     Returns the base priority of the thread which is computed by combining the
-        ///     process priority class with the priority level of the associated thread.
-        /// </devdoc>
+        /// <summary>
+        /// Returns the base priority of the thread which is computed by combining the
+        /// process priority class with the priority level of the associated thread.
+        /// </summary>
         public int BasePriority
         {
             get { return _threadInfo._basePriority; }
         }
 
-        /// <devdoc>
-        ///     The current priority indicates the actual priority of the associated thread,
-        ///     which may deviate from the base priority based on how the OS is currently
-        ///     scheduling the thread.
-        /// </devdoc>
+        /// <summary>
+        /// The current priority indicates the actual priority of the associated thread,
+        /// which may deviate from the base priority based on how the OS is currently
+        /// scheduling the thread.
+        /// </summary>
         public int CurrentPriority
         {
             get { return _threadInfo._currentPriority; }
         }
 
-        /// <devdoc>
-        ///     Returns the unique identifier for the associated thread.
-        /// </devdoc>
+        /// <summary>Returns the unique identifier for the associated thread.</summary>
         public int Id
         {
             get { return unchecked((int)_threadInfo._threadId); }
@@ -107,26 +99,19 @@ namespace System.Diagnostics
             }
         }
 
-        /// <devdoc>
-        ///     Returns the memory address of the function that was called when the associated
-        ///     thread was started.
-        /// </devdoc>
+        /// <summary>Returns the memory address of the function that was called when the associated thread was started.</summary>
         public IntPtr StartAddress
         {
             get { return _threadInfo._startAddress; }
         }
 
-        /// <devdoc>
-        ///     Returns the current state of the associated thread, e.g. is it running, waiting, etc.
-        /// </devdoc>
+        /// <summary>Returns the current state of the associated thread, e.g. is it running, waiting, etc.</summary>
         public ThreadState ThreadState
         {
             get { return _threadInfo._threadState; }
         }
 
-        /// <devdoc>
-        ///     Returns the reason the associated thread is waiting, if any.
-        /// </devdoc>
+        /// <summary>Returns the reason the associated thread is waiting, if any.</summary>
         public ThreadWaitReason WaitReason
         {
             get
@@ -184,9 +169,6 @@ namespace System.Diagnostics
         [SupportedOSPlatform("maccatalyst")]
         public TimeSpan TotalProcessorTime => GetTotalProcessorTime();
 
-        /// <devdoc>
-        ///     Helper to check preconditions for property access.
-        /// </devdoc>
         /// <summary>
         /// Returns the amount of time the associated thread has spent running code
         /// inside the application (not the operating system core).
@@ -195,6 +177,8 @@ namespace System.Diagnostics
         [UnsupportedOSPlatform("tvos")]
         [SupportedOSPlatform("maccatalyst")]
         public TimeSpan UserProcessorTime => GetUserProcessorTime();
+
+        /// <summary>Helper to check preconditions for property access.</summary>
         private void EnsureState(State state)
         {
             if (((state & State.IsLocal) != (State)0) && _isRemoteMachine)
@@ -203,10 +187,7 @@ namespace System.Diagnostics
             }
         }
 
-        /// <summary>
-        ///      Preconditions for accessing properties.
-        /// </summary>
-        /// <internalonly/>
+        /// <summary>Preconditions for accessing properties.</summary>
         private enum State
         {
             IsLocal = 0x2

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.iOS.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.iOS.cs
@@ -7,53 +7,18 @@ namespace System.Diagnostics
 {
     public partial class ProcessThread
     {
-        /// <summary>
-        /// Returns or sets the priority level of the associated thread.  The priority level is
-        /// not an absolute level, but instead contributes to the actual thread priority by
-        /// considering the priority class of the process.
-        /// </summary>
         private static ThreadPriorityLevel PriorityLevelCore
         {
             get { throw new PlatformNotSupportedException(); }
             set { throw new PlatformNotSupportedException(); }
         }
 
-        /// <summary>
-        /// Returns the amount of time the thread has spent running code inside the operating
-        /// system core.
-        /// </summary>
-        [UnsupportedOSPlatform("ios")]
-        [UnsupportedOSPlatform("tvos")]
-        [SupportedOSPlatform("maccatalyst")]
-        public TimeSpan PrivilegedProcessorTime
-        {
-            get { throw new PlatformNotSupportedException(); }
-        }
+        private static TimeSpan GetPrivilegedProcessorTime() => throw new PlatformNotSupportedException();
 
         private static DateTime GetStartTime() => throw new PlatformNotSupportedException();
-        /// <summary>
-        /// Returns the amount of time the associated thread has spent utilizing the CPU.
-        /// It is the sum of the System.Diagnostics.ProcessThread.UserProcessorTime and
-        /// System.Diagnostics.ProcessThread.PrivilegedProcessorTime.
-        /// </summary>
-        [UnsupportedOSPlatform("ios")]
-        [UnsupportedOSPlatform("tvos")]
-        [SupportedOSPlatform("maccatalyst")]
-        public TimeSpan TotalProcessorTime
-        {
-            get { throw new PlatformNotSupportedException(); }
-        }
 
-        /// <summary>
-        /// Returns the amount of time the associated thread has spent running code
-        /// inside the application (not the operating system core).
-        /// </summary>
-        [UnsupportedOSPlatform("ios")]
-        [UnsupportedOSPlatform("tvos")]
-        [SupportedOSPlatform("maccatalyst")]
-        public TimeSpan UserProcessorTime
-        {
-            get { throw new PlatformNotSupportedException(); }
-        }
+        private static TimeSpan GetTotalProcessorTime() => throw new PlatformNotSupportedException();
+
+        private static TimeSpan GetUserProcessorTime() => throw new PlatformNotSupportedException();
     }
 }


### PR DESCRIPTION
In order to avoid API docs and compat inconsistencies (https://github.com/dotnet/runtime/pull/68834#pullrequestreview-961435659), we could use the facade pattern. The only disadvantage I can see right now is having an additional method invocation. But since these methods usually perform a very expensive sys-call, I don't believe that it matters.

I took `ProcessThread` and experimented with it and got 316 deletions and 114 additions.

@ericstj @stephentoub @Jozkee please let me know if you believe that this is the right direction. If it is, I am going to refactor the rest of the `System.Diagnostics.Processes` APIs.