### PR TITLE
Workaround crash in Microsoft.DiaSymReader.Native

### DIFF
--- a/src/coreclr/vm/debugdebugger.cpp
+++ b/src/coreclr/vm/debugdebugger.cpp
@@ -540,6 +540,9 @@ FCIMPL4(void, DebugStackTrace::GetStackFramesInternal,
             {
 #ifdef FEATURE_ISYM_READER
                 BOOL fPortablePDB = FALSE;
+                // We are checking if the PE image's debug directory contains a portable or embedded PDB because
+                // the native diasymreader's portable PDB support has various bugs (crashes on certain PDBs) and
+                // limitations (doesn't support in-memory or embedded PDBs).
                 if (pModule->GetPEAssembly()->HasLoadedPEImage())
                 {
                     PEDecoder* pe = pModule->GetPEAssembly()->GetLoadedLayout();

--- a/src/coreclr/vm/debugdebugger.cpp
+++ b/src/coreclr/vm/debugdebugger.cpp
@@ -569,7 +569,10 @@ FCIMPL4(void, DebugStackTrace::GetStackFramesInternal,
                 }
                 if (!fPortablePDB)
                 {
+                    // We didn't see a portable PDB in the debug directory but to just make sure we defensively assume that is
+                    // portable and if the diasymreader doesn't exist or fails, we go down the portable PDB path.
                     fPortablePDB = TRUE;
+
                     BOOL fFileInfoSet = FALSE;
                     ULONG32 sourceLine = 0;
                     ULONG32 sourceColumn = 0;

--- a/src/coreclr/vm/debugdebugger.cpp
+++ b/src/coreclr/vm/debugdebugger.cpp
@@ -540,24 +540,27 @@ FCIMPL4(void, DebugStackTrace::GetStackFramesInternal,
             {
 #ifdef FEATURE_ISYM_READER
                 BOOL fPortablePDB = FALSE;
-                PEDecoder* pe = pModule->GetPEAssembly()->GetLoadedLayout();
-                IMAGE_DATA_DIRECTORY* debugDirectoryEntry = pe->GetDirectoryEntry(IMAGE_DIRECTORY_ENTRY_DEBUG);
-                if (debugDirectoryEntry != nullptr)
+                if (pModule->GetPEAssembly()->HasLoadedPEImage())
                 {
-                    IMAGE_DEBUG_DIRECTORY* debugDirectory = (IMAGE_DEBUG_DIRECTORY*)pe->GetDirectoryData(debugDirectoryEntry);
-                    if (debugDirectory != nullptr)
+                    PEDecoder* pe = pModule->GetPEAssembly()->GetLoadedLayout();
+                    IMAGE_DATA_DIRECTORY* debugDirectoryEntry = pe->GetDirectoryEntry(IMAGE_DIRECTORY_ENTRY_DEBUG);
+                    if (debugDirectoryEntry != nullptr)
                     {
-                        size_t nbytes = 0;
-                        while (nbytes < debugDirectoryEntry->Size)
+                        IMAGE_DEBUG_DIRECTORY* debugDirectory = (IMAGE_DEBUG_DIRECTORY*)pe->GetDirectoryData(debugDirectoryEntry);
+                        if (debugDirectory != nullptr)
                         {
-                            if ((debugDirectory->Type == IMAGE_DEBUG_TYPE_CODEVIEW && debugDirectory->MinorVersion == PORTABLE_PDB_MINOR_VERSION) ||
-                                (debugDirectory->Type == IMAGE_DEBUG_TYPE_EMBEDDED_PORTABLE_PDB))
+                            size_t nbytes = 0;
+                            while (nbytes < debugDirectoryEntry->Size)
                             {
-                                fPortablePDB = TRUE;
-                                break;
+                                if ((debugDirectory->Type == IMAGE_DEBUG_TYPE_CODEVIEW && debugDirectory->MinorVersion == PORTABLE_PDB_MINOR_VERSION) ||
+                                    (debugDirectory->Type == IMAGE_DEBUG_TYPE_EMBEDDED_PORTABLE_PDB))
+                                {
+                                    fPortablePDB = TRUE;
+                                    break;
+                                }
+                                debugDirectory++;
+                                nbytes += sizeof(*debugDirectory);
                             }
-                            debugDirectory++;
-                            nbytes += sizeof(*debugDirectory);
                         }
                     }
                 }

--- a/src/coreclr/vm/debugdebugger.cpp
+++ b/src/coreclr/vm/debugdebugger.cpp
@@ -29,6 +29,9 @@
 #include "generics.h"
 #include "stackwalk.h"
 
+#define PORTABLE_PDB_MINOR_VERSION              20557
+#define IMAGE_DEBUG_TYPE_EMBEDDED_PORTABLE_PDB  17
+
 #ifndef DACCESS_COMPILE
 //----------------------------------------------------------------------------
 //
@@ -532,182 +535,205 @@ FCIMPL4(void, DebugStackTrace::GetStackFramesInternal,
                 }
             }
 #endif
-            BOOL fPortablePDB = TRUE;
-
             // Check if the user wants the filenumber, linenumber info and that it is possible.
             if (!fIsEnc && fNeedFileInfo)
             {
 #ifdef FEATURE_ISYM_READER
-                BOOL fFileInfoSet = FALSE;
-                ULONG32 sourceLine = 0;
-                ULONG32 sourceColumn = 0;
-                WCHAR wszFileName[MAX_LONGPATH];
-                ULONG32 fileNameLength = 0;
+                BOOL fPortablePDB = FALSE;
+                PEDecoder* pe = pModule->GetPEAssembly()->GetLoadedLayout();
+                IMAGE_DATA_DIRECTORY* debugDirectoryEntry = pe->GetDirectoryEntry(IMAGE_DIRECTORY_ENTRY_DEBUG);
+                if (debugDirectoryEntry != nullptr)
                 {
-                    // Note: we need to enable preemptive GC when accessing the unmanages symbol store.
-                    GCX_PREEMP();
-
-                    // Note: we use the NoThrow version of GetISymUnmanagedReader. If getting the unmanaged
-                    // reader fails, then just leave the pointer NULL and leave any symbol info off of the
-                    // stack trace.
-                    ReleaseHolder<ISymUnmanagedReader> pISymUnmanagedReader(
-                        pModule->GetISymUnmanagedReaderNoThrow());
-
-                    if (pISymUnmanagedReader != NULL)
+                    IMAGE_DEBUG_DIRECTORY* debugDirectory = (IMAGE_DEBUG_DIRECTORY*)pe->GetDirectoryData(debugDirectoryEntry);
+                    if (debugDirectory != nullptr)
                     {
-                        // Found a ISymUnmanagedReader for the regular PDB so don't attempt to
-                        // read it as a portable PDB in CoreLib's StackFrameHelper.
-                        fPortablePDB = FALSE;
-
-                        ReleaseHolder<ISymUnmanagedMethod> pISymUnmanagedMethod;
-                        HRESULT hr = pISymUnmanagedReader->GetMethod(pMethod->GetMemberDef(),
-                                                                     &pISymUnmanagedMethod);
-
-                        if (SUCCEEDED(hr))
+                        size_t nbytes = 0;
+                        while (nbytes < debugDirectoryEntry->Size)
                         {
-                            // get all the sequence points and the documents
-                            // associated with those sequence points.
-                            // from the doument get the filename using GetURL()
-                            ULONG32 SeqPointCount = 0;
-                            ULONG32 RealSeqPointCount = 0;
-
-                            hr = pISymUnmanagedMethod->GetSequencePointCount(&SeqPointCount);
-                            _ASSERTE (SUCCEEDED(hr) || (hr == E_OUTOFMEMORY) );
-
-                            if (SUCCEEDED(hr) && SeqPointCount > 0)
+                            if ((debugDirectory->Type == IMAGE_DEBUG_TYPE_CODEVIEW && debugDirectory->MinorVersion == PORTABLE_PDB_MINOR_VERSION) ||
+                                (debugDirectory->Type == IMAGE_DEBUG_TYPE_EMBEDDED_PORTABLE_PDB))
                             {
-                                // allocate memory for the objects to be fetched
-                                NewArrayHolder<ULONG32> offsets    (new (nothrow) ULONG32 [SeqPointCount]);
-                                NewArrayHolder<ULONG32> lines      (new (nothrow) ULONG32 [SeqPointCount]);
-                                NewArrayHolder<ULONG32> columns    (new (nothrow) ULONG32 [SeqPointCount]);
-                                NewArrayHolder<ULONG32> endlines   (new (nothrow) ULONG32 [SeqPointCount]);
-                                NewArrayHolder<ULONG32> endcolumns (new (nothrow) ULONG32 [SeqPointCount]);
-
-                                // we free the array automatically, but we have to manually call release
-                                // on each element in the array when we're done with it.
-                                NewArrayHolder<ISymUnmanagedDocument*> documents (
-                                    (ISymUnmanagedDocument **)new PVOID [SeqPointCount]);
-
-                                if ((offsets && lines && columns && documents && endlines && endcolumns))
-                                {
-                                    hr = pISymUnmanagedMethod->GetSequencePoints (
-                                                        SeqPointCount,
-                                                        &RealSeqPointCount,
-                                                        offsets,
-                                                        (ISymUnmanagedDocument **)documents,
-                                                        lines,
-                                                        columns,
-                                                        endlines,
-                                                        endcolumns);
-
-                                    _ASSERTE(SUCCEEDED(hr) || (hr == E_OUTOFMEMORY) );
-
-                                    if (SUCCEEDED(hr))
-                                    {
-                                        _ASSERTE(RealSeqPointCount == SeqPointCount);
-
-#ifdef _DEBUG
-                                        {
-                                            // This is just some debugging code to help ensure that the array
-                                            // returned contains valid interface pointers.
-                                            for (ULONG32 i = 0; i < RealSeqPointCount; i++)
-                                            {
-                                                _ASSERTE(documents[i] != NULL);
-                                                documents[i]->AddRef();
-                                                documents[i]->Release();
-                                            }
-                                        }
-#endif
-
-                                        // This is the IL offset of the current frame
-                                        DWORD dwCurILOffset = data.pElements[i].dwILOffset;
-
-                                        // search for the correct IL offset
-                                        DWORD j;
-                                        for (j=0; j<RealSeqPointCount; j++)
-                                        {
-                                            // look for the entry matching the one we're looking for
-                                            if (offsets[j] >= dwCurILOffset)
-                                            {
-                                                // if this offset is > what we're looking for, adjust the index
-                                                if (offsets[j] > dwCurILOffset && j > 0)
-                                                {
-                                                    j--;
-                                                }
-
-                                                break;
-                                            }
-                                        }
-
-                                        // If we didn't find a match, default to the last sequence point
-                                        if  (j == RealSeqPointCount)
-                                        {
-                                            j--;
-                                        }
-
-                                        while (lines[j] == 0x00feefee && j > 0)
-                                        {
-                                            j--;
-                                        }
-
-#ifdef DEBUGGING_SUPPORTED
-                                        if (lines[j] != 0x00feefee)
-                                        {
-                                            sourceLine = lines [j];
-                                            sourceColumn = columns [j];
-                                        }
-                                        else
-#endif // DEBUGGING_SUPPORTED
-                                        {
-                                            sourceLine = 0;
-                                            sourceColumn = 0;
-                                        }
-
-                                        // Also get the filename from the document...
-                                        _ASSERTE (documents [j] != NULL);
-
-                                        hr = documents [j]->GetURL (MAX_LONGPATH, &fileNameLength, wszFileName);
-                                        _ASSERTE ( SUCCEEDED(hr) || (hr == E_OUTOFMEMORY) || (hr == HRESULT_FROM_WIN32(ERROR_NOT_ENOUGH_MEMORY)) );
-
-                                        // indicate that the requisite information has been set!
-                                        fFileInfoSet = TRUE;
-
-                                        // release the documents set by GetSequencePoints
-                                        for (DWORD x=0; x<RealSeqPointCount; x++)
-                                        {
-                                            documents [x]->Release();
-                                        }
-                                    } // if got sequence points
-
-                                }  // if all memory allocations succeeded
-
-                                // holders will now delete the arrays.
+                                fPortablePDB = TRUE;
+                                break;
                             }
+                            debugDirectory++;
+                            nbytes += sizeof(*debugDirectory);
                         }
-                        // Holder will release pISymUnmanagedMethod
                     }
-
-                } // GCX_PREEMP()
-
-                if (fFileInfoSet)
-                {
-                    // Set the line and column numbers
-                    I4 *pI4Line = (I4 *)((I4ARRAYREF)pStackFrameHelper->rgiLineNumber)->GetDirectPointerToNonObjectElements();
-                    pI4Line[iNumValidFrames] = sourceLine;
-
-                    I4 *pI4Column = (I4 *)((I4ARRAYREF)pStackFrameHelper->rgiColumnNumber)->GetDirectPointerToNonObjectElements();
-                    pI4Column[iNumValidFrames] = sourceColumn;
-
-                    // Set the file name
-                    OBJECTREF obj = (OBJECTREF) StringObject::NewString(wszFileName);
-                    pStackFrameHelper->rgFilename->SetAt(iNumValidFrames, obj);
                 }
-#endif // FEATURE_ISYM_READER
+                if (!fPortablePDB)
+                {
+                    fPortablePDB = TRUE;
+                    BOOL fFileInfoSet = FALSE;
+                    ULONG32 sourceLine = 0;
+                    ULONG32 sourceColumn = 0;
+                    WCHAR wszFileName[MAX_LONGPATH];
+                    ULONG32 fileNameLength = 0;
+                    {
+                        // Note: we need to enable preemptive GC when accessing the unmanages symbol store.
+                        GCX_PREEMP();
 
-                // If the above isym reader code did NOT set the source info either because it is ifdef'ed out (on xplat)
-                // or because the pdb is the new portable format on Windows then set the information needed to call the
-                // portable pdb reader in the StackTraceHelper.
+                        // Note: we use the NoThrow version of GetISymUnmanagedReader. If getting the unmanaged
+                        // reader fails, then just leave the pointer NULL and leave any symbol info off of the
+                        // stack trace.
+                        ReleaseHolder<ISymUnmanagedReader> pISymUnmanagedReader(
+                            pModule->GetISymUnmanagedReaderNoThrow());
+
+                        if (pISymUnmanagedReader != NULL)
+                        {
+                            // Found a ISymUnmanagedReader for the regular PDB so don't attempt to
+                            // read it as a portable PDB in CoreLib's StackFrameHelper.
+                            fPortablePDB = FALSE;
+
+                            ReleaseHolder<ISymUnmanagedMethod> pISymUnmanagedMethod;
+                            HRESULT hr = pISymUnmanagedReader->GetMethod(pMethod->GetMemberDef(),
+                                                                         &pISymUnmanagedMethod);
+
+                            if (SUCCEEDED(hr))
+                            {
+                                // get all the sequence points and the documents
+                                // associated with those sequence points.
+                                // from the doument get the filename using GetURL()
+                                ULONG32 SeqPointCount = 0;
+                                ULONG32 RealSeqPointCount = 0;
+
+                                hr = pISymUnmanagedMethod->GetSequencePointCount(&SeqPointCount);
+                                _ASSERTE (SUCCEEDED(hr) || (hr == E_OUTOFMEMORY) );
+
+                                if (SUCCEEDED(hr) && SeqPointCount > 0)
+                                {
+                                    // allocate memory for the objects to be fetched
+                                    NewArrayHolder<ULONG32> offsets    (new (nothrow) ULONG32 [SeqPointCount]);
+                                    NewArrayHolder<ULONG32> lines      (new (nothrow) ULONG32 [SeqPointCount]);
+                                    NewArrayHolder<ULONG32> columns    (new (nothrow) ULONG32 [SeqPointCount]);
+                                    NewArrayHolder<ULONG32> endlines   (new (nothrow) ULONG32 [SeqPointCount]);
+                                    NewArrayHolder<ULONG32> endcolumns (new (nothrow) ULONG32 [SeqPointCount]);
+
+                                    // we free the array automatically, but we have to manually call release
+                                    // on each element in the array when we're done with it.
+                                    NewArrayHolder<ISymUnmanagedDocument*> documents (
+                                        (ISymUnmanagedDocument **)new PVOID [SeqPointCount]);
+
+                                    if ((offsets && lines && columns && documents && endlines && endcolumns))
+                                    {
+                                        hr = pISymUnmanagedMethod->GetSequencePoints (
+                                                            SeqPointCount,
+                                                            &RealSeqPointCount,
+                                                            offsets,
+                                                            (ISymUnmanagedDocument **)documents,
+                                                            lines,
+                                                            columns,
+                                                            endlines,
+                                                            endcolumns);
+
+                                        _ASSERTE(SUCCEEDED(hr) || (hr == E_OUTOFMEMORY) );
+
+                                        if (SUCCEEDED(hr))
+                                        {
+                                            _ASSERTE(RealSeqPointCount == SeqPointCount);
+
+    #ifdef _DEBUG
+                                            {
+                                                // This is just some debugging code to help ensure that the array
+                                                // returned contains valid interface pointers.
+                                                for (ULONG32 i = 0; i < RealSeqPointCount; i++)
+                                                {
+                                                    _ASSERTE(documents[i] != NULL);
+                                                    documents[i]->AddRef();
+                                                    documents[i]->Release();
+                                                }
+                                            }
+    #endif
+
+                                            // This is the IL offset of the current frame
+                                            DWORD dwCurILOffset = data.pElements[i].dwILOffset;
+
+                                            // search for the correct IL offset
+                                            DWORD j;
+                                            for (j=0; j<RealSeqPointCount; j++)
+                                            {
+                                                // look for the entry matching the one we're looking for
+                                                if (offsets[j] >= dwCurILOffset)
+                                                {
+                                                    // if this offset is > what we're looking for, adjust the index
+                                                    if (offsets[j] > dwCurILOffset && j > 0)
+                                                    {
+                                                        j--;
+                                                    }
+
+                                                    break;
+                                                }
+                                            }
+
+                                            // If we didn't find a match, default to the last sequence point
+                                            if  (j == RealSeqPointCount)
+                                            {
+                                                j--;
+                                            }
+
+                                            while (lines[j] == 0x00feefee && j > 0)
+                                            {
+                                                j--;
+                                            }
+
+    #ifdef DEBUGGING_SUPPORTED
+                                            if (lines[j] != 0x00feefee)
+                                            {
+                                                sourceLine = lines [j];
+                                                sourceColumn = columns [j];
+                                            }
+                                            else
+    #endif // DEBUGGING_SUPPORTED
+                                            {
+                                                sourceLine = 0;
+                                                sourceColumn = 0;
+                                            }
+
+                                            // Also get the filename from the document...
+                                            _ASSERTE (documents [j] != NULL);
+
+                                            hr = documents [j]->GetURL (MAX_LONGPATH, &fileNameLength, wszFileName);
+                                            _ASSERTE ( SUCCEEDED(hr) || (hr == E_OUTOFMEMORY) || (hr == HRESULT_FROM_WIN32(ERROR_NOT_ENOUGH_MEMORY)) );
+
+                                            // indicate that the requisite information has been set!
+                                            fFileInfoSet = TRUE;
+
+                                            // release the documents set by GetSequencePoints
+                                            for (DWORD x=0; x<RealSeqPointCount; x++)
+                                            {
+                                                documents [x]->Release();
+                                            }
+                                        } // if got sequence points
+
+                                    }  // if all memory allocations succeeded
+
+                                    // holders will now delete the arrays.
+                                }
+                            }
+                            // Holder will release pISymUnmanagedMethod
+                        }
+
+                    } // GCX_PREEMP()
+
+                    if (fFileInfoSet)
+                    {
+                        // Set the line and column numbers
+                        I4 *pI4Line = (I4 *)((I4ARRAYREF)pStackFrameHelper->rgiLineNumber)->GetDirectPointerToNonObjectElements();
+                        pI4Line[iNumValidFrames] = sourceLine;
+
+                        I4 *pI4Column = (I4 *)((I4ARRAYREF)pStackFrameHelper->rgiColumnNumber)->GetDirectPointerToNonObjectElements();
+                        pI4Column[iNumValidFrames] = sourceColumn;
+
+                        // Set the file name
+                        OBJECTREF obj = (OBJECTREF) StringObject::NewString(wszFileName);
+                        pStackFrameHelper->rgFilename->SetAt(iNumValidFrames, obj);
+                    }
+                }
+
+                // If the above isym reader code did NOT set the source info either because the pdb is the new portable format on
+                // Windows then set the information needed to call the portable pdb reader in the StackTraceHelper.
                 if (fPortablePDB)
+#endif // FEATURE_ISYM_READER
                 {
                     // Save MethodToken for the function
                     I4 *pMethodToken = (I4 *)((I4ARRAYREF)pStackFrameHelper->rgiMethodToken)->GetDirectPointerToNonObjectElements();


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/59077

The fix is to check if the module has a portable PDB in the debug directory
and use the well-tested managed portable PDB source/line number code.

Add support for in-memory embedded PDBs.