### PR TITLE
Use Docker images from mcr.microsoft.com in EnterpriseTests

### DIFF
--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/Dockerfile
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20220421022739-9c434db
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/kdc/Dockerfile
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/kdc/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20220421022739-9c434db
 
 COPY ./kdc/kadm5.acl /etc/krb5kdc/
 COPY ./kdc/kdc.conf /etc/krb5kdc/


### PR DESCRIPTION
We started getting warnings in the build about using images from docker directly, see https://docs.opensource.microsoft.com/tools/nuget_security_analysis/container_registry_analysis/

The image from dotnet-buildtools-prereqs-docker can be used instead.