### PR TITLE
Fix VSTest and dotnet test broken on .NETFramework

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -155,7 +155,7 @@
     <MicrosoftDotNetHotReloadUtilsGeneratorBuildToolVersion>1.0.2-alpha.0.22178.2</MicrosoftDotNetHotReloadUtilsGeneratorBuildToolVersion>
     <XUnitVersion>2.4.2-pre.22</XUnitVersion>
     <XUnitAnalyzersVersion>0.12.0-pre.20</XUnitAnalyzersVersion>
-    <XUnitRunnerVisualStudioVersion>2.4.2</XUnitRunnerVisualStudioVersion>
+    <XUnitRunnerVisualStudioVersion>2.4.4</XUnitRunnerVisualStudioVersion>
     <CoverletCollectorVersion>3.1.2</CoverletCollectorVersion>
     <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
     <SQLitePCLRawbundle_greenVersion>2.0.4</SQLitePCLRawbundle_greenVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -155,7 +155,7 @@
     <MicrosoftDotNetHotReloadUtilsGeneratorBuildToolVersion>1.0.2-alpha.0.22178.2</MicrosoftDotNetHotReloadUtilsGeneratorBuildToolVersion>
     <XUnitVersion>2.4.2-pre.22</XUnitVersion>
     <XUnitAnalyzersVersion>0.12.0-pre.20</XUnitAnalyzersVersion>
-    <XUnitRunnerVisualStudioVersion>2.4.4</XUnitRunnerVisualStudioVersion>
+    <XUnitRunnerVisualStudioVersion>2.4.5</XUnitRunnerVisualStudioVersion>
     <CoverletCollectorVersion>3.1.2</CoverletCollectorVersion>
     <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
     <SQLitePCLRawbundle_greenVersion>2.0.4</SQLitePCLRawbundle_greenVersion>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/68384

For a detailed explanation why updating the xunit.runner.visualstudio fixes .NETFramework dotnet test and VSTest invocation please see the above linked issue.