### PR TITLE
Specify action permissions in cleanup task

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,6 +15,8 @@ jobs:
   cleanup_old_runs:
     if: github.event.schedule == '0 13 * * *'
     runs-on: ubuntu-20.04
+    permissions:
+      actions: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
We are getting errors from the new cleanup task

![image](https://user-images.githubusercontent.com/3840695/167262280-81daac21-1e2b-4f54-aff1-92ffcdb7e103.png)

I read somewhere that original repository normally doesn't require permissions (only forks do), but apparently it was wrong. This is something I am using in my fork to fix the same error.