### PR TITLE
remove internal socket exception from NameResolution

### DIFF
--- a/src/libraries/System.Net.NameResolution/src/System.Net.NameResolution.csproj
+++ b/src/libraries/System.Net.NameResolution/src/System.Net.NameResolution.csproj
@@ -41,8 +41,6 @@
     <!-- System.Net.Internals -->
     <Compile Include="$(CommonPath)System\Net\Internals\IPAddressExtensions.cs"
              Link="Common\System\Net\Internals\IPAddressExtensions.cs" />
-    <Compile Include="$(CommonPath)System\Net\Internals\SocketExceptionFactory.Windows.cs"
-             Link="Common\System\Net\Internals\SocketExceptionFactory.Windows.cs" />
     <Compile Include="$(CommonPath)System\Net\SocketProtocolSupportPal.Windows.cs"
              Link="Common\System\Net\SocketProtocolSupportPal.Windows" />
     <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Windows.cs"
@@ -81,10 +79,6 @@
              Link="Common\System\Net\Internals\SocketAddressPal.Unix.cs" />
     <Compile Include="$(CommonPath)System\Net\SocketProtocolSupportPal.Unix.cs"
              Link="Common\System\Net\SocketProtocolSupportPal.Unix" />
-    <Compile Include="$(CommonPath)System\Net\Internals\SocketExceptionFactory.cs"
-             Link="Common\System\Net\Internals\SocketExceptionFactory.cs" />
-    <Compile Include="$(CommonPath)System\Net\Internals\SocketExceptionFactory.Unix.cs"
-             Link="Common\System\Net\Internals\SocketExceptionFactory.Unix.cs" />
     <Compile Include="$(CommonPath)Interop\Interop.CheckedAccess.cs"
              Link="Common\System\Net\Internals\Interop.CheckedAccess.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\Interop.Errors.cs"

--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -390,7 +390,7 @@ namespace System.Net
                 if (errorCode != SocketError.Success)
                 {
                     if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(hostName, $"{hostName} DNS lookup failed with {errorCode}");
-                    throw SocketExceptionFactory.CreateSocketException(errorCode, nativeErrorCode);
+                    throw CreateException(errorCode, nativeErrorCode);
                 }
 
                 result = justAddresses ? (object)
@@ -440,7 +440,7 @@ namespace System.Net
                 if (errorCode != SocketError.Success)
                 {
                     if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(address, $"{address} DNS lookup failed with {errorCode}");
-                    throw SocketExceptionFactory.CreateSocketException(errorCode, nativeErrorCode);
+                    throw CreateException(errorCode, nativeErrorCode);
                 }
                 Debug.Assert(name != null);
             }
@@ -710,6 +710,13 @@ namespace System.Net
             }
 
             return task;
+        }
+
+        private static Exception CreateException(SocketError error, int nativeError)
+        {
+            SocketException e = new SocketException((int)error);
+            e.HResult = nativeError;
+            return e;
         }
     }
 }

--- a/src/libraries/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/libraries/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -343,7 +343,7 @@ namespace System.Net.NameResolution.PalTests
 
                 if (error == SocketError.HostNotFound && !OperatingSystem.IsWindows())
                 {
-                    // On Unix, we are not guaranteed to be able to resove the local host. The ability to do so depends on the
+                    // On Unix, we are not guaranteed to be able to resolve the local host. The ability to do so depends on the
                     // machine configurations, which varies by distro and is often inconsistent.
                     return;
                 }
@@ -393,7 +393,7 @@ namespace System.Net.NameResolution.PalTests
 
                 if (error == SocketError.HostNotFound && !OperatingSystem.IsWindows())
                 {
-                    // On Unix, we are not guaranteed to be able to resove the local host. The ability to do so depends on the
+                    // On Unix, we are not guaranteed to be able to resolve the local host. The ability to do so depends on the
                     // machine configurations, which varies by distro and is often inconsistent.
                     return;
                 }
@@ -463,7 +463,7 @@ namespace System.Net.NameResolution.PalTests
 
             const string hostName = "test.123";
 
-            SocketException socketException = await Assert.ThrowsAnyAsync<SocketException>(() => NameResolutionPal.GetAddrInfoAsync(hostName, justAddresses, AddressFamily.Unspecified, CancellationToken.None)).ConfigureAwait(false);
+            SocketException socketException = await Assert.ThrowsAsync<SocketException>(() => NameResolutionPal.GetAddrInfoAsync(hostName, justAddresses, AddressFamily.Unspecified, CancellationToken.None)).ConfigureAwait(false);
             SocketError socketError = socketException.SocketErrorCode;
 
             Assert.Equal(SocketError.HostNotFound, socketError);

--- a/src/libraries/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
+++ b/src/libraries/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
@@ -25,6 +25,8 @@
              Link="Common\System\Net\Sockets\ProtocolType.cs" />
     <Compile Include="$(CommonPath)System\Net\Sockets\SocketType.cs" Condition="'$(TargetPlatformIdentifier)' == 'windows'"
              Link="Common\System\Net\Sockets\SocketType.cs" />
+    <Compile Include="$(CommonPath)System\Net\Sockets\ProtocolFamily.cs"
+              Link="Common\System\Net\Sockets\ProtocolFamily.cs" />
     <Compile Include="$(CommonPath)System\Net\IPEndPointStatics.cs"
              Link="Common\System\Net\IPEndPointStatics.cs" />
     <Compile Include="$(CommonPath)System\Net\IPAddressParserStatics.cs"
@@ -69,8 +71,6 @@
              Link="Common\Interop\Windows\WinSock\Interop.WSASocketW.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.SocketConstructorFlags.cs"
              Link="Common\Interop\Windows\WinSock\Interop.SocketConstructorFlags.cs" />
-    <Compile Include="$(CommonPath)System\Net\Sockets\ProtocolFamily.cs"
-             Link="Common\System\Net\Sockets\ProtocolFamily.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.GetAddrInfoExW.cs"
              Link="Common\Interop\Windows\WinSock\Interop.GetAddrInfoExW.cs" />
   </ItemGroup>
@@ -81,10 +81,6 @@
              Link="Common\System\Net\Internals\Interop.CheckedAccess.cs" />
     <Compile Include="$(CommonPath)System\Net\InteropIPAddressExtensions.Unix.cs"
              Link="Common\System\Net\InteropIPAddressExtensions.Unix.cs" />
-    <Compile Include="$(CommonPath)System\Net\Internals\SocketExceptionFactory.cs"
-             Link="ProductionCode\Common\System\Net\Internals\SocketExceptionFactory.cs" />
-    <Compile Include="$(CommonPath)System\Net\Internals\SocketExceptionFactory.Unix.cs"
-             Link="ProductionCode\Common\System\Net\Internals\SocketExceptionFactory.Unix.cs" />
     <Compile Include="..\..\src\System\Net\NameResolutionPal.Unix.cs"
              Link="ProductionCode\System\Net\NameResolutionPal.Unix.cs" />
     <Compile Include="$(CommonPath)System\Net\SocketProtocolSupportPal.Unix.cs"


### PR DESCRIPTION
contributes to https://github.com/dotnet/runtime/issues/37150. 

We will throw 
```
System.Net.Sockets.SocketException (00000001, 11): Resource temporarily unavailable
   at System.Net.Dns.GetHostEntryOrAddressesCore(String hostName, Boolean justAddresses, AddressFamily addressFamily, Int64 startingTimestamp) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs:line 393
   at System.Net.Dns.GetHostAddressesCore(String hostName, AddressFamily addressFamily, Int64 startingTimestamp) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs:line 374
   at System.Net.Dns.GetHostAddresses(String hostNameOrAddress, AddressFamily family) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs:line 208
   at System.Net.Dns.GetHostAddresses(String hostNameOrAddress) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs:line 180
```

instead of 
```
System.Net.Internals.SocketExceptionFactory+ExtendedSocketException (00000001, 11): Resource temporarily unavailable
   at System.Net.Dns.GetHostEntryOrAddressesCore(String hostName, Boolean justAddresses, AddressFamily addressFamily, ValueStopwatch stopwatch)
   at System.Net.Dns.GetHostAddresses(String hostNameOrAddress, AddressFamily family)
```

The `System.Net.Internals.SocketExceptionFactory` is derived type from `SocketException`. This is probably breaking change but I'm not sure what is likelihood that somebody depends on the current `Internals.SocketExceptionFactory`
This should be back to what .NET Framework did.

This is part of https://github.com/dotnet/runtime/pull/68918.
Socket change is waiting for #69266 
