### PR TITLE
Fix for FileStream.Lock(Int64, Int64) always fails on FreeBSD #65831

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/FileStream/LockUnlock.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/LockUnlock.cs
@@ -38,7 +38,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.OSX)]
+        [PlatformSpecific(TestPlatforms.OSX | TestPlatforms.FreeBSD)]
         public void LockUnlock_Unsupported_OSX()
         {
             string path = GetTestFilePath();
@@ -58,7 +58,7 @@ namespace System.IO.Tests
         [InlineData(200, 50, 150)]
         [InlineData(200, 100, 100)]
         [InlineData(20, 2000, 1000)]
-        [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "Not supported on macOS/iOS/tvOS/MacCatalyst.")]
+        [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS | TestPlatforms.FreeBSD, "Not supported on macOS/iOS/tvOS/MacCatalyst/FreeBSD.")]
         public void Lock_Unlock_Successful(long fileLength, long position, long length)
         {
             string path = GetTestFilePath();
@@ -75,7 +75,7 @@ namespace System.IO.Tests
         [InlineData(FileAccess.Read)]
         [InlineData(FileAccess.Write)]
         [InlineData(FileAccess.ReadWrite)]
-        [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "Not supported on macOS/iOS/tvOS/MacCatalyst.")]
+        [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS | TestPlatforms.FreeBSD, "Not supported on macOS/iOS/tvOS/MacCatalyst/FreeBSD.")]
         public void Lock_Unlock_Successful_AlternateFileAccess(FileAccess fileAccess)
         {
             string path = GetTestFilePath();
@@ -89,7 +89,7 @@ namespace System.IO.Tests
 
         [Theory]
         [InlineData(10, 0, 2, 3, 5)]
-        [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "Not supported on macOS/iOS/tvOS/MacCatalyst.")]
+        [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS| TestPlatforms.FreeBSD, "Not supported on macOS/iOS/tvOS/MacCatalyst/FreeBSD.")]
         public void NonOverlappingRegions_Success(long fileLength, long firstPosition, long firstLength, long secondPosition, long secondLength)
         {
             string path = GetTestFilePath();
@@ -176,7 +176,7 @@ namespace System.IO.Tests
         [InlineData(10, 3, 5, 2, 6)]
         [InlineData(10, 3, 5, 2, 4)]
         [InlineData(10, 3, 5, 4, 6)]
-        [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.iOS | TestPlatforms.tvOS, "Not supported on macOS/iOS/tvOS/MacCatalyst.")]
+        [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.FreeBSD, "Not supported on macOS/iOS/tvOS/MacCatalyst/FreeBSD.")]
         public void OverlappingRegionsFromOtherProcess_ThrowsException(long fileLength, long firstPosition, long firstLength, long secondPosition, long secondLength)
         {
             string path = GetTestFilePath();
@@ -224,14 +224,14 @@ namespace System.IO.Tests
 
             }, path).Dispose();
 
-            fs1.Unlock(0, 100);            
+            fs1.Unlock(0, 100);
         }
 
         [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         [InlineData(FileAccess.Read)]
         [InlineData(FileAccess.Write)]
         [InlineData(FileAccess.ReadWrite)]
-        [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.iOS | TestPlatforms.tvOS, "Not supported on macOS/iOS/tvOS/MacCatalyst.")]
+        [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.FreeBSD, "Not supported on macOS/iOS/tvOS/MacCatalyst/FreeBSD.")]
         public void OverlappingRegionsFromOtherProcess_With_WriteLock_ThrowsException(FileAccess fileAccess)
         {
             string path = GetTestFilePath();

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
@@ -219,6 +219,7 @@ namespace System.IO
         [UnsupportedOSPlatform("ios")]
         [UnsupportedOSPlatform("macos")]
         [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public virtual void Lock(long position, long length)
         {
             if (position < 0 || length < 0)
@@ -236,6 +237,7 @@ namespace System.IO
         [UnsupportedOSPlatform("ios")]
         [UnsupportedOSPlatform("macos")]
         [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public virtual void Unlock(long position, long length)
         {
             if (position < 0 || length < 0)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Unix.cs
@@ -58,7 +58,7 @@ namespace System.IO.Strategies
 
         internal static void Lock(SafeFileHandle handle, bool canWrite, long position, long length)
         {
-            if (OperatingSystem.IsOSXLike())
+            if (OperatingSystem.IsOSXLike() || OperatingSystem.IsFreeBSD())
             {
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_OSXFileLocking);
             }
@@ -68,7 +68,7 @@ namespace System.IO.Strategies
 
         internal static void Unlock(SafeFileHandle handle, long position, long length)
         {
-            if (OperatingSystem.IsOSXLike())
+            if (OperatingSystem.IsOSXLike() || OperatingSystem.IsFreeBSD())
             {
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_OSXFileLocking);
             }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -8918,6 +8918,7 @@ namespace System.IO
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("macos")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("freebsd")]
         public virtual void Lock(long position, long length) { }
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
         public override int Read(System.Span<byte> buffer) { throw null; }
@@ -8929,6 +8930,7 @@ namespace System.IO
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("macos")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("freebsd")]
         public virtual void Unlock(long position, long length) { }
         public override void Write(byte[] buffer, int offset, int count) { }
         public override void Write(System.ReadOnlySpan<byte> buffer) { }


### PR DESCRIPTION
This PR aims to fix the Issue [#65831](https://github.com/dotnet/runtime/issues/65831).
- [x] Updated the checks in FileStream.Lock() and FileStream.Unlock() to consider if Operating System is FreeBSD
- [x] Updated the tests using FIleStream.Lock() and FileStream.Unlock() to adjust to the change
- [x] Updated Reference Assembly to match FileStream.Lock() and FileStream.Unlock() signatures to have the extra added attributes.