### PR TITLE
Fix double-validation in BoundedChannelOptions

### DIFF
--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelOptions.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelOptions.cs
@@ -56,7 +56,7 @@ namespace System.Threading.Channels
                 throw new ArgumentOutOfRangeException(nameof(capacity));
             }
 
-            Capacity = capacity;
+            _capacity = capacity;
         }
 
         /// <summary>Gets or sets the maximum number of items the bounded channel may store.</summary>


### PR DESCRIPTION
Hi there folks.
This pull request fixes double-validation in BoundedChannelOptions class.
https://github.com/dotnet/runtime/issues/68936
