### PR TITLE
Implement constant-folding for `VNF_BitCast`

### DIFF
--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -307,8 +307,9 @@ private:
     // Returns "true" iff "vnf" is a comparison (and thus binary) operator.
     static bool VNFuncIsComparison(VNFunc vnf);
 
-    // Returns "true" iff "vnf" can be evaluated for constant arguments.
-    static bool CanEvalForConstantArgs(VNFunc vnf);
+    bool VNEvalCanFoldBinaryFunc(var_types type, VNFunc func, ValueNum arg0VN, ValueNum arg1VN);
+
+    bool VNEvalCanFoldUnaryFunc(var_types type, VNFunc func, ValueNum arg0VN);
 
     // Returns "true" iff "vnf" should be folded by evaluating the func with constant arguments.
     bool VNEvalShouldFold(var_types typ, VNFunc func, ValueNum arg0VN, ValueNum arg1VN);

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -355,6 +355,7 @@ private:
     ValueNum EvalFuncForConstantArgs(var_types typ, VNFunc vnf, ValueNum vn0, ValueNum vn1);
     ValueNum EvalFuncForConstantFPArgs(var_types typ, VNFunc vnf, ValueNum vn0, ValueNum vn1);
     ValueNum EvalCastForConstantArgs(var_types typ, VNFunc vnf, ValueNum vn0, ValueNum vn1);
+    ValueNum EvalBitCastForConstantArgs(var_types dstType, ValueNum arg0VN);
 
     ValueNum EvalUsingMathIdentity(var_types typ, VNFunc vnf, ValueNum vn0, ValueNum vn1);
 


### PR DESCRIPTION
Completes the support for said function.

A small number of [diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1758948&view=ms.vss-build-web.run-extensions-tab):

1) Improvements: we form new constants from `FP <-> integer` reinterpretations.
2) Regressions: we discover new CSEs due to the fact `BitCast` logic can skip redundant casts for small types in some cases. This new precision is not all that useful however because the new CSE defs throw exceptions different from their uses (typical case: `Def: field = array[0]; Use: read field; Use: read field`).