### PR TITLE
Update minimum required version of VS to 17.3

### DIFF
--- a/docs/workflow/requirements/windows-requirements.md
+++ b/docs/workflow/requirements/windows-requirements.md
@@ -19,7 +19,7 @@ git config --system core.longpaths true
 
 ## Visual Studio
 
-- Install [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/). The Community edition is available free of charge.
+- Install [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/). The Community edition is available free of charge. Visual Studio 2022 17.3 or later is required.
 
 Visual Studio 2022 installation process:
 - It's recommended to use **Workloads** installation approach. The following are the minimum requirements:
@@ -36,8 +36,6 @@ Visual Studio 2022 installation process:
   - **C++/CLI support for v142 build tools (Latest)** (v14.23 or newer).
 
 A `.vsconfig` file is included in the root of the dotnet/runtime repository that includes all components needed to build the dotnet/runtime repository. You can [import `.vsconfig` in your Visual Studio installer](https://docs.microsoft.com/en-us/visualstudio/install/import-export-installation-configurations?view=vs-2022#import-a-configuration) to install all necessary components. You may get a message saying  'Microsoft.Net.Component.4.5.2.TargetingPack has no matching workload or component found'. This is not an issue as long as you have a newer targeting pack installed.
-
-Visual Studio 2022 or later is required.
 
 ## Build Tools
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/68764

The in the above issue mentioned warnings are resolved by using VS 17.3 (currently Preview1).