### PR TITLE
Fix System.Collections.Immutable version in ILCompiler.Build.Tasks

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -92,6 +92,7 @@
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>
     <StyleCopAnalyzersVersion>1.2.0-beta.406</StyleCopAnalyzersVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
+    <SystemCollectionsImmutableVersion>6.0.0</SystemCollectionsImmutableVersion>
     <SystemComponentModelAnnotationsVersion>5.0.0</SystemComponentModelAnnotationsVersion>
     <SystemDataSqlClientVersion>4.8.3</SystemDataSqlClientVersion>
     <SystemDataDataSetExtensionsVersion>4.5.0</SystemDataDataSetExtensionsVersion>

--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ILCompiler.Build.Tasks.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ILCompiler.Build.Tasks.csproj
@@ -30,7 +30,7 @@
     <Content Include="$(NuGetPackageRoot)\system.reflection.metadata\$(SystemReflectionMetadataVersion)\lib\netstandard2.0\System.Reflection.Metadata.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="$(NuGetPackageRoot)\system.collections.immutable\$(SystemReflectionMetadataVersion)\lib\netstandard2.0\System.Collections.Immutable.dll">
+    <Content Include="$(NuGetPackageRoot)\system.collections.immutable\$(SystemCollectionsImmutableVersion)\lib\netstandard2.0\System.Collections.Immutable.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
In source-build, we reference newer versions of System.Collections.Immutable and System.Reflection.Metadata. The latest version of System.Collections.Immutable is 6.0.0, while System.Reflection.Metadata is at version 6.0.1. That causes this project to fail to build because it is looking for a version of System.Collections.Immutable that doesn't exist. This fix uses the correct version of System.Collections.Immutable when copying the package content.