### PR TITLE
Collect more info for host tests

### DIFF
--- a/eng/pipelines/installer/jobs/steps/upload-job-artifacts.yml
+++ b/eng/pipelines/installer/jobs/steps/upload-job-artifacts.yml
@@ -33,7 +33,7 @@ steps:
     TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
     CleanTargetFolder: true
   continueOnError: true
-  condition: succeededOrFailed()
+  condition: always()
 
 - task: PublishPipelineArtifact@1
   displayName: Publish BuildLogs
@@ -41,4 +41,4 @@ steps:
     targetPath: '$(Build.StagingDirectory)/BuildLogs'
     artifactName: Installer-Logs-${{parameters.pgoType }}${{ parameters.runtimeFlavor }}-${{ parameters.runtimeVariant }}-${{ parameters.name }}-$(_BuildConfig)
   continueOnError: true
-  condition: succeededOrFailed()
+  condition: always()

--- a/src/installer/tests/Directory.Build.props
+++ b/src/installer/tests/Directory.Build.props
@@ -10,7 +10,7 @@
     <InternalNupkgCacheDir>$(ArtifactsObjDir)ExtraNupkgsForTestRestore\</InternalNupkgCacheDir>
     <TestArchitectures>$(TargetArchitecture)</TestArchitectures>
     <TestInfraTargetFramework>$(NetCoreAppToolCurrent)</TestInfraTargetFramework>
-    <TestRunnerAdditionalArguments>-notrait category=failing</TestRunnerAdditionalArguments>
+    <TestRunnerAdditionalArguments>-notrait category=failing -verbose</TestRunnerAdditionalArguments>
     <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 


### PR DESCRIPTION
- Always publish build / test logs
  - We were not publishing logs on timeout
- Enable verbose output when running tests
  - This should make the logs print when it starts/finishes running a test case.

Hopefully will help with investigating https://github.com/dotnet/runtime/issues/69114.