### PR TITLE
[release/6.0] Docker fixes for the enterprise linux testing pipeline

### DIFF
--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -18,10 +18,6 @@ pr:
       - src/libraries/System.Net.Http/*
       - src/libraries/System.Net.Security/*
 
-pool:
-  name: NetCore1ESPool-Svc-Public
-  demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
-
 variables:
   - template: ../variables.yml
   - name: enterpriseTestsSetup
@@ -31,45 +27,54 @@ variables:
   - name: containerLibrariesRoot
     value: /repo/src/libraries
 
-steps:
-- bash: |
-    cd $(enterpriseTestsSetup)
-    docker-compose build
-  displayName: Build test machine images
-  env:
-    DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
+jobs:
+- job: EnterpriseLinuxTests
+  timeoutInMinutes: 120
+  pool:
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+  steps:
+  - bash: |
+      cd $(enterpriseTestsSetup)
+      docker-compose build
+    displayName: Build test machine images
+    env:
+      DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
 
-- bash: |
-    cd $(enterpriseTestsSetup)
-    docker-compose up -d
-  displayName: Start test network and machines
-  env:
-    DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
+  - bash: |
+      cd $(enterpriseTestsSetup)
+      docker-compose up -d
+    displayName: Start test network and machines
+    env:
+      DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
 
-- bash: |
-    docker exec linuxclient bash /setup/test-webserver.sh
-  displayName: Test linuxclient connection to web server
+  - bash: |
+      docker exec linuxclient bash /setup/test-webserver.sh
+    displayName: Test linuxclient connection to web server
 
-- bash: |
-    docker exec linuxclient bash -c '/repo/build.sh -subset clr+libs -runtimeconfiguration release -ci /p:NoPgoOptimize=true'
-  displayName: Build product sources
+  - bash: |
+      docker exec linuxclient bash -c '/repo/build.sh -subset clr+libs -runtimeconfiguration release -ci /p:NoPgoOptimize=true'
+      docker exec linuxclient bash -c '/repo/dotnet.sh build $(containerLibrariesRoot)/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj'
+      docker exec linuxclient bash -c '/repo/dotnet.sh build $(containerLibrariesRoot)/System.Net.Security/tests/EnterpriseTests/System.Net.Security.Enterprise.Tests.csproj'
+    displayName: Build product sources
 
-- bash: |
-    docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj
-    docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Security/tests/EnterpriseTests/System.Net.Security.Enterprise.Tests.csproj
-  displayName: Build and run tests
+  - bash: |
+      docker exec linuxclient bash -c 'if [ -f /erc/resolv.conf.ORI ]; then cp -f /erc/resolv.conf.ORI /etc/resolv.conf; fi'
+      docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj
+      docker exec linuxclient $(containerRunTestsCommand) $(containerLibrariesRoot)/System.Net.Security/tests/EnterpriseTests/System.Net.Security.Enterprise.Tests.csproj
+    displayName: Build and run tests
 
-- bash: |
-    cd $(enterpriseTestsSetup)
-    docker-compose down
-  displayName: Stop test network and machines
-  env:
-    DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
+  - bash: |
+      cd $(enterpriseTestsSetup)
+      docker-compose down
+    displayName: Stop test network and machines
+    env:
+      DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
 
-- task: PublishTestResults@2
-  inputs:
-    testRunner: 'xUnit'
-    testResultsFiles: '**/testResults.xml'
-    testRunTitle: 'Enterprise Tests'
-    mergeTestResults: true
-    failTaskOnFailedTests: true
+  - task: PublishTestResults@2
+    inputs:
+      testRunner: 'xUnit'
+      testResultsFiles: '**/testResults.xml'
+      testRunTitle: 'Enterprise Tests'
+      mergeTestResults: true
+      failTaskOnFailedTests: true

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/Dockerfile
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20220421022739-9c434db
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/docker-compose.yml
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/docker-compose.yml
@@ -60,6 +60,9 @@ services:
     hostname: linuxclient
     domainname: linux.contoso.com
     dns_search: linux.contoso.com
+    privileged: true
+    dns:
+      - 8.8.8.8
     volumes:
       - shared-volume:/SHARED
       - ${DOTNET_RUNTIME_REPO_ROOT}:/repo

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/kdc/Dockerfile
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/kdc/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20220421022739-9c434db
 
 COPY ./kdc/kadm5.acl /etc/krb5kdc/
 COPY ./kdc/kdc.conf /etc/krb5kdc/

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/Dockerfile
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20211022152710-047508b
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20220421022739-9c434db
 
 # Prevents dialog prompting when installing packages
 ARG DEBIAN_FRONTEND=noninteractive

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/test-webserver.sh
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/test-webserver.sh
@@ -4,3 +4,6 @@ kdestroy
 echo password | kinit user1
 curl --verbose --negotiate -u: http://apacheweb.linux.contoso.com
 kdestroy
+
+nslookup github.com
+


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/65981, https://github.com/dotnet/runtime/pull/68311 and https://github.com/dotnet/runtime/pull/68875 to release/6.0

## Customer Impact

We started getting warnings in the build about using images from docker directly, see [docs.opensource.microsoft.com/tools/nuget_security_analysis/container_registry_analysis](https://docs.opensource.microsoft.com/tools/nuget_security_analysis/container_registry_analysis/).

Eventually these will be turned into errors and will break the build at that point so we need to backport this before that happens.

/cc @dotnet/runtime-infrastructure 

## Testing

Tested in main and this PR.

## Risk

Very low, it only affects a testing pipeline.