### PR TITLE
Support Requires on type in NativeAot

### DIFF
--- a/src/coreclr/tools/Common/Compiler/Logging/MessageOrigin.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/MessageOrigin.cs
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Text;
-
+using Internal.IL;
 using Internal.TypeSystem;
 
 namespace ILCompiler.Logging
@@ -33,6 +34,29 @@ namespace ILCompiler.Logging
             MemberDefinition = memberDefinition;
             SourceLine = sourceLine;
             SourceColumn = sourceColumn;
+        }
+
+        public MessageOrigin(MethodIL origin, int ilOffset)
+        {
+            string document = null;
+            int? lineNumber = null;
+
+            IEnumerable<ILSequencePoint> sequencePoints = origin.GetDebugInfo()?.GetSequencePoints();
+            if (sequencePoints != null)
+            {
+                foreach (var sequencePoint in sequencePoints)
+                {
+                    if (sequencePoint.Offset <= ilOffset)
+                    {
+                        document = sequencePoint.Document;
+                        lineNumber = sequencePoint.LineNumber;
+                    }
+                }
+            }
+            FileName = document;
+            MemberDefinition = origin.OwningMethod;
+            SourceLine = lineNumber;
+            SourceColumn = null;
         }
 
         public override string ToString()

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/DiagnosticUtilities.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/DiagnosticUtilities.cs
@@ -1,6 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection.Metadata;
+using ILCompiler.Logging;
+using ILLink.Shared;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 
@@ -44,40 +50,110 @@ namespace ILCompiler.Dataflow
                 return ((TypeDesc)parent).GetDisplayName();
         }
 
-        internal static string GetRequiresAttributeMessage(MethodDesc method, string requiresAttributeName)
+        internal static bool TryGetRequiresAttribute(TypeSystemEntity member, string requiresAttributeName, [NotNullWhen(returnValue: true)] out CustomAttributeValue<TypeDesc>? attribute)
         {
-            var ecmaMethod = method.GetTypicalMethodDefinition() as EcmaMethod;
-            if (ecmaMethod == null)
-                return null;
+            attribute = default;
+            CustomAttributeValue<TypeDesc>? decoded = default;
+            switch (member)
+            {
+                case MethodDesc method:
+                    var ecmaMethod = method.GetTypicalMethodDefinition() as EcmaMethod;
+                    if (ecmaMethod == null)
+                        return false;
+                    decoded = ecmaMethod.GetDecodedCustomAttribute("System.Diagnostics.CodeAnalysis", requiresAttributeName);
+                    break;
+                case MetadataType type:
+                    var ecmaType = type as EcmaType;
+                    if (ecmaType == null)
+                        return false;
+                    decoded = ecmaType.GetDecodedCustomAttribute("System.Diagnostics.CodeAnalysis", requiresAttributeName);
+                    break;
+                default:
+                    Debug.Fail(member.GetType().ToString());
+                    break;
+            }
+            if (!decoded.HasValue)
+                return false;
 
-            var decoded = ecmaMethod.GetDecodedCustomAttribute("System.Diagnostics.CodeAnalysis", requiresAttributeName);
-            if (decoded == null)
-                return null;
+            attribute = decoded.Value;
+            return true;
+        }
 
-            var decodedValue = decoded.Value;
-
-            if (decodedValue.FixedArguments.Length != 0)
-                return (string)decodedValue.FixedArguments[0].Value;
+        internal static string GetRequiresAttributeMessage(CustomAttributeValue<TypeDesc> attribute)
+        {
+            if (attribute.FixedArguments.Length != 0)
+                return (string)attribute.FixedArguments[0].Value;
 
             return null;
         }
 
-        internal static string GetRequiresAttributeUrl(MethodDesc method, string requiresAttributeName)
+        internal static string GetRequiresAttributeUrl(CustomAttributeValue<TypeDesc> attribute)
         {
-            var ecmaMethod = method.GetTypicalMethodDefinition() as EcmaMethod;
-            if (ecmaMethod == null)
-                return null;
-
-            var decoded = ecmaMethod.GetDecodedCustomAttribute("System.Diagnostics.CodeAnalysis", requiresAttributeName);
-            if (decoded == null)
-                return null;
-
-            var decodedValue = decoded.Value;
-
-            if (decodedValue.NamedArguments.Length != 0 && decodedValue.NamedArguments[0].Name == "Url")
-                return (string)decodedValue.NamedArguments[0].Value;
+            if (attribute.NamedArguments.Length != 0 && attribute.NamedArguments[0].Name == "Url")
+                return (string)attribute.NamedArguments[0].Value;
 
             return null;
+        }
+
+        /// <summary>
+        /// Determines if method is within a declared Requires scope - this typically means that trim analysis
+        /// warnings should be suppressed in such a method.
+        /// </summary>
+        /// <remarks>Unlike <see cref="DoesMethodRequires(MethodDesc, string, out CustomAttributeValue?)"/>
+        /// if a declaring type has Requires, all methods in that type are considered "in scope" of that Requires. So this includes also
+        /// instance methods (not just statics and .ctors).</remarks>
+        internal static bool IsMethodInRequiresScope(this MethodDesc method, string requiresAttribute)
+        {
+            if (method.HasCustomAttribute("System.Diagnostics.CodeAnalysis", requiresAttribute) && !method.IsStaticConstructor)
+                return true;
+
+            if (method.OwningType is TypeDesc type && TryGetRequiresAttribute(type, requiresAttribute, out _))
+                return true;
+
+            return false;
+        }
+
+        /// <summary>
+		/// Determines if method requires (and thus any usage of such method should be warned about).
+		/// </summary>
+		/// <remarks>Unlike <see cref="IsMethodInRequiresScope(MethodDesc, string)"/> only static methods 
+		/// and .ctors are reported as requires when the declaring type has Requires on it.</remarks>
+		internal static bool DoesMethodRequires(this MethodDesc method, string requiresAttribute, [NotNullWhen(returnValue: true)] out CustomAttributeValue<TypeDesc>? attribute)
+        {
+            attribute = null;
+            if (method.IsStaticConstructor)
+                return false;
+
+            if (TryGetRequiresAttribute(method, requiresAttribute, out attribute))
+                return true;
+
+            if ((method.Signature.IsStatic || method.IsConstructor) && method.OwningType is not null &&
+                TryGetRequiresAttribute(method.OwningType, requiresAttribute, out attribute))
+                return true;
+
+            return false;
+        }
+
+        internal static bool DoesFieldRequires(this FieldDesc field, string requiresAttribute, [NotNullWhen(returnValue: true)] out CustomAttributeValue<TypeDesc>? attribute)
+        {
+            if (!field.IsStatic || field.OwningType is null)
+            {
+                attribute = null;
+                return false;
+            }
+
+            return TryGetRequiresAttribute(field.OwningType, requiresAttribute, out attribute);
+        }
+
+        internal static bool DoesMemberRequires(this TypeSystemEntity member, string requiresAttribute, [NotNullWhen(returnValue: true)] out CustomAttributeValue<TypeDesc>? attribute)
+        {
+            attribute = null;
+            return member switch
+            {
+                MethodDesc method => DoesMethodRequires(method, requiresAttribute, out attribute),
+                FieldDesc field => DoesFieldRequires(field, requiresAttribute, out attribute),
+                _ => false
+            };
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/DiagnosticUtilities.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/DiagnosticUtilities.cs
@@ -72,7 +72,7 @@ namespace ILCompiler.Dataflow
                     decoded = property.GetDecodedCustomAttribute("System.Diagnostics.CodeAnalysis", requiresAttributeName);
                     break;
                 default:
-                    Debug.Fail(member.GetType().ToString());
+                    Debug.Fail("Trying to operate with unsupported TypeSystemEntity " + member.GetType().ToString());
                     break;
             }
             if (!decoded.HasValue)
@@ -155,8 +155,8 @@ namespace ILCompiler.Dataflow
             if (TryGetRequiresAttribute(method, requiresAttribute, out attribute))
                 return true;
 
-            if ((method.Signature.IsStatic || method.IsConstructor) && method.OwningType is not null &&
-                TryGetRequiresAttribute(method.OwningType, requiresAttribute, out attribute))
+            if ((method.Signature.IsStatic || method.IsConstructor) && method.OwningType is TypeDesc owningType &&
+                !owningType.IsArray && TryGetRequiresAttribute(owningType, requiresAttribute, out attribute))
                 return true;
 
             return false;
@@ -164,7 +164,7 @@ namespace ILCompiler.Dataflow
 
         internal static bool DoesFieldRequire(this FieldDesc field, string requiresAttribute, [NotNullWhen(returnValue: true)] out CustomAttributeValue<TypeDesc>? attribute)
         {
-            if (!field.IsStatic || field.OwningType is null)
+            if (!field.IsStatic || field.OwningType is not TypeDesc owningType || owningType.IsArray)
             {
                 attribute = null;
                 return false;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/DiagnosticUtilities.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/DiagnosticUtilities.cs
@@ -82,13 +82,12 @@ namespace ILCompiler.Dataflow
             return true;
         }
 
-        public static CustomAttributeValue<TypeDesc>? GetDecodedCustomAttribute(this PropertyPseudoDesc This,
-            string attributeNamespace, string attributeName)
+        public static CustomAttributeValue<TypeDesc>? GetDecodedCustomAttribute(this PropertyPseudoDesc prop, string attributeNamespace, string attributeName)
         {
-            var ecmaType = This.OwningType as EcmaType;
+            var ecmaType = prop.OwningType as EcmaType;
             var metadataReader = ecmaType.MetadataReader;
 
-            var attributeHandle = metadataReader.GetCustomAttributeHandle(This.GetCustomAttributes,
+            var attributeHandle = metadataReader.GetCustomAttributeHandle(prop.GetCustomAttributes,
                 attributeNamespace, attributeName);
 
             if (attributeHandle.IsNil)
@@ -117,7 +116,7 @@ namespace ILCompiler.Dataflow
         /// Determines if method is within a declared Requires scope - this typically means that trim analysis
         /// warnings should be suppressed in such a method.
         /// </summary>
-        /// <remarks>Unlike <see cref="DoesMemberRequires(TypeSystemEntity, string, out CustomAttributeValue{TypeDesc}?)"/>
+        /// <remarks>Unlike <see cref="DoesMemberRequire(TypeSystemEntity, string, out CustomAttributeValue{TypeDesc}?)"/>
         /// if a declaring type has Requires, all methods in that type are considered "in scope" of that Requires. So this includes also
         /// instance methods (not just statics and .ctors).</remarks>
         internal static bool IsInRequiresScope(this MethodDesc method, string requiresAttribute) =>
@@ -147,7 +146,7 @@ namespace ILCompiler.Dataflow
             return false;
         }
 
-		internal static bool DoesMethodRequires(this MethodDesc method, string requiresAttribute, [NotNullWhen(returnValue: true)] out CustomAttributeValue<TypeDesc>? attribute)
+        internal static bool DoesMethodRequire(this MethodDesc method, string requiresAttribute, [NotNullWhen(returnValue: true)] out CustomAttributeValue<TypeDesc>? attribute)
         {
             attribute = null;
             if (method.IsStaticConstructor)
@@ -163,7 +162,7 @@ namespace ILCompiler.Dataflow
             return false;
         }
 
-        internal static bool DoesFieldRequires(this FieldDesc field, string requiresAttribute, [NotNullWhen(returnValue: true)] out CustomAttributeValue<TypeDesc>? attribute)
+        internal static bool DoesFieldRequire(this FieldDesc field, string requiresAttribute, [NotNullWhen(returnValue: true)] out CustomAttributeValue<TypeDesc>? attribute)
         {
             if (!field.IsStatic || field.OwningType is null)
             {
@@ -174,7 +173,7 @@ namespace ILCompiler.Dataflow
             return TryGetRequiresAttribute(field.OwningType, requiresAttribute, out attribute);
         }
 
-        internal static bool DoesPropertyRequires(this PropertyPseudoDesc property, string requiresAttribute, [NotNullWhen(returnValue: true)] out CustomAttributeValue<TypeDesc>? attribute) =>
+        internal static bool DoesPropertyRequire(this PropertyPseudoDesc property, string requiresAttribute, [NotNullWhen(returnValue: true)] out CustomAttributeValue<TypeDesc>? attribute) =>
             TryGetRequiresAttribute(property, requiresAttribute, out attribute);
 
         /// <summary>
@@ -182,14 +181,14 @@ namespace ILCompiler.Dataflow
 		/// </summary>
 		/// <remarks>Unlike <see cref="IsInRequiresScope(MethodDesc, string)"/> only static methods 
 		/// and .ctors are reported as requires when the declaring type has Requires on it.</remarks>
-        internal static bool DoesMemberRequires(this TypeSystemEntity member, string requiresAttribute, [NotNullWhen(returnValue: true)] out CustomAttributeValue<TypeDesc>? attribute)
+        internal static bool DoesMemberRequire(this TypeSystemEntity member, string requiresAttribute, [NotNullWhen(returnValue: true)] out CustomAttributeValue<TypeDesc>? attribute)
         {
             attribute = null;
             return member switch
             {
-                MethodDesc method => DoesMethodRequires(method, requiresAttribute, out attribute),
-                FieldDesc field => DoesFieldRequires(field, requiresAttribute, out attribute),
-                PropertyPseudoDesc property => DoesPropertyRequires(property, requiresAttribute, out attribute),
+                MethodDesc method => DoesMethodRequire(method, requiresAttribute, out attribute),
+                FieldDesc field => DoesFieldRequire(field, requiresAttribute, out attribute),
+                PropertyPseudoDesc property => DoesPropertyRequire(property, requiresAttribute, out attribute),
                 _ => false
             };
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/EcmaExtensions.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/EcmaExtensions.cs
@@ -66,7 +66,8 @@ namespace ILCompiler.Dataflow
 
         public static PropertyPseudoDesc GetPropertyForAccessor(this MethodDesc accessor)
         {
-            var ecmaAccessor = (EcmaMethod)accessor.GetTypicalMethodDefinition();
+            if (accessor.GetTypicalMethodDefinition() is not EcmaMethod ecmaAccessor)
+                return null;
             var type = (EcmaType)ecmaAccessor.OwningType;
             var reader = type.MetadataReader;
             var module = type.EcmaModule;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -1237,7 +1237,8 @@ namespace ILCompiler.Dataflow
                                         _dependencies.Add(_factory.ConstructedTypeSymbol(systemTypeValue.TypeRepresented.MakeArrayType()), "Enum.GetValues");
                                     }
                                 }
-                                CheckAndReportRequires(calledMethod, new MessageOrigin(callingMethodBody, offset),RequiresDynamicCodeAttribute);
+                                else
+                                    CheckAndReportRequires(calledMethod, new MessageOrigin(callingMethodBody, offset),RequiresDynamicCodeAttribute);
                             }
                         }
                         break;
@@ -1271,7 +1272,8 @@ namespace ILCompiler.Dataflow
                                         _dependencies.Add(_factory.StructMarshallingData((DefType)systemTypeValue.TypeRepresented), "Marshal API");
                                     }
                                 }
-                                CheckAndReportRequires(calledMethod, new MessageOrigin(callingMethodBody, offset), RequiresDynamicCodeAttribute);
+                                else
+                                    CheckAndReportRequires(calledMethod, new MessageOrigin(callingMethodBody, offset), RequiresDynamicCodeAttribute);
                             }
                         }
                         break;
@@ -1295,7 +1297,8 @@ namespace ILCompiler.Dataflow
                                         _dependencies.Add(_factory.DelegateMarshallingData((DefType)systemTypeValue.TypeRepresented), "Marshal API");
                                     }
                                 }
-                                CheckAndReportRequires(calledMethod, new MessageOrigin(callingMethodBody, offset), RequiresDynamicCodeAttribute);
+                                else
+                                    CheckAndReportRequires(calledMethod, new MessageOrigin(callingMethodBody, offset), RequiresDynamicCodeAttribute);
                             }
                         }
                         break;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -40,8 +40,8 @@ namespace ILCompiler.Dataflow
             return
                 GetIntrinsicIdForMethod(methodDefinition) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel ||
                 flowAnnotations.RequiresDataflowAnalysis(methodDefinition) ||
-                methodDefinition.DoesMethodRequires(RequiresUnreferencedCodeAttribute, out _) ||
-                methodDefinition.DoesMethodRequires(RequiresDynamicCodeAttribute, out _) ||
+                methodDefinition.DoesMethodRequire(RequiresUnreferencedCodeAttribute, out _) ||
+                methodDefinition.DoesMethodRequire(RequiresDynamicCodeAttribute, out _) ||
                 methodDefinition.IsPInvoke;
         }
 
@@ -55,8 +55,8 @@ namespace ILCompiler.Dataflow
         public static bool RequiresReflectionMethodBodyScannerForAccess(FlowAnnotations flowAnnotations, FieldDesc fieldDefinition)
         {
             return flowAnnotations.RequiresDataflowAnalysis(fieldDefinition) ||
-                fieldDefinition.DoesFieldRequires(RequiresUnreferencedCodeAttribute, out _) ||
-                fieldDefinition.DoesFieldRequires(RequiresDynamicCodeAttribute, out _);
+                fieldDefinition.DoesFieldRequire(RequiresUnreferencedCodeAttribute, out _) ||
+                fieldDefinition.DoesFieldRequire(RequiresDynamicCodeAttribute, out _);
         }
 
         void CheckAndReportRequires(TypeSystemEntity calledMember, in MessageOrigin origin, string requiresAttributeName)
@@ -66,7 +66,7 @@ namespace ILCompiler.Dataflow
             if (ShouldSuppressAnalysisWarningsForRequires(origin.MemberDefinition, requiresAttributeName))
                 return;
 
-            if (!calledMember.DoesMemberRequires(requiresAttributeName, out var requiresAttribute))
+            if (!calledMember.DoesMemberRequire(requiresAttributeName, out var requiresAttribute))
                 return;
 
             DiagnosticId diagnosticId = requiresAttributeName switch

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/PropertyPseudoDesc.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/PropertyPseudoDesc.cs
@@ -42,6 +42,14 @@ namespace ILCompiler
             }
         }
 
+        public CustomAttributeHandleCollection GetCustomAttributes
+        {
+            get
+            {
+                return Definition.GetCustomAttributes();
+            }
+        }
+
         public MetadataType OwningType
         {
             get

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -692,8 +692,8 @@ namespace ILCompiler
 
         public static bool HasMismatchingAttributes (MethodDesc baseMethod, MethodDesc overridingMethod, string requiresAttributeName)
         {
-            bool baseMethodCreatesRequirement = baseMethod.DoesMethodRequires(requiresAttributeName, out _);
-            bool overridingMethodCreatesRequirement = overridingMethod.DoesMethodRequires(requiresAttributeName, out _);
+            bool baseMethodCreatesRequirement = baseMethod.DoesMethodRequire(requiresAttributeName, out _);
+            bool overridingMethodCreatesRequirement = overridingMethod.DoesMethodRequire(requiresAttributeName, out _);
             bool baseMethodFulfillsRequirement = baseMethod.IsOverrideInRequiresScope(requiresAttributeName);
             bool overridingMethodFulfillsRequirement = overridingMethod.IsOverrideInRequiresScope(requiresAttributeName);
             return (baseMethodCreatesRequirement && !overridingMethodFulfillsRequirement) || (overridingMethodCreatesRequirement && !baseMethodFulfillsRequirement);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -27,6 +27,7 @@ using EcmaType = Internal.TypeSystem.Ecma.EcmaType;
 using CustomAttributeHandle = System.Reflection.Metadata.CustomAttributeHandle;
 using CustomAttributeTypeProvider = Internal.TypeSystem.Ecma.CustomAttributeTypeProvider;
 using MetadataExtensions = Internal.TypeSystem.Ecma.MetadataExtensions;
+using ILCompiler.Dataflow;
 
 namespace ILCompiler
 {
@@ -671,30 +672,31 @@ namespace ILCompiler
         public override void NoteOverridingMethod(MethodDesc baseMethod, MethodDesc overridingMethod)
         {
             // We validate that the various dataflow/Requires* annotations are consistent across virtual method overrides
-
-            bool baseMethodRequiresUnreferencedCode = baseMethod.HasCustomAttribute("System.Diagnostics.CodeAnalysis", "RequiresUnreferencedCodeAttribute");
-            bool overridingMethodRequiresUnreferencedCode = overridingMethod.HasCustomAttribute("System.Diagnostics.CodeAnalysis", "RequiresUnreferencedCodeAttribute");
-
-            bool baseMethodRequiresDynamicCode = baseMethod.HasCustomAttribute("System.Diagnostics.CodeAnalysis", "RequiresDynamicCodeAttribute");
-            bool overridingMethodRequiresDynamicCode = overridingMethod.HasCustomAttribute("System.Diagnostics.CodeAnalysis", "RequiresDynamicCodeAttribute");
-
-            bool baseMethodRequiresDataflow = FlowAnnotations.RequiresDataflowAnalysis(baseMethod);
-            bool overridingMethodRequiresDataflow = FlowAnnotations.RequiresDataflowAnalysis(overridingMethod);
-
-            if (baseMethodRequiresUnreferencedCode != overridingMethodRequiresUnreferencedCode)
+            if (HasMismatchingAttributes(baseMethod, overridingMethod, "RequiresUnreferencedCodeAttribute"))
             {
                 Logger.LogWarning(overridingMethod, DiagnosticId.RequiresUnreferencedCodeAttributeMismatch, overridingMethod.GetDisplayName(), baseMethod.GetDisplayName());
             }
 
-            if (baseMethodRequiresDynamicCode != overridingMethodRequiresDynamicCode)
+            if (HasMismatchingAttributes(baseMethod, overridingMethod, "RequiresDynamicCodeAttribute"))
             {
                 Logger.LogWarning(overridingMethod, DiagnosticId.RequiresDynamicCodeAttributeMismatch, overridingMethod.GetDisplayName(), baseMethod.GetDisplayName());
             }
 
+            bool baseMethodRequiresDataflow = FlowAnnotations.RequiresDataflowAnalysis(baseMethod);
+            bool overridingMethodRequiresDataflow = FlowAnnotations.RequiresDataflowAnalysis(overridingMethod);
             if (baseMethodRequiresDataflow || overridingMethodRequiresDataflow)
             {
                 FlowAnnotations.ValidateMethodAnnotationsAreSame(overridingMethod, baseMethod);
             }
+        }
+
+        public static bool HasMismatchingAttributes (MethodDesc baseMethod, MethodDesc overridingMethod, string requiresAttributeName)
+        {
+            bool baseMethodCreatesRequirement = baseMethod.DoesMethodRequires(requiresAttributeName, out _);
+            bool overridingMethodCreatesRequirement = overridingMethod.DoesMethodRequires(requiresAttributeName, out _);
+            bool baseMethodFulfillsRequirement = baseMethod.IsMethodInRequiresScope(requiresAttributeName);
+            bool overridingMethodFulfillsRequirement = overridingMethod.IsMethodInRequiresScope(requiresAttributeName);
+            return (baseMethodCreatesRequirement && !overridingMethodFulfillsRequirement) || (overridingMethodCreatesRequirement && !baseMethodFulfillsRequirement);
         }
 
         public MetadataManager ToAnalysisBasedMetadataManager()

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -694,8 +694,8 @@ namespace ILCompiler
         {
             bool baseMethodCreatesRequirement = baseMethod.DoesMethodRequires(requiresAttributeName, out _);
             bool overridingMethodCreatesRequirement = overridingMethod.DoesMethodRequires(requiresAttributeName, out _);
-            bool baseMethodFulfillsRequirement = baseMethod.IsMethodInRequiresScope(requiresAttributeName);
-            bool overridingMethodFulfillsRequirement = overridingMethod.IsMethodInRequiresScope(requiresAttributeName);
+            bool baseMethodFulfillsRequirement = baseMethod.IsOverrideInRequiresScope(requiresAttributeName);
+            bool overridingMethodFulfillsRequirement = overridingMethod.IsOverrideInRequiresScope(requiresAttributeName);
             return (baseMethodCreatesRequirement && !overridingMethodFulfillsRequirement) || (overridingMethodCreatesRequirement && !baseMethodFulfillsRequirement);
         }
 

--- a/src/coreclr/tools/aot/ILLink.Shared/DiagnosticId.cs
+++ b/src/coreclr/tools/aot/ILLink.Shared/DiagnosticId.cs
@@ -187,6 +187,7 @@ namespace ILLink.Shared
         AssemblyProducedAOTWarnings = 3053,
         GenericRecursionCycle = 3054,
         CorrectnessOfAbstractDelegatesCannotBeGuaranteed = 3055,
+        RequiresDynamicCodeOnStaticConstructor = 3056,
     }
 
     public static class DiagnosticIdExtensions


### PR DESCRIPTION
Support Requires on type in NativeAot
- Adds new overload for MessageOrigin creation that uses MethodIL and an offset as parameters. Eventually, this will be used to produce warnings
- Share methods used in linker/analyzer for asking questions about members being in RequiresScope, members Requiring and Requires warning generation. These methods include handling of Requires on a type.
- The ReflectionMethodBodyScanner on-field access now verifies for requires on type, since implicitly can call the static constructor
- Updated the mismatch attribute rules to take into account Requires on type