### PR TITLE
Removing comments so won't overwrite doc changes

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
@@ -309,7 +309,6 @@ namespace System.Runtime.CompilerServices
     }
 
     /// <summary>Provides an awaiter for awaiting a <see cref="System.Threading.Tasks.Task{TResult}"/>.</summary>
-    /// <remarks>This type is intended for compiler use only.</remarks>
     public readonly struct TaskAwaiter<TResult> : ICriticalNotifyCompletion, ITaskAwaiter
     {
         // WARNING: Unsafe.As is used to access TaskAwaiter<> as the non-generic TaskAwaiter.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
@@ -52,7 +52,6 @@ using System.Threading.Tasks;
 namespace System.Runtime.CompilerServices
 {
     /// <summary>Provides an awaiter for awaiting a <see cref="System.Threading.Tasks.Task"/>.</summary>
-    /// <remarks>This type is intended for compiler use only.</remarks>
     public readonly struct TaskAwaiter : ICriticalNotifyCompletion, ITaskAwaiter
     {
         // WARNING: Unsafe.As is used to access the generic TaskAwaiter<> as TaskAwaiter.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
@@ -516,7 +516,6 @@ namespace System.Threading.Tasks
 
         /// <summary>Gets an awaiter used to await this <see cref="System.Threading.Tasks.Task{TResult}"/>.</summary>
         /// <returns>An awaiter instance.</returns>
-        /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
         public new TaskAwaiter<TResult> GetAwaiter()
         {
             return new TaskAwaiter<TResult>(this);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -2440,7 +2440,6 @@ namespace System.Threading.Tasks
         #region Await Support
         /// <summary>Gets an awaiter used to await this <see cref="System.Threading.Tasks.Task"/>.</summary>
         /// <returns>An awaiter instance.</returns>
-        /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
         public TaskAwaiter GetAwaiter()
         {
             return new TaskAwaiter(this);


### PR DESCRIPTION
Changes I made in https://github.com/dotnet/dotnet-api-docs/pull/7968 were overwritten because the code comments replaced what was in the docs. According to @carlossanlop, this will happen until the code comments are removed.

Comments from @stephentoub  in https://github.com/dotnet/dotnet-api-docs/pull/7941 were:

> Now, there's the related question of "what about GetAwaiter().GetResult() on a Task rather than on a configured awaiter, as those docs also say the same thing". When all of this support was introduced, the intent was in fact that no one should ever be using these directly, that they were purely for compiler consumption. However, there's a behavioral difference between task.Wait() and task.GetAwaiter().GetResult(), which is that, while functionally identical in terms of how they wait, the latter propagates the first exception that faulted/canceled the task whereas the former wraps the one or more exceptions into an AggregateException and throws that wrapper. As such, developers that want the original exception propagated often use .GetAwaiter().GetResult() instead of Wait. **At this point, the right thing for TaskAwaiter and TaskAwaiter<T> is probably to just strike those sentence from the docs, though some extra verbiage around the distinction from Task.Wait would be welcome.** No one should be using GetAwaiter().GetResult() on any of the ValueTask variants for all the reasons discussed in https://devblogs.microsoft.com/dotnet/understanding-the-whys-whats-and-whens-of-valuetask/.