### PR TITLE
Fixing wrong stack size calculation in the mono interpreter for back edges

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -5687,7 +5687,7 @@ retry_code_gen:
 					td->last_ins->flags |= INTERP_INST_FLAG_PROTECTED_NEWOBJ;
 				// Parameters and this pointer are popped of the stack. The return value remains
 				td->sp -= csignature->param_count + 1;
-				// Save the arguments for the call
+				 // Save the arguments for the call
 				int *call_args = (int*) mono_mempool_alloc (td->mempool, (csignature->param_count + 2) * sizeof (int));
 				for (int i = 0; i < csignature->param_count + 1; i++)
 					call_args [i] = td->sp [i].local;
@@ -6797,7 +6797,7 @@ retry_code_gen:
 		}
 		case MONO_CUSTOM_PREFIX:
 			++td->ip;
-				switch (*td->ip) {
+		        switch (*td->ip) {
 				case CEE_MONO_RETHROW:
 					CHECK_STACK (td, 1);
 					interp_add_ins (td, MINT_MONO_RETHROW);
@@ -7161,11 +7161,11 @@ retry_code_gen:
 					 *    newobj Delegate::.ctor
 					 */
 					if (next_ip < end &&
-						*next_ip == CEE_NEWOBJ &&
-						((ctor_method = interp_get_method (method, read32 (next_ip + 1), image, generic_context, error))) &&
-						is_ok (error) &&
-						m_class_get_parent (ctor_method->klass) == mono_defaults.multicastdelegate_class &&
-						!strcmp (ctor_method->name, ".ctor")) {
+					    *next_ip == CEE_NEWOBJ &&
+					    ((ctor_method = interp_get_method (method, read32 (next_ip + 1), image, generic_context, error))) &&
+					    is_ok (error) &&
+					    m_class_get_parent (ctor_method->klass) == mono_defaults.multicastdelegate_class &&
+					    !strcmp (ctor_method->name, ".ctor")) {
 						mono_error_set_not_supported (error, "Cannot create delegate from method with UnmanagedCallersOnlyAttribute");
 						goto exit;
 					}

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -7438,9 +7438,9 @@ retry_code_gen:
 			interp_add_ins (td, MINT_NOP);
 	}
 
-	// Mark the last block with emitting information
+	// Mark the last block with emitting information (if not already marked)
 	// and retry code generation if there was any skipped block.
-	td->cbb->already_emitted = emitting;
+	td->cbb->already_emitted |= emitting;
 	if (skipped_bbs_present) {
 		// Reset the instruction, stack pointer, bbs and flags for the next pass
 		td->ip = header->code;

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2724,12 +2724,11 @@ interp_inline_method (TransformData *td, MonoMethod *target_method, MonoMethodHe
 			tmp_bb->il_offset = prev_ip - prev_il_code;
 			tmp_bb = tmp_bb->next_bb;
 		}
-		// After inlining, new blocks have been added as continuation to the original 'prev' block.
-		// Once the inlining is complete, we need to mark the original block as emitted as well.
-		// NOTE: There is also a potential problem with:
-		// td->offset_to_bb[td->cdd->il_offset] which will not point to the newly added block (containing inlined call),
-		// but to the original 'prev' block.
-		prev_cbb->already_emitted = TRUE; // FIX ME: this is fishy
+		// At this point, new blocks have been added as continuation to the caller - 'prev' block,
+		// and td->cbb becomes the last inlined block.
+		// Because of this, we need to force-mark the 'prev' block as 'already_emitted', so we do
+		// not lose the information.
+		prev_cbb->already_emitted = TRUE;
 	}
 
 	td->ip = prev_ip;

--- a/src/mono/mono/mini/interp/transform.h
+++ b/src/mono/mono/mini/interp/transform.h
@@ -126,6 +126,9 @@ struct _InterpBasicBlock {
 	// This block has special semantics and it shouldn't be optimized away
 	int eh_block : 1;
 	int dead: 1;
+
+	// Mark the block if its code has been emitted
+	gboolean already_emitted;
 };
 
 typedef enum {

--- a/src/mono/mono/mini/interp/transform.h
+++ b/src/mono/mono/mini/interp/transform.h
@@ -128,7 +128,7 @@ struct _InterpBasicBlock {
 	int dead: 1;
 
 	// Mark the block if its code has been emitted
-	gboolean already_emitted;
+	int already_emitted : 1;
 };
 
 typedef enum {

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1917,9 +1917,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_18295/**">
             <Issue>https://github.com/dotnet/runtime/issues/34196</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_23411/**">
-            <Issue>https://github.com/dotnet/runtime/issues/34196</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_23791/**">
             <Issue>https://github.com/dotnet/runtime/issues/34385</Issue>
         </ExcludeList>
@@ -2723,6 +2720,12 @@
             <Issue>needs triage</Issue>
         </ExcludeList>
         <!-- End interpreter issues -->
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and '$(RuntimeVariant)' != 'monointerpreter' ">
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_23411/**">
+            <Issue>https://github.com/dotnet/runtime/issues/68905</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and '$(RuntimeVariant)' == 'llvmaot' ">


### PR DESCRIPTION
Introduced changes are fixing the problem of wrong stack size calculation for control flows with back edges.

This has been achieved by modifying the code generation loop in `generate_code` function to:

- Skip blocks which have uninitialised stack sizes 
- Mark emitted blocks
- When the loop finishes if the code generation is not complete (there were some skipped blocks), the code generation loop is repeated
- Following passes only handle blocks skipped in previous ones (already emitted blocks are not taken into account)

This change may impact performance.

Fixes #68757.