### PR TITLE
Fixed the yp_spin_count_unit to be a factor of the original_spin_count_unit rather than a continually increasing value

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -44306,8 +44306,8 @@ void GCHeap::SetYieldProcessorScalingFactor (float scalingFactor)
     int saved_yp_spin_count_unit = yp_spin_count_unit;
     yp_spin_count_unit = (int)((float)original_spin_count_unit * scalingFactor / (float)9);
 
-    // It's very suspicious if it becomes 0
-    if (yp_spin_count_unit == 0)
+    // It's very suspicious if it becomes 0 and also, we don't want to spin too much.
+    if ((yp_spin_count_unit == 0) || (yp_spin_count_unit > 32768))
     {
         yp_spin_count_unit = saved_yp_spin_count_unit;
     }

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -92,6 +92,7 @@ BOOL bgc_heap_walk_for_etw_p = FALSE;
 #define UOH_ALLOCATION_RETRY_MAX_COUNT 2
 
 uint32_t yp_spin_count_unit = 0;
+uint32_t original_spin_count_unit = 0;
 size_t loh_size_threshold = LARGE_OBJECT_SIZE;
 
 #ifdef GC_CONFIG_DRIVEN
@@ -13217,6 +13218,8 @@ HRESULT gc_heap::initialize_gc (size_t soh_segment_size,
 #else
     yp_spin_count_unit = 32 * g_num_processors;
 #endif //MULTIPLE_HEAPS
+
+    original_spin_count_unit = yp_spin_count_unit;
 
 #if defined(__linux__)
     GCToEEInterface::UpdateGCEventStatus(static_cast<int>(GCEventStatus::GetEnabledLevel(GCEventProvider_Default)),
@@ -44301,7 +44304,7 @@ void GCHeap::SetYieldProcessorScalingFactor (float scalingFactor)
 {
     assert (yp_spin_count_unit != 0);
     int saved_yp_spin_count_unit = yp_spin_count_unit;
-    yp_spin_count_unit = (int)((float)yp_spin_count_unit * scalingFactor / (float)9);
+    yp_spin_count_unit = (int)((float)original_spin_count_unit * scalingFactor / (float)9);
 
     // It's very suspicious if it becomes 0
     if (yp_spin_count_unit == 0)

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -44303,8 +44303,8 @@ size_t GCHeap::GetPromotedBytes(int heap_index)
 void GCHeap::SetYieldProcessorScalingFactor (float scalingFactor)
 {
     assert (yp_spin_count_unit != 0);
-    int saved_yp_spin_count_unit = yp_spin_count_unit;
-    yp_spin_count_unit = (int)((float)original_spin_count_unit * scalingFactor / (float)9);
+    uint32_t saved_yp_spin_count_unit = yp_spin_count_unit;
+    yp_spin_count_unit = (uint32_t)((float)original_spin_count_unit * scalingFactor / (float)9);
 
     // It's very suspicious if it becomes 0 and also, we don't want to spin too much.
     if ((yp_spin_count_unit == 0) || (yp_spin_count_unit > 32768))


### PR DESCRIPTION
## Summary

This PR is to address https://github.com/dotnet/runtime/issues/68839 where it's clear that ``SetYieldProcessorScalingFactor`` is called multiple times thereby increasing the value of ``yp_spin_count_unit`` and as a result the spin counts are monotonically increasing each time ``SetYieldProcessorScalingFactor`` is called; this function was previously assumed to be called only once but that changed with the following PR: https://github.com/dotnet/runtime/pull/55295.

The fix is to store the original spin count unit and use that value to set the ``yp_spin_count_unit`` rather than adjusting the value based on the last ``yp_spin_count_unit``. 