### PR TITLE
Clean up specialized value num functions

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -2895,53 +2895,6 @@ bool ValueNumStore::SelectIsBeingEvaluatedRecursively(ValueNum map, ValueNum ind
     return false;
 }
 
-// Specialized here as MSVC does not do well with naive version with loop.
-template <>
-bool ValueNumStore::VNDefFuncApp<1>::operator==(const ValueNumStore::VNDefFuncApp<1>& y) const
-{
-    return m_func == y.m_func && m_args[0] == y.m_args[0];
-}
-
-template <>
-bool ValueNumStore::VNDefFuncApp<2>::operator==(const ValueNumStore::VNDefFuncApp<2>& y) const
-{
-    return m_func == y.m_func && m_args[0] == y.m_args[0] && m_args[1] == y.m_args[1];
-}
-
-template <>
-bool ValueNumStore::VNDefFuncApp<3>::operator==(const ValueNumStore::VNDefFuncApp<3>& y) const
-{
-    return m_func == y.m_func && m_args[0] == y.m_args[0] && m_args[1] == y.m_args[1] && m_args[2] == y.m_args[2];
-}
-
-template <>
-bool ValueNumStore::VNDefFuncApp<4>::operator==(const ValueNumStore::VNDefFuncApp<4>& y) const
-{
-    return m_func == y.m_func && m_args[0] == y.m_args[0] && m_args[1] == y.m_args[1] && m_args[2] == y.m_args[2] &&
-           m_args[3] == y.m_args[3];
-}
-
-template <>
-unsigned ValueNumStore::VNDefFuncAppKeyFuncs<1>::GetHashCode(const ValueNumStore::VNDefFuncApp<1>& val)
-{
-    return (val.m_func << 24) + val.m_args[0];
-}
-template <>
-unsigned ValueNumStore::VNDefFuncAppKeyFuncs<2>::GetHashCode(const ValueNumStore::VNDefFuncApp<2>& val)
-{
-    return (val.m_func << 24) + (val.m_args[0] << 8) + val.m_args[1];
-}
-template <>
-unsigned ValueNumStore::VNDefFuncAppKeyFuncs<3>::GetHashCode(const ValueNumStore::VNDefFuncApp<3>& val)
-{
-    return (val.m_func << 24) + (val.m_args[0] << 16) + (val.m_args[1] << 8) + val.m_args[2];
-}
-template <>
-unsigned ValueNumStore::VNDefFuncAppKeyFuncs<4>::GetHashCode(const ValueNumStore::VNDefFuncApp<4>& val)
-{
-    return (val.m_func << 24) + (val.m_args[0] << 16) + (val.m_args[1] << 8) + val.m_args[2] + (val.m_args[3] << 12);
-}
-
 #ifdef DEBUG
 bool ValueNumStore::FixedPointMapSelsTopHasValue(ValueNum map, ValueNum index)
 {

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -1130,9 +1130,17 @@ private:
             static_assert_no_msg(NumArgs == sizeof...(VNs));
         }
 
-        // operator== specialized for NumArgs=1..4 in .cpp as MSVC does not do
-        // a good job of unrolling the loop in a naive version.
-        bool operator==(const VNDefFuncApp& y) const;
+        bool operator==(const VNDefFuncApp& y) const
+        {
+            bool result = true;
+            // Intentionally written without early-out or MSVC cannot unroll this.
+            for (size_t i = 0; i < NumArgs; i++)
+            {
+                result = result && m_args[i] == y.m_args[i];
+            }
+
+            return result;
+        }
     };
 
     // We will allocate value numbers in "chunks".  Each chunk will have the same type and "constness".
@@ -1383,9 +1391,17 @@ private:
     template <size_t NumArgs>
     struct VNDefFuncAppKeyFuncs : public JitKeyFuncsDefEquals<VNDefFuncApp<NumArgs>>
     {
-        // GetHashCode specialized for NumArgs=1..4 in .cpp as MSVC does not do
-        // a good job of unrolling the loop in a naive version.
-        static unsigned GetHashCode(const VNDefFuncApp<NumArgs>& val);
+        static unsigned GetHashCode(const VNDefFuncApp<NumArgs>& val)
+        {
+            unsigned hashCode = val.m_func;
+            for (size_t i = 0; i < NumArgs; i++)
+            {
+                hashCode = (hashCode << 8) | (hashCode >> 24);
+                hashCode ^= val.m_args[i];
+            }
+
+            return hashCode;
+        }
     };
 
     typedef VNMap<VNFunc> VNFunc0ToValueNumMap;

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -1132,7 +1132,7 @@ private:
 
         bool operator==(const VNDefFuncApp& y) const
         {
-            bool result = true;
+            bool result = m_func == y.m_func;
             // Intentionally written without early-out or MSVC cannot unroll this.
             for (size_t i = 0; i < NumArgs; i++)
             {


### PR DESCRIPTION
The reason the operator== implementation was not unrolled previously was
just because I used an early exit. Without the early exit it is unrolled
fine.