### PR TITLE
Increase helix job timeout for win-arm64 to 300 minutes

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -136,7 +136,7 @@ jobs:
 
     - name: testTreeFilterArg
       value: ''
-    
+
     # Only build GCSimulator tests when the gc-simulator group is specified.
     - ${{ if eq(parameters.testGroup, 'gc-simulator') }}:
       - ${{ if eq(parameters.osGroup, 'windows') }}:
@@ -223,7 +223,10 @@ jobs:
 
     # TODO: update these numbers as they were determined long ago
     ${{ if eq(parameters.testGroup, 'innerloop') }}:
-      timeoutInMinutes: 200
+      ${{ if and(eq(parameters.osGroup, 'windows'), eq(parameters.archType, 'arm64')) }}:
+        timeoutInMinutes: 300
+      ${{ else }}:
+        timeoutInMinutes: 200
     ${{ if in(parameters.testGroup, 'outerloop', 'jit-experimental', 'pgo', 'jit-cfg') }}:
       timeoutInMinutes: 270
     ${{ if in(parameters.testGroup, 'gc-longrunning', 'gc-simulator') }}:


### PR DESCRIPTION
The capacity of this queue is still not back to normal levels and we are still seeing widespread timeouts. It was suggested that we increase the timeout here as a mitigation (for an example case, @MattGal noted that around ~30 minutes more would have been enough to get results). This adds 100 minutes to the timeout.