### PR TITLE
Add test for multiple calls of QuicConnection.CloseAsync

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -667,8 +667,10 @@ namespace System.Net.Quic.Tests
             }
         }
 
-        [Fact]
-        public async Task CloseAsync_MultipleCalls_FollowingCallsAreIgnored()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CloseAsync_MultipleCalls_FollowingCallsAreIgnored(bool client)
         {
 
             (QuicConnection clientConnection, QuicConnection serverConnection) = await CreateConnectedQuicConnection();
@@ -676,10 +678,16 @@ namespace System.Net.Quic.Tests
             using (clientConnection)
             using (serverConnection)
             {
-                await clientConnection.CloseAsync(0);
-                await clientConnection.CloseAsync(0);
-
-                await serverConnection.CloseAsync(0);
+                if (client)
+                {
+                    await clientConnection.CloseAsync(0);
+                    await clientConnection.CloseAsync(0);
+                }
+                else
+                {
+                    await serverConnection.CloseAsync(0);
+                    await serverConnection.CloseAsync(0);
+                }
             }
         }
 

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -667,6 +667,22 @@ namespace System.Net.Quic.Tests
             }
         }
 
+        [Fact]
+        public async Task CloseAsync_MultipleCalls_FollowingCallsAreIgnored()
+        {
+
+            (QuicConnection clientConnection, QuicConnection serverConnection) = await CreateConnectedQuicConnection();
+
+            using (clientConnection)
+            using (serverConnection)
+            {
+                await clientConnection.CloseAsync(0);
+                await clientConnection.CloseAsync(0);
+
+                await serverConnection.CloseAsync(0);
+            }
+        }
+
         internal static ReadOnlySequence<byte> CreateReadOnlySequenceFromBytes(byte[] data)
         {
             List<byte[]> segments = new List<byte[]>


### PR DESCRIPTION
Closes #56851.

This PR adds a test for multiple calls to QuicConnection.CloseAsync().