### PR TITLE
[release/6.0] Fixed the yp_spin_count_unit to be a factor of the original_spin_count_unit rather than a continually increasing value 

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -43040,8 +43040,8 @@ size_t GCHeap::GetPromotedBytes(int heap_index)
 void GCHeap::SetYieldProcessorScalingFactor (float scalingFactor)
 {
     assert (yp_spin_count_unit != 0);
-    int saved_yp_spin_count_unit = yp_spin_count_unit;
-    yp_spin_count_unit = (int)((float)original_spin_count_unit * scalingFactor / (float)9);
+    uint32_t saved_yp_spin_count_unit = yp_spin_count_unit;
+    yp_spin_count_unit = (uint32_t)((float)original_spin_count_unit * scalingFactor / (float)9);
 
     // It's very suspicious if it becomes 0 and also, we don't want to spin too much.
     if ((yp_spin_count_unit == 0) || (yp_spin_count_unit > 32768))

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -86,6 +86,7 @@ BOOL bgc_heap_walk_for_etw_p = FALSE;
 #define LOH_PIN_DECAY 10
 
 uint32_t yp_spin_count_unit = 0;
+uint32_t original_spin_count_unit = 0;
 size_t loh_size_threshold = LARGE_OBJECT_SIZE;
 
 #ifdef GC_CONFIG_DRIVEN
@@ -12727,6 +12728,8 @@ HRESULT gc_heap::initialize_gc (size_t soh_segment_size,
 #else
     yp_spin_count_unit = 32 * g_num_processors;
 #endif //MULTIPLE_HEAPS
+
+    original_spin_count_unit = yp_spin_count_unit;
 
 #if defined(__linux__)
     GCToEEInterface::UpdateGCEventStatus(static_cast<int>(GCEventStatus::GetEnabledLevel(GCEventProvider_Default)),
@@ -43038,10 +43041,10 @@ void GCHeap::SetYieldProcessorScalingFactor (float scalingFactor)
 {
     assert (yp_spin_count_unit != 0);
     int saved_yp_spin_count_unit = yp_spin_count_unit;
-    yp_spin_count_unit = (int)((float)yp_spin_count_unit * scalingFactor / (float)9);
+    yp_spin_count_unit = (int)((float)original_spin_count_unit * scalingFactor / (float)9);
 
-    // It's very suspicious if it becomes 0
-    if (yp_spin_count_unit == 0)
+    // It's very suspicious if it becomes 0 and also, we don't want to spin too much.
+    if ((yp_spin_count_unit == 0) || (yp_spin_count_unit > 32768))
     {
         yp_spin_count_unit = saved_yp_spin_count_unit;
     }


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/68879 to release/6.0. 

## Customer Impact

Reported by Cosmos; the associated bug can be found here: https://github.com/dotnet/runtime/issues/68839  

## Details

This PR is to address https://github.com/dotnet/runtime/issues/68839 where it's clear that ``SetYieldProcessorScalingFactor`` is called multiple times thereby increasing the value of ``yp_spin_count_unit`` and as a result the spin counts are monotonically increasing each time ``SetYieldProcessorScalingFactor`` is called; this function was previously assumed to be called only once but that changed with the following PR: https://github.com/dotnet/runtime/pull/55295.

The fix is to store the original spin count unit and use that value to set the ``yp_spin_count_unit`` rather than adjusting the value based on the last ``yp_spin_count_unit``. 

## Testing

Tested on a simple console app that has Server GC enabled and made sure the spin lock count is constrained. The repro code as a simple console app is:

```csharp
var ALLOC_SIZE = 10_000;

while (true)
{
    Thread.SpinWait(10000);
    byte[] buffer = new byte[ALLOC_SIZE];
    buffer = new byte[ALLOC_SIZE];
    buffer = new byte[ALLOC_SIZE];
}
```

``Thread.SpinWait`` eventually calls ``SetYieldProcessorScalingFactor``; the result of the testing indicated that the ``yp_spin_count`` wasn't monotonically increasing like before. 

## Risk

This PR mitigates a high-risk issue and reduces the risk of the spin count growing by constraining max count. 