### PR TITLE
Fix linker tests not running and show full path during trimming test execution

### DIFF
--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -31,16 +31,16 @@
       <!-- We need to separate Item metadata declaration in two in order to be able to use ProjectDir and TestRuntimeIdentifier below -->
       <TestConsoleAppSourceFiles>
         <ProjectFile>%(ProjectDir)project.csproj</ProjectFile>
-        <TestCommand Condition="'$(TargetArchitecture)' != 'wasm' Or '$(TargetOs)' != 'browser'">$([MSBuild]::NormalizePath('%(ProjectDir)', 'bin', '$(Configuration)', '%(TargetFramework)', '%(TestRuntimeIdentifier)', 'publish', 'project'))</TestCommand>
-        <TestCommand Condition="'$(TargetArchitecture)' == 'wasm' And '$(TargetOs)' == 'browser'">$([MSBuild]::NormalizePath('%(ProjectDir)', 'bin', '$(Configuration)', '%(TargetFramework)', '%(TestRuntimeIdentifier)', 'AppBundle', 'run-v8.sh'))</TestCommand>
-        <TestExecutionDirectory Condition="'$(TargetArchitecture)' != 'wasm' Or '$(TargetOs)' != 'browser'">$([MSBuild]::NormalizeDirectory('%(ProjectDir)', 'bin', '$(Configuration)', '%(TargetFramework)', '%(TestRuntimeIdentifier)', 'publish'))</TestExecutionDirectory>
-        <TestExecutionDirectory Condition="'$(TargetArchitecture)' == 'wasm' And '$(TargetOs)' == 'browser'">$([MSBuild]::NormalizeDirectory('%(ProjectDir)', 'bin', '$(Configuration)', '%(TargetFramework)', '%(TestRuntimeIdentifier)', 'AppBundle'))</TestExecutionDirectory>
+        <TestCommand Condition="'$(TargetArchitecture)' != 'wasm' or '$(TargetOS)' != 'browser'">$([MSBuild]::NormalizePath('%(ProjectDir)', 'bin', '$(Configuration)', '%(TargetFramework)', '%(TestRuntimeIdentifier)', 'publish', 'project'))</TestCommand>
+        <TestCommand Condition="'$(TargetArchitecture)' == 'wasm' and '$(TargetOS)' == 'browser'">$([MSBuild]::NormalizePath('%(ProjectDir)', 'bin', '$(Configuration)', '%(TargetFramework)', '%(TestRuntimeIdentifier)', 'AppBundle', 'run-v8.sh'))</TestCommand>
+        <TestExecutionDirectory Condition="'$(TargetArchitecture)' != 'wasm' or '$(TargetOS)' != 'browser'">$([MSBuild]::NormalizeDirectory('%(ProjectDir)', 'bin', '$(Configuration)', '%(TargetFramework)', '%(TestRuntimeIdentifier)', 'publish'))</TestExecutionDirectory>
+        <TestExecutionDirectory Condition="'$(TargetArchitecture)' == 'wasm' and '$(TargetOS)' == 'browser'">$([MSBuild]::NormalizeDirectory('%(ProjectDir)', 'bin', '$(Configuration)', '%(TargetFramework)', '%(TestRuntimeIdentifier)', 'AppBundle'))</TestExecutionDirectory>
       </TestConsoleAppSourceFiles>
     </ItemGroup>
 
     <ItemGroup Condition="!$(SkipOnTestRuntimes.Contains('$(PackageRID)'))">
       <TestConsoleApps Include="@(TestConsoleAppSourceFiles->'%(ProjectFile)')" Condition="!$([System.String]::Copy('%(TestConsoleAppSourceFiles.SkipOnTestRuntimes)').Contains('$(PackageRID)'))">
-        <ProjectCompileItems>%(Identity)</ProjectCompileItems>
+        <ProjectCompileItems>%(FullPath)</ProjectCompileItems>
       </TestConsoleApps>
       <TestConsoleApps AdditionalProperties="MSBuildEnableWorkloadResolver=$(MSBuildEnableWorkloadResolver)" Condition="'$(MSBuildEnableWorkloadResolver)' != ''" />
     </ItemGroup>
@@ -134,12 +134,12 @@
           Outputs="_unused"
           Condition="'$(ArchiveTests)' != 'true'">
 
-    <Message Importance="High" Text="[Trimming Tests] Running test: %(TestConsoleApps.ProjectCompileItems)..." />
+    <Message Importance="High" Text="[Trimming Tests] Running test: %(TestConsoleApps.ProjectCompileItems) ..." />
     <Exec IgnoreExitCode="true" Command="%(TestConsoleApps.TestCommand)" StandardOutputImportance="Low" WorkingDirectory="%(TestConsoleApps.TestExecutionDirectory)">
       <Output TaskParameter="ExitCode" PropertyName="ExecutionExitCode" />
     </Exec>
 
-    <Error Condition="'$(ExecutionExitCode)' != '100'" Text="Error: [Failed Test]: %(TestConsoleApps.ProjectCompileItems) The Command %(TestConsoleApps.TestCommand) return a non-success exit code." ContinueOnError="ErrorAndContinue" />
+    <Error Condition="'$(ExecutionExitCode)' != '100'" Text="Error: [Failed Test]: %(TestConsoleApps.ProjectCompileItems). The Command %(TestConsoleApps.TestCommand) return a non-success exit code." ContinueOnError="ErrorAndContinue" />
   </Target>
 
   <Target Name="Build" DependsOnTargets="ExecuteApplications" />

--- a/src/libraries/System.Runtime/tests/TrimmingTests/InvariantGlobalizationTrue.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/InvariantGlobalizationTrue.cs
@@ -29,7 +29,7 @@ class Program
         }
         
         // Ensure the internal GlobalizationMode class is trimmed correctly.
-        Type globalizationMode = typeof(object).Assembly.GetType("System.Globalization.GlobalizationMode", throwOnError: false);
+        Type globalizationMode = GetCoreLibType("System.Globalization.GlobalizationMode");
 
         if (OperatingSystem.IsWindows())
         {
@@ -55,9 +55,14 @@ class Program
         // On non Windows platforms, the full type is trimmed.
         else if (globalizationMode is not null)
         {
-            return -4;
+            Console.WriteLine("It is expected to have System.Globalization.GlobalizationMode type trimmed in non-Windows platforms");
+            return -5;
         }
 
         return 100;
-    }        
+    }
+
+    // The intention of this method is to ensure the trimmer doesn't preserve the Type.
+    private static Type GetCoreLibType(string name) =>
+        typeof(object).Assembly.GetType(name, throwOnError: false);
 }

--- a/src/libraries/System.Runtime/tests/TrimmingTests/InvariantGlobalizationTrue.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/InvariantGlobalizationTrue.cs
@@ -27,12 +27,12 @@ class Program
         {
             return -3;
         }
+        
+        // Ensure the internal GlobalizationMode class is trimmed correctly.
+        Type globalizationMode = typeof(object).Assembly.GetType("System.Globalization.GlobalizationMode", throwOnError: false);
 
         if (OperatingSystem.IsWindows())
         {
-            // Ensure the internal GlobalizationMode class is trimmed correctly
-            Type globalizationMode = GetCoreLibType("System.Globalization.GlobalizationMode");
-            
             foreach (MemberInfo member in globalizationMode.GetMembers(allStatics))
             {
                 // properties and their backing getter methods are OK
@@ -52,10 +52,12 @@ class Program
                 return -4;
             }
         }
+        // On non Windows platforms, the full type is trimmed.
+        else if (globalizationMode is not null)
+        {
+            return -4;
+        }
 
         return 100;
-    }
-
-    private static Type GetCoreLibType(string name) =>
-        typeof(object).Assembly.GetType(name, throwOnError: true);
+    }        
 }

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -4,7 +4,7 @@
     <!-- Build for NetCoreAppCurrent by default if no BuildTargetFramework is supplied or if not all configurations are built. -->
     <TargetFramework>$([MSBuild]::ValueOrDefault('$(BuildTargetFramework)', '$(NetCoreAppCurrent)'))-$(TargetOS)</TargetFramework>
     <!-- Filter ProjectReferences to build the best matching target framework only. -->
-    <FilterTraversalProjectReferences>true</FilterTraversalProjectReferences>
+    <FilterTraversalProjectReferences Condition="'$(TestTrimming)' != 'true'">true</FilterTraversalProjectReferences>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/38377
Fixes https://github.com/dotnet/runtime/issues/69139

Also addresses @danmoseley's additional feedback regarding separating the "..." from the path.