### PR TITLE
Deleting field sequences from `LCL_FLD` and `VNF_PtrToArrElem`

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -470,8 +470,6 @@ public:
     unsigned char lvInSsa : 1;       // The variable is in SSA form (set by SsaBuilder)
     unsigned char lvIsCSE : 1;       // Indicates if this LclVar is a CSE variable.
     unsigned char lvHasLdAddrOp : 1; // has ldloca or ldarga opcode on this local.
-    unsigned char lvStackByref : 1;  // This is a compiler temporary of TYP_BYREF that is known to point into our local
-                                     // stack frame.
 
     unsigned char lvHasILStoreOp : 1;         // there is at least one STLOC or STARG on this local
     unsigned char lvHasMultipleILStoreOp : 1; // there is more than one STLOC on this local
@@ -4781,8 +4779,6 @@ public:
     // Does value-numbering for a block assignment.
     void fgValueNumberBlockAssignment(GenTree* tree);
 
-    bool fgValueNumberBlockAssignmentTypeCheck(LclVarDsc* dstVarDsc, FieldSeqNode* dstFldSeq, GenTree* src);
-
     // Does value-numbering for a cast tree.
     void fgValueNumberCastTree(GenTree* tree);
 
@@ -5700,8 +5696,6 @@ private:
     GenTree* fgMorphSmpOpOptional(GenTreeOp* tree);
     GenTree* fgMorphMultiOp(GenTreeMultiOp* multiOp);
     GenTree* fgMorphConst(GenTree* tree);
-
-    bool fgMorphCanUseLclFldForCopy(unsigned lclNum1, unsigned lclNum2);
 
     GenTreeLclVar* fgMorphTryFoldObjAsLclVar(GenTreeObj* obj, bool destroyNodes = true);
     GenTreeOp* fgMorphCommutative(GenTreeOp* tree);

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1348,7 +1348,7 @@ inline void GenTree::SetOper(genTreeOps oper, ValueNumberUpdate vnUpdate)
 #endif
         case GT_LCL_FLD:
             AsLclFld()->SetLclOffs(0);
-            AsLclFld()->SetFieldSeq(FieldSeqStore::NotAField());
+            AsLclFld()->SetLayout(nullptr);
             break;
 
         case GT_CALL:

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -366,11 +366,9 @@ GenTree* DecomposeLongs::DecomposeLclVar(LIR::Use& use)
         m_compiler->lvaSetVarDoNotEnregister(varNum DEBUGARG(DoNotEnregisterReason::LocalField));
         loResult->SetOper(GT_LCL_FLD);
         loResult->AsLclFld()->SetLclOffs(0);
-        loResult->AsLclFld()->SetFieldSeq(FieldSeqStore::NotAField());
 
         hiResult->SetOper(GT_LCL_FLD);
         hiResult->AsLclFld()->SetLclOffs(4);
-        hiResult->AsLclFld()->SetFieldSeq(FieldSeqStore::NotAField());
     }
 
     return FinalizeDecomposition(use, loResult, hiResult, hiResult);

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -961,13 +961,6 @@ bool Compiler::fgAddrCouldBeNull(GenTree* addr)
         {
             return false;
         }
-
-        LclVarDsc* varDsc = lvaGetDesc(varNum);
-
-        if (varDsc->lvStackByref)
-        {
-            return false;
-        }
     }
     else if (addr->gtOper == GT_ADDR)
     {

--- a/src/coreclr/jit/gcinfo.cpp
+++ b/src/coreclr/jit/gcinfo.cpp
@@ -346,25 +346,6 @@ GCInfo::WriteBarrierForm GCInfo::gcWriteBarrierFormFromTargetAddress(GenTree* tg
         return GCInfo::WBF_NoBarrier;
     }
 
-    if (tgtAddr->OperGet() == GT_LCL_VAR)
-    {
-        unsigned   lclNum = tgtAddr->AsLclVar()->GetLclNum();
-        LclVarDsc* varDsc = compiler->lvaGetDesc(lclNum);
-
-        // Instead of marking LclVar with 'lvStackByref',
-        // Consider decomposing the Value Number given to this LclVar to see if it was
-        // created using a GT_ADDR(GT_LCLVAR)  or a GT_ADD( GT_ADDR(GT_LCLVAR), Constant)
-
-        // We may have an internal compiler temp created in fgMorphCopyBlock() that we know
-        // points at one of our stack local variables, it will have lvStackByref set to true.
-        //
-        if (varDsc->lvStackByref)
-        {
-            assert(varDsc->TypeGet() == TYP_BYREF);
-            return GCInfo::WBF_NoBarrier;
-        }
-    }
-
     if (tgtAddr->TypeGet() == TYP_REF)
     {
         return GCInfo::WBF_BarrierUnchecked;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1919,13 +1919,6 @@ public:
                       bool*                 pIsEntire = nullptr,
                       ssize_t*              pOffset   = nullptr);
 
-    bool IsLocalAddrExpr(Compiler*             comp,
-                         GenTreeLclVarCommon** pLclVarTree,
-                         FieldSeqNode**        pFldSeq,
-                         ssize_t*              pOffset = nullptr);
-
-    // Simpler variant of the above which just returns the local node if this is an expression that
-    // yields an address into a local
     const GenTreeLclVarCommon* IsLocalAddrExpr() const;
     GenTreeLclVarCommon*       IsLocalAddrExpr()
     {
@@ -1935,10 +1928,6 @@ public:
     // Determine if this tree represents the value of an entire implicit byref parameter,
     // and if so return the tree for the parameter.
     GenTreeLclVar* IsImplicitByrefParameterValue(Compiler* compiler);
-
-    // Determine if this is a LclVarCommon node and return some additional info about it in the
-    // two out parameters.
-    bool IsLocalExpr(Compiler* comp, GenTreeLclVarCommon** pLclVarTree, FieldSeqNode** pFldSeq);
 
     // Determine whether this is an assignment tree of the form X = X (op) Y,
     // where Y is an arbitrary tree, and X is a lclVar.
@@ -3504,12 +3493,12 @@ public:
 struct GenTreeLclFld : public GenTreeLclVarCommon
 {
 private:
-    uint16_t      m_lclOffs;  // offset into the variable to access
-    FieldSeqNode* m_fieldSeq; // This LclFld node represents some sequences of accesses.
+    uint16_t     m_lclOffs; // offset into the variable to access
+    ClassLayout* m_layout;  // The struct layout for this local field.
 
 public:
-    GenTreeLclFld(genTreeOps oper, var_types type, unsigned lclNum, unsigned lclOffs)
-        : GenTreeLclVarCommon(oper, type, lclNum), m_lclOffs(static_cast<uint16_t>(lclOffs)), m_fieldSeq(nullptr)
+    GenTreeLclFld(genTreeOps oper, var_types type, unsigned lclNum, unsigned lclOffs, ClassLayout* layout = nullptr)
+        : GenTreeLclVarCommon(oper, type, lclNum), m_lclOffs(static_cast<uint16_t>(lclOffs)), m_layout(layout)
     {
         assert(lclOffs <= UINT16_MAX);
     }
@@ -3525,14 +3514,14 @@ public:
         m_lclOffs = static_cast<uint16_t>(lclOffs);
     }
 
-    FieldSeqNode* GetFieldSeq() const
+    ClassLayout* GetLayout() const
     {
-        return m_fieldSeq;
+        return m_layout;
     }
 
-    void SetFieldSeq(FieldSeqNode* fieldSeq)
+    void SetLayout(ClassLayout* layout)
     {
-        m_fieldSeq = fieldSeq;
+        m_layout = layout;
     }
 
     unsigned GetSize() const;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1909,15 +1909,12 @@ public:
     // is not the same size as the type of the GT_LCL_VAR.
     bool IsPartialLclFld(Compiler* comp);
 
-    // Returns "true" iff "this" defines a local variable.  Requires "comp" to be the
-    // current compilation.  If returns "true", sets "*pLclVarTree" to the
-    // tree for the local that is defined, and, if "pIsEntire" is non-null, sets "*pIsEntire" to
-    // true or false, depending on whether the assignment writes to the entirety of the local
-    // variable, or just a portion of it.
     bool DefinesLocal(Compiler*             comp,
                       GenTreeLclVarCommon** pLclVarTree,
                       bool*                 pIsEntire = nullptr,
                       ssize_t*              pOffset   = nullptr);
+
+    bool DefinesLocalAddr(GenTreeLclVarCommon** pLclVarTree, ssize_t* pOffset = nullptr);
 
     const GenTreeLclVarCommon* IsLocalAddrExpr() const;
     GenTreeLclVarCommon*       IsLocalAddrExpr()
@@ -1939,14 +1936,6 @@ public:
     bool IsFieldAddr(Compiler* comp, GenTree** pBaseAddr, FieldSeqNode** pFldSeq, ssize_t* pOffset);
 
     bool IsArrayAddr(GenTreeArrAddr** pArrAddr);
-
-    // Assumes that "this" occurs in a context where it is being dereferenced as the LHS of an assignment-like
-    // statement (assignment, initblk, or copyblk).  The "width" should be the number of bytes copied by the
-    // operation.  Returns "true" if "this" is an address of (or within)
-    // a local variable; sets "*pLclVarTree" to that local variable instance; and, if "pIsEntire" is non-null,
-    // sets "*pIsEntire" to true if this assignment writes the full width of the local.
-    bool DefinesLocalAddr(
-        Compiler* comp, unsigned width, GenTreeLclVarCommon** pLclVarTree, bool* pIsEntire, ssize_t* pOffset = nullptr);
 
     // These are only used for dumping.
     // The GetRegNum() is only valid in LIR, but the dumping methods are not easily

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3678,16 +3678,11 @@ GenTree* Compiler::impCreateSpanIntrinsic(CORINFO_SIG_INFO* sig)
     unsigned             spanTempNum = lvaGrabTemp(true DEBUGARG("ReadOnlySpan<T> for CreateSpan<T>"));
     lvaSetStruct(spanTempNum, spanHnd, false);
 
-    CORINFO_FIELD_HANDLE pointerFieldHnd = info.compCompHnd->getFieldInClass(spanHnd, 0);
-    CORINFO_FIELD_HANDLE lengthFieldHnd  = info.compCompHnd->getFieldInClass(spanHnd, 1);
+    GenTreeLclFld* pointerField    = gtNewLclFldNode(spanTempNum, TYP_BYREF, 0);
+    GenTree*       pointerFieldAsg = gtNewAssignNode(pointerField, pointerValue);
 
-    GenTreeLclFld* pointerField = gtNewLclFldNode(spanTempNum, TYP_BYREF, 0);
-    pointerField->SetFieldSeq(GetFieldSeqStore()->CreateSingleton(pointerFieldHnd, 0));
-    GenTree* pointerFieldAsg = gtNewAssignNode(pointerField, pointerValue);
-
-    GenTreeLclFld* lengthField = gtNewLclFldNode(spanTempNum, TYP_INT, TARGET_POINTER_SIZE);
-    lengthField->SetFieldSeq(GetFieldSeqStore()->CreateSingleton(lengthFieldHnd, TARGET_POINTER_SIZE));
-    GenTree* lengthFieldAsg = gtNewAssignNode(lengthField, lengthValue);
+    GenTreeLclFld* lengthField    = gtNewLclFldNode(spanTempNum, TYP_INT, TARGET_POINTER_SIZE);
+    GenTree*       lengthFieldAsg = gtNewAssignNode(lengthField, lengthValue);
 
     // Now append a few statements the initialize the span
     impAppendTree(lengthFieldAsg, (unsigned)CHECK_SPILL_NONE, impCurStmtDI);

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -34,18 +34,16 @@ class LocalAddressVisitor final : public GenTreeVisitor<LocalAddressVisitor>
     //
     class Value
     {
-        GenTree*      m_node;
-        FieldSeqNode* m_fieldSeq;
-        unsigned      m_lclNum;
-        unsigned      m_offset;
-        bool          m_address;
+        GenTree* m_node;
+        unsigned m_lclNum;
+        unsigned m_offset;
+        bool     m_address;
         INDEBUG(bool m_consumed;)
 
     public:
         // Produce an unknown value associated with the specified node.
         Value(GenTree* node)
             : m_node(node)
-            , m_fieldSeq(nullptr)
             , m_lclNum(BAD_VAR_NUM)
             , m_offset(0)
             , m_address(false)
@@ -91,12 +89,6 @@ class LocalAddressVisitor final : public GenTreeVisitor<LocalAddressVisitor>
             return m_offset;
         }
 
-        // Get the location's field sequence.
-        FieldSeqNode* FieldSeq() const
-        {
-            return m_fieldSeq;
-        }
-
         //------------------------------------------------------------------------
         // Location: Produce a location value.
         //
@@ -114,7 +106,6 @@ class LocalAddressVisitor final : public GenTreeVisitor<LocalAddressVisitor>
             m_lclNum = lclVar->GetLclNum();
 
             assert(m_offset == 0);
-            assert(m_fieldSeq == nullptr);
         }
 
         //------------------------------------------------------------------------
@@ -135,7 +126,6 @@ class LocalAddressVisitor final : public GenTreeVisitor<LocalAddressVisitor>
             m_address = true;
 
             assert(m_offset == 0);
-            assert(m_fieldSeq == nullptr);
         }
 
         //------------------------------------------------------------------------
@@ -152,9 +142,8 @@ class LocalAddressVisitor final : public GenTreeVisitor<LocalAddressVisitor>
             assert(lclFld->OperIs(GT_LCL_FLD));
             assert(!IsLocation() && !IsAddress());
 
-            m_lclNum   = lclFld->GetLclNum();
-            m_offset   = lclFld->GetLclOffs();
-            m_fieldSeq = lclFld->GetFieldSeq();
+            m_lclNum = lclFld->GetLclNum();
+            m_offset = lclFld->GetLclOffs();
         }
 
         //------------------------------------------------------------------------
@@ -171,10 +160,9 @@ class LocalAddressVisitor final : public GenTreeVisitor<LocalAddressVisitor>
             assert(lclFld->OperIs(GT_LCL_FLD_ADDR));
             assert(!IsLocation() && !IsAddress());
 
-            m_lclNum   = lclFld->GetLclNum();
-            m_offset   = lclFld->GetLclOffs();
-            m_fieldSeq = lclFld->GetFieldSeq();
-            m_address  = true;
+            m_lclNum  = lclFld->GetLclNum();
+            m_offset  = lclFld->GetLclOffs();
+            m_address = true;
         }
 
         //------------------------------------------------------------------------
@@ -195,10 +183,9 @@ class LocalAddressVisitor final : public GenTreeVisitor<LocalAddressVisitor>
 
             if (val.IsLocation())
             {
-                m_address  = true;
-                m_lclNum   = val.m_lclNum;
-                m_offset   = val.m_offset;
-                m_fieldSeq = val.m_fieldSeq;
+                m_address = true;
+                m_lclNum  = val.m_lclNum;
+                m_offset  = val.m_offset;
             }
 
             INDEBUG(val.Consume();)
@@ -245,76 +232,6 @@ class LocalAddressVisitor final : public GenTreeVisitor<LocalAddressVisitor>
 
                 m_lclNum = val.m_lclNum;
                 m_offset = newOffset.Value();
-
-                bool haveCorrectFieldForVN;
-                if (field->gtFldMayOverlap)
-                {
-                    haveCorrectFieldForVN = false;
-                }
-                else
-                {
-                    LclVarDsc* varDsc = compiler->lvaGetDesc(m_lclNum);
-                    if (!varTypeIsStruct(varDsc))
-                    {
-                        haveCorrectFieldForVN = false;
-                    }
-                    else if (val.m_fieldSeq == nullptr)
-                    {
-
-                        CORINFO_CLASS_HANDLE clsHnd = varDsc->GetStructHnd();
-                        // If the answer is no we are probably accessing a canon type with a non-canon fldHnd,
-                        // currently it could happen in crossgen2 scenario where VM distinguishes class<canon>._field
-                        // from class<not-canon-ref-type>._field.
-                        haveCorrectFieldForVN =
-                            compiler->info.compCompHnd->doesFieldBelongToClass(field->gtFldHnd, clsHnd);
-                    }
-                    else
-                    {
-                        FieldSeqNode* lastSeqNode = val.m_fieldSeq->GetTail();
-                        assert(lastSeqNode != nullptr);
-                        if (lastSeqNode == FieldSeqStore::NotAField())
-                        {
-                            haveCorrectFieldForVN = false;
-                        }
-                        else
-                        {
-                            CORINFO_FIELD_HANDLE lastFieldBeforeTheCurrent = lastSeqNode->GetFieldHandle();
-
-                            CORINFO_CLASS_HANDLE clsHnd;
-                            CorInfoType          fieldCorType =
-                                compiler->info.compCompHnd->getFieldType(lastFieldBeforeTheCurrent, &clsHnd);
-                            if (fieldCorType != CORINFO_TYPE_VALUECLASS)
-                            {
-                                // For example, System.IntPtr:ToInt64, when inlined, creates trees like
-                                // *  FIELD     long   _value
-                                // \--*  ADDR      byref
-                                //    \--*  FIELD     long   Information
-                                //       \--*  ADDR      byref
-                                //          \--*  LCL_VAR   struct<Interop+NtDll+IO_STATUS_BLOCK, 16> V08 tmp7
-                                haveCorrectFieldForVN = false;
-                            }
-                            else
-                            {
-
-                                haveCorrectFieldForVN =
-                                    compiler->info.compCompHnd->doesFieldBelongToClass(field->gtFldHnd, clsHnd);
-                                noway_assert(haveCorrectFieldForVN);
-                            }
-                        }
-                    }
-                }
-
-                if (haveCorrectFieldForVN)
-                {
-                    FieldSeqStore* fieldSeqStore = compiler->GetFieldSeqStore();
-                    FieldSeqNode*  fieldSeqNode  = fieldSeqStore->CreateSingleton(field->gtFldHnd, field->gtFldOffset);
-                    m_fieldSeq                   = fieldSeqStore->Append(val.m_fieldSeq, fieldSeqNode);
-                }
-                else
-                {
-                    m_fieldSeq = FieldSeqStore::NotAField();
-                    JITDUMP("Setting NotAField for [%06u],\n", compiler->dspTreeID(field));
-                }
             }
 
             INDEBUG(val.Consume();)
@@ -348,9 +265,8 @@ class LocalAddressVisitor final : public GenTreeVisitor<LocalAddressVisitor>
 
             if (val.IsAddress())
             {
-                m_lclNum   = val.m_lclNum;
-                m_offset   = val.m_offset;
-                m_fieldSeq = val.m_fieldSeq;
+                m_lclNum = val.m_lclNum;
+                m_offset = val.m_offset;
             }
 
             INDEBUG(val.Consume();)
@@ -939,14 +855,14 @@ private:
             // use ADD(LCL_VAR_ADDR, offset) instead.
             addr->ChangeOper(GT_ADD);
             addr->AsOp()->gtOp1 = m_compiler->gtNewLclVarAddrNode(val.LclNum());
-            addr->AsOp()->gtOp2 = m_compiler->gtNewIconNode(val.Offset(), val.FieldSeq());
+            addr->AsOp()->gtOp2 = m_compiler->gtNewIconNode(val.Offset(), TYP_I_IMPL);
         }
-        else if ((val.Offset() != 0) || (val.FieldSeq() != nullptr))
+        else if (val.Offset() != 0)
         {
             addr->ChangeOper(GT_LCL_FLD_ADDR);
             addr->AsLclFld()->SetLclNum(val.LclNum());
             addr->AsLclFld()->SetLclOffs(val.Offset());
-            addr->AsLclFld()->SetFieldSeq(val.FieldSeq());
+            addr->AsLclFld()->SetLayout(nullptr);
         }
         else
         {
@@ -980,33 +896,10 @@ private:
             return;
         }
 
-        GenTree*      indir    = val.Node();
-        FieldSeqNode* fieldSeq = val.FieldSeq();
-
-        if (fieldSeq == nullptr)
-        {
-            fieldSeq = FieldSeqStore::NotAField();
-        }
-
-        if (fieldSeq != FieldSeqStore::NotAField())
-        {
-            if (!indir->OperIs(GT_FIELD))
-            {
-                // TODO-PhysicalVN: with the physical VN scheme, we no longer need the below check.
-                if (indir->TypeGet() != m_compiler->eeGetFieldType(fieldSeq->GetTail()->GetFieldHandle()))
-                {
-                    fieldSeq = FieldSeqStore::NotAField();
-                }
-            }
-            else
-            {
-                // FIELDs are correctly typed by construction.
-                assert(indir->AsField()->gtFldHnd == fieldSeq->GetTail()->GetFieldHandle());
-            }
-        }
-
+        GenTree*             indir        = val.Node();
         GenTreeLclVarCommon* lclNode      = nullptr;
         GenTreeFlags         lclNodeFlags = GTF_EMPTY;
+
         switch (transform)
         {
             case IndirTransform::LclVar:
@@ -1020,12 +913,12 @@ private:
                 indir->ChangeOper(GT_LCL_FLD);
                 indir->AsLclFld()->SetLclNum(val.LclNum());
                 indir->AsLclFld()->SetLclOffs(val.Offset());
-                indir->AsLclFld()->SetFieldSeq(fieldSeq);
+                indir->AsLclFld()->SetLayout(indirLayout);
 
                 lclNode = indir->AsLclVarCommon();
                 break;
 
-            // TODO-ADDR: support TYP_STRUCT LCL_FLD and use it instead.
+            // TODO-ADDR: support TYP_STRUCT LCL_FLD for all users and use it instead.
             case IndirTransform::ObjAddrLclFld:
             {
                 indir->SetOper(indirLayout->IsBlockLayout() ? GT_BLK : GT_OBJ);
@@ -1044,7 +937,7 @@ private:
                 location->ChangeOper(GT_LCL_FLD);
                 location->AsLclFld()->SetLclNum(val.LclNum());
                 location->AsLclFld()->SetLclOffs(val.Offset());
-                location->AsLclFld()->SetFieldSeq(fieldSeq);
+                location->AsLclFld()->SetLayout(nullptr);
 
                 lclNode = location->AsLclVarCommon();
                 lclNodeFlags |= GTF_DONT_CSE;
@@ -1081,6 +974,18 @@ private:
         INDEBUG(m_stmtModified = true);
     }
 
+    //------------------------------------------------------------------------
+    // SelectLocalIndirTransform: Select the transformation appropriate for an
+    //    indirect access of a local variable.
+    //
+    // Arguments:
+    //    val           - a value that represents the local indirection
+    //    user          - the indirection's user node
+    //    pStructLayout - [out] parameter for layout of struct indirections
+    //
+    // Return Value:
+    //    The transformation the caller should perform on this indirection.
+    //
     IndirTransform SelectLocalIndirTransform(const Value& val, GenTree* user, ClassLayout** pStructLayout)
     {
         GenTree* indir = val.Node();

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -7805,10 +7805,6 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
     {
         printf(" pinned");
     }
-    if (varDsc->lvStackByref)
-    {
-        printf(" stack-byref");
-    }
     if (varDsc->lvClassHnd != NO_CLASS_HANDLE)
     {
         printf(" class-hnd");

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -243,18 +243,17 @@ void Compiler::fgPerNodeLocalVarLiveness(GenTree* tree)
             // Otherwise, we treat it as a use here.
             if ((tree->gtFlags & GTF_IND_ASG_LHS) == 0)
             {
-                GenTreeLclVarCommon* dummyLclVarTree = nullptr;
-                bool                 dummyIsEntire   = false;
-                GenTree*             addrArg         = tree->AsOp()->gtOp1->gtEffectiveVal(/*commaOnly*/ true);
-                if (!addrArg->DefinesLocalAddr(this, /*width doesn't matter*/ 0, &dummyLclVarTree, &dummyIsEntire))
+                GenTreeLclVarCommon* lclVarTree = nullptr;
+                GenTree*             addrArg    = tree->AsOp()->gtOp1->gtEffectiveVal(/*commaOnly*/ true);
+                if (!addrArg->DefinesLocalAddr(&lclVarTree))
                 {
                     fgCurMemoryUse |= memoryKindSet(GcHeap, ByrefExposed);
                 }
                 else
                 {
                     // Defines a local addr
-                    assert(dummyLclVarTree != nullptr);
-                    fgMarkUseDef(dummyLclVarTree->AsLclVarCommon());
+                    assert(lclVarTree != nullptr);
+                    fgMarkUseDef(lclVarTree->AsLclVarCommon());
                 }
             }
             break;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11764,6 +11764,7 @@ DONE_MORPHING_CHILDREN:
                 // 'temp' because a GT_ADDR always marks it for its operand.
                 temp->gtFlags &= ~GTF_DONT_CSE;
                 temp->gtFlags |= (tree->gtFlags & GTF_DONT_CSE);
+                temp->SetVNsFromNode(tree);
 
                 if (op1->OperGet() == GT_ADD)
                 {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3420,11 +3420,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
             // (tmp.ptr=argx),(tmp.type=handle)
             GenTreeLclFld* destPtrSlot  = gtNewLclFldNode(tmp, TYP_I_IMPL, OFFSETOF__CORINFO_TypedReference__dataPtr);
             GenTreeLclFld* destTypeSlot = gtNewLclFldNode(tmp, TYP_I_IMPL, OFFSETOF__CORINFO_TypedReference__type);
-            destPtrSlot->SetFieldSeq(
-                GetFieldSeqStore()->CreateSingleton(GetRefanyDataField(), OFFSETOF__CORINFO_TypedReference__dataPtr));
             destPtrSlot->gtFlags |= GTF_VAR_DEF;
-            destTypeSlot->SetFieldSeq(
-                GetFieldSeqStore()->CreateSingleton(GetRefanyTypeField(), OFFSETOF__CORINFO_TypedReference__type));
             destTypeSlot->gtFlags |= GTF_VAR_DEF;
 
             GenTree* asgPtrSlot  = gtNewAssignNode(destPtrSlot, argx->AsOp()->gtOp1);
@@ -9644,45 +9640,6 @@ GenTree* Compiler::fgMorphBlockOperand(GenTree* tree, var_types asgType, unsigne
     return tree;
 }
 
-//------------------------------------------------------------------------
-// fgMorphCanUseLclFldForCopy: check if we can access LclVar2 using LclVar1's fields.
-//
-// Arguments:
-//    lclNum1 - a promoted lclVar that is used in fieldwise assignment;
-//    lclNum2 - the local variable on the other side of ASG, can be BAD_VAR_NUM.
-//
-// Return Value:
-//    True if the second local is valid and has the same struct handle as the first,
-//    false otherwise.
-//
-// Notes:
-//   TODO-PhysicalVN: with the physical VN scheme, this method is no longer needed.
-//
-bool Compiler::fgMorphCanUseLclFldForCopy(unsigned lclNum1, unsigned lclNum2)
-{
-    assert(lclNum1 != BAD_VAR_NUM);
-    if (lclNum2 == BAD_VAR_NUM)
-    {
-        return false;
-    }
-    const LclVarDsc* varDsc1 = lvaGetDesc(lclNum1);
-    const LclVarDsc* varDsc2 = lvaGetDesc(lclNum2);
-    assert(varTypeIsStruct(varDsc1));
-    if (!varTypeIsStruct(varDsc2))
-    {
-        return false;
-    }
-    CORINFO_CLASS_HANDLE struct1 = varDsc1->GetStructHnd();
-    CORINFO_CLASS_HANDLE struct2 = varDsc2->GetStructHnd();
-    assert(struct1 != NO_CLASS_HANDLE);
-    assert(struct2 != NO_CLASS_HANDLE);
-    if (struct1 != struct2)
-    {
-        return false;
-    }
-    return true;
-}
-
 // insert conversions and normalize to make tree amenable to register
 // FP architectures
 GenTree* Compiler::fgMorphForRegisterFP(GenTree* tree)
@@ -11671,11 +11628,7 @@ DONE_MORPHING_CHILDREN:
 
                             if ((fieldSeq != nullptr) && (temp->OperGet() == GT_LCL_FLD))
                             {
-                                // Append the field sequence, change the type.
-                                temp->AsLclFld()->SetFieldSeq(
-                                    GetFieldSeqStore()->Append(temp->AsLclFld()->GetFieldSeq(), fieldSeq));
-                                temp->gtType = typ;
-
+                                temp->gtType      = typ;
                                 foldAndReturnTemp = true;
                             }
                         }
@@ -11729,13 +11682,6 @@ DONE_MORPHING_CHILDREN:
 
                         ival1    = op1->AsOp()->gtOp2->AsIntCon()->gtIconVal;
                         fieldSeq = op1->AsOp()->gtOp2->AsIntCon()->gtFieldSeq;
-
-                        // Does the address have an associated zero-offset field sequence?
-                        FieldSeqNode* addrFieldSeq = nullptr;
-                        if (GetZeroOffsetFieldMap()->Lookup(op1->AsOp()->gtOp1, &addrFieldSeq))
-                        {
-                            fieldSeq = GetFieldSeqStore()->Append(addrFieldSeq, fieldSeq);
-                        }
 
                         if (ival1 == 0 && typ == temp->TypeGet() && temp->TypeGet() != TYP_STRUCT)
                         {
@@ -11794,7 +11740,6 @@ DONE_MORPHING_CHILDREN:
                     {
                         lclFld = temp->AsLclFld();
                         lclFld->SetLclOffs(lclFld->GetLclOffs() + static_cast<unsigned>(ival1));
-                        lclFld->SetFieldSeq(GetFieldSeqStore()->Append(lclFld->GetFieldSeq(), fieldSeq));
                     }
                     else // We have a GT_LCL_VAR.
                     {
@@ -11802,12 +11747,6 @@ DONE_MORPHING_CHILDREN:
                         temp->ChangeOper(GT_LCL_FLD); // Note that this makes the gtFieldSeq "NotAField".
                         lclFld = temp->AsLclFld();
                         lclFld->SetLclOffs(static_cast<unsigned>(ival1));
-
-                        if (fieldSeq != nullptr)
-                        {
-                            // If it does represent a field, note that.
-                            lclFld->SetFieldSeq(fieldSeq);
-                        }
                     }
 
                     temp->gtType      = tree->gtType;
@@ -17249,18 +17188,6 @@ void Compiler::fgAddFieldSeqForZeroOffset(GenTree* addr, FieldSeqNode* fieldSeqZ
             fieldSeqRecorded             = true;
             break;
 
-        case GT_ADDR:
-            if (addr->AsOp()->gtOp1->OperGet() == GT_LCL_FLD)
-            {
-                fieldSeqNode = addr->AsOp()->gtOp1;
-
-                GenTreeLclFld* lclFld = addr->AsOp()->gtOp1->AsLclFld();
-                fieldSeqUpdate        = GetFieldSeqStore()->Append(lclFld->GetFieldSeq(), fieldSeqZero);
-                lclFld->SetFieldSeq(fieldSeqUpdate);
-                fieldSeqRecorded = true;
-            }
-            break;
-
         case GT_ADD:
             if (addr->AsOp()->gtOp1->OperGet() == GT_CNS_INT)
             {
@@ -17406,7 +17333,7 @@ bool Compiler::fgMorphCombineSIMDFieldAssignments(BasicBlock* block, Statement* 
     {
         dstNode         = originalLHS;
         dstNode->gtType = simdType;
-        dstNode->AsLclFld()->SetFieldSeq(FieldSeqStore::NotAField());
+        dstNode->AsLclFld()->SetLayout(nullptr);
 
         // This may have changed a partial local field into full local field
         if (dstNode->IsPartialLclFld(this))

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -39,7 +39,6 @@ protected:
     unsigned             m_dstLclNum          = BAD_VAR_NUM;
     GenTreeLclVarCommon* m_dstLclNode         = nullptr;
     LclVarDsc*           m_dstVarDsc          = nullptr;
-    FieldSeqNode*        m_dstFldSeq          = nullptr;
     unsigned             m_dstLclOffset       = 0;
     bool                 m_dstUseLclFld       = false;
     bool                 m_dstSingleLclVarAsg = false;
@@ -222,7 +221,6 @@ void MorphInitBlockHelper::PrepareDst()
             assert(m_dst->OperIs(GT_LCL_FLD) && !m_dst->TypeIs(TYP_STRUCT));
             GenTreeLclFld* destFld = m_dst->AsLclFld();
             m_blockSize            = genTypeSize(destFld->TypeGet());
-            m_dstFldSeq            = destFld->GetFieldSeq();
         }
     }
     else
@@ -244,9 +242,10 @@ void MorphInitBlockHelper::PrepareDst()
         }
 
         noway_assert(dstAddr->TypeIs(TYP_BYREF, TYP_I_IMPL));
-        if (dstAddr->IsLocalAddrExpr(m_comp, &m_dstLclNode, &m_dstFldSeq, &m_dstAddOff))
+        if (dstAddr->DefinesLocalAddr(m_comp, /* width */ 0, &m_dstLclNode, /* pIsEntire */ nullptr, &m_dstAddOff))
         {
             // Note that lclNode can be a field, like `BLK<4> struct(ADD(ADDR(LCL_FLD int), CNST_INT))`.
+            m_dstAddOff = m_dstAddOff - m_dstLclNode->GetLclOffs();
             m_dstVarDsc = m_comp->lvaGetDesc(m_dstLclNode);
         }
     }
@@ -529,7 +528,6 @@ protected:
     unsigned             m_srcLclNum          = BAD_VAR_NUM;
     LclVarDsc*           m_srcVarDsc          = nullptr;
     GenTreeLclVarCommon* m_srcLclNode         = nullptr;
-    FieldSeqNode*        m_srcFldSeq          = nullptr;
     bool                 m_srcUseLclFld       = false;
     unsigned             m_srcLclOffset       = 0;
     bool                 m_srcSingleLclVarAsg = false;
@@ -588,15 +586,12 @@ void MorphCopyBlockHelper::PrepareSrc()
     {
         m_srcLclNode = m_src->AsLclVarCommon();
         m_srcLclNum  = m_srcLclNode->GetLclNum();
-        if (m_src->OperGet() == GT_LCL_FLD)
-        {
-            m_srcFldSeq = m_src->AsLclFld()->GetFieldSeq();
-        }
     }
     else if (m_src->OperIsIndir())
     {
-        if (m_src->AsOp()->gtOp1->IsLocalAddrExpr(m_comp, &m_srcLclNode, &m_srcFldSeq, &m_srcAddOff))
+        if (m_src->AsOp()->gtOp1->DefinesLocalAddr(m_comp, /* width */ 0, &m_srcLclNode, /* pIsEntire */ nullptr, &m_srcAddOff))
         {
+            m_srcAddOff = m_srcAddOff - m_srcLclNode->GetLclOffs();
             m_srcLclNum = m_srcLclNode->GetLclNum();
         }
         else
@@ -726,8 +721,8 @@ void MorphCopyBlockHelper::MorphStructCases()
 
     // Check to see if we are doing a copy to/from the same local block.
     // If so, morph it to a nop.
-    if ((m_dstVarDsc != nullptr) && (m_srcVarDsc == m_dstVarDsc) && (m_dstFldSeq == m_srcFldSeq) &&
-        m_dstFldSeq != FieldSeqStore::NotAField())
+    if ((m_dstVarDsc != nullptr) && (m_srcVarDsc == m_dstVarDsc) && (m_dstLclOffset == m_srcLclOffset) &&
+        (m_dstAddOff == m_srcAddOff))
     {
         JITDUMP("Self-copy; replaced with a NOP.\n");
         m_transformationDecision = BlockTransformation::Nop;
@@ -1010,12 +1005,11 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
     }
     else if (m_dstDoFldAsg)
     {
-        fieldCnt = m_dstVarDsc->lvFieldCnt;
-        m_src    = m_comp->fgMorphBlockOperand(m_src, m_asg->TypeGet(), m_blockSize, false /*isBlkReqd*/);
+        fieldCnt       = m_dstVarDsc->lvFieldCnt;
+        m_src          = m_comp->fgMorphBlockOperand(m_src, m_asg->TypeGet(), m_blockSize, false /*isBlkReqd*/);
+        m_srcUseLclFld = m_srcVarDsc != nullptr;
 
-        m_srcUseLclFld = m_comp->fgMorphCanUseLclFldForCopy(m_dstLclNum, m_srcLclNum);
-
-        if (!m_srcUseLclFld && m_srcAddr == nullptr)
+        if (!m_srcUseLclFld && (m_srcAddr == nullptr))
         {
             m_srcAddr = m_comp->fgMorphGetStructAddr(&m_src, m_dstVarDsc->GetStructHnd(), true /* rValue */);
         }
@@ -1037,8 +1031,7 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
                     // We will spill m_srcAddr (i.e. assign to a temp "BlockOp address local")
                     // no need to clone a new copy as it is only used once
                     //
-                    addrSpill          = m_srcAddr; // addrSpill represents the 'm_srcAddr'
-                    addrSpillSrcLclNum = m_srcLclNum;
+                    addrSpill = m_srcAddr; // addrSpill represents the 'm_srcAddr'
                 }
             }
         }
@@ -1046,25 +1039,22 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
     else
     {
         assert(m_srcDoFldAsg);
-        fieldCnt = m_srcVarDsc->lvFieldCnt;
-        m_dst    = m_comp->fgMorphBlockOperand(m_dst, m_dst->TypeGet(), m_blockSize, false /*isBlkReqd*/);
+        fieldCnt       = m_srcVarDsc->lvFieldCnt;
+        m_dst          = m_comp->fgMorphBlockOperand(m_dst, m_dst->TypeGet(), m_blockSize, false /*isBlkReqd*/);
+        m_dstUseLclFld = m_dstVarDsc != nullptr;
+
         if (m_dst->OperIsBlk())
         {
             m_dst->SetOper(GT_IND);
             m_dst->gtType = TYP_STRUCT;
         }
-        m_dstUseLclFld = m_comp->fgMorphCanUseLclFldForCopy(m_srcLclNum, m_dstLclNum);
+
         if (!m_dstUseLclFld)
         {
             m_dstAddr = m_comp->gtNewOperNode(GT_ADDR, TYP_BYREF, m_dst);
         }
 
-        // If we're doing field-wise stores, to an address within a local, and we copy
-        // the address into "addrSpill", do *not* declare the original local var node in the
-        // field address as GTF_VAR_DEF and GTF_VAR_USEASG; we will declare each of the
-        // field-wise assignments as an "indirect" assignment to the local.
-        // ("m_dstLclNode" is a subtree of "m_dstAddr"; make sure we remove the flags before
-        // we clone it.)
+        // Clear the def flags, we'll reuse the node below and reset them.
         if (m_dstLclNode != nullptr)
         {
             m_dstLclNode->gtFlags &= ~(GTF_VAR_DEF | GTF_VAR_USEASG);
@@ -1087,8 +1077,7 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
                     // We will spill m_dstAddr (i.e. assign to a temp "BlockOp address local")
                     // no need to clone a new copy as it is only used once
                     //
-                    addrSpill          = m_dstAddr; // addrSpill represents the 'm_dstAddr'
-                    addrSpillSrcLclNum = m_dstLclNum;
+                    addrSpill = m_dstAddr; // addrSpill represents the 'm_dstAddr'
                 }
             }
         }
@@ -1103,30 +1092,10 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
         addrSpillTemp = m_comp->lvaGrabTemp(true DEBUGARG("BlockOp address local"));
 
         LclVarDsc* addrSpillDsc = m_comp->lvaGetDesc(addrSpillTemp);
-
-        addrSpillDsc->lvType = TYP_BYREF;
-
-        if (addrSpillSrcLclNum != BAD_VAR_NUM)
-        {
-            // addrSpill represents the address of LclVar[varNum] in our local stack frame.
-            addrSpillDsc->lvStackByref = true;
-        }
+        addrSpillDsc->lvType    = TYP_BYREF;
 
         GenTreeLclVar* addrSpillNode = m_comp->gtNewLclvNode(addrSpillTemp, TYP_BYREF);
         addrSpillAsg                 = m_comp->gtNewAssignNode(addrSpillNode, addrSpill);
-
-        // If we are assigning the address of a LclVar here liveness will not
-        // account for this kind of address taken use. Mark the local as
-        // address-exposed so that we don't do illegal optimizations with it.
-        //
-        // TODO-CQ: usage of "addrSpill" for local addresses is a workaround
-        // for cases where we fail to use LCL_FLD nodes instead. Fix them and
-        // delete this code.
-        //
-        if (addrSpillSrcLclNum != BAD_VAR_NUM)
-        {
-            m_comp->lvaSetVarAddrExposed(addrSpillSrcLclNum DEBUGARG(AddressExposedReason::COPY_FLD_BY_FLD));
-        }
     }
 
     // We may have allocated a temp above, and that may have caused the lvaTable to be expanded.
@@ -1197,19 +1166,6 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
                             // Morph the newly created tree
                             dstAddrClone = m_comp->fgMorphTree(dstAddrClone);
                         }
-
-                        // Is the address of a local?
-                        GenTreeLclVarCommon* lclVarTree = nullptr;
-                        bool                 isEntire   = false;
-                        bool*                pIsEntire  = &isEntire;
-                        if (dstAddrClone->DefinesLocalAddr(m_comp, m_blockSize, &lclVarTree, pIsEntire))
-                        {
-                            lclVarTree->gtFlags |= GTF_VAR_DEF;
-                            if (!isEntire)
-                            {
-                                lclVarTree->gtFlags |= GTF_VAR_USEASG;
-                            }
-                        }
                     }
                 }
 
@@ -1228,7 +1184,6 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
 
                 if (!m_dstUseLclFld)
                 {
-
                     if (srcFieldOffset == 0)
                     {
                         m_comp->fgAddFieldSeqForZeroOffset(dstAddrClone, curFieldSeq);
@@ -1245,13 +1200,11 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
                 {
                     assert(m_dstAddOff == 0);
                     assert(dstAddrClone == nullptr);
-                    assert((m_dstLclOffset == 0) || (m_dstFldSeq != nullptr));
+
                     // If the dst was a struct type field "B" in a struct "A" then we add
                     // add offset of ("B" in "A") + current offset in "B".
-                    unsigned summOffset        = m_dstLclOffset + srcFieldOffset;
-                    dstFld                     = m_comp->gtNewLclFldNode(m_dstLclNum, srcType, summOffset);
-                    FieldSeqNode* dstFldFldSeq = m_comp->GetFieldSeqStore()->Append(m_dstFldSeq, curFieldSeq);
-                    dstFld->AsLclFld()->SetFieldSeq(dstFldFldSeq);
+                    unsigned totalOffset = m_dstLclOffset + srcFieldOffset;
+                    dstFld               = m_comp->gtNewLclFldNode(m_dstLclNum, srcType, totalOffset);
 
                     // TODO-1stClassStructs: remove this and implement storing to a field in a struct in a reg.
                     m_comp->lvaSetVarDoNotEnregister(m_dstLclNum DEBUGARG(DoNotEnregisterReason::LocalField));
@@ -1344,7 +1297,6 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
                             m_srcLclNode->gtFlags |= GTF_VAR_CAST;
                             m_srcLclNode->ChangeOper(GT_LCL_FLD);
                             m_srcLclNode->gtType = destType;
-                            m_srcLclNode->AsLclFld()->SetFieldSeq(curFieldSeq);
                             m_comp->lvaSetVarDoNotEnregister(m_srcLclNum DEBUGARG(DoNotEnregisterReason::LocalField));
                             srcFld = m_srcLclNode;
                             done   = true;
@@ -1369,16 +1321,14 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
                     }
                     else
                     {
-                        assert((m_srcLclOffset == 0) || (m_srcFldSeq != 0));
                         assert(m_srcAddOff == 0);
+
                         // If the src was a struct type field "B" in a struct "A" then we add
                         // add offset of ("B" in "A") + current offset in "B".
-                        unsigned summOffset        = m_srcLclOffset + fldOffset;
-                        srcFld                     = m_comp->gtNewLclFldNode(m_srcLclNum, destType, summOffset);
-                        FieldSeqNode* srcFldFldSeq = m_comp->GetFieldSeqStore()->Append(m_srcFldSeq, curFieldSeq);
-                        srcFld->AsLclFld()->SetFieldSeq(srcFldFldSeq);
-                        // TODO-1stClassStructs: remove this and implement reading a field from a struct in a
-                        // reg.
+                        unsigned totalOffset = m_srcLclOffset + fldOffset;
+                        srcFld               = m_comp->gtNewLclFldNode(m_srcLclNum, destType, totalOffset);
+
+                        // TODO-1stClassStructs: remove this and implement reading a field from a struct in a reg.
                         m_comp->lvaSetVarDoNotEnregister(m_srcLclNum DEBUGARG(DoNotEnregisterReason::LocalField));
                     }
                 }
@@ -1388,14 +1338,6 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
         noway_assert(dstFld->TypeGet() == srcFld->TypeGet());
 
         GenTreeOp* asgOneFld = m_comp->gtNewAssignNode(dstFld, srcFld);
-
-        // If we spilled the address, and we didn't do individual field assignments to promoted fields,
-        // and it was of a local, ensure that the destination local variable has been marked as address
-        // exposed. Neither liveness nor SSA are able to track this kind of indirect assignments.
-        if (addrSpill && !m_dstDoFldAsg && m_dstLclNum != BAD_VAR_NUM)
-        {
-            noway_assert(m_comp->lvaGetDesc(m_dstLclNum)->IsAddressExposed());
-        }
 
         if (m_comp->optLocalAssertionProp)
         {

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -242,7 +242,7 @@ void MorphInitBlockHelper::PrepareDst()
         }
 
         noway_assert(dstAddr->TypeIs(TYP_BYREF, TYP_I_IMPL));
-        if (dstAddr->DefinesLocalAddr(m_comp, /* width */ 0, &m_dstLclNode, /* pIsEntire */ nullptr, &m_dstAddOff))
+        if (dstAddr->DefinesLocalAddr(&m_dstLclNode, &m_dstAddOff))
         {
             // Note that lclNode can be a field, like `BLK<4> struct(ADD(ADDR(LCL_FLD int), CNST_INT))`.
             m_dstAddOff = m_dstAddOff - m_dstLclNode->GetLclOffs();
@@ -589,7 +589,7 @@ void MorphCopyBlockHelper::PrepareSrc()
     }
     else if (m_src->OperIsIndir())
     {
-        if (m_src->AsOp()->gtOp1->DefinesLocalAddr(m_comp, /* width */ 0, &m_srcLclNode, /* pIsEntire */ nullptr, &m_srcAddOff))
+        if (m_src->AsOp()->gtOp1->DefinesLocalAddr(&m_srcLclNode, &m_srcAddOff))
         {
             m_srcAddOff = m_srcAddOff - m_srcLclNode->GetLclOffs();
             m_srcLclNum = m_srcLclNode->GetLclNum();

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -146,7 +146,6 @@ void Rationalizer::RewriteSIMDIndir(LIR::Use& use)
         {
             addr->SetOper(GT_LCL_FLD);
             addr->AsLclFld()->SetLclOffs(0);
-            addr->AsLclFld()->SetFieldSeq(FieldSeqStore::NotAField());
 
             if (((addr->gtFlags & GTF_VAR_DEF) != 0) && (genTypeSize(simdType) < genTypeSize(lclType)))
             {
@@ -362,7 +361,7 @@ static void RewriteAssignmentIntoStoreLclCore(GenTreeOp* assignment,
     if (locationOp == GT_LCL_FLD)
     {
         store->AsLclFld()->SetLclOffs(var->AsLclFld()->GetLclOffs());
-        store->AsLclFld()->SetFieldSeq(var->AsLclFld()->GetFieldSeq());
+        store->AsLclFld()->SetLayout(var->AsLclFld()->GetLayout());
     }
 
     copyFlags(store, var, (GTF_LIVENESS_MASK | GTF_VAR_MULTIREG));

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -17,8 +17,7 @@ ValueNumFuncDef(PhiMemoryDef, 2, false, false, false)       // Args: 0: VN for b
 ValueNumFuncDef(Phi, 2, false, false, false)                // A phi function.  Only occurs as arg of PhiDef or PhiMemoryDef.  Arguments are SSA numbers of var being defined.
 
 ValueNumFuncDef(PtrToLoc, 2, false, true, false)            // Pointer (byref) to a local variable.  Args: VN's of: 0: local's number, 1: offset.
-ValueNumFuncDef(PtrToArrElem, 4, false, false, false)       // Pointer (byref) to an array element.  Args: 0: array elem type eq class var_types value, VN's of: 1: array, 2: index, 3: "ArrElemOffset" VN.
-ValueNumFuncDef(ArrElemOffset, 2, false, false, false)      // Args: 0: (VN of) the field sequence, 1: (VN of) the offset
+ValueNumFuncDef(PtrToArrElem, 4, false, false, false)       // Pointer (byref) to an array element.  Args: 0: array elem type eq class var_types value, VN's of: 1: array, 2: index, 3: offset.
 ValueNumFuncDef(PtrToStatic, 3, false, true, false)         // Pointer (byref) to a static variable (or possibly a field thereof, if the static variable is a struct).
                                                             // Args: 0: (VN of) the box's address if the static is "boxed",
                                                             //       1: (VN of) the field sequence, of which the first element is the static itself.

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -16,7 +16,7 @@ ValueNumFuncDef(PhiDef, 3, false, false, false)             // Args: 0: local va
 ValueNumFuncDef(PhiMemoryDef, 2, false, false, false)       // Args: 0: VN for basic block pointer, 1: VN of definition
 ValueNumFuncDef(Phi, 2, false, false, false)                // A phi function.  Only occurs as arg of PhiDef or PhiMemoryDef.  Arguments are SSA numbers of var being defined.
 
-ValueNumFuncDef(PtrToLoc, 2, false, true, false)            // Pointer (byref) to a local variable.  Args: VN's of: 0: var num, 1: FieldSeq.
+ValueNumFuncDef(PtrToLoc, 2, false, true, false)            // Pointer (byref) to a local variable.  Args: VN's of: 0: local's number, 1: offset.
 ValueNumFuncDef(PtrToArrElem, 4, false, false, false)       // Pointer (byref) to an array element.  Args: 0: array elem type eq class var_types value, VN's of: 1: array, 2: index, 3: "ArrElemOffset" VN.
 ValueNumFuncDef(ArrElemOffset, 2, false, false, false)      // Args: 0: (VN of) the field sequence, 1: (VN of) the offset
 ValueNumFuncDef(PtrToStatic, 3, false, true, false)         // Pointer (byref) to a static variable (or possibly a field thereof, if the static variable is a struct).


### PR DESCRIPTION
The first round of deleting field sequences:

1) From `LCL_FLD`: replace it with a `ClassLayout*` pointer (for now, unused). De-pessimize block morphing and block numbering, remove quirks from VN.
2) From `VNF_PtrToArrElem`: not replaced by anything because it is not needed anymore.

Also includes clean up of `DefinesLocalAddr` and a miscellaneous fix for the numbering of return buffer locals.

[The diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1784596&view=ms.vss-build-web.run-extensions-tab) are pretty nice, including the throughput ones, and come mainly from the deletion of `fgMorphCanUseLclFldForCopy`, but also from the array change. We see some regressions with CSEs and hoisting (there is one extreme case of this on x86 where 6 new SIMD CSEs trigger pathological RA behavior and we see it "spill the world", fortunately it is in a PMI-instantiated method). There are also a few cases where locals become tracked and `optRemoveRedundantZeroInits` no longer removes the explicit zero-initialization.

This also saves `~0.16%` in memory consumption when CG-ing CoreLib.

Closes #12142.