### PR TITLE
Revert FileSystemEventArgs/RenamedEventArgs FullPath/OldFullPath changes

### DIFF
--- a/src/libraries/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
@@ -27,8 +27,6 @@
              Link="Common\DisableRuntimeMarshalling.cs" />
     <Compile Include="$(CommonPath)System\IO\PathInternal.CaseSensitivity.cs"
              Link="Common\System\IO\PathInternal.CaseSensitivity.cs" />
-    <Compile Include="$(CommonPath)System\IO\PathInternal.cs"
-            Link="Common\System\IO\PathInternal.cs" />
     <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"
              Link="Common\System\Text\ValueStringBuilder.cs" />
   </ItemGroup>

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
@@ -27,6 +27,8 @@
              Link="Common\DisableRuntimeMarshalling.cs" />
     <Compile Include="$(CommonPath)System\IO\PathInternal.CaseSensitivity.cs"
              Link="Common\System\IO\PathInternal.CaseSensitivity.cs" />
+    <Compile Include="$(CommonPath)System\IO\PathInternal.cs"
+             Link="Common\System\IO\PathInternal.cs" />
     <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"
              Link="Common\System\Text\ValueStringBuilder.cs" />
   </ItemGroup>

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
@@ -19,12 +19,29 @@ namespace System.IO
         {
             _changeType = changeType;
             _name = name;
-            _fullPath = Path.Join(Path.GetFullPath(directory), name);
+            _fullPath = Combine(directory, name);
+        }
 
-            if (string.IsNullOrWhiteSpace(name))
+        /// <summary>Combines a directory path and a relative file name into a single path.</summary>
+        /// <param name="directoryPath">The directory path.</param>
+        /// <param name="name">The file name.</param>
+        /// <returns>The combined name.</returns>
+        /// <remarks>
+        /// This is like Path.Combine, except without argument validation,
+        /// and a separator is used even if the name argument is empty.
+        /// </remarks>
+        internal static string Combine(string directoryPath, string? name)
+        {
+            bool hasSeparator = false;
+            if (directoryPath.Length > 0)
             {
-                _fullPath = PathInternal.EnsureTrailingSeparator(_fullPath);
+                char c = directoryPath[directoryPath.Length - 1];
+                hasSeparator = c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
             }
+
+            return hasSeparator ?
+                directoryPath + name :
+                directoryPath + Path.DirectorySeparatorChar + name;
         }
 
         /// <devdoc>

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
@@ -25,25 +25,20 @@ namespace System.IO
         }
 
         /// <summary>Combines a directory path and a relative file name into a single path.</summary>
-        /// <param name="directoryPath">The directory path.</param>
+        /// <param name="directory">The directory path.</param>
         /// <param name="name">The file name.</param>
         /// <returns>The combined name.</returns>
         /// <remarks>
         /// This is like Path.Combine, except without argument validation,
         /// and a separator is used even if the name argument is empty.
         /// </remarks>
-        internal static string Combine(string directoryPath, string? name)
+        internal static string Combine(string directory, string? name)
         {
-            bool hasSeparator = false;
-            if (directoryPath.Length > 0)
-            {
-                char c = directoryPath[directoryPath.Length - 1];
-                hasSeparator = c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
-            }
+            bool hasSeparator = directory.Length != 0 && PathInternal.IsDirectorySeparator(directory[^1]);
 
             return hasSeparator ?
-                directoryPath + name :
-                directoryPath + Path.DirectorySeparatorChar + name;
+                directory + name :
+                directory + Path.DirectorySeparatorChar + name;
         }
 
         /// <devdoc>

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
@@ -17,18 +17,14 @@ namespace System.IO
         /// </devdoc>
         public FileSystemEventArgs(WatcherChangeTypes changeType, string directory, string? name)
         {
-            ArgumentNullException.ThrowIfNull(directory);
-
             _changeType = changeType;
             _name = name;
+            _fullPath = Path.Join(Path.GetFullPath(directory), name);
 
-            if (directory.Length == 0) // empty directory means current working dir
+            if (string.IsNullOrWhiteSpace(name))
             {
-                directory = ".";
+                _fullPath = PathInternal.EnsureTrailingSeparator(_fullPath);
             }
-
-            string fullDirectoryPath = Path.GetFullPath(directory);
-            _fullPath = string.IsNullOrEmpty(name) ? PathInternal.EnsureTrailingSeparator(fullDirectoryPath) : Path.Join(fullDirectoryPath, name);
         }
 
         /// <devdoc>

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
@@ -17,6 +17,8 @@ namespace System.IO
         /// </devdoc>
         public FileSystemEventArgs(WatcherChangeTypes changeType, string directory, string? name)
         {
+            ArgumentNullException.ThrowIfNull(directory);
+
             _changeType = changeType;
             _name = name;
             _fullPath = Combine(directory, name);

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/RenamedEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/RenamedEventArgs.cs
@@ -18,12 +18,7 @@ namespace System.IO
             : base(changeType, directory, name)
         {
             _oldName = oldName;
-            _oldFullPath = Path.Join(Path.GetFullPath(directory), oldName);
-
-            if (string.IsNullOrWhiteSpace(oldName))
-            {
-                _oldFullPath = PathInternal.EnsureTrailingSeparator(_oldFullPath);
-            }
+            _oldFullPath = Combine(directory, oldName);
         }
 
         /// <devdoc>

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/RenamedEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/RenamedEventArgs.cs
@@ -18,14 +18,12 @@ namespace System.IO
             : base(changeType, directory, name)
         {
             _oldName = oldName;
+            _oldFullPath = Path.Join(Path.GetFullPath(directory), oldName);
 
-            if (directory.Length == 0) // empty directory means current working dir
+            if (string.IsNullOrWhiteSpace(oldName))
             {
-                directory = ".";
+                _oldFullPath = PathInternal.EnsureTrailingSeparator(_oldFullPath);
             }
-
-            string fullDirectoryPath = Path.GetFullPath(directory);
-            _oldFullPath = string.IsNullOrEmpty(oldName) ? PathInternal.EnsureTrailingSeparator(fullDirectoryPath) : Path.Join(fullDirectoryPath, oldName);
         }
 
         /// <devdoc>

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Args.FileSystemEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Args.FileSystemEventArgs.cs
@@ -12,24 +12,105 @@ namespace System.IO.Tests
         [InlineData(WatcherChangeTypes.All, "C:", "foo.txt")]
         [InlineData((WatcherChangeTypes)0, "", "")]
         [InlineData((WatcherChangeTypes)0, "", null)]
-        public static void FileSystemEventArgs_ctor(WatcherChangeTypes changeType, string directory, string name)
+        public static void FileSystemEventArgs_ctor_NonPathPropertiesAreSetCorrectly(WatcherChangeTypes changeType, string directory, string name)
         {
             FileSystemEventArgs args = new FileSystemEventArgs(changeType, directory, name);
 
-            if (!directory.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
-            {
-                directory += Path.DirectorySeparatorChar;
-            }
-
             Assert.Equal(changeType, args.ChangeType);
-            Assert.Equal(directory + name, args.FullPath);
             Assert.Equal(name, args.Name);
+        }
+
+        [Theory]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [InlineData("D:\\", null, "D:\\")]
+        [InlineData("D:\\", "", "D:\\")]
+        [InlineData("D:\\", "foo.txt", "D:\\foo.txt")]
+        [InlineData("E:\\bar", null, "E:\\bar\\")]
+        [InlineData("E:\\bar", "", "E:\\bar\\")]
+        [InlineData("E:\\bar", "foo.txt", "E:\\bar\\foo.txt")]
+        [InlineData("E:\\bar\\", null, "E:\\bar\\")]
+        [InlineData("E:\\bar\\", "", "E:\\bar\\")]
+        [InlineData("E:\\bar\\", "foo.txt", "E:\\bar\\foo.txt")]
+        public static void FileSystemEventArgs_ctor_DirectoryIsAbsolutePath_Windows(string directory, string name, string expectedFullPath)
+        {
+            FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
+
+            Assert.Equal(expectedFullPath, args.FullPath);
+        }
+
+        [Theory]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [InlineData("/", null, "/")]
+        [InlineData("/", "", "/")]
+        [InlineData("/", "   ", "/   ")]
+        [InlineData("/", "foo.txt", "/foo.txt")]
+        [InlineData("/bar", null, "/bar/")]
+        [InlineData("/bar", "", "/bar/")]
+        [InlineData("/bar", "foo.txt", "/bar/foo.txt")]
+        [InlineData("/bar/", null, "/bar/")]
+        [InlineData("/bar/", "", "/bar/")]
+        [InlineData("/bar/", "foo.txt", "/bar/foo.txt")]
+        public static void FileSystemEventArgs_ctor_DirectoryIsAbsolutePath_Unix(string directory, string name, string expectedFullPath)
+        {
+            FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
+
+            Assert.Equal(expectedFullPath, args.FullPath);
+        }
+
+        [Theory]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [InlineData("", "", "\\")]
+        [InlineData("", "foo.txt", "\\foo.txt")]
+        [InlineData("bar", "foo.txt", "bar\\foo.txt")]
+        [InlineData("bar\\baz", "foo.txt", "bar\\baz\\foo.txt")]
+        public static void FileSystemEventArgs_ctor_DirectoryIsRelativePath_Windows(string directory, string name, string expectedFullPath)
+        {
+            FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
+
+            Assert.Equal(expectedFullPath, args.FullPath);
+        }
+
+        [Theory]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [InlineData("", "", "/")]
+        [InlineData("", "foo.txt", "/foo.txt")]
+        [InlineData("   ", "    ", "   /    ")]
+        [InlineData("   ", "foo.txt", "   /foo.txt")]
+        [InlineData("bar", "foo.txt", "bar/foo.txt")]
+        [InlineData("bar/baz", "foo.txt", "bar/baz/foo.txt")]
+        public static void FileSystemEventArgs_ctor_DirectoryIsRelativePath_Unix(string directory, string name, string expectedFullPath)
+        {
+            FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
+
+            Assert.Equal(expectedFullPath, args.FullPath);
+        }
+
+        [Theory]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [InlineData("bar", "", "bar\\")]
+        [InlineData("bar", null, "bar\\")]
+        public static void FileSystemEventArgs_ctor_EmptyFileName_Windows(string directory, string name, string expectedFullPath)
+        {
+            FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
+
+            Assert.Equal(expectedFullPath, args.FullPath);
+        }
+
+        [Theory]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [InlineData("bar", "", "bar/")]
+        [InlineData("bar", null, "bar/")]
+        public static void FileSystemEventArgs_ctor_EmptyFileName_Unix(string directory, string name, string expectedFullPath)
+        {
+            FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
+
+            Assert.Equal(expectedFullPath, args.FullPath);
         }
 
         [Fact]
         public static void FileSystemEventArgs_ctor_Invalid()
         {
-            Assert.Throws<NullReferenceException>(() => new FileSystemEventArgs((WatcherChangeTypes)0, null, string.Empty));
+            Assert.Throws<ArgumentNullException>(() => new FileSystemEventArgs((WatcherChangeTypes)0, null, "foo.txt"));
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Args.FileSystemEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Args.FileSystemEventArgs.cs
@@ -8,79 +8,28 @@ namespace System.IO.Tests
     public class FileSystemEventArgsTests
     {
         [Theory]
-        [InlineData(WatcherChangeTypes.Changed, "bar", "foo.txt")]
-        [InlineData(WatcherChangeTypes.All, "bar", "foo.txt")]
-        [InlineData((WatcherChangeTypes)0, "bar", "")]
-        [InlineData((WatcherChangeTypes)0, "bar", null)]
-        public static void FileSystemEventArgs_ctor_NonPathPropertiesAreSetCorrectly(WatcherChangeTypes changeType, string directory, string name)
+        [InlineData(WatcherChangeTypes.Changed, "C:", "foo.txt")]
+        [InlineData(WatcherChangeTypes.All, "C:", "foo.txt")]
+        [InlineData((WatcherChangeTypes)0, "", "")]
+        [InlineData((WatcherChangeTypes)0, "", null)]
+        public static void FileSystemEventArgs_ctor(WatcherChangeTypes changeType, string directory, string name)
         {
             FileSystemEventArgs args = new FileSystemEventArgs(changeType, directory, name);
 
+            if (!directory.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
+            {
+                directory += Path.DirectorySeparatorChar;
+            }
+
             Assert.Equal(changeType, args.ChangeType);
+            Assert.Equal(directory + name, args.FullPath);
             Assert.Equal(name, args.Name);
-        }
-
-        [Theory]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        [InlineData("D:\\", "foo.txt", "D:\\foo.txt")]
-        [InlineData("E:\\bar", "foo.txt", "E:\\bar\\foo.txt")]
-        public static void FileSystemEventArgs_ctor_DirectoryIsAbsolutePath_Windows(string directory, string name, string expectedFullPath)
-        {
-            FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
-
-            Assert.Equal(expectedFullPath, args.FullPath);
-        }
-
-        [Theory]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [InlineData("/", "foo.txt", "/foo.txt")]
-        [InlineData("/bar", "foo.txt", "/bar/foo.txt")]
-        public static void FileSystemEventArgs_ctor_DirectoryIsAbsolutePath_Unix(string directory, string name, string expectedFullPath)
-        {
-            FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
-
-            Assert.Equal(expectedFullPath, args.FullPath);
-        }
-
-        [Theory]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        [InlineData("bar", "foo.txt")]
-        [InlineData("bar\\baz", "foo.txt")]
-        public static void FileSystemEventArgs_ctor_DirectoryIsRelativePath_Windows(string directory, string name)
-        {
-            FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
-
-            Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), directory, name), args.FullPath);
-        }
-
-        [Theory]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [InlineData("bar", "foo.txt")]
-        [InlineData("bar/baz", "foo.txt")]
-        public static void FileSystemEventArgs_ctor_DirectoryIsRelativePath_Unix(string directory, string name)
-        {
-            FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
-
-            Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), directory, name), args.FullPath);
-        }
-
-        [Theory]
-        [InlineData("bar", "")]
-        [InlineData("bar", null)]
-        public static void FileSystemEventArgs_ctor_When_EmptyFileName_Then_FullPathReturnsTheDirectoryFullPath_WithTrailingSeparator(string directory, string name)
-        {
-            FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
-
-            directory = PathInternal.EnsureTrailingSeparator(directory);
-
-            Assert.Equal(PathInternal.EnsureTrailingSeparator(Directory.GetCurrentDirectory()) + directory, args.FullPath);
         }
 
         [Fact]
         public static void FileSystemEventArgs_ctor_Invalid()
         {
-            Assert.Throws<ArgumentNullException>(() => new FileSystemEventArgs((WatcherChangeTypes)0, null, "foo.txt"));
-            Assert.Throws<ArgumentException>(() => new FileSystemEventArgs((WatcherChangeTypes)0, "", "foo.txt"));
+            Assert.Throws<NullReferenceException>(() => new FileSystemEventArgs((WatcherChangeTypes)0, null, string.Empty));
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Args.FileSystemEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Args.FileSystemEventArgs.cs
@@ -22,15 +22,8 @@ namespace System.IO.Tests
 
         [Theory]
         [PlatformSpecific(TestPlatforms.Windows)]
-        [InlineData("D:\\", null, "D:\\")]
-        [InlineData("D:\\", "", "D:\\")]
         [InlineData("D:\\", "foo.txt", "D:\\foo.txt")]
-        [InlineData("E:\\bar", null, "E:\\bar\\")]
-        [InlineData("E:\\bar", "", "E:\\bar\\")]
         [InlineData("E:\\bar", "foo.txt", "E:\\bar\\foo.txt")]
-        [InlineData("E:\\bar\\", null, "E:\\bar\\")]
-        [InlineData("E:\\bar\\", "", "E:\\bar\\")]
-        [InlineData("E:\\bar\\", "foo.txt", "E:\\bar\\foo.txt")]
         public static void FileSystemEventArgs_ctor_DirectoryIsAbsolutePath_Windows(string directory, string name, string expectedFullPath)
         {
             FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
@@ -40,16 +33,8 @@ namespace System.IO.Tests
 
         [Theory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [InlineData("/", null, "/")]
-        [InlineData("/", "", "/")]
-        [InlineData("/", "   ", "/   ")]
         [InlineData("/", "foo.txt", "/foo.txt")]
-        [InlineData("/bar", null, "/bar/")]
-        [InlineData("/bar", "", "/bar/")]
         [InlineData("/bar", "foo.txt", "/bar/foo.txt")]
-        [InlineData("/bar/", null, "/bar/")]
-        [InlineData("/bar/", "", "/bar/")]
-        [InlineData("/bar/", "foo.txt", "/bar/foo.txt")]
         public static void FileSystemEventArgs_ctor_DirectoryIsAbsolutePath_Unix(string directory, string name, string expectedFullPath)
         {
             FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
@@ -59,32 +44,24 @@ namespace System.IO.Tests
 
         [Theory]
         [PlatformSpecific(TestPlatforms.Windows)]
-        [InlineData("", "")]
-        [InlineData("", "foo.txt")]
         [InlineData("bar", "foo.txt")]
         [InlineData("bar\\baz", "foo.txt")]
         public static void FileSystemEventArgs_ctor_DirectoryIsRelativePath_Windows(string directory, string name)
         {
             FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
 
-            var expectedDirectory = PathInternal.EnsureTrailingSeparator(Path.Combine(Directory.GetCurrentDirectory(), directory));
-            Assert.Equal(Path.Combine(expectedDirectory, name), args.FullPath);
+            Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), directory, name), args.FullPath);
         }
 
         [Theory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [InlineData("", "")]
-        [InlineData("", "foo.txt")]
-        [InlineData("   ", "    ")]
-        [InlineData("   ", "foo.txt")]
         [InlineData("bar", "foo.txt")]
         [InlineData("bar/baz", "foo.txt")]
         public static void FileSystemEventArgs_ctor_DirectoryIsRelativePath_Unix(string directory, string name)
         {
             FileSystemEventArgs args = new FileSystemEventArgs(WatcherChangeTypes.All, directory, name);
 
-            var expectedDirectory = PathInternal.EnsureTrailingSeparator(Path.Combine(Directory.GetCurrentDirectory(), directory));
-            Assert.Equal(Path.Combine(expectedDirectory, name), args.FullPath);
+            Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), directory, name), args.FullPath);
         }
 
         [Theory]
@@ -103,6 +80,7 @@ namespace System.IO.Tests
         public static void FileSystemEventArgs_ctor_Invalid()
         {
             Assert.Throws<ArgumentNullException>(() => new FileSystemEventArgs((WatcherChangeTypes)0, null, "foo.txt"));
+            Assert.Throws<ArgumentException>(() => new FileSystemEventArgs((WatcherChangeTypes)0, "", "foo.txt"));
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Args.RenamedEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Args.RenamedEventArgs.cs
@@ -85,9 +85,9 @@ namespace System.IO.Tests
 
         [Theory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [InlineData("bar", "", "", "bar\\")]
-        [InlineData("bar", null, null, "bar\\")]
-        [InlineData("bar", "foo.txt", null, "bar\\")]
+        [InlineData("bar", "", "", "bar/")]
+        [InlineData("bar", null, null, "bar/")]
+        [InlineData("bar", "foo.txt", null, "bar/")]
         public static void RenamedEventArgs_ctor_EmptyOldFileName_Unix(string directory, string name, string oldName, string expectedOldFullPath)
         {
             RenamedEventArgs args = new RenamedEventArgs(WatcherChangeTypes.All, directory, name, oldName);

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Args.RenamedEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Args.RenamedEventArgs.cs
@@ -47,30 +47,24 @@ namespace System.IO.Tests
 
         [Theory]
         [PlatformSpecific(TestPlatforms.Windows)]
-        [InlineData("", "", "")]
-        [InlineData("", "foo.txt", "bar.txt")]
         [InlineData("bar", "foo.txt", "bar.txt")]
         [InlineData("bar\\baz", "foo.txt", "bar.txt")]
         public static void RenamedEventArgs_ctor_OldFullPath_DirectoryIsRelativePath_Windows(string directory, string name, string oldName)
         {
             RenamedEventArgs args = new RenamedEventArgs(WatcherChangeTypes.All, directory, name, oldName);
 
-            var expectedDirectory = PathInternal.EnsureTrailingSeparator(Path.Combine(Directory.GetCurrentDirectory(), directory));
-            Assert.Equal(Path.Combine(expectedDirectory, oldName), args.OldFullPath);
+            Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), directory, oldName), args.OldFullPath);
         }
 
         [Theory]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [InlineData("", "", "")]
-        [InlineData("", "foo.txt", "bar.txt")]
         [InlineData("bar", "foo.txt", "bar.txt")]
         [InlineData("bar/baz", "foo.txt", "bar.txt")]
         public static void RenamedEventArgs_ctor_OldFullPath_DirectoryIsRelativePath_Unix(string directory, string name, string oldName)
         {
             RenamedEventArgs args = new RenamedEventArgs(WatcherChangeTypes.All, directory, name, oldName);
 
-            var expectedDirectory = PathInternal.EnsureTrailingSeparator(Path.Combine(Directory.GetCurrentDirectory(), directory));
-            Assert.Equal(Path.Combine(expectedDirectory, oldName), args.OldFullPath);
+            Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), directory, oldName), args.OldFullPath);
         }
 
         [Theory]
@@ -89,6 +83,7 @@ namespace System.IO.Tests
         [Fact]
         public static void RenamedEventArgs_ctor_Invalid()
         {
+            Assert.Throws<ArgumentException>(() => new RenamedEventArgs((WatcherChangeTypes)0, "", "foo.txt", "bar.txt"));
             Assert.Throws<ArgumentNullException>(() => new RenamedEventArgs((WatcherChangeTypes)0, null, "foo.txt", "bar.txt"));
         }
     }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Args.RenamedEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Args.RenamedEventArgs.cs
@@ -8,83 +8,34 @@ namespace System.IO.Tests
     public class RenamedEventArgsTests
     {
         [Theory]
-        [InlineData(WatcherChangeTypes.Changed, "bar", "foo.txt", "bar.txt")]
-        [InlineData(WatcherChangeTypes.All, "bar", "foo.txt", "bar.txt")]
-        [InlineData((WatcherChangeTypes)0, "bar", "", "")]
-        [InlineData((WatcherChangeTypes)0, "bar", null, null)]
-        public static void RenamedEventArgs_ctor_NonPathPropertiesAreSetCorrectly(WatcherChangeTypes changeType, string directory, string name, string oldName)
+        [InlineData(WatcherChangeTypes.Changed, "C:", "foo.txt", "bar.txt")]
+        [InlineData(WatcherChangeTypes.All, "C:", "foo.txt", "bar.txt")]
+        [InlineData((WatcherChangeTypes)0, "", "", "")]
+        [InlineData((WatcherChangeTypes)0, "", null, null)]
+        public static void RenamedEventArgs_ctor(WatcherChangeTypes changeType, string directory, string name, string oldName)
         {
             RenamedEventArgs args = new RenamedEventArgs(changeType, directory, name, oldName);
-
             Assert.Equal(changeType, args.ChangeType);
+            Assert.Equal(directory + Path.DirectorySeparatorChar + name, args.FullPath);
             Assert.Equal(name, args.Name);
             Assert.Equal(oldName, args.OldName);
-
-            // FullPath is tested as part of the base class FileSystemEventArgs tests
         }
 
         [Theory]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        [InlineData("D:\\", "foo.txt", "bar.txt", "D:\\bar.txt")]
-        [InlineData("E:\\bar", "foo.txt", "bar.txt", "E:\\bar\\bar.txt")]
-        public static void RenamedEventArgs_ctor_OldFullPath_DirectoryIsAnAbsolutePath_Windows(string directory, string name, string oldName, string expectedOldFullPath)
+        [InlineData(WatcherChangeTypes.Changed, "C:", "foo.txt", "bar.txt")]
+        [InlineData(WatcherChangeTypes.All, "C:", "foo.txt", "bar.txt")]
+        [InlineData((WatcherChangeTypes)0, "", "", "")]
+        [InlineData((WatcherChangeTypes)0, "", null, null)]
+        public static void RenamedEventArgs_ctor_OldFullPath(WatcherChangeTypes changeType, string directory, string name, string oldName)
         {
-            RenamedEventArgs args = new RenamedEventArgs(WatcherChangeTypes.All, directory, name, oldName);
-
-            Assert.Equal(expectedOldFullPath, args.OldFullPath);
-        }
-
-        [Theory]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [InlineData("/", "foo.txt", "bar.txt", "/bar.txt")]
-        [InlineData("/bar", "foo.txt", "bar.txt", "/bar/bar.txt")]
-        public static void RenamedEventArgs_ctor_OldFullPath_DirectoryIsAnAbsolutePath_Unix(string directory, string name, string oldName, string expectedOldFullPath)
-        {
-            RenamedEventArgs args = new RenamedEventArgs(WatcherChangeTypes.All, directory, name, oldName);
-
-            Assert.Equal(expectedOldFullPath, args.OldFullPath);
-        }
-
-        [Theory]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        [InlineData("bar", "foo.txt", "bar.txt")]
-        [InlineData("bar\\baz", "foo.txt", "bar.txt")]
-        public static void RenamedEventArgs_ctor_OldFullPath_DirectoryIsRelativePath_Windows(string directory, string name, string oldName)
-        {
-            RenamedEventArgs args = new RenamedEventArgs(WatcherChangeTypes.All, directory, name, oldName);
-
-            Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), directory, oldName), args.OldFullPath);
-        }
-
-        [Theory]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [InlineData("bar", "foo.txt", "bar.txt")]
-        [InlineData("bar/baz", "foo.txt", "bar.txt")]
-        public static void RenamedEventArgs_ctor_OldFullPath_DirectoryIsRelativePath_Unix(string directory, string name, string oldName)
-        {
-            RenamedEventArgs args = new RenamedEventArgs(WatcherChangeTypes.All, directory, name, oldName);
-
-            Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), directory, oldName), args.OldFullPath);
-        }
-
-        [Theory]
-        [InlineData("bar", "", "")]
-        [InlineData("bar", null, null)]
-        [InlineData("bar", "foo.txt", null)]
-        public static void RenamedEventArgs_ctor_When_EmptyOldFileName_Then_OldFullPathReturnsTheDirectoryFullPath_WithTrailingSeparator(string directory, string name, string oldName)
-        {
-            RenamedEventArgs args = new RenamedEventArgs(WatcherChangeTypes.All, directory, name, oldName);
-
-            directory = PathInternal.EnsureTrailingSeparator(directory);
-
-            Assert.Equal(PathInternal.EnsureTrailingSeparator(Directory.GetCurrentDirectory()) + directory, args.OldFullPath);
+            RenamedEventArgs args = new RenamedEventArgs(changeType, directory, name, oldName);
+            Assert.Equal(directory + Path.DirectorySeparatorChar + oldName, args.OldFullPath);
         }
 
         [Fact]
         public static void RenamedEventArgs_ctor_Invalid()
         {
-            Assert.Throws<ArgumentException>(() => new RenamedEventArgs((WatcherChangeTypes)0, "", "foo.txt", "bar.txt"));
-            Assert.Throws<ArgumentNullException>(() => new RenamedEventArgs((WatcherChangeTypes)0, null, "foo.txt", "bar.txt"));
+            Assert.Throws<NullReferenceException>(() => new RenamedEventArgs((WatcherChangeTypes)0, null, string.Empty, string.Empty));
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Args.RenamedEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Args.RenamedEventArgs.cs
@@ -8,34 +8,97 @@ namespace System.IO.Tests
     public class RenamedEventArgsTests
     {
         [Theory]
-        [InlineData(WatcherChangeTypes.Changed, "C:", "foo.txt", "bar.txt")]
-        [InlineData(WatcherChangeTypes.All, "C:", "foo.txt", "bar.txt")]
-        [InlineData((WatcherChangeTypes)0, "", "", "")]
-        [InlineData((WatcherChangeTypes)0, "", null, null)]
-        public static void RenamedEventArgs_ctor(WatcherChangeTypes changeType, string directory, string name, string oldName)
+        [InlineData(WatcherChangeTypes.Changed, "bar", "foo.txt", "bar.txt")]
+        [InlineData(WatcherChangeTypes.All, "bar", "foo.txt", "bar.txt")]
+        [InlineData((WatcherChangeTypes)0, "bar", "", "")]
+        [InlineData((WatcherChangeTypes)0, "bar", null, null)]
+        public static void RenamedEventArgs_ctor_NonPathPropertiesAreSetCorrectly(WatcherChangeTypes changeType, string directory, string name, string oldName)
         {
             RenamedEventArgs args = new RenamedEventArgs(changeType, directory, name, oldName);
+
             Assert.Equal(changeType, args.ChangeType);
-            Assert.Equal(directory + Path.DirectorySeparatorChar + name, args.FullPath);
             Assert.Equal(name, args.Name);
             Assert.Equal(oldName, args.OldName);
+
+            // FullPath is tested as part of the base class FileSystemEventArgs tests
         }
 
         [Theory]
-        [InlineData(WatcherChangeTypes.Changed, "C:", "foo.txt", "bar.txt")]
-        [InlineData(WatcherChangeTypes.All, "C:", "foo.txt", "bar.txt")]
-        [InlineData((WatcherChangeTypes)0, "", "", "")]
-        [InlineData((WatcherChangeTypes)0, "", null, null)]
-        public static void RenamedEventArgs_ctor_OldFullPath(WatcherChangeTypes changeType, string directory, string name, string oldName)
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [InlineData("D:\\", "foo.txt", "bar.txt", "D:\\bar.txt")]
+        [InlineData("E:\\bar", "foo.txt", "bar.txt", "E:\\bar\\bar.txt")]
+        public static void RenamedEventArgs_ctor_OldFullPath_DirectoryIsAnAbsolutePath_Windows(string directory, string name, string oldName, string expectedOldFullPath)
         {
-            RenamedEventArgs args = new RenamedEventArgs(changeType, directory, name, oldName);
-            Assert.Equal(directory + Path.DirectorySeparatorChar + oldName, args.OldFullPath);
+            RenamedEventArgs args = new RenamedEventArgs(WatcherChangeTypes.All, directory, name, oldName);
+
+            Assert.Equal(expectedOldFullPath, args.OldFullPath);
+        }
+
+        [Theory]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [InlineData("/", "foo.txt", "bar.txt", "/bar.txt")]
+        [InlineData("/bar", "foo.txt", "bar.txt", "/bar/bar.txt")]
+        public static void RenamedEventArgs_ctor_OldFullPath_DirectoryIsAnAbsolutePath_Unix(string directory, string name, string oldName, string expectedOldFullPath)
+        {
+            RenamedEventArgs args = new RenamedEventArgs(WatcherChangeTypes.All, directory, name, oldName);
+
+            Assert.Equal(expectedOldFullPath, args.OldFullPath);
+        }
+
+        [Theory]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [InlineData("", "", "", "\\")]
+        [InlineData("", "foo.txt", "bar.txt", "\\bar.txt")]
+        [InlineData("bar", "foo.txt", "bar.txt", "bar\\bar.txt")]
+        [InlineData("bar\\baz", "foo.txt", "bar.txt", "bar\\baz\\bar.txt")]
+        public static void RenamedEventArgs_ctor_OldFullPath_DirectoryIsRelativePath_Windows(string directory, string name, string oldName, string expectedOldFullPath)
+        {
+            RenamedEventArgs args = new RenamedEventArgs(WatcherChangeTypes.All, directory, name, oldName);
+
+            Assert.Equal(expectedOldFullPath, args.OldFullPath);
+        }
+
+        [Theory]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [InlineData("", "", "", "/")]
+        [InlineData("", "foo.txt", "bar.txt", "/bar.txt")]
+        [InlineData("bar", "foo.txt", "bar.txt", "bar/bar.txt")]
+        [InlineData("bar/baz", "foo.txt", "bar.txt", "bar/baz/bar.txt")]
+        public static void RenamedEventArgs_ctor_OldFullPath_DirectoryIsRelativePath_Unix(string directory, string name, string oldName, string expectedOldFullPath)
+        {
+            RenamedEventArgs args = new RenamedEventArgs(WatcherChangeTypes.All, directory, name, oldName);
+
+            Assert.Equal(expectedOldFullPath, args.OldFullPath);
+        }
+
+        [Theory]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [InlineData("bar", "", "", "bar\\")]
+        [InlineData("bar", null, null, "bar\\")]
+        [InlineData("bar", "foo.txt", null, "bar\\")]
+        public static void RenamedEventArgs_ctor_EmptyOldFileName_Windows(string directory, string name, string oldName, string expectedOldFullPath)
+        {
+            RenamedEventArgs args = new RenamedEventArgs(WatcherChangeTypes.All, directory, name, oldName);
+
+            Assert.Equal(expectedOldFullPath, args.OldFullPath);
+        }
+
+        [Theory]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [InlineData("bar", "", "", "bar\\")]
+        [InlineData("bar", null, null, "bar\\")]
+        [InlineData("bar", "foo.txt", null, "bar\\")]
+        public static void RenamedEventArgs_ctor_EmptyOldFileName_Unix(string directory, string name, string oldName, string expectedOldFullPath)
+        {
+            RenamedEventArgs args = new RenamedEventArgs(WatcherChangeTypes.All, directory, name, oldName);
+
+            Assert.Equal(expectedOldFullPath, args.OldFullPath);
         }
 
         [Fact]
         public static void RenamedEventArgs_ctor_Invalid()
         {
-            Assert.Throws<NullReferenceException>(() => new RenamedEventArgs((WatcherChangeTypes)0, null, string.Empty, string.Empty));
+            Assert.Throws<ArgumentNullException>(() => new RenamedEventArgs((WatcherChangeTypes)0, null, "foo.txt", "bar.txt"));
         }
     }
 }


### PR DESCRIPTION
After fixing #68566 with #68582, which was addressing a regression caused by #63051, which fixed #62606, I've reconsidered the original issue further. This PR reverts both #68582 and #63051 and returns `FileSystemEventArgs` and `RenamedEventArgs` back to their previous behavior for `FullPath` and `OldFullPath` that dates back to .NET Framework.

The regression was reported involved using an empty directory name, and it was relying on `FullPath` being relative to the process's directory. From that regression report, it's easy to imagine scenarios where the non-rooted nature of `FullPath` is utilized and perhaps even leveraged to combine that full path to a different root. I remember such code I wrote myself back in .NET Framework days that would be broken by the changes we had made.

I've confirmed that with these reverts, `FileSystemEventArgs` and `RenamedEventArgs` are now functionally equivalent to what existed in .NET Core 1.0 and .NET Framework, with only these exceptions:

1. Nullability annotations
2. Allowing for UNIX directory separators
3. Throwing an `ArgumentNullException` instead of `NullReferenceException` when `directory` is null

I will follow up with a documentation issue that clarifies that `FullPath` and `OldFullPath` are not rooted, but they are mere combinations of the specified directory and file name, and when directory is an empty string, the values will begin with a directory separator character.