### PR TITLE
StringMarshaller optimizations

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/AnsiStringMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/AnsiStringMarshaller.cs
@@ -44,15 +44,14 @@ namespace System.Runtime.InteropServices.Marshalling
                 return;
             }
 
-            // + 1 for null terminator
-            int maxByteCount = checked(Marshal.SystemMaxDBCSCharSize * str.Length + 1);
-            if (maxByteCount > buffer.Length)
+            // >= for null terminator
+            if ((long)Marshal.SystemMaxDBCSCharSize * str.Length >= buffer.Length)
             {
                 // Calculate accurate byte count when the provided stack-allocated buffer is not sufficient
-                maxByteCount = Marshal.GetAnsiStringByteCount(str); // Includes null terminator
-                if (maxByteCount > buffer.Length)
+                int exactByteCount = Marshal.GetAnsiStringByteCount(str); // Includes null terminator
+                if (exactByteCount > buffer.Length)
                 {
-                    buffer = new Span<byte>((byte*)Marshal.AllocCoTaskMem(maxByteCount), maxByteCount);
+                    buffer = new Span<byte>((byte*)Marshal.AllocCoTaskMem(exactByteCount), exactByteCount);
                     _allocated = true;
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/AnsiStringMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/AnsiStringMarshaller.cs
@@ -13,8 +13,8 @@ namespace System.Runtime.InteropServices.Marshalling
         Features = CustomTypeMarshallerFeatures.UnmanagedResources | CustomTypeMarshallerFeatures.TwoStageMarshalling | CustomTypeMarshallerFeatures.CallerAllocatedBuffer)]
     public unsafe ref struct AnsiStringMarshaller
     {
-        private byte* _allocated;
-        private readonly Span<byte> _span;
+        private byte* _nativeValue;
+        private bool _allocated;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AnsiStringMarshaller"/>.
@@ -36,25 +36,30 @@ namespace System.Runtime.InteropServices.Marshalling
         /// </remarks>
         public AnsiStringMarshaller(string? str, Span<byte> buffer)
         {
-            _allocated = null;
+            _allocated = false;
+
             if (str is null)
             {
-                _span = default;
+                _nativeValue = null;
                 return;
             }
 
             // + 1 for null terminator
-            int maxByteCount = (str.Length + 1) * Marshal.SystemMaxDBCSCharSize + 1;
-            if (buffer.Length >= maxByteCount)
+            int maxByteCount = checked(Marshal.SystemMaxDBCSCharSize * str.Length + 1);
+            if (maxByteCount > buffer.Length)
             {
-                Marshal.StringToAnsiString(str, (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(buffer)), buffer.Length);
-                _span = buffer;
+                // Calculate accurate byte count when the provided stack-allocated buffer is not sufficient
+                maxByteCount = Marshal.GetAnsiStringByteCount(str); // Includes null terminator
+                if (maxByteCount > buffer.Length)
+                {
+                    buffer = new Span<byte>((byte*)Marshal.AllocCoTaskMem(maxByteCount), maxByteCount);
+                    _allocated = true;
+                }
             }
-            else
-            {
-                _allocated = (byte*)Marshal.StringToCoTaskMemAnsi(str);
-                _span = default;
-            }
+
+            _nativeValue = (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(buffer));
+
+            Marshal.GetAnsiStringBytes(str, buffer); // Includes null terminator
         }
 
         /// <summary>
@@ -63,7 +68,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.TwoStageMarshalling"/>
         /// </remarks>
-        public byte* ToNativeValue() => _allocated != null ? _allocated : (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(_span));
+        public byte* ToNativeValue() => _nativeValue;
 
         /// <summary>
         /// Sets the native value representing the string.
@@ -72,7 +77,11 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.TwoStageMarshalling"/>
         /// </remarks>
-        public void FromNativeValue(byte* value) => _allocated = value;
+        public void FromNativeValue(byte* value)
+        {
+            _nativeValue = value;
+            _allocated = true;
+        }
 
         /// <summary>
         /// Returns the managed string.
@@ -80,7 +89,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <remarks>
         /// <seealso cref="CustomTypeMarshallerDirection.Out"/>
         /// </remarks>
-        public string? ToManaged() => _allocated == null ? null : new string((sbyte*)_allocated);
+        public string? ToManaged() => Marshal.PtrToStringAnsi((IntPtr)_nativeValue);
 
         /// <summary>
         /// Frees native resources.
@@ -90,8 +99,8 @@ namespace System.Runtime.InteropServices.Marshalling
         /// </remarks>
         public void FreeNative()
         {
-            if (_allocated != null)
-                Marshal.FreeCoTaskMem((IntPtr)_allocated);
+            if (_allocated)
+                Marshal.FreeCoTaskMem((IntPtr)_nativeValue);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/Utf16StringMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/Utf16StringMarshaller.cs
@@ -18,6 +18,10 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <summary>
         /// Initializes a new instance of the <see cref="Utf16StringMarshaller"/>.
         /// </summary>
+        /// <remarks>
+        /// The caller allocated constructor option is not provided because
+        /// pinning should be preferred for UTF-16 scenarios.
+        /// </remarks>
         /// <param name="str">The string to marshal.</param>
         public Utf16StringMarshaller(string? str)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/Utf8StringMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/Utf8StringMarshaller.cs
@@ -14,8 +14,8 @@ namespace System.Runtime.InteropServices.Marshalling
         Features = CustomTypeMarshallerFeatures.UnmanagedResources | CustomTypeMarshallerFeatures.TwoStageMarshalling | CustomTypeMarshallerFeatures.CallerAllocatedBuffer)]
     public unsafe ref struct Utf8StringMarshaller
     {
-        private byte* _allocated;
-        private readonly Span<byte> _span;
+        private byte* _nativeValue;
+        private bool _allocated;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Utf8StringMarshaller"/>.
@@ -37,32 +37,33 @@ namespace System.Runtime.InteropServices.Marshalling
         /// </remarks>
         public Utf8StringMarshaller(string? str, Span<byte> buffer)
         {
-            _allocated = null;
+            _allocated = false;
+
             if (str is null)
             {
-                _span = default;
+                _nativeValue = null;
                 return;
             }
 
+            const int MaxUtf8BytesPerChar = 3;
+
             // + 1 for null terminator
-            int maxByteCount =  Encoding.UTF8.GetMaxByteCount(str.Length) + 1;
-            if (buffer.Length >= maxByteCount)
+            int maxByteCount = checked(MaxUtf8BytesPerChar * str.Length + 1);
+            if (maxByteCount > buffer.Length)
             {
-                int byteCount = Encoding.UTF8.GetBytes(str, buffer);
-                buffer[byteCount] = 0; // null-terminate
-                _span = buffer;
-            }
-            else
-            {
-                _allocated = (byte*)Marshal.AllocCoTaskMem(maxByteCount);
-                int byteCount;
-                fixed (char* ptr = str)
+                // Calculate accurate byte count when the provided stack-allocated buffer is not sufficient
+                maxByteCount = Encoding.UTF8.GetByteCount(str) + 1;
+                if (maxByteCount > buffer.Length)
                 {
-                    byteCount = Encoding.UTF8.GetBytes(ptr, str.Length, _allocated, maxByteCount);
+                    buffer = new Span<byte>((byte*)Marshal.AllocCoTaskMem(maxByteCount), maxByteCount);
+                    _allocated = true;
                 }
-                _allocated[byteCount] = 0; // null-terminate
-                _span = default;
             }
+
+            _nativeValue = (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(buffer));
+
+            int byteCount = Encoding.UTF8.GetBytes(str, buffer);
+            buffer[byteCount] = 0; // null-terminate
         }
 
         /// <summary>
@@ -71,7 +72,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.TwoStageMarshalling"/>
         /// </remarks>
-        public byte* ToNativeValue() => _allocated != null ? _allocated : (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(_span));
+        public byte* ToNativeValue() => _nativeValue;
 
         /// <summary>
         /// Sets the native value representing the string.
@@ -80,7 +81,11 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <remarks>
         /// <seealso cref="CustomTypeMarshallerFeatures.TwoStageMarshalling"/>
         /// </remarks>
-        public void FromNativeValue(byte* value) => _allocated = value;
+        public void FromNativeValue(byte* value)
+        {
+            _nativeValue = value;
+            _allocated = true;
+        }
 
         /// <summary>
         /// Returns the managed string.
@@ -88,7 +93,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <remarks>
         /// <seealso cref="CustomTypeMarshallerDirection.Out"/>
         /// </remarks>
-        public string? ToManaged() => _allocated == null ? null : Marshal.PtrToStringUTF8((IntPtr)_allocated);
+        public string? ToManaged() => Marshal.PtrToStringUTF8((IntPtr)_nativeValue);
 
         /// <summary>
         /// Frees native resources.
@@ -98,8 +103,8 @@ namespace System.Runtime.InteropServices.Marshalling
         /// </remarks>
         public void FreeNative()
         {
-            if (_allocated != null)
-                Marshal.FreeCoTaskMem((IntPtr)_allocated);
+            if (_allocated)
+                Marshal.FreeCoTaskMem((IntPtr)_nativeValue);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/Utf8StringMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/Utf8StringMarshaller.cs
@@ -47,15 +47,14 @@ namespace System.Runtime.InteropServices.Marshalling
 
             const int MaxUtf8BytesPerChar = 3;
 
-            // + 1 for null terminator
-            int maxByteCount = checked(MaxUtf8BytesPerChar * str.Length + 1);
-            if (maxByteCount > buffer.Length)
+            // >= for null terminator
+            if ((long)MaxUtf8BytesPerChar * str.Length >= buffer.Length)
             {
                 // Calculate accurate byte count when the provided stack-allocated buffer is not sufficient
-                maxByteCount = Encoding.UTF8.GetByteCount(str) + 1;
-                if (maxByteCount > buffer.Length)
+                int exactByteCount = checked(Encoding.UTF8.GetByteCount(str) + 1); // + 1 for null terminator
+                if (exactByteCount > buffer.Length)
                 {
-                    buffer = new Span<byte>((byte*)Marshal.AllocCoTaskMem(maxByteCount), maxByteCount);
+                    buffer = new Span<byte>((byte*)Marshal.AllocCoTaskMem(exactByteCount), exactByteCount);
                     _allocated = true;
                 }
             }

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -2187,14 +2187,12 @@ namespace System.Runtime.InteropServices.Marshalling
         public void FreeNative() { }
     }
     [System.CLSCompliant(false)]
-    [System.Runtime.InteropServices.Marshalling.CustomTypeMarshallerAttribute(typeof(string), BufferSize = 0x100,
+    [System.Runtime.InteropServices.Marshalling.CustomTypeMarshallerAttribute(typeof(string),
         Features = System.Runtime.InteropServices.Marshalling.CustomTypeMarshallerFeatures.UnmanagedResources
-            | System.Runtime.InteropServices.Marshalling.CustomTypeMarshallerFeatures.CallerAllocatedBuffer
             | System.Runtime.InteropServices.Marshalling.CustomTypeMarshallerFeatures.TwoStageMarshalling )]
     public unsafe ref struct Utf16StringMarshaller
     {
         public Utf16StringMarshaller(string? str) { }
-        public Utf16StringMarshaller(string? str, System.Span<ushort> buffer) { }
         public ushort* ToNativeValue() { throw null; }
         public void FromNativeValue(ushort* value) { }
         public string? ToManaged() { throw null; }

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -2195,7 +2195,6 @@ namespace System.Runtime.InteropServices.Marshalling
     {
         public Utf16StringMarshaller(string? str) { }
         public Utf16StringMarshaller(string? str, System.Span<ushort> buffer) { }
-        public ref ushort GetPinnableReference() { throw null; }
         public ushort* ToNativeValue() { throw null; }
         public void FromNativeValue(ushort* value) { }
         public string? ToManaged() { throw null; }


### PR DESCRIPTION
- Make the StringMarshallers smaller. They do not need to store the full stackallocated Span.
- Use the stack allocated buffer more often.
- Other fixes for consistency