### PR TITLE
Simple runtime.yml change hoping it fixes rolling builds not triggering

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -750,7 +750,6 @@ jobs:
 # Only do this on PR builds since we use the Release builds for these test runs in CI
 # and those are already built above
 #
-
 - ${{ if eq(variables['isRollingBuild'], false) }}:
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:


### PR DESCRIPTION
Azure seems to have stopped triggering our rolling builds (e.g. https://runfo.azurewebsites.net/search/builds/?q=started%3A~7%20definition%3A686%20kind%3Arolling%20targetbranch%3Amain -- last triggered run was on Friday).
I'm hoping a random change here will fix the problem.