### PR TITLE
fix GetContentAsync_ErrorStatusCode_ExpectedExceptionThrown test

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -220,19 +220,22 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [OuterLoop("Failing connection attempts take long on windows")]
         [SkipOnPlatform(TestPlatforms.Browser, "Socket is not supported on Browser")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/66692", TestPlatforms.OSX)]
         public async Task GetContentAsync_WhenCanNotConnect_ExceptionContainsHostInfo()
         {
-            using Socket portReserver = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            portReserver.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-            IPEndPoint ep = (IPEndPoint)portReserver.LocalEndPoint;
+            const string host = "localhost:1234";
 
-            using var client = CreateHttpClient();
+            using HttpClientHandler handler = CreateHttpClientHandler();
+            handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
+            var socketsHandler = (SocketsHttpHandler)GetUnderlyingSocketsHttpHandler(handler);
+            socketsHandler.ConnectCallback = (context, token) =>
+            {
+                throw new InvalidOperationException(nameof(GetContentAsync_WhenCanNotConnect_ExceptionContainsHostInfo));
+            };
 
-            HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => client.GetStreamAsync($"http://localhost:{ep.Port}"));
-            Assert.Contains($"localhost:{ep.Port}", ex.Message);
+            using var client = CreateHttpClient(handler);
+            HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => client.GetStreamAsync($"http://{host}"));
+            Assert.Contains(host, ex.Message);
         }
 
         [Fact]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -221,21 +221,21 @@ namespace System.Net.Http.Functional.Tests
 
         [Fact]
         [SkipOnPlatform(TestPlatforms.Browser, "Socket is not supported on Browser")]
-        public async Task GetContentAsync_WhenCanNotConnect_ExceptionContainsHostInfo()
+        public async Task GetContentAsync_WhenCannotConnect_ExceptionContainsHostInfo()
         {
-            const string host = "localhost:1234";
+            const string Host = "localhost:1234";
 
             using HttpClientHandler handler = CreateHttpClientHandler();
             handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
             var socketsHandler = (SocketsHttpHandler)GetUnderlyingSocketsHttpHandler(handler);
             socketsHandler.ConnectCallback = (context, token) =>
             {
-                throw new InvalidOperationException(nameof(GetContentAsync_WhenCanNotConnect_ExceptionContainsHostInfo));
+                throw new InvalidOperationException(nameof(GetContentAsync_WhenCannotConnect_ExceptionContainsHostInfo));
             };
 
             using var client = CreateHttpClient(handler);
-            HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => client.GetStreamAsync($"http://{host}"));
-            Assert.Contains(host, ex.Message);
+            HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => client.GetStreamAsync($"http://{Host}"));
+            Assert.Contains(Host, ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
This was curious one. It fails quickly on Linux but it takes ~30s on my Mac. 

First connect attempt would get RST but there would be subsequent attempt that just hangs long time. 
I'm wondering if this is related to dual mode sockets and fact that `loopback` can resolve to address other than 127.0.0.1 we are binding to. (e.g. ::1)


```
20:01:02.629187 IP6 localhost.63197 > localhost.63196: Flags [S], seq 1783575866, win 65535, options [mss 16324,nop,wscale 6,nop,nop,TS val 3452286497 ecr 0,sackOK,eol], length 0
20:01:02.629209 IP6 localhost.63196 > localhost.63197: Flags [R.], seq 0, ack 1783575867, win 0, length 0
20:01:02.642907 IP localhost.63198 > localhost.63196: Flags [S], seq 171587046, win 65535, options [mss 16344,nop,wscale 6,nop,nop,TS val 1376932488 ecr 0,sackOK,eol], length 0
20:01:02.743679 IP localhost.63198 > localhost.63196: Flags [S], seq 171587046, win 65535, options [mss 16344,nop,wscale 6,nop,nop,TS val 1376932588 ecr 0,sackOK,eol], length 0
20:01:02.843829 IP localhost.63198 > localhost.63196: Flags [S], seq 171587046, win 65535, options [mss 16344,nop,wscale 6,nop,nop,TS val 1376932688 ecr 0,sackOK,eol], length 0
20:01:02.944871 IP localhost.63198 > localhost.63196: Flags [S], seq 171587046, win 65535, options [mss 16344,nop,wscale 6,nop,nop,TS val 1376932789 ecr 0,sackOK,eol], length 0
20:01:03.050811 IP localhost.63198 > localhost.63196: Flags [S], seq 171587046, win 65535, options [mss 16344,nop,wscale 6,nop,nop,TS val 1376932889 ecr 0,sackOK,eol], length 0
20:01:03.157259 IP localhost.63198 > localhost.63196: Flags [S], seq 171587046, win 65535, options [mss 16344,nop,wscale 6,nop,nop,TS val 1376932989 ecr 0,sackOK,eol], length 0
20:01:03.359627 IP localhost.63198 > localhost.63196: Flags [S], seq 171587046, win 65535, options [mss 16344,nop,wscale 6,nop,nop,TS val 1376933189 ecr 0,sackOK,eol], length 0
20:01:03.767245 IP localhost.63198 > localhost.63196: Flags [S], seq 171587046, win 65535, options [mss 16344,nop,wscale 6,nop,nop,TS val 1376933590 ecr 0,sackOK,eol], length 0
20:01:04.568357 IP localhost.63198 > localhost.63196: Flags [S], seq 171587046, win 65535, options [mss 16344,nop,wscale 6,nop,nop,TS val 1376934390 ecr 0,sackOK,eol], length 0
20:01:06.168704 IP localhost.63198 > localhost.63196: Flags [S], seq 171587046, win 65535, options [mss 16344,nop,wscale 6,nop,nop,TS val 1376935990 ecr 0,sackOK,eol], length 0
20:01:09.375190 IP localhost.63198 > localhost.63196: Flags [S], seq 171587046, win 65535, options [mss 16344,sackOK,eol], length 0
20:01:15.832366 IP localhost.63198 > localhost.63196: Flags [S], seq 171587046, win 65535, options [mss 16344,sackOK,eol], length 0
20:01:22.284380 IP localhost.63198 > localhost.63196: Flags [S], seq 171587046, win 65535, options [mss 16344,sackOK,eol], length 0
20:07:17.893322 IP localhost.63351 > localhost.5037: Flags [S], seq 3993744937, win 65535, options [mss 16344,nop,wscale 6,nop,nop,TS val 372351349 ecr 0,sackOK,eol], length 0
```

This all comes from Socket.Connect(DnsEndpoint).

However, this test is trying to verify that the HttpRequestException has the info and that does not really depend on underlying socket operations. I replaced real socket with ConnectCallback that fails immediately and the test takes 0.2s instead of +30s. Since there is no real networking it should be fast and reliable. I removed the OuterLoop label as well. 

fixes #66692
