### PR TITLE
JIT: redundant branch destructure dominating and/or

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -70,16 +70,17 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  *                  Forward declarations
  */
 
-struct InfoHdr;            // defined in GCInfo.h
-struct escapeMapping_t;    // defined in fgdiagnostic.cpp
-class emitter;             // defined in emit.h
-struct ShadowParamVarInfo; // defined in GSChecks.cpp
-struct InitVarDscInfo;     // defined in register_arg_convention.h
-class FgStack;             // defined in fgbasic.cpp
-class Instrumentor;        // defined in fgprofile.cpp
-class SpanningTreeVisitor; // defined in fgprofile.cpp
-class CSE_DataFlow;        // defined in OptCSE.cpp
-class OptBoolsDsc;         // defined in optimizer.cpp
+struct InfoHdr;              // defined in GCInfo.h
+struct escapeMapping_t;      // defined in fgdiagnostic.cpp
+class emitter;               // defined in emit.h
+struct ShadowParamVarInfo;   // defined in GSChecks.cpp
+struct InitVarDscInfo;       // defined in register_arg_convention.h
+class FgStack;               // defined in fgbasic.cpp
+class Instrumentor;          // defined in fgprofile.cpp
+class SpanningTreeVisitor;   // defined in fgprofile.cpp
+class CSE_DataFlow;          // defined in OptCSE.cpp
+class OptBoolsDsc;           // defined in optimizer.cpp
+struct RelopImplicationInfo; // defined in redundantbranchopts.cpp
 #ifdef DEBUG
 struct IndentStack;
 #endif
@@ -6899,6 +6900,7 @@ public:
     bool optRedundantBranch(BasicBlock* const block);
     bool optJumpThread(BasicBlock* const block, BasicBlock* const domBlock, bool domIsSameRelop);
     bool optReachable(BasicBlock* const fromBlock, BasicBlock* const toBlock, BasicBlock* const excludedBlock);
+    void optRelopImpliesRelop(RelopImplicationInfo* rii);
 
     /**************************************************************************
      *               Value/Assertion propagation

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -400,6 +400,7 @@ CONFIG_INTEGER(JitDoLoopHoisting, W("JitDoLoopHoisting"), 1)   // Perform loop h
 CONFIG_INTEGER(JitDoLoopInversion, W("JitDoLoopInversion"), 1) // Perform loop inversion on "for/while" loops
 CONFIG_INTEGER(JitDoRangeAnalysis, W("JitDoRangeAnalysis"), 1) // Perform range check analysis
 CONFIG_INTEGER(JitDoRedundantBranchOpts, W("JitDoRedundantBranchOpts"), 1) // Perform redundant branch optimizations
+
 CONFIG_INTEGER(JitDoSsa, W("JitDoSsa"), 1) // Perform Static Single Assignment (SSA) numbering on the variables
 CONFIG_INTEGER(JitDoValueNumber, W("JitDoValueNumber"), 1) // Perform value numbering on method expressions
 

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -129,7 +129,7 @@ bool Compiler::optRedundantBranch(BasicBlock* const block)
     //
     if (vnStore->IsVNConstant(treeNormVN))
     {
-        relopValue = vnStore->VNZeroForType(TYP_INT) ? 0 : 1;
+        relopValue = (treeNormVN == vnStore->VNZeroForType(TYP_INT)) ? 0 : 1;
     }
 
     const ValueNumStore::VN_RELATION_KIND vnRelations[] = {ValueNumStore::VN_RELATION_KIND::VRK_Same,

--- a/src/tests/JIT/opt/RedundantBranch/RedundantBranchAnd.cs
+++ b/src/tests/JIT/opt/RedundantBranch/RedundantBranchAnd.cs
@@ -1,0 +1,149 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class RedundantBranchAnd
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int And_00(int a, int b)
+    {
+        if ((a > 0) & (b > 0))
+        {
+            // redundant
+            if (a > 0)
+            {
+                return 1;
+            }
+            return -1;
+        }
+        return 3;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int And_01(int a, int b)
+    {
+        if ((a > 0) & (b > 0))
+        {
+            // redundant
+            if (a <= 0)
+            {
+                return -1;
+            }
+            return 1;
+        }
+        return 3;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int And_02(int a, int b)
+    {
+        if ((a > 0) & (b > 0))
+        {
+            // redundant
+            if (b > 0)
+            {
+                return 1;
+            }
+
+            return -1;
+        }
+
+        return 3;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int And_03(int a, int b)
+    {
+        if ((a > 0) & (b > 0))
+        {
+            // redundant
+            if (b <= 0)
+            {
+                return -1;
+            }
+
+            return 1;
+        }
+
+        return 3;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int And_04(int a, int b)
+    {
+        if ((a > 0) & (b > 0))
+        {
+            // redundant
+            if ((a > 0) & (b > 0))
+            {
+                return 1;
+            }
+            return -1;
+        }
+        return 3;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int And_05(int a, int b)
+    {
+        if ((a == 0) & (b > 0))
+        {
+            // redundant
+            if (a == 0)
+            {
+                return 1;
+            }
+            return -1;
+        }
+        return 3;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int And_06(int a, int b)
+    {
+        if ((a == 0) & (b > 0))
+        {
+            // redundant
+            if (b > 0)
+            {
+                return 1;
+            }
+            return -1;
+        }
+        return 3;
+    }
+
+
+    public static int Main()
+    {
+        Func<int, int, int>[] funcs = {And_00, And_01, And_02, And_03, And_04, And_05, And_06};
+        int funcNum = 0;
+        int cases = 0;
+        int errors= 0;
+
+        foreach (var f in funcs)
+        {
+            for (int a = -1; a <= 1; a++)
+            {
+                for (int b = -1; b <= 1; b++)
+                {
+                    cases++;
+                    int result = f(a, b);
+
+                    if (result < 0)
+                    {
+                        Console.WriteLine($"And_0{funcNum}({a},{b}) = {result} wrong\n");
+                        errors++;
+                    }
+                }
+            }
+            
+            funcNum++;
+        }
+
+        Console.WriteLine($"{cases} tests, {errors} errors");
+        return errors > 0 ? -1 : 100;
+    }
+}

--- a/src/tests/JIT/opt/RedundantBranch/RedundantBranchAnd.csproj
+++ b/src/tests/JIT/opt/RedundantBranch/RedundantBranchAnd.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType />
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/opt/RedundantBranch/RedundantBranchOr.cs
+++ b/src/tests/JIT/opt/RedundantBranch/RedundantBranchOr.cs
@@ -1,0 +1,145 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class RedundantBranchOr
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Or_00(int a, int b)
+    {
+        if ((a > 0) | (b > 0))
+        {
+            return 1;
+        }
+        // redundant
+        else if (a > 0)
+        {
+            return -1;
+        }
+        return 3;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Or_01(int a, int b)
+    {
+        if ((a > 0) | (b > 0))
+        {
+            return 1;
+        }
+        // redundant
+        else if (a <= 0)
+        {
+            return 3;
+        }
+        return -1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Or_02(int a, int b)
+    {
+        if ((a > 0) | (b > 0))
+        {
+            return 1;
+        }
+        // redundant
+        else if (b > 0)
+        {
+            return -1;
+        }
+        return 3;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Or_03(int a, int b)
+    {
+        if ((a > 0) | (b > 0))
+        {
+            return 1;
+        }
+        // redundant
+        else if (b <= 0)
+        {
+            return 3;
+        }
+
+        return -1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Or_04(int a, int b)
+    {
+        if ((a > 0) | (b > 0))
+        {
+            // redundant
+            if ((a > 0) | (b > 0))
+            {
+                return 1;
+            }
+            return -1;
+        }
+        return 3;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Or_05(int a, int b)
+    {
+        if ((a == 0) | (b > 0))
+        {
+            return 1;
+        }
+        // redundant
+        else if (a == 0)
+        {
+            return -1;
+        }
+        return 3;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Or_06(int a, int b)
+    {
+        if ((a == 0) | (b > 0))
+        {
+            return 1;
+        }
+        // redundant
+        else if (b > 0)
+        {
+            return -1;
+        }
+        return 3;
+    }
+
+    public static int Main()
+    {
+        Func<int, int, int>[] funcs = {Or_00, Or_01, Or_02, Or_03, Or_04, Or_05, Or_06};
+        int funcNum = 0;
+        int cases = 0;
+        int errors= 0;
+
+        foreach (var f in funcs)
+        {
+            for (int a = -1; a <= 1; a++)
+            {
+                for (int b = -1; b <= 1; b++)
+                {
+                    cases++;
+                    int result = f(a, b);
+
+                    if (result < 0)
+                    {
+                        Console.WriteLine($"Or_0{funcNum}({a},{b}) = {result} wrong\n");
+                        errors++;
+                    }
+                }
+            }
+            
+            funcNum++;
+        }
+
+        Console.WriteLine($"{cases} tests, {errors} errors");
+        return errors > 0 ? -1 : 100;
+    }
+}

--- a/src/tests/JIT/opt/RedundantBranch/RedundantBranchOr.csproj
+++ b/src/tests/JIT/opt/RedundantBranch/RedundantBranchOr.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType />
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
If a branch predicate `p` is dominated by another branch with predicate
`AND(p, ..)` or `OR(p, ...)` we may be able to infer the value of `p`.

This is useful on its own, and should help unblock #62689.