### PR TITLE
Wasm conditional audit + remove CompileFunction

### DIFF
--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
@@ -15,8 +15,6 @@ internal static partial class Interop
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern string InvokeJS(string str, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern void CompileFunctionRef(in string str, out int exceptionalResult, out object result);
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern void InvokeJSWithArgsRef(IntPtr jsHandle, in string method, in object?[] parms, out int exceptionalResult, out object result);
         // FIXME: All of these signatures need to be object? in various places and not object, but the nullability
         //  warnings will take me hours and hours to fix so I'm not doing that right now since they're already broken
@@ -69,15 +67,6 @@ internal static partial class Interop
             if (exception != 0)
                 throw new JSException(res);
             return res;
-        }
-
-        public static System.Runtime.InteropServices.JavaScript.Function? CompileFunction(string snippet)
-        {
-            CompileFunctionRef(snippet, out int exception, out object res);
-            if (exception != 0)
-                throw new JSException((string)res);
-            ReleaseInFlight(res);
-            return res as System.Runtime.InteropServices.JavaScript.Function;
         }
 
         public static object GetGlobalObject(string? str = null)

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -22,11 +22,6 @@ namespace System.Runtime.InteropServices.JavaScript
             return Interop.Runtime.InvokeJS(str);
         }
 
-        public static Function? CompileFunction(string snippet)
-        {
-            return Interop.Runtime.CompileFunction(snippet);
-        }
-
         public static object GetGlobalObject(string? str = null)
         {
             return Interop.Runtime.GetGlobalObject(str);

--- a/src/mono/wasm/runtime/buffers.ts
+++ b/src/mono/wasm/runtime/buffers.ts
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import { JSHandle, MonoArray, MonoObject, MonoObjectRef } from "./types";
+import { JSHandle, MonoArray, MonoObject, MonoObjectRef, is_nullish } from "./types";
 import { Module } from "./imports";
 import { mono_wasm_get_jsobj_from_js_handle } from "./gc-handles";
 import { wrap_error_root } from "./method-calls";
@@ -139,7 +139,7 @@ export function mono_wasm_typed_array_copy_to_ref(js_handle: JSHandle, pinned_ar
     const resultRoot = mono_wasm_new_external_root<MonoObject>(result_address);
     try {
         const js_obj = mono_wasm_get_jsobj_from_js_handle(js_handle);
-        if (!js_obj) {
+        if (is_nullish(js_obj)) {
             wrap_error_root(is_exception, "ERR07: Invalid JS object handle '" + js_handle + "'", resultRoot);
             return;
         }
@@ -173,7 +173,7 @@ export function mono_wasm_typed_array_copy_from_ref(js_handle: JSHandle, pinned_
     const resultRoot = mono_wasm_new_external_root<MonoObject>(result_address);
     try {
         const js_obj = mono_wasm_get_jsobj_from_js_handle(js_handle);
-        if (!js_obj) {
+        if (is_nullish(js_obj)) {
             wrap_error_root(is_exception, "ERR08: Invalid JS object handle '" + js_handle + "'", resultRoot);
             return;
         }

--- a/src/mono/wasm/runtime/corebindings.c
+++ b/src/mono/wasm/runtime/corebindings.c
@@ -35,7 +35,6 @@ extern void mono_wasm_web_socket_send (int webSocket_js_handle, void* buffer_ptr
 extern void mono_wasm_web_socket_receive (int webSocket_js_handle, void* buffer_ptr, int offset, int length, void* response_ptr, int *thenable_js_handle, int *is_exception, MonoObject **result);
 extern void mono_wasm_web_socket_close_ref (int webSocket_js_handle, int code, MonoString **reason, int wait_for_close_received, int *thenable_js_handle, int *is_exception, MonoObject **result);
 extern void mono_wasm_web_socket_abort (int webSocket_js_handle, int *is_exception, MonoString **result);
-extern void mono_wasm_compile_function_ref (MonoString *str, int *is_exception, MonoObject **result);
 
 void core_initialize_internals ()
 {
@@ -51,7 +50,6 @@ void core_initialize_internals ()
 	mono_add_internal_call ("Interop/Runtime::TypedArrayCopyToRef", mono_wasm_typed_array_copy_to_ref);
 	mono_add_internal_call ("Interop/Runtime::TypedArrayFromRef", mono_wasm_typed_array_from_ref);
 	mono_add_internal_call ("Interop/Runtime::TypedArrayCopyFromRef", mono_wasm_typed_array_copy_from_ref);
-	mono_add_internal_call ("Interop/Runtime::CompileFunctionRef", mono_wasm_compile_function_ref);
 	mono_add_internal_call ("Interop/Runtime::WebSocketOpenRef", mono_wasm_web_socket_open_ref);
 	mono_add_internal_call ("Interop/Runtime::WebSocketSend", mono_wasm_web_socket_send);
 	mono_add_internal_call ("Interop/Runtime::WebSocketReceive", mono_wasm_web_socket_receive);

--- a/src/mono/wasm/runtime/cs-to-js.ts
+++ b/src/mono/wasm/runtime/cs-to-js.ts
@@ -5,7 +5,7 @@ import { mono_wasm_new_root, WasmRoot, mono_wasm_new_external_root } from "./roo
 import {
     GCHandle, JSHandleDisposed, MarshalError, MarshalType, MonoArray,
     MonoArrayNull, MonoObject, MonoObjectNull, MonoString,
-    MonoType, MonoTypeNull, MonoObjectRef, MonoStringRef
+    MonoType, MonoTypeNull, MonoObjectRef, MonoStringRef, is_nullish
 } from "./types";
 import { runtimeHelpers } from "./imports";
 import { conv_string_root } from "./strings";
@@ -350,7 +350,7 @@ export function _unbox_ref_type_root_as_js_object(root: WasmRoot<MonoObject>): a
     let result = _lookup_js_owned_object(gc_handle);
 
     // If the JS object for this gc_handle was already collected (or was never created)
-    if (!result) {
+    if (is_nullish(result)) {
         result = {};
 
         // keep the gc_handle so that we could easily convert it back to original C# object for roundtrip

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -259,7 +259,7 @@ function initializeImportsAndExports(
             let value: any = undefined;
             Object.defineProperty(globalThis, name, {
                 get: () => {
-                    if (!is_nullish(value)) {
+                    if (is_nullish(value)) {
                         const stack = (new Error()).stack;
                         const nextLine = stack ? stack.substr(stack.indexOf("\n", 8) + 1) : "";
                         console.warn(`global ${name} is obsolete, please use Module.${name} instead ${nextLine}`);

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -47,7 +47,6 @@ import {
 import {
     call_static_method, mono_bind_static_method, mono_call_assembly_entry_point,
     mono_method_resolve,
-    mono_wasm_compile_function_ref,
     mono_wasm_get_by_index_ref, mono_wasm_get_global_object_ref, mono_wasm_get_object_property_ref,
     mono_wasm_invoke_js,
     mono_wasm_invoke_js_blazor,
@@ -347,7 +346,6 @@ export const __linker_exports: any = {
     mono_wasm_web_socket_receive,
     mono_wasm_web_socket_close_ref,
     mono_wasm_web_socket_abort,
-    mono_wasm_compile_function_ref,
 
     //  also keep in sync with pal_icushim_static.c
     mono_wasm_load_icu_data,

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -30,7 +30,7 @@ import {
     mono_wasm_debugger_attached,
 } from "./debug";
 import { ENVIRONMENT_IS_WEB, ExitStatusError, runtimeHelpers, setImportsAndExports } from "./imports";
-import { DotnetModuleConfigImports, DotnetModule } from "./types";
+import { DotnetModuleConfigImports, DotnetModule, is_nullish } from "./types";
 import {
     mono_load_runtime_and_bcl_args, mono_wasm_load_config,
     mono_wasm_setenv, mono_wasm_set_runtime_options,
@@ -259,7 +259,7 @@ function initializeImportsAndExports(
             let value: any = undefined;
             Object.defineProperty(globalThis, name, {
                 get: () => {
-                    if (!value) {
+                    if (!is_nullish(value)) {
                         const stack = (new Error()).stack;
                         const nextLine = stack ? stack.substr(stack.indexOf("\n", 8) + 1) : "";
                         console.warn(`global ${name} is obsolete, please use Module.${name} instead ${nextLine}`);

--- a/src/mono/wasm/runtime/js-to-cs.ts
+++ b/src/mono/wasm/runtime/js-to-cs.ts
@@ -15,7 +15,7 @@ import { wrap_error_root } from "./method-calls";
 import { js_string_to_mono_string_root, js_string_to_mono_string_interned_root } from "./strings";
 import { isThenable } from "./cancelable-promise";
 import { has_backing_array_buffer } from "./buffers";
-import { JSHandle, MonoArray, MonoMethod, MonoObject, MonoObjectNull, wasm_type_symbol, MonoClass, MonoObjectRef } from "./types";
+import { JSHandle, MonoArray, MonoMethod, MonoObject, MonoObjectNull, wasm_type_symbol, MonoClass, MonoObjectRef, is_nullish } from "./types";
 import { setI32, setU32, setF64 } from "./memory";
 import { Int32Ptr, TypedArray } from "./types/emscripten";
 
@@ -278,7 +278,7 @@ export function mono_wasm_typed_array_to_array_ref(js_handle: JSHandle, is_excep
     const resultRoot = mono_wasm_new_external_root<MonoObject>(result_address);
     try {
         const js_obj = mono_wasm_get_jsobj_from_js_handle(js_handle);
-        if (!js_obj) {
+        if (is_nullish(js_obj)) {
             wrap_error_root(is_exception, "ERR06: Invalid JS object handle '" + js_handle + "'", resultRoot);
             return;
         }

--- a/src/mono/wasm/runtime/method-calls.ts
+++ b/src/mono/wasm/runtime/method-calls.ts
@@ -6,7 +6,7 @@ import {
     JSHandle, MonoArray, MonoMethod, MonoObject,
     MonoObjectNull, MonoString, coerceNull as coerceNull,
     VoidPtrNull, MonoStringNull, MonoObjectRef,
-    MonoStringRef
+    MonoStringRef, is_nullish
 } from "./types";
 import { BINDING, INTERNAL, Module, MONO, runtimeHelpers } from "./imports";
 import { mono_array_root_to_js_array, unbox_mono_obj_root } from "./cs-to-js";
@@ -225,14 +225,14 @@ export function _teardown_after_call(
     _release_args_root_buffer_from_method_call(converter, token, argsRootBuffer);
     _release_buffer_from_method_call(converter, token, buffer);
 
-    if (resultRoot) {
+    if (typeof (resultRoot) === "object") {
         resultRoot.clear();
         if ((token !== null) && (token.scratchResultRoot === null))
             token.scratchResultRoot = resultRoot;
         else
             resultRoot.release();
     }
-    if (exceptionRoot) {
+    if (typeof (exceptionRoot) === "object") {
         exceptionRoot.clear();
         if ((token !== null) && (token.scratchExceptionRoot === null))
             token.scratchExceptionRoot = exceptionRoot;
@@ -284,7 +284,7 @@ export function mono_bind_assembly_entry_point(assembly: string, signature?: str
     if (!method)
         throw new Error("Could not find entry point for assembly: " + assembly);
 
-    if (!signature)
+    if (typeof (signature) !== "string")
         signature = mono_method_get_call_signature_ref(method, undefined);
 
     return async function (...args: any[]) {
@@ -302,7 +302,7 @@ export function mono_call_assembly_entry_point(assembly: string, args?: any[], s
 }
 
 export function mono_wasm_invoke_js_with_args_ref(js_handle: JSHandle, method_name: MonoStringRef, args: MonoObjectRef, is_exception: Int32Ptr, result_address: MonoObjectRef): any {
-    const argsRoot = mono_wasm_new_external_root<MonoArray>(args), 
+    const argsRoot = mono_wasm_new_external_root<MonoArray>(args),
         nameRoot = mono_wasm_new_external_root<MonoString>(method_name),
         resultRoot = mono_wasm_new_external_root<MonoObject>(result_address);
     try {
@@ -313,7 +313,7 @@ export function mono_wasm_invoke_js_with_args_ref(js_handle: JSHandle, method_na
         }
 
         const obj = get_js_obj(js_handle);
-        if (!obj) {
+        if (is_nullish(obj)) {
             wrap_error_root(is_exception, "ERR13: Invalid JS object handle '" + js_handle + "' while invoking '" + js_name + "'", resultRoot);
             return;
         }
@@ -348,7 +348,7 @@ export function mono_wasm_get_object_property_ref(js_handle: JSHandle, property_
         }
 
         const obj = mono_wasm_get_jsobj_from_js_handle(js_handle);
-        if (!obj) {
+        if (is_nullish(obj)) {
             wrap_error_root(is_exception, "ERR01: Invalid JS object handle '" + js_handle + "' while geting '" + js_name + "'", resultRoot);
             return;
         }
@@ -376,7 +376,7 @@ export function mono_wasm_set_object_property_ref(js_handle: JSHandle, property_
         }
 
         const js_obj = mono_wasm_get_jsobj_from_js_handle(js_handle);
-        if (!js_obj) {
+        if (is_nullish(js_obj)) {
             wrap_error_root(is_exception, "ERR02: Invalid JS object handle '" + js_handle + "' while setting '" + property + "'", resultRoot);
             return;
         }
@@ -422,7 +422,7 @@ export function mono_wasm_get_by_index_ref(js_handle: JSHandle, property_index: 
     const resultRoot = mono_wasm_new_external_root<MonoObject>(result_address);
     try {
         const obj = mono_wasm_get_jsobj_from_js_handle(js_handle);
-        if (!obj) {
+        if (is_nullish(obj)) {
             wrap_error_root(is_exception, "ERR03: Invalid JS object handle '" + js_handle + "' while getting [" + property_index + "]", resultRoot);
             return;
         }
@@ -441,7 +441,7 @@ export function mono_wasm_set_by_index_ref(js_handle: JSHandle, property_index: 
         resultRoot = mono_wasm_new_external_root<MonoObject>(result_address);
     try {
         const obj = mono_wasm_get_jsobj_from_js_handle(js_handle);
-        if (!obj) {
+        if (is_nullish(obj)) {
             wrap_error_root(is_exception, "ERR04: Invalid JS object handle '" + js_handle + "' while setting [" + property_index + "]", resultRoot);
             return;
         }
@@ -626,6 +626,7 @@ export function mono_wasm_compile_function_ref(code: MonoStringRef, is_exception
 
     const js_code = conv_string_root(codeRoot);
     if (!js_code) {
+        // FIXME: We should probably throw an error here, compiling an empty function is almost certainly a mistake
         js_to_mono_obj_root(MonoStringNull, resultRoot, true);
         return;
     }

--- a/src/mono/wasm/runtime/queue.ts
+++ b/src/mono/wasm/runtime/queue.ts
@@ -36,7 +36,7 @@ export class Queue<T> {
     dequeue(): T | undefined {
 
         // if the queue is empty, return immediately
-        if (this.queue.length == 0) return undefined;
+        if (this.queue.length === 0) return undefined;
 
         // store the item at the front of the queue
         const item = this.queue[this.offset];

--- a/src/mono/wasm/runtime/roots.ts
+++ b/src/mono/wasm/runtime/roots.ts
@@ -4,7 +4,7 @@
 import cwraps from "./cwraps";
 import { Module } from "./imports";
 import { VoidPtr, ManagedPointer, NativePointer } from "./types/emscripten";
-import { MonoObjectRef, MonoObjectRefNull, MonoObject } from "./types";
+import { MonoObjectRef, MonoObjectRefNull, MonoObject, is_nullish } from "./types";
 
 const maxScratchRoots = 8192;
 let _scratch_root_buffer: WasmRootBuffer | null = null;
@@ -138,7 +138,7 @@ export function mono_wasm_new_roots<T extends MonoObject>(count_or_values: numbe
  */
 export function mono_wasm_release_roots(...args: WasmRoot<any>[]): void {
     for (let i = 0; i < args.length; i++) {
-        if (!args[i])
+        if (is_nullish(args[i]))
             continue;
 
         args[i].release();
@@ -162,7 +162,7 @@ function _mono_wasm_release_scratch_index(index: number) {
 }
 
 function _mono_wasm_claim_scratch_index() {
-    if (!_scratch_root_buffer || !_scratch_root_free_indices) {
+    if (is_nullish(_scratch_root_buffer) || !_scratch_root_free_indices) {
         _scratch_root_buffer = mono_wasm_new_root_buffer(maxScratchRoots, "js roots");
 
         _scratch_root_free_indices = new Int32Array(maxScratchRoots);

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -198,7 +198,9 @@ function _handle_fetched_asset(asset: AssetEntry, url?: string) {
     if (ctx.tracing)
         console.log(`MONO_WASM: Loaded:${asset.name} as ${asset.behavior} size ${bytes.length} from ${url}`);
 
-    const virtualName: string = asset.virtual_path || asset.name;
+    const virtualName: string = typeof (asset.virtual_path) === "string"
+        ? asset.virtual_path
+        : asset.name;
     let offset: VoidPtr | null = null;
 
     switch (asset.behavior) {
@@ -304,7 +306,7 @@ function finalize_startup(config: MonoConfig | MonoConfigError | undefined): voi
 
         if(!Module.disableDotnet6Compatibility && Module.exports){
             // Export emscripten defined in module through EXPORTED_RUNTIME_METHODS
-            // Useful to export IDBFS or other similar types generally exposed as 
+            // Useful to export IDBFS or other similar types generally exposed as
             // global types when emscripten is not modularized.
             for (let i = 0; i < Module.exports.length; ++i) {
                 const exportName = Module.exports[i];

--- a/src/mono/wasm/runtime/strings.ts
+++ b/src/mono/wasm/runtime/strings.ts
@@ -167,9 +167,16 @@ function _store_string_in_intern_table(string: string, root: WasmRoot<MonoString
 }
 
 export function js_string_to_mono_string_interned_root(string: string | symbol, result: WasmRoot<MonoString>): void {
-    const text = (typeof (string) === "symbol")
-        ? (string.description || Symbol.keyFor(string) || "<unknown Symbol>")
-        : string;
+    let text : string | undefined;
+    if (typeof (string) === "symbol") {
+        text = string.description;
+        if (typeof (text) !== "string")
+            text = Symbol.keyFor(string);
+        if (typeof (text) !== "string")
+            text = "<unknown Symbol>";
+    } else if (typeof (string) === "string") {
+        text = string;
+    }
 
     if (typeof(text) !== "string") {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/mono/wasm/runtime/strings.ts
+++ b/src/mono/wasm/runtime/strings.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { mono_wasm_new_root_buffer, WasmRootBuffer } from "./roots";
-import { MonoString, MonoStringNull } from "./types";
+import { MonoString, MonoStringNull, is_nullish } from "./types";
 import { Module } from "./imports";
 import cwraps from "./cwraps";
 import { mono_wasm_new_root, WasmRoot } from "./roots";
@@ -48,25 +48,25 @@ export class StringDecoder {
 
         cwraps.mono_wasm_string_get_data_ref(root.address, <any>ppChars, <any>pLengthBytes, <any>pIsInterned);
 
-        let result = mono_wasm_empty_string;
+        let result = undefined;
         const lengthBytes = getI32(pLengthBytes),
             pChars = getI32(ppChars),
             isInterned = getI32(pIsInterned);
 
-        if (pLengthBytes && pChars) {
-            if (isInterned) {
-                result = interned_string_table.get(root.value)!;
-                // console.log(`intern table cache hit ${mono_string} ${result.length}`);
-            }
+        if (isInterned)
+            result = interned_string_table.get(root.value)!;
 
-            if (!isInterned || !result) {
+        if (result === undefined) {
+            if (lengthBytes && pChars) {
                 result = this.decode(<any>pChars, <any>pChars + lengthBytes);
-                if (isInterned) {
-                    // console.log("interned", mono_string, result.length);
+                if (isInterned)
                     interned_string_table.set(root.value, result);
-                }
-            }
+            } else
+                result = mono_wasm_empty_string;
         }
+
+        if (result === undefined)
+            throw new Error(`internal error when decoding string at location ${root.value}`);
 
         return result;
     }
@@ -123,7 +123,7 @@ export function mono_intern_string(string: string): string {
     //  interned string, so the address will never change and it is safe for us to use the raw pointer. Don't do this though
     const ptr = js_string_to_mono_string_interned(string);
     const result = interned_string_table.get(ptr);
-    if (!result)
+    if (is_nullish(result))
         throw new Error("internal error: interned_string_table did not contain string after js_string_to_mono_string_interned");
     return result!;
 }

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -60,7 +60,10 @@ export const CharPtrNull: CharPtr = <CharPtr><any>0;
 export const NativePointerNull: NativePointer = <NativePointer><any>0;
 
 export function coerceNull<T extends ManagedPointer | NativePointer>(ptr: T | null | undefined): T {
-    return (<any>ptr | <any>0) as any;
+    if ((ptr === null) || (ptr === undefined))
+        return (0 as any) as T;
+    else
+        return ptr as T;
 }
 
 export type MonoConfig = {
@@ -262,4 +265,11 @@ export const enum MarshalError {
     NULL_TYPE_POINTER = 514,
     UNSUPPORTED_TYPE = 515,
     FIRST = BUFFER_TOO_SMALL
+}
+
+// Evaluates whether a value is nullish (same definition used as the ?? operator,
+//  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator)
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function is_nullish (value: any): boolean {
+    return (value === undefined) || (value === null);
 }

--- a/src/mono/wasm/runtime/web-socket.ts
+++ b/src/mono/wasm/runtime/web-socket.ts
@@ -202,7 +202,7 @@ export function mono_wasm_web_socket_close_ref(webSocket_js_handle: JSHandle, co
             const { promise, promise_control } = _create_cancelable_promise();
             ws[wasm_ws_pending_close_promises].push(promise_control);
 
-            if (js_reason) {
+            if (typeof (js_reason) === "string") {
                 ws.close(code, js_reason);
             } else {
                 ws.close(code);
@@ -219,7 +219,7 @@ export function mono_wasm_web_socket_close_ref(webSocket_js_handle: JSHandle, co
                 mono_wasm_web_socket_close_warning = true;
                 console.warn("WARNING: Web browsers do not support closing the output side of a WebSocket. CloseOutputAsync has closed the socket and discarded any incoming messages.");
             }
-            if (js_reason) {
+            if (typeof (js_reason) === "string") {
                 ws.close(code, js_reason);
             } else {
                 ws.close(code);


### PR DESCRIPTION
I've previously overlooked in a few places that ```if (x)```, ```if (!x)``` and ```x || y``` will use whether x is 'falsy', which has a very complex and confusing implementation, and for strings was causing a few bugs (see https://stackoverflow.com/a/19839953 among others). I suspect it also has an odd interaction with valueOf but I can't actually find documentation on that.

This PR also removes the unused CompileFunction interop API

Thanks to @pavelsavara for noticing the bug in the string decoder