### PR TITLE
Arm64: Make unroll code for cpblk non-interruptible

### DIFF
--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -2816,16 +2816,16 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
     regNumber             srcReg = srcAddrBaseReg;
 
 #ifdef DEBUG
-    bool                  isSrcRegAddrAlignmentKnown = false;
-    bool                  isDstRegAddrAlignmentKnown = false;
+    bool isSrcRegAddrAlignmentKnown = false;
+    bool isDstRegAddrAlignmentKnown = false;
 #endif
-    
+
     if (srcLclNum != BAD_VAR_NUM)
     {
         bool      fpBased;
         const int baseAddr = compiler->lvaFrameAddress(srcLclNum, &fpBased);
 
-        srcReg                     = fpBased ? REG_FPBASE : REG_SPBASE;
+        srcReg = fpBased ? REG_FPBASE : REG_SPBASE;
         helper.SetSrcOffset(baseAddr + srcOffset);
 
 #ifdef DEBUG
@@ -2840,7 +2840,7 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
         bool      fpBased;
         const int baseAddr = compiler->lvaFrameAddress(dstLclNum, &fpBased);
 
-        dstReg                     = fpBased ? REG_FPBASE : REG_SPBASE;
+        dstReg = fpBased ? REG_FPBASE : REG_SPBASE;
         helper.SetDstOffset(baseAddr + dstOffset);
 
 #ifdef DEBUG

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -2965,6 +2965,7 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
         // If node is not already marked as non-interruptible, and if are about to generate code
         // that produce GC references in temporary registers not reported, then mark the block
         // as non-interruptible.
+        // Corresponding EnableGC() will be done by the caller of this method.
         node->gtBlkOpGcUnsafe = true;
         GetEmitter()->emitDisableGC();
     }

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -440,17 +440,9 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
 
         if (blkNode->OperIs(GT_STORE_OBJ))
         {
-            if (!blkNode->AsObj()->GetLayout()->HasGCPtr())
+            if (!blkNode->AsObj()->GetLayout()->HasGCPtr() || (isDstAddrLocal && (size <= copyBlockUnrollLimit)))
             {
                 blkNode->SetOper(GT_STORE_BLK);
-            }
-            else if (isDstAddrLocal && (size <= copyBlockUnrollLimit))
-            {
-                // If the size is small enough to unroll then we need to mark the block as non-interruptible
-                // to actually allow unrolling. The generated code does not report GC references loaded in the
-                // temporary register(s) used for copying.
-                blkNode->SetOper(GT_STORE_BLK);
-                blkNode->gtBlkOpGcUnsafe = true;
             }
         }
 
@@ -463,6 +455,17 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
         else if (blkNode->OperIs(GT_STORE_BLK) && (size <= copyBlockUnrollLimit))
         {
             blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindUnroll;
+
+            if (!isSrcAddrLocal || !isDstAddrLocal)
+            {
+                // If the size is small enough to unroll then we need to mark the block as non-interruptible
+                // to actually allow unrolling. The generated code does not report GC references loaded in the
+                // temporary register(s) used for copying.
+                // Although marking it here would sometime make blkop gcUnsafe for more scenarios than needed,
+                // it will be less complex if marked in genCodeForCpBlkUnroll() for scenarios that generate
+                // code of GC references.
+                blkNode->gtBlkOpGcUnsafe = true;
+            }
 
             if (src->OperIs(GT_IND))
             {

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -456,17 +456,6 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
         {
             blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindUnroll;
 
-            if (!isSrcAddrLocal || !isDstAddrLocal)
-            {
-                // If the size is small enough to unroll then we need to mark the block as non-interruptible
-                // to actually allow unrolling. The generated code does not report GC references loaded in the
-                // temporary register(s) used for copying.
-                // Although marking it here would sometime make blkop gcUnsafe for more scenarios than needed,
-                // it will be less complex if marked in genCodeForCpBlkUnroll() for scenarios that generate
-                // code of GC references.
-                blkNode->gtBlkOpGcUnsafe = true;
-            }
-
             if (src->OperIs(GT_IND))
             {
                 ContainBlockStoreAddress(blkNode, size, src->AsIndir()->Addr());


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/68085, I relaxed the heuristics under which we would use SIMD registers for copy block unroll code. The code generated uses temporary registers to addresses to copy (could be GC references) and they are not reported. As such, we should mark the unroll code region as GC non-interruptible to make sure GC doesn't kick in and collect the wrong objects.

Note: We were marking `gtBlkOpGcUnsafe` only for situation where destination address was local, but never checked about the source address. This PR expands it to situation when either src/dst addresses are non-local (on heap).

Fixes: https://github.com/dotnet/runtime/issues/68530