### PR TITLE
Do not sign the .js files

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -20,6 +20,8 @@
     <!-- apphost and comhost template files are not signed, by design. -->
     <FileSignInfo Include="apphost.exe;singlefilehost.exe;comhost.dll" CertificateName="None" />
 
+    <FileExtensionSignInfo Include=".js" CertificateName="None" />
+
     <!-- Third-party components which should be signed.  -->
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Mono.Cecil.dll" CertificateName="3PartySHA2" />

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -20,6 +20,7 @@
     <!-- apphost and comhost template files are not signed, by design. -->
     <FileSignInfo Include="apphost.exe;singlefilehost.exe;comhost.dll" CertificateName="None" />
 
+    <!-- We don't need to code sign .js files because they are not used in Windows Script Host. -->
     <FileExtensionSignInfo Include=".js" CertificateName="None" />
 
     <!-- Third-party components which should be signed.  -->


### PR DESCRIPTION
We want to avoid the js files in wasm templates from getting the
signature block in user visible files.

Fixes https://github.com/dotnet/runtime/issues/69288 .