### PR TITLE
Enable corelib source generator in design time

### DIFF
--- a/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -300,11 +300,7 @@
   <!-- Include additional sources shared files in the compilation -->
   <Import Project="$(LibrariesProjectRoot)\System.Private.CoreLib\src\System.Private.CoreLib.Shared.projitems" Label="Shared" />
 
-  <!--
-  TODO https://github.com/dotnet/roslyn/pull/51964: EventSource generator is currently disabled for design time builds as it is
-  causing impactful slowdowns while typing in the Corelib project.
-  -->
-  <ItemGroup Condition="'$(DesignTimeBuild)'!='true' or '$(SlnGenMainProject)' != ''">
+  <ItemGroup>
     <ProjectReference Include="$(LibrariesProjectRoot)\System.Private.CoreLib\gen\System.Private.CoreLib.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 


### PR DESCRIPTION
The underlying issue was fixed with 4d39501439d438b9c749c7d2bca5b3c1a60c823b, which made the source generator incremental. With this condition, I get errors when trying to build System.Runtime inside VS when System.Private.CoreLib isn't yet built.