### PR TITLE
Unblock SDK merge by fixing Assembly.GetCallingAssembly()

### DIFF
--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -1521,9 +1521,15 @@ bool SystemDomain::IsReflectionInvocationMethod(MethodDesc* pMeth)
     }
     CONTRACTL_END;
 
-    MethodTable* pCaller = pMeth->GetMethodTable();
+    // Check for dynamically generated Invoke methods.
+    if (pMeth->IsDynamicMethod())
+    {
+        if (strncmp(pMeth->GetName(), "InvokeStub_", ARRAY_SIZE("InvokeStub_") - 1) == 0)
+            return true;
+    }
 
-    // All Reflection Invocation methods are defined in CoreLib
+    // All other reflection invocation methods are defined in CoreLib.
+    MethodTable* pCaller = pMeth->GetMethodTable();
     if (!pCaller->GetModule()->IsSystem())
         return false;
 
@@ -1577,13 +1583,6 @@ bool SystemDomain::IsReflectionInvocationMethod(MethodDesc* pMeth)
         for (unsigned i = 0; i < ARRAY_SIZE(reflectionInvocationTypes); i++)
         {
             if (CoreLibBinder::GetExistingClass(reflectionInvocationTypes[i]) == pCaller)
-                return true;
-        }
-
-        // Check for dynamically generated Invoke methods.
-        if (pMeth->IsDynamicMethod())
-        {
-            if (strncmp(pMeth->GetName(), "InvokeStub_", ARRAY_SIZE("InvokeStub_") - 1) == 0)
                 return true;
         }
     }


### PR DESCRIPTION
SDK merge is blocked due to test failures; see https://github.com/dotnet/sdk/pull/25317#issuecomment-1122710754.

The issue is that the test is calling `Assembly.GetCallingAssembly()` which returns the "Anonymously Hosted DynamicMethods Assembly" instead of the expected assembly. This broke due to the recent Invoke+Emit work where a `DynamicMethod` is created to invoke that method and the native code that attempts to skip the reflection stack frames was not correct.

Todo: 
- This issue can be reproduced in a stand-alone console app by simply using reflection to invoke a method that calls `GetCallingAssembly()`. However, adding the equivalent to an Xunit test I was unable to reproduce the issue. The console app included several more stack frames, including the "InvokeStub_" frame and the `MethodInvoker` or `ConstructorInvoker` frame however the xUnit test did not include those frames. We need to determine why this is the case and add an appropriate test.
- The fix here simply checks for a dynamic method starting with "InvokeStub_"; ideally it also checks to see if that dynamic method is the one generated for invoke vs. some other code that also generates a dynamic method that starts with "InvokeStub_".