### PR TITLE
Fix incorrect none_no value when NUMA node is undefined in distribute_other_procs

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -6192,6 +6192,9 @@ public:
             if (!GCToOSInterface::GetProcessorForHeap ((uint16_t)i, &proc_no, &node_no))
                 break;
 
+            if (node_no == NUMA_NODE_UNDEFINED)
+                node_no = 0;
+
             int start_heap = (int)numa_node_to_heap_map[node_no];
             int end_heap = (int)(numa_node_to_heap_map[node_no + 1]);
 


### PR DESCRIPTION
Call `GetProcessorForHeap` in distribute_other_procs sets `node_no` to 0xFFFF (NUMA_NODE_UNDEFINIED) causes sigsegv in GetHeap. 
Problem occurs when NUMA node is undefined and number of gc heaps is limited by hard limits or configuration.   
Value of `no_node` (65535) is greather than size of  `numa_node_to_heap_map` array (1028 for 64bit).  Read from outside the array `numa_node_to_heap_map[node_no]`  returns random value (e.g. 32684).  The incorrect value is assigned to `end_heap` .The condition `current_heap_on_node >= end_heap` is incorrectly met by invalid value of `end_heap`, It causes that `current_heap_on_node`  is greater than `n_heaps` and is out of bound `g_heaps` . The incorrect value is assigned to `proc_no_to_heap_no`.  Call `AssignHeap` from affected processor causes sigsegv. `select_heap`  returns incorrect value from `proc_no_to_heap_no` which is out of bounds `g_heaps`  array. It causing SIGSEGV in GetHeap `gc_heap::g_heaps[n]->vm_heap` - `n >= n_heap`


Fixes #67008.