### PR TITLE
Fix typo in AssemblyName handling

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -356,7 +356,7 @@ namespace System.Reflection
             byte[]? publicKeyOrToken;
             if ((publicKeyOrToken = assemblyName.RawPublicKeyToken) != null)
             {
-                flags |= ~AssemblyNameFlags.PublicKey;
+                flags &= ~AssemblyNameFlags.PublicKey;
             }
             else if ((publicKeyOrToken = assemblyName.RawPublicKey) != null)
             {

--- a/src/libraries/System.Reflection/tests/AssemblyTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyTests.cs
@@ -697,6 +697,28 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        public void AssemblyLoadWithPublicKey()
+        {
+            AssemblyName an = new AssemblyName("System.Runtime");
+
+            Assembly a = Assembly.Load(an);
+
+            byte[] publicKey = a.GetName().GetPublicKey();
+            Assert.True(publicKey.Length > 0);
+            an.SetPublicKey(publicKey);
+
+            Assembly a1 = Assembly.Load(an);
+            Assert.Equal(a, a1);
+
+            // Force the public key token to be created
+            Assert.True(an.GetPublicKeyToken().Length > 0);
+
+            // Verify that we can still load the assembly
+            Assembly a2 = Assembly.Load(an);
+            Assert.Equal(a, a2);
+        }
+
+        [Fact]
         public void AssemblyLoadFromString()
         {
             AssemblyName an = typeof(AssemblyTests).Assembly.GetName();


### PR DESCRIPTION
Fix typo in AssemblyName handling and add test that catches the bug introduced by the typo