### PR TITLE
[release/6.0] Deadlock mitigation for debugging

### DIFF
--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -513,6 +513,7 @@ RETAIL_CONFIG_DWORD_INFO(EXTERNAL_ProfAPI_DetachMinSleepMs, W("ProfAPI_DetachMin
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_ProfAPI_DetachMaxSleepMs, W("ProfAPI_DetachMaxSleepMs"), 0, "The maximum time, in milliseconds, the CLR will wait before checking whether a profiler that is in the process of detaching is ready to be unloaded.")
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_ProfAPI_RejitOnAttach, W("ProfApi_RejitOnAttach"), 1, "Enables the ability for profilers to rejit methods on attach.")
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_ProfAPI_InliningTracking, W("ProfApi_InliningTracking"), 1, "Enables the runtime's tracking of inlining for profiler ReJIT.")
+RETAIL_CONFIG_DWORD_INFO(EXTERNAL_DebuggerLaunchDisablesCodeVersioning, W("EXTERNAL_DebuggerLaunchDisablesCodeVersioning"), 1, "Attaching a debugger at startup will disable TieredCompilation and RejitOnAttach.")
 CONFIG_DWORD_INFO(INTERNAL_ProfAPI_EnableRejitDiagnostics, W("ProfAPI_EnableRejitDiagnostics"), 0, "Enable extra dumping to stdout of rejit structures")
 CONFIG_DWORD_INFO(INTERNAL_ProfAPIFault, W("ProfAPIFault"), 0, "Test-only bitmask to inject various types of faults in the profapi code")
 CONFIG_DWORD_INFO(INTERNAL_TestOnlyAllowedEventMask, W("TestOnlyAllowedEventMask"), 0, "Test-only bitmask to allow profiler tests to override CLR enforcement of COR_PRF_ALLOWABLE_AFTER_ATTACH and COR_PRF_MONITOR_IMMUTABLE")

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -2001,6 +2001,11 @@ static void InitializeDebugger(void)
         }
     }
 
+    static ConfigDWORD debuggerDisablesCodeVersioning;
+    if( (debuggerDisablesCodeVersioning.val(CLRConfig::EXTERNAL_DebuggerLaunchDisablesCodeVersioning) != 0) && CORDebuggerAttached())
+    {
+        g_pConfig->DisableDefaultCodeVersioning();
+    }
 
     LOG((LF_CORDB, LL_INFO10, "Left-side debugging services setup.\n"));
 

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -2004,6 +2004,7 @@ static void InitializeDebugger(void)
     static ConfigDWORD debuggerDisablesCodeVersioning;
     if( (debuggerDisablesCodeVersioning.val(CLRConfig::EXTERNAL_DebuggerLaunchDisablesCodeVersioning) != 0) && CORDebuggerAttached())
     {
+        LOG((LF_CORDB, LL_INFO10, "Debugger is active at startup, disabling code versioning to prevent a potential deadlock.\n"));
         g_pConfig->DisableDefaultCodeVersioning();
     }
 

--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -237,6 +237,8 @@ HRESULT EEConfig::Init()
     bDiagnosticSuspend = false;
 #endif
 
+    fDisableDefaultCodeVersioning = false;
+
 #if defined(FEATURE_TIERED_COMPILATION)
     fTieredCompilation = false;
     fTieredCompilation_QuickJit = false;

--- a/src/coreclr/vm/eeconfig.h
+++ b/src/coreclr/vm/eeconfig.h
@@ -77,17 +77,20 @@ public:
     bool          JitFramed(void)                           const {LIMITED_METHOD_CONTRACT;  return fJitFramed; }
     bool          JitMinOpts(void)                          const {LIMITED_METHOD_CONTRACT;  return fJitMinOpts; }
 
+    void          DisableDefaultCodeVersioning()            { fDisableDefaultCodeVersioning = TRUE; }
+    bool          DefaultCodeVersioningDisabled()           const {LIMITED_METHOD_CONTRACT;  return fDisableDefaultCodeVersioning; }
+
     // Tiered Compilation config
 #if defined(FEATURE_TIERED_COMPILATION)
-    bool          TieredCompilation(void)           const { LIMITED_METHOD_CONTRACT;  return fTieredCompilation; }
-    bool          TieredCompilation_QuickJit() const { LIMITED_METHOD_CONTRACT; return fTieredCompilation_QuickJit; }
-    bool          TieredCompilation_QuickJitForLoops() const { LIMITED_METHOD_CONTRACT; return fTieredCompilation_QuickJitForLoops; }
-    DWORD         TieredCompilation_BackgroundWorkerTimeoutMs() const { LIMITED_METHOD_CONTRACT; return tieredCompilation_BackgroundWorkerTimeoutMs; }
-    bool          TieredCompilation_CallCounting()  const { LIMITED_METHOD_CONTRACT; return fTieredCompilation_CallCounting; }
-    UINT16        TieredCompilation_CallCountThreshold() const { LIMITED_METHOD_CONTRACT; return tieredCompilation_CallCountThreshold; }
-    DWORD         TieredCompilation_CallCountingDelayMs() const { LIMITED_METHOD_CONTRACT; return tieredCompilation_CallCountingDelayMs; }
-    bool          TieredCompilation_UseCallCountingStubs() const { LIMITED_METHOD_CONTRACT; return fTieredCompilation_UseCallCountingStubs; }
-    DWORD         TieredCompilation_DeleteCallCountingStubsAfter() const { LIMITED_METHOD_CONTRACT; return tieredCompilation_DeleteCallCountingStubsAfter; }
+    bool          TieredCompilation(void)           const { LIMITED_METHOD_CONTRACT;  return fTieredCompilation && !fDisableDefaultCodeVersioning; }
+    bool          TieredCompilation_QuickJit() const { LIMITED_METHOD_CONTRACT; return fTieredCompilation_QuickJit && !fDisableDefaultCodeVersioning; }
+    bool          TieredCompilation_QuickJitForLoops() const { LIMITED_METHOD_CONTRACT; return fTieredCompilation_QuickJitForLoops && !fDisableDefaultCodeVersioning; }
+    DWORD         TieredCompilation_BackgroundWorkerTimeoutMs() const { LIMITED_METHOD_CONTRACT; return fDisableDefaultCodeVersioning ? 0 : tieredCompilation_BackgroundWorkerTimeoutMs; }
+    bool          TieredCompilation_CallCounting()  const { LIMITED_METHOD_CONTRACT; return fTieredCompilation_CallCounting && !fDisableDefaultCodeVersioning; }
+    UINT16        TieredCompilation_CallCountThreshold() const { LIMITED_METHOD_CONTRACT; return fDisableDefaultCodeVersioning ? 1 : tieredCompilation_CallCountThreshold; }
+    DWORD         TieredCompilation_CallCountingDelayMs() const { LIMITED_METHOD_CONTRACT; return fDisableDefaultCodeVersioning ? 0 : tieredCompilation_CallCountingDelayMs; }
+    bool          TieredCompilation_UseCallCountingStubs() const { LIMITED_METHOD_CONTRACT; return fTieredCompilation_UseCallCountingStubs && !fDisableDefaultCodeVersioning; }
+    DWORD         TieredCompilation_DeleteCallCountingStubsAfter() const { LIMITED_METHOD_CONTRACT; return fDisableDefaultCodeVersioning ? 0 : tieredCompilation_DeleteCallCountingStubsAfter; }
 #endif
 
 #if defined(FEATURE_ON_STACK_REPLACEMENT)
@@ -676,6 +679,8 @@ private: //----------------------------------------------------------------
     DWORD fShouldInjectFault;
     DWORD testThreadAbort;
 #endif
+
+    bool fDisableDefaultCodeVersioning;
 
 #if defined(FEATURE_TIERED_COMPILATION)
     bool fTieredCompilation;

--- a/src/coreclr/vm/rejit.inl
+++ b/src/coreclr/vm/rejit.inl
@@ -28,7 +28,7 @@ inline BOOL ReJitManager::IsReJITEnabled()
     static bool profilerStartupRejit = CORProfilerEnableRejit() != FALSE;
     static ConfigDWORD rejitOnAttachEnabled;
 
-    return  profilerStartupRejit || (rejitOnAttachEnabled.val(CLRConfig::EXTERNAL_ProfAPI_RejitOnAttach) != 0);
+    return  profilerStartupRejit || ((rejitOnAttachEnabled.val(CLRConfig::EXTERNAL_ProfAPI_RejitOnAttach) != 0) && !g_pConfig->DefaultCodeVersioningDisabled());
 }
 
 inline BOOL ReJitManager::IsReJITInlineTrackingEnabled()
@@ -36,7 +36,7 @@ inline BOOL ReJitManager::IsReJITInlineTrackingEnabled()
     LIMITED_METHOD_CONTRACT;
 
     static ConfigDWORD rejitInliningEnabled;
-    return rejitInliningEnabled.val(CLRConfig::EXTERNAL_ProfAPI_RejitOnAttach) != 0;
+    return rejitInliningEnabled.val(CLRConfig::EXTERNAL_ProfAPI_RejitOnAttach) != 0 && !g_pConfig->DefaultCodeVersioningDisabled();
 }
 
 #ifndef DACCESS_COMPILE


### PR DESCRIPTION
## Customer impact
We have had multiple reports of the runtime deadlocking during debugging, e.g. #58471. Kount fixed it for 7 the "right way" with https://github.com/dotnet/runtime/pull/67160, but that fix is far too broad for servicing in 6.0. This targeted fix disables code versioning (through both profiler rejit and tiered compilation) when debugging from startup. It does not change the debugger attach behavior.

We have had reports from multiple different customers about this issue, there are likely many more running in to it daily that haven't figured it out and tracked us down.

## Testing
I did manual verification that the flag was set when a debugger is present at startup and is not set when a debugger attaches, plus ran the private diagnostic test suite.

## Risk
The risk is low, and in case someone depends on being able to debug from startup and have code versioning active they can set the flag to disable this fix.