### PR TITLE
[wasm] Move `Microsoft.Extensions.Logging.Generators.Roslyn4.0.Tests` to

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -38,6 +38,8 @@
 
     <!-- https://github.com/dotnet/runtime/issues/66647 -->
     <HighAOTResourceRequiringProject Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.Abstractions\tests\Microsoft.Extensions.Logging.Generators.Tests\Microsoft.Extensions.Logging.Generators.Roslyn3.11.Tests.csproj" />
+
+    <HighAOTResourceRequiringProject Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.Abstractions\tests\Microsoft.Extensions.Logging.Generators.Tests\Microsoft.Extensions.Logging.Generators.Roslyn4.0.Tests.csproj" />
   </ItemGroup>
 
   <!-- Samples which are too complex for CI -->


### PR DESCRIPTION
the high-resource-aot build job.

This is the same as what we got the `Roslyn3.11` variant of the same tests.
Prompted by oomkills seen on CI.