### PR TITLE
Modify tests to distinguish between emit- and interpreted-based invoke

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/Reflection/InvokeStrategy.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/Reflection/InvokeStrategy.cs
@@ -1,0 +1,292 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace System.Reflection.Tests
+{
+    /// <summary>
+    /// Base class for invoke-based tests that support invoking both emit- and interpreter-based runtime implementations.
+    /// </summary>
+    public abstract class InvokeStrategy
+    {
+        public bool UseEmit { get; }
+
+        public InvokeStrategy(bool useEmit)
+        {
+            UseEmit = useEmit;
+        }
+
+#if NETCOREAPP
+        public static bool AreTestingBindingFlagsSupported => !PlatformDetection.IsReleaseRuntime && RuntimeFeature.IsDynamicCodeCompiled
+            && !PlatformDetection.IsNotMonoRuntime; // Temporary until Mono is updated.
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime))] // Temporary until Mono is updated.
+        public void MethodInvoker_AutoEmitOrInterpreted()
+        {
+            Exception e;
+            MethodInfo method = typeof(ExceptionThrower).GetMethod(nameof(ExceptionThrower.ThrowForStackTrace), BindingFlags.Static | BindingFlags.Public)!;
+
+            // The first time emit may or may not be used depending if it was already called and whether emit is available.
+            e = Assert.Throws<TargetInvocationException>(() => method.Invoke(obj: null, parameters: null));
+            Assert.Contains("LocateMe", e.InnerException.Message);
+
+            // The second time uses emit if available.
+            e = Assert.Throws<TargetInvocationException>(() => method.Invoke(obj: null, parameters: null));
+            Assert.Contains("LocateMe", e.InnerException.Message);
+
+            if (RuntimeFeature.IsDynamicCodeCompiled)
+            {
+                Assert.Contains("InvokeStub_", e.InnerException.StackTrace);
+            }
+            else
+            {
+                Assert.DoesNotContain("InvokeStub_", e.InnerException.StackTrace);
+            }
+        }
+
+        [ConditionalFact(typeof(InvokeStrategy), nameof(InvokeStrategy.AreTestingBindingFlagsSupported))]
+        public void MethodInvoker_ExplicitEmitAndInterpreted()
+        {
+            Exception e;
+            MethodInfo method = typeof(ExceptionThrower).GetMethod(nameof(ExceptionThrower.ThrowForStackTrace), BindingFlags.Static | BindingFlags.Public)!;
+
+            e = Assert.Throws<TargetInvocationException>(() =>
+                method.Invoke(obj: null, (BindingFlags)TestingBindingFlags.InvokeWithEmit, binder: null, parameters: null, culture: null));
+            Assert.Contains("LocateMe", e.InnerException.Message);
+            Assert.Contains("InvokeStub_", e.InnerException.StackTrace);
+
+            e = Assert.Throws<TargetInvocationException>(() =>
+                method.Invoke(obj: null, (BindingFlags)TestingBindingFlags.InvokeWithInterpreter, binder: null, parameters: null, culture: null));
+            Assert.Contains("LocateMe", e.InnerException.Message);
+            Assert.DoesNotContain("InvokeStub_", e.InnerException.StackTrace);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime))] // Temporary until Mono is updated.
+        public void ConstructorInvoker_AutoEmitOrInterpreted()
+        {
+            Exception e;
+            ConstructorInfo method = typeof(ExceptionThrower).GetConstructor(Type.EmptyTypes)!;
+
+            // The first time emit may or may not be used depending if it was already called and whether emit is available.
+            e = Assert.Throws<TargetInvocationException>(() => method.Invoke(parameters: null));
+            Assert.Contains("LocateMe", e.InnerException.Message);
+
+            // The second time uses emit if available.
+            e = Assert.Throws<TargetInvocationException>(() => method.Invoke(parameters: null));
+            Assert.Contains("LocateMe", e.InnerException.Message);
+
+            if (RuntimeFeature.IsDynamicCodeCompiled)
+            {
+                Assert.Contains("InvokeStub_", e.InnerException.StackTrace);
+            }
+            else
+            {
+                Assert.DoesNotContain("InvokeStub_", e.InnerException.StackTrace);
+            }
+        }
+
+        [ConditionalFact(typeof(InvokeStrategy), nameof(InvokeStrategy.AreTestingBindingFlagsSupported))]
+        public void ConstructorInvoker_ExplicitEmitAndInterpreted()
+        {
+            Exception e;
+            ConstructorInfo method = typeof(ExceptionThrower).GetConstructor(Type.EmptyTypes)!;
+
+            e = Assert.Throws<TargetInvocationException>(() =>
+                method.Invoke((BindingFlags)TestingBindingFlags.InvokeWithEmit, binder: null, parameters: null, culture: null));
+            Assert.Contains("LocateMe", e.InnerException.Message);
+            Assert.Contains("InvokeStub_", e.InnerException.StackTrace);
+
+            e = Assert.Throws<TargetInvocationException>(() =>
+                method.Invoke((BindingFlags)TestingBindingFlags.InvokeWithInterpreter, binder: null, parameters: null, culture: null));
+            Assert.Contains("LocateMe", e.InnerException.Message);
+            Assert.DoesNotContain("InvokeStub_", e.InnerException.StackTrace);
+        }
+#endif
+
+        public object? Invoke(MethodBase method, object? obj, object?[]? parameters)
+        {
+            return method.Invoke(
+                obj,
+                (BindingFlags)(UseEmit ? TestingBindingFlags.InvokeWithEmit : TestingBindingFlags.InvokeWithInterpreter),
+                binder: null,
+                parameters,
+                culture: null);
+        }
+
+        public object? Invoke(
+            MethodBase method,
+            object? obj,
+            BindingFlags invokeAttr,
+            Binder? binder,
+            object?[]? parameters,
+            CultureInfo? culture)
+        {
+            return method.Invoke(
+                obj,
+                invokeAttr | (BindingFlags)(UseEmit ? TestingBindingFlags.InvokeWithEmit : TestingBindingFlags.InvokeWithInterpreter),
+                binder,
+                parameters,
+                culture);
+        }
+
+        public object? Invoke(ConstructorInfo method, object?[]? parameters)
+        {
+            return method.Invoke(
+                (BindingFlags)(UseEmit ? TestingBindingFlags.InvokeWithEmit : TestingBindingFlags.InvokeWithInterpreter),
+                binder: null,
+                parameters,
+                culture: null);
+        }
+
+        public object? Invoke(
+            ConstructorInfo method,
+            BindingFlags invokeAttr,
+            Binder? binder,
+            object?[]? parameters,
+            CultureInfo? culture)
+        {
+            return method.Invoke(
+                invokeAttr | (BindingFlags)(UseEmit ? TestingBindingFlags.InvokeWithEmit : TestingBindingFlags.InvokeWithInterpreter),
+                binder,
+                parameters,
+                culture);
+        }
+
+        public object? InvokeMember(
+            Type type,
+            string name,
+            BindingFlags invokeAttr,
+            Binder? binder,
+            object? target,
+            object?[]? args,
+            ParameterModifier[]? modifiers,
+            CultureInfo? culture,
+            string[]? namedParameters)
+        {
+            return type.InvokeMember(
+                name,
+                invokeAttr | (BindingFlags)(UseEmit ? TestingBindingFlags.InvokeWithEmit : TestingBindingFlags.InvokeWithInterpreter),
+                binder,
+                target,
+                args,
+                modifiers,
+                culture,
+                namedParameters);
+        }
+
+        public object? GetValue(
+            PropertyInfo property,
+            object? obj)
+        {
+            return property.GetValue(
+                obj,
+                (BindingFlags)(UseEmit ? TestingBindingFlags.InvokeWithEmit : TestingBindingFlags.InvokeWithInterpreter),
+                binder : null,
+                index : null,
+                culture : null);
+        }
+
+        public object? GetValue(
+            PropertyInfo property,
+            object? obj,
+            object?[]? index)
+        {
+            return property.GetValue(
+                obj,
+                (BindingFlags)(UseEmit ? TestingBindingFlags.InvokeWithEmit : TestingBindingFlags.InvokeWithInterpreter),
+                binder: null,
+                index: index,
+                culture: null);
+        }
+
+        public object? GetValue(
+            PropertyInfo property,
+            object? obj,
+            BindingFlags invokeAttr,
+            Binder? binder,
+            object?[]? index,
+            CultureInfo? culture)
+        {
+            return property.GetValue(
+                obj,
+                invokeAttr | (BindingFlags)(UseEmit ? TestingBindingFlags.InvokeWithEmit : TestingBindingFlags.InvokeWithInterpreter),
+                binder,
+                index,
+                culture);
+        }
+
+        public void SetValue(
+            PropertyInfo property,
+            object? obj,
+            object? value)
+        {
+            property.SetValue(
+                obj,
+                value,
+                (BindingFlags)(UseEmit ? TestingBindingFlags.InvokeWithEmit : TestingBindingFlags.InvokeWithInterpreter),
+                binder: null,
+                index: null,
+                culture: null);
+        }
+
+        public void SetValue(
+            PropertyInfo property,
+            object? obj,
+            object? value,
+            object?[]? index)
+        {
+            property.SetValue(
+                obj,
+                value,
+                (BindingFlags)(UseEmit ? TestingBindingFlags.InvokeWithEmit : TestingBindingFlags.InvokeWithInterpreter),
+                binder: null,
+                index: index,
+                culture: null);
+        }
+
+        public void SetValue(
+            PropertyInfo property,
+            object? obj,
+            object? value,
+            BindingFlags invokeAttr,
+            Binder? binder,
+            object?[]? index,
+            CultureInfo? culture)
+        {
+            property.SetValue(
+                obj,
+                value,
+                invokeAttr | (BindingFlags)(UseEmit ? TestingBindingFlags.InvokeWithEmit : TestingBindingFlags.InvokeWithInterpreter),
+                binder,
+                index,
+                culture);
+        }
+
+        /// <summary>
+        /// Internal enums for testing only. These are subject to change depending on test strategy.
+        /// If changed, also change BindingFlags.cs.
+        /// </summary>
+        [Flags]
+        internal enum TestingBindingFlags
+        {
+            /// <summary>
+            /// Use IL Emit (if available) for Invoke()
+            /// </summary>
+            InvokeWithEmit = 0x20000000,
+
+            /// <summary>
+            /// Use the native interpreter for Invoke()
+            /// </summary>
+            InvokeWithInterpreter = 0x40000000
+        }
+
+        private class ExceptionThrower
+        {
+            public ExceptionThrower() => throw new Exception("LocateMe");
+            public static void ThrowForStackTrace() => throw new Exception("LocateMe");
+        }
+    }
+}

--- a/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
+++ b/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
@@ -35,6 +35,7 @@
     <Compile Include="System\PlatformDetection.cs" />
     <Compile Include="System\PlatformDetection.Unix.cs" />
     <Compile Include="System\PlatformDetection.Windows.cs" />
+    <Compile Include="System\Reflection\InvokeStrategy.cs" />
     <Compile Include="System\WindowsIdentityFixture.cs" />
 
     <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/BindingFlags.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/BindingFlags.cs
@@ -46,5 +46,27 @@ namespace System.Reflection
         // These are a couple of misc attributes used
         IgnoreReturn = 0x01000000,  // This is used in COM Interop
         DoNotWrapExceptions = 0x02000000, // Disables wrapping exceptions in TargetInvocationException
+
+        // Softly reserved for test reasons; see TestingBindingFlags.
+        // InvokeWithEmit = 0x20000000,
+        // InvokeWithInterpreter = 0x40000000
+    }
+
+    /// <summary>
+    /// Internal enums for testing only. These are subject to change depending on test strategy.
+    /// If changed, also change InvokeStrategy.cs.
+    /// </summary>
+    [Flags]
+    internal enum TestingBindingFlags
+    {
+        /// <summary>
+        /// Use IL Emit (if available) for Invoke()
+        /// </summary>
+        InvokeWithEmit = 0x20000000,
+
+        /// <summary>
+        /// Use the native interpreter for Invoke()
+        /// </summary>
+        InvokeWithInterpreter = 0x40000000
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodInvoker.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodInvoker.cs
@@ -35,7 +35,12 @@ namespace System.Reflection
         {
             if (!_strategyDetermined)
             {
-                if (!_invoked)
+                if (!_invoked
+#if !RELEASE
+                    // For testing reasons, determine the strategy on the first invoke.
+                    && (invokeAttr & (BindingFlags)(TestingBindingFlags.InvokeWithEmit | TestingBindingFlags.InvokeWithInterpreter)) == 0
+#endif
+                    )
                 {
                     // The first time, ignoring race conditions, use the slow path.
                     _invoked = true;
@@ -55,7 +60,11 @@ namespace System.Reflection
             {
                 try
                 {
-                    if (_invokeFunc != null)
+                    if (_invokeFunc != null
+#if !RELEASE
+                        && (invokeAttr & (BindingFlags)TestingBindingFlags.InvokeWithInterpreter) == 0
+#endif
+                        )
                     {
                         ret = _invokeFunc(obj, args);
                     }
@@ -69,7 +78,11 @@ namespace System.Reflection
                     throw new TargetInvocationException(e);
                 }
             }
-            else if (_invokeFunc != null)
+            else if (_invokeFunc != null
+#if !RELEASE
+                && (invokeAttr & (BindingFlags)TestingBindingFlags.InvokeWithInterpreter) == 0
+#endif
+                )
             {
                 ret = _invokeFunc(obj, args);
             }

--- a/src/libraries/System.Reflection/tests/MethodInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/MethodInfoTests.cs
@@ -9,8 +9,20 @@ using Xunit;
 
 namespace System.Reflection.Tests
 {
-    public class MethodInfoTests
+    public class MethodInfoTests_Emit : MethodInfoTests
     {
+        public MethodInfoTests_Emit() : base(useEmit: true) { }
+    }
+
+    public class MethodInfoTests_Interpreted : MethodInfoTests
+    {
+        public MethodInfoTests_Interpreted() : base(useEmit: false) { }
+    }
+
+    public abstract class MethodInfoTests : InvokeStrategy
+    {
+        public MethodInfoTests(bool useEmit) : base(useEmit) { }
+
         [Fact]
         public void CreateDelegate_PublicMethod()
         {
@@ -361,24 +373,24 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(Invoke_TestData))]
-        public void Invoke(Type methodDeclaringType, string methodName, object obj, object[] parameters, object result)
+        public void Invoke_Method(Type methodDeclaringType, string methodName, object obj, object[] parameters, object result)
         {
             MethodInfo method = GetMethod(methodDeclaringType, methodName);
-            Assert.Equal(result, method.Invoke(obj, parameters));
+            Assert.Equal(result, Invoke(method, obj, parameters));
         }
 
         [Fact]
         public void Invoke_ParameterSpecification_ArrayOfMissing()
         {
-            Invoke(typeof(MethodInfoDefaultParameters), "OptionalObjectParameter", new MethodInfoDefaultParameters(), new object[] { Type.Missing }, Type.Missing);
-            Invoke(typeof(MethodInfoDefaultParameters), "OptionalObjectParameter", new MethodInfoDefaultParameters(), new Missing[] { Missing.Value }, Missing.Value);
+            Invoke_Method(typeof(MethodInfoDefaultParameters), "OptionalObjectParameter", new MethodInfoDefaultParameters(), new object[] { Type.Missing }, Type.Missing);
+            Invoke_Method(typeof(MethodInfoDefaultParameters), "OptionalObjectParameter", new MethodInfoDefaultParameters(), new Missing[] { Missing.Value }, Missing.Value);
         }
 
         [Fact]
         [ActiveIssue("https://github.com/mono/mono/issues/15025", TestRuntimes.Mono)]
-        public static void Invoke_OptionalParameterUnassingableFromMissing_WithMissingValue_ThrowsArgumentException()
+        public void Invoke_OptionalParameterUnassingableFromMissing_WithMissingValue_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => GetMethod(typeof(MethodInfoDefaultParameters), "OptionalStringParameter").Invoke(new MethodInfoDefaultParameters(), new object[] { Type.Missing }));
+            AssertExtensions.Throws<ArgumentException>(null, () => Invoke(GetMethod(typeof(MethodInfoDefaultParameters), "OptionalStringParameter"), new MethodInfoDefaultParameters(), new object[] { Type.Missing }));
         }
 
         [Fact]
@@ -387,7 +399,7 @@ namespace System.Reflection.Tests
         {
             MethodInfo method = GetMethod(typeof(MI_SubClass), nameof(MI_SubClass.StaticIntIntMethodReturningInt));
             var args = new object[] { "10", "100" };
-            Assert.Equal(110, method.Invoke(null, BindingFlags.Default, new ConvertStringToIntBinder(), args, null));
+            Assert.Equal(110, Invoke(method, null, BindingFlags.Default, new ConvertStringToIntBinder(), args, null));
             Assert.True(args[0] is int);
             Assert.True(args[1] is int);
         }
@@ -627,27 +639,27 @@ namespace System.Reflection.Tests
 
             int? iNull = null;
             args = new object[] { iNull };
-            Assert.True((bool)GetMethod(nameof(NullableRefMethods.Null)).Invoke(null, args));
+            Assert.True((bool)Invoke(GetMethod(nameof(NullableRefMethods.Null)), null, args));
             Assert.Null(args[0]);
             Assert.False(((int?)args[0]).HasValue);
 
             args = new object[] { iNull };
-            Assert.True((bool)GetMethod(nameof(NullableRefMethods.NullBoxed)).Invoke(null, args));
+            Assert.True((bool)Invoke(GetMethod(nameof(NullableRefMethods.NullBoxed)), null, args));
             Assert.Null(args[0]);
 
             args = new object[] { iNull, 10 };
-            Assert.True((bool)GetMethod(nameof(NullableRefMethods.NullToValue)).Invoke(null, args));
+            Assert.True((bool)Invoke(GetMethod(nameof(NullableRefMethods.NullToValue)), null, args));
             Assert.IsType<int>(args[0]);
             Assert.Equal(10, (int)args[0]);
 
             iNull = 42;
             args = new object[] { iNull, 42 };
-            Assert.True((bool)GetMethod(nameof(NullableRefMethods.ValueToNull)).Invoke(null, args));
+            Assert.True((bool)Invoke(GetMethod(nameof(NullableRefMethods.ValueToNull)), null, args));
             Assert.Null(args[0]);
 
             iNull = null;
             args = new object[] { iNull, 10 };
-            Assert.True((bool)GetMethod(nameof(NullableRefMethods.NullToValueBoxed)).Invoke(null, args));
+            Assert.True((bool)Invoke(GetMethod(nameof(NullableRefMethods.NullToValueBoxed)), null, args));
             Assert.IsType<int>(args[0]);
             Assert.Equal(10, (int)args[0]);
 
@@ -662,26 +674,26 @@ namespace System.Reflection.Tests
 
             object? iNull = null;
             args = new object[] { iNull };
-            Assert.True((bool)GetMethod(nameof(NullableRefMethods.Null)).Invoke(null, args));
+            Assert.True((bool)Invoke(GetMethod(nameof(NullableRefMethods.Null)), null, args));
             Assert.Null(args[0]);
 
             args = new object[] { iNull };
-            Assert.True((bool)GetMethod(nameof(NullableRefMethods.NullBoxed)).Invoke(null, args));
+            Assert.True((bool)Invoke(GetMethod(nameof(NullableRefMethods.NullBoxed)), null, args));
             Assert.Null(args[0]);
 
             args = new object[] { iNull, 10 };
-            Assert.True((bool)GetMethod(nameof(NullableRefMethods.NullToValue)).Invoke(null, args));
+            Assert.True((bool)Invoke(GetMethod(nameof(NullableRefMethods.NullToValue)), null, args));
             Assert.IsType<int>(args[0]);
             Assert.Equal(10, (int)args[0]);
 
             iNull = 42;
             args = new object[] { iNull, 42 };
-            Assert.True((bool)GetMethod(nameof(NullableRefMethods.ValueToNull)).Invoke(null, args));
+            Assert.True((bool)Invoke(GetMethod(nameof(NullableRefMethods.ValueToNull)), null, args));
             Assert.Null(args[0]);
 
             iNull = null;
             args = new object[] { iNull, 10 };
-            Assert.True((bool)GetMethod(nameof(NullableRefMethods.NullToValueBoxed)).Invoke(null, args));
+            Assert.True((bool)Invoke(GetMethod(nameof(NullableRefMethods.NullToValueBoxed)), null, args));
             Assert.IsType<int>(args[0]);
             Assert.Equal(10, (int)args[0]);
 
@@ -693,16 +705,16 @@ namespace System.Reflection.Tests
         public void InvokeEnum()
         {
             // Enums only need to match by primitive type.
-            Assert.True((bool)GetMethod(nameof(EnumMethods.PassColorsInt)).
-                Invoke(null, new object[] { OtherColorsInt.Red }));
+            Assert.True((bool)Invoke(GetMethod(nameof(EnumMethods.PassColorsInt)),
+                null, new object[] { OtherColorsInt.Red }));
 
             // Widening allowed
-            Assert.True((bool)GetMethod(nameof(EnumMethods.PassColorsInt)).
-                Invoke(null, new object[] { ColorsShort.Red }));
+            Assert.True((bool)Invoke(GetMethod(nameof(EnumMethods.PassColorsInt)),
+                null, new object[] { ColorsShort.Red }));
 
             // Narrowing not allowed
-            Assert.Throws<ArgumentException>(() => GetMethod(nameof(EnumMethods.PassColorsShort)).
-                Invoke(null, new object[] { OtherColorsInt.Red }));
+            Assert.Throws<ArgumentException>(() => Invoke(GetMethod(nameof(EnumMethods.PassColorsShort)),
+                null, new object[] { OtherColorsInt.Red }));
 
             static MethodInfo GetMethod(string name) => typeof(EnumMethods).GetMethod(
                 name, BindingFlags.Public | BindingFlags.Static)!;
@@ -714,12 +726,12 @@ namespace System.Reflection.Tests
             ValueTypeWithOverrides obj = new() { Id = 1 };
 
             // ToString is overridden.
-            Assert.Equal("Hello", (string)GetMethod(typeof(ValueTypeWithOverrides), nameof(ValueTypeWithOverrides.ToString)).
-                Invoke(obj, null));
+            Assert.Equal("Hello", (string)Invoke(GetMethod(typeof(ValueTypeWithOverrides), nameof(ValueTypeWithOverrides.ToString)),
+                obj, null));
 
             // Ensure a normal method works.
-            Assert.Equal(1, (int)GetMethod(typeof(ValueTypeWithOverrides), nameof(ValueTypeWithOverrides.GetId)).
-                Invoke(obj, null));
+            Assert.Equal(1, (int)Invoke(GetMethod(typeof(ValueTypeWithOverrides), nameof(ValueTypeWithOverrides.GetId)),
+                obj, null));
         }
 
         [Fact]
@@ -728,12 +740,12 @@ namespace System.Reflection.Tests
             ValueTypeWithoutOverrides obj = new() { Id = 1 };
 
             // ToString is not overridden.
-            Assert.Equal(typeof(ValueTypeWithoutOverrides).ToString(), (string)GetMethod(typeof(ValueTypeWithoutOverrides), nameof(ValueTypeWithoutOverrides.ToString)).
-                Invoke(obj, null));
+            Assert.Equal(typeof(ValueTypeWithoutOverrides).ToString(), (string)Invoke(GetMethod(typeof(ValueTypeWithoutOverrides), nameof(ValueTypeWithoutOverrides.ToString)),
+                obj, null));
 
             // Ensure a normal method works.
-            Assert.Equal(1, (int)GetMethod(typeof(ValueTypeWithoutOverrides), nameof(ValueTypeWithoutOverrides.GetId)).
-                Invoke(obj, null));
+            Assert.Equal(1, (int)Invoke(GetMethod(typeof(ValueTypeWithoutOverrides), nameof(ValueTypeWithoutOverrides.GetId)),
+                obj, null));
         }
 
         [Fact]
@@ -741,7 +753,7 @@ namespace System.Reflection.Tests
         {
             // Ensure calling a method on Nullable<T> works.
             MethodInfo mi = GetMethod(typeof(int?), nameof(Nullable<int>.GetValueOrDefault));
-            Assert.Equal(42, mi.Invoke(42, null));
+            Assert.Equal(42, Invoke(mi, 42, null));
         }
 
         [Fact]
@@ -749,24 +761,24 @@ namespace System.Reflection.Tests
         {
             object i = 42;
             object[] args = new object[] { i };
-            GetMethod(typeof(CopyBackMethods), nameof(CopyBackMethods.IncrementByRef)).Invoke(null, args);
+            Invoke(GetMethod(typeof(CopyBackMethods), nameof(CopyBackMethods.IncrementByRef)), null, args);
             Assert.Equal(43, (int)args[0]);
             Assert.NotSame(i, args[0]); // A copy should be made; a boxed instance should never be directly updated.
 
             i = 42;
             args = new object[] { i };
-            GetMethod(typeof(CopyBackMethods), nameof(CopyBackMethods.IncrementByNullableRef)).Invoke(null, args);
+            Invoke(GetMethod(typeof(CopyBackMethods), nameof(CopyBackMethods.IncrementByNullableRef)), null, args);
             Assert.Equal(43, (int)args[0]);
             Assert.NotSame(i, args[0]);
 
             object o = null;
             args = new object[] { o };
-            GetMethod(typeof(CopyBackMethods), nameof(CopyBackMethods.SetToNonNullByRef)).Invoke(null, args);
+            Invoke(GetMethod(typeof(CopyBackMethods), nameof(CopyBackMethods.SetToNonNullByRef)), null, args);
             Assert.NotNull(args[0]);
 
             o = new object();
             args = new object[] { o };
-            GetMethod(typeof(CopyBackMethods), nameof(CopyBackMethods.SetToNullByRef)).Invoke(null, args);
+            Invoke(GetMethod(typeof(CopyBackMethods), nameof(CopyBackMethods.SetToNullByRef)), null, args);
             Assert.Null(args[0]);
         }
 

--- a/src/libraries/System.Reflection/tests/PropertyInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/PropertyInfoTests.cs
@@ -8,8 +8,20 @@ using Xunit;
 
 namespace System.Reflection.Tests
 {
-    public class PropertyInfoTests
+    public class PropertyInfoTests_Emit : PropertyInfoTests
     {
+        public PropertyInfoTests_Emit() : base(useEmit: true) { }
+    }
+
+    public class PropertyInfoTests_Interpreted : PropertyInfoTests
+    {
+        public PropertyInfoTests_Interpreted() : base(useEmit: false) { }
+    }
+
+    public abstract class PropertyInfoTests : InvokeStrategy
+    {
+        public PropertyInfoTests(bool useEmit) : base(useEmit) { }
+
         [Theory]
         [InlineData(typeof(BaseClass), nameof(BaseClass.IntProperty))]
         [InlineData(typeof(BaseClass), nameof(BaseClass.StringProperty))]
@@ -54,14 +66,14 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(GetValue_TestData))]
-        public void GetValue(Type type, string name, object obj, object[] index, object expected)
+        public void GetPropertyValue(Type type, string name, object obj, object[] index, object expected)
         {
             PropertyInfo propertyInfo = GetProperty(type, name);
             if (index == null)
             {
-                Assert.Equal(expected, propertyInfo.GetValue(obj));
+                Assert.Equal(expected, GetValue(propertyInfo, obj));
             }
-            Assert.Equal(expected, propertyInfo.GetValue(obj, index));
+            Assert.Equal(expected, GetValue(propertyInfo, obj, index));
         }
 
         public static IEnumerable<object[]> GetValue_Invalid_TestData()
@@ -86,7 +98,7 @@ namespace System.Reflection.Tests
         public void GetValue_Invalid(Type type, string name, object obj, object[] index, Type exceptionType)
         {
             PropertyInfo propertyInfo = GetProperty(type, name);
-            Assert.Throws(exceptionType, () => propertyInfo.GetValue(obj, index));
+            Assert.Throws(exceptionType, () => GetValue(propertyInfo, obj, index));
         }
 
         public static IEnumerable<object[]> SetValue_TestData()
@@ -103,34 +115,34 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(SetValue_TestData))]
-        public void SetValue(Type type, string name, object obj, object value, object[] index, object expected)
+        public void SetPropertyValue(Type type, string name, object obj, object value, object[] index, object expected)
         {
             PropertyInfo PropertyInfo = GetProperty(type, name);
             object originalValue;
             if (index == null)
             {
                 // Use SetValue(object, object)
-                originalValue = PropertyInfo.GetValue(obj);
+                originalValue = GetValue(PropertyInfo, obj);
                 try
                 {
-                    PropertyInfo.SetValue(obj, value);
-                    Assert.Equal(expected, PropertyInfo.GetValue(obj));
+                    SetValue(PropertyInfo, obj, value);
+                    Assert.Equal(expected, GetValue(PropertyInfo, obj));
                 }
                 finally
                 {
-                    PropertyInfo.SetValue(obj, originalValue);
+                    SetValue(PropertyInfo, obj, originalValue);
                 }
             }
             // Use SetValue(object, object, object[])
-            originalValue = PropertyInfo.GetValue(obj, index);
+            originalValue = GetValue(PropertyInfo, obj, index);
             try
             {
-                PropertyInfo.SetValue(obj, value, index);
-                Assert.Equal(expected, PropertyInfo.GetValue(obj, index));
+                SetValue(PropertyInfo, obj, value, index);
+                Assert.Equal(expected, GetValue(PropertyInfo, obj, index));
             }
             finally
             {
-                PropertyInfo.SetValue(obj, originalValue, index);
+                SetValue(PropertyInfo, obj, originalValue, index);
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System/Reflection/PointerTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/PointerTests.cs
@@ -38,8 +38,20 @@ namespace System.Reflection.Tests
     unsafe delegate bool* ReturnDelegate(int expected);
     unsafe delegate object ReturnDelegateWithSystemPointer(int expected);
 
-    public unsafe class PointerTests
+    public class PointerTests_Emit : PointerTests
     {
+        public PointerTests_Emit() : base(useEmit: true) { }
+    }
+
+    public class PointerTests_Interpreted : PointerTests
+    {
+        public PointerTests_Interpreted() : base(useEmit: false) { }
+    }
+
+    public abstract unsafe class PointerTests : InvokeStrategy
+    {
+        public PointerTests(bool useEmit) : base(useEmit) { }
+
         [Fact]
         public void Box_TypeNull()
         {
@@ -155,7 +167,7 @@ namespace System.Reflection.Tests
         {
             var obj = new PointerHolder();
             PropertyInfo property = typeof(PointerHolder).GetProperty("Property");
-            property.SetValue(obj, Pointer.Box(unchecked((void*)value), typeof(char*)));
+            SetValue(property, obj, Pointer.Box(unchecked((void*)value), typeof(char*)));
             Assert.Equal(value, unchecked((int)obj.Property));
         }
 
@@ -165,7 +177,7 @@ namespace System.Reflection.Tests
         {
             var obj = new PointerHolder();
             PropertyInfo property = typeof(PointerHolder).GetProperty("Property");
-            property.SetValue(obj, (IntPtr)value);
+            SetValue(property, obj, (IntPtr)value);
             Assert.Equal(value, unchecked((int)obj.Property));
         }
 
@@ -177,7 +189,7 @@ namespace System.Reflection.Tests
             PropertyInfo property = typeof(PointerHolder).GetProperty("Property");
             AssertExtensions.Throws<ArgumentException>(null, () =>
             {
-                property.SetValue(obj, Pointer.Box(unchecked((void*)value), typeof(long*)));
+                SetValue(property, obj, Pointer.Box(unchecked((void*)value), typeof(long*)));
             });
         }
 
@@ -189,7 +201,7 @@ namespace System.Reflection.Tests
             var obj = new PointerHolder();
             obj.Property = unchecked((char*)value);
             PropertyInfo property = typeof(PointerHolder).GetProperty("Property");
-            object actualValue = property.GetValue(obj);
+            object actualValue = GetValue(property, obj);
             Assert.IsType<Pointer>(actualValue);
             void* actualPointer = Pointer.Unbox(actualValue);
             Assert.Equal(value, unchecked((int)actualPointer));
@@ -201,7 +213,7 @@ namespace System.Reflection.Tests
         {
             var obj = new PointerHolder();
             MethodInfo method = typeof(PointerHolder).GetMethod("Method");
-            method.Invoke(obj, new[] { Pointer.Box(unchecked((void*)value), typeof(byte*)), value });
+            Invoke(method, obj, new[] { Pointer.Box(unchecked((void*)value), typeof(byte*)), value });
         }
 
         [Fact]
@@ -209,7 +221,7 @@ namespace System.Reflection.Tests
         {
             var obj = new PointerHolder();
             MethodInfo method = typeof(PointerHolder).GetMethod("Method");
-            method.Invoke(obj, new object[] { null, 0 });
+            Invoke(method, obj, new object[] { null, 0 });
         }
 
         [Theory]
@@ -218,7 +230,7 @@ namespace System.Reflection.Tests
         {
             var obj = new PointerHolder();
             MethodInfo method = typeof(PointerHolder).GetMethod("Method");
-            method.Invoke(obj, new object[] { (IntPtr)value, value });
+            Invoke(method, obj, new object[] { (IntPtr)value, value });
         }
 
         [Theory]
@@ -229,7 +241,7 @@ namespace System.Reflection.Tests
             MethodInfo method = typeof(PointerHolder).GetMethod("Method");
             AssertExtensions.Throws<ArgumentException>(null, () =>
             {
-                method.Invoke(obj, new[] { Pointer.Box(unchecked((void*)value), typeof(long*)), value });
+                Invoke(method, obj, new[] { Pointer.Box(unchecked((void*)value), typeof(long*)), value });
             });
         }
 


### PR DESCRIPTION
As a follow-up to https://github.com/dotnet/runtime/pull/67917, explicitly support testing of both emit-based and interpreter-based invoke.

No functional changes made to the Release build. The invoke-based tests will run twice, and thus be indirectly tested under both emit and interpreter.

The Checked and Debug runtime builds however support passing in 2 new binding flags to use either the emit or interpreter-based invoke. These do not actually change the public `System.Reflection.BindingFlags` enum but do apply a soft reservation on that enum for those 2 values to support these test scenarios in an explicit and stable manner.

