### PR TITLE
Add the capability to walk up the inheritance chain for GetMemberWithSameMetadataDefinitionAs

### DIFF
--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.GetMember.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.GetMember.cs
@@ -123,6 +123,21 @@ namespace System.Reflection.Runtime.TypeInfos
             if (member is null)
                 throw new ArgumentNullException(nameof(member));
 
+            // Need to walk up the inheritance chain if member is not found
+            // Leverage the existing cache mechanism of per type to store members
+            RuntimeTypeInfo? runtimeType = this;
+            while (runtimeType != null)
+            {
+                MemberInfo result = runtimeType.GetMemberWithSameMetadataDefinitionAsInternal(member);
+                if (result != null)
+                    return result;
+                runtimeType = runtimeType.BaseType as RuntimeTypeInfo;
+            }
+            throw new ArgumentException(SR.Format(SR.Arg_MemberInfoNotFound, member.Name), nameof(member));
+        }
+
+        private MemberInfo GetMemberWithSameMetadataDefinitionAsInternal(MemberInfo member)
+        {
             MemberInfo result = member.MemberType switch
             {
                 MemberTypes.Method => QueryMemberWithSameMetadataDefinitionAs<MethodInfo>(member),
@@ -133,9 +148,6 @@ namespace System.Reflection.Runtime.TypeInfos
                 MemberTypes.NestedType => QueryMemberWithSameMetadataDefinitionAs<Type>(member),
                 _ => null,
             };
-
-            if (result is null)
-                throw new ArgumentException(SR.Format(SR.Arg_MemberInfoNotFound, member.Name), nameof(member));
 
             return result;
         }

--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.GetMember.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.GetMember.cs
@@ -128,7 +128,7 @@ namespace System.Reflection.Runtime.TypeInfos
             RuntimeTypeInfo? runtimeType = this;
             while (runtimeType != null)
             {
-                MemberInfo result = runtimeType.GetMemberWithSameMetadataDefinitionAsInternal(member);
+                MemberInfo result = runtimeType.GetDeclaredMemberWithSameMetadataDefinitionAs(member);
                 if (result != null)
                     return result;
                 runtimeType = runtimeType.BaseType as RuntimeTypeInfo;
@@ -136,9 +136,9 @@ namespace System.Reflection.Runtime.TypeInfos
             throw new ArgumentException(SR.Format(SR.Arg_MemberInfoNotFound, member.Name), nameof(member));
         }
 
-        private MemberInfo GetMemberWithSameMetadataDefinitionAsInternal(MemberInfo member)
+        private MemberInfo GetDeclaredMemberWithSameMetadataDefinitionAs(MemberInfo member)
         {
-            MemberInfo result = member.MemberType switch
+            return member.MemberType switch
             {
                 MemberTypes.Method => QueryMemberWithSameMetadataDefinitionAs<MethodInfo>(member),
                 MemberTypes.Constructor => QueryMemberWithSameMetadataDefinitionAs<ConstructorInfo>(member),
@@ -148,8 +148,6 @@ namespace System.Reflection.Runtime.TypeInfos
                 MemberTypes.NestedType => QueryMemberWithSameMetadataDefinitionAs<Type>(member),
                 _ => null,
             };
-
-            return result;
         }
 
         private M QueryMemberWithSameMetadataDefinitionAs<M>(MemberInfo member) where M : MemberInfo

--- a/src/libraries/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/TypeInfoTests.cs
@@ -1656,7 +1656,6 @@ namespace System.Reflection.Tests
         }
 
         [Theory, MemberData(nameof(GetMemberWithSameMetadataDefinitionAsData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/67533", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void GetMemberWithSameMetadataDefinitionAs(Type openGenericType, Type closedGenericType, bool checkDeclaringType)
         {
             BindingFlags all = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly;

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -382,6 +382,8 @@
     <!-- Run only a small randomly chosen set of passing test suites -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\*.Tests.csproj" />
     <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Collections\tests\System.Collections.Tests.csproj" />
+    <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Reflection\tests\System.Reflection.Tests.csproj" />
+    <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -63,7 +63,6 @@ internal class ReflectionTest
         TestInvokeMemberParamsCornerCase.Run();
         TestDefaultInterfaceInvoke.Run();
         TestCovariantReturnInvoke.Run();
-        TestGetMemberWithSameMetadataDefinitionAs.Run();
 #if !CODEGEN_CPP
         TypeConstructionTest.Run();
         TestThreadStaticFields.Run();
@@ -393,38 +392,6 @@ internal class ReflectionTest
 
             if (((Foo)mi.Invoke(new SuperDerived(), Array.Empty<object>())).State != "SuperDerived")
                 throw new Exception();
-        }
-    }
-
-    class TestGetMemberWithSameMetadataDefinitionAs
-    {
-        public class B_T<T>
-        {
-            static B_T() { }
-        }
-
-        public class D_T<T> : B_T<T>
-        {
-        }
-
-        public static void Run()
-        {
-            Console.WriteLine(nameof(TestGetMemberWithSameMetadataDefinitionAs));
-
-            TestGetMemberWithSameMetadataDefinitionAs p = new TestGetMemberWithSameMetadataDefinitionAs();
-            p.GetMemberWithSameMetadataDefinitionAs(typeof(B_T<>), typeof(D_T<int>));
-        }
-
-        public void GetMemberWithSameMetadataDefinitionAs(Type openGenericType, Type closedGenericType)
-        {
-            BindingFlags all = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly;
-            foreach (MemberInfo openGenericMember in openGenericType.GetMembers(all))
-            {
-                MemberInfo closedGenericMember = closedGenericType.GetMemberWithSameMetadataDefinitionAs(openGenericMember);
-                if (!closedGenericMember.Name.Equals(openGenericMember.Name))
-                    throw new Exception();
-
-            }
         }
     }
 

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -63,6 +63,7 @@ internal class ReflectionTest
         TestInvokeMemberParamsCornerCase.Run();
         TestDefaultInterfaceInvoke.Run();
         TestCovariantReturnInvoke.Run();
+        TestGetMemberWithSameMetadataDefinitionAs.Run();
 #if !CODEGEN_CPP
         TypeConstructionTest.Run();
         TestThreadStaticFields.Run();
@@ -392,6 +393,38 @@ internal class ReflectionTest
 
             if (((Foo)mi.Invoke(new SuperDerived(), Array.Empty<object>())).State != "SuperDerived")
                 throw new Exception();
+        }
+    }
+
+    class TestGetMemberWithSameMetadataDefinitionAs
+    {
+        public class B_T<T>
+        {
+            static B_T() { }
+        }
+
+        public class D_T<T> : B_T<T>
+        {
+        }
+
+        public static void Run()
+        {
+            Console.WriteLine(nameof(TestGetMemberWithSameMetadataDefinitionAs));
+
+            TestGetMemberWithSameMetadataDefinitionAs p = new TestGetMemberWithSameMetadataDefinitionAs();
+            p.GetMemberWithSameMetadataDefinitionAs(typeof(B_T<>), typeof(D_T<int>));
+        }
+
+        public void GetMemberWithSameMetadataDefinitionAs(Type openGenericType, Type closedGenericType)
+        {
+            BindingFlags all = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly;
+            foreach (MemberInfo openGenericMember in openGenericType.GetMembers(all))
+            {
+                MemberInfo closedGenericMember = closedGenericType.GetMemberWithSameMetadataDefinitionAs(openGenericMember);
+                if (!closedGenericMember.Name.Equals(openGenericMember.Name))
+                    throw new Exception();
+
+            }
         }
     }
 


### PR DESCRIPTION
Issue #67533 has a scenario where a `MemberInfo `is in the parent of a type and `nativeAOT `fails for `GetMemberWithSameMetadataDefinitionAs` since it only checks the current type. The fix is to walk up the chain leveraging the existing caching mechanism.