### PR TITLE
Clear `NO_CSE` on struct addresses in `MorphCommaBlock`

### DIFF
--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -470,6 +470,9 @@ GenTree* MorphInitBlockHelper::MorphCommaBlock(Compiler* comp, GenTreeOp* firstC
     {
         GenTree* comma = commas.Pop();
         comma->gtType  = TYP_BYREF;
+
+        // The "IND(COMMA)" => "COMMA(IND)" transform may have set NO_CSEs on these COMMAs, clear them.
+        comma->ClearDoNotCSE();
         comp->gtUpdateNodeSideEffects(comma);
     }
 


### PR DESCRIPTION
When we morph an `IND(COMMA(...))` into `COMMA(IND(...))`, we copy the `NO_CSE` on the `IND` flag to the `COMMA`s (the main reason being that `COMMA`s in question could be on the LHS of an ASG, but there are also unrelated CQ implications to this). However, when we transform this back into an `IND(COMMA)` in `MorphCommaBlock`, we can and should clear `NO_CSE`, as the `COMMA`s now always represent R-values.

This is another change that supports the replacement of `INDEX` nodes with `INDEX_ADDR` nodes.

A small number of positive [diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1765843&view=ms.vss-build-web.run-extensions-tab) due to new CSEs.