### PR TITLE
Reduce overhead associated with setting up Regex timeout

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Timeout.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Timeout.cs
@@ -44,6 +44,7 @@ namespace System.Text.RegularExpressions
         internal static readonly TimeSpan s_defaultMatchTimeout = InitDefaultMatchTimeout();
 
         /// <summary>Timeout for the execution of this <see cref="Regex"/>.</summary>
+        /// <remarks>This value should not be changed after construction. Any such changes may not be respected by the implementation.</remarks>
         protected internal TimeSpan internalMatchTimeout;
 
         /// <summary>Gets the timeout interval of the current instance.</summary>


### PR DESCRIPTION
Small but repeatable improvement based on @GrabYourPitchforks seeing that the timeout initialization was adding measurable overhead.

```C#
private Regex _regexNoTimeout = new Regex("a", RegexOptions.Compiled);
private Regex _regexWithTimeout = new Regex("a", RegexOptions.Compiled, TimeSpan.FromDays(1));

[Benchmark] public bool NoTimeout() => _regexNoTimeout.IsMatch("b");
[Benchmark] public bool WithTimeout() => _regexWithTimeout.IsMatch("b");
```


|      Method |         Toolchain |     Mean | Ratio |
|------------ |------------------ |---------:|------:|
|   NoTimeout | \main\corerun.exe | 29.20 ns |  1.00 |
|   NoTimeout |   \pr\corerun.exe | 28.00 ns |  0.96 |
|             |                   |          |       |
| WithTimeout | \main\corerun.exe | 32.62 ns |  1.00 |
| WithTimeout |   \pr\corerun.exe | 30.87 ns |  0.95 |