### PR TITLE
I noticed some initalizations were missing…

### DIFF
--- a/src/coreclr/tools/StressLogAnalyzer/StressLogPlugin.cpp
+++ b/src/coreclr/tools/StressLogAnalyzer/StressLogPlugin.cpp
@@ -1226,7 +1226,22 @@ int ProcessStressLog(void* baseAddress, int argc, char* argv[])
     s_outputFileName = nullptr;
     s_fPrintFormatStrings = false;
     s_showAllMessages = false;
+    s_maxHeapNumberSeen = -1;
+    s_interestingStringCount = IS_INTERESTING;
+    s_levelFilterCount = 0;
+    s_gcFilterStart = 0;
+    s_gcFilterEnd = 0;
+    s_valueFilterCount = 0;
+    s_threadFilterCount = 0;
+    s_hadGcThreadFilters = false;
+    s_printHexTidForGcThreads = false;
+    s_facilityIgnore = 0;
+    s_printEarliestMessages = false;
+    s_printEarliestMessageFromThreadCount = 0;
+    memset(s_gcThreadFilter, 0, sizeof(s_gcThreadFilter));
     memset(&mapImageToStringId, 0, sizeof(mapImageToStringId));
+    memset(s_interestingStringFilter, 0, sizeof(s_interestingStringFilter));
+    memset(s_printEarliestMessageFromGcThread, 0, sizeof(s_printEarliestMessageFromGcThread));
 
     if (!ParseOptions(argc, argv))
         return 1;


### PR DESCRIPTION
 at the beginning of ProcessStressLog().

The effect is that some command line options appear sticky, e.g. if you give a filter, run, and rerun without it, it will still take effect