### PR TITLE
Expose the `RuntimeFeature.NumericIntPtr` member for C# 11

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.cs
@@ -38,6 +38,11 @@ namespace System.Runtime.CompilerServices
         public const string VirtualStaticsInInterfaces = nameof(VirtualStaticsInInterfaces);
 
         /// <summary>
+        /// Indicates that this version of runtime supports <see cref="System.IntPtr" /> and <see cref="System.UIntPtr" /> as numeric types.
+        /// </summary>
+        public const string NumericIntPtr = nameof(NumericIntPtr);
+
+        /// <summary>
         /// Checks whether a certain feature is supported by the Runtime.
         /// </summary>
         public static bool IsSupported(string feature)
@@ -50,6 +55,7 @@ namespace System.Runtime.CompilerServices
                 case UnmanagedSignatureCallingConvention:
                 case DefaultImplementationsOfInterfaces:
                 case VirtualStaticsInInterfaces:
+                case NumericIntPtr:
                     return true;
                 case nameof(IsDynamicCodeSupported):
                     return IsDynamicCodeSupported;

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -11817,6 +11817,7 @@ namespace System.Runtime.CompilerServices
         public const string ByRefFields = "ByRefFields";
         public const string CovariantReturnsOfClasses = "CovariantReturnsOfClasses";
         public const string DefaultImplementationsOfInterfaces = "DefaultImplementationsOfInterfaces";
+        public const string NumericIntPtr = "NumericIntPtr";
         public const string PortablePdb = "PortablePdb";
         public const string UnmanagedSignatureCallingConvention = "UnmanagedSignatureCallingConvention";
         public const string VirtualStaticsInInterfaces = "VirtualStaticsInInterfaces";


### PR DESCRIPTION
This resolves https://github.com/dotnet/runtime/issues/67966

Relates to test plan https://github.com/dotnet/roslyn/issues/60578