### PR TITLE
Update NoTargets.SDK and remove unnecessary properties being set

### DIFF
--- a/eng/NoTargetsSdk.BeforeTargets.targets
+++ b/eng/NoTargetsSdk.BeforeTargets.targets
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <!-- NoTargets SDK projects don't produce symbols. Set here as Arcade and Directory.Build.props overwrite the SDKs setting. -->
+    <!-- TODO: Remove when https://github.com/microsoft/MSBuildSdks/pull/360 is merged and consumed.
     <DebugSymbols>false</DebugSymbols>
     <DebugType>none</DebugType>
 

--- a/eng/NoTargetsSdk.BeforeTargets.targets
+++ b/eng/NoTargetsSdk.BeforeTargets.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- NoTargets SDK projects don't produce symbols. Set here as Arcade and Directory.Build.props overwrite the SDKs setting. -->
-    <!-- TODO: Remove when https://github.com/microsoft/MSBuildSdks/pull/360 is merged and consumed.
+    <!-- TODO: Remove when https://github.com/microsoft/MSBuildSdks/pull/360 is merged and consumed. -->
     <DebugSymbols>false</DebugSymbols>
     <DebugType>none</DebugType>
 

--- a/eng/NoTargetsSdk.BeforeTargets.targets
+++ b/eng/NoTargetsSdk.BeforeTargets.targets
@@ -1,6 +1,10 @@
 <Project>
 
   <PropertyGroup>
+    <!-- NoTargets SDK projects don't produce symbols. Set here as Arcade and Directory.Build.props overwrite the SDKs setting. -->
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>none</DebugType>
+
     <!-- NoTargets SDK needs a TFM set. Set a default if the project doesn't multi target. -->
     <TargetFramework Condition="'$(TargetFramework)' == '' and '$(TargetFrameworks)' == ''">$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -11,7 +11,7 @@
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22255.2",
     "Microsoft.DotNet.Helix.Sdk": "7.0.0-beta.22255.2",
     "Microsoft.DotNet.SharedFramework.Sdk": "7.0.0-beta.22255.2",
-    "Microsoft.Build.NoTargets": "3.3.0",
+    "Microsoft.Build.NoTargets": "3.4.0",
     "Microsoft.Build.Traversal": "3.1.6",
     "Microsoft.NET.Sdk.IL": "7.0.0-preview.5.22258.4"
   }

--- a/src/libraries/Microsoft.Internal.Runtime.AspNetCore.Transport/src/Microsoft.Internal.Runtime.AspNetCore.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.AspNetCore.Transport/src/Microsoft.Internal.Runtime.AspNetCore.Transport.proj
@@ -6,8 +6,6 @@
     <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>true</IncludeBuildOutput>
-    <DebugSymbols>false</DebugSymbols>
-    <DebugType>none</DebugType>
     <!-- Enable when the package shipped with NET6. -->
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <PackageDescription>Internal transport package to provide aspnetcore with the assemblies from dotnet/runtime that make up the Microsoft.AspNetCore.App shared framework.</PackageDescription>

--- a/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
@@ -6,8 +6,6 @@
     <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>true</IncludeBuildOutput>
-    <DebugSymbols>false</DebugSymbols>
-    <DebugType>none</DebugType>
     <!-- Enable when the package shipped with NET6. -->
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <PackageDescription>Internal transport package to provide windowsdesktop with the assemblies from dotnet/runtime that make up the Microsoft.WindowsDesktop.App shared framework.</PackageDescription>

--- a/src/libraries/Microsoft.NET.WebAssembly.Threading/src/Microsoft.NET.WebAssembly.Threading.proj
+++ b/src/libraries/Microsoft.NET.WebAssembly.Threading/src/Microsoft.NET.WebAssembly.Threading.proj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <IncludeBuildOutput>true</IncludeBuildOutput>
-    <DebugSymbols>false</DebugSymbols>
-    <DebugType>none</DebugType>
     <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <IsPackable>true</IsPackable>

--- a/src/libraries/System.IO.Ports/pkg/runtime.native.System.IO.Ports.props
+++ b/src/libraries/System.IO.Ports/pkg/runtime.native.System.IO.Ports.props
@@ -4,8 +4,6 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <!-- IncludeBuildOutput needs to be set to true to make NuGet include the passed in debug symbol files. -->
     <IncludeBuildOutput>true</IncludeBuildOutput>
-    <DebugSymbols>false</DebugSymbols>
-    <DebugType>none</DebugType>
     <IsPackable>true</IsPackable>
     <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>$(SymbolsSuffix)</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
     <!-- When KeepNativeSymbols is set, debug symbols are kept in the .so files.  Separate symbol files do not exist that need to be packed. -->


### PR DESCRIPTION
The NoTargets.SDK now already sets the DebugType and DebugSymbols properties to None/false (as NoTargets projects don't compile anything).