### PR TITLE
Use static abstract members on two occasions.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.IO.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.IO.Windows.cs
@@ -148,7 +148,7 @@ namespace System.Threading
                     _nativeEvents =
                         (Interop.Kernel32.OVERLAPPED_ENTRY*)
                         NativeMemory.Alloc(NativeEventCapacity, (nuint)sizeof(Interop.Kernel32.OVERLAPPED_ENTRY));
-                    _events = new ThreadPoolTypedWorkItemQueue<Event, Callback>(default);
+                    _events = new ThreadPoolTypedWorkItemQueue<Event, Callback>();
 
                     // These threads don't run user code, use a smaller stack size
                     _thread = new Thread(Poll, SmallStackSizeBytes);
@@ -247,7 +247,7 @@ namespace System.Threading
 
             private struct Callback : IThreadPoolTypedWorkItemQueueCallback<Event>
             {
-                public void Invoke(Event e)
+                public static void Invoke(Event e)
                 {
                     if (NativeRuntimeEventSource.Log.IsEnabled())
                     {


### PR DESCRIPTION
[I noticed](https://github.com/dotnet/runtime/blob/fed030a1ff34c6eff874b4153adbab83b6b26df7/src/libraries/System.Net.Security/src/System/Net/Security/ReadWriteAdapter.cs#L10-L17) that static abstract members have started being used used in regular BCL code, and used them on two occasions.