### PR TITLE
Add Mac ARM64 coverage to runtime-dev-innerloop

### DIFF
--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -22,6 +22,7 @@ pr:
     - eng/pipelines/libraries/*.*
     - eng/pipelines/installer/*.*
     - eng/pipelines/*.*
+    - !eng/pipelines/global-build.yml
     - PATENTS.TXT
     - THIRD-PARTY-NOTICES.TXT
 

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -36,6 +36,7 @@ jobs:
     platforms:
     - windows_x86
     - OSX_x64
+    - OSX_arm64
     jobParameters:
       testGroup: innerloop
       nameSuffix: Runtime_Debug

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -21,8 +21,6 @@ pr:
     - eng/pipelines/coreclr/*.*
     - eng/pipelines/libraries/*.*
     - eng/pipelines/installer/*.*
-    - eng/pipelines/*.*
-    - !eng/pipelines/global-build.yml
     - PATENTS.TXT
     - THIRD-PARTY-NOTICES.TXT
 


### PR DESCRIPTION
Seems useful in both getting more arm64 coverage, and providing coverage for an increasingly more popular developer platform.