### PR TITLE
Add integer type discriminator support to System.Text.Json polymorphism

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -874,8 +874,9 @@ namespace System.Text.Json.Serialization
     {
         public JsonDerivedTypeAttribute(System.Type derivedType) { }
         public JsonDerivedTypeAttribute(System.Type derivedType, string typeDiscriminatorId) { }
+        public JsonDerivedTypeAttribute(System.Type derivedType, int typeDiscriminatorId) { }
         public System.Type DerivedType { get { throw null; } }
-        public string? TypeDiscriminatorId { get { throw null; } }
+        public object? TypeDiscriminatorId { get { throw null; } }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple = false)]
     public sealed partial class JsonExtensionDataAttribute : System.Text.Json.Serialization.JsonAttribute
@@ -991,28 +992,32 @@ namespace System.Text.Json.Serialization
         JsonElement = 0,
         JsonNode = 1,
     }
-    public partial class JsonPolymorphicTypeConfiguration : System.Collections.Generic.ICollection<(System.Type DerivedType, string? TypeDiscriminatorId)>, System.Collections.Generic.IEnumerable<(System.Type DerivedType, string? TypeDiscriminatorId)>, System.Collections.IEnumerable
+    public partial class JsonPolymorphicTypeConfiguration : System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminatorId)>, System.Collections.Generic.IEnumerable<(System.Type DerivedType, object? TypeDiscriminatorId)>, System.Collections.IEnumerable
     {
         public JsonPolymorphicTypeConfiguration(System.Type baseType) { }
         public System.Type BaseType { get { throw null; } }
         public string? CustomTypeDiscriminatorPropertyName { get { throw null; } set { } }
         public bool IgnoreUnrecognizedTypeDiscriminators { get { throw null; } set { } }
-        int System.Collections.Generic.ICollection<(System.Type DerivedType, string? TypeDiscriminatorId)>.Count { get { throw null; } }
+        int System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminatorId)>.Count { get { throw null; } }
         public System.Text.Json.Serialization.JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get { throw null; } set { } }
-        bool System.Collections.Generic.ICollection<(System.Type DerivedType, string? TypeDiscriminatorId)>.IsReadOnly { get { throw null; } }
-        void System.Collections.Generic.ICollection<(System.Type DerivedType, string? TypeDiscriminatorId)>.Add((System.Type DerivedType, string TypeDiscriminatorId) item) { }
-        void System.Collections.Generic.ICollection<(System.Type DerivedType, string? TypeDiscriminatorId)>.Clear() { }
-        bool System.Collections.Generic.ICollection<(System.Type DerivedType, string? TypeDiscriminatorId)>.Contains((System.Type DerivedType, string TypeDiscriminatorId) item) { throw null; }
-        void System.Collections.Generic.ICollection<(System.Type DerivedType, string? TypeDiscriminatorId)>.CopyTo((System.Type DerivedType, string TypeDiscriminatorId)[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<(System.Type DerivedType, string? TypeDiscriminatorId)>.Remove((System.Type DerivedType, string TypeDiscriminatorId) item) { throw null; }
-        System.Collections.Generic.IEnumerator<(System.Type DerivedType, string? TypeDiscriminatorId)> System.Collections.Generic.IEnumerable<(System.Type DerivedType, string? TypeDiscriminatorId)>.GetEnumerator() { throw null; }
+        bool System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminatorId)>.IsReadOnly { get { throw null; } }
+        void System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminatorId)>.Add((System.Type DerivedType, object? TypeDiscriminatorId) item) { }
+        void System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminatorId)>.Clear() { }
+        bool System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminatorId)>.Contains((System.Type DerivedType, object? TypeDiscriminatorId) item) { throw null; }
+        void System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminatorId)>.CopyTo((System.Type DerivedType, object? TypeDiscriminatorId)[] array, int arrayIndex) { }
+        bool System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminatorId)>.Remove((System.Type DerivedType, object? TypeDiscriminatorId) item) { throw null; }
+        System.Collections.Generic.IEnumerator<(System.Type DerivedType, object? TypeDiscriminatorId)> System.Collections.Generic.IEnumerable<(System.Type DerivedType, object? TypeDiscriminatorId)>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration WithDerivedType(System.Type derivedType, string? typeDiscriminatorId = null) { throw null; }
+        public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration WithDerivedType(System.Type derivedType) { throw null; }
+        public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration WithDerivedType(System.Type derivedType, int typeDiscriminatorId) { throw null; }
+        public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration WithDerivedType(System.Type derivedType, string typeDiscriminatorId) { throw null; }
     }
     public partial class JsonPolymorphicTypeConfiguration<TBaseType> : System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration where TBaseType : class
     {
         public JsonPolymorphicTypeConfiguration() : base(default(System.Type)) { }
-        public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>(string? typeDiscriminatorId = null) where TDerivedType : TBaseType { throw null; }
+        public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>() where TDerivedType : TBaseType { throw null; }
+        public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>(int typeDiscriminatorId) where TDerivedType : TBaseType { throw null; }
+        public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>(string typeDiscriminatorId) where TDerivedType : TBaseType { throw null; }
     }
     public abstract partial class ReferenceHandler
     {

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -873,8 +873,8 @@ namespace System.Text.Json.Serialization
     public partial class JsonDerivedTypeAttribute : System.Text.Json.Serialization.JsonAttribute
     {
         public JsonDerivedTypeAttribute(System.Type derivedType) { }
-        public JsonDerivedTypeAttribute(System.Type derivedType, string typeDiscriminatorId) { }
         public JsonDerivedTypeAttribute(System.Type derivedType, int typeDiscriminatorId) { }
+        public JsonDerivedTypeAttribute(System.Type derivedType, string typeDiscriminatorId) { }
         public System.Type DerivedType { get { throw null; } }
         public object? TypeDiscriminatorId { get { throw null; } }
     }
@@ -924,7 +924,7 @@ namespace System.Text.Json.Serialization
     public sealed partial class JsonPolymorphicAttribute : System.Text.Json.Serialization.JsonAttribute
     {
         public JsonPolymorphicAttribute() { }
-        public string? CustomTypeDiscriminatorPropertyName { get { throw null; } set { } }
+        public string? TypeDiscriminatorPropertyName { get { throw null; } set { } }
         public bool IgnoreUnrecognizedTypeDiscriminators { get { throw null; } set { } }
         public System.Text.Json.Serialization.JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get { throw null; } set { } }
     }
@@ -984,8 +984,8 @@ namespace System.Text.Json.Serialization
     public enum JsonUnknownDerivedTypeHandling
     {
         FailSerialization = 0,
-        FallbackToBaseType = 1,
-        FallbackToNearestAncestor = 2
+        FallBackToBaseType = 1,
+        FallBackToNearestAncestor = 2
     }
     public enum JsonUnknownTypeHandling
     {
@@ -996,7 +996,7 @@ namespace System.Text.Json.Serialization
     {
         public JsonPolymorphicTypeConfiguration(System.Type baseType) { }
         public System.Type BaseType { get { throw null; } }
-        public string? CustomTypeDiscriminatorPropertyName { get { throw null; } set { } }
+        public string? TypeDiscriminatorPropertyName { get { throw null; } set { } }
         public bool IgnoreUnrecognizedTypeDiscriminators { get { throw null; } set { } }
         int System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminatorId)>.Count { get { throw null; } }
         public System.Text.Json.Serialization.JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get { throw null; } set { } }

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -873,10 +873,10 @@ namespace System.Text.Json.Serialization
     public partial class JsonDerivedTypeAttribute : System.Text.Json.Serialization.JsonAttribute
     {
         public JsonDerivedTypeAttribute(System.Type derivedType) { }
-        public JsonDerivedTypeAttribute(System.Type derivedType, int typeDiscriminatorId) { }
-        public JsonDerivedTypeAttribute(System.Type derivedType, string typeDiscriminatorId) { }
+        public JsonDerivedTypeAttribute(System.Type derivedType, int typeDiscriminator) { }
+        public JsonDerivedTypeAttribute(System.Type derivedType, string typeDiscriminator) { }
         public System.Type DerivedType { get { throw null; } }
-        public object? TypeDiscriminatorId { get { throw null; } }
+        public object? TypeDiscriminator { get { throw null; } }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple = false)]
     public sealed partial class JsonExtensionDataAttribute : System.Text.Json.Serialization.JsonAttribute
@@ -992,32 +992,32 @@ namespace System.Text.Json.Serialization
         JsonElement = 0,
         JsonNode = 1,
     }
-    public partial class JsonPolymorphicTypeConfiguration : System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminatorId)>, System.Collections.Generic.IEnumerable<(System.Type DerivedType, object? TypeDiscriminatorId)>, System.Collections.IEnumerable
+    public partial class JsonPolymorphicTypeConfiguration : System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminator)>, System.Collections.Generic.IEnumerable<(System.Type DerivedType, object? TypeDiscriminator)>, System.Collections.IEnumerable
     {
         public JsonPolymorphicTypeConfiguration(System.Type baseType) { }
         public System.Type BaseType { get { throw null; } }
         public string? TypeDiscriminatorPropertyName { get { throw null; } set { } }
         public bool IgnoreUnrecognizedTypeDiscriminators { get { throw null; } set { } }
-        int System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminatorId)>.Count { get { throw null; } }
+        int System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminator)>.Count { get { throw null; } }
         public System.Text.Json.Serialization.JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get { throw null; } set { } }
-        bool System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminatorId)>.IsReadOnly { get { throw null; } }
-        void System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminatorId)>.Add((System.Type DerivedType, object? TypeDiscriminatorId) item) { }
-        void System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminatorId)>.Clear() { }
-        bool System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminatorId)>.Contains((System.Type DerivedType, object? TypeDiscriminatorId) item) { throw null; }
-        void System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminatorId)>.CopyTo((System.Type DerivedType, object? TypeDiscriminatorId)[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminatorId)>.Remove((System.Type DerivedType, object? TypeDiscriminatorId) item) { throw null; }
-        System.Collections.Generic.IEnumerator<(System.Type DerivedType, object? TypeDiscriminatorId)> System.Collections.Generic.IEnumerable<(System.Type DerivedType, object? TypeDiscriminatorId)>.GetEnumerator() { throw null; }
+        bool System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminator)>.IsReadOnly { get { throw null; } }
+        void System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminator)>.Add((System.Type DerivedType, object? TypeDiscriminator) item) { }
+        void System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminator)>.Clear() { }
+        bool System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminator)>.Contains((System.Type DerivedType, object? TypeDiscriminator) item) { throw null; }
+        void System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminator)>.CopyTo((System.Type DerivedType, object? TypeDiscriminator)[] array, int arrayIndex) { }
+        bool System.Collections.Generic.ICollection<(System.Type DerivedType, object? TypeDiscriminator)>.Remove((System.Type DerivedType, object? TypeDiscriminator) item) { throw null; }
+        System.Collections.Generic.IEnumerator<(System.Type DerivedType, object? TypeDiscriminator)> System.Collections.Generic.IEnumerable<(System.Type DerivedType, object? TypeDiscriminator)>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration WithDerivedType(System.Type derivedType) { throw null; }
-        public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration WithDerivedType(System.Type derivedType, int typeDiscriminatorId) { throw null; }
-        public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration WithDerivedType(System.Type derivedType, string typeDiscriminatorId) { throw null; }
+        public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration WithDerivedType(System.Type derivedType, int typeDiscriminator) { throw null; }
+        public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration WithDerivedType(System.Type derivedType, string typeDiscriminator) { throw null; }
     }
     public partial class JsonPolymorphicTypeConfiguration<TBaseType> : System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration where TBaseType : class
     {
         public JsonPolymorphicTypeConfiguration() : base(default(System.Type)) { }
         public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>() where TDerivedType : TBaseType { throw null; }
-        public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>(int typeDiscriminatorId) where TDerivedType : TBaseType { throw null; }
-        public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>(string typeDiscriminatorId) where TDerivedType : TBaseType { throw null; }
+        public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>(int typeDiscriminator) where TDerivedType : TBaseType { throw null; }
+        public System.Text.Json.Serialization.JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>(string typeDiscriminator) where TDerivedType : TBaseType { throw null; }
     }
     public abstract partial class ReferenceHandler
     {

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -612,7 +612,7 @@
     <value>Specified type '{0}' does not support polymorphism. Polymorphic types cannot be structs, sealed types, generic types or System.Object.</value>
   </data>
   <data name="Polymorphism_DerivedTypeIsNotSupported" xml:space="preserve">
-    <value>Specified type '{0}' is not a supported derived type for the polymorphic type '{1}'. Derived types must be assignable to the base type, must not be generic and cannot be abstact classes or interfaces unless 'JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor' is specified.</value>
+    <value>Specified type '{0}' is not a supported derived type for the polymorphic type '{1}'. Derived types must be assignable to the base type, must not be generic and cannot be abstact classes or interfaces unless 'JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor' is specified.</value>
   </data>
   <data name="Polymorphism_DerivedTypeIsAlreadySpecified" xml:space="preserve">
     <value>The polymorphic type '{0}' has already specified derived type '{1}'.</value>
@@ -633,6 +633,6 @@
     <value>Runtime type '{0}' is not supported by polymorphic type '{1}'.</value>
   </data>
   <data name="Polymorphism_RuntimeTypeDiamondAmbiguity" xml:space="preserve">
-    <value>Runtime type '{0}' has a diamond ambiguity between derived types '{1}' and '{2}' of polymorphic type '{3}'. Consider either removing one of the derived types or removing the 'JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor' setting.</value>
+    <value>Runtime type '{0}' has a diamond ambiguity between derived types '{1}' and '{2}' of polymorphic type '{3}'. Consider either removing one of the derived types or removing the 'JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor' setting.</value>
   </data>
 </root>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonDerivedTypeAttribute.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonDerivedTypeAttribute.cs
@@ -30,6 +30,17 @@ namespace System.Text.Json.Serialization
         }
 
         /// <summary>
+        /// Initializes a new attribute with specified parameters.
+        /// </summary>
+        /// <param name="derivedType">A derived type that should be supported in polymorphic serialization of the declared base type.</param>
+        /// <param name="typeDiscriminatorId">The type discriminator identifier to be used for the serialization of the subtype.</param>
+        public JsonDerivedTypeAttribute(Type derivedType, int typeDiscriminatorId)
+        {
+            DerivedType = derivedType;
+            TypeDiscriminatorId = typeDiscriminatorId;
+        }
+
+        /// <summary>
         /// A derived type that should be supported in polymorphic serialization of the declared base type.
         /// </summary>
         public Type DerivedType { get; }
@@ -37,6 +48,6 @@ namespace System.Text.Json.Serialization
         /// <summary>
         /// The type discriminator identifier to be used for the serialization of the subtype.
         /// </summary>
-        public string? TypeDiscriminatorId { get; }
+        public object? TypeDiscriminatorId { get; }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonDerivedTypeAttribute.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonDerivedTypeAttribute.cs
@@ -22,22 +22,22 @@ namespace System.Text.Json.Serialization
         /// Initializes a new attribute with specified parameters.
         /// </summary>
         /// <param name="derivedType">A derived type that should be supported in polymorphic serialization of the declared base type.</param>
-        /// <param name="typeDiscriminatorId">The type discriminator identifier to be used for the serialization of the subtype.</param>
-        public JsonDerivedTypeAttribute(Type derivedType, string typeDiscriminatorId)
+        /// <param name="typeDiscriminator">The type discriminator identifier to be used for the serialization of the subtype.</param>
+        public JsonDerivedTypeAttribute(Type derivedType, string typeDiscriminator)
         {
             DerivedType = derivedType;
-            TypeDiscriminatorId = typeDiscriminatorId;
+            TypeDiscriminator = typeDiscriminator;
         }
 
         /// <summary>
         /// Initializes a new attribute with specified parameters.
         /// </summary>
         /// <param name="derivedType">A derived type that should be supported in polymorphic serialization of the declared base type.</param>
-        /// <param name="typeDiscriminatorId">The type discriminator identifier to be used for the serialization of the subtype.</param>
-        public JsonDerivedTypeAttribute(Type derivedType, int typeDiscriminatorId)
+        /// <param name="typeDiscriminator">The type discriminator identifier to be used for the serialization of the subtype.</param>
+        public JsonDerivedTypeAttribute(Type derivedType, int typeDiscriminator)
         {
             DerivedType = derivedType;
-            TypeDiscriminatorId = typeDiscriminatorId;
+            TypeDiscriminator = typeDiscriminator;
         }
 
         /// <summary>
@@ -48,6 +48,6 @@ namespace System.Text.Json.Serialization
         /// <summary>
         /// The type discriminator identifier to be used for the serialization of the subtype.
         /// </summary>
-        public object? TypeDiscriminatorId { get; }
+        public object? TypeDiscriminator { get; }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonPolymorphicAttribute.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonPolymorphicAttribute.cs
@@ -13,7 +13,7 @@ namespace System.Text.Json.Serialization
         /// Gets or sets a custom type discriminator property name for the polymorhic type.
         /// Uses the default '$type' property name if left unset.
         /// </summary>
-        public string? CustomTypeDiscriminatorPropertyName { get; set; }
+        public string? TypeDiscriminatorPropertyName { get; set; }
 
         /// <summary>
         /// Gets or sets the behavior when serializing an undeclared derived runtime type.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.MetadataHandling.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.MetadataHandling.cs
@@ -86,7 +86,7 @@ namespace System.Text.Json.Serialization
                     {
                         Debug.Assert(CanHaveMetadata);
 
-                        if (resolver.TryGetDerivedJsonTypeInfo(runtimeType, out JsonTypeInfo? derivedJsonTypeInfo, out string? typeDiscriminatorId))
+                        if (resolver.TryGetDerivedJsonTypeInfo(runtimeType, out JsonTypeInfo? derivedJsonTypeInfo, out object? typeDiscriminatorId))
                         {
                             polymorphicConverter = state.Current.InitializePolymorphicReEntry(derivedJsonTypeInfo);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.MetadataHandling.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.MetadataHandling.cs
@@ -86,18 +86,18 @@ namespace System.Text.Json.Serialization
                     {
                         Debug.Assert(CanHaveMetadata);
 
-                        if (resolver.TryGetDerivedJsonTypeInfo(runtimeType, out JsonTypeInfo? derivedJsonTypeInfo, out object? typeDiscriminatorId))
+                        if (resolver.TryGetDerivedJsonTypeInfo(runtimeType, out JsonTypeInfo? derivedJsonTypeInfo, out object? typeDiscriminator))
                         {
                             polymorphicConverter = state.Current.InitializePolymorphicReEntry(derivedJsonTypeInfo);
 
-                            if (typeDiscriminatorId is not null)
+                            if (typeDiscriminator is not null)
                             {
                                 if (!polymorphicConverter.CanHaveMetadata)
                                 {
                                     ThrowHelper.ThrowNotSupportedException_DerivedConverterDoesNotSupportMetadata(derivedJsonTypeInfo.Type);
                                 }
 
-                                state.PolymorphicTypeDiscriminator = typeDiscriminatorId;
+                                state.PolymorphicTypeDiscriminator = typeDiscriminator;
                             }
                         }
                         else

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPolymorphicTypeConfiguration.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPolymorphicTypeConfiguration.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization
@@ -10,9 +11,9 @@ namespace System.Text.Json.Serialization
     /// <summary>
     /// Defines polymorphic configuration for a specified base type.
     /// </summary>
-    public class JsonPolymorphicTypeConfiguration : IJsonPolymorphicTypeConfiguration, ICollection<(Type DerivedType, string? TypeDiscriminatorId)>
+    public class JsonPolymorphicTypeConfiguration : IJsonPolymorphicTypeConfiguration, ICollection<(Type DerivedType, object? TypeDiscriminatorId)>
     {
-        private readonly List<(Type DerivedType, string? TypeDiscriminatorId)> _derivedTypes = new();
+        private readonly List<(Type DerivedType, object? TypeDiscriminatorId)> _derivedTypes = new();
         private string? _customTypeDiscriminatorPropertyName;
         private JsonUnknownDerivedTypeHandling _unknownDerivedTypeHandling;
         private bool _ignoreUnrecognizedTypeDiscriminators;
@@ -87,10 +88,32 @@ namespace System.Text.Json.Serialization
         /// Opts in polymorphic serialization for the specified derived type.
         /// </summary>
         /// <param name="derivedType">The derived type for which to enable polymorphism.</param>
+        /// <returns>The same <see cref="JsonPolymorphicTypeConfiguration"/> instance after it has been updated.</returns>
+        public JsonPolymorphicTypeConfiguration WithDerivedType(Type derivedType)
+            => WithDerivedTypeCore(derivedType, null);
+
+        /// <summary>
+        /// Opts in polymorphic serialization for the specified derived type.
+        /// </summary>
+        /// <param name="derivedType">The derived type for which to enable polymorphism.</param>
         /// <param name="typeDiscriminatorId">The type discriminator id to use for the specified derived type.</param>
         /// <returns>The same <see cref="JsonPolymorphicTypeConfiguration"/> instance after it has been updated.</returns>
-        public JsonPolymorphicTypeConfiguration WithDerivedType(Type derivedType, string? typeDiscriminatorId = null)
+        public JsonPolymorphicTypeConfiguration WithDerivedType(Type derivedType, string typeDiscriminatorId) =>
+            WithDerivedTypeCore(derivedType, typeDiscriminatorId);
+
+        /// <summary>
+        /// Opts in polymorphic serialization for the specified derived type.
+        /// </summary>
+        /// <param name="derivedType">The derived type for which to enable polymorphism.</param>
+        /// <param name="typeDiscriminatorId">The type discriminator id to use for the specified derived type.</param>
+        /// <returns>The same <see cref="JsonPolymorphicTypeConfiguration"/> instance after it has been updated.</returns>
+        public JsonPolymorphicTypeConfiguration WithDerivedType(Type derivedType, int typeDiscriminatorId) =>
+            WithDerivedTypeCore(derivedType, typeDiscriminatorId);
+
+        private JsonPolymorphicTypeConfiguration WithDerivedTypeCore(Type derivedType, object? typeDiscriminatorId)
         {
+            Debug.Assert(typeDiscriminatorId is null or string or int);
+
             VerifyMutable();
 
             if (derivedType is null)
@@ -106,14 +129,14 @@ namespace System.Text.Json.Serialization
             // Perform a linear traversal to determine any duplicate derived types or discriminator Id's
             // The assumption is that each type maintains a small number of subtypes so this is preferable
             // to maintaing hashtables to existing entries.
-            foreach ((Type DerivedType, string? TypeDiscriminatorId) entry in _derivedTypes)
+            foreach ((Type DerivedType, object? TypeDiscriminatorId) entry in _derivedTypes)
             {
                 if (entry.DerivedType == derivedType)
                 {
                     throw new ArgumentException(SR.Format(SR.Polymorphism_DerivedTypeIsAlreadySpecified, BaseType, derivedType), nameof(derivedType));
                 }
 
-                if (typeDiscriminatorId != null && entry.TypeDiscriminatorId == typeDiscriminatorId)
+                if (typeDiscriminatorId != null && typeDiscriminatorId.Equals(entry.TypeDiscriminatorId))
                 {
                     throw new ArgumentException(SR.Format(SR.Polymorphism_TypeDicriminatorIdIsAlreadySpecified, BaseType, typeDiscriminatorId), nameof(typeDiscriminatorId));
                 }
@@ -124,7 +147,7 @@ namespace System.Text.Json.Serialization
             return this;
         }
 
-        IEnumerable<(Type DerivedType, string? TypeDiscriminatorId)> IJsonPolymorphicTypeConfiguration.GetSupportedDerivedTypes()
+        IEnumerable<(Type DerivedType, object? TypeDiscriminatorId)> IJsonPolymorphicTypeConfiguration.GetSupportedDerivedTypes()
         {
             foreach ((Type, string?) entry in _derivedTypes)
             {
@@ -142,24 +165,33 @@ namespace System.Text.Json.Serialization
             }
         }
 
-        bool ICollection<(Type DerivedType, string? TypeDiscriminatorId)>.Contains((Type DerivedType, string? TypeDiscriminatorId) item) => _derivedTypes.Contains(item);
-        void ICollection<(Type DerivedType, string? TypeDiscriminatorId)>.CopyTo((Type DerivedType, string? TypeDiscriminatorId)[] array, int arrayIndex) => _derivedTypes.CopyTo(array, arrayIndex);
-        bool ICollection<(Type DerivedType, string? TypeDiscriminatorId)>.Remove((Type DerivedType, string? TypeDiscriminatorId) item)
+        bool ICollection<(Type DerivedType, object? TypeDiscriminatorId)>.Contains((Type DerivedType, object? TypeDiscriminatorId) item) => _derivedTypes.Contains(item);
+        void ICollection<(Type DerivedType, object? TypeDiscriminatorId)>.CopyTo((Type DerivedType, object? TypeDiscriminatorId)[] array, int arrayIndex) => _derivedTypes.CopyTo(array, arrayIndex);
+        bool ICollection<(Type DerivedType, object? TypeDiscriminatorId)>.Remove((Type DerivedType, object? TypeDiscriminatorId) item)
         {
             VerifyMutable();
             return _derivedTypes.Remove(item);
         }
 
-        bool ICollection<(Type DerivedType, string? TypeDiscriminatorId)>.IsReadOnly => IsAssignedToOptionsInstance;
-        int ICollection<(Type DerivedType, string? TypeDiscriminatorId)>.Count => _derivedTypes.Count;
-        void ICollection<(Type DerivedType, string? TypeDiscriminatorId)>.Add((Type DerivedType, string? TypeDiscriminatorId) item) => WithDerivedType(item.DerivedType, item.TypeDiscriminatorId);
-        void ICollection<(Type DerivedType, string? TypeDiscriminatorId)>.Clear()
+        bool ICollection<(Type DerivedType, object? TypeDiscriminatorId)>.IsReadOnly => IsAssignedToOptionsInstance;
+        int ICollection<(Type DerivedType, object? TypeDiscriminatorId)>.Count => _derivedTypes.Count;
+        void ICollection<(Type DerivedType, object? TypeDiscriminatorId)>.Add((Type DerivedType, object? TypeDiscriminatorId) item)
+        {
+            if (item.TypeDiscriminatorId is not (null or string or int))
+            {
+                throw new ArgumentException(nameof(item));
+            }
+
+            WithDerivedTypeCore(item.DerivedType, item.TypeDiscriminatorId);
+        }
+
+        void ICollection<(Type DerivedType, object? TypeDiscriminatorId)>.Clear()
         {
             VerifyMutable();
             _derivedTypes.Clear();
         }
 
-        IEnumerator<(Type DerivedType, string? TypeDiscriminatorId)> IEnumerable<(Type DerivedType, string? TypeDiscriminatorId)>.GetEnumerator() => _derivedTypes.GetEnumerator();
+        IEnumerator<(Type DerivedType, object? TypeDiscriminatorId)> IEnumerable<(Type DerivedType, object? TypeDiscriminatorId)>.GetEnumerator() => _derivedTypes.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => _derivedTypes.GetEnumerator();
     }
 
@@ -180,9 +212,32 @@ namespace System.Text.Json.Serialization
         /// Associates specified derived type with supplied string identifier.
         /// </summary>
         /// <typeparam name="TDerivedType">The derived type with which to associate a type identifier.</typeparam>
+        /// <returns>The same <see cref="JsonPolymorphicTypeConfiguration"/> instance after it has been updated.</returns>
+        public JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>() where TDerivedType : TBaseType
+        {
+            WithDerivedType(typeof(TDerivedType));
+            return this;
+        }
+
+        /// <summary>
+        /// Associates specified derived type with supplied string identifier.
+        /// </summary>
+        /// <typeparam name="TDerivedType">The derived type with which to associate a type identifier.</typeparam>
         /// <param name="typeDiscriminatorId">The type identifier to use for the specified derived type.</param>
         /// <returns>The same <see cref="JsonPolymorphicTypeConfiguration"/> instance after it has been updated.</returns>
-        public JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>(string? typeDiscriminatorId = null) where TDerivedType : TBaseType
+        public JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>(string typeDiscriminatorId) where TDerivedType : TBaseType
+        {
+            WithDerivedType(typeof(TDerivedType), typeDiscriminatorId);
+            return this;
+        }
+
+        /// <summary>
+        /// Associates specified derived type with supplied string identifier.
+        /// </summary>
+        /// <typeparam name="TDerivedType">The derived type with which to associate a type identifier.</typeparam>
+        /// <param name="typeDiscriminatorId">The type identifier to use for the specified derived type.</param>
+        /// <returns>The same <see cref="JsonPolymorphicTypeConfiguration"/> instance after it has been updated.</returns>
+        public JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>(int typeDiscriminatorId) where TDerivedType : TBaseType
         {
             WithDerivedType(typeof(TDerivedType), typeDiscriminatorId);
             return this;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPolymorphicTypeConfiguration.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPolymorphicTypeConfiguration.cs
@@ -74,7 +74,7 @@ namespace System.Text.Json.Serialization
         /// Gets or sets a custom type discriminator property name for the polymorhic type.
         /// Uses the default '$type' property name if left unset.
         /// </summary>
-        public string? CustomTypeDiscriminatorPropertyName
+        public string? TypeDiscriminatorPropertyName
         {
             get => _customTypeDiscriminatorPropertyName;
             set

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPolymorphicTypeConfiguration.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPolymorphicTypeConfiguration.cs
@@ -11,9 +11,9 @@ namespace System.Text.Json.Serialization
     /// <summary>
     /// Defines polymorphic configuration for a specified base type.
     /// </summary>
-    public class JsonPolymorphicTypeConfiguration : IJsonPolymorphicTypeConfiguration, ICollection<(Type DerivedType, object? TypeDiscriminatorId)>
+    public class JsonPolymorphicTypeConfiguration : IJsonPolymorphicTypeConfiguration, ICollection<(Type DerivedType, object? TypeDiscriminator)>
     {
-        private readonly List<(Type DerivedType, object? TypeDiscriminatorId)> _derivedTypes = new();
+        private readonly List<(Type DerivedType, object? TypeDiscriminator)> _derivedTypes = new();
         private string? _customTypeDiscriminatorPropertyName;
         private JsonUnknownDerivedTypeHandling _unknownDerivedTypeHandling;
         private bool _ignoreUnrecognizedTypeDiscriminators;
@@ -96,23 +96,23 @@ namespace System.Text.Json.Serialization
         /// Opts in polymorphic serialization for the specified derived type.
         /// </summary>
         /// <param name="derivedType">The derived type for which to enable polymorphism.</param>
-        /// <param name="typeDiscriminatorId">The type discriminator id to use for the specified derived type.</param>
+        /// <param name="typeDiscriminator">The type discriminator id to use for the specified derived type.</param>
         /// <returns>The same <see cref="JsonPolymorphicTypeConfiguration"/> instance after it has been updated.</returns>
-        public JsonPolymorphicTypeConfiguration WithDerivedType(Type derivedType, string typeDiscriminatorId) =>
-            WithDerivedTypeCore(derivedType, typeDiscriminatorId);
+        public JsonPolymorphicTypeConfiguration WithDerivedType(Type derivedType, string typeDiscriminator) =>
+            WithDerivedTypeCore(derivedType, typeDiscriminator);
 
         /// <summary>
         /// Opts in polymorphic serialization for the specified derived type.
         /// </summary>
         /// <param name="derivedType">The derived type for which to enable polymorphism.</param>
-        /// <param name="typeDiscriminatorId">The type discriminator id to use for the specified derived type.</param>
+        /// <param name="typeDiscriminator">The type discriminator id to use for the specified derived type.</param>
         /// <returns>The same <see cref="JsonPolymorphicTypeConfiguration"/> instance after it has been updated.</returns>
-        public JsonPolymorphicTypeConfiguration WithDerivedType(Type derivedType, int typeDiscriminatorId) =>
-            WithDerivedTypeCore(derivedType, typeDiscriminatorId);
+        public JsonPolymorphicTypeConfiguration WithDerivedType(Type derivedType, int typeDiscriminator) =>
+            WithDerivedTypeCore(derivedType, typeDiscriminator);
 
-        private JsonPolymorphicTypeConfiguration WithDerivedTypeCore(Type derivedType, object? typeDiscriminatorId)
+        private JsonPolymorphicTypeConfiguration WithDerivedTypeCore(Type derivedType, object? typeDiscriminator)
         {
-            Debug.Assert(typeDiscriminatorId is null or string or int);
+            Debug.Assert(typeDiscriminator is null or string or int);
 
             VerifyMutable();
 
@@ -129,25 +129,25 @@ namespace System.Text.Json.Serialization
             // Perform a linear traversal to determine any duplicate derived types or discriminator Id's
             // The assumption is that each type maintains a small number of subtypes so this is preferable
             // to maintaing hashtables to existing entries.
-            foreach ((Type DerivedType, object? TypeDiscriminatorId) entry in _derivedTypes)
+            foreach ((Type DerivedType, object? TypeDiscriminator) entry in _derivedTypes)
             {
                 if (entry.DerivedType == derivedType)
                 {
                     throw new ArgumentException(SR.Format(SR.Polymorphism_DerivedTypeIsAlreadySpecified, BaseType, derivedType), nameof(derivedType));
                 }
 
-                if (typeDiscriminatorId != null && typeDiscriminatorId.Equals(entry.TypeDiscriminatorId))
+                if (typeDiscriminator != null && typeDiscriminator.Equals(entry.TypeDiscriminator))
                 {
-                    throw new ArgumentException(SR.Format(SR.Polymorphism_TypeDicriminatorIdIsAlreadySpecified, BaseType, typeDiscriminatorId), nameof(typeDiscriminatorId));
+                    throw new ArgumentException(SR.Format(SR.Polymorphism_TypeDicriminatorIdIsAlreadySpecified, BaseType, typeDiscriminator), nameof(typeDiscriminator));
                 }
             }
 
             // Validation complete; update the configuration state.
-            _derivedTypes.Add((derivedType, typeDiscriminatorId));
+            _derivedTypes.Add((derivedType, typeDiscriminator));
             return this;
         }
 
-        IEnumerable<(Type DerivedType, object? TypeDiscriminatorId)> IJsonPolymorphicTypeConfiguration.GetSupportedDerivedTypes()
+        IEnumerable<(Type DerivedType, object? TypeDiscriminator)> IJsonPolymorphicTypeConfiguration.GetSupportedDerivedTypes()
         {
             foreach ((Type, string?) entry in _derivedTypes)
             {
@@ -165,33 +165,33 @@ namespace System.Text.Json.Serialization
             }
         }
 
-        bool ICollection<(Type DerivedType, object? TypeDiscriminatorId)>.Contains((Type DerivedType, object? TypeDiscriminatorId) item) => _derivedTypes.Contains(item);
-        void ICollection<(Type DerivedType, object? TypeDiscriminatorId)>.CopyTo((Type DerivedType, object? TypeDiscriminatorId)[] array, int arrayIndex) => _derivedTypes.CopyTo(array, arrayIndex);
-        bool ICollection<(Type DerivedType, object? TypeDiscriminatorId)>.Remove((Type DerivedType, object? TypeDiscriminatorId) item)
+        bool ICollection<(Type DerivedType, object? TypeDiscriminator)>.Contains((Type DerivedType, object? TypeDiscriminator) item) => _derivedTypes.Contains(item);
+        void ICollection<(Type DerivedType, object? TypeDiscriminator)>.CopyTo((Type DerivedType, object? TypeDiscriminator)[] array, int arrayIndex) => _derivedTypes.CopyTo(array, arrayIndex);
+        bool ICollection<(Type DerivedType, object? TypeDiscriminator)>.Remove((Type DerivedType, object? TypeDiscriminator) item)
         {
             VerifyMutable();
             return _derivedTypes.Remove(item);
         }
 
-        bool ICollection<(Type DerivedType, object? TypeDiscriminatorId)>.IsReadOnly => IsAssignedToOptionsInstance;
-        int ICollection<(Type DerivedType, object? TypeDiscriminatorId)>.Count => _derivedTypes.Count;
-        void ICollection<(Type DerivedType, object? TypeDiscriminatorId)>.Add((Type DerivedType, object? TypeDiscriminatorId) item)
+        bool ICollection<(Type DerivedType, object? TypeDiscriminator)>.IsReadOnly => IsAssignedToOptionsInstance;
+        int ICollection<(Type DerivedType, object? TypeDiscriminator)>.Count => _derivedTypes.Count;
+        void ICollection<(Type DerivedType, object? TypeDiscriminator)>.Add((Type DerivedType, object? TypeDiscriminator) item)
         {
-            if (item.TypeDiscriminatorId is not (null or string or int))
+            if (item.TypeDiscriminator is not (null or string or int))
             {
                 throw new ArgumentException(nameof(item));
             }
 
-            WithDerivedTypeCore(item.DerivedType, item.TypeDiscriminatorId);
+            WithDerivedTypeCore(item.DerivedType, item.TypeDiscriminator);
         }
 
-        void ICollection<(Type DerivedType, object? TypeDiscriminatorId)>.Clear()
+        void ICollection<(Type DerivedType, object? TypeDiscriminator)>.Clear()
         {
             VerifyMutable();
             _derivedTypes.Clear();
         }
 
-        IEnumerator<(Type DerivedType, object? TypeDiscriminatorId)> IEnumerable<(Type DerivedType, object? TypeDiscriminatorId)>.GetEnumerator() => _derivedTypes.GetEnumerator();
+        IEnumerator<(Type DerivedType, object? TypeDiscriminator)> IEnumerable<(Type DerivedType, object? TypeDiscriminator)>.GetEnumerator() => _derivedTypes.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => _derivedTypes.GetEnumerator();
     }
 
@@ -223,11 +223,11 @@ namespace System.Text.Json.Serialization
         /// Associates specified derived type with supplied string identifier.
         /// </summary>
         /// <typeparam name="TDerivedType">The derived type with which to associate a type identifier.</typeparam>
-        /// <param name="typeDiscriminatorId">The type identifier to use for the specified derived type.</param>
+        /// <param name="typeDiscriminator">The type identifier to use for the specified derived type.</param>
         /// <returns>The same <see cref="JsonPolymorphicTypeConfiguration"/> instance after it has been updated.</returns>
-        public JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>(string typeDiscriminatorId) where TDerivedType : TBaseType
+        public JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>(string typeDiscriminator) where TDerivedType : TBaseType
         {
-            WithDerivedType(typeof(TDerivedType), typeDiscriminatorId);
+            WithDerivedType(typeof(TDerivedType), typeDiscriminator);
             return this;
         }
 
@@ -235,11 +235,11 @@ namespace System.Text.Json.Serialization
         /// Associates specified derived type with supplied string identifier.
         /// </summary>
         /// <typeparam name="TDerivedType">The derived type with which to associate a type identifier.</typeparam>
-        /// <param name="typeDiscriminatorId">The type identifier to use for the specified derived type.</param>
+        /// <param name="typeDiscriminator">The type identifier to use for the specified derived type.</param>
         /// <returns>The same <see cref="JsonPolymorphicTypeConfiguration"/> instance after it has been updated.</returns>
-        public JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>(int typeDiscriminatorId) where TDerivedType : TBaseType
+        public JsonPolymorphicTypeConfiguration<TBaseType> WithDerivedType<TDerivedType>(int typeDiscriminator) where TDerivedType : TBaseType
         {
-            WithDerivedType(typeof(TDerivedType), typeDiscriminatorId);
+            WithDerivedType(typeof(TDerivedType), typeDiscriminator);
             return this;
         }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleMetadata.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleMetadata.cs
@@ -183,13 +183,21 @@ namespace System.Text.Json
                         break;
 
                     case MetadataPropertyName.Type:
-                        if (reader.TokenType != JsonTokenType.String)
+                        Debug.Assert(state.PolymorphicTypeDiscriminator == null);
+
+                        switch (reader.TokenType)
                         {
-                            ThrowHelper.ThrowJsonException_MetadataValueWasNotString(reader.TokenType);
+                            case JsonTokenType.String:
+                                state.PolymorphicTypeDiscriminator = reader.GetString();
+                                break;
+                            case JsonTokenType.Number:
+                                state.PolymorphicTypeDiscriminator = reader.GetInt32();
+                                break;
+                            default:
+                                ThrowHelper.ThrowJsonException_MetadataValueWasNotString(reader.TokenType);
+                                break;
                         }
 
-                        Debug.Assert(state.PolymorphicTypeDiscriminator == null);
-                        state.PolymorphicTypeDiscriminator = reader.GetString();
                         break;
 
                     case MetadataPropertyName.Values:

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleMetadata.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleMetadata.cs
@@ -32,7 +32,7 @@ namespace System.Text.Json
                 state.NewReferenceId = null;
             }
 
-            if (state.PolymorphicTypeDiscriminator is string typeDiscriminatorId)
+            if (state.PolymorphicTypeDiscriminator is object discriminator)
             {
                 Debug.Assert(state.Parent.JsonPropertyInfo!.JsonTypeInfo.PolymorphicTypeResolver != null);
 
@@ -41,7 +41,16 @@ namespace System.Text.Json
                     ? customPropertyName
                     : s_metadataType;
 
-                writer.WriteString(propertyName, typeDiscriminatorId);
+                if (discriminator is string stringId)
+                {
+                    writer.WriteString(propertyName, stringId);
+                }
+                else
+                {
+                    Debug.Assert(discriminator is int);
+                    writer.WriteNumber(propertyName, (int)discriminator);
+                }
+
                 writtenMetadata |= MetadataPropertyName.Type;
                 state.PolymorphicTypeDiscriminator = null;
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonUnknownDerivedTypeHandling.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonUnknownDerivedTypeHandling.cs
@@ -15,11 +15,11 @@ namespace System.Text.Json.Serialization
         /// <summary>
         /// An object of undeclared runtime type will fall back to the serialization contract of the base type.
         /// </summary>
-        FallbackToBaseType = 1,
+        FallBackToBaseType = 1,
         /// <summary>
         /// An object of undeclared runtime type will revert to the serialization contract of the nearest declared ancestor type.
         /// Certain interface hierarchies are not supported due to diamond ambiguity constraints.
         /// </summary>
-        FallbackToNearestAncestor = 2
+        FallBackToNearestAncestor = 2
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/AttributePolymorphicTypeConfiguration.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/AttributePolymorphicTypeConfiguration.cs
@@ -49,7 +49,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         public bool IgnoreUnrecognizedTypeDiscriminators => _polymorphicTypeAttribute?.IgnoreUnrecognizedTypeDiscriminators ?? false;
 
-        public IEnumerable<(Type DerivedType, string? TypeDiscriminatorId)> GetSupportedDerivedTypes()
+        public IEnumerable<(Type DerivedType, object? TypeDiscriminatorId)> GetSupportedDerivedTypes()
         {
             foreach (JsonDerivedTypeAttribute attribute in _derivedTypeAttributes)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/AttributePolymorphicTypeConfiguration.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/AttributePolymorphicTypeConfiguration.cs
@@ -49,11 +49,11 @@ namespace System.Text.Json.Serialization.Metadata
 
         public bool IgnoreUnrecognizedTypeDiscriminators => _polymorphicTypeAttribute?.IgnoreUnrecognizedTypeDiscriminators ?? false;
 
-        public IEnumerable<(Type DerivedType, object? TypeDiscriminatorId)> GetSupportedDerivedTypes()
+        public IEnumerable<(Type DerivedType, object? TypeDiscriminator)> GetSupportedDerivedTypes()
         {
             foreach (JsonDerivedTypeAttribute attribute in _derivedTypeAttributes)
             {
-                yield return (attribute.DerivedType, attribute.TypeDiscriminatorId);
+                yield return (attribute.DerivedType, attribute.TypeDiscriminator);
             }
         }
 #pragma warning restore CA2252 // This API requires opting into preview features

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/AttributePolymorphicTypeConfiguration.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/AttributePolymorphicTypeConfiguration.cs
@@ -43,7 +43,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         public Type BaseType { get; }
 
-        public string? CustomTypeDiscriminatorPropertyName => _polymorphicTypeAttribute?.CustomTypeDiscriminatorPropertyName;
+        public string? TypeDiscriminatorPropertyName => _polymorphicTypeAttribute?.TypeDiscriminatorPropertyName;
 
         public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling => _polymorphicTypeAttribute?.UnknownDerivedTypeHandling ?? default;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IJsonPolymorphicTypeConfiguration.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IJsonPolymorphicTypeConfiguration.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json.Serialization.Metadata
         string? CustomTypeDiscriminatorPropertyName { get; }
         JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get; }
         bool IgnoreUnrecognizedTypeDiscriminators { get; }
-        IEnumerable<(Type DerivedType, string? TypeDiscriminatorId)> GetSupportedDerivedTypes();
+        IEnumerable<(Type DerivedType, object? TypeDiscriminatorId)> GetSupportedDerivedTypes();
 #pragma warning restore CA2252 // This API requires opting into preview features
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IJsonPolymorphicTypeConfiguration.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IJsonPolymorphicTypeConfiguration.cs
@@ -9,7 +9,7 @@ namespace System.Text.Json.Serialization.Metadata
     {
 #pragma warning disable CA2252 // This API requires opting into preview features
         Type BaseType { get; }
-        string? CustomTypeDiscriminatorPropertyName { get; }
+        string? TypeDiscriminatorPropertyName { get; }
         JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get; }
         bool IgnoreUnrecognizedTypeDiscriminators { get; }
         IEnumerable<(Type DerivedType, object? TypeDiscriminatorId)> GetSupportedDerivedTypes();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IJsonPolymorphicTypeConfiguration.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IJsonPolymorphicTypeConfiguration.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json.Serialization.Metadata
         string? TypeDiscriminatorPropertyName { get; }
         JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get; }
         bool IgnoreUnrecognizedTypeDiscriminators { get; }
-        IEnumerable<(Type DerivedType, object? TypeDiscriminatorId)> GetSupportedDerivedTypes();
+        IEnumerable<(Type DerivedType, object? TypeDiscriminator)> GetSupportedDerivedTypes();
 #pragma warning restore CA2252 // This API requires opting into preview features
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
@@ -41,15 +41,7 @@ namespace System.Text.Json.Serialization.Metadata
                     ThrowHelper.ThrowInvalidOperationException_DerivedTypeNotSupported(BaseType, derivedType);
                 }
 
-                if (typeDiscriminatorId is not null)
-                {
-                    if (typeDiscriminatorId is not (int or string))
-                    {
-                        throw new Exception("A type discriminator can either be of type string or int.");
-                    }
-
-                    UsesTypeDiscriminators = true;
-                }
+                Debug.Assert(typeDiscriminatorId is null or int or string);
 
                 var derivedJsonTypeInfo = new DerivedJsonTypeInfo(derivedType, typeDiscriminatorId);
 
@@ -64,6 +56,8 @@ namespace System.Text.Json.Serialization.Metadata
                     {
                         ThrowHelper.ThrowInvalidOperationException_TypeDicriminatorIdIsAlreadySpecified(BaseType, typeDiscriminatorId);
                     }
+
+                    UsesTypeDiscriminators = true;
                 }
 
                 containsDerivedTypes = true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
@@ -36,7 +36,7 @@ namespace System.Text.Json.Serialization.Metadata
             foreach ((Type derivedType, object? typeDiscriminatorId) in configuration.GetSupportedDerivedTypes())
             {
                 if (!IsSupportedDerivedType(BaseType, derivedType) ||
-                    (derivedType.IsAbstract && UnknownDerivedTypeHandling != JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor))
+                    (derivedType.IsAbstract && UnknownDerivedTypeHandling != JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor))
                 {
                     ThrowHelper.ThrowInvalidOperationException_DerivedTypeNotSupported(BaseType, derivedType);
                 }
@@ -81,7 +81,7 @@ namespace System.Text.Json.Serialization.Metadata
                     ThrowHelper.ThrowNotSupportedException_BaseConverterDoesNotSupportMetadata(BaseType);
                 }
 
-                if (configuration.CustomTypeDiscriminatorPropertyName is string customPropertyName)
+                if (configuration.TypeDiscriminatorPropertyName is string customPropertyName)
                 {
                     JsonEncodedText jsonEncodedName = JsonEncodedText.Encode(customPropertyName, options.Encoder);
 
@@ -91,7 +91,7 @@ namespace System.Text.Json.Serialization.Metadata
                         ThrowHelper.ThrowInvalidOperationException_InvalidCustomTypeDiscriminatorPropertyName();
                     }
 
-                    CustomTypeDiscriminatorPropertyName = customPropertyName;
+                    TypeDiscriminatorPropertyName = customPropertyName;
                     CustomTypeDiscriminatorPropertyNameUtf8 = jsonEncodedName.EncodedUtf8Bytes.ToArray();
                     CustomTypeDiscriminatorPropertyNameJsonEncoded = jsonEncodedName;
                 }
@@ -102,7 +102,7 @@ namespace System.Text.Json.Serialization.Metadata
         public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get; }
         public bool UsesTypeDiscriminators { get; }
         public bool IgnoreUnrecognizedTypeDiscriminators { get; }
-        public string? CustomTypeDiscriminatorPropertyName { get; }
+        public string? TypeDiscriminatorPropertyName { get; }
         public byte[]? CustomTypeDiscriminatorPropertyNameUtf8 { get; }
         public JsonEncodedText? CustomTypeDiscriminatorPropertyNameJsonEncoded { get; }
 
@@ -114,13 +114,13 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 switch (UnknownDerivedTypeHandling)
                 {
-                    case JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor:
+                    case JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor:
                         // Calculate (and cache the result) of the nearest ancestor for given runtime type.
                         // A `null` result denotes no matching ancestor type, we also cache that.
                         result = CalculateNearestAncestor(runtimeType);
                         _typeToDiscriminatorId[runtimeType] = result;
                         break;
-                    case JsonUnknownDerivedTypeHandling.FallbackToBaseType:
+                    case JsonUnknownDerivedTypeHandling.FallBackToBaseType:
                         // Recover the polymorphic contract (i.e. any type discriminators) for the base type, if it exists.
                         _typeToDiscriminatorId.TryGetValue(BaseType, out result);
                         _typeToDiscriminatorId[runtimeType] = result;
@@ -190,7 +190,7 @@ namespace System.Text.Json.Serialization.Metadata
         {
             Debug.Assert(!type.IsAbstract);
             Debug.Assert(BaseType.IsAssignableFrom(type));
-            Debug.Assert(UnknownDerivedTypeHandling == JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor);
+            Debug.Assert(UnknownDerivedTypeHandling == JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor);
 
             if (type == BaseType)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -69,7 +69,7 @@ namespace System.Text.Json
         /// <summary>
         /// Holds the value of $type of the currently read object
         /// </summary>
-        public string? PolymorphicTypeDiscriminator;
+        public object? PolymorphicTypeDiscriminator;
 
         /// <summary>
         /// Global flag indicating whether we can read preserved references.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -112,7 +112,7 @@ namespace System.Text.Json
         /// <summary>
         /// Indicates that the next converter is polymorphic and must serialize a type discriminator.
         /// </summary>
-        public string? PolymorphicTypeDiscriminator;
+        public object? PolymorphicTypeDiscriminator;
 
         /// <summary>
         /// Whether the current frame needs to write out any metadata.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -672,9 +672,9 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowInvalidOperationException_TypeDicriminatorIdIsAlreadySpecified(Type baseType, object typeDiscriminatorId)
+        public static void ThrowInvalidOperationException_TypeDicriminatorIdIsAlreadySpecified(Type baseType, object typeDiscriminator)
         {
-            throw new InvalidOperationException(SR.Format(SR.Polymorphism_TypeDicriminatorIdIsAlreadySpecified, baseType, typeDiscriminatorId));
+            throw new InvalidOperationException(SR.Format(SR.Polymorphism_TypeDicriminatorIdIsAlreadySpecified, baseType, typeDiscriminator));
         }
 
         [DoesNotReturn]
@@ -690,9 +690,9 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowJsonException_UnrecognizedTypeDiscriminator(object typeDiscriminatorId)
+        public static void ThrowJsonException_UnrecognizedTypeDiscriminator(object typeDiscriminator)
         {
-            ThrowJsonException(SR.Format(SR.Polymorphism_UnrecognizedTypeDiscriminator, typeDiscriminatorId));
+            ThrowJsonException(SR.Format(SR.Polymorphism_UnrecognizedTypeDiscriminator, typeDiscriminator));
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -672,7 +672,7 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowInvalidOperationException_TypeDicriminatorIdIsAlreadySpecified(Type baseType, string typeDiscriminatorId)
+        public static void ThrowInvalidOperationException_TypeDicriminatorIdIsAlreadySpecified(Type baseType, object typeDiscriminatorId)
         {
             throw new InvalidOperationException(SR.Format(SR.Polymorphism_TypeDicriminatorIdIsAlreadySpecified, baseType, typeDiscriminatorId));
         }
@@ -690,7 +690,7 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowJsonException_UnrecognizedTypeDiscriminator(string typeDiscriminatorId)
+        public static void ThrowJsonException_UnrecognizedTypeDiscriminator(object typeDiscriminatorId)
         {
             ThrowJsonException(SR.Format(SR.Polymorphism_UnrecognizedTypeDiscriminator, typeDiscriminatorId));
         }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonPolymorphicTypeConfigurationTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonPolymorphicTypeConfigurationTests.cs
@@ -33,10 +33,13 @@ namespace System.Text.Json.Tests.Serialization
         public static void SupportedDerivedTypeArgument_ShouldSucced(Type baseType, Type derivedType)
         {
             var configuration = new JsonPolymorphicTypeConfiguration(baseType).WithDerivedType(derivedType);
-            Assert.Equal(new[] { (derivedType, (string)null) }, configuration);
+            Assert.Equal(new (Type, object?)[] { (derivedType, null) }, configuration);
 
             configuration = new JsonPolymorphicTypeConfiguration(baseType).WithDerivedType(derivedType, "typeDiscriminator");
-            Assert.Equal(new[] { (derivedType, "typeDiscriminator") }, configuration);
+            Assert.Equal(new (Type, object?)[] { (derivedType, "typeDiscriminator") }, configuration);
+
+            configuration = new JsonPolymorphicTypeConfiguration(baseType).WithDerivedType(derivedType, 42);
+            Assert.Equal(new (Type, object?)[] { (derivedType, 42) }, configuration);
         }
 
         [Fact]
@@ -46,13 +49,19 @@ namespace System.Text.Json.Tests.Serialization
                 new JsonPolymorphicTypeConfiguration(typeof(Class))
                     .WithDerivedType(typeof(Class));
 
-            Assert.Equal(new[] { (typeof(Class), (string)null) }, configuration);
+            Assert.Equal(new (Type, object?)[] { (typeof(Class), null) }, configuration);
 
             configuration =
                 new JsonPolymorphicTypeConfiguration(typeof(Class))
                     .WithDerivedType(typeof(Class), "typeDiscriminatorId");
 
-            Assert.Equal(new[] { (typeof(Class), "typeDiscriminatorId") }, configuration);
+            Assert.Equal(new (Type, object?)[] { (typeof(Class), "typeDiscriminatorId") }, configuration);
+
+            configuration =
+                new JsonPolymorphicTypeConfiguration(typeof(Class))
+                    .WithDerivedType(typeof(Class), 42);
+
+            Assert.Equal(new (Type, object?)[] { (typeof(Class), 42) }, configuration);
         }
 
         [Fact]
@@ -60,11 +69,17 @@ namespace System.Text.Json.Tests.Serialization
         {
             var configuration =
                 new JsonPolymorphicTypeConfiguration(typeof(Class))
-                    .WithDerivedType(typeof(GenericClass<int>), "typeDiscriminator")
-                    .WithDerivedType(typeof(GenericClass<string>));
+                    .WithDerivedType(typeof(GenericClass<bool>))
+                    .WithDerivedType(typeof(GenericClass<int>), 42)
+                    .WithDerivedType(typeof(GenericClass<string>), "typeDiscriminator");
 
             Assert.Equal(
-                new[] { (typeof(GenericClass<int>), "typeDiscriminator"), (typeof(GenericClass<string>), (string)null) },
+                new (Type, object?)[]
+                {
+                    (typeof(GenericClass<bool>), null),
+                    (typeof(GenericClass<int>), 42),
+                    (typeof(GenericClass<string>), "typeDiscriminator"),
+                },
                 configuration);
         }
 
@@ -117,22 +132,37 @@ namespace System.Text.Json.Tests.Serialization
         {
             var configuration = new JsonPolymorphicTypeConfiguration(typeof(Class)).WithDerivedType(typeof(GenericClass<int>));
             Assert.Throws<ArgumentException>(() => configuration.WithDerivedType(typeof(GenericClass<int>)));
-            Assert.Equal(new[] { (typeof(GenericClass<int>), (string)null) }, configuration);
+            Assert.Equal(new (Type, object?)[] { (typeof(GenericClass<int>), null) }, configuration);
         }
 
         [Fact]
-        public static void DuplicateTypeDiscriminator_ThrowsArgumentException()
+        public static void DuplicateTypeDiscriminator_String_ThrowsArgumentException()
         {
             var configuration =
                 new JsonPolymorphicTypeConfiguration(typeof(Class))
                     .WithDerivedType(typeof(GenericClass<int>), "discriminator1")
                     .WithDerivedType(typeof(GenericClass<string>), "discriminator2");
 
-            Assert.Equal(new[] { (typeof(GenericClass<int>), "discriminator1"), (typeof(GenericClass<string>), "discriminator2") }, configuration);
+            Assert.Equal(new (Type, object?)[] { (typeof(GenericClass<int>), "discriminator1"), (typeof(GenericClass<string>), "discriminator2") }, configuration);
 
             Assert.Throws<ArgumentException>(() => configuration.WithDerivedType(typeof(GenericClass<bool>), "discriminator2"));
 
-            Assert.Equal(new[] { (typeof(GenericClass<int>), "discriminator1"), (typeof(GenericClass<string>), "discriminator2") }, configuration);
+            Assert.Equal(new (Type, object?)[] { (typeof(GenericClass<int>), "discriminator1"), (typeof(GenericClass<string>), "discriminator2") }, configuration);
+        }
+
+        [Fact]
+        public static void DuplicateTypeDiscriminator_Int_ThrowsArgumentException()
+        {
+            var configuration =
+                new JsonPolymorphicTypeConfiguration(typeof(Class))
+                    .WithDerivedType(typeof(GenericClass<int>), 0)
+                    .WithDerivedType(typeof(GenericClass<string>), 1);
+
+            Assert.Equal(new (Type, object?)[] { (typeof(GenericClass<int>), 0), (typeof(GenericClass<string>), 1) }, configuration);
+
+            Assert.Throws<ArgumentException>(() => configuration.WithDerivedType(typeof(GenericClass<bool>), 1));
+
+            Assert.Equal(new (Type, object?)[] { (typeof(GenericClass<int>), 0), (typeof(GenericClass<string>), 1) }, configuration);
         }
 
         [Fact]
@@ -144,6 +174,7 @@ namespace System.Text.Json.Tests.Serialization
             _ = new JsonSerializerOptions { PolymorphicTypeConfigurations = { config } };
 
             Assert.Throws<InvalidOperationException>(() => config.WithDerivedType(typeof(GenericClass<string>), "derived2"));
+            Assert.Throws<InvalidOperationException>(() => config.WithDerivedType(typeof(GenericClass<string>), 42));
             Assert.Throws<InvalidOperationException>(() => config.CustomTypeDiscriminatorPropertyName = "_case");
             Assert.Throws<InvalidOperationException>(() => config.UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToBaseType);
             Assert.Throws<InvalidOperationException>(() => config.IgnoreUnrecognizedTypeDiscriminators = true);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonPolymorphicTypeConfigurationTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonPolymorphicTypeConfigurationTests.cs
@@ -175,8 +175,8 @@ namespace System.Text.Json.Tests.Serialization
 
             Assert.Throws<InvalidOperationException>(() => config.WithDerivedType(typeof(GenericClass<string>), "derived2"));
             Assert.Throws<InvalidOperationException>(() => config.WithDerivedType(typeof(GenericClass<string>), 42));
-            Assert.Throws<InvalidOperationException>(() => config.CustomTypeDiscriminatorPropertyName = "_case");
-            Assert.Throws<InvalidOperationException>(() => config.UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToBaseType);
+            Assert.Throws<InvalidOperationException>(() => config.TypeDiscriminatorPropertyName = "_case");
+            Assert.Throws<InvalidOperationException>(() => config.UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType);
             Assert.Throws<InvalidOperationException>(() => config.IgnoreUnrecognizedTypeDiscriminators = true);
         }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonPolymorphicTypeConfigurationTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/JsonPolymorphicTypeConfigurationTests.cs
@@ -53,9 +53,9 @@ namespace System.Text.Json.Tests.Serialization
 
             configuration =
                 new JsonPolymorphicTypeConfiguration(typeof(Class))
-                    .WithDerivedType(typeof(Class), "typeDiscriminatorId");
+                    .WithDerivedType(typeof(Class), "typeDiscriminator");
 
-            Assert.Equal(new (Type, object?)[] { (typeof(Class), "typeDiscriminatorId") }, configuration);
+            Assert.Equal(new (Type, object?)[] { (typeof(Class), "typeDiscriminator") }, configuration);
 
             configuration =
                 new JsonPolymorphicTypeConfiguration(typeof(Class))

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.CustomTypeHierarchies.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.CustomTypeHierarchies.cs
@@ -64,7 +64,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("$.$values", @"{ ""Number"" : 42, ""$values"" : [] }")]
         [InlineData("$.$type", @"{ ""Number"" : 42, ""$type"" : ""derivedClass"" }")]
         [InlineData("$", @"{ ""$type"" : ""invalidDiscriminator"", ""Number"" : 42 }")]
-        [InlineData("$.$type", @"{ ""$type"" : 0, ""Number"" : 42 }")]
+        [InlineData("$", @"{ ""$type"" : 0, ""Number"" : 42 }")]
         [InlineData("$.$type", @"{ ""$type"" : false, ""Number"" : 42 }")]
         [InlineData("$.$type", @"{ ""$type"" : {}, ""Number"" : 42 }")]
         [InlineData("$.$type", @"{ ""$type"" : [], ""Number"" : 42 }")]
@@ -140,7 +140,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("$.$values", @"{ ""_case"" : ""derivedClass1"", ""Number"" : 42, ""$values"" : [] }")]
         [InlineData("$._case", @"{ ""Number"" : 42, ""_case"" : ""derivedClass1"" }")]
         [InlineData("$", @"{ ""_case"" : ""invalidDiscriminator"", ""Number"" : 42 }")]
-        [InlineData("$._case", @"{ ""_case"" : 0, ""Number"" : 42 }")]
+        [InlineData("$", @"{ ""_case"" : 0, ""Number"" : 42 }")]
         [InlineData("$._case", @"{ ""_case"" : false, ""Number"" : 42 }")]
         [InlineData("$._case", @"{ ""_case"" : {}, ""Number"" : 42 }")]
         [InlineData("$._case", @"{ ""_case"" : [], ""Number"" : 42 }")]
@@ -216,7 +216,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("$.$values", @"{ ""_case"" : ""derivedClass1"", ""Number"" : 42, ""$values"" : [] }")]
         [InlineData("$._case", @"{ ""Number"" : 42, ""_case"" : ""derivedClass1"" }")]
         [InlineData("$", @"{ ""_case"" : ""invalidDiscriminator"", ""Number"" : 42 }")]
-        [InlineData("$._case", @"{ ""_case"" : 0, ""Number"" : 42 }")]
+        [InlineData("$", @"{ ""_case"" : 0, ""Number"" : 42 }")]
         [InlineData("$._case", @"{ ""_case"" : false, ""Number"" : 42 }")]
         [InlineData("$._case", @"{ ""_case"" : {}, ""Number"" : 42 }")]
         [InlineData("$._case", @"{ ""_case"" : [], ""Number"" : 42 }")]
@@ -252,6 +252,7 @@ namespace System.Text.Json.Serialization.Tests
         [JsonDerivedType(typeof(DerivedClass1_TypeDiscriminator.DerivedClass), "derivedClassOfDerivedClass1")]
         [JsonDerivedType(typeof(DerivedClass2_NoTypeDiscriminator))]
         [JsonDerivedType(typeof(DerivedClass2_TypeDiscriminator), "derivedClass2")]
+        [JsonDerivedType(typeof(DerivedClass_IntegerTypeDiscriminator), typeDiscriminatorId: -1)]
         [JsonDerivedType(typeof(DerivedCollection_NoTypeDiscriminator))]
         [JsonDerivedType(typeof(DerivedCollection_TypeDiscriminator), "derivedCollection")]
         [JsonDerivedType(typeof(DerivedCollection_TypeDiscriminator.DerivedClass), "derivedCollectionOfDerivedCollection")]
@@ -310,6 +311,11 @@ namespace System.Text.Json.Serialization.Tests
                 {
                     public string ExtraProperty { get; set; }
                 }
+            }
+
+            public class DerivedClass_IntegerTypeDiscriminator : PolymorphicClass
+            {
+                public string String { get; set; }
             }
 
             public abstract class DerivedAbstractClass : PolymorphicClass
@@ -517,6 +523,11 @@ namespace System.Text.Json.Serialization.Tests
                     Value: new DerivedClass2_TypeDiscriminator { Number = 42, Boolean = true },
                     ExpectedJson: @"{ ""$type"" : ""derivedClass2"", ""Number"" : 42, ""Boolean"" : true }",
                     ExpectedRoundtripValue: new DerivedClass2_TypeDiscriminator { Number = 42, Boolean = true });
+
+                yield return new TestData(
+                    Value: new DerivedClass_IntegerTypeDiscriminator { Number = 42, String = "str" },
+                    ExpectedJson: @"{ ""$type"" : -1, ""Number"" : 42, ""String"" : ""str"" }",
+                    ExpectedRoundtripValue: new DerivedClass_IntegerTypeDiscriminator { Number = 42, String = "str" });
 
                 yield return new TestData(
                     Value: new DerivedCollection_NoTypeDiscriminator { Number = 42 },
@@ -1134,7 +1145,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("$.$id", @"{ ""$type"" : ""derivedClass"", ""Number"" : 42, ""$id"" : ""referenceId""}")]
         [InlineData("$.$values", @"{ ""$type"" : ""derivedClass"", ""Number"" : 42, ""$values"" : [] }")]
         [InlineData("$", @"{ ""$type"" : ""invalidDiscriminator"", ""Number"" : 42 }")]
-        [InlineData("$.$type", @"{ ""$type"" : 0, ""Number"" : 42 }")]
+        [InlineData("$", @"{ ""$type"" : 0, ""Number"" : 42 }")]
         [InlineData("$.$type", @"{ ""$type"" : false, ""Number"" : 42 }")]
         [InlineData("$.$type", @"{ ""$type"" : {}, ""Number"" : 42 }")]
         [InlineData("$.$type", @"{ ""$type"" : [], ""Number"" : 42 }")]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.CustomTypeHierarchies.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.CustomTypeHierarchies.cs
@@ -252,7 +252,7 @@ namespace System.Text.Json.Serialization.Tests
         [JsonDerivedType(typeof(DerivedClass1_TypeDiscriminator.DerivedClass), "derivedClassOfDerivedClass1")]
         [JsonDerivedType(typeof(DerivedClass2_NoTypeDiscriminator))]
         [JsonDerivedType(typeof(DerivedClass2_TypeDiscriminator), "derivedClass2")]
-        [JsonDerivedType(typeof(DerivedClass_IntegerTypeDiscriminator), typeDiscriminatorId: -1)]
+        [JsonDerivedType(typeof(DerivedClass_IntegerTypeDiscriminator), typeDiscriminator: -1)]
         [JsonDerivedType(typeof(DerivedCollection_NoTypeDiscriminator))]
         [JsonDerivedType(typeof(DerivedCollection_TypeDiscriminator), "derivedCollection")]
         [JsonDerivedType(typeof(DerivedCollection_TypeDiscriminator.DerivedClass), "derivedCollectionOfDerivedCollection")]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.CustomTypeHierarchies.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.CustomTypeHierarchies.cs
@@ -230,7 +230,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [InlineData(JsonUnknownDerivedTypeHandling.FailSerialization)]
-        [InlineData(JsonUnknownDerivedTypeHandling.FallbackToBaseType)]
+        [InlineData(JsonUnknownDerivedTypeHandling.FallBackToBaseType)]
         public async Task PolymorphicClass_ConfigWithAbstractClass_ShouldThrowNotSupportedException(JsonUnknownDerivedTypeHandling jsonUnknownDerivedTypeHandling)
         {
             var options = new JsonSerializerOptions
@@ -278,7 +278,7 @@ namespace System.Text.Json.Serialization.Tests
             }
 
             // Ensure derived class polymorphic configuration is not inherited by base class polymorphic configuration
-            [JsonPolymorphic(CustomTypeDiscriminatorPropertyName = "$case")]
+            [JsonPolymorphic(TypeDiscriminatorPropertyName = "$case")]
             [JsonDerivedType(typeof(DerivedClass), "derivedClassOfDerivedClass1")]
             public class DerivedClass1_TypeDiscriminator : PolymorphicClass
             {
@@ -598,8 +598,8 @@ namespace System.Text.Json.Serialization.Tests
                     {
                         new JsonPolymorphicTypeConfiguration<PolymorphicClass>
                         {
-                            CustomTypeDiscriminatorPropertyName = "_case",
-                            UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToBaseType
+                            TypeDiscriminatorPropertyName = "_case",
+                            UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType
                         }
                         .WithDerivedType<DerivedClass1_NoTypeDiscriminator>()
                         .WithDerivedType<DerivedClass1_TypeDiscriminator>("derivedClass1")
@@ -722,8 +722,8 @@ namespace System.Text.Json.Serialization.Tests
                     {
                         new JsonPolymorphicTypeConfiguration<PolymorphicClass>
                         {
-                            CustomTypeDiscriminatorPropertyName = "_case",
-                            UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor
+                            TypeDiscriminatorPropertyName = "_case",
+                            UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor
                         }
                         .WithDerivedType<DerivedClass1_NoTypeDiscriminator>()
                         .WithDerivedType<DerivedClass1_TypeDiscriminator>("derivedClass1")
@@ -1336,7 +1336,7 @@ namespace System.Text.Json.Serialization.Tests
                         {
                             new JsonPolymorphicTypeConfiguration<PolymorphicInterface>
                             {
-                                UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor
+                                UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor
                             }
                             .WithDerivedType<DerivedClass_TypeDiscriminator>("derivedClass")
                             .WithDerivedType<DerivedStruct_NoTypeDiscriminator>()
@@ -1391,13 +1391,13 @@ namespace System.Text.Json.Serialization.Tests
                 {
                     yield return (
                         new DiamondKind1(),
-                        new JsonPolymorphicTypeConfiguration<PolymorphicInterface> { UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor }
+                        new JsonPolymorphicTypeConfiguration<PolymorphicInterface> { UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor }
                             .WithDerivedType<DerivedInterface1>()
                             .WithDerivedType<DerivedInterface2>());
 
                     yield return (
                         new DiamondKind2(),
-                        new JsonPolymorphicTypeConfiguration<PolymorphicInterface> { UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor }
+                        new JsonPolymorphicTypeConfiguration<PolymorphicInterface> { UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor }
                             .WithDerivedType<DerivedInterface1>()
                             .WithDerivedType<DerivedClass_TypeDiscriminator>());
                 }
@@ -1471,7 +1471,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(expectedJsonPath, exception.Path);
         }
 
-        [JsonPolymorphic(UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor, IgnoreUnrecognizedTypeDiscriminators = true)]
+        [JsonPolymorphic(UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor, IgnoreUnrecognizedTypeDiscriminators = true)]
         [JsonDerivedType(typeof(PolymorphicList), "baseList")]
         [JsonDerivedType(typeof(DerivedList1), "derivedList")]
         public class PolymorphicList : List<int>
@@ -1561,7 +1561,7 @@ namespace System.Text.Json.Serialization.Tests
                 {
                     new JsonPolymorphicTypeConfiguration<IEnumerable<int>>
                     {
-                        UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor
+                        UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor
                     }
                     .WithDerivedType<List<int>>("list")
                     .WithDerivedType<Queue<int>>("queue")
@@ -1630,7 +1630,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(expectedJsonPath, exception.Path);
         }
 
-        [JsonPolymorphic(UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor, IgnoreUnrecognizedTypeDiscriminators = true)]
+        [JsonPolymorphic(UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor, IgnoreUnrecognizedTypeDiscriminators = true)]
         [JsonDerivedType(typeof(PolymorphicDictionary), "baseDictionary")]
         [JsonDerivedType(typeof(DerivedDictionary1), "derivedDictionary")]
         public class PolymorphicDictionary : Dictionary<string, int>
@@ -1720,7 +1720,7 @@ namespace System.Text.Json.Serialization.Tests
                 {
                     new JsonPolymorphicTypeConfiguration<IEnumerable<KeyValuePair<int, object>>>
                     {
-                        UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor
+                        UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor
                     }
                     .WithDerivedType<Dictionary<int, object>>("dictionary")
                     .WithDerivedType<SortedDictionary<int, object>>("sortedDictionary")
@@ -1994,7 +1994,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(expectedValues, result, PolymorphicEqualityComparer<PolymorphicClassWithCustomTypeDiscriminator>.Instance);
         }
 
-        [JsonPolymorphic(CustomTypeDiscriminatorPropertyName = "case")]
+        [JsonPolymorphic(TypeDiscriminatorPropertyName = "case")]
         [JsonDerivedType(typeof(PolymorphicClassWithCustomTypeDiscriminator), "baseClass")]
         [JsonDerivedType(typeof(DerivedClass), "derivedClass")]
         [JsonDerivedType(typeof(DerivedCollection), "derivedCollection")]
@@ -2165,7 +2165,7 @@ namespace System.Text.Json.Serialization.Tests
                 {
                     new JsonPolymorphicTypeConfiguration<PolymorphicInterfaceWithInterfaceDerivedType>()
                     {
-                        UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallbackToNearestAncestor
+                        UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor
                     }
                     .WithDerivedType<PolymorphicInterfaceWithInterfaceDerivedType.DerivedInterface>("derivedInterface")
                     .WithDerivedType<PolymorphicInterfaceWithInterfaceDerivedType.DerivedClass>("derivedClass")
@@ -2368,7 +2368,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.IsType<PolymorphicClass_InvalidCustomTypeDiscriminatorPropertyName.DerivedClass>(deserializeResult);
         }
 
-        [JsonPolymorphic(CustomTypeDiscriminatorPropertyName = "$id")]
+        [JsonPolymorphic(TypeDiscriminatorPropertyName = "$id")]
         [JsonDerivedType(typeof(DerivedClass), "derivedClass")]
         public class PolymorphicClass_InvalidCustomTypeDiscriminatorPropertyName
         {
@@ -2392,7 +2392,7 @@ namespace System.Text.Json.Serialization.Tests
                     {
                         new JsonPolymorphicTypeConfiguration<PolymorphicClass_InvalidCustomTypeDiscriminatorPropertyName>
                         {
-                            CustomTypeDiscriminatorPropertyName = customPropertyName
+                            TypeDiscriminatorPropertyName = customPropertyName
                         }
                         .WithDerivedType<DerivedClass>("derivedClass")
                     }


### PR DESCRIPTION
Adds support for integer type discriminators in System.Text.Json polymorphism and incorporates API review feedback for the polymorphism attributes.

Contributes to #63747.

cc @RamjotSingh