### PR TITLE
Substitute GT_RET_EXPR in inline candidate arguments

### DIFF
--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1663,12 +1663,10 @@ Statement* Compiler::fgInlinePrependStatements(InlineInfo* inlineInfo)
                         // This helper call is marked as a "Special DCE" helper during
                         // importation, over in fgGetStaticsCCtorHelper.
                         //
-                        // (2) NYI. If, after tunneling through GT_RET_VALs, we find that
-                        // the actual arg expression has no side effects, we can skip
-                        // appending all together. This will help jit TP a bit.
+                        // (2) NYI. If we find that the actual arg expression
+                        // has no side effects, we can skip appending all
+                        // together. This will help jit TP a bit.
                         //
-                        // Chase through any GT_RET_EXPRs to find the actual argument
-                        // expression.
                         assert(!argNode->OperIs(GT_RET_EXPR));
 
                         // For case (1)

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -721,7 +721,7 @@ Compiler::fgWalkResult Compiler::fgLateDevirtualization(GenTree** pTree, fgWalkD
             const bool             isLateDevirtualization = true;
             const bool             explicitTailCall       = call->IsTailPrefixedCall();
 
-            if ((call->gtCallMoreFlags & GTF_CALL_M_LATE_DEVIRT) != 0)
+            if ((call->gtCallMoreFlags & GTF_CALL_M_HAS_LATE_DEVIRT_INFO) != 0)
             {
                 context = call->gtLateDevirtualizationInfo->exactContextHnd;
                 // Note: we might call this multiple times for the same trees.

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -138,6 +138,15 @@ PhaseStatus Compiler::fgInline()
                 // they belong.
                 if (call->IsInlineCandidate() || call->IsGuardedDevirtualizationCandidate())
                 {
+                    // Yes. We may still have GT_RET_EXPR in arguments,
+                    // substitute those here so the inlinee does not need to
+                    // deal with them.
+                    // Note that we leave late devirts in arguments for when we
+                    // handle inlined statements as fgLateDevirtualization
+                    // cannot handle being called twice on a late devirt
+                    // candidate.
+                    fgWalkTree(stmt->GetRootNodePointer(), fgUpdateInlineReturnExpressionPlaceHolder, nullptr, &madeChanges);
+
                     InlineResult inlineResult(this, call, stmt, "fgInline");
 
                     fgMorphStmt = stmt;

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -187,7 +187,7 @@ PhaseStatus Compiler::fgInline()
             // replacement may have enabled optimizations by providing more
             // specific types for trees or variables.
             fgWalkTree(stmt->GetRootNodePointer(), fgUpdateInlineReturnExpressionPlaceHolder, fgLateDevirtualization,
-                       (void*)&madeChanges);
+                       &madeChanges);
 
             // See if stmt is of the form GT_COMMA(call, nop)
             // If yes, we can get rid of GT_COMMA.

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6161,42 +6161,6 @@ GenTree* GenTree::gtGetParent(GenTree*** pUse)
     return user;
 }
 
-//-------------------------------------------------------------------------
-// gtRetExprVal - walk back through GT_RET_EXPRs
-//
-// Arguments:
-//    pbbFlags - out-parameter that is set to the flags of the basic block
-//               containing the inlinee return value. The value is 0
-//               for unsuccessful inlines.
-//
-// Returns:
-//    tree representing return value from a successful inline,
-//    or original call for failed or yet to be determined inline.
-//
-// Notes:
-//    Multi-level inlines can form chains of GT_RET_EXPRs.
-//    This method walks back to the root of the chain.
-//
-GenTree* GenTree::gtRetExprVal(BasicBlockFlags* pbbFlags /* = nullptr */)
-{
-    GenTree*        retExprVal = this;
-    BasicBlockFlags bbFlags    = BBF_EMPTY;
-
-    while (retExprVal->OperIs(GT_RET_EXPR))
-    {
-        const GenTreeRetExpr* retExpr = retExprVal->AsRetExpr();
-        bbFlags                       = retExpr->bbFlags;
-        retExprVal                    = retExpr->gtInlineCandidate;
-    }
-
-    if (pbbFlags != nullptr)
-    {
-        *pbbFlags = bbFlags;
-    }
-
-    return retExprVal;
-}
-
 //------------------------------------------------------------------------------
 // OperRequiresAsgFlag : Check whether the operation requires GTF_ASG flag regardless
 //                       of the children's flags.

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3757,7 +3757,7 @@ enum GenTreeCallFlags : unsigned int
     GTF_CALL_M_EXP_RUNTIME_LOOKUP      = 0x02000000, // this call needs to be tranformed into CFG for the dynamic dictionary expansion feature.
     GTF_CALL_M_STRESS_TAILCALL         = 0x04000000, // the call is NOT "tail" prefixed but GTF_CALL_M_EXPLICIT_TAILCALL was added because of tail call stress mode
     GTF_CALL_M_EXPANDED_EARLY          = 0x08000000, // the Virtual Call target address is expanded and placed in gtControlExpr in Morph rather than in Lower
-    GTF_CALL_M_LATE_DEVIRT             = 0x10000000, // this call has late devirtualzation info
+    GTF_CALL_M_HAS_LATE_DEVIRT_INFO    = 0x10000000, // this call has late devirtualzation info
 };
 
 inline constexpr GenTreeCallFlags operator ~(GenTreeCallFlags a)

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1762,9 +1762,6 @@ public:
 
     inline GenTree* gtCommaAssignVal();
 
-    // Tunnel through any GT_RET_EXPRs
-    GenTree* gtRetExprVal(BasicBlockFlags* pbbFlags = nullptr);
-
     // Return the child of this node if it is a GT_RELOAD or GT_COPY; otherwise simply return the node itself
     inline GenTree* gtSkipReloadOrCopy();
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10032,7 +10032,7 @@ DONE_CALL:
                     (origCall->gtClassProfileCandidateInfo == nullptr))
                 {
                     JITDUMP("\nSaving context %p for call [%06u]\n", exactContextHnd, dspTreeID(origCall));
-                    origCall->gtCallMoreFlags |= GTF_CALL_M_LATE_DEVIRT;
+                    origCall->gtCallMoreFlags |= GTF_CALL_M_HAS_LATE_DEVIRT_INFO;
                     LateDevirtualizationInfo* const info = new (this, CMK_Inlining) LateDevirtualizationInfo;
                     info->exactContextHnd                = exactContextHnd;
                     origCall->gtLateDevirtualizationInfo = info;
@@ -21300,7 +21300,7 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
     // it's a union field used for other things by virtual
     // stubs)
     call->gtInlineCandidateInfo = nullptr;
-    call->gtCallMoreFlags &= ~GTF_CALL_M_LATE_DEVIRT;
+    call->gtCallMoreFlags &= ~GTF_CALL_M_HAS_LATE_DEVIRT_INFO;
 
 #if defined(DEBUG)
     if (verbose)

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -19572,7 +19572,7 @@ void Compiler::impInlineRecordArgInfo(InlineInfo*   pInlineInfo,
     inlCurArgInfo->arg = arg;
     GenTree* curArgVal = arg->GetNode();
 
-    curArgVal = curArgVal->gtRetExprVal();
+    assert(!curArgVal->OperIs(GT_RET_EXPR));
 
     if (curArgVal->gtOper == GT_MKREFANY)
     {
@@ -20168,7 +20168,8 @@ GenTree* Compiler::impInlineFetchArg(unsigned lclNum, InlArgInfo* inlArgInfo, In
     const var_types      lclTyp           = lclInfo.lclTypeInfo;
     GenTree*             op1              = nullptr;
 
-    GenTree* argNode = argInfo.arg->GetNode()->gtRetExprVal();
+    GenTree* argNode = argInfo.arg->GetNode();
+    assert(!argNode->OperIs(GT_RET_EXPR));
 
     if (argInfo.argIsInvariant && !argCanBeModified)
     {

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -21300,6 +21300,7 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
     // it's a union field used for other things by virtual
     // stubs)
     call->gtInlineCandidateInfo = nullptr;
+    call->gtCallMoreFlags &= ~GTF_CALL_M_LATE_DEVIRT;
 
 #if defined(DEBUG)
     if (verbose)


### PR DESCRIPTION
These `GT_RET_EXPR` nodes would previously make it into the inlinees as part of the inline argument table. This was confusing to me, and it additionally means that we call `gtRetExprVal()` in a few places to compensate (while for non-toplevel cases it would essentially cause the argument node containing the `GT_RET_EXPR` to become "opaque" to the JIT). With this change we only ever expect to substitute `GT_RET_EXPR` inside `fgUpdateInlineReturnExpressionPlaceHolder` called from the main `fgInline` loop, so I have inlined `gtRetExprVal()` here and removed that function.