### PR TITLE
Improve some use of Regex

### DIFF
--- a/src/coreclr/debug/ee/amd64/gen_amd64InstrDecode/Amd64InstructionTableGenerator.cs
+++ b/src/coreclr/debug/ee/amd64/gen_amd64InstrDecode/Amd64InstructionTableGenerator.cs
@@ -161,9 +161,6 @@ namespace Amd64InstructionTableGenerator
 
             var match = encDisassemblySplit.Match(disassembly);
 
-            if (match == null)
-                throw new ArgumentException($"Unable to parse disassembly: {disassembly}");
-
             // foreach (Group g in match.Groups)
             // {
             //     Console.WriteLine($"{g.Name}:'{g.ToString()}");
@@ -202,17 +199,10 @@ namespace Amd64InstructionTableGenerator
             {
                 var opMatch = encOperandSplit.Match(rest);
 
-                if (opMatch != null)
-                {
-                    string op = opMatch.Groups["op"].ToString();
-                    operands.Add(op);
-                    allOperands.Add(op);
-                    rest = opMatch.Groups["rest"].ToString();
-                }
-                else
-                {
-                    throw new Exception($"Op parsing failed {operandDisassemby}");
-                }
+                string op = opMatch.Groups["op"].ToString();
+                operands.Add(op);
+                allOperands.Add(op);
+                rest = opMatch.Groups["rest"].ToString();
             }
             return operands;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ProcessLinkerXmlBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ProcessLinkerXmlBase.cs
@@ -208,7 +208,7 @@ namespace ILCompiler
         {
             StringBuilder sb = new StringBuilder();
             CecilTypeNameFormatter.Instance.AppendName(sb, type);
-            if (regex.Match(sb.ToString()).Success)
+            if (regex.IsMatch(sb.ToString()))
                 ProcessType(type, nav);
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ReferenceSource/ProcessLinkerXmlBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ReferenceSource/ProcessLinkerXmlBase.cs
@@ -215,7 +215,7 @@ namespace Mono.Linker.Steps
 
         void MatchType(TypeDefinition type, Regex regex, XPathNavigator nav)
         {
-            if (regex.Match(type.FullName).Success)
+            if (regex.IsMatch(type.FullName))
                 ProcessType(type, nav);
 
             if (!type.HasNestedTypes)
@@ -238,7 +238,7 @@ namespace Mono.Linker.Steps
             {
                 foreach (var exported in assembly.MainModule.ExportedTypes)
                 {
-                    if (regex.Match(exported.FullName).Success)
+                    if (regex.IsMatch(exported.FullName))
                     {
                         var type = ProcessExportedType(exported, assembly, nav);
                         if (type != null)

--- a/src/installer/tests/TestUtils/Assertions/CommandResultAssertions.cs
+++ b/src/installer/tests/TestUtils/Assertions/CommandResultAssertions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public AndConstraint<CommandResultAssertions> HaveStdOutMatching(string pattern, RegexOptions options = RegexOptions.None)
         {
-            Execute.Assertion.ForCondition(Regex.Match(Result.StdOut, pattern, options).Success)
+            Execute.Assertion.ForCondition(Regex.IsMatch(Result.StdOut, pattern, options))
                 .FailWithPreformatted($"Matching the command output failed. Pattern: '{pattern}'{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public AndConstraint<CommandResultAssertions> HaveStdErrMatching(string pattern, RegexOptions options = RegexOptions.None)
         {
-            Execute.Assertion.ForCondition(Regex.Match(Result.StdErr, pattern, options).Success)
+            Execute.Assertion.ForCondition(Regex.IsMatch(Result.StdErr, pattern, options))
                 .FailWithPreformatted($"Matching the command error output failed. Pattern: '{pattern}'{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }

--- a/src/libraries/Common/src/System/Data/Common/DbConnectionOptions.Common.cs
+++ b/src/libraries/Common/src/System/Data/Common/DbConnectionOptions.Common.cs
@@ -68,8 +68,6 @@ namespace System.Data.Common
 
 #pragma warning disable CA1823 // used in some compilations and not others
         private static readonly Regex s_connectionStringValidKeyRegex = new Regex("^(?![;\\s])[^\\p{Cc}]+(?<!\\s)$", RegexOptions.Compiled); // key not allowed to start with semi-colon or space or contain non-visible characters or end with space
-        private static readonly Regex s_connectionStringValidValueRegex = new Regex("^[^\u0000]*$", RegexOptions.Compiled); // value not allowed to contain embedded null
-
         private static readonly Regex s_connectionStringQuoteValueRegex = new Regex("^[^\"'=;\\s\\p{Cc}]*$", RegexOptions.Compiled); // generally do not quote the value if it matches the pattern
         private static readonly Regex s_connectionStringQuoteOdbcValueRegex = new Regex("^\\{([^\\}\u0000]|\\}\\})*\\}$", RegexOptions.ExplicitCapture | RegexOptions.Compiled); // do not quote odbc value if it matches this pattern
 #pragma warning restore CA1823
@@ -402,10 +400,6 @@ namespace System.Data.Common
         {
             if (null != keyvalue)
             {
-#if DEBUG
-                bool compValue = s_connectionStringValidValueRegex.IsMatch(keyvalue);
-                Debug.Assert((-1 == keyvalue.IndexOf('\u0000')) == compValue, "IsValueValid mismatch with regex");
-#endif
                 return (-1 == keyvalue.IndexOf('\u0000')); // string.Contains(char) is .NetCore2.1+ specific
             }
             return true;

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RegularExpressionAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RegularExpressionAttribute.cs
@@ -66,11 +66,14 @@ namespace System.ComponentModel.DataAnnotations
                 return true;
             }
 
-            var m = Regex!.Match(stringValue);
+            foreach (ValueMatch m in Regex!.EnumerateMatches(stringValue))
+            {
+                // We are looking for an exact match, not just a search hit. This matches what
+                // the RegularExpressionValidator control does
+                return m.Index == 0 && m.Length == stringValue.Length;
+            }
 
-            // We are looking for an exact match, not just a search hit. This matches what
-            // the RegularExpressionValidator control does
-            return (m.Success && m.Index == 0 && m.Length == stringValue.Length);
+            return false;
         }
 
         /// <summary>

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/RegexStringValidator.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/RegexStringValidator.cs
@@ -27,11 +27,10 @@ namespace System.Configuration
         {
             ValidatorUtils.HelperParamValidation(value, typeof(string));
 
-            if (value == null) return;
-
-            Match match = _regex.Match((string)value);
-
-            if (!match.Success) throw new ArgumentException(SR.Format(SR.Regex_validator_error, _expression));
+            if (value is string s && !_regex.IsMatch(s))
+            {
+                throw new ArgumentException(SR.Format(SR.Regex_validator_error, _expression));
+            }
         }
     }
 }

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbConnectionOptions.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbConnectionOptions.cs
@@ -188,7 +188,7 @@ namespace System.Data.Common
             {
                 throw ADP.InvalidKeyname(keyword);
             }
-            if ((null != value) && !s_connectionStringValidValueRegex.IsMatch(value))
+            if ((null != value) && value.Contains('\0'))
             {
                 throw ADP.InvalidValue(keyword);
             }

--- a/src/libraries/System.Data.Odbc/src/Common/System/Data/Common/DbConnectionOptions.cs
+++ b/src/libraries/System.Data.Odbc/src/Common/System/Data/Common/DbConnectionOptions.cs
@@ -452,7 +452,7 @@ namespace System.Data.Common
             {
                 throw ADP.InvalidKeyname(keyword);
             }
-            if ((null != value) && !s_connectionStringValidValueRegex.IsMatch(value))
+            if ((null != value) && value.IndexOf('\0') >= 0)
             {
                 throw ADP.InvalidValue(keyword);
             }

--- a/src/libraries/System.Data.OleDb/src/DbConnectionOptions.cs
+++ b/src/libraries/System.Data.OleDb/src/DbConnectionOptions.cs
@@ -71,7 +71,6 @@ namespace System.Data.Common
 
         private static readonly Regex ConnectionStringRegex = new Regex(ConnectionStringPattern, RegexOptions.ExplicitCapture | RegexOptions.Compiled);
         private static readonly Regex ConnectionStringRegexOdbc = new Regex(ConnectionStringPatternOdbc, RegexOptions.ExplicitCapture | RegexOptions.Compiled);
-        private static readonly Regex ConnectionStringValidValueRegex = new Regex("^[^\u0000]*$", RegexOptions.Compiled); // value not allowed to contain embedded null
 #endif
         private static readonly Regex ConnectionStringValidKeyRegex = new Regex("^(?![;\\s])[^\\p{Cc}]+(?<!\\s)$", RegexOptions.Compiled); // key not allowed to start with semi-colon or space or contain non-visible characters or end with space
 
@@ -752,10 +751,6 @@ namespace System.Data.Common
         {
             if (null != keyvalue)
             {
-#if DEBUG
-                bool compValue = ConnectionStringValidValueRegex.IsMatch(keyvalue);
-                Debug.Assert((-1 == keyvalue.IndexOf('\u0000')) == compValue, "IsValueValid mismatch with regex");
-#endif
                 return (-1 == keyvalue.IndexOf('\u0000'));
             }
             return true;

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMQuerySet.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMQuerySet.cs
@@ -339,9 +339,7 @@ namespace System.DirectoryServices.AccountManagement
                 filter.Extra = regex;
             }
 
-            Match match = regex.Match(property);
-
-            return match.Success;
+            return regex.IsMatch(property);
         }
         // returns true if specified WinNT property's value matches filter.Value
         private delegate bool MatcherDelegate(FilterBase filter, string winNTPropertyName, DirectoryEntry de);

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlConvert.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlConvert.cs
@@ -76,46 +76,36 @@ namespace System.Xml
         public static string? DecodeName(string? name)
         {
             if (string.IsNullOrEmpty(name))
+            {
                 return name;
-
-            StringBuilder? bufBld = null;
-
-            int length = name.Length;
-            int copyPosition = 0;
+            }
 
             int underscorePos = name.IndexOf('_');
-            MatchCollection? mc;
-            IEnumerator? en;
-            if (underscorePos >= 0)
-            {
-                mc = DecodeCharRegex().Matches(name, underscorePos);
-                en = mc.GetEnumerator();
-            }
-            else
+            if (underscorePos < 0)
             {
                 return name;
             }
+
+            Regex.ValueMatchEnumerator en = DecodeCharRegex().EnumerateMatches(name.AsSpan(underscorePos));
             int matchPos = -1;
-            if (en != null && en.MoveNext())
+            if (en.MoveNext())
             {
-                Match m = (Match)en.Current!;
-                matchPos = m.Index;
+                matchPos = underscorePos + en.Current.Index;
             }
 
+            StringBuilder? bufBld = null;
+            int length = name.Length;
+            int copyPosition = 0;
             for (int position = 0; position < length - EncodedCharLength + 1; position++)
             {
                 if (position == matchPos)
                 {
-                    if (en!.MoveNext())
+                    if (en.MoveNext())
                     {
-                        Match m = (Match)en.Current!;
-                        matchPos = m.Index;
+                        matchPos = underscorePos + en.Current.Index;
                     }
 
-                    if (bufBld == null)
-                    {
-                        bufBld = new StringBuilder(length + 20);
-                    }
+                    bufBld ??= new StringBuilder(length + 20);
                     bufBld.Append(name, copyPosition, position - copyPosition);
 
                     if (name[position + 6] != '_')

--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -700,8 +700,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
                 }
 
                 Regex regex = new Regex(pattern);
-                Match match = regex.Match(testDataLine);
-                if (match.Success)
+                if (regex.IsMatch(testDataLine))
                 {
                     numberOfFoundBlobs++;
                 }

--- a/src/mono/sample/wasm/browser-bench/Program.cs
+++ b/src/mono/sample/wasm/browser-bench/Program.cs
@@ -113,7 +113,7 @@ namespace Sample
             {
                 measurementIdx++;
 
-                if (Task.pattern == null || Task.pattern.Match(Task.Measurements[measurementIdx].Name).Success)
+                if (Task.pattern == null || Task.pattern.IsMatch(Task.Measurements[measurementIdx].Name))
                     return true;
             }
 

--- a/src/tests/ilasm/System/Runtime/CompilerServices/MethodImplOptionsTests.cs
+++ b/src/tests/ilasm/System/Runtime/CompilerServices/MethodImplOptionsTests.cs
@@ -92,8 +92,7 @@ public static class MethodImplOptionsTests
                 new Regex(
                     @"\bvoid\s+Main\s*\(\s*\).*?\b" + ilDisasmAttributeKeyword + @"\b",
                     RegexOptions.Compiled | RegexOptions.Multiline);
-            Match match = findMainAttributeRegex.Match(disasmIl);
-            if (!match.Success)
+            if (!findMainAttributeRegex.IsMatch(disasmIl))
             {
                 Console.WriteLine($"Attribute '{ilDisasmAttributeKeyword}' did not round-trip through ilasm and ildasm");
                 return false;


### PR DESCRIPTION
- Use IsMatch instead of Match(...).Success
- Use EnumerateMatches when Index/Length are needed but not captures
- Remove Regex that could just be IndexOf
- Regex.Match never returns null, so remove null checks