### PR TITLE
Update ApiCompat.proj

### DIFF
--- a/src/libraries/apicompat/ApiCompat.proj
+++ b/src/libraries/apicompat/ApiCompat.proj
@@ -7,8 +7,7 @@
     <!-- Target reference assemblies instead of implementation assemblies. -->
     <CompileUsingReferenceAssemblies>true</CompileUsingReferenceAssemblies>
     <TrimOutPrivateAssembliesFromReferencePath>true</TrimOutPrivateAssembliesFromReferencePath>
-    <!-- Temporarily disable baseline validation so that we can add baselines for the upcoming API compat fix https://github.com/dotnet/arcade/pull/9168 -->
-    <ValidateBaseline>false</ValidateBaseline>
+    <ValidateBaseline>true</ValidateBaseline>
 
     <ApiCompatNetStandard20BaselineFile>$(MSBuildThisFileDirectory)ApiCompatBaseline.netstandard2.0.txt</ApiCompatNetStandard20BaselineFile>
     <ApiCompatNetStandard21BaselineFile>$(MSBuildThisFileDirectory)ApiCompatBaseline.netstandard2.1.txt</ApiCompatNetStandard21BaselineFile>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/68730 but keeps the separate `ValidateBaseline` property as it might be useful to disable the baseline validation again in the future.