### PR TITLE
Fix CoreLib fast up-to-date check

### DIFF
--- a/eng/NoTargetsSdk.BeforeTargets.targets
+++ b/eng/NoTargetsSdk.BeforeTargets.targets
@@ -1,10 +1,6 @@
 <Project>
 
   <PropertyGroup>
-    <!-- NoTargets SDK projects don't produce symbols. Set here as Arcade and Directory.Build.props overwrite the SDKs setting. -->
-    <DebugSymbols>false</DebugSymbols>
-    <DebugType>none</DebugType>
-
     <!-- NoTargets SDK needs a TFM set. Set a default if the project doesn't multi target. -->
     <TargetFramework Condition="'$(TargetFramework)' == '' and '$(TargetFrameworks)' == ''">$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>

--- a/eng/NoTargetsSdk.BeforeTargets.targets
+++ b/eng/NoTargetsSdk.BeforeTargets.targets
@@ -1,6 +1,10 @@
 <Project>
 
   <PropertyGroup>
+    <!-- NoTargets SDK projects don't produce symbols. Set here as Arcade and Directory.Build.props overwrite the SDKs setting. -->
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>none</DebugType>
+
     <!-- NoTargets SDK needs a TFM set. Set a default if the project doesn't multi target. -->
     <TargetFramework Condition="'$(TargetFramework)' == '' and '$(TargetFrameworks)' == ''">$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -11,7 +11,7 @@
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22255.2",
     "Microsoft.DotNet.Helix.Sdk": "7.0.0-beta.22255.2",
     "Microsoft.DotNet.SharedFramework.Sdk": "7.0.0-beta.22255.2",
-    "Microsoft.Build.NoTargets": "3.3.0",
+    "Microsoft.Build.NoTargets": "3.4.0",
     "Microsoft.Build.Traversal": "3.1.6",
     "Microsoft.NET.Sdk.IL": "7.0.0-preview.5.22258.4"
   }

--- a/global.json
+++ b/global.json
@@ -11,7 +11,7 @@
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22255.2",
     "Microsoft.DotNet.Helix.Sdk": "7.0.0-beta.22255.2",
     "Microsoft.DotNet.SharedFramework.Sdk": "7.0.0-beta.22255.2",
-    "Microsoft.Build.NoTargets": "3.4.0",
+    "Microsoft.Build.NoTargets": "3.3.0",
     "Microsoft.Build.Traversal": "3.1.6",
     "Microsoft.NET.Sdk.IL": "7.0.0-preview.5.22258.4"
   }

--- a/src/coreclr/Directory.Build.targets
+++ b/src/coreclr/Directory.Build.targets
@@ -17,8 +17,10 @@
   <!-- Consolidate all PDBs into a single location, except the aotsdk PDBs, as S.P.C will overwrite the coreclr PDBs. -->
   <Target Name="MoveSymbolFiles"
           AfterTargets="CopyFilesToOutputDirectory"
+          DependsOnTargets="_CheckForCompileOutputs"
           Inputs="@(_DebugSymbolToMove)"
-          Outputs="@(_DebugSymbolToMove->Metadata('Destination'))">
+          Outputs="@(_DebugSymbolToMove->Metadata('Destination'))"
+          Condition="'$(_DebugSymbolsProduced)' == 'true'">
     <Copy SourceFiles="@(_DebugSymbolToMove)"
           DestinationFiles="@(_DebugSymbolToMove->Metadata('Destination'))"
           UseHardlinksIfPossible="false" />

--- a/src/coreclr/Directory.Build.targets
+++ b/src/coreclr/Directory.Build.targets
@@ -2,36 +2,26 @@
   <Import Project="..\..\Directory.Build.targets" />
 
   <ItemGroup>
-    <BuiltBinary Include="$(TargetPath)" />
-    <_AllPdbs Include="@(BuiltBinary -> '%(RootDir)%(Directory)%(Filename).pdb')">
-      <FolderName>$([System.IO.Directory]::GetParent(`%(Identity)`).Name)</FolderName>
-    </_AllPdbs>
+    <_DebugSymbolToMove Include="@(DebugSymbolsProjectOutputGroupOutput->Metadata('FinalOutputPath'))"
+                        FolderName="$([System.IO.Directory]::GetParent('%(Identity)').Name)" />
+    <_DebugSymbolToMoveToExclude Include="@(_DebugSymbolToMove->WithMetadataValue('FolderName', 'aotsdk'))" />
+    <_DebugSymbolToMoveToUpdate Include="@(_DebugSymbolToMove)"
+                                Exclude="@(_DebugSymbolToMoveToExclude)" />
+    <!-- Remove the FolderName metadata for projects that don't reside under an aotsdk folder. -->
+    <_DebugSymbolToMove Update="@(_DebugSymbolToMoveToUpdate)"
+                        FolderName="" />
+    <_DebugSymbolToMove Update="@(_DebugSymbolToMove)"
+                        Destination="$(RuntimeBinDir)PDB\%(FolderName)\%(Filename)%(Extension)" />
   </ItemGroup>
 
-  <!-- Target used to consolidate all PDBs into a single location, except the aotsdk
-       PDBs, as S.P.C will overwrite the coreclr PDBs -->
+  <!-- Consolidate all PDBs into a single location, except the aotsdk PDBs, as S.P.C will overwrite the coreclr PDBs. -->
   <Target Name="MoveSymbolFiles"
-          AfterTargets="Build"
-          Condition="Exists(@(_AllPdbs))"
-          Inputs="@(_AllPdbs)"
-          Outputs="@(_AllPdbs -> '$(RuntimeBinDir)PDB/%(Filename).pdb')">
-
-    <Move SourceFiles="@(_AllPdbs)"
-          DestinationFolder="$(RuntimeBinDir)PDB"
-          Condition="'%(_AllPdbs.FolderName)' != 'aotsdk'" />
-
-  </Target>
-
-  <Target Name="MoveAotSymbolFiles"
-          AfterTargets="Build"
-          Condition="Exists(@(_AllPdbs))"
-          Inputs="@(_AllPdbs)"
-          Outputs="@(_AllPdbs -> '$(RuntimeBinDir)PDB/aotsdk/%(Filename).pdb')">
-
-    <Move SourceFiles="@(_AllPdbs)"
-          DestinationFolder="$(RuntimeBinDir)PDB/aotsdk"
-          Condition="'%(_AllPdbs.FolderName)' == 'aotsdk'" />
-
+          AfterTargets="CopyFilesToOutputDirectory"
+          Inputs="@(_DebugSymbolToMove)"
+          Outputs="@(_DebugSymbolToMove->Metadata('Destination'))">
+    <Copy SourceFiles="@(_DebugSymbolToMove)"
+          DestinationFiles="@(_DebugSymbolToMove->Metadata('Destination'))"
+          UseHardlinksIfPossible="false" />
   </Target>
 
   <!-- Import targets here to have TargetPath and other macros defined. Limit to CoreLib. -->

--- a/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -9,7 +9,7 @@
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
 
     <!-- Force System.Private.CoreLib.dll into a special IL output directory -->
-    <OutputPath>$(RuntimeBinDir)/IL/</OutputPath>
+    <OutputPath>$(RuntimeBinDir)IL\</OutputPath>
     <Configurations>Debug;Release;Checked</Configurations>
     <Platforms>x64;x86;arm;arm64</Platforms>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/68698

CoreLib's fast up-to-date check was broken because the output pdb was
moved into a different folder. Changing this to use a copy task instead
and consolidate the two targets into one.

I couldn't find a publicly exposed property that allows to change the
pdb's output path, hence I decided to copy.