### PR TITLE
[GDBJIT] Fix "section extending past end of file" warning

### DIFF
--- a/src/coreclr/vm/gdbjit.cpp
+++ b/src/coreclr/vm/gdbjit.cpp
@@ -2164,7 +2164,7 @@ void Elf_Builder::Initialize(PCODE codePtr, TADDR codeLen)
     //
     // Create '.text' section
     //
-    Elf_SectionTracker *text = OpenSection(".text", SHT_PROGBITS, SHF_ALLOC | SHF_EXECINSTR);
+    Elf_SectionTracker *text = OpenSection(".text", SHT_NOBITS, SHF_ALLOC | SHF_EXECINSTR);
     {
         text->DisableHeaderUpdate();
         text->Header()->sh_addr = codePtr;


### PR DESCRIPTION
GDB frequently prints the following complaint:

    BFD: warning: <in-memory> has a section extending past end of file
    warning: Discarding section .text which has a section size (28e) larger than the file size [in module <in-memory>]

The problem is that GDBJIT emits the .text section with the type
SHT_PROGBITS, but does not provide any contents. Fix by using
SHT_NOBITS instead - this is how .text in separate debuginfo normally
looks like.