### PR TITLE
Stop running both normal and no_tiered_compilation scenarios for coreclr PRs

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -394,9 +394,16 @@ jobs:
         helixProjectArguments: '$(Build.SourcesDirectory)/src/tests/Common/helixpublishwitharcade.proj'
 
         ${{ if in(parameters.testGroup, 'innerloop', 'outerloop') }}:
-          scenarios:
-          - normal
-          - ${{ if ne(parameters.runtimeFlavor, 'mono') }}: # tiered compilation isn't done on mono yet
+          ${{ if eq(parameters.runtimeFlavor, 'mono') }}:
+            # tiered compilation isn't done on mono yet
+            scenarios:
+            - normal 
+          ${{ elseif eq(variables['Build.Reason'], 'PullRequest') }}:
+            scenarios:
+            - no_tiered_compilation
+          ${{ else }}:
+            scenarios:
+            - normal
             - no_tiered_compilation
 
         ${{ if in(parameters.testGroup, 'jitstress') }}:


### PR DESCRIPTION
This changes innerloop/outerloop test groups to run only in the no_tiered_compilation scenario on PRs, as discussed in #69122.