### PR TITLE
make sure NetworkInfo works without IPv6 on Linux

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -221,7 +221,4 @@
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != '' and '$(TargetPlatformIdentifier)' != 'windows'">
     <Reference Include="System.Threading.Thread" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'linux'">
-    <Reference Include="System.Net.Socket" />
-  </ItemGroup>
 </Project>

--- a/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -221,4 +221,7 @@
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != '' and '$(TargetPlatformIdentifier)' != 'windows'">
     <Reference Include="System.Threading.Thread" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'linux'">
+    <Reference Include="System.Net.Socket" />
+  </ItemGroup>
 </Project>

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPGlobalProperties.cs
@@ -1,5 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using System.Net.Sockets;
 
 namespace System.Net.NetworkInformation
 {
@@ -7,17 +8,20 @@ namespace System.Net.NetworkInformation
     {
         public override TcpConnectionInformation[] GetActiveTcpConnections()
         {
-            return StringParsingHelpers.ParseActiveTcpConnectionsFromFiles(NetworkFiles.Tcp4ConnectionsFile, NetworkFiles.Tcp6ConnectionsFile);
+            return StringParsingHelpers.ParseActiveTcpConnectionsFromFiles(Socket.OSSupportsIPv4 ? NetworkFiles.Tcp4ConnectionsFile : null,
+                                                                           Socket.OSSupportsIPv6 ? NetworkFiles.Tcp6ConnectionsFile : null);
         }
 
         public override IPEndPoint[] GetActiveTcpListeners()
         {
-            return StringParsingHelpers.ParseActiveTcpListenersFromFiles(NetworkFiles.Tcp4ConnectionsFile, NetworkFiles.Tcp6ConnectionsFile);
+            return StringParsingHelpers.ParseActiveTcpListenersFromFiles(Socket.OSSupportsIPv4 ? NetworkFiles.Tcp4ConnectionsFile : null,
+                                                                         Socket.OSSupportsIPv6 ? NetworkFiles.Tcp6ConnectionsFile : null);
         }
 
         public override IPEndPoint[] GetActiveUdpListeners()
         {
-            return StringParsingHelpers.ParseActiveUdpListenersFromFiles(NetworkFiles.Udp4ConnectionsFile, NetworkFiles.Udp6ConnectionsFile);
+            return StringParsingHelpers.ParseActiveUdpListenersFromFiles(Socket.OSSupportsIPv4 ? NetworkFiles.Udp4ConnectionsFile : null,
+                                                                         Socket.OSSupportsIPv6 ? NetworkFiles.Udp6ConnectionsFile : null);
         }
 
         public override IcmpV4Statistics GetIcmpV4Statistics()

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
@@ -24,13 +24,30 @@ namespace System.Net.NetworkInformation
             return sockstatParser.ParseNextInt32();
         }
 
-        internal static TcpConnectionInformation[] ParseActiveTcpConnectionsFromFiles(string tcp4ConnectionsFile, string tcp6ConnectionsFile)
+        internal static TcpConnectionInformation[] ParseActiveTcpConnectionsFromFiles(string? tcp4ConnectionsFile, string? tcp6ConnectionsFile)
         {
-            string tcp4FileContents = ReadAllText(tcp4ConnectionsFile);
-            string[] v4connections = tcp4FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
+            string[] v4connections;
+            string[] v6connections;
 
-            string tcp6FileContents = ReadAllText(tcp6ConnectionsFile);
-            string[] v6connections = tcp6FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
+            if (tcp4ConnectionsFile != null)
+            {
+                string tcp4FileContents = ReadAllText(tcp4ConnectionsFile);
+                v4connections = tcp4FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
+            }
+            else
+            {
+                v4connections = Array.Empty<string>();
+            }
+
+            if (tcp6ConnectionsFile != null)
+            {
+                string tcp6FileContents = ReadAllText(tcp6ConnectionsFile);
+                v6connections = tcp6FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
+            }
+            else
+            {
+                v6connections = Array.Empty<string>();
+            }
 
             // First line is header in each file. On WSL, this file may be empty.
             int count = 0;
@@ -87,13 +104,30 @@ namespace System.Net.NetworkInformation
             return connections;
         }
 
-        internal static IPEndPoint[] ParseActiveTcpListenersFromFiles(string tcp4ConnectionsFile, string tcp6ConnectionsFile)
+        internal static IPEndPoint[] ParseActiveTcpListenersFromFiles(string? tcp4ConnectionsFile, string? tcp6ConnectionsFile)
         {
-            string tcp4FileContents = ReadAllText(tcp4ConnectionsFile);
-            string[] v4connections = tcp4FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
+            string[] v4connections;
+            string[] v6connections;
 
-            string tcp6FileContents = ReadAllText(tcp6ConnectionsFile);
-            string[] v6connections = tcp6FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
+            if (tcp4ConnectionsFile != null)
+            {
+                string tcp4FileContents = ReadAllText(tcp4ConnectionsFile);
+                v4connections = tcp4FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
+            }
+            else
+            {
+                v4connections = Array.Empty<string>();
+            }
+
+            if (tcp6ConnectionsFile != null)
+            {
+                string tcp6FileContents = ReadAllText(tcp6ConnectionsFile);
+                v6connections = tcp6FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
+            }
+            else
+            {
+                v6connections = Array.Empty<string>();
+            }
 
             // First line is header in each file. On WSL, this file may be empty.
             int count = 0;
@@ -150,13 +184,30 @@ namespace System.Net.NetworkInformation
             return endPoints;
         }
 
-        public static IPEndPoint[] ParseActiveUdpListenersFromFiles(string udp4File, string udp6File)
+        public static IPEndPoint[] ParseActiveUdpListenersFromFiles(string? udp4File, string? udp6File)
         {
-            string udp4FileContents = ReadAllText(udp4File);
-            string[] v4connections = udp4FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
+            string[] v4connections;
+            string[] v6connections;
 
-            string udp6FileContents = ReadAllText(udp6File);
-            string[] v6connections = udp6FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
+            if (udp4File != null)
+            {
+                string udp4FileContents = ReadAllText(udp4File);
+                v4connections = udp4FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
+            }
+            else
+            {
+                v4connections = Array.Empty<string>();
+            }
+
+            if (udp6File != null)
+            {
+                string udp6FileContents = ReadAllText(udp6File);
+                v6connections = udp6FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
+            }
+            else
+            {
+                v6connections = Array.Empty<string>();
+            }
 
             // First line is header in each file. On WSL, this file may be empty.
             int count = 0;

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using System.Net.Test.Common;
@@ -14,11 +15,19 @@ namespace System.Net.NetworkInformation.Tests
     public class IPGlobalPropertiesTest
     {
         private readonly ITestOutputHelper _log;
-        public static readonly object[][] Loopbacks = new[]
+
+        public static IEnumerable<object[]> Loopbacks()
         {
-            new object[] { IPAddress.Loopback },
-            new object[] { IPAddress.IPv6Loopback },
-        };
+            if (Socket.OSSupportsIPv4)
+            {
+                yield return new object[] { IPAddress.Loopback };
+            }
+
+            if (Socket.OSSupportsIPv6)
+            {
+                yield return new object[] { IPAddress.IPv6Loopback };
+            }
+        }
 
         public IPGlobalPropertiesTest(ITestOutputHelper output)
         {
@@ -35,19 +44,26 @@ namespace System.Net.NetworkInformation.Tests
             Assert.NotNull(gp.GetActiveTcpListeners());
             Assert.NotNull(gp.GetActiveUdpListeners());
 
-            Assert.NotNull(gp.GetIPv4GlobalStatistics());
-            if (!OperatingSystem.IsMacOS() && !OperatingSystem.IsIOS() && !OperatingSystem.IsTvOS() && !OperatingSystem.IsFreeBSD())
+            if (Socket.OSSupportsIPv4)
             {
-                // OSX and FreeBSD do not provide IPv6  stats.
-                Assert.NotNull(gp.GetIPv6GlobalStatistics());
+                Assert.NotNull(gp.GetIPv4GlobalStatistics());
+                Assert.NotNull(gp.GetIcmpV4Statistics());
+                Assert.NotNull(gp.GetTcpIPv4Statistics());
+                Assert.NotNull(gp.GetUdpIPv4Statistics());
             }
 
-            Assert.NotNull(gp.GetIcmpV4Statistics());
-            Assert.NotNull(gp.GetIcmpV6Statistics());
-            Assert.NotNull(gp.GetTcpIPv4Statistics());
-            Assert.NotNull(gp.GetTcpIPv6Statistics());
-            Assert.NotNull(gp.GetUdpIPv4Statistics());
-            Assert.NotNull(gp.GetUdpIPv6Statistics());
+            if (Socket.OSSupportsIPv6)
+            {
+                Assert.NotNull(gp.GetIcmpV6Statistics());
+                Assert.NotNull(gp.GetTcpIPv6Statistics());
+                Assert.NotNull(gp.GetUdpIPv6Statistics());
+
+                if (!OperatingSystem.IsMacOS() && !OperatingSystem.IsIOS() && !OperatingSystem.IsTvOS() && !OperatingSystem.IsFreeBSD())
+                {
+                    // OSX and FreeBSD do not provide IPv6  stats.
+                    Assert.NotNull(gp.GetIPv6GlobalStatistics());
+                }
+            }
         }
 
         [Fact]

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Linux.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Linux.cs
@@ -165,8 +165,8 @@ namespace System.Net.NetworkInformation.Tests
             }).WaitAsync(TestHelper.PassingTestTimeout);
         }
 
-        [Fact]
         [Trait("IPv6", "true")]
+        [ConditionalFact(typeof(Socket), nameof(Socket.OSSupportsIPv6))]
         public async Task IPv6ScopeId_AccessAllValues_Success()
         {
             await Task.Run(() =>
@@ -220,8 +220,8 @@ namespace System.Net.NetworkInformation.Tests
             }).WaitAsync(TestHelper.PassingTestTimeout);
         }
 
-        [Fact]
         [Trait("IPv6", "true")]
+        [ConditionalFact(typeof(Socket), nameof(Socket.OSSupportsIPv6))]
         public async Task IPInfoTest_IPv6Loopback_ProperAddress()
         {
             await Task.Run(() =>

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -4,7 +4,7 @@
 using System.Net.Sockets;
 using System.Net.Test.Common;
 using System.Threading.Tasks;
-
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -161,8 +161,8 @@ namespace System.Net.NetworkInformation.Tests
             _log.WriteLine("Loopback IPv4 index: " + NetworkInterface.LoopbackInterfaceIndex);
         }
 
-        [Fact]
         [Trait("IPv6", "true")]
+        [ConditionalFact(typeof(Socket), nameof(Socket.OSSupportsIPv6))]
         public void BasicTest_StaticIPv6LoopbackIndex_MatchesLoopbackNetworkInterface()
         {
             Assert.True(Capability.IPv6Support());
@@ -185,8 +185,8 @@ namespace System.Net.NetworkInformation.Tests
             }
         }
 
-        [Fact]
         [Trait("IPv6", "true")]
+        [ConditionalFact(typeof(Socket), nameof(Socket.OSSupportsIPv6))]
         public void BasicTest_StaticIPv6LoopbackIndex_ExceptionIfV6NotSupported()
         {
             Assert.True(Capability.IPv6Support());
@@ -272,7 +272,7 @@ namespace System.Net.NetworkInformation.Tests
             Assert.True(NetworkInterface.GetIsNetworkAvailable());
         }
 
-        [Theory]
+        [ConditionalTheory]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34690", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.FreeBSD, "Expected behavior is different on OSX or FreeBSD")]
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "Not supported on Browser, iOS, MacCatalyst, or tvOS.")]
@@ -280,6 +280,11 @@ namespace System.Net.NetworkInformation.Tests
         [InlineData(true)]
         public async Task NetworkInterface_LoopbackInterfaceIndex_MatchesReceivedPackets(bool ipv6)
         {
+            if (ipv6 && !Socket.OSSupportsIPv6)
+            {
+                throw new SkipTestException("IPv6 is not supported");
+            }
+
             using (var client = new Socket(SocketType.Dgram, ProtocolType.Udp))
             using (var server = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {


### PR DESCRIPTION
Files NetworkInfo expects may or may not exist depending on IPv4 and IPv6 availability. 
This changes uses Socket.OSSupportsIPv4 and Socket.OSSupportsIPv6 to drive expectation for /proc entries. 

fixes #59015

Since I had IPv4 only system configured, I also updated NetworkInfo tests so they all pass without IPv6 enabled.
