### PR TITLE
[release/6.0] Fix missing metadata for ThreadPool Event

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/NativeRuntimeEventSource.PortableThreadPool.NativeSinks.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/NativeRuntimeEventSource.PortableThreadPool.NativeSinks.cs
@@ -49,6 +49,7 @@ namespace System.Diagnostics.Tracing
         {
             public const EventOpcode IOEnqueue = (EventOpcode)13;
             public const EventOpcode IODequeue = (EventOpcode)14;
+            public const EventOpcode IOPack = (EventOpcode)15;
             public const EventOpcode Wait = (EventOpcode)90;
             public const EventOpcode Sample = (EventOpcode)100;
             public const EventOpcode Adjustment = (EventOpcode)101;
@@ -203,6 +204,18 @@ namespace System.Diagnostics.Tracing
                 return;
             }
             LogThreadPoolWorkingThreadCount(Count, ClrInstanceID);
+        }
+
+        [Event(65, Level = EventLevel.Verbose, Message = Messages.IO, Task = Tasks.ThreadPool, Opcode = Opcodes.IOPack, Version = 0, Keywords = Keywords.ThreadingKeyword)]
+        private unsafe void ThreadPoolIOPack(
+            IntPtr NativeOverlapped,
+            IntPtr Overlapped,
+            ushort ClrInstanceID = DefaultClrInstanceId)
+        {
+            // In .NET 6, this event is exclusively fired in CoreCLR from a QCALL.
+            // This function only needs to exist for the EventSource to generate metadata
+            // for in-process EventListeners. It will not be called.
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/NativeRuntimeEventSource.PortableThreadPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/NativeRuntimeEventSource.PortableThreadPool.cs
@@ -51,6 +51,7 @@ namespace System.Diagnostics.Tracing
         {
             public const EventOpcode IOEnqueue = (EventOpcode)13;
             public const EventOpcode IODequeue = (EventOpcode)14;
+            public const EventOpcode IOPack = (EventOpcode)15;
             public const EventOpcode Wait = (EventOpcode)90;
             public const EventOpcode Sample = (EventOpcode)100;
             public const EventOpcode Adjustment = (EventOpcode)101;

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -960,6 +960,10 @@
 
     <!-- Known failures for mono runtime on *all* architectures/operating systems in *all* runtime modes -->
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono'" >
+        <ExcludeList Include = "$(XunitTestBinBase)/tracing/runtimeeventsource/nativeruntimeeventsource/*">
+            <Issue>https://github.com/dotnet/runtime/issues/68032</Issue>
+        </ExcludeList>
+        
         <ExcludeList Include = "$(XunitTestBinBase)/reflection/GenericAttribute/**">
             <Issue>https://github.com/dotnet/runtime/issues/56887</Issue>
         </ExcludeList>

--- a/src/tests/tracing/runtimeeventsource/nativeruntimeeventsource.csproj
+++ b/src/tests/tracing/runtimeeventsource/nativeruntimeeventsource.csproj
@@ -7,15 +7,9 @@
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- This test has a secondary thread with an infinite loop -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <!--
-      Test is blocking official build.
-      Related failures: #18907, #19340, #22441, #22729.
-      Issue tracking to re-enable: #22898.
-    -->
-    <DisableProjectBuild>true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="RuntimeEventSourceTest.cs" />
+    <Compile Include="NativeRuntimeEventSourceTest.cs" />
     <ProjectReference Include="../common/common.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
fixes #65630

Minimal version of #67150

## Customer Impact
This is a customer-reported issue.

If a user subscribes an `EventListener` to threadpool events in .NET 6 on Windows, it may cause a `NullReferenceException` when the `EventListener` is disposed.

Root cause: There is a missing ThreadPool event method on `NativeRuntimeEventSource` for overlapped IO. This event was never implemented, so `EventSource` never generates the metadata for it. When the `EventListener` receives this event and tries to look up the metadata (stored in an array of structs), it encounters `null` values unexpectedly. This causes the `Task` to fail. This `Task` is awaited in the `Dispose` method and renders the exception then.

See #65630 for more details

## Testing

This patch includes a test and is currently passing in main. This test covers this issue as well as the overall functionality of `NativeRuntimeEventSource`.

## Risk
 
Low risk.

In order to actualize the NRE from the issue, a user must do the following:
1. Be on Windows.
2. Create an implementation of `EventListener`
3. Enable ThreadPool events
4. Trigger OverlappedIO <-- causes the NRE on a background task and stops all events from being read in the `EventListener`
5. Dispose the `EventListener` <-- actualizes the NRE by awaiting the background task