### PR TITLE
Fix memory leak at AssemblyLoadContext unload

### DIFF
--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -928,6 +928,10 @@ void Module::Destruct()
 
     m_pPEAssembly->Release();
 
+#if defined(PROFILING_SUPPORTED)
+    delete m_pJitInlinerTrackingMap;
+#endif
+
     // If this module was loaded as domain-specific, then
     // we must free its ModuleIndex so that it can be reused
     FreeModuleIndex();


### PR DESCRIPTION
I have found there was a small memory leak when unloading
AssemblyLoadContext. A customer had a quite extreme testing case that
ran millions of iterations of creating an AssemblyLoadContext, loading
some assemblies into it and then unloading it. After 80 million
iterations on their machine with 8GB memory, the testing app was getting
out of memory.

Using PerfView, I was able to locate the source of the leak. It was a
missing destruction of the Module::m_pJitInlinerTrackingMap.

I have verified that with the fix applied, the memory doesn't grow at all in
that testing app.