### PR TITLE
Fix packs.product subset build with gcc

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -382,7 +382,8 @@ while [[ $# > 0 ]]; do
       ;;
 
      -clang*)
-      arguments="$arguments /p:Compiler=$opt"
+      compiler="${opt/#-/}" # -clang-9 => clang-9 or clang-9 => (unchanged)
+      arguments="$arguments /p:Compiler=$compiler /p:CppCompilerAndLinker=$compiler"
       shift 1
       ;;
 
@@ -396,7 +397,8 @@ while [[ $# > 0 ]]; do
       ;;
 
      -gcc*)
-      arguments="$arguments /p:Compiler=$opt"
+      compiler="${opt/#-/}" # -gcc-9 => gcc-9 or gcc-9 => (unchanged)
+      arguments="$arguments /p:Compiler=$compiler /p:CppCompilerAndLinker=$compiler"
       shift 1
       ;;
 


### PR DESCRIPTION
After 7ff3ac64bbd82144c0c9a00d09763cfeeb3f438d was merged, the gcc build was failing. I have narrowed it down to `packs.product` subset:

```sh
$ ./build.sh packs.product -gcc
....
  crossgen2 -> /runtime/artifacts/bin/coreclr/Linux.x64.Debug/crossgen2/linux-x64/crossgen2.dll
/runtime/artifacts/bin/coreclr/Linux.x64.Debug/build/Microsoft.NETCore.Native.Unix.props(110,5): error : Platform linker ('clang') not found. Try installing clang or the appropriate package for your platform to resolve the problem. [/runtime/src/coreclr/tools/aot/crossgen2/crossgen2.csproj]
...
```

This fix sets `CppCompilerAndLinker` property in `eng/build.sh` (where we set another property `Compiler` for similar purpose).

The leading hyphen, if present, is proactively trimmed off from the value for both properties (currently it eventually gets dropped [here](https://github.com/dotnet/arcade/blob/ba1c3aff4be864c493031d989259ef92aaa23fc3/eng/common/native/init-compiler.sh#L30) and line 39).