### PR TITLE
[wasm][debugger][tests] Fix crash in `EvaluateOnCallFrameTests` on CI

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -2256,10 +2256,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             {
                 int methodId = await FindDebuggerProxyConstructorIdFor(typeId, token);
                 if (methodId == -1)
-                {
-                    logger.LogInformation($"GetValuesFromDebuggerProxyAttribute: could not find proxy constructor id for objectId {objectId}");
                     return null;
-                }
 
                 using var ctorArgsWriter = new MonoBinaryWriter();
                 ctorArgsWriter.Write((byte)ValueTypeId.Null);
@@ -2284,7 +2281,6 @@ namespace Microsoft.WebAssembly.Diagnostics
                 }
 
                 var retMethod = await InvokeMethod(ctorArgsWriter.GetParameterBuffer(), methodId, token);
-                logger.LogInformation($"* GetValuesFromDebuggerProxyAttribute got from InvokeMethod: {retMethod}");
                 if (!DotnetObjectId.TryParse(retMethod?["value"]?["objectId"]?.Value<string>(), out DotnetObjectId dotnetObjectId))
                     throw new Exception($"Invoking .ctor ({methodId}) for DebuggerTypeProxy on type {typeId} returned {retMethod}");
 
@@ -2296,7 +2292,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             }
             catch (Exception e)
             {
-                logger.LogInformation($"Could not evaluate DebuggerTypeProxyAttribute of type {await GetTypeName(typeId, token)} - {e}");
+                logger.LogDebug($"Could not evaluate DebuggerTypeProxyAttribute of type {await GetTypeName(typeId, token)} - {e}");
             }
 
             return null;


### PR DESCRIPTION
In `TestHarnessProxy`, we recently started adding proxy instances to a
static table, to enable getting the correct exit state from the client.
But the instances were not removed from the table, which prevented the
GC from collecting them.

This manifests as the test process crashing on systems with 8GB of
memory, when running `EvaluateOnCallFrameTests`. It would end up getting
to a resident size of 2.2-2.7G, and then crash after about 30 tests. With these changes, the
proxy gets collected, and the resident memory hovers around 500M.

Future work: this will change once we start using the upcoming app host
work, and thus moving the proxy to a separate process via `dotnet run
--debug`.