### PR TITLE
Use more char.Is helpers from RegexCompiler / source generator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -4270,6 +4270,51 @@ namespace System.Text.RegularExpressions.Generator
                     AddIsWordCharHelper(requiredHelpers);
                     negate ^= charClass == RegexCharClass.NotWordClass;
                     return $"{(negate ? "!" : "")}{HelpersTypeName}.IsWordChar({chExpr})";
+
+                case RegexCharClass.ControlClass:
+                case RegexCharClass.NotControlClass:
+                    negate ^= charClass == RegexCharClass.NotControlClass;
+                    return $"{(negate ? "!" : "")}char.IsControl({chExpr})";
+
+                case RegexCharClass.LetterClass:
+                case RegexCharClass.NotLetterClass:
+                    negate ^= charClass == RegexCharClass.NotLetterClass;
+                    return $"{(negate ? "!" : "")}char.IsLetter({chExpr})";
+
+                case RegexCharClass.LetterOrDigitClass:
+                case RegexCharClass.NotLetterOrDigitClass:
+                    negate ^= charClass == RegexCharClass.NotLetterOrDigitClass;
+                    return $"{(negate ? "!" : "")}char.IsLetterOrDigit({chExpr})";
+
+                case RegexCharClass.LowerClass:
+                case RegexCharClass.NotLowerClass:
+                    negate ^= charClass == RegexCharClass.NotLowerClass;
+                    return $"{(negate ? "!" : "")}char.IsLower({chExpr})";
+
+                case RegexCharClass.UpperClass:
+                case RegexCharClass.NotUpperClass:
+                    negate ^= charClass == RegexCharClass.NotUpperClass;
+                    return $"{(negate ? "!" : "")}char.IsUpper({chExpr})";
+
+                case RegexCharClass.NumberClass:
+                case RegexCharClass.NotNumberClass:
+                    negate ^= charClass == RegexCharClass.NotNumberClass;
+                    return $"{(negate ? "!" : "")}char.IsNumber({chExpr})";
+
+                case RegexCharClass.PunctuationClass:
+                case RegexCharClass.NotPunctuationClass:
+                    negate ^= charClass == RegexCharClass.NotPunctuationClass;
+                    return $"{(negate ? "!" : "")}char.IsPunctuation({chExpr})";
+
+                case RegexCharClass.SeparatorClass:
+                case RegexCharClass.NotSeparatorClass:
+                    negate ^= charClass == RegexCharClass.NotSeparatorClass;
+                    return $"{(negate ? "!" : "")}char.IsSeparator({chExpr})";
+
+                case RegexCharClass.SymbolClass:
+                case RegexCharClass.NotSymbolClass:
+                    negate ^= charClass == RegexCharClass.NotSymbolClass;
+                    return $"{(negate ? "!" : "")}char.IsSymbol({chExpr})";
             }
 
             // Next, handle simple sets of one range, e.g. [A-Z], [0-9], etc.  This includes some built-in classes, like ECMADigitClass.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -48,12 +48,30 @@ namespace System.Text.RegularExpressions
         private const string WordCategories = "\u0000\u0002\u0004\u0005\u0003\u0001\u0006\u0009\u0013\u0000";
         private const string NotWordCategories = "\u0000\uFFFE\uFFFC\uFFFB\uFFFD\uFFFF\uFFFA\uFFF7\uFFED\u0000";
 
-        internal const string SpaceClass = "\u0000\u0000\u0001\u0064";
-        internal const string NotSpaceClass = "\u0000\u0000\u0001\uFF9C";
-        internal const string WordClass = "\u0000\u0000\u000A\u0000\u0002\u0004\u0005\u0003\u0001\u0006\u0009\u0013\u0000";
-        internal const string NotWordClass = "\u0000\u0000\u000A\u0000\uFFFE\uFFFC\uFFFB\uFFFD\uFFFF\uFFFA\uFFF7\uFFED\u0000";
-        internal const string DigitClass = "\u0000\u0000\u0001\u0009";
-        internal const string NotDigitClass = "\u0000\u0000\u0001\uFFF7";
+        internal const string SpaceClass = "\u0000\u0000\u0001\u0064"; // \s
+        internal const string NotSpaceClass = "\u0000\u0000\u0001\uFF9C"; // \S
+        internal const string WordClass = "\u0000\u0000\u000A\u0000\u0002\u0004\u0005\u0003\u0001\u0006\u0009\u0013\u0000"; // \w
+        internal const string NotWordClass = "\u0000\u0000\u000A\u0000\uFFFE\uFFFC\uFFFB\uFFFD\uFFFF\uFFFA\uFFF7\uFFED\u0000"; // \W
+        internal const string DigitClass = "\u0000\u0000\u0001\u0009"; // \d
+        internal const string NotDigitClass = "\u0000\u0000\u0001\uFFF7"; // \D
+        internal const string ControlClass = "\0\0\a\0\u000f\u0010\u001e\u0012\u0011\0"; // \p{C}
+        internal const string NotControlClass = "\0\0\u0007\0\ufff1\ufff0\uffe2\uffee\uffef\0"; // \P{C}
+        internal const string LetterClass = "\0\0\a\0\u0002\u0004\u0005\u0003\u0001\0"; // \p{L}
+        internal const string NotLetterClass = "\0\0\u0007\0\ufffe\ufffc\ufffb\ufffd\uffff\0"; // \P{L}
+        internal const string LetterOrDigitClass = "\0\0\b\0\u0002\u0004\u0005\u0003\u0001\0\t"; // [\p{L}\d]
+        internal const string NotLetterOrDigitClass = "\u0001\0\b\0\u0002\u0004\u0005\u0003\u0001\0\t"; // [^\p{L}\d]
+        internal const string LowerClass = "\0\0\u0001\u0002"; // \p{Ll}
+        internal const string NotLowerClass = "\0\0\u0001\ufffe"; // \P{Ll}
+        internal const string UpperClass = "\0\0\u0001\u0001"; // \p{Lu}
+        internal const string NotUpperClass = "\0\0\u0001\uffff"; // \P{Lu}
+        internal const string NumberClass = "\0\0\u0005\0\t\n\v\0"; // \p{N}
+        internal const string NotNumberClass = "\0\0\u0005\0\ufff7\ufff6\ufff5\0"; // \P{N}
+        internal const string PunctuationClass = "\0\0\t\0\u0013\u0014\u0016\u0019\u0015\u0018\u0017\0"; // \p{P}
+        internal const string NotPunctuationClass = "\0\0\u0009\0\uffed\uffec\uffea\uffe7\uffeb\uffe8\uffe9\0"; // \P{P}
+        internal const string SeparatorClass = "\0\0\u0005\0\r\u000e\f\0"; // \p{Z}
+        internal const string NotSeparatorClass = "\0\0\u0005\0\ufff3\ufff2\ufff4\0"; // \P{Z}
+        internal const string SymbolClass = "\0\0\u0006\0\u001b\u001c\u001a\u001d\0"; // \p{S}
+        internal const string NotSymbolClass = "\0\0\u0006\0\uffe5\uffe4\uffe6\uffe3\0"; // \P{S}
 
         private const string ECMASpaceRanges = "\u0009\u000E\u0020\u0021";
         private const string NotECMASpaceRanges = "\0\u0009\u000E\u0020\u0021";

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -41,6 +41,15 @@ namespace System.Text.RegularExpressions
         private static readonly MethodInfo s_regexCaseEquivalencesTryFindCaseEquivalencesForCharWithIBehaviorMethod = typeof(RegexCaseEquivalences).GetMethod("TryFindCaseEquivalencesForCharWithIBehavior", BindingFlags.Static | BindingFlags.Public)!;
         private static readonly MethodInfo s_charIsDigitMethod = typeof(char).GetMethod("IsDigit", new Type[] { typeof(char) })!;
         private static readonly MethodInfo s_charIsWhiteSpaceMethod = typeof(char).GetMethod("IsWhiteSpace", new Type[] { typeof(char) })!;
+        private static readonly MethodInfo s_charIsControlMethod = typeof(char).GetMethod("IsControl", new Type[] { typeof(char) })!;
+        private static readonly MethodInfo s_charIsLetterMethod = typeof(char).GetMethod("IsLetter", new Type[] { typeof(char) })!;
+        private static readonly MethodInfo s_charIsLetterOrDigitMethod = typeof(char).GetMethod("IsLetterOrDigit", new Type[] { typeof(char) })!;
+        private static readonly MethodInfo s_charIsLowerMethod = typeof(char).GetMethod("IsLower", new Type[] { typeof(char) })!;
+        private static readonly MethodInfo s_charIsUpperMethod = typeof(char).GetMethod("IsUpper", new Type[] { typeof(char) })!;
+        private static readonly MethodInfo s_charIsNumberMethod = typeof(char).GetMethod("IsNumber", new Type[] { typeof(char) })!;
+        private static readonly MethodInfo s_charIsPunctuationMethod = typeof(char).GetMethod("IsPunctuation", new Type[] { typeof(char) })!;
+        private static readonly MethodInfo s_charIsSeparatorMethod = typeof(char).GetMethod("IsSeparator", new Type[] { typeof(char) })!;
+        private static readonly MethodInfo s_charIsSymbolMethod = typeof(char).GetMethod("IsSymbol", new Type[] { typeof(char) })!;
         private static readonly MethodInfo s_charGetUnicodeInfo = typeof(char).GetMethod("GetUnicodeCategory", new Type[] { typeof(char) })!;
         private static readonly MethodInfo s_spanGetItemMethod = typeof(ReadOnlySpan<char>).GetMethod("get_Item", new Type[] { typeof(int) })!;
         private static readonly MethodInfo s_spanGetLengthMethod = typeof(ReadOnlySpan<char>).GetMethod("get_Length")!;
@@ -1758,7 +1767,7 @@ namespace System.Text.RegularExpressions
                     Call(s_regexCaseEquivalencesTryFindCaseEquivalencesForCharWithIBehaviorMethod);
                     BrfalseFar(doneLabel);
 
-                    // if (equivalences.IndexOf(slice[i]) == -1) // Or if (equivalences.IndexOf(inputSpan[pos - matchLength + i]) == -1) when rtl
+                    // if (equivalences.IndexOf(slice[i]) < 0) // Or if (equivalences.IndexOf(inputSpan[pos - matchLength + i]) < 0) when rtl
                     Ldloc(caseEquivalences);
                     if (!rtl)
                     {
@@ -1777,10 +1786,9 @@ namespace System.Text.RegularExpressions
                     Call(s_spanGetItemMethod);
                     LdindU2();
                     Call(s_spanIndexOfChar);
-                    Ldc(-1);
-                    Ceq();
+                    Ldc(0);
                     // return false; // input didn't match.
-                    BrtrueFar(doneLabel);
+                    BltFar(doneLabel);
                 }
                 else
                 {
@@ -5049,39 +5057,87 @@ namespace System.Text.RegularExpressions
                     return;
 
                 case RegexCharClass.DigitClass:
+                case RegexCharClass.NotDigitClass:
                     // char.IsDigit(ch)
                     Call(s_charIsDigitMethod);
-                    return;
-
-                case RegexCharClass.NotDigitClass:
-                    // !char.IsDigit(ch)
-                    Call(s_charIsDigitMethod);
-                    Ldc(0);
-                    Ceq();
+                    NegateIf(charClass == RegexCharClass.NotDigitClass);
                     return;
 
                 case RegexCharClass.SpaceClass:
+                case RegexCharClass.NotSpaceClass:
                     // char.IsWhiteSpace(ch)
                     Call(s_charIsWhiteSpaceMethod);
-                    return;
-
-                case RegexCharClass.NotSpaceClass:
-                    // !char.IsWhiteSpace(ch)
-                    Call(s_charIsWhiteSpaceMethod);
-                    Ldc(0);
-                    Ceq();
+                    NegateIf(charClass == RegexCharClass.NotSpaceClass);
                     return;
 
                 case RegexCharClass.WordClass:
+                case RegexCharClass.NotWordClass:
                     // RegexRunner.IsWordChar(ch)
                     Call(s_isWordCharMethod);
+                    NegateIf(charClass == RegexCharClass.NotWordClass);
                     return;
 
-                case RegexCharClass.NotWordClass:
-                    // !RegexRunner.IsWordChar(ch)
-                    Call(s_isWordCharMethod);
-                    Ldc(0);
-                    Ceq();
+                case RegexCharClass.ControlClass:
+                case RegexCharClass.NotControlClass:
+                    // char.IsControl(ch)
+                    Call(s_charIsControlMethod);
+                    NegateIf(charClass == RegexCharClass.NotControlClass);
+                    return;
+
+                case RegexCharClass.LetterClass:
+                case RegexCharClass.NotLetterClass:
+                    // char.IsLetter(ch)
+                    Call(s_charIsLetterMethod);
+                    NegateIf(charClass == RegexCharClass.NotLetterClass);
+                    return;
+
+                case RegexCharClass.LetterOrDigitClass:
+                case RegexCharClass.NotLetterOrDigitClass:
+                    // char.IsLetterOrDigit(ch)
+                    Call(s_charIsLetterOrDigitMethod);
+                    NegateIf(charClass == RegexCharClass.NotLetterOrDigitClass);
+                    return;
+
+                case RegexCharClass.LowerClass:
+                case RegexCharClass.NotLowerClass:
+                    // char.IsLower(ch)
+                    Call(s_charIsLowerMethod);
+                    NegateIf(charClass == RegexCharClass.NotLowerClass);
+                    return;
+
+                case RegexCharClass.UpperClass:
+                case RegexCharClass.NotUpperClass:
+                    // char.IsUpper(ch)
+                    Call(s_charIsUpperMethod);
+                    NegateIf(charClass == RegexCharClass.NotUpperClass);
+                    return;
+
+                case RegexCharClass.NumberClass:
+                case RegexCharClass.NotNumberClass:
+                    // char.IsNumber(ch)
+                    Call(s_charIsNumberMethod);
+                    NegateIf(charClass == RegexCharClass.NotNumberClass);
+                    return;
+
+                case RegexCharClass.PunctuationClass:
+                case RegexCharClass.NotPunctuationClass:
+                    // char.IsPunctuation(ch)
+                    Call(s_charIsPunctuationMethod);
+                    NegateIf(charClass == RegexCharClass.NotPunctuationClass);
+                    return;
+
+                case RegexCharClass.SeparatorClass:
+                case RegexCharClass.NotSeparatorClass:
+                    // char.IsSeparator(ch)
+                    Call(s_charIsSeparatorMethod);
+                    NegateIf(charClass == RegexCharClass.NotSeparatorClass);
+                    return;
+
+                case RegexCharClass.SymbolClass:
+                case RegexCharClass.NotSymbolClass:
+                    // char.IsSymbol(ch)
+                    Call(s_charIsSymbolMethod);
+                    NegateIf(charClass == RegexCharClass.NotSymbolClass);
                     return;
             }
 
@@ -5104,11 +5160,7 @@ namespace System.Text.RegularExpressions
                 }
 
                 // Negate the answer if the negation flag was set
-                if (RegexCharClass.IsNegated(charClass))
-                {
-                    Ldc(0);
-                    Ceq();
-                }
+                NegateIf(RegexCharClass.IsNegated(charClass));
 
                 return;
             }
@@ -5125,12 +5177,7 @@ namespace System.Text.RegularExpressions
                 Call(s_charGetUnicodeInfo);
                 Ldc((int)categories[0]);
                 Ceq();
-                if (negated)
-                {
-                    Ldc(0);
-                    Ceq();
-                }
-
+                NegateIf(negated);
                 return;
             }
 
@@ -5175,11 +5222,7 @@ namespace System.Text.RegularExpressions
                     Or();
                 }
 
-                if (RegexCharClass.IsNegated(charClass))
-                {
-                    Ldc(0);
-                    Ceq();
-                }
+                NegateIf(RegexCharClass.IsNegated(charClass));
                 return;
             }
 
@@ -5202,11 +5245,7 @@ namespace System.Text.RegularExpressions
                 Sub();
                 Ldc(rangeUpper.HighInclusive - rangeUpper.LowInclusive + 1);
                 CltUn();
-                if (negate)
-                {
-                    Ldc(0);
-                    Ceq();
-                }
+                NegateIf(negate);
                 return;
             }
 
@@ -5269,11 +5308,7 @@ namespace System.Text.RegularExpressions
                 Ldc(0);
                 _ilg!.Emit(OpCodes.Conv_I8);
                 _ilg!.Emit(OpCodes.Clt);
-                if (negatedClass)
-                {
-                    Ldc(0);
-                    Ceq();
-                }
+                NegateIf(negatedClass);
 
                 return;
             }
@@ -5299,11 +5334,7 @@ namespace System.Text.RegularExpressions
                     Ldc(range0.HighInclusive - range0.LowInclusive + 1);
                     CltUn();
                 }
-                if (negate)
-                {
-                    Ldc(0);
-                    Ceq();
-                }
+                NegateIf(negate);
 
                 if (range1.LowInclusive == range1.HighInclusive)
                 {
@@ -5321,11 +5352,7 @@ namespace System.Text.RegularExpressions
                     Ldc(range1.HighInclusive - range1.LowInclusive + 1);
                     CltUn();
                 }
-                if (negate)
-                {
-                    Ldc(0);
-                    Ceq();
-                }
+                NegateIf(negate);
 
                 if (negate)
                 {
@@ -5473,6 +5500,16 @@ namespace System.Text.RegularExpressions
             }
             MarkLabel(doneLabel);
             Ldloc(resultLocal);
+        }
+
+        /// <summary>Emits negation of the value on top of the evaluation stack if <paramref name="condition"/> is true.</summary>
+        private void NegateIf(bool condition)
+        {
+            if (condition)
+            {
+                Ldc(0);
+                Ceq();
+            }
         }
 
         /// <summary>Emits a timeout check if one has been set explicitly or implicitly via a default setting.</summary>


### PR DESCRIPTION
This PR causes regex to now specially-recognize additional categories that map to sets `char` already has `IsXx` methods for and call them, e.g. `char.IsControl`, `char.IsLetter`, etc.

Example:
```C#
[RegexGenerator(@"\p{C}\P{C}\p{L}\P{L}[\p{L}\d][^\p{L}\d]\p{Ll}\P{Ll}\p{Lu}\P{Lu}\p{N}\P{N}\p{P}\P{P}\p{Z}\P{Z}\p{S}\P{S}")]
```
previously resulted in:
```C#
if ((uint)slice.Length < 18 ||
    (char.GetUnicodeCategory(slice[0]) switch { UnicodeCategory.Control or UnicodeCategory.Format or UnicodeCategory.OtherNotAssigned or UnicodeCategory.PrivateUse or UnicodeCategory.Surrogate => false, _ => true }) || // Match a character in the set [\p{C}].
    (char.GetUnicodeCategory(slice[1]) switch { UnicodeCategory.Control or UnicodeCategory.Format or UnicodeCategory.OtherNotAssigned or UnicodeCategory.PrivateUse or UnicodeCategory.Surrogate => true, _ => false }) || // Match a character in the set [\P{C}].
    (char.GetUnicodeCategory(slice[2]) switch { UnicodeCategory.LowercaseLetter or UnicodeCategory.ModifierLetter or UnicodeCategory.OtherLetter or UnicodeCategory.TitlecaseLetter or UnicodeCategory.UppercaseLetter => false, _ => true }) || // Match a character in the set [\p{L}].
    (char.GetUnicodeCategory(slice[3]) switch { UnicodeCategory.LowercaseLetter or UnicodeCategory.ModifierLetter or UnicodeCategory.OtherLetter or UnicodeCategory.TitlecaseLetter or UnicodeCategory.UppercaseLetter => true, _ => false }) || // Match a character in the set [\P{L}].
    (char.GetUnicodeCategory(slice[4]) switch { UnicodeCategory.LowercaseLetter or UnicodeCategory.ModifierLetter or UnicodeCategory.OtherLetter or UnicodeCategory.TitlecaseLetter or UnicodeCategory.UppercaseLetter or UnicodeCategory.DecimalDigitNumber => false, _ => true }) || // Match a character in the set [\p{L}\d].
    (char.GetUnicodeCategory(slice[5]) switch { UnicodeCategory.LowercaseLetter or UnicodeCategory.ModifierLetter or UnicodeCategory.OtherLetter or UnicodeCategory.TitlecaseLetter or UnicodeCategory.UppercaseLetter or UnicodeCategory.DecimalDigitNumber => true, _ => false }) || // Match a character in the set [^\p{L}\d].
    (char.GetUnicodeCategory(slice[6]) != UnicodeCategory.LowercaseLetter) || // Match a character in the set [\p{Ll}].
    (char.GetUnicodeCategory(slice[7]) == UnicodeCategory.LowercaseLetter) || // Match a character in the set [\P{Ll}].
    (char.GetUnicodeCategory(slice[8]) != UnicodeCategory.UppercaseLetter) || // Match a character in the set [\p{Lu}].
    (char.GetUnicodeCategory(slice[9]) == UnicodeCategory.UppercaseLetter) || // Match a character in the set [\P{Lu}].
    (char.GetUnicodeCategory(slice[10]) switch { UnicodeCategory.DecimalDigitNumber or UnicodeCategory.LetterNumber or UnicodeCategory.OtherNumber => false, _ => true }) || // Match a character in the set [\p{N}].
    (char.GetUnicodeCategory(slice[11]) switch { UnicodeCategory.DecimalDigitNumber or UnicodeCategory.LetterNumber or UnicodeCategory.OtherNumber => true, _ => false }) || // Match a character in the set [\P{N}].
    (char.GetUnicodeCategory(slice[12]) switch { UnicodeCategory.ConnectorPunctuation or UnicodeCategory.DashPunctuation or UnicodeCategory.ClosePunctuation or UnicodeCategory.OtherPunctuation or UnicodeCategory.OpenPunctuation or UnicodeCategory.FinalQuotePunctuation or UnicodeCategory.InitialQuotePunctuation => false, _ => true }) || // Match a character in the set [\p{P}].
    (char.GetUnicodeCategory(slice[13]) switch { UnicodeCategory.ConnectorPunctuation or UnicodeCategory.DashPunctuation or UnicodeCategory.ClosePunctuation or UnicodeCategory.OtherPunctuation or UnicodeCategory.OpenPunctuation or UnicodeCategory.FinalQuotePunctuation or UnicodeCategory.InitialQuotePunctuation => true, _ => false }) || // Match a character in the set [\P{P}].
    (char.GetUnicodeCategory(slice[14]) switch { UnicodeCategory.LineSeparator or UnicodeCategory.ParagraphSeparator or UnicodeCategory.SpaceSeparator => false, _ => true }) || // Match a character in the set [\p{Z}].
    (char.GetUnicodeCategory(slice[15]) switch { UnicodeCategory.LineSeparator or UnicodeCategory.ParagraphSeparator or UnicodeCategory.SpaceSeparator => true, _ => false }) || // Match a character in the set [\P{Z}].
    (char.GetUnicodeCategory(slice[16]) switch { UnicodeCategory.CurrencySymbol or UnicodeCategory.ModifierSymbol or UnicodeCategory.MathSymbol or UnicodeCategory.OtherSymbol => false, _ => true }) || // Match a character in the set [\p{S}].
    (char.GetUnicodeCategory(slice[17]) switch { UnicodeCategory.CurrencySymbol or UnicodeCategory.ModifierSymbol or UnicodeCategory.MathSymbol or UnicodeCategory.OtherSymbol => true, _ => false })) // Match a character in the set [\P{S}].
{
    return false; // The input didn't match.
}
```
and now results in:
```C#
if ((uint)slice.Length < 18 ||
    !char.IsControl(slice[0]) || // Match a character in the set [\p{C}].
    char.IsControl(slice[1]) || // Match a character in the set [\P{C}].
    !char.IsLetter(slice[2]) || // Match a character in the set [\p{L}].
    char.IsLetter(slice[3]) || // Match a character in the set [\P{L}].
    !char.IsLetterOrDigit(slice[4]) || // Match a character in the set [\p{L}\d].
    char.IsLetterOrDigit(slice[5]) || // Match a character in the set [^\p{L}\d].
    !char.IsLower(slice[6]) || // Match a character in the set [\p{Ll}].
    char.IsLower(slice[7]) || // Match a character in the set [\P{Ll}].
    !char.IsUpper(slice[8]) || // Match a character in the set [\p{Lu}].
    char.IsUpper(slice[9]) || // Match a character in the set [\P{Lu}].
    !char.IsNumber(slice[10]) || // Match a character in the set [\p{N}].
    char.IsNumber(slice[11]) || // Match a character in the set [\P{N}].
    !char.IsPunctuation(slice[12]) || // Match a character in the set [\p{P}].
    char.IsPunctuation(slice[13]) || // Match a character in the set [\P{P}].
    !char.IsSeparator(slice[14]) || // Match a character in the set [\p{Z}].
    char.IsSeparator(slice[15]) || // Match a character in the set [\P{Z}].
    !char.IsSymbol(slice[16]) || // Match a character in the set [\p{S}].
    char.IsSymbol(slice[17])) // Match a character in the set [\P{S}].
{
    return false; // The input didn't match.
}
```