### PR TITLE
Remove ActiveIssue for S.S.C.Xml tests that rely on DSA key generation

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/tests/DSAKeyValueTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/DSAKeyValueTest.cs
@@ -55,7 +55,13 @@ namespace System.Security.Cryptography.Xml.Tests
         {
             using (DSA dsaKey = DSA.Create())
             {
-                dsaKey.ImportPkcs8PrivateKey(TestHelpers.DsaPkcs8Key, out _);
+#if NETCOREAPP
+                if (OperatingSystem.IsMacOS())
+                {
+                    // macOS cannot generate DSA keys, so for this platform we will use a fixed key.
+                    dsaKey.ImportParameters(TestHelpers.DsaKey);
+                }
+#endif
                 DSAKeyValue dsa = new DSAKeyValue(dsaKey);
                 XmlElement xmlkey = dsa.GetXml();
 
@@ -86,7 +92,7 @@ namespace System.Security.Cryptography.Xml.Tests
         {
             using (DSA dsa = DSA.Create())
             {
-                dsa.ImportPkcs8PrivateKey(TestHelpers.DsaPkcs8Key, out _);
+                dsa.ImportParameters(TestHelpers.DsaKey);
                 DSAKeyValue dsaKeyValue1 = new DSAKeyValue(dsa);
                 DSAKeyValue dsaKeyValue2 = new DSAKeyValue(dsa);
                 Assert.Equal(dsaKeyValue1.GetXml(), dsaKeyValue2.GetXml());

--- a/src/libraries/System.Security.Cryptography.Xml/tests/DSAKeyValueTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/DSAKeyValueTest.cs
@@ -77,7 +77,7 @@ namespace System.Security.Cryptography.Xml.Tests
                 Assert.True(elements.All(element => !string.IsNullOrEmpty(element.InnerText)));
 
                 //Existing elements MUST be convertible from BASE64
-                elements.Select(element => Convert.FromBase64String(element.InnerText));
+                Assert.True(elements.All(element => Convert.FromBase64String(element.InnerText).Length > 0));
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Xml/tests/DSAKeyValueTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/DSAKeyValueTest.cs
@@ -53,15 +53,8 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void GetXml()
         {
-            using (DSA dsaKey = DSA.Create())
+            using (DSA dsaKey = TestHelpers.GetWorkingDSA())
             {
-#if NETCOREAPP
-                if (OperatingSystem.IsMacOS())
-                {
-                    // macOS cannot generate DSA keys, so for this platform we will use a fixed key.
-                    dsaKey.ImportParameters(TestHelpers.DsaKey);
-                }
-#endif
                 DSAKeyValue dsa = new DSAKeyValue(dsaKey);
                 XmlElement xmlkey = dsa.GetXml();
 
@@ -90,9 +83,8 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void GetXml_SameDsa()
         {
-            using (DSA dsa = DSA.Create())
+            using (DSA dsa = TestHelpers.GetWorkingDSA())
             {
-                dsa.ImportParameters(TestHelpers.DsaKey);
                 DSAKeyValue dsaKeyValue1 = new DSAKeyValue(dsa);
                 DSAKeyValue dsaKeyValue2 = new DSAKeyValue(dsa);
                 Assert.Equal(dsaKeyValue1.GetXml(), dsaKeyValue2.GetXml());

--- a/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
@@ -293,8 +293,7 @@ namespace System.Security.Cryptography.Xml.Tests
         {
             SignedXml signedXml = MSDNSample();
 
-            DSA key = DSA.Create();
-            key.ImportParameters(TestHelpers.DsaKey);
+            DSA key = TestHelpers.GetWorkingDSA();
             signedXml.SigningKey = key;
 
             // Add a KeyInfo.

--- a/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
@@ -294,7 +294,7 @@ namespace System.Security.Cryptography.Xml.Tests
             SignedXml signedXml = MSDNSample();
 
             DSA key = DSA.Create();
-            key.ImportPkcs8PrivateKey(TestHelpers.DsaPkcs8Key, out _);
+            key.ImportParameters(TestHelpers.DsaKey);
             signedXml.SigningKey = key;
 
             // Add a KeyInfo.

--- a/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
@@ -288,13 +288,13 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/20575", TestPlatforms.OSX)]
         [SkipOnPlatform(PlatformSupport.MobileAppleCrypto, "DSA is not available")]
         public void AsymmetricDSASignature()
         {
             SignedXml signedXml = MSDNSample();
 
             DSA key = DSA.Create();
+            key.ImportPkcs8PrivateKey(TestHelpers.DsaPkcs8Key, out _);
             signedXml.SigningKey = key;
 
             // Add a KeyInfo.

--- a/src/libraries/System.Security.Cryptography.Xml/tests/TestHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/TestHelpers.cs
@@ -225,14 +225,23 @@ namespace System.Security.Cryptography.Xml.Tests
             "v02cMSUwIwYJKoZIhvcNAQkVMRYEFDdYxa4ZJsCeAQZDzHLZ+cdpC2z5MDEwITAJ" +
             "BgUrDgMCGgUABBS0CMJuJYzpHkxOFI+r0PA67eJbzQQI4yGr4jgshqECAggA");
 
-        internal static readonly byte[] DsaPkcs8Key = Convert.FromBase64String(@"
-            MIIBSgIBADCCASsGByqGSM44BAEwggEeAoGBAJxMe6y5lIPhS6tt1wf/K1RVN08Z
-            LXeDWFaaRqyTHUSotBZLRI9/YO7zN96wNIPF3wbq0LvR5HG5UkduROW3mKzG1PKS
-            Q9Wapq5bW555Qfjx1+T4G7vdQQq9neVIwCH4gKiJZ8kjLldF0qm29QN6slhiMdwE
-            1wWlzfZpvqWhdorRAhUAvV0TbUwrTOkOoiyTJDxsaKWqWjECgYBdkRLOuyBQVpLr
-            3uyB5AScUquGHdLoL6B9UbbAv0kG/rfpCwSra7Gk4yX/VVDGOrELKzfH1gU6R1jX
-            Fh2ThrKFyjothWvzVf+VFS3HRhnGlpO3XReByeUvDHvvalgJw4dSXLIbGrcZgIDV
-            yCVe1LzSA8chiJ46qZSG8EdcxgEICAQWAhQNCtBkcG4jHIuUuq02o5Qun+2UfQ==");
+        internal static readonly DSAParameters DsaKey = new DSAParameters
+            {
+                P = Convert.FromBase64String(@"
+                    nEx7rLmUg+FLq23XB/8rVFU3Txktd4NYVppGrJMdRKi0FktEj39g7vM33rA0g8Xf
+                    BurQu9HkcblSR25E5beYrMbU8pJD1ZqmrltbnnlB+PHX5Pgbu91BCr2d5UjAIfiA
+                    qIlnySMuV0XSqbb1A3qyWGIx3ATXBaXN9mm+paF2itE="),
+                Q = Convert.FromBase64String("vV0TbUwrTOkOoiyTJDxsaKWqWjE="),
+                G = Convert.FromBase64String(@"
+                    XZESzrsgUFaS697sgeQEnFKrhh3S6C+gfVG2wL9JBv636QsEq2uxpOMl/1VQxjqx
+                    Cys3x9YFOkdY1xYdk4ayhco6LYVr81X/lRUtx0YZxpaTt10XgcnlLwx772pYCcOH
+                    UlyyGxq3GYCA1cglXtS80gPHIYieOqmUhvBHXMYBCAg="),
+                Y = Convert.FromBase64String(@"
+                    e7NMNCxX/44GS2gUH+JyReWzdCUXcp6ax0PcF/XvIZ1mak74P8o8yqWseGa/10hR
+                    CT92or4YBROsGtKqD/wqN0yJvVMkpPHHsWU9zs1Zt4CsQaZgUTw+vyjkw674OuyN
+                    933pL+qQNvPuJcb/HK9ME2vSN/3Ki1lAqqKWuzcvggY="),
+                X = Convert.FromBase64String(@"DQrQZHBuIxyLlLqtNqOULp/tlH0="),
+            };
 
         public static X509Certificate2 GetSampleX509Certificate()
         {

--- a/src/libraries/System.Security.Cryptography.Xml/tests/TestHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/TestHelpers.cs
@@ -225,23 +225,37 @@ namespace System.Security.Cryptography.Xml.Tests
             "v02cMSUwIwYJKoZIhvcNAQkVMRYEFDdYxa4ZJsCeAQZDzHLZ+cdpC2z5MDEwITAJ" +
             "BgUrDgMCGgUABBS0CMJuJYzpHkxOFI+r0PA67eJbzQQI4yGr4jgshqECAggA");
 
-        internal static readonly DSAParameters DsaKey = new DSAParameters
+        internal static DSA GetWorkingDSA()
+        {
+            DSA dsa = DSA.Create();
+
+#if NETCOREAPP
+            if (OperatingSystem.IsMacOS())
             {
-                P = Convert.FromBase64String(@"
-                    nEx7rLmUg+FLq23XB/8rVFU3Txktd4NYVppGrJMdRKi0FktEj39g7vM33rA0g8Xf
-                    BurQu9HkcblSR25E5beYrMbU8pJD1ZqmrltbnnlB+PHX5Pgbu91BCr2d5UjAIfiA
-                    qIlnySMuV0XSqbb1A3qyWGIx3ATXBaXN9mm+paF2itE="),
-                Q = Convert.FromBase64String("vV0TbUwrTOkOoiyTJDxsaKWqWjE="),
-                G = Convert.FromBase64String(@"
-                    XZESzrsgUFaS697sgeQEnFKrhh3S6C+gfVG2wL9JBv636QsEq2uxpOMl/1VQxjqx
-                    Cys3x9YFOkdY1xYdk4ayhco6LYVr81X/lRUtx0YZxpaTt10XgcnlLwx772pYCcOH
-                    UlyyGxq3GYCA1cglXtS80gPHIYieOqmUhvBHXMYBCAg="),
-                Y = Convert.FromBase64String(@"
-                    e7NMNCxX/44GS2gUH+JyReWzdCUXcp6ax0PcF/XvIZ1mak74P8o8yqWseGa/10hR
-                    CT92or4YBROsGtKqD/wqN0yJvVMkpPHHsWU9zs1Zt4CsQaZgUTw+vyjkw674OuyN
-                    933pL+qQNvPuJcb/HK9ME2vSN/3Ki1lAqqKWuzcvggY="),
-                X = Convert.FromBase64String(@"DQrQZHBuIxyLlLqtNqOULp/tlH0="),
-            };
+                // macOS cannot generate DSA keys, so for this platform we will use a fixed key.
+                // Other platforms will use a generated DSA key.
+                dsa.ImportParameters(new DSAParameters
+                {
+                    P = Convert.FromBase64String(@"
+                        nEx7rLmUg+FLq23XB/8rVFU3Txktd4NYVppGrJMdRKi0FktEj39g7vM33rA0g8Xf
+                        BurQu9HkcblSR25E5beYrMbU8pJD1ZqmrltbnnlB+PHX5Pgbu91BCr2d5UjAIfiA
+                        qIlnySMuV0XSqbb1A3qyWGIx3ATXBaXN9mm+paF2itE="),
+                    Q = Convert.FromBase64String("vV0TbUwrTOkOoiyTJDxsaKWqWjE="),
+                    G = Convert.FromBase64String(@"
+                        XZESzrsgUFaS697sgeQEnFKrhh3S6C+gfVG2wL9JBv636QsEq2uxpOMl/1VQxjqx
+                        Cys3x9YFOkdY1xYdk4ayhco6LYVr81X/lRUtx0YZxpaTt10XgcnlLwx772pYCcOH
+                        UlyyGxq3GYCA1cglXtS80gPHIYieOqmUhvBHXMYBCAg="),
+                    Y = Convert.FromBase64String(@"
+                        e7NMNCxX/44GS2gUH+JyReWzdCUXcp6ax0PcF/XvIZ1mak74P8o8yqWseGa/10hR
+                        CT92or4YBROsGtKqD/wqN0yJvVMkpPHHsWU9zs1Zt4CsQaZgUTw+vyjkw674OuyN
+                        933pL+qQNvPuJcb/HK9ME2vSN/3Ki1lAqqKWuzcvggY="),
+                    X = Convert.FromBase64String(@"DQrQZHBuIxyLlLqtNqOULp/tlH0="),
+                });
+            }
+#endif
+
+            return dsa;
+        }
 
         public static X509Certificate2 GetSampleX509Certificate()
         {

--- a/src/libraries/System.Security.Cryptography.Xml/tests/TestHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/TestHelpers.cs
@@ -225,6 +225,15 @@ namespace System.Security.Cryptography.Xml.Tests
             "v02cMSUwIwYJKoZIhvcNAQkVMRYEFDdYxa4ZJsCeAQZDzHLZ+cdpC2z5MDEwITAJ" +
             "BgUrDgMCGgUABBS0CMJuJYzpHkxOFI+r0PA67eJbzQQI4yGr4jgshqECAggA");
 
+        internal static readonly byte[] DsaPkcs8Key = Convert.FromBase64String(@"
+            MIIBSgIBADCCASsGByqGSM44BAEwggEeAoGBAJxMe6y5lIPhS6tt1wf/K1RVN08Z
+            LXeDWFaaRqyTHUSotBZLRI9/YO7zN96wNIPF3wbq0LvR5HG5UkduROW3mKzG1PKS
+            Q9Wapq5bW555Qfjx1+T4G7vdQQq9neVIwCH4gKiJZ8kjLldF0qm29QN6slhiMdwE
+            1wWlzfZpvqWhdorRAhUAvV0TbUwrTOkOoiyTJDxsaKWqWjECgYBdkRLOuyBQVpLr
+            3uyB5AScUquGHdLoL6B9UbbAv0kG/rfpCwSra7Gk4yX/VVDGOrELKzfH1gU6R1jX
+            Fh2ThrKFyjothWvzVf+VFS3HRhnGlpO3XReByeUvDHvvalgJw4dSXLIbGrcZgIDV
+            yCVe1LzSA8chiJ46qZSG8EdcxgEICAQWAhQNCtBkcG4jHIuUuq02o5Qun+2UfQ==");
+
         public static X509Certificate2 GetSampleX509Certificate()
         {
             return new X509Certificate2(SamplePfx, "mono");


### PR DESCRIPTION
MacOS cannot generate DSA keys, so make a pre-generated key and use that.

Closes #20575