### PR TITLE
Enable dumping of R2R manifest metadata from ildasm

### DIFF
--- a/src/coreclr/ildasm/dasm.cpp
+++ b/src/coreclr/ildasm/dasm.cpp
@@ -11,6 +11,7 @@
 #include "dynamicarray.h"
 #include <metamodelpub.h>
 #include "formattype.h"
+#include "readytorun.h"
 
 #define DECLARE_DATA
 #include "dasmenum.hpp"
@@ -94,6 +95,7 @@ BOOL                    g_fThisIsInstanceMethod;
 BOOL                    g_fTryInCode = TRUE;
 
 BOOL                    g_fLimitedVisibility = FALSE;
+BOOL                    g_fR2RNativeManifestMetadata = FALSE;
 BOOL                    g_fHidePub = TRUE;
 BOOL                    g_fHidePriv = TRUE;
 BOOL                    g_fHideFam = TRUE;
@@ -7002,8 +7004,16 @@ void DumpMetaInfo(_In_ __nullterminated const WCHAR* pwzFileName, _In_opt_z_ con
             if(g_pAssemblyImport==NULL) g_pAssemblyImport = GetAssemblyImport(NULL);
             printLine(GUICookie,RstrUTF(IDS_E_MISTART));
             //MDInfo metaDataInfo(g_pPubImport, g_pAssemblyImport, (LPCWSTR)pwzFileName, DumpMI, g_ulMetaInfoFilter);
-            MDInfo metaDataInfo(g_pDisp,(LPCWSTR)pwzFileName, DumpMI, g_ulMetaInfoFilter);
-            metaDataInfo.DisplayMD();
+            if (g_fR2RNativeManifestMetadata)
+            {
+                MDInfo metaDataInfo(g_pDisp, (PBYTE)g_pMetaData, g_cbMetaData, DumpMI, g_ulMetaInfoFilter);
+                metaDataInfo.DisplayMD();
+            }
+            else
+            {
+                MDInfo metaDataInfo(g_pDisp,(LPCWSTR)pwzFileName, DumpMI, g_ulMetaInfoFilter);
+                metaDataInfo.DisplayMD();
+            }
             printLine(GUICookie,RstrUTF(IDS_E_MIEND));
         }
     }
@@ -7447,6 +7457,41 @@ BOOL DumpFile()
     g_tkEntryPoint = VAL32(IMAGE_COR20_HEADER_FIELD(*g_CORHeader, EntryPointToken)); // integration with MetaInfo
 
 
+    if (g_fR2RNativeManifestMetadata)
+    {
+        //if this is a r2r image, use the native metadata.
+        if( !(g_CORHeader->ManagedNativeHeader.Size >= sizeof(READYTORUN_HEADER) ) )
+        {
+            printError( g_pFile, "/r2rnativemetadata only works on non-composite R2R images." );
+            goto exit;
+        }
+        READYTORUN_HEADER * pR2RHeader;
+        g_pPELoader->getVAforRVA(VAL32(g_CORHeader->ManagedNativeHeader.VirtualAddress), (void**)&pR2RHeader);
+
+        if (pR2RHeader->Signature != READYTORUN_SIGNATURE)
+        {
+            printError( g_pFile, "/r2rnativemetadata only works on non-composite R2R images." );
+            goto exit;
+        }
+
+        g_cbMetaData = 0;
+        READYTORUN_SECTION *pSections = (READYTORUN_SECTION *)((&pR2RHeader->CoreHeader) + 1);
+        for (DWORD iSection = 0; iSection < pR2RHeader->CoreHeader.NumberOfSections; iSection++)
+        {
+            if (pSections[iSection].Type == ReadyToRunSectionType::ManifestMetadata)
+            {
+                g_pPELoader->getVAforRVA(VAL32(pSections[iSection].Section.VirtualAddress), &g_pMetaData);
+                g_cbMetaData = VAL32(pSections[iSection].Section.Size);
+                break;
+            }
+        }
+        if (g_cbMetaData == 0)
+        {
+            printError( g_pFile, "This R2R file does not have an R2R manifest metadata" );
+            goto exit;
+        }
+    }
+    else
     {
     if (g_pPELoader->getVAforRVA(VAL32(g_CORHeader->MetaData.VirtualAddress),&g_pMetaData) == FALSE)
     {

--- a/src/coreclr/ildasm/dasm.cpp
+++ b/src/coreclr/ildasm/dasm.cpp
@@ -7465,10 +7465,10 @@ BOOL DumpFile()
             printError( g_pFile, "/r2rnativemetadata only works on non-composite R2R images." );
             goto exit;
         }
-        READYTORUN_HEADER * pR2RHeader;
+        READYTORUN_HEADER * pR2RHeader = NULL;
         g_pPELoader->getVAforRVA(VAL32(g_CORHeader->ManagedNativeHeader.VirtualAddress), (void**)&pR2RHeader);
 
-        if (pR2RHeader->Signature != READYTORUN_SIGNATURE)
+        if (pR2RHeader == NULL || pR2RHeader->Signature != READYTORUN_SIGNATURE)
         {
             printError( g_pFile, "/r2rnativemetadata only works on non-composite R2R images." );
             goto exit;

--- a/src/coreclr/ildasm/dasm.rc
+++ b/src/coreclr/ildasm/dasm.rc
@@ -79,6 +79,7 @@ BEGIN
     IDS_USAGE_15            L"  /QUOTEALLNAMES      Include all names into single quotes.\n"
     IDS_USAGE_15A           L"  /NOCA               Suppress output of custom attributes.\n"
     IDS_USAGE_15B           L"  /CAVERBAL           Output CA blobs in verbal form (default - in binary form).\n"
+    IDS_USAGE_16            L"  /R2RNATIVEMETADATA  Output the metadata from the R2R Native manifest.\n"
     IDS_USAGE_17            L"The following options are valid for file/console output only:\n"
     IDS_USAGE_18            L"Options for EXE and DLL files:\n"
     IDS_USAGE_19            L"  /UTF8               Use UTF-8 encoding for output (default - ANSI).\n"

--- a/src/coreclr/ildasm/windasm.cpp
+++ b/src/coreclr/ildasm/windasm.cpp
@@ -63,6 +63,7 @@ extern char*                    g_pszObjFileName;
 extern FILE*                    g_pFile;
 
 extern BOOL                 g_fLimitedVisibility;
+extern BOOL                 g_fR2RNativeManifestMetadata;
 extern BOOL                 g_fHidePub;
 extern BOOL                 g_fHidePriv;
 extern BOOL                 g_fHideFam;
@@ -244,6 +245,11 @@ int ProcessOneArg(_In_ __nullterminated char* szArg, _Out_ char** ppszObjFileNam
         {
             g_fLimitedVisibility = TRUE;
             g_fHidePub = FALSE;
+        }
+        else if (_stricmp(szOpt, "r2r") == 0)
+        {
+             g_fR2RNativeManifestMetadata = TRUE;
+             g_fDumpMetaInfo = TRUE;
         }
         else if (_stricmp(szOpt, "pre") == 0)
         {


### PR DESCRIPTION
The R2R manifest assembly is a metadata stream, but we had no dump tool to display it. Adjust ildasm to have a new command line switch which can do so.