### PR TITLE
Initial plumbing for JsonTypeInfoResolver

### DIFF
--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -240,6 +240,9 @@
   <data name="JsonElementHasWrongType" xml:space="preserve">
     <value>The requested operation requires an element of type '{0}', but the target element has type '{1}'.</value>
   </data>
+  <data name="TypeInfoResolverImmutable" xml:space="preserve">
+    <value>TypeInfoResolver cannot be changed after first usage.</value>
+  </data>
   <data name="MaxDepthMustBePositive" xml:space="preserve">
     <value>Max depth must be positive.</value>
   </data>

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -127,6 +127,8 @@ System.Text.Json.Nodes.JsonValue</PackageDescription>
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Write.Node.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializerContext.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonUnknownDerivedTypeHandling.cs" />
+    <Compile Include="System\Text\Json\Serialization\Metadata\DefaultJsonTypeInfoResolver.cs" />
+    <Compile Include="System\Text\Json\Serialization\Metadata\IJsonTypeInfoResolver.cs" />
     <Compile Include="System\Text\Json\Serialization\PolymorphicSerializationState.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonPolymorphicTypeConfiguration.cs" />
     <Compile Include="System\Text\Json\Serialization\ReferenceEqualsWrapper.cs" />
@@ -381,12 +383,7 @@ System.Text.Json.Nodes.JsonValue</PackageDescription>
   </ItemGroup>
 
   <ItemGroup>
-    <AnalyzerReference Include="..\gen\System.Text.Json.SourceGeneration.Roslyn3.11.csproj"
-                       Pack="true"
-                       ReferenceAnalyzer="false"
-                       Condition="'$(DotNetBuildFromSource)' != 'true'" />
-    <AnalyzerReference Include="..\gen\System.Text.Json.SourceGeneration.Roslyn4.0.csproj"
-                       Pack="true"
-                       ReferenceAnalyzer="false" />
+    <AnalyzerReference Include="..\gen\System.Text.Json.SourceGeneration.Roslyn3.11.csproj" Pack="true" ReferenceAnalyzer="false" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+    <AnalyzerReference Include="..\gen\System.Text.Json.SourceGeneration.Roslyn4.0.csproj" Pack="true" ReferenceAnalyzer="false" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ConfigurationList.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ConfigurationList.cs
@@ -13,19 +13,17 @@ namespace System.Text.Json.Serialization
     internal sealed class ConfigurationList<TItem> : IList<TItem>
     {
         private readonly List<TItem> _list;
-        private readonly JsonSerializerOptions _options;
 
         public Action<TItem>? OnElementAdded { get; set; }
+        public Action? VerifyMutable { get; set; }
 
-        public ConfigurationList(JsonSerializerOptions options)
+        public ConfigurationList()
         {
-            _options = options;
             _list = new List<TItem>();
         }
 
-        public ConfigurationList(JsonSerializerOptions options, IList<TItem> source)
+        public ConfigurationList(IList<TItem> source)
         {
-            _options = options;
             _list = new List<TItem>(source is ConfigurationList<TItem> cl ? cl._list : source);
         }
 
@@ -42,7 +40,7 @@ namespace System.Text.Json.Serialization
                     throw new ArgumentNullException(nameof(value));
                 }
 
-                _options.VerifyMutable();
+                VerifyMutable?.Invoke();
                 _list[index] = value;
                 OnElementAdded?.Invoke(value);
             }
@@ -59,14 +57,14 @@ namespace System.Text.Json.Serialization
                 ThrowHelper.ThrowArgumentNullException(nameof(item));
             }
 
-            _options.VerifyMutable();
+            VerifyMutable?.Invoke();
             _list.Add(item);
             OnElementAdded?.Invoke(item);
         }
 
         public void Clear()
         {
-            _options.VerifyMutable();
+            VerifyMutable?.Invoke();
             _list.Clear();
         }
 
@@ -97,20 +95,20 @@ namespace System.Text.Json.Serialization
                 ThrowHelper.ThrowArgumentNullException(nameof(item));
             }
 
-            _options.VerifyMutable();
+            VerifyMutable?.Invoke();
             _list.Insert(index, item);
             OnElementAdded?.Invoke(item);
         }
 
         public bool Remove(TItem item)
         {
-            _options.VerifyMutable();
+            VerifyMutable?.Invoke();
             return _list.Remove(item);
         }
 
         public void RemoveAt(int index)
         {
-            _options.VerifyMutable();
+            VerifyMutable?.Invoke();
             _list.RemoveAt(index);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
@@ -20,10 +20,7 @@ namespace System.Text.Json
             Debug.Assert(runtimeType != null);
 
             options ??= JsonSerializerOptions.Default;
-            if (!options.IsInitializedForReflectionSerializer)
-            {
-                options.InitializeForReflectionSerializer();
-            }
+            options.EnsureInitializedForReflectionSerializer();
 
             return options.GetOrAddJsonTypeInfoForRootType(runtimeType);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -369,10 +369,7 @@ namespace System.Text.Json
             }
 
             options ??= JsonSerializerOptions.Default;
-            if (!options.IsInitializedForReflectionSerializer)
-            {
-                options.InitializeForReflectionSerializer();
-            }
+            options.EnsureInitializedForReflectionSerializer();
 
             JsonTypeInfo jsonTypeInfo = options.GetOrAddJsonTypeInfoForRootType(typeof(TValue));
             return CreateAsyncEnumerableDeserializer<TValue>(utf8Json, jsonTypeInfo, cancellationToken);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -74,9 +74,10 @@ namespace System.Text.Json
         private void InitializeCachingContext()
         {
             _cachingContext = TrackedCachingContexts.GetOrCreate(this);
-            if (IsInitializedForReflectionSerializer)
+            if (_typeInfoResolver != null)
             {
-                _cachingContext.Options.IsInitializedForReflectionSerializer = true;
+                Debug.Assert(_typeInfoResolver == s_defaultTypeInfoResolver, "Equality should guarantee that null is equivalent to s_defaultTypeInfoResolver");
+                _cachingContext.Options._typeInfoResolver ??= s_defaultTypeInfoResolver;
             }
         }
 
@@ -168,6 +169,7 @@ namespace System.Text.Json
                         // Copy fields ignored by the copy constructor
                         // but are necessary to determine equivalence.
                         _serializerContext = options._serializerContext,
+                        _typeInfoResolver = options._typeInfoResolver,
                     };
                     Debug.Assert(key._cachingContext == null);
 
@@ -269,6 +271,7 @@ namespace System.Text.Json
             public bool Equals(JsonSerializerOptions? left, JsonSerializerOptions? right)
             {
                 Debug.Assert(left != null && right != null);
+
                 return
                     left._dictionaryKeyPolicy == right._dictionaryKeyPolicy &&
                     left._jsonPropertyNamingPolicy == right._jsonPropertyNamingPolicy &&

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Runtime.ExceptionServices;
 using System.Text.Json.Reflection;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Converters;
@@ -26,7 +25,7 @@ namespace System.Text.Json
         private static JsonConverter[]? s_defaultFactoryConverters;
 
         // Stores the JsonTypeInfo factory, which requires unreferenced code and must be rooted by the reflection-based serializer.
-        private static Func<Type, JsonSerializerOptions, JsonTypeInfo>? s_typeInfoCreationFunc;
+        private static IJsonTypeInfoResolver? s_defaultTypeInfoResolver;
 
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
@@ -34,42 +33,18 @@ namespace System.Text.Json
         {
             // s_typeInfoCreationFunc is the last field assigned.
             // Use it as the sentinel to ensure that all dependencies are initialized.
-            if (Volatile.Read(ref s_typeInfoCreationFunc) is null)
+            if (Volatile.Read(ref s_defaultTypeInfoResolver) is null)
             {
                 s_defaultSimpleConverters = GetDefaultSimpleConverters();
                 s_defaultFactoryConverters = GetDefaultFactoryConverters();
                 // Explicitly ensure that the previous fields are initialized along with this one.
-                Volatile.Write(ref s_typeInfoCreationFunc, CreateJsonTypeInfo);
-            }
-
-            [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
-            [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
-            static JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options)
-            {
-                JsonTypeInfo.ValidateType(type, null, null, options);
-
-                MethodInfo methodInfo = typeof(JsonSerializerOptions).GetMethod(nameof(CreateReflectionJsonTypeInfo), BindingFlags.NonPublic | BindingFlags.Instance)!;
-#if NETCOREAPP
-                return (JsonTypeInfo)methodInfo.MakeGenericMethod(type).Invoke(options, BindingFlags.NonPublic | BindingFlags.DoNotWrapExceptions, null, null, null)!;
-#else
-                try
-                {
-                    return (JsonTypeInfo)methodInfo.MakeGenericMethod(type).Invoke(options, null)!;
-                }
-                catch (TargetInvocationException ex)
-                {
-                    // Some of the validation is done during construction (i.e. validity of JsonConverter, inner types etc.)
-                    // therefore we need to unwrap TargetInvocationException for better user experience
-                    ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                    throw null!;
-                }
-#endif
+                Volatile.Write(ref s_defaultTypeInfoResolver, new DefaultJsonTypeInfoResolver());
             }
         }
 
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
-        private JsonTypeInfo<T> CreateReflectionJsonTypeInfo<T>()
+        internal JsonTypeInfo<T> CreateReflectionJsonTypeInfo<T>()
         {
             return new ReflectionJsonTypeInfo<T>(this);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -42,7 +42,7 @@ namespace System.Text.Json
                 // We also need to ensure that all threads use same instance of s_defaultTypeInfoResolver or
                 // otherwise EqualityComparer for CachingContext may fail even though
                 // two options might assign _typeInfoResolver to s_defaultTypeInfoResolver
-                Interlocked.CompareExchange(ref s_defaultTypeInfoResolver, new DefaultJsonTypeInfoResolver(), null);
+                Interlocked.CompareExchange(ref s_defaultTypeInfoResolver, new DefaultJsonTypeInfoResolver(mutable: false), null);
             }
 
             // This isn't strictly needed but we will get nullability warning because `Volatile.Read(ref s_defaultTypeInfoResolver) is null`

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -65,11 +65,12 @@ namespace System.Text.Json
         /// </summary>
         public JsonSerializerOptions()
         {
-            _converters = new ConfigurationList<JsonConverter>(this);
+            _converters = new ConfigurationList<JsonConverter>() { VerifyMutable = VerifyMutable };
 
 #pragma warning disable CA2252 // This API requires opting into preview features
-            _polymorphicTypeConfigurations = new ConfigurationList<JsonPolymorphicTypeConfiguration>(this)
+            _polymorphicTypeConfigurations = new ConfigurationList<JsonPolymorphicTypeConfiguration>()
             {
+                VerifyMutable = VerifyMutable,
                 OnElementAdded = static config => { config.IsAssignedToOptionsInstance = true; }
             };
 #pragma warning restore CA2252 // This API requires opting into preview features
@@ -96,9 +97,9 @@ namespace System.Text.Json
             _jsonPropertyNamingPolicy = options._jsonPropertyNamingPolicy;
             _readCommentHandling = options._readCommentHandling;
             _referenceHandler = options._referenceHandler;
-            _converters = new ConfigurationList<JsonConverter>(this, options._converters);
+            _converters = new ConfigurationList<JsonConverter>(options._converters) { VerifyMutable = VerifyMutable };
 #pragma warning disable CA2252 // This API requires opting into preview features
-            _polymorphicTypeConfigurations = new ConfigurationList<JsonPolymorphicTypeConfiguration>(this, options._polymorphicTypeConfigurations);
+            _polymorphicTypeConfigurations = new ConfigurationList<JsonPolymorphicTypeConfiguration>(options._polymorphicTypeConfigurations) { VerifyMutable = VerifyMutable };
 #pragma warning restore CA2252 // This API requires opting into preview features
             _encoder = options._encoder;
             _defaultIgnoreCondition = options._defaultIgnoreCondition;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -623,9 +623,9 @@ namespace System.Text.Json
             if (info == null && IsInitializedForReflectionSerializer)
             {
                 Debug.Assert(
-                    s_typeInfoCreationFunc != null,
+                    s_defaultTypeInfoResolver != null,
                     "Reflection-based JsonTypeInfo creator should be initialized if IsInitializedForReflectionSerializer is true.");
-                info = s_typeInfoCreationFunc(type, this);
+                info = s_defaultTypeInfoResolver.GetTypeInfo(type, this);
             }
 
             if (info == null)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
@@ -14,16 +14,23 @@ namespace System.Text.Json.Serialization.Metadata
     /// </summary>
     internal sealed class DefaultJsonTypeInfoResolver : IJsonTypeInfoResolver
     {
-        private bool _mutable = true;
+        private bool _mutable;
 
         /// <summary>
         /// Constructs DefaultJsonTypeInfoResolver.
         /// </summary>
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
-        public DefaultJsonTypeInfoResolver()
+        public DefaultJsonTypeInfoResolver() : this(mutable: true)
+        {
+        }
+
+        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
+        internal DefaultJsonTypeInfoResolver(bool mutable)
         {
             Modifiers = new ConfigurationList<Action<JsonTypeInfo>>() { VerifyMutable = VerifyMutable };
+            _mutable = mutable;
         }
 
         /// <inheritdoc/>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    internal sealed class DefaultJsonTypeInfoResolver : IJsonTypeInfoResolver
+    {
+        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
+        public DefaultJsonTypeInfoResolver()
+        {
+        }
+
+        public JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)
+        {
+            JsonTypeInfo.ValidateType(type, null, null, options);
+            JsonTypeInfo typeInfo = CreateJsonTypeInfo(type, options);
+
+            foreach (Action<JsonTypeInfo> modifier in Modifiers)
+            {
+                modifier(typeInfo);
+            }
+
+            return typeInfo;
+        }
+
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "The ctor is marked RequiresUnreferencedCode.")]
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+            Justification = "The ctor is marked RequiresDynamicCode.")]
+        private JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options)
+        {
+            MethodInfo methodInfo = typeof(JsonSerializerOptions).GetMethod(nameof(JsonSerializerOptions.CreateReflectionJsonTypeInfo), BindingFlags.NonPublic | BindingFlags.Instance)!;
+#if NETCOREAPP
+            return (JsonTypeInfo)methodInfo.MakeGenericMethod(type).Invoke(options, BindingFlags.NonPublic | BindingFlags.DoNotWrapExceptions, null, null, null)!;
+#else
+            try
+            {
+                return (JsonTypeInfo)methodInfo.MakeGenericMethod(type).Invoke(options, null)!;
+            }
+            catch (TargetInvocationException ex)
+            {
+                // Some of the validation is done during construction (i.e. validity of JsonConverter, inner types etc.)
+                // therefore we need to unwrap TargetInvocationException for better user experience
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw null!;
+            }
+#endif
+        }
+
+        public IList<Action<JsonTypeInfo>> Modifiers { get; } = new List<Action<JsonTypeInfo>>(); // TODO
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IJsonTypeInfoResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IJsonTypeInfoResolver.cs
@@ -18,7 +18,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// </summary>
         /// <param name="type">Type to be resolved.</param>
         /// <param name="options">JsonSerializerOptions instance defining resolution parameters.</param>
-        /// <returns>Returns resolved JsonTypeInfo instance or null if Type cannot be resolved by this resolver.</returns>
+        /// <returns>Returns JsonTypeInfo instance or null if the resolver cannot produce metadata for this type.</returns>
         JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IJsonTypeInfoResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IJsonTypeInfoResolver.cs
@@ -8,8 +8,17 @@ using System.Threading.Tasks;
 
 namespace System.Text.Json.Serialization.Metadata
 {
+    /// <summary>
+    /// Exposes method for resolving Type into JsonTypeInfo for given options.
+    /// </summary>
     internal interface IJsonTypeInfoResolver
     {
+        /// <summary>
+        /// Resolves Type into JsonTypeInfo which defines serialization and deserialization logic.
+        /// </summary>
+        /// <param name="type">Type to be resolved.</param>
+        /// <param name="options">JsonSerializerOptions instance defining resolution parameters.</param>
+        /// <returns>Returns resolved JsonTypeInfo instance or null if Type cannot be resolved by this resolver.</returns>
         JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IJsonTypeInfoResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IJsonTypeInfoResolver.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    internal interface IJsonTypeInfoResolver
+    {
+        JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options);
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -140,6 +140,12 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        public static void ThrowInvalidOperationException_SerializerContextOptionsImmutable()
+        {
+            throw new InvalidOperationException(SR.SerializerContextOptionsImmutable);
+        }
+
+        [DoesNotReturn]
         public static void ThrowInvalidOperationException_TypeInfoResolverImmutable()
         {
             throw new InvalidOperationException(SR.TypeInfoResolverImmutable);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -140,6 +140,12 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        public static void ThrowInvalidOperationException_TypeInfoResolverImmutable()
+        {
+            throw new InvalidOperationException(SR.TypeInfoResolverImmutable);
+        }
+
+        [DoesNotReturn]
         public static void ThrowInvalidOperationException_SerializerPropertyNameConflict(Type type, JsonPropertyInfo jsonPropertyInfo)
         {
             throw new InvalidOperationException(SR.Format(SR.SerializerPropertyNameConflict, type, jsonPropertyInfo.ClrName));

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
@@ -48,7 +48,7 @@ namespace System.Text.Json.SourceGeneration.Tests
                     AssertFieldNull("s_defaultFactoryConverters", optionsInstance: null);
 
                     // Confirm type info dynamic creator not set.
-                    AssertFieldNull("s_typeInfoCreationFunc", optionsInstance: null);
+                    AssertFieldNull("s_defaultTypeInfoResolver", optionsInstance: null);
 
                     static void AssertFieldNull(string fieldName, JsonSerializerOptions? optionsInstance)
                     {


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/63686

Adds initial plumbing for IJsonTypeInfoResolver and DefaultJsonTypeInfoResolver. There still needs to be a bit of work done around this but it will be easier to review when split.

Commits can be looked at individually or altogether