### PR TITLE
Fold range checks with constant operands

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5066,12 +5066,13 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
     JITDUMP("fgMorphArrayIndex (before remorph):\n")
     DISPTREE(tree)
 
-    tree = fgMorphTree(tree);
+    GenTree* morphedTree = fgMorphTree(tree);
+    DBEXEC(morphedTree != tree, morphedTree->gtDebugFlags &= ~GTF_DEBUG_NODE_MORPHED);
 
     JITDUMP("fgMorphArrayIndex (after remorph):\n")
-    DISPTREE(tree)
+    DISPTREE(morphedTree)
 
-    return tree;
+    return morphedTree;
 }
 
 #ifdef TARGET_X86


### PR DESCRIPTION
Addresses an old `TODO-CQ` from #59963.

Some diffs in tests because redundant assertions make way for more useful ones.

Also one small diff where we see better CSE because a range check on span was folded early in morph.

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1759913&view=ms.vss-build-web.run-extensions-tab).