### PR TITLE
fix invalid Host header for link-local IPv6

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -229,10 +229,11 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
-        [InlineData("[::1234]")]
-        [InlineData("[::1234]:8080")]
+        [InlineData("[::1234]", "[::1234]")]
+        [InlineData("[::1234]:8080", "[::1234]:8080")]
+        [InlineData("[fe80::9c3a:b64d:6249:1de8%2]", "[fe80::9c3a:b64d:6249:1de8]")]
         [SkipOnPlatform(TestPlatforms.Browser, "Proxy not supported on Browser")]
-        public async Task GetAsync_IPv6AddressInHostHeader_CorrectlyFormatted(string host)
+        public async Task GetAsync_IPv6AddressInHostHeader_CorrectlyFormatted(string host, string hostHeader)
         {
             string ipv6Address = "http://" + host;
             bool connectionAccepted = false;
@@ -261,7 +262,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 connectionAccepted = true;
                 List<string> headers = await connection.ReadRequestHeaderAndSendResponseAsync();
-                Assert.Contains($"Host: {host}", headers);
+                Assert.Contains($"Host: {hostHeader}", headers);
             }));
 
             Assert.True(connectionAccepted);

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -21,11 +21,12 @@ namespace System.Net.Http.Functional.Tests
 #if WINHTTPHANDLER_TEST
     using HttpClientHandler = System.Net.Http.WinHttpClientHandler;
 #endif
-
     // Note:  Disposing the HttpClient object automatically disposes the handler within. So, it is not necessary
     // to separately Dispose (or have a 'using' statement) for the handler.
     public abstract class HttpClientHandlerTest : HttpClientHandlerTestBase
     {
+        public static bool IsNotWinHttpHandler = !IsWinHttpHandler;
+
         public HttpClientHandlerTest(ITestOutputHelper output) : base(output)
         {
         }
@@ -228,7 +229,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(IsNotWinHttpHandler))]
         [InlineData("[::1234]", "[::1234]")]
         [InlineData("[::1234]:8080", "[::1234]:8080")]
         [InlineData("[fe80::9c3a:b64d:6249:1de8%2]", "[fe80::9c3a:b64d:6249:1de8]")]

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpAuthority.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpAuthority.cs
@@ -13,6 +13,7 @@ namespace System.Net.Http
         // public string AlpnProtocolName { get; }
 
         public string IdnHost { get; }
+        public string HostValue { get; }
         public int Port { get; }
 
         public HttpAuthority(string host, int port)
@@ -23,10 +24,18 @@ namespace System.Net.Http
             var builder = new UriBuilder(Uri.UriSchemeHttp, host, port);
             Uri uri = builder.Uri;
 
-            // TODO https://github.com/dotnet/runtime/issues/25782:
-            // Uri.IdnHost is missing '[', ']' characters around IPv6 address.
-            // So, we need to add them manually for now.
+            // This includes brackets for IPv6 and ScopeId for IPv6 LLA so Connect works.
             IdnHost = uri.HostNameType == UriHostNameType.IPv6 ? "[" + uri.IdnHost + "]" : uri.IdnHost;
+            if (uri.HostNameType == UriHostNameType.IPv6)
+            {
+                // This is bracket enclosed IPv6 without ScopeID for LLA
+                HostValue = uri.Host;
+            }
+            else
+            {
+                // IPv4 address, dns or puny encoded name
+                HostValue = IdnHost;
+            }
             Port = port;
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpAuthority.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpAuthority.cs
@@ -24,17 +24,17 @@ namespace System.Net.Http
             var builder = new UriBuilder(Uri.UriSchemeHttp, host, port);
             Uri uri = builder.Uri;
 
-            // This includes brackets for IPv6 and ScopeId for IPv6 LLA so Connect works.
-            IdnHost = uri.HostNameType == UriHostNameType.IPv6 ? "[" + uri.IdnHost + "]" : uri.IdnHost;
             if (uri.HostNameType == UriHostNameType.IPv6)
             {
+                // This includes brackets for IPv6 and ScopeId for IPv6 LLA so Connect works.
+                IdnHost = $"[{uri.IdnHost}]";
                 // This is bracket enclosed IPv6 without ScopeID for LLA
                 HostValue = uri.Host;
             }
             else
             {
                 // IPv4 address, dns or puny encoded name
-                HostValue = IdnHost;
+                HostValue = IdnHost = uri.IdnHost;
             }
             Port = port;
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -334,14 +334,11 @@ namespace System.Net.Http
             {
                 Debug.Assert(Kind == HttpConnectionKind.Proxy);
 
-                // TODO https://github.com/dotnet/runtime/issues/25782:
-                // Uri.IdnHost is missing '[', ']' characters around IPv6 address.
-                // So, we need to add them manually for now.
+                // Uri.IdnHost is missing '[', ']' characters around IPv6 address
+                // and it also contains ScopeID for Link-Local addresses
                 if (uri.HostNameType == UriHostNameType.IPv6)
                 {
-                    await WriteByteAsync((byte)'[', async).ConfigureAwait(false);
-                    await WriteAsciiStringAsync(uri.IdnHost, async).ConfigureAwait(false);
-                    await WriteByteAsync((byte)']', async).ConfigureAwait(false);
+                    await WriteAsciiStringAsync(uri.Host, async).ConfigureAwait(false);
                 }
                 else
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -226,8 +226,8 @@ namespace System.Net.Http
                 // Note that if _host is null, this is a (non-tunneled) proxy connection, and we can't cache the hostname.
                 hostHeader =
                     (_originAuthority.Port != (sslHostName == null ? DefaultHttpPort : DefaultHttpsPort)) ?
-                    $"{_originAuthority.IdnHost}:{_originAuthority.Port}" :
-                    _originAuthority.IdnHost;
+                    $"{_originAuthority.HostValue}:{_originAuthority.Port}" :
+                    _originAuthority.HostValue;
 
                 // Note the IDN hostname should always be ASCII, since it's already been IDNA encoded.
                 _hostHeaderValueBytes = Encoding.ASCII.GetBytes(hostHeader);


### PR DESCRIPTION
LLA are difficult to deal with. We need to preserve the ScopeID and pass it to Socket.Connect. But they should not be part of the Host header. The ScopeId is basically index of local interface and makes no sense to the peer. It still needs to be surrounded by brackets as any other IPv6.

To preserve both, I added extra field to HttpAuthority so we don't need to figure it out later from the string. 
They would be identical for everything but LLA. 

fixes  #59341 HTTP 400 ("Invalid Host header") for link-local IPv6 addresses