### PR TITLE
Revert "Add the capability to walk up the inheritance chain for GetMemberWithSameMetadataDefinitionAs"

### DIFF
--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.GetMember.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.GetMember.cs
@@ -123,22 +123,7 @@ namespace System.Reflection.Runtime.TypeInfos
             if (member is null)
                 throw new ArgumentNullException(nameof(member));
 
-            // Need to walk up the inheritance chain if member is not found
-            // Leverage the existing cache mechanism of per type to store members
-            RuntimeTypeInfo? runtimeType = this;
-            while (runtimeType != null)
-            {
-                MemberInfo result = runtimeType.GetDeclaredMemberWithSameMetadataDefinitionAs(member);
-                if (result != null)
-                    return result;
-                runtimeType = runtimeType.BaseType as RuntimeTypeInfo;
-            }
-            throw new ArgumentException(SR.Format(SR.Arg_MemberInfoNotFound, member.Name), nameof(member));
-        }
-
-        private MemberInfo GetDeclaredMemberWithSameMetadataDefinitionAs(MemberInfo member)
-        {
-            return member.MemberType switch
+            MemberInfo result = member.MemberType switch
             {
                 MemberTypes.Method => QueryMemberWithSameMetadataDefinitionAs<MethodInfo>(member),
                 MemberTypes.Constructor => QueryMemberWithSameMetadataDefinitionAs<ConstructorInfo>(member),
@@ -148,6 +133,11 @@ namespace System.Reflection.Runtime.TypeInfos
                 MemberTypes.NestedType => QueryMemberWithSameMetadataDefinitionAs<Type>(member),
                 _ => null,
             };
+
+            if (result is null)
+                throw new ArgumentException(SR.Format(SR.Arg_MemberInfoNotFound, member.Name), nameof(member));
+
+            return result;
         }
 
         private M QueryMemberWithSameMetadataDefinitionAs<M>(MemberInfo member) where M : MemberInfo

--- a/src/libraries/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/TypeInfoTests.cs
@@ -1656,6 +1656,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory, MemberData(nameof(GetMemberWithSameMetadataDefinitionAsData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/67533", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void GetMemberWithSameMetadataDefinitionAs(Type openGenericType, Type closedGenericType, bool checkDeclaringType)
         {
             BindingFlags all = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly;

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -377,8 +377,6 @@
     <!-- Run only a small randomly chosen set of passing test suites -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\*.Tests.csproj" />
     <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Collections\tests\System.Collections.Tests.csproj" />
-    <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Reflection\tests\System.Reflection.Tests.csproj" />
-    <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Reverts dotnet/runtime#69057 to resolve https://github.com/dotnet/runtime/issues/69136