### PR TITLE
Update generators.targets

### DIFF
--- a/eng/generators.targets
+++ b/eng/generators.targets
@@ -31,11 +31,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'@(EnabledGenerators)' != '' and
-                        @(EnabledGenerators->AnyHaveMetadataValue('Identity', 'LibraryImportGenerator'))">
-    <!-- Only add the following files if we are not on the latest TFM. -->
-    <Compile Include="$(CoreLibSharedDir)System\Runtime\InteropServices\LibraryImportAttribute.cs;
-                      $(CoreLibSharedDir)System\Runtime\InteropServices\StringMarshalling.cs"
-             Condition="'$(TargetFrameworkMoniker)' != '$(NetCoreAppCurrentTargetFrameworkMoniker)'" />
+                        @(EnabledGenerators->AnyHaveMetadataValue('Identity', 'LibraryImportGenerator')) and
+                        !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">
+    <Compile Include="$(CoreLibSharedDir)System\Runtime\InteropServices\LibraryImportAttribute.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Runtime\InteropServices\StringMarshalling.cs" />
   </ItemGroup>
 
   <!-- Use this complex item list based filtering to add the ProjectReference to make sure dotnet/runtime stays compatible with NuGet Static Graph Restore. -->

--- a/eng/generators.targets
+++ b/eng/generators.targets
@@ -7,7 +7,7 @@
   <ItemGroup>
     <EnabledGenerators Include="LibraryImportGenerator" Condition="'$(EnableLibraryImportGenerator)' == 'true'" />
     <!-- If the current project is not System.Private.CoreLib, we enable the LibraryImportGenerator source generator
-         when the project is a C# source project that either:
+         when the project is a C# source project that:
          - doesn't target the latest TFM or
          - references everything from the targeting pack (OOB) or
          - references System.Private.CoreLib, or

--- a/eng/generators.targets
+++ b/eng/generators.targets
@@ -37,7 +37,8 @@
     <Compile Include="$(CoreLibSharedDir)System\Runtime\InteropServices\StringMarshalling.cs" />
   </ItemGroup>
 
-  <!-- Use this complex item list based filtering to add the ProjectReference to make sure dotnet/runtime stays compatible with NuGet Static Graph Restore. -->
+  <!-- Use this complex item list based filtering to add the ProjectReference to make sure dotnet/runtime stays compatible with NuGet Static Graph Restore.
+       That is required as the EnabledGenerators condition checks on the Reference and ProjectReference items and hence can't be a property condition. -->
   <ItemGroup Condition="'@(EnabledGenerators)' != '' and
                         @(EnabledGenerators->AnyHaveMetadataValue('Identity', 'LibraryImportGenerator'))">
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\LibraryImportGenerator\LibraryImportGenerator.csproj;
@@ -46,6 +47,7 @@
                       ReferenceOutputAssembly="false" />
   </ItemGroup>
 
+  <!-- Use a normal property condition as this source generator is opt-in and doesn't read from an item list. -->
   <ItemGroup Condition="'$(EnableRegexGenerator)' == 'true'">
     <ProjectReference Include="$(LibrariesProjectRoot)System.Text.RegularExpressions\gen\System.Text.RegularExpressions.Generator.csproj"
                       OutputItemType="Analyzer"

--- a/eng/generators.targets
+++ b/eng/generators.targets
@@ -1,68 +1,56 @@
 <Project>
-
   <PropertyGroup>
-    <EnableLibraryImportGenerator Condition="'$(EnableLibraryImportGenerator)' == ''
-                        and '$(MSBuildProjectName)' == 'System.Private.CoreLib'">true</EnableLibraryImportGenerator>
-    <IncludeLibraryImportGeneratorSources Condition="'$(IncludeLibraryImportGeneratorSources)' == ''">true</IncludeLibraryImportGeneratorSources>
+    <EnableLibraryImportGenerator Condition="'$(EnableLibraryImportGenerator)' == '' and
+                                             '$(MSBuildProjectName)' == 'System.Private.CoreLib'">true</EnableLibraryImportGenerator>
   </PropertyGroup>
+
   <ItemGroup>
     <EnabledGenerators Include="LibraryImportGenerator" Condition="'$(EnableLibraryImportGenerator)' == 'true'" />
     <!-- If the current project is not System.Private.CoreLib, we enable the LibraryImportGenerator source generator
          when the project is a C# source project that either:
+         - doesn't target the latest TFM or
+         - references everything from the targeting pack (OOB) or
          - references System.Private.CoreLib, or
          - references System.Runtime.InteropServices -->
     <EnabledGenerators Include="LibraryImportGenerator"
-                       Condition="'$(EnableLibraryImportGenerator)' == ''
-                        and '$(IsSourceProject)' == 'true'
-                        and '$(MSBuildProjectExtension)' == '.csproj'
-                        and (
-                          ('@(Reference)' != ''
-                            and @(Reference->AnyHaveMetadataValue('Identity', 'System.Runtime.InteropServices')))
-                          or ('@(ProjectReference)' != ''
-                            and @(ProjectReference->AnyHaveMetadataValue('Identity', '$(CoreLibProject)')))
-                          or ('$(NetCoreAppCurrentTargetFrameworkMoniker)' == '$(TargetFrameworkMoniker)'
-                            and '$(DisableImplicitFrameworkReferences)' != 'true'))" />
-    <EnabledGenerators Include="LibraryImportGenerator"
-                       Condition="'$(EnableLibraryImportGenerator)' == ''
-                        and '$(IsSourceProject)' == 'true'
-                        and '$(MSBuildProjectExtension)' == '.csproj'
-                        and ('$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == '.NETFramework' or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '$(NetCoreAppCurrentVersion)'))))" />
+                       Condition="'$(EnableLibraryImportGenerator)' == '' and
+                                  '$(IsSourceProject)' == 'true' and
+                                  '$(MSBuildProjectExtension)' == '.csproj' and
+                                  (
+                                    '$(TargetFrameworkMoniker)' != '$(NetCoreAppCurrentTargetFrameworkMoniker)' or
+                                    '$(DisableImplicitFrameworkReferences)' != 'true' or
+                                    (
+                                      '@(Reference)' != '' and
+                                      @(Reference->AnyHaveMetadataValue('Identity', 'System.Runtime.InteropServices'))
+                                    ) or
+                                    (
+                                      '@(ProjectReference)' != '' and
+                                      @(ProjectReference->AnyHaveMetadataValue('Identity', '$(CoreLibProject)'))
+                                    )
+                                  )" />
   </ItemGroup>
 
-  <!-- Use this complex ItemGroup-based filtering to add the ProjectReference to make sure dotnet/runtime stays compatible with NuGet Static Graph Restore. -->
-  <ItemGroup Condition="'@(EnabledGenerators)' != ''
-                        and @(EnabledGenerators->AnyHaveMetadataValue('Identity', 'LibraryImportGenerator'))">
-    <ProjectReference
-      Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\LibraryImportGenerator\LibraryImportGenerator.csproj"
-      OutputItemType="Analyzer"
-      ReferenceOutputAssembly="false" />
-    <ProjectReference
-      Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\Microsoft.Interop.SourceGeneration\Microsoft.Interop.SourceGeneration.csproj"
-      OutputItemType="Analyzer"
-      ReferenceOutputAssembly="false" />
-  </ItemGroup>
-  <ItemGroup Condition="'@(EnabledGenerators)' != ''
-                        and @(EnabledGenerators->AnyHaveMetadataValue('Identity', 'LibraryImportGenerator'))
-                        and '$(IncludeLibraryImportGeneratorSources)' == 'true'">
-
+  <ItemGroup Condition="'@(EnabledGenerators)' != '' and
+                        @(EnabledGenerators->AnyHaveMetadataValue('Identity', 'LibraryImportGenerator'))">
     <!-- Only add the following files if we are not on the latest TFM. -->
-    <Compile Condition="'$(NetCoreAppCurrentTargetFrameworkMoniker)' != '$(TargetFrameworkMoniker)'"
-             Include="$(CoreLibSharedDir)System\Runtime\InteropServices\LibraryImportAttribute.cs" />
-    <Compile Condition="'$(NetCoreAppCurrentTargetFrameworkMoniker)' != '$(TargetFrameworkMoniker)'"
-             Include="$(CoreLibSharedDir)System\Runtime\InteropServices\StringMarshalling.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Runtime\InteropServices\LibraryImportAttribute.cs;
+                      $(CoreLibSharedDir)System\Runtime\InteropServices\StringMarshalling.cs"
+             Condition="'$(TargetFrameworkMoniker)' != '$(NetCoreAppCurrentTargetFrameworkMoniker)'" />
   </ItemGroup>
 
-  <ItemGroup>
-    <EnabledGenerators Include="RegexGenerator" Condition="'$(EnableRegexGenerator)' == 'true'" />
+  <!-- Use this complex item list based filtering to add the ProjectReference to make sure dotnet/runtime stays compatible with NuGet Static Graph Restore. -->
+  <ItemGroup Condition="'@(EnabledGenerators)' != '' and
+                        @(EnabledGenerators->AnyHaveMetadataValue('Identity', 'LibraryImportGenerator'))">
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\LibraryImportGenerator\LibraryImportGenerator.csproj;
+                                $(LibrariesProjectRoot)System.Runtime.InteropServices\gen\Microsoft.Interop.SourceGeneration\Microsoft.Interop.SourceGeneration.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
-  <!-- Use this complex ItemGroup-based filtering to add the ProjectReference to make sure dotnet/runtime stays compatible with NuGet Static Graph Restore. -->
-  <ItemGroup Condition="'@(EnabledGenerators)' != ''
-                        and @(EnabledGenerators->AnyHaveMetadataValue('Identity', 'RegexGenerator'))">
-    <ProjectReference
-      Include="$(LibrariesProjectRoot)System.Text.RegularExpressions/gen/System.Text.RegularExpressions.Generator.csproj"
-      OutputItemType="Analyzer"
-      ReferenceOutputAssembly="false" />
+  <ItemGroup Condition="'$(EnableRegexGenerator)' == 'true'">
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Text.RegularExpressions\gen\System.Text.RegularExpressions.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <Target Name="ConfigureGenerators"
@@ -79,5 +67,5 @@
     </PropertyGroup>
   </Target>
 
-  <Import Project="$(LibrariesProjectRoot)System.Runtime.InteropServices/gen/LibraryImportGenerator/Microsoft.Interop.LibraryImportGenerator.props" />
+  <Import Project="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\LibraryImportGenerator\Microsoft.Interop.LibraryImportGenerator.props" />
 </Project>


### PR DESCRIPTION
Changes:
- Improve perf of LibraryImportGenerator condition and simplify it
- Use the same msbuild code styling as in other projects in src/libraries
- Update comments that were outdated
- Remove the item conditions for the regex source generator which doesn't
  work well with the CPS (common project system) inside VS.
- Remove unnecessary property