### PR TITLE
[release/6.0] Disable ZipFile_Unix.UnixCreateSetsPermissionsInExternalAttributes on Apple OSs

### DIFF
--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Unix.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Unix.cs
@@ -9,6 +9,8 @@ namespace System.IO.Compression.Tests
     public class ZipFile_Unix : ZipFileTestBase
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/68293", TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60581", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void UnixCreateSetsPermissionsInExternalAttributes()
         {
             // '7600' tests that S_ISUID, S_ISGID, and S_ISVTX bits get preserved in ExternalAttributes


### PR DESCRIPTION
Something related to Unix permissions changed in all the Apple platforms and is currently affecting CI in `main` and `release/6.0`.

Related issues:

- https://github.com/dotnet/runtime/issues/68293
- https://github.com/dotnet/runtime/issues/60581

Disabling tests in this branch too to unblock CI in backport PRs.

Test-only change, so no need for tactics approval.