### PR TITLE
Remove an allocation during RSA key generation

### DIFF
--- a/src/libraries/System.Security.Cryptography.Cng/tests/PropertyTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/PropertyTests.cs
@@ -106,5 +106,12 @@ namespace System.Security.Cryptography.Cng.Tests
                 Assert.Equal(CngPropertyOptions.CustomProperty, retrievedProperty.Options);
             }
         }
+
+        [Fact]
+        public static void NullValueRoundtrip()
+        {
+            CngProperty property = new CngProperty("banana", null, CngPropertyOptions.CustomProperty);
+            Assert.Null(property.GetValue());
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngAlgorithmCore.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngAlgorithmCore.cs
@@ -66,7 +66,11 @@ namespace System.Security.Cryptography
                     ExportPolicy = CngExportPolicies.AllowPlaintextExport,
                 };
 
-                CngProperty keySizeProperty = new CngProperty(KeyPropertyName.Length, BitConverter.GetBytes(keySize), CngPropertyOptions.None);
+                Span<byte> keySizeBuffer = stackalloc byte[sizeof(int)];
+                bool success = BitConverter.TryWriteBytes(keySizeBuffer, keySize);
+                Debug.Assert(success);
+
+                CngProperty keySizeProperty = new CngProperty(KeyPropertyName.Length, keySizeBuffer, CngPropertyOptions.None);
                 creationParameters.Parameters.Add(keySizeProperty);
 
                 _lazyKey = CngKey.Create(algorithm, null, creationParameters);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngProperty.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngProperty.cs
@@ -24,7 +24,7 @@ namespace System.Security.Cryptography
             Name = name;
             Options = options;
             _lazyHashCode = default(int?);
-            _value = (value == null) ? null : value.CloneByteArray();
+            _value = value.CloneByteArray();
         }
 
         internal CngProperty(string name, ReadOnlySpan<byte> value, CngPropertyOptions options)
@@ -47,10 +47,7 @@ namespace System.Security.Cryptography
         ///     Contents of the property
         /// </summary>
         /// <returns></returns>
-        public byte[]? GetValue()
-        {
-            return (_value == null) ? null : _value.CloneByteArray();
-        }
+        public byte[]? GetValue() => _value.CloneByteArray();
 
         /// <summary>
         ///     Options used to set / get the property

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngProperty.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngProperty.cs
@@ -27,6 +27,17 @@ namespace System.Security.Cryptography
             _value = (value == null) ? null : value.CloneByteArray();
         }
 
+        internal CngProperty(string name, ReadOnlySpan<byte> value, CngPropertyOptions options)
+            : this()
+        {
+            ArgumentNullException.ThrowIfNull(name);
+
+            Name = name;
+            Options = options;
+            _lazyHashCode = default;
+            _value = value.ToArray();
+        }
+
         /// <summary>
         ///     Name of the property
         /// </summary>


### PR DESCRIPTION
When generating an RSA key, we are creating a `CngProperty`. Since `CngProperty` always created a defensive copy of data, this adds an internal constructor that accepts a `ReadOnlySpan<byte>` and copies it, with the added benefit that the source doesn't have to be a `byte[]` already.

So this effectively changes a `new byte[4]` to a `stackalloc byte[4]`.

This also removes a full null checks that were not required.

