### PR TITLE
Error if a reference assembly is platform specific

### DIFF
--- a/eng/references.targets
+++ b/eng/references.targets
@@ -74,12 +74,14 @@
     </TargetPathWithTargetPlatformMoniker>
   </ItemDefinitionGroup>
 
-  <Target Name="ValidateReferenceAssemblyProjectReferences"
+  <Target Name="ValidateReferenceAssemblyProjectReferencesAndTargetFramework"
           AfterTargets="ResolveReferences"
           Condition="'$(IsReferenceAssemblyProject)' == 'true' and
                      '$(SkipValidateReferenceAssemblyProjectReferences)' != 'true'">
-    <Error Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference' and '%(ReferencePath.IsReferenceAssemblyProject)' != 'true' and '%(ReferencePath.ReferenceAssembly)' == ''"
-           Text="Reference assemblies must only reference other reference assemblies and '%(ReferencePath.ProjectReferenceOriginalItemSpec)' is not a reference assembly project and does not set 'ProduceReferenceAssembly'." />
+    <Error Text="Reference assemblies must only reference other reference assemblies and '%(ReferencePath.ProjectReferenceOriginalItemSpec)' is not a reference assembly project and does not set 'ProduceReferenceAssembly'."
+           Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference' and '%(ReferencePath.IsReferenceAssemblyProject)' != 'true' and '%(ReferencePath.ReferenceAssembly)' == ''" />
+    <Error Text="Reference assemblies must be TargetPlatform agnostic. $(MSBuildProjectName) incorrectly targets $(TargetFramework), platform: $(TargetPlatformIdentifier)."
+           Condition="'$(TargetPlatformIdentifier)' != ''" />
   </Target>
 
   <!-- An opt-in target to trim out private assemblies from the ref assembly ReferencePath. -->
@@ -92,13 +94,12 @@
     </ItemGroup>
   </Target>
 
-    <!-- For experimental ref assemblies (which typically have the same name as a regular ref
+  <!-- For experimental ref assemblies (which typically have the same name as a regular ref
        assembly), bump their minor file version by 100 to make it distinguishable from the regular
-       ref assembly.
-  -->
+       ref assembly. -->
   <Target Name="UpdateExperimentalRefAssemblyFileVersion"
           AfterTargets="_InitializeAssemblyVersion"
-	  Condition="'$(IsReferenceAssemblyProject)' == 'true' and '$(IsExperimentalRefAssembly)' == 'true'">
+	        Condition="'$(IsReferenceAssemblyProject)' == 'true' and '$(IsExperimentalRefAssembly)' == 'true'">
     <PropertyGroup>
       <_FileVersionMaj>$(FileVersion.Split('.')[0])</_FileVersionMaj>
       <_FileVersionMin>$(FileVersion.Split('.')[1])</_FileVersionMin>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/29154. I didn't introduce a new target to keep the validation cost as low as possible.