### PR TITLE
Improve BOL anchor handling with literal search

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -615,7 +615,7 @@ namespace System.Text.RegularExpressions
                                 // if (pos > 0...
                                 Ldloc(pos!);
                                 Ldc(0);
-                                Ble(label);
+                                BleFar(label);
 
                                 // ... && inputSpan[pos - 1] != '\n') { ... }
                                 Ldloca(inputSpan);
@@ -625,7 +625,7 @@ namespace System.Text.RegularExpressions
                                 Call(s_spanGetItemMethod);
                                 LdindU2();
                                 Ldc('\n');
-                                Beq(label);
+                                BeqFar(label);
 
                                 // int nextPos = inputSpan.Slice(pos).IndexOf('\n');
                                 Ldloca(inputSpan);


### PR DESCRIPTION
If a pattern begins with a BOL (beginning of line) anchor, today we start a search by jumping to the next '\n' via IndexOf if we're not already positioned at a line beginning.  However, if the pattern contains a string that every match must contain, we can do better than this by then also doing IndexOf(thatString) and then backing off to the previous '\n'.  Worst case, this is unnecessary overhead as we do an IndexOf and LastIndexOf that just brings us back to the same place.  But best case, we end up skipping many lines.  The assumption is that if you're doing such an anchored search, you a) have shorter lines (rather than input that's all in a single line or a few very long lines), and b) the pattern doesn't match some at least small percentage of lines. Various grep utilities do a similar operation.

For example, here's a microbenchmark that's reading every .cs file under the libraries CoreLib directory and counting the number of lines that contain various strings:
```C#
[Params(RegexOptions.None, RegexOptions.Compiled)]
public RegexOptions Options { get; set; }

[Params("  ", ");", "Length")]
public string Literal { get; set; }

[GlobalSetup]
public void Setup() => _regex = new Regex($@"^.*{Regex.Escape(Literal)}.*$", RegexOptions.Multiline | Options);

private Regex _regex;

[Benchmark]
public int CountMatchingLines()
{
    int total = 0;
    foreach (string path in Directory.EnumerateFiles(@"D:\repos\runtime\src\libraries\System.Private.CoreLib\src", "*.cs", SearchOption.AllDirectories))
    {
        total += _regex.Count(File.ReadAllText(path));
    }
    return total;
}
```
Even with the file interactions, it shows up as a win for the less-common strings:

|             Method |         Toolchain |  Options | Literal |     Mean | Ratio |
|------------------- |------------------ |--------- |-------- |---------:|------:|
| CountMatchingLines | \main\corerun.exe |     None |         | 460.7 ms |  1.00 |
| CountMatchingLines |   \pr\corerun.exe |     None |         | 439.1 ms |  0.95 |
|                    |                   |          |         |          |       |
| CountMatchingLines | \main\corerun.exe |     None |      ); | 429.0 ms |  1.00 |
| CountMatchingLines |   \pr\corerun.exe |     None |      ); | 179.9 ms |  0.42 |
|                    |                   |          |         |          |       |
| CountMatchingLines | \main\corerun.exe |     None |  Length | 471.5 ms |  1.00 |
| CountMatchingLines |   \pr\corerun.exe |     None |  Length | 173.6 ms |  0.37 |
|                    |                   |          |         |          |       |
| CountMatchingLines | \main\corerun.exe | Compiled |         | 209.3 ms |  1.00 |
| CountMatchingLines |   \pr\corerun.exe | Compiled |         | 209.2 ms |  1.00 |
|                    |                   |          |         |          |       |
| CountMatchingLines | \main\corerun.exe | Compiled |      ); | 201.2 ms |  1.00 |
| CountMatchingLines |   \pr\corerun.exe | Compiled |      ); | 176.8 ms |  0.89 |
|                    |                   |          |         |          |       |
| CountMatchingLines | \main\corerun.exe | Compiled |  Length | 202.8 ms |  1.00 |
| CountMatchingLines |   \pr\corerun.exe | Compiled |  Length | 168.7 ms |  0.83 |

Or here searching the complete works of Mark Twain for how many lines contain the word "start":

```C#
[Params(RegexOptions.None, RegexOptions.Compiled)]
public RegexOptions Options { get; set; }

private Regex _regex;
private string _input;

[GlobalSetup]
public async Task Setup()
{
    _regex = new Regex($@"^.*\bstart\b.*$", RegexOptions.Multiline | Options);
    using (var c = new HttpClient())
        _input = await c.GetStringAsync(@"https://www.gutenberg.org/cache/epub/3200/pg3200.txt");
}

[Benchmark]
public int Count() => _regex.Count(_input);
```

| Method |         Toolchain |  Options |       Mean | Ratio |
|------- |------------------ |--------- |-----------:|------:|
|  Count | \main\corerun.exe |     None | 289.521 ms |  1.00 |
|  Count |   \pr\corerun.exe |     None |   4.337 ms |  0.02 |
|        |                   |          |            |       |
|  Count | \main\corerun.exe | Compiled |  62.483 ms |  1.00 |
|  Count |   \pr\corerun.exe | Compiled |   3.028 ms |  0.05 |

This won't always be a win, e.g. if every line contains the string being searched for, the additional {Last}IndexOf operations are pure overhead.  The expectation is that's less common than the thing being searched for showing up in the minority of lines.