### PR TITLE
Remove the pid argument on Windows createdump only take dumps of the parent process

### DIFF
--- a/src/coreclr/debug/createdump/CMakeLists.txt
+++ b/src/coreclr/debug/createdump/CMakeLists.txt
@@ -30,6 +30,7 @@ if(CLR_CMAKE_HOST_WIN32)
         version.lib
         dbghelp.lib
         ws2_32.lib
+        ntdll.lib
     )
 
 else(CLR_CMAKE_HOST_WIN32)

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -4046,7 +4046,7 @@ BuildCreateDumpCommandLine(
         }
     }
 
-    commandLine.AppendPrintf("%s %d", DumpGeneratorName, GetCurrentProcessId());
+    commandLine.AppendASCII(DumpGeneratorName);
 
     if (dumpName != nullptr)
     {


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/42646

I double checked that NtQueryInformationProcess is supported across all the version of Windows .NET supports.