### PR TITLE
Add OpenTelemetry with Geneva exporter to NetCoreServer used for testing

### DIFF
--- a/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/NetCoreServer.csproj
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/NetCoreServer.csproj
@@ -5,10 +5,20 @@
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <OutputType>Exe</OutputType>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+
+    <DefineConstants Condition="'$(GenevaTelemetry)' == 'true'">$(DefineConstants);GENEVA_TELEMETRY</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(GenevaTelemetry)' == 'true'">
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Geneva" Version="1.2.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Startup.cs
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Startup.cs
@@ -4,13 +4,47 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+
+#if GENEVA_TELEMETRY
+using OpenTelemetry.Trace;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Exporter.Geneva;
+using System.Diagnostics.Metrics;
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using System.Collections.Generic;
+#endif
 
 namespace NetCoreServer
 {
     public class Startup
     {
+        public IConfiguration Configuration { get; }
+
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
         public void ConfigureServices(IServiceCollection services)
         {
+#if GENEVA_TELEMETRY
+            services.AddOpenTelemetryMetrics((builder) => builder
+                .AddAspNetCoreInstrumentation()
+                .AddGenevaMetricExporter(options =>
+                {
+                    options.PrepopulatedMetricDimensions = new Dictionary<string, object>()
+                    {
+                        ["CustomerResourceId"] = Configuration["GenevaExport:CustomerResourceId"],
+                        ["LocationId"] = Configuration["GenevaExport:LocationId"]
+                    };
+
+                    options.ConnectionString = Configuration["GenevaExport:ConnectionString"];
+                })
+            );
+#endif
             services.AddCors(o => o.AddPolicy("AnyCors", builder =>
             {
                 builder.AllowAnyOrigin()


### PR DESCRIPTION
This PR adds exporting of telemetry on the echo servers used for functional tests against which `SslStream` and `HttpClient` functional tests run. The telemetry is necessary due to policies on internal services.

Since the Telemetry is necessary only for deployments on azurewebsites.net, the implementation is hidden behind an MsBuild property so that other uses of the code (Android tests) are not affected.