### PR TITLE
Fix NRE in EmitCall for DynamicMethod

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/SignatureHelper.cs
@@ -734,6 +734,61 @@ namespace System.Reflection.Emit
             return temp;
         }
 
+        internal void AddDynamicArgument(DynamicScope dynamicScope, Type clsArgument, Type[]? requiredCustomModifiers, Type[]? optionalCustomModifiers)
+        {
+            IncrementArgCounts();
+
+            Debug.Assert(clsArgument != null);
+
+            if (optionalCustomModifiers != null)
+            {
+                for (int i = 0; i < optionalCustomModifiers.Length; i++)
+                {
+                    Type t = optionalCustomModifiers[i];
+
+                    if (t is not RuntimeType rtType)
+                        throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(optionalCustomModifiers));
+
+                    if (t.HasElementType)
+                        throw new ArgumentException(SR.Argument_ArraysInvalid, nameof(optionalCustomModifiers));
+
+                    if (t.ContainsGenericParameters)
+                        throw new ArgumentException(SR.Argument_GenericsInvalid, nameof(optionalCustomModifiers));
+
+                    AddElementType(CorElementType.ELEMENT_TYPE_CMOD_OPT);
+
+                    int token = dynamicScope.GetTokenFor(rtType.TypeHandle);
+                    Debug.Assert(!MetadataToken.IsNullToken(token));
+                    AddToken(token);
+                }
+            }
+
+            if (requiredCustomModifiers != null)
+            {
+                for (int i = 0; i < requiredCustomModifiers.Length; i++)
+                {
+                    Type t = requiredCustomModifiers[i];
+
+                    if (t is not RuntimeType rtType)
+                        throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(requiredCustomModifiers));
+
+                    if (t.HasElementType)
+                        throw new ArgumentException(SR.Argument_ArraysInvalid, nameof(requiredCustomModifiers));
+
+                    if (t.ContainsGenericParameters)
+                        throw new ArgumentException(SR.Argument_GenericsInvalid, nameof(requiredCustomModifiers));
+
+                    AddElementType(CorElementType.ELEMENT_TYPE_CMOD_REQD);
+
+                    int token = dynamicScope.GetTokenFor(rtType.TypeHandle);
+                    Debug.Assert(!MetadataToken.IsNullToken(token));
+                    AddToken(token);
+                }
+            }
+
+            AddOneArgTypeHelper(clsArgument);
+        }
+
         #endregion
 
         #region Public Methods

--- a/src/libraries/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit5Tests.cs
+++ b/src/libraries/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit5Tests.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace System.Reflection.Emit.Tests
+{
+    public sealed class ILGeneratorEmit5
+    {
+        public interface IHelper
+        {
+            int PassThrough(in int value);
+        }
+
+        public sealed class Helper : IHelper
+        {
+            public int PassThrough(in int value) => value;
+        }
+
+        [Fact]
+        public void TestEmitCallFunctionWithInArgumentFromDynamicMethod()
+        {
+            var methodToCall = typeof(IHelper).GetMethod("PassThrough");
+
+            var dynamicMethod = new DynamicMethod("CallingPassThrough",
+                MethodAttributes.Public | MethodAttributes.Static,
+                CallingConventions.Standard,
+                typeof(int),
+                new[]
+                {
+                  typeof(IHelper),
+                  typeof(int),
+                },
+                typeof(ILGeneratorEmit5),
+                true);
+
+            var il = dynamicMethod.GetILGenerator();
+
+            var copy = il.DeclareLocal(typeof(int), false);
+
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Stloc, (ushort)copy.LocalIndex);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloca, (ushort)copy.LocalIndex);
+
+            il.EmitCall(OpCodes.Callvirt, methodToCall, null);
+
+            il.Emit(OpCodes.Ret);
+
+            var func = (Func<IHelper, int, int>)dynamicMethod.CreateDelegate(typeof(Func<IHelper, int, int>));
+
+            var helperInstance = new Helper();
+
+            var sum = func(helperInstance, 888);
+
+            Assert.Equal(888, sum);
+        }
+    }
+
+}

--- a/src/libraries/System.Reflection.Emit.ILGeneration/tests/ILGenerator/EmitWithModsTests.cs
+++ b/src/libraries/System.Reflection.Emit.ILGeneration/tests/ILGenerator/EmitWithModsTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace System.Reflection.Emit.Tests
 {
-    public sealed class ILGeneratorEmit5
+    public sealed class EmitWithMods
     {
         public interface IHelper
         {
@@ -20,7 +20,7 @@ namespace System.Reflection.Emit.Tests
         [Fact]
         public void TestEmitCallFunctionWithInArgumentFromDynamicMethod()
         {
-            var methodToCall = typeof(IHelper).GetMethod("PassThrough");
+            MethodInfo methodToCall = typeof(IHelper).GetMethod("PassThrough");
 
             var dynamicMethod = new DynamicMethod("CallingPassThrough",
                 MethodAttributes.Public | MethodAttributes.Static,
@@ -31,12 +31,12 @@ namespace System.Reflection.Emit.Tests
                   typeof(IHelper),
                   typeof(int),
                 },
-                typeof(ILGeneratorEmit5),
+                typeof(EmitWithMods),
                 true);
 
-            var il = dynamicMethod.GetILGenerator();
+            ILGenerator il = dynamicMethod.GetILGenerator();
 
-            var copy = il.DeclareLocal(typeof(int), false);
+            LocalBuilder copy = il.DeclareLocal(typeof(int), false);
 
             il.Emit(OpCodes.Ldarg_1);
             il.Emit(OpCodes.Stloc, (ushort)copy.LocalIndex);
@@ -52,7 +52,7 @@ namespace System.Reflection.Emit.Tests
 
             var helperInstance = new Helper();
 
-            var sum = func(helperInstance, 888);
+            int sum = func(helperInstance, 888);
 
             Assert.Equal(888, sum);
         }

--- a/src/libraries/System.Reflection.Emit.ILGeneration/tests/System.Reflection.Emit.ILGeneration.Tests.csproj
+++ b/src/libraries/System.Reflection.Emit.ILGeneration/tests/System.Reflection.Emit.ILGeneration.Tests.csproj
@@ -10,6 +10,7 @@
     <Compile Include="ILGenerator\Emit2Tests.cs" />
     <Compile Include="ILGenerator\Emit3Tests.cs" />
     <Compile Include="ILGenerator\Emit4Tests.cs" />
+    <Compile Include="ILGenerator\Emit5Tests.cs" />
     <Compile Include="ILGenerator\EmitMethodInfo.cs" />
     <Compile Include="ILGenerator\EmitWriteLineTests.cs" />
     <Compile Include="ILGenerator\ExceptionEmitTests.cs" />

--- a/src/libraries/System.Reflection.Emit.ILGeneration/tests/System.Reflection.Emit.ILGeneration.Tests.csproj
+++ b/src/libraries/System.Reflection.Emit.ILGeneration/tests/System.Reflection.Emit.ILGeneration.Tests.csproj
@@ -10,8 +10,8 @@
     <Compile Include="ILGenerator\Emit2Tests.cs" />
     <Compile Include="ILGenerator\Emit3Tests.cs" />
     <Compile Include="ILGenerator\Emit4Tests.cs" />
-    <Compile Include="ILGenerator\Emit5Tests.cs" />
     <Compile Include="ILGenerator\EmitMethodInfo.cs" />
+    <Compile Include="ILGenerator\EmitWithModsTests.cs" />
     <Compile Include="ILGenerator\EmitWriteLineTests.cs" />
     <Compile Include="ILGenerator\ExceptionEmitTests.cs" />
     <Compile Include="ILGenerator\ILOffsetTests.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/67084

Added an internal `SignatureHelper.AddDynamicArgument` to pass `DynamicScope` to get tokens for custom modifiers.
It expects the type to be a `RuntimeType`