### PR TITLE
Reenable win-arm64 runtime tests on PRs

### DIFF
--- a/eng/pipelines/coreclr/crossgen2-composite.yml
+++ b/eng/pipelines/coreclr/crossgen2-composite.yml
@@ -22,8 +22,7 @@ jobs:
     - OSX_x64
     - windows_x86
     - windows_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: innerloop
@@ -50,8 +49,7 @@ jobs:
     - OSX_x64
     - windows_x86
     - windows_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     jobParameters:
       testGroup: innerloop
       readyToRun: true

--- a/eng/pipelines/coreclr/crossgen2-outerloop.yml
+++ b/eng/pipelines/coreclr/crossgen2-outerloop.yml
@@ -22,8 +22,7 @@ jobs:
     - OSX_x64
     - windows_x86
     - windows_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: outerloop
@@ -54,8 +53,7 @@ jobs:
     - OSX_x64
     - windows_x86
     - windows_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       isOfficialBuild: false

--- a/eng/pipelines/coreclr/crossgen2.yml
+++ b/eng/pipelines/coreclr/crossgen2.yml
@@ -20,8 +20,7 @@ jobs:
     - OSX_arm64
     - OSX_x64
     - windows_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: innerloop
@@ -46,8 +45,7 @@ jobs:
     - OSX_arm64
     - OSX_x64
     - windows_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     jobParameters:
       testGroup: innerloop
       readyToRun: true

--- a/eng/pipelines/coreclr/exploratory.yml
+++ b/eng/pipelines/coreclr/exploratory.yml
@@ -27,8 +27,7 @@ jobs:
     - Linux_x64
     - windows_x64
     - windows_x86
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - OSX_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
@@ -45,8 +44,7 @@ jobs:
     - Linux_x64
     - windows_x64
     - windows_x86
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - OSX_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml

--- a/eng/pipelines/coreclr/gc-longrunning.yml
+++ b/eng/pipelines/coreclr/gc-longrunning.yml
@@ -18,8 +18,7 @@ jobs:
     - Linux_x64
     - Linux_arm64
     - windows_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - OSX_x64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
@@ -42,8 +41,7 @@ jobs:
     - Linux_x64
     - Linux_arm64
     - windows_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/gc-simulator.yml
+++ b/eng/pipelines/coreclr/gc-simulator.yml
@@ -19,8 +19,7 @@ jobs:
     # - Linux_x64
     - Linux_arm64
     - windows_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - OSX_x64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
@@ -44,8 +43,7 @@ jobs:
     # - Linux_x64
     - Linux_arm64
     - windows_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/jit-cfg.yml
+++ b/eng/pipelines/coreclr/jit-cfg.yml
@@ -17,8 +17,7 @@ jobs:
     platforms:
     - Linux_arm64
     - Linux_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - windows_x64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
@@ -40,8 +39,7 @@ jobs:
     platforms:
     - Linux_arm64
     - Linux_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - windows_x64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml

--- a/eng/pipelines/coreclr/jit-experimental.yml
+++ b/eng/pipelines/coreclr/jit-experimental.yml
@@ -19,8 +19,7 @@ jobs:
     - OSX_x64
     - Linux_arm64
     - Linux_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - windows_x64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
@@ -44,8 +43,7 @@ jobs:
     - OSX_x64
     - Linux_arm64
     - Linux_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - windows_x64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml

--- a/eng/pipelines/coreclr/jitstress-isas-arm.yml
+++ b/eng/pipelines/coreclr/jitstress-isas-arm.yml
@@ -17,8 +17,7 @@ jobs:
     platforms:
     - Linux_arm64
     - OSX_arm64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: jitstress-isas-arm
@@ -39,8 +38,7 @@ jobs:
     platforms:
     - Linux_arm64
     - OSX_arm64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/jitstress.yml
+++ b/eng/pipelines/coreclr/jitstress.yml
@@ -22,8 +22,7 @@ jobs:
     - Linux_x64
     - windows_x64
     - windows_x86
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: jitstress
@@ -49,8 +48,7 @@ jobs:
     - Linux_x64
     - windows_x64
     - windows_x86
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/jitstress2-jitstressregs.yml
+++ b/eng/pipelines/coreclr/jitstress2-jitstressregs.yml
@@ -22,8 +22,7 @@ jobs:
     - Linux_x64
     - windows_x64
     - windows_x86
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: jitstress2-jitstressregs
@@ -49,8 +48,7 @@ jobs:
     - Linux_x64
     - windows_x64
     - windows_x86
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/libraries-jitstress.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress.yml
@@ -23,8 +23,7 @@ jobs:
     - Linux_arm64
     - windows_x86
     - windows_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     jobParameters:
       # libraries test build platforms
       testBuildPlatforms:
@@ -42,8 +41,7 @@ jobs:
     - Linux_arm
     - Linux_arm64
     - Linux_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - windows_x64
     - windows_x86
     helixQueueGroup: libraries

--- a/eng/pipelines/coreclr/libraries-jitstress2-jitstressregs.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress2-jitstressregs.yml
@@ -23,8 +23,7 @@ jobs:
     - Linux_arm64
     - windows_x86
     - windows_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     jobParameters:
       # libraries test build platforms
       testBuildPlatforms:
@@ -42,8 +41,7 @@ jobs:
     - Linux_arm
     - Linux_arm64
     - Linux_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - windows_x64
     - windows_x86
     helixQueueGroup: libraries

--- a/eng/pipelines/coreclr/libraries-jitstressregs.yml
+++ b/eng/pipelines/coreclr/libraries-jitstressregs.yml
@@ -23,8 +23,7 @@ jobs:
     - Linux_arm64
     - windows_x86
     - windows_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     jobParameters:
       # libraries test build platforms
       testBuildPlatforms:
@@ -42,8 +41,7 @@ jobs:
     - Linux_arm
     - Linux_arm64
     - Linux_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - windows_x64
     - windows_x86
     helixQueueGroup: libraries

--- a/eng/pipelines/coreclr/libraries-pgo.yml
+++ b/eng/pipelines/coreclr/libraries-pgo.yml
@@ -23,8 +23,7 @@ jobs:
     - Linux_arm64
     - windows_x86
     - windows_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     jobParameters:
       # libraries test build platforms
       testBuildPlatforms:
@@ -42,8 +41,7 @@ jobs:
     - Linux_arm
     - Linux_arm64
     - Linux_x64
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - windows_x64
     - windows_x86
     helixQueueGroup: libraries

--- a/eng/pipelines/coreclr/pgo.yml
+++ b/eng/pipelines/coreclr/pgo.yml
@@ -20,8 +20,7 @@ jobs:
     - Linux_x64
     - OSX_arm64
     - windows_arm
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - windows_x64
     - windows_x86
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
@@ -47,8 +46,7 @@ jobs:
     - Linux_x64
     - OSX_arm64
     - windows_arm
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - windows_x64
     - windows_x86
     helixQueueGroup: ci

--- a/eng/pipelines/coreclr/r2r.yml
+++ b/eng/pipelines/coreclr/r2r.yml
@@ -20,8 +20,7 @@ jobs:
     - Linux_x64
     - OSX_arm64
     - windows_arm
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - windows_x64
     - windows_x86
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
@@ -47,8 +46,7 @@ jobs:
     - Linux_x64
     - OSX_arm64
     - windows_arm
-    # Disable arm64 run until https://github.com/dotnet/runtime/issues/68626 gets solved
-    # - windows_arm64
+    - windows_arm64
     - windows_x64
     - windows_x86
     helixQueueGroup: ci

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -858,6 +858,7 @@ jobs:
     platforms:
     - Linux_arm
     - windows_x86
+    - windows_arm64
     helixQueueGroup: pr
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:
@@ -868,23 +869,6 @@ jobs:
           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
-          
-#
-# CoreCLR Test execution on Windows ARM64 using live libraries for rolling.
-# TODO: move to PR testing in the bracket above once https://github.com/dotnet/runtime/issues/68626 is closed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - windows_arm64
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: innerloop
-      liveLibrariesBuildConfig: Release
-      condition: eq(variables['isRollingBuild'], true)
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:


### PR DESCRIPTION
Testing capacity is back to a point where we have been told we can reenable our workloads.

Closes #68626

cc @hoyosjs @agocke 