### PR TITLE
Call simpler overloads of Substring and Slice

### DIFF
--- a/src/coreclr/tools/Common/Compiler/Logging/DocumentationSignatureParser.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/DocumentationSignatureParser.cs
@@ -538,7 +538,7 @@ namespace ILCompiler.Logging
                 if (indexOfLastDot > 0 && indexOfLastDot < name.Length - 1)
                 {
                     namespacepart = name.Substring(indexOfLastDot - 1);
-                    namepart = name.Substring(indexOfLastDot + 1, name.Length - indexOfLastDot - 1);
+                    namepart = name.Substring(indexOfLastDot + 1);
                 }
                 else
                 {

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -460,7 +460,7 @@ namespace ILCompiler
                 Dictionary<string, bool> instructionSetSpecification = new Dictionary<string, bool>();
                 foreach (string instructionSetSpecifier in instructionSetParams)
                 {
-                    string instructionSet = instructionSetSpecifier.Substring(1, instructionSetSpecifier.Length - 1);
+                    string instructionSet = instructionSetSpecifier.Substring(1);
 
                     bool enabled = instructionSetSpecifier[0] == '+' ? true : false;
                     if (enabled)

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -262,7 +262,7 @@ namespace ILCompiler
                 Dictionary<string, bool> instructionSetSpecification = new Dictionary<string, bool>();
                 foreach (string instructionSetSpecifier in instructionSetParams)
                 {
-                    string instructionSet = instructionSetSpecifier.Substring(1, instructionSetSpecifier.Length - 1);
+                    string instructionSet = instructionSetSpecifier.Substring(1);
 
                     bool enabled = instructionSetSpecifier[0] == '+' ? true : false;
                     if (enabled)

--- a/src/libraries/Microsoft.Win32.Registry/src/Microsoft/Win32/Registry.cs
+++ b/src/libraries/Microsoft.Win32.Registry/src/Microsoft/Win32/Registry.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Win32
             {
                 subKeyName = (i == -1 || i == keyName.Length) ?
                     string.Empty :
-                    keyName.Substring(i + 1, keyName.Length - i - 1);
+                    keyName.Substring(i + 1);
 
                 return baseKey;
             }

--- a/src/libraries/System.Data.Common/src/System/Data/DataTable.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataTable.cs
@@ -6508,7 +6508,7 @@ namespace System.Data
                     {
                         CurrentTableNamespace = CurrentTableFullName.Substring(0, nsSeperator);
                     }
-                    string CurrentTableName = CurrentTableFullName.Substring(nsSeperator + 1, CurrentTableFullName.Length - nsSeperator - 1);
+                    string CurrentTableName = CurrentTableFullName.Substring(nsSeperator + 1);
 
                     currentTable = ds.Tables[CurrentTableName, CurrentTableNamespace];
                 }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -755,13 +755,13 @@ namespace System.Diagnostics
                 {
                     activitySourceName = entry.Slice(0, eventNameIndex).Trim();
 
-                    ReadOnlySpan<char> suffixPart = entry.Slice(eventNameIndex + 1, entry.Length - eventNameIndex - 1).Trim();
+                    ReadOnlySpan<char> suffixPart = entry.Slice(eventNameIndex + 1).Trim();
                     int samplingResultIndex = suffixPart.IndexOf('-');
                     if (samplingResultIndex >= 0)
                     {
                         // We have the format "[AS]SourceName/[EventName]-[SamplingResult]
                         eventName = suffixPart.Slice(0, samplingResultIndex).Trim();
-                        suffixPart = suffixPart.Slice(samplingResultIndex + 1, suffixPart.Length - samplingResultIndex - 1).Trim();
+                        suffixPart = suffixPart.Slice(samplingResultIndex + 1).Trim();
 
                         if (suffixPart.Length > 0)
                         {

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Utils.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Utils.cs
@@ -606,7 +606,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 if ((index = tmpUsername.IndexOf('\\')) != -1)
                 {
                     domain = tmpUsername.Substring(0, index);
-                    username = tmpUsername.Substring(index + 1, tmpUsername.Length - index - 1);
+                    username = tmpUsername.Substring(index + 1);
                 }
                 else
                 {

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/FontConverter.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/FontConverter.cs
@@ -153,7 +153,7 @@ namespace System.Drawing
                 if (styleIndex != -1)
                 {
                     // style found.
-                    style = font.Substring(styleIndex, font.Length - styleIndex);
+                    style = font.Substring(styleIndex);
 
                     // Get the mid-substring containing the size information.
                     sizeStr = font.Substring(nameIndex + 1, styleIndex - nameIndex - 1);

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
@@ -124,7 +124,7 @@ namespace System.IO.Compression
                 }
                 if (copied > 0)
                 {
-                    bytes = bytes.Slice(copied, bytes.Length - copied);
+                    bytes = bytes.Slice(copied);
                     count += copied;
                 }
 

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PartBasedPackageProperties.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PartBasedPackageProperties.cs
@@ -623,7 +623,7 @@ namespace System.IO.Packaging
             //  The namespace of the prefix (string before ":") matches "ns"
             //  The name (string after ":") matches "name"
             if (!object.ReferenceEquals(ns, reader.LookupNamespace(typeValue.Substring(0, index)))
-                    || string.CompareOrdinal(name, typeValue.Substring(index + 1, typeValue.Length - index - 1)) != 0)
+                    || string.CompareOrdinal(name, typeValue.Substring(index + 1)) != 0)
             {
                 throw new XmlException(SR.Format(SR.UnknownDCDateTimeXsiType, reader.Name),
                     null, ((IXmlLineInfo)reader).LineNumber, ((IXmlLineInfo)reader).LinePosition);

--- a/src/libraries/System.Management/src/System/Management/ManagementDateTime.cs
+++ b/src/libraries/System.Management/src/System/Management/ManagementDateTime.cs
@@ -255,7 +255,7 @@ namespace System.Management
             else
             {
                 string strTemp = OffsetMins.ToString(frmInt32);
-                UtcString = "-" + strTemp.Substring(1, strTemp.Length - 1).PadLeft(3, '0');
+                UtcString = "-" + strTemp.Substring(1).PadLeft(3, '0');
             }
 
             string dmtfDateTime = date.Year.ToString(frmInt32).PadLeft(4, '0');

--- a/src/libraries/System.Management/src/System/Management/WMIGenerator.cs
+++ b/src/libraries/System.Management/src/System/Management/WMIGenerator.cs
@@ -825,7 +825,7 @@ namespace System.Management
             if (strTemp.Length > 0)
             {
                 string strFirstChar = strTemp.Substring(0, 1).ToUpperInvariant();
-                strTemp = strFirstChar + strTemp.Substring(1, strTemp.Length - 1);
+                strTemp = strFirstChar + strTemp.Substring(1);
             }
 
             return strTemp;
@@ -7142,7 +7142,7 @@ namespace System.Management
                 else
                 {
                     string strTemp = OffsetMins.ToString();
-                    UtcString = "-" + strTemp.Substring(1, strTemp.Length-1).PadLeft(3,'0');
+                    UtcString = "-" + strTemp.Substring(1).PadLeft(3,'0');
                 }
             */
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ContentDispositionHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ContentDispositionHeaderValue.cs
@@ -518,7 +518,7 @@ namespace System.Net.Http.Headers
             }
 
             string encodingString = input.Substring(0, quoteIndex);
-            string dataString = input.Substring(lastQuoteIndex + 1, input.Length - (lastQuoteIndex + 1));
+            string dataString = input.Substring(lastQuoteIndex + 1);
 
             StringBuilder decoded = new StringBuilder();
             try

--- a/src/libraries/System.Net.Requests/src/System/Net/FtpControlStream.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FtpControlStream.cs
@@ -770,7 +770,7 @@ namespace System.Net
             else
             {
                 directory = path.Substring(0, index + 1);
-                filename = path.Substring(index + 1, path.Length - (index + 1));
+                filename = path.Substring(index + 1);
             }
 
             // strip off trailing '/' on directory if present

--- a/src/libraries/System.Net.Requests/src/System/Net/FtpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FtpWebRequest.cs
@@ -510,7 +510,7 @@ namespace System.Net
                 {
                     username = Uri.UnescapeDataString(userInfo.Substring(0, index));
                     index++; // skip ':'
-                    password = Uri.UnescapeDataString(userInfo.Substring(index, userInfo.Length - index));
+                    password = Uri.UnescapeDataString(userInfo.Substring(index));
                 }
                 networkCredential = new NetworkCredential(username, password);
             }

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -1361,7 +1361,7 @@ namespace System.Net.WebSockets
                 // While we don't have enough data, read more.
                 while (_receiveBufferCount < minimumRequiredBytes)
                 {
-                    int numRead = await _stream.ReadAsync(_receiveBuffer.Slice(_receiveBufferCount, _receiveBuffer.Length - _receiveBufferCount), cancellationToken).ConfigureAwait(false);
+                    int numRead = await _stream.ReadAsync(_receiveBuffer.Slice(_receiveBufferCount), cancellationToken).ConfigureAwait(false);
                     Debug.Assert(numRead >= 0, $"Expected non-negative bytes read, got {numRead}");
                     if (numRead <= 0)
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
@@ -243,7 +243,7 @@ namespace System.IO
             for (int i = path.Length; --i >= 0;)
             {
                 if (i < root || PathInternal.IsDirectorySeparator(path[i]))
-                    return path.Slice(i + 1, path.Length - i - 1);
+                    return path.Slice(i + 1);
             }
 
             return path;

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XNodeReader.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XNodeReader.cs
@@ -1152,7 +1152,7 @@ namespace System.Xml.Linq
                     XNamespace? ns = e.GetNamespaceOfPrefix(qualifiedName.Substring(0, i));
                     if (ns != null)
                     {
-                        localName = qualifiedName.Substring(i + 1, qualifiedName.Length - i - 1);
+                        localName = qualifiedName.Substring(i + 1);
                         namespaceName = ns.NamespaceName;
                         return;
                     }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaDataType.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaDataType.cs
@@ -253,7 +253,7 @@ namespace System.Xml.Schema
 
             if (convert)
             {
-                canonicalUri = nameTable.Add(string.Concat(uri.AsSpan(0, offset), uri.Substring(offset, uri.Length - offset).ToUpperInvariant()));
+                canonicalUri = nameTable.Add(string.Concat(uri.AsSpan(0, offset), uri.Substring(offset).ToUpperInvariant()));
             }
             else
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/ValidateNames.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/ValidateNames.cs
@@ -626,7 +626,7 @@ namespace System.Xml
             {
                 prefix = name.Substring(0, colonPos);
                 colonPos++; // move after colon
-                lname = name.Substring(colonPos, name.Length - colonPos);
+                lname = name.Substring(colonPos);
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/XmlKeyHelper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/XmlKeyHelper.cs
@@ -117,7 +117,7 @@ namespace System.Security.Cryptography
                 start++;
             }
 
-            WriteCryptoBinary(name, valBuf.Slice(start, valBuf.Length - start), builder);
+            WriteCryptoBinary(name, valBuf.Slice(start), builder);
         }
 
         internal static void WriteCryptoBinary(string name, ReadOnlySpan<byte> value, StringBuilder builder)

--- a/src/libraries/System.Speech/src/Internal/ObjectToken/RegistryDataKey.cs
+++ b/src/libraries/System.Speech/src/Internal/ObjectToken/RegistryDataKey.cs
@@ -470,7 +470,7 @@ namespace System.Speech.Internal.ObjectTokens
             if (index >= 0)
             {
                 firstKey = registryPath.Substring(0, index);
-                registryPath = registryPath.Substring(index + 1, registryPath.Length - index - 1);
+                registryPath = registryPath.Substring(index + 1);
             }
             else
             {

--- a/src/libraries/System.Speech/src/Recognition/RecognizerBase.cs
+++ b/src/libraries/System.Speech/src/Recognition/RecognizerBase.cs
@@ -1440,7 +1440,7 @@ ISpGrammarResourceLoader
                     //  - Modify SAPI so LoadCmdFromFile works with dictation Uris.
                     //  - Modify the engine and use a regular grammar with a special ruleref to dictation.
                     //  - Call back to the Grammar and let it manage the loading activation.
-                    string topicName = string.IsNullOrEmpty(uri.Fragment) ? null : uri.Fragment.Substring(1, uri.Fragment.Length - 1);
+                    string topicName = string.IsNullOrEmpty(uri.Fragment) ? null : uri.Fragment.Substring(1);
                     sapiGrammar.LoadDictation(topicName, SPLOADOPTIONS.SPLO_STATIC);
                 }
                 else

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Split.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Split.cs
@@ -112,7 +112,7 @@ namespace System.Text.RegularExpressions
                     return new[] { input };
                 }
 
-                state.results.Add(input.Substring(state.prevat, input.Length - state.prevat));
+                state.results.Add(input.Substring(state.prevat));
             }
             else
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
@@ -228,7 +228,7 @@ namespace System.Text.RegularExpressions
                     return input;
                 }
 
-                state.segments.Add(state.inputMemory.Slice(state.prevat, input.Length - state.prevat));
+                state.segments.Add(state.inputMemory.Slice(state.prevat));
             }
             else
             {


### PR DESCRIPTION
Minor code simplification which looks for places where we have code utilizing one of the following patterns:

```cs
someString.Substring(newOffset, someString.Length - newOffset);
someSpan.Slice(newOffset, someSpan.Length - newOffset);
```

And calls the single-parameter overload instead:

```cs
someString.Substring(newOffset);
someSpan.Slice(newOffset);
```

In particular, I _did not_ try to improve the perf of the call sites, such as changing from an allocating call to an allocation-free call, etc. This is just a code simplification and doesn't try to change any of the logic.