### PR TITLE
Adjust the usage of ReverseEndianness in BinaryPrimitives

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/ReaderBigEndian.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/ReaderBigEndian.cs
@@ -48,12 +48,9 @@ namespace System.Buffers.Binary
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static short ReadInt16BigEndian(ReadOnlySpan<byte> source)
         {
-            short result = MemoryMarshal.Read<short>(source);
-            if (BitConverter.IsLittleEndian)
-            {
-                result = ReverseEndianness(result);
-            }
-            return result;
+            return BitConverter.IsLittleEndian ?
+                ReverseEndianness(MemoryMarshal.Read<short>(source)) :
+                MemoryMarshal.Read<short>(source);
         }
 
         /// <summary>
@@ -62,12 +59,9 @@ namespace System.Buffers.Binary
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int ReadInt32BigEndian(ReadOnlySpan<byte> source)
         {
-            int result = MemoryMarshal.Read<int>(source);
-            if (BitConverter.IsLittleEndian)
-            {
-                result = ReverseEndianness(result);
-            }
-            return result;
+            return BitConverter.IsLittleEndian ?
+                ReverseEndianness(MemoryMarshal.Read<int>(source)) :
+                MemoryMarshal.Read<int>(source);
         }
 
         /// <summary>
@@ -76,12 +70,9 @@ namespace System.Buffers.Binary
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long ReadInt64BigEndian(ReadOnlySpan<byte> source)
         {
-            long result = MemoryMarshal.Read<long>(source);
-            if (BitConverter.IsLittleEndian)
-            {
-                result = ReverseEndianness(result);
-            }
-            return result;
+            return BitConverter.IsLittleEndian ?
+                ReverseEndianness(MemoryMarshal.Read<long>(source)) :
+                MemoryMarshal.Read<long>(source);
         }
 
         /// <summary>
@@ -108,12 +99,9 @@ namespace System.Buffers.Binary
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort ReadUInt16BigEndian(ReadOnlySpan<byte> source)
         {
-            ushort result = MemoryMarshal.Read<ushort>(source);
-            if (BitConverter.IsLittleEndian)
-            {
-                result = ReverseEndianness(result);
-            }
-            return result;
+            return BitConverter.IsLittleEndian ?
+                ReverseEndianness(MemoryMarshal.Read<ushort>(source)) :
+                MemoryMarshal.Read<ushort>(source);
         }
 
         /// <summary>
@@ -123,12 +111,9 @@ namespace System.Buffers.Binary
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint ReadUInt32BigEndian(ReadOnlySpan<byte> source)
         {
-            uint result = MemoryMarshal.Read<uint>(source);
-            if (BitConverter.IsLittleEndian)
-            {
-                result = ReverseEndianness(result);
-            }
-            return result;
+            return BitConverter.IsLittleEndian ?
+                ReverseEndianness(MemoryMarshal.Read<uint>(source)) :
+                MemoryMarshal.Read<uint>(source);
         }
 
         /// <summary>
@@ -138,12 +123,9 @@ namespace System.Buffers.Binary
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong ReadUInt64BigEndian(ReadOnlySpan<byte> source)
         {
-            ulong result = MemoryMarshal.Read<ulong>(source);
-            if (BitConverter.IsLittleEndian)
-            {
-                result = ReverseEndianness(result);
-            }
-            return result;
+            return BitConverter.IsLittleEndian ?
+                ReverseEndianness(MemoryMarshal.Read<ulong>(source)) :
+                MemoryMarshal.Read<ulong>(source);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/ReaderLittleEndian.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/ReaderLittleEndian.cs
@@ -48,12 +48,9 @@ namespace System.Buffers.Binary
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static short ReadInt16LittleEndian(ReadOnlySpan<byte> source)
         {
-            short result = MemoryMarshal.Read<short>(source);
-            if (!BitConverter.IsLittleEndian)
-            {
-                result = ReverseEndianness(result);
-            }
-            return result;
+            return !BitConverter.IsLittleEndian ?
+                ReverseEndianness(MemoryMarshal.Read<short>(source)) :
+                MemoryMarshal.Read<short>(source);
         }
 
         /// <summary>
@@ -62,12 +59,9 @@ namespace System.Buffers.Binary
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int ReadInt32LittleEndian(ReadOnlySpan<byte> source)
         {
-            int result = MemoryMarshal.Read<int>(source);
-            if (!BitConverter.IsLittleEndian)
-            {
-                result = ReverseEndianness(result);
-            }
-            return result;
+            return !BitConverter.IsLittleEndian ?
+                ReverseEndianness(MemoryMarshal.Read<int>(source)) :
+                MemoryMarshal.Read<int>(source);
         }
 
         /// <summary>
@@ -76,12 +70,9 @@ namespace System.Buffers.Binary
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long ReadInt64LittleEndian(ReadOnlySpan<byte> source)
         {
-            long result = MemoryMarshal.Read<long>(source);
-            if (!BitConverter.IsLittleEndian)
-            {
-                result = ReverseEndianness(result);
-            }
-            return result;
+            return !BitConverter.IsLittleEndian ?
+                ReverseEndianness(MemoryMarshal.Read<long>(source)) :
+                MemoryMarshal.Read<long>(source);
         }
 
         /// <summary>
@@ -108,12 +99,9 @@ namespace System.Buffers.Binary
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort ReadUInt16LittleEndian(ReadOnlySpan<byte> source)
         {
-            ushort result = MemoryMarshal.Read<ushort>(source);
-            if (!BitConverter.IsLittleEndian)
-            {
-                result = ReverseEndianness(result);
-            }
-            return result;
+            return !BitConverter.IsLittleEndian ?
+                ReverseEndianness(MemoryMarshal.Read<ushort>(source)) :
+                MemoryMarshal.Read<ushort>(source);
         }
 
         /// <summary>
@@ -123,12 +111,9 @@ namespace System.Buffers.Binary
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint ReadUInt32LittleEndian(ReadOnlySpan<byte> source)
         {
-            uint result = MemoryMarshal.Read<uint>(source);
-            if (!BitConverter.IsLittleEndian)
-            {
-                result = ReverseEndianness(result);
-            }
-            return result;
+            return !BitConverter.IsLittleEndian ?
+                ReverseEndianness(MemoryMarshal.Read<uint>(source)) :
+                MemoryMarshal.Read<uint>(source);
         }
 
         /// <summary>
@@ -138,12 +123,9 @@ namespace System.Buffers.Binary
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong ReadUInt64LittleEndian(ReadOnlySpan<byte> source)
         {
-            ulong result = MemoryMarshal.Read<ulong>(source);
-            if (!BitConverter.IsLittleEndian)
-            {
-                result = ReverseEndianness(result);
-            }
-            return result;
+            return !BitConverter.IsLittleEndian ?
+                ReverseEndianness(MemoryMarshal.Read<ulong>(source)) :
+                MemoryMarshal.Read<ulong>(source);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/WriterBigEndian.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/WriterBigEndian.cs
@@ -62,9 +62,13 @@ namespace System.Buffers.Binary
         {
             if (BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                short tmp = ReverseEndianness(value);
+                MemoryMarshal.Write(destination, ref tmp);
             }
-            MemoryMarshal.Write(destination, ref value);
+            else
+            {
+                MemoryMarshal.Write(destination, ref value);
+            }
         }
 
         /// <summary>
@@ -75,9 +79,13 @@ namespace System.Buffers.Binary
         {
             if (BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                int tmp = ReverseEndianness(value);
+                MemoryMarshal.Write(destination, ref tmp);
             }
-            MemoryMarshal.Write(destination, ref value);
+            else
+            {
+                MemoryMarshal.Write(destination, ref value);
+            }
         }
 
         /// <summary>
@@ -88,9 +96,13 @@ namespace System.Buffers.Binary
         {
             if (BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                long tmp = ReverseEndianness(value);
+                MemoryMarshal.Write(destination, ref tmp);
             }
-            MemoryMarshal.Write(destination, ref value);
+            else
+            {
+                MemoryMarshal.Write(destination, ref value);
+            }
         }
 
         /// <summary>
@@ -125,9 +137,13 @@ namespace System.Buffers.Binary
         {
             if (BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                ushort tmp = ReverseEndianness(value);
+                MemoryMarshal.Write(destination, ref tmp);
             }
-            MemoryMarshal.Write(destination, ref value);
+            else
+            {
+                MemoryMarshal.Write(destination, ref value);
+            }
         }
 
         /// <summary>
@@ -139,9 +155,13 @@ namespace System.Buffers.Binary
         {
             if (BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                uint tmp = ReverseEndianness(value);
+                MemoryMarshal.Write(destination, ref tmp);
             }
-            MemoryMarshal.Write(destination, ref value);
+            else
+            {
+                MemoryMarshal.Write(destination, ref value);
+            }
         }
 
         /// <summary>
@@ -153,9 +173,13 @@ namespace System.Buffers.Binary
         {
             if (BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                ulong tmp = ReverseEndianness(value);
+                MemoryMarshal.Write(destination, ref tmp);
             }
-            MemoryMarshal.Write(destination, ref value);
+            else
+            {
+                MemoryMarshal.Write(destination, ref value);
+            }
         }
 
         /// <summary>
@@ -209,8 +233,10 @@ namespace System.Buffers.Binary
         {
             if (BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                short tmp = ReverseEndianness(value);
+                return MemoryMarshal.TryWrite(destination, ref tmp);
             }
+
             return MemoryMarshal.TryWrite(destination, ref value);
         }
 
@@ -223,8 +249,10 @@ namespace System.Buffers.Binary
         {
             if (BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                int tmp = ReverseEndianness(value);
+                return MemoryMarshal.TryWrite(destination, ref tmp);
             }
+
             return MemoryMarshal.TryWrite(destination, ref value);
         }
 
@@ -237,8 +265,10 @@ namespace System.Buffers.Binary
         {
             if (BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                long tmp = ReverseEndianness(value);
+                return MemoryMarshal.TryWrite(destination, ref tmp);
             }
+
             return MemoryMarshal.TryWrite(destination, ref value);
         }
 
@@ -273,8 +303,10 @@ namespace System.Buffers.Binary
         {
             if (BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                ushort tmp = ReverseEndianness(value);
+                return MemoryMarshal.TryWrite(destination, ref tmp);
             }
+
             return MemoryMarshal.TryWrite(destination, ref value);
         }
 
@@ -288,8 +320,10 @@ namespace System.Buffers.Binary
         {
             if (BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                uint tmp = ReverseEndianness(value);
+                return MemoryMarshal.TryWrite(destination, ref tmp);
             }
+
             return MemoryMarshal.TryWrite(destination, ref value);
         }
 
@@ -303,8 +337,10 @@ namespace System.Buffers.Binary
         {
             if (BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                ulong tmp = ReverseEndianness(value);
+                return MemoryMarshal.TryWrite(destination, ref tmp);
             }
+
             return MemoryMarshal.TryWrite(destination, ref value);
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/WriterLittleEndian.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/WriterLittleEndian.cs
@@ -62,9 +62,13 @@ namespace System.Buffers.Binary
         {
             if (!BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                short tmp = ReverseEndianness(value);
+                MemoryMarshal.Write(destination, ref tmp);
             }
-            MemoryMarshal.Write(destination, ref value);
+            else
+            {
+                MemoryMarshal.Write(destination, ref value);
+            }
         }
 
         /// <summary>
@@ -75,9 +79,13 @@ namespace System.Buffers.Binary
         {
             if (!BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                int tmp = ReverseEndianness(value);
+                MemoryMarshal.Write(destination, ref tmp);
             }
-            MemoryMarshal.Write(destination, ref value);
+            else
+            {
+                MemoryMarshal.Write(destination, ref value);
+            }
         }
 
         /// <summary>
@@ -88,9 +96,13 @@ namespace System.Buffers.Binary
         {
             if (!BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                long tmp = ReverseEndianness(value);
+                MemoryMarshal.Write(destination, ref tmp);
             }
-            MemoryMarshal.Write(destination, ref value);
+            else
+            {
+                MemoryMarshal.Write(destination, ref value);
+            }
         }
 
         /// <summary>
@@ -125,9 +137,13 @@ namespace System.Buffers.Binary
         {
             if (!BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                ushort tmp = ReverseEndianness(value);
+                MemoryMarshal.Write(destination, ref tmp);
             }
-            MemoryMarshal.Write(destination, ref value);
+            else
+            {
+                MemoryMarshal.Write(destination, ref value);
+            }
         }
 
         /// <summary>
@@ -139,9 +155,13 @@ namespace System.Buffers.Binary
         {
             if (!BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                uint tmp = ReverseEndianness(value);
+                MemoryMarshal.Write(destination, ref tmp);
             }
-            MemoryMarshal.Write(destination, ref value);
+            else
+            {
+                MemoryMarshal.Write(destination, ref value);
+            }
         }
 
         /// <summary>
@@ -153,9 +173,13 @@ namespace System.Buffers.Binary
         {
             if (!BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                ulong tmp = ReverseEndianness(value);
+                MemoryMarshal.Write(destination, ref tmp);
             }
-            MemoryMarshal.Write(destination, ref value);
+            else
+            {
+                MemoryMarshal.Write(destination, ref value);
+            }
         }
 
         /// <summary>
@@ -209,8 +233,10 @@ namespace System.Buffers.Binary
         {
             if (!BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                short tmp = ReverseEndianness(value);
+                return MemoryMarshal.TryWrite(destination, ref tmp);
             }
+
             return MemoryMarshal.TryWrite(destination, ref value);
         }
 
@@ -223,8 +249,10 @@ namespace System.Buffers.Binary
         {
             if (!BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                int tmp = ReverseEndianness(value);
+                return MemoryMarshal.TryWrite(destination, ref tmp);
             }
+
             return MemoryMarshal.TryWrite(destination, ref value);
         }
 
@@ -237,8 +265,10 @@ namespace System.Buffers.Binary
         {
             if (!BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                long tmp = ReverseEndianness(value);
+                return MemoryMarshal.TryWrite(destination, ref tmp);
             }
+
             return MemoryMarshal.TryWrite(destination, ref value);
         }
 
@@ -273,8 +303,10 @@ namespace System.Buffers.Binary
         {
             if (!BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                ushort tmp = ReverseEndianness(value);
+                return MemoryMarshal.TryWrite(destination, ref tmp);
             }
+
             return MemoryMarshal.TryWrite(destination, ref value);
         }
 
@@ -288,8 +320,10 @@ namespace System.Buffers.Binary
         {
             if (!BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                uint tmp = ReverseEndianness(value);
+                return MemoryMarshal.TryWrite(destination, ref tmp);
             }
+
             return MemoryMarshal.TryWrite(destination, ref value);
         }
 
@@ -303,8 +337,10 @@ namespace System.Buffers.Binary
         {
             if (!BitConverter.IsLittleEndian)
             {
-                value = ReverseEndianness(value);
+                ulong tmp = ReverseEndianness(value);
+                return MemoryMarshal.TryWrite(destination, ref tmp);
             }
+
             return MemoryMarshal.TryWrite(destination, ref value);
         }
     }


### PR DESCRIPTION
Follow up on #66965

Adjusts the usage of ReverseEndianness in BinaryPrimitives to allow the JIT to recognize the pattern and optimize them to `movbe`