### PR TITLE
Don't return SslStreamBuffer when disposing during handshake

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
@@ -56,8 +56,8 @@ namespace System.Net.Security
             // block potential future read and auth operations since SslStream is disposing.
             // This leaves the _nestedRead = 1 and _nestedAuth = 1, but that's ok, since
             // subsequent operations check the _exception sentinel first
-            if (Interlocked.CompareExchange(ref _nestedRead, 1, 0) == 0 &&
-                Interlocked.CompareExchange(ref _nestedAuth, 1, 0) == 0)
+            if (Interlocked.Exchange(ref _nestedRead, 1) == 0 &&
+                Interlocked.Exchange(ref _nestedAuth, 1) == 0)
             {
                 _buffer.ReturnBuffer();
             }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
@@ -52,11 +52,12 @@ namespace System.Net.Security
             _exception = s_disposedSentinel;
             CloseContext();
 
-            // Ensure a Read operation is not in progress,
-            // block potential reads since SslStream is disposing.
-            // This leaves the _nestedRead = 1, but that's ok, since
-            // subsequent Reads first check if the context is still available.
-            if (Interlocked.CompareExchange(ref _nestedRead, 1, 0) == 0)
+            // Ensure a Read or Auth operation is not in progress,
+            // block potential future read and auth operations since SslStream is disposing.
+            // This leaves the _nestedRead = 1 and _nestedAuth = 1, but that's ok, since
+            // subsequent operations check the _exception sentinel first
+            if (Interlocked.CompareExchange(ref _nestedRead, 1, 0) == 0 &&
+                Interlocked.CompareExchange(ref _nestedAuth, 1, 0) == 0)
             {
                 _buffer.ReturnBuffer();
             }
@@ -121,7 +122,7 @@ namespace System.Net.Security
 
             try
             {
-                Task task = isAsync?
+                Task task = isAsync ?
                     ForceAuthenticationAsync<AsyncReadWriteAdapter>(IsServer, null, cancellationToken) :
                     ForceAuthenticationAsync<SyncReadWriteAdapter>(IsServer, null, cancellationToken);
 
@@ -377,7 +378,7 @@ namespace System.Net.Security
                 case TlsContentType.Handshake:
                     if (!_isRenego && _buffer.EncryptedReadOnlySpan[TlsFrameHelper.HeaderSize] == (byte)TlsHandshakeType.ClientHello &&
                         _sslAuthenticationOptions!.IsServer) // guard against malicious endpoints. We should not see ClientHello on client.
-                     {
+                    {
                         TlsFrameHelper.ProcessingOptions options = NetEventSource.Log.IsEnabled() ?
                                                                     TlsFrameHelper.ProcessingOptions.All :
                                                                     TlsFrameHelper.ProcessingOptions.ServerName;


### PR DESCRIPTION
Fixes #66818.

This PR makes sure we don't dispose buffers which may be still in use by ongoing handshake, which on debug builds led to an assert firing and crashing entire test sutite (see #65455 for example).

Dispose during ongoing read operations was handled correctly before.

@wfurt you mentioned we should have some tests which dispose the `SslStream` mid-operation on purpose. Would something like below suffice? It is essentially what we did before #66682.

<details>

```cs

        SslProtocols clientProtocol;
        SslProtocols serverProtocol;

        clientProtocol = SslProtocols.Tls13;
        serverProtocol = SslProtocols.Tls12;

        TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
        listener.Start();

        string certPath = Path.Join(new FileInfo(Assembly.GetExecutingAssembly().Location).Directory.FullName, "contoso.com.pfx");
        System.Console.WriteLine(certPath);
        using X509Certificate2 serverCertificate = new X509Certificate2(File.ReadAllBytes(certPath), "testcertificate");

        while (true)
        {
            System.Console.Write('.');
            using (TcpClient client = new TcpClient())
            {
                Task clientConnectTask = client.ConnectAsync(IPAddress.Loopback, ((IPEndPoint)listener.LocalEndpoint).Port);
                Task<TcpClient> listenerAcceptTask = listener.AcceptTcpClientAsync();

                await Task.WhenAll(clientConnectTask, listenerAcceptTask);

                TcpClient server = listenerAcceptTask.Result;
                using (SslStream clientStream = new SslStream(
                    client.GetStream(),
                    false,
                    new RemoteCertificateValidationCallback(delegate { return true; }),
                    null,
                    EncryptionPolicy.RequireEncryption))
                using (SslStream serverStream = new SslStream(
                    server.GetStream(),
                    false,
                    null,
                    null,
                    EncryptionPolicy.RequireEncryption))
                {

                    Task clientAuthenticationTask = clientStream.AuthenticateAsClientAsync(
                        serverCertificate.GetNameInfo(X509NameType.SimpleName, false),
                        null,
                        clientProtocol,
                        false);

                    try
                    {
                        await serverStream.AuthenticateAsServerAsync(
                           serverCertificate,
                           false,
                           serverProtocol,
                           false);
                    }
                    catch (AuthenticationException)
                    {
                    }

                    // e = await Assert.ThrowsAsync<AuthenticationException>(() => clientAuthenticationTask);
                }
            }
        }
```
</details/