### PR TITLE
Normalize Nil PublicKeyToken to an empty array

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.netstandard.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.netstandard.cs
@@ -17,7 +17,7 @@ namespace System.Reflection.Metadata
             // compat: normalize Nil culture name to "" to match original behavior of AssemblyName.GetAssemblyName()
             string cultureName = (!cultureHandle.IsNil) ? GetString(cultureHandle) : "";
             var hashAlgorithm = (Configuration.Assemblies.AssemblyHashAlgorithm)assemblyHashAlgorithm;
-            // compat: normalize Nil token to empty array to match original behavior of AssemblyName.GetAssemblyName()
+            // compat: native BaseAssemblySpec::Init guarantees that publicKeyOrToken is never null.
             byte[]? publicKeyOrToken = !publicKeyOrTokenHandle.IsNil ? GetBlobBytes(publicKeyOrTokenHandle) : Array.Empty<byte>();
 
             var assemblyName = new AssemblyName()

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.netstandard.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.netstandard.cs
@@ -17,7 +17,7 @@ namespace System.Reflection.Metadata
             // compat: normalize Nil culture name to "" to match original behavior of AssemblyName.GetAssemblyName()
             string cultureName = (!cultureHandle.IsNil) ? GetString(cultureHandle) : "";
             var hashAlgorithm = (Configuration.Assemblies.AssemblyHashAlgorithm)assemblyHashAlgorithm;
-            // compat: native BaseAssemblySpec::Init guarantees that publicKeyOrToken is never null.
+            // compat: original native implementation used to guarantee that publicKeyOrToken is never null in this scenario.
             byte[]? publicKeyOrToken = !publicKeyOrTokenHandle.IsNil ? GetBlobBytes(publicKeyOrTokenHandle) : Array.Empty<byte>();
 
             var assemblyName = new AssemblyName()

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.netstandard.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.netstandard.cs
@@ -20,8 +20,9 @@ namespace System.Reflection.Metadata
             // compat: normalize Nil token to empty array to match original behavior of AssemblyName.GetAssemblyName()
             byte[]? publicKeyOrToken = !publicKeyOrTokenHandle.IsNil ? GetBlobBytes(publicKeyOrTokenHandle) : Array.Empty<byte>();
 
-            var assemblyName = new AssemblyName(name)
+            var assemblyName = new AssemblyName()
             {
+                Name = name,
                 Version = version,
                 CultureName = cultureName,
 #pragma warning disable SYSLIB0037 // AssemblyName.HashAlgorithm is obsolete

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.netstandard.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.netstandard.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.IO;
 using System.IO.MemoryMappedFiles;
 using System.Reflection.PortableExecutable;
@@ -13,10 +14,11 @@ namespace System.Reflection.Metadata
         internal AssemblyName GetAssemblyName(StringHandle nameHandle, Version version, StringHandle cultureHandle, BlobHandle publicKeyOrTokenHandle, AssemblyHashAlgorithm assemblyHashAlgorithm, AssemblyFlags flags)
         {
             string name = GetString(nameHandle);
-            // compat: normalize 'null' culture name to "" to match AssemblyName.GetAssemblyName()
+            // compat: normalize Nil culture name to "" to match original behavior of AssemblyName.GetAssemblyName()
             string cultureName = (!cultureHandle.IsNil) ? GetString(cultureHandle) : "";
             var hashAlgorithm = (Configuration.Assemblies.AssemblyHashAlgorithm)assemblyHashAlgorithm;
-            byte[]? publicKeyOrToken = !publicKeyOrTokenHandle.IsNil ? GetBlobBytes(publicKeyOrTokenHandle) : null;
+            // compat: normalize Nil token to empty array to match original behavior of AssemblyName.GetAssemblyName()
+            byte[]? publicKeyOrToken = !publicKeyOrTokenHandle.IsNil ? GetBlobBytes(publicKeyOrTokenHandle) : Array.Empty<byte>();
 
             var assemblyName = new AssemblyName(name)
             {

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/AssemblyDefinition.netstandard.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/AssemblyDefinition.netstandard.cs
@@ -7,7 +7,15 @@ namespace System.Reflection.Metadata
     {
         public AssemblyName GetAssemblyName()
         {
-            return _reader.GetAssemblyName(Name, Version, Culture, PublicKey, HashAlgorithm, Flags);
+            AssemblyFlags flags = Flags;
+
+            // compat: assembly names from metadata definitions should set the bit for the full key.
+            if (!PublicKey.IsNil)
+            {
+                flags |= AssemblyFlags.PublicKey;
+            }
+
+            return _reader.GetAssemblyName(Name, Version, Culture, PublicKey, HashAlgorithm, flags);
         }
     }
 }

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/TypeSystem/AssemblyDefinitionTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/TypeSystem/AssemblyDefinitionTests.cs
@@ -27,7 +27,7 @@ namespace System.Reflection.Metadata.Tests
                 Assert.Equal(assembly.Culture, assemblyName.CultureName);
                 Assert.Equal(Configuration.Assemblies.AssemblyHashAlgorithm.SHA1, assemblyName.HashAlgorithm);
                 Assert.Null(assemblyName.GetPublicKey());
-                Assert.Null(assemblyName.GetPublicKeyToken());
+                Assert.Empty(assemblyName.GetPublicKeyToken());
                 Assert.Equal(AssemblyNameFlags.None, assemblyName.Flags);
 
                 // Validate against AssemblyDefinition
@@ -97,7 +97,7 @@ namespace System.Reflection.Metadata.Tests
                     Assert.Equal("", assemblyName.CultureName);
                     Assert.Equal(Configuration.Assemblies.AssemblyHashAlgorithm.SHA1, assemblyName.HashAlgorithm);
                     Assert.Null(assemblyName.GetPublicKey());
-                    Assert.Null(assemblyName.GetPublicKeyToken());
+                    Assert.Empty(assemblyName.GetPublicKeyToken());
                     Assert.Equal(AssemblyNameFlags.None, assemblyName.Flags);
 
                     // Validate against AssemblyDefinition


### PR DESCRIPTION
This fixes https://github.com/dotnet/runtime/issues/66785   
(I verified manually, but I also had to re-baseline couple existing tests)

Also fixes https://github.com/dotnet/runtime/issues/69153