### PR TITLE
Fix HTTP3 stress

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -31,7 +31,7 @@ jobs:
     DUMPS_SHARE_MOUNT_ROOT: "/dumps-share"
   pool:
     name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+    demands: ImageOverride -equals 1es-ubuntu-1804-open
 
   steps:
   - checkout: self

--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -39,13 +39,13 @@ jobs:
     fetchDepth: 5
 
   - bash: |
-      $(dockerfilesFolder)/build-docker-sdk.sh -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION)
+      $(dockerfilesFolder)/build-docker-sdk.sh -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION) && \
       echo "##vso[task.setvariable variable=succeeded;isOutput=true]true"
     name: buildRuntime
     displayName: Build CLR and Libraries
 
   - bash: |
-      $(httpStressProject)/run-docker-compose.sh -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage)
+      $(httpStressProject)/run-docker-compose.sh -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage) && \
       echo "##vso[task.setvariable variable=succeeded;isOutput=true]true"
     name: buildStress
     displayName: Build HttpStress

--- a/src/libraries/Common/src/System/Net/SocketAddress.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddress.cs
@@ -133,6 +133,7 @@ namespace System.Net.Internals
         {
             Buffer = buffer.ToArray();
             InternalSize = Buffer.Length;
+            SocketAddressPal.SetAddressFamily(Buffer, addressFamily);
         }
 
         internal IPAddress GetIPAddress()

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -5,15 +5,15 @@ FROM $SDK_BASE_IMAGE
 # Pulling the msquic Debian package from packages.microsoft.com
 # Build latest msquic locally
 WORKDIR /msquic
-RUN apt-get update -y
-RUN apt-get upgrade -y
-RUN apt-get install -y cmake clang ruby-dev gem lttng-tools libssl-dev && \
+RUN apt-get update -y && \
+    apt-get upgrade -y && \
+    apt-get install -y cmake clang ruby-dev gem lttng-tools libssl-dev && \
     gem install fpm
 RUN git clone --recursive https://github.com/dotnet/msquic
 RUN cd msquic/src/msquic && \
     mkdir build && \
     options="-DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off" && \
-    cmake -B build -DCMAKE_BUILD_TYPE=Release -DQUIC_ENABLE_LOGGING=true -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off && \
+    cmake -B build -DCMAKE_BUILD_TYPE=Release -DQUIC_ENABLE_LOGGING=false -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off && \
     cd build && \
     cmake --build . --config Release
 RUN cd msquic/src/msquic/build/bin/Release && \
@@ -27,12 +27,7 @@ ARG VERSION=7.0
 ARG CONFIGURATION=Release
 
 WORKDIR /app
-COPY *.cs .
-COPY *.csproj .
-COPY *.props .
-COPY *.targets .
-COPY *.json .
-COPY *.sln .
+COPY . .
 
 RUN dotnet build -c $CONFIGURATION \
     -p:TargetingPacksTargetsLocation=/live-runtime-artifacts/targetingpacks.targets \
@@ -48,6 +43,6 @@ EXPOSE 5001
 
 ENV VERSION=$VERSION
 ENV CONFIGURATION=$CONFIGURATION
-# ENV LD_DEBUG=all
 ENV HTTPSTRESS_ARGS=''
-CMD /live-runtime-artifacts/testhost/net$VERSION-Linux-$CONFIGURATION-x64/dotnet exec ./bin/$CONFIGURATION/net$VERSION/HttpStress.dll $HTTPSTRESS_ARGS
+CMD /live-runtime-artifacts/testhost/net$VERSION-Linux-$CONFIGURATION-x64/dotnet exec \
+    ./bin/$CONFIGURATION/net$VERSION/HttpStress.dll $HTTPSTRESS_ARGS

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update -y && \
 RUN git clone --recursive https://github.com/dotnet/msquic
 RUN cd msquic/src/msquic && \
     mkdir build && \
-    options="-DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off" && \
     cmake -B build -DCMAKE_BUILD_TYPE=Release -DQUIC_ENABLE_LOGGING=false -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off && \
     cd build && \
     cmake --build . --config Release

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -1,20 +1,38 @@
 ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:6.0-bullseye-slim
 FROM $SDK_BASE_IMAGE
 
-WORKDIR /app
-COPY . .
 
 # Pulling the msquic Debian package from packages.microsoft.com
+# Build latest msquic locally
+WORKDIR /msquic
 RUN apt-get update -y
-RUN apt-get install -y gnupg2 software-properties-common
-RUN curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-RUN apt-add-repository https://packages.microsoft.com/debian/11/prod
-RUN apt-get update -y
-RUN apt-get install -y libmsquic
 RUN apt-get upgrade -y
+RUN apt-get install -y cmake clang ruby-dev gem lttng-tools libssl-dev && \
+    gem install fpm
+RUN git clone --recursive https://github.com/dotnet/msquic
+RUN cd msquic/src/msquic && \
+    mkdir build && \
+    options="-DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off" && \
+    cmake -B build -DCMAKE_BUILD_TYPE=Release -DQUIC_ENABLE_LOGGING=true -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off && \
+    cd build && \
+    cmake --build . --config Release
+RUN cd msquic/src/msquic/build/bin/Release && \
+    rm libmsquic.so && \
+    fpm -f -s dir -t deb -n libmsquic -v $( find -type f | cut -d "." -f 4- ) \
+    --license MIT --url https://github.com/microsoft/msquic --log error \
+    $( ls ./* | cut -d "/" -f 2 | sed -r "s/(.*)/\1=\/usr\/lib\/\1/g" ) && \
+    dpkg -i libmsquic_*.deb
 
 ARG VERSION=7.0
 ARG CONFIGURATION=Release
+
+WORKDIR /app
+COPY *.cs .
+COPY *.csproj .
+COPY *.props .
+COPY *.targets .
+COPY *.json .
+COPY *.sln .
 
 RUN dotnet build -c $CONFIGURATION \
     -p:TargetingPacksTargetsLocation=/live-runtime-artifacts/targetingpacks.targets \
@@ -30,6 +48,6 @@ EXPOSE 5001
 
 ENV VERSION=$VERSION
 ENV CONFIGURATION=$CONFIGURATION
+# ENV LD_DEBUG=all
 ENV HTTPSTRESS_ARGS=''
-CMD /live-runtime-artifacts/testhost/net$VERSION-Linux-$CONFIGURATION-x64/dotnet exec \
-    ./bin/$CONFIGURATION/net$VERSION/HttpStress.dll $HTTPSTRESS_ARGS
+CMD /live-runtime-artifacts/testhost/net$VERSION-Linux-$CONFIGURATION-x64/dotnet exec ./bin/$CONFIGURATION/net$VERSION/HttpStress.dll $HTTPSTRESS_ARGS

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -1,8 +1,6 @@
 ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:6.0-bullseye-slim
 FROM $SDK_BASE_IMAGE
 
-
-# Pulling the msquic Debian package from packages.microsoft.com
 # Build latest msquic locally
 WORKDIR /msquic
 RUN apt-get update -y && \
@@ -25,6 +23,7 @@ RUN cd msquic/src/msquic/build/bin/Release && \
 ARG VERSION=7.0
 ARG CONFIGURATION=Release
 
+# Build the stress server
 WORKDIR /app
 COPY . .
 

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
@@ -83,7 +83,16 @@ namespace HttpStress
                     {
                         case "+":
                         case "*":
-                            ko.ListenAnyIP(port, ConfigureListenOptions);
+                            // Workaround for a msquic bug: can't connect via IPv4 when listening on IPv6
+                            // https://github.com/microsoft/msquic/issues/2704
+                            if (configuration.HttpVersion == HttpVersion.Version30)
+                            {
+                                ko.Listen(IPAddress.Any, port, ConfigureListenOptions);
+                            }
+                            else
+                            {
+                                ko.ListenAnyIP(port, ConfigureListenOptions);
+                            }
                             break;
                         default:
                             IPAddress iPAddress = Dns.GetHostAddresses(hostname).First();
@@ -118,9 +127,9 @@ namespace HttpStress
                         else
                         {
                             listenOptions.Protocols =
-                                configuration.HttpVersion ==  HttpVersion.Version20 ?
+                                configuration.HttpVersion == HttpVersion.Version20 ?
                                 HttpProtocols.Http2 :
-                                HttpProtocols.Http1 ;
+                                HttpProtocols.Http1;
                         }
                     }
                 });
@@ -139,7 +148,8 @@ namespace HttpStress
                     try
                     {
                         File.Delete(filename);
-                    } catch {}
+                    }
+                    catch { }
                 }
 
                 loggerConfiguration = loggerConfiguration

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
@@ -83,16 +83,7 @@ namespace HttpStress
                     {
                         case "+":
                         case "*":
-                            // Workaround for a msquic bug: can't connect via IPv4 when listening on IPv6
-                            // https://github.com/microsoft/msquic/issues/2704
-                            if (configuration.HttpVersion == HttpVersion.Version30)
-                            {
-                                ko.Listen(IPAddress.Any, port, ConfigureListenOptions);
-                            }
-                            else
-                            {
-                                ko.ListenAnyIP(port, ConfigureListenOptions);
-                            }
+                            ko.ListenAnyIP(port, ConfigureListenOptions);
                             break;
                         default:
                             IPAddress iPAddress = Dns.GetHostAddresses(hostname).First();

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicAddressHelpers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicAddressHelpers.cs
@@ -1,6 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using Microsoft.Quic;
+
 namespace System.Net.Quic.Implementations.MsQuic.Internal
 {
     internal static class MsQuicAddressHelpers
@@ -10,6 +15,19 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             // MsQuic always uses storage size as if IPv6 was used
             Span<byte> addressBytes = new Span<byte>((byte*)pInetAddress, Internals.SocketAddress.IPv6AddressSize);
             return new Internals.SocketAddress(SocketAddressPal.GetAddressFamily(addressBytes), addressBytes).GetIPEndPoint();
+        }
+
+        internal static unsafe QuicAddr ToQuicAddr(this IPEndPoint iPEndPoint)
+        {
+            // TODO: is the layout same for SocketAddress.Buffer and QuicAddr?
+            QuicAddr result = default;
+            Span<byte> rawAddress = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref result, 1));
+
+            Internals.SocketAddress address = IPEndPointExtensions.Serialize(iPEndPoint);
+            Debug.Assert(address.Size <= rawAddress.Length);
+
+            address.Buffer.AsSpan(0, address.Size).CopyTo(rawAddress);
+            return result;
         }
     }
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicAddressHelpers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicAddressHelpers.cs
@@ -19,7 +19,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 
         internal static unsafe QuicAddr ToQuicAddr(this IPEndPoint iPEndPoint)
         {
-            // TODO: is the layout same for SocketAddress.Buffer and QuicAddr?
+            // TODO: is the layout same for SocketAddress.Buffer and QuicAddr on all platforms?
             QuicAddr result = default;
             Span<byte> rawAddress = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref result, 1));
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicParameterHelpers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicParameterHelpers.cs
@@ -11,22 +11,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 {
     internal static class MsQuicParameterHelpers
     {
-        internal static unsafe QuicAddr GetQuicAddrParam(MsQuicApi api, MsQuicSafeHandle nativeObject, uint param)
-        {
-            QuicAddr value = default;
-            uint valueLen = (uint)sizeof(QuicAddr);
-
-            ThrowIfFailure(api.ApiTable->GetParam(
-                nativeObject.QuicHandle,
-                param,
-                &valueLen,
-                (byte*)&value), "GetQuicAddrParam failed");
-            Debug.Assert(valueLen == sizeof(QuicAddr));
-
-            return value;
-        }
-
-        internal static unsafe IPEndPoint GetIPEndPointParam(MsQuicApi api, MsQuicSafeHandle nativeObject, uint param)
+        internal static unsafe IPEndPoint GetIPEndPointParam(MsQuicApi api, MsQuicSafeHandle nativeObject, uint param, AddressFamily? addressFamilyOverride = null)
         {
             // MsQuic always uses storage size as if IPv6 was used
             uint valueLen = (uint)Internals.SocketAddress.IPv6AddressSize;
@@ -43,7 +28,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 
             address = address.Slice(0, (int)valueLen);
 
-            return new Internals.SocketAddress(SocketAddressPal.GetAddressFamily(address), address).GetIPEndPoint();
+            return new Internals.SocketAddress(addressFamilyOverride ?? SocketAddressPal.GetAddressFamily(address), address).GetIPEndPoint();
         }
 
         internal static unsafe void SetIPEndPointParam(MsQuicApi api, MsQuicSafeHandle nativeObject, uint param, IPEndPoint value)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicParameterHelpers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicParameterHelpers.cs
@@ -4,12 +4,28 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Net.Sockets;
+using Microsoft.Quic;
 using static Microsoft.Quic.MsQuic;
 
 namespace System.Net.Quic.Implementations.MsQuic.Internal
 {
     internal static class MsQuicParameterHelpers
     {
+        internal static unsafe QuicAddr GetQuicAddrParam(MsQuicApi api, MsQuicSafeHandle nativeObject, uint param)
+        {
+            QuicAddr value = default;
+            uint valueLen = (uint)sizeof(QuicAddr);
+
+            ThrowIfFailure(api.ApiTable->GetParam(
+                nativeObject.QuicHandle,
+                param,
+                &valueLen,
+                (byte*)&value), "GetQuicAddrParam failed");
+            Debug.Assert(valueLen == sizeof(QuicAddr));
+
+            return value;
+        }
+
         internal static unsafe IPEndPoint GetIPEndPointParam(MsQuicApi api, MsQuicSafeHandle nativeObject, uint param)
         {
             // MsQuic always uses storage size as if IPv6 was used

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicListener.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -12,7 +13,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using System.Net.Sockets;
 using Microsoft.Quic;
 using System.Runtime.CompilerServices;
 using static Microsoft.Quic.MsQuic;
@@ -179,26 +179,27 @@ namespace System.Net.Quic.Implementations.MsQuic
             List<SslApplicationProtocol> applicationProtocols = options.ServerAuthenticationOptions!.ApplicationProtocols!;
             IPEndPoint listenEndPoint = options.ListenEndPoint!;
 
-            Internals.SocketAddress address = IPEndPointExtensions.Serialize(listenEndPoint);
-
             Debug.Assert(_stateHandle.IsAllocated);
             try
             {
                 Debug.Assert(!Monitor.IsEntered(_state), "!Monitor.IsEntered(_state)");
                 using var msquicBuffers = new MsQuicBuffers();
                 msquicBuffers.Initialize(applicationProtocols, applicationProtocol => applicationProtocol.Protocol);
-                // TODO: is the layout same for SocketAddress.Buffer and QuicAddr?
-                // TODO: maybe add simple extensions/helpers:
-                //       - QuicAddr ToQuicAddr(this IPEndPoint ipEndPoint)
-                //       - IPEndPoint ToIPEndPoint(this ref QuicAddr quicAddress)
-                fixed (byte* paddress = address.Buffer)
+
+                QuicAddr address = listenEndPoint.ToQuicAddr();
+
+                if (listenEndPoint.Address == IPAddress.IPv6Any)
                 {
-                    ThrowIfFailure(MsQuicApi.Api.ApiTable->ListenerStart(
-                        _state.Handle.QuicHandle,
-                        msquicBuffers.Buffers,
-                        (uint)applicationProtocols.Count,
-                        (QuicAddr*)paddress), "ListenerStart failed");
+                    // For IPv6Any, MsQuic would listen only for IPv6 connections. To mimic the behavior of TCP sockets,
+                    // we leave the address family unspecified and let MsQuic handle connections from all IP addresses.
+                    address.Family = QUIC_ADDRESS_FAMILY_UNSPEC;
                 }
+
+                ThrowIfFailure(MsQuicApi.Api.ApiTable->ListenerStart(
+                    _state.Handle.QuicHandle,
+                    msquicBuffers.Buffers,
+                    (uint)applicationProtocols.Count,
+                    &address), "ListenerStart failed");
             }
             catch
             {
@@ -206,8 +207,13 @@ namespace System.Net.Quic.Implementations.MsQuic
                 throw;
             }
 
+            // return the actual bound address, including a port. Since the address family may be Unspecified,
+            // we cannot use GetIPEndPointParam. We have to manually read the port from the raw QuicAddr structure.
+            // The actual address is unchanged.
             Debug.Assert(!Monitor.IsEntered(_state), "!Monitor.IsEntered(_state)");
-            return MsQuicParameterHelpers.GetIPEndPointParam(MsQuicApi.Api, _state.Handle, QUIC_PARAM_LISTENER_LOCAL_ADDRESS);
+            QuicAddr listenAddr = MsQuicParameterHelpers.GetQuicAddrParam(MsQuicApi.Api, _state.Handle, QUIC_PARAM_LISTENER_LOCAL_ADDRESS);
+            int port = BinaryPrimitives.ReadUInt16BigEndian(MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref listenAddr.Ipv4.sin_port, 1)));
+            return new IPEndPoint(listenEndPoint.Address, port);
         }
 
         private unsafe Task StopAsync()

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicListener.cs
@@ -207,13 +207,9 @@ namespace System.Net.Quic.Implementations.MsQuic
                 throw;
             }
 
-            // return the actual bound address, including a port. Since the address family may be Unspecified,
-            // we cannot use GetIPEndPointParam. We have to manually read the port from the raw QuicAddr structure.
-            // The actual address is unchanged.
             Debug.Assert(!Monitor.IsEntered(_state), "!Monitor.IsEntered(_state)");
-            QuicAddr listenAddr = MsQuicParameterHelpers.GetQuicAddrParam(MsQuicApi.Api, _state.Handle, QUIC_PARAM_LISTENER_LOCAL_ADDRESS);
-            int port = BinaryPrimitives.ReadUInt16BigEndian(MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref listenAddr.Ipv4.sin_port, 1)));
-            return new IPEndPoint(listenEndPoint.Address, port);
+            // override the address family to the original value in case we had to use UNSPEC
+            return MsQuicParameterHelpers.GetIPEndPointParam(MsQuicApi.Api, _state.Handle, QUIC_PARAM_LISTENER_LOCAL_ADDRESS, listenEndPoint.AddressFamily);
         }
 
         private unsafe Task StopAsync()

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
@@ -41,6 +41,21 @@ namespace System.Net.Quic.Tests
                 await clientStreamTask;
             }).WaitAsync(TimeSpan.FromSeconds(6));
         }
+
+        [ConditionalFact(nameof(IsMsQuicProvider))]
+        public async Task Listener_IPv6Any_Accepts_IPv4()
+        {
+            await Task.Run(async () =>
+            {
+                using QuicListener listener = CreateQuicListener(new IPEndPoint(IPAddress.IPv6Any, 0));
+
+                using QuicConnection clientConnection = CreateQuicConnection(new IPEndPoint(IPAddress.Loopback, listener.ListenEndPoint.Port));
+                var clientStreamTask = clientConnection.ConnectAsync();
+
+                using QuicConnection serverConnection = await listener.AcceptConnectionAsync();
+                await clientStreamTask;
+            }).WaitAsync(TimeSpan.FromSeconds(6));
+        }
     }
 
     [ConditionalClass(typeof(QuicTestBase<MockProviderFactory>), nameof(QuicTestBase<MockProviderFactory>.IsSupported))]


### PR DESCRIPTION
Fixes #67442, #68958.

This PR builds latest MsQuic inside the http stress docker image.

It also adds special case for listening on IPv6Any to accept connections from all IP addresses (i.e. including IPv4), which does not happen by default (see https://github.com/microsoft/msquic/issues/2704).