### PR TITLE
Add WaitAsync to prevent CI hangs of System.Net.Http.Functional.Tests

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
@@ -89,9 +89,10 @@ namespace System.Net.Http.Functional.Tests
             Uri serverUri = secureServer ? Configuration.Http.SecureRemoteEchoServer : Configuration.Http.RemoteEchoServer;
 
             var options = new LoopbackProxyServer.Options
-                { AuthenticationSchemes = proxyAuthScheme,
-                  ConnectionCloseAfter407 = proxyClosesConnectionAfterFirst407Response
-                };
+            {
+                AuthenticationSchemes = proxyAuthScheme,
+                ConnectionCloseAfter407 = proxyClosesConnectionAfterFirst407Response
+            };
             using (LoopbackProxyServer proxyServer = LoopbackProxyServer.Create(options))
             {
                 using (HttpClientHandler handler = CreateHttpClientHandler())
@@ -434,12 +435,12 @@ namespace System.Net.Http.Functional.Tests
                         Assert.Equal(proxyServer.Uri, handler.Proxy.GetProxy(uri));
 
                         Task<HttpResponseMessage> clientTask = client.GetAsync(uri);
-                        await server.AcceptConnectionSendResponseAndCloseAsync(statusCode: HttpStatusCode.ProxyAuthenticationRequired, additionalHeaders: "Proxy-Authenticate: Basic");
-                        using (var response = await clientTask)
+                        await server.AcceptConnectionSendResponseAndCloseAsync(statusCode: HttpStatusCode.ProxyAuthenticationRequired, additionalHeaders: "Proxy-Authenticate: Basic").WaitAsync(TestHelper.PassingTestTimeout);
+                        using (var response = await clientTask.WaitAsync(TestHelper.PassingTestTimeout))
                         {
                             Assert.Equal(HttpStatusCode.ProxyAuthenticationRequired, response.StatusCode);
                         }
-                    }, options);
+                    }, options).WaitAsync(TestHelper.PassingTestTimeout);
                 }
 
                 Assert.Contains("CONNECT", proxyServer.Requests[0].RequestLine);


### PR DESCRIPTION
Contributes to #68531.

While not solving the issue, this PR prevents a single test hang from timeouting the entire test suite.