### PR TITLE
Use intrinsic for genLog2()

### DIFF
--- a/src/coreclr/inc/bitposition.h
+++ b/src/coreclr/inc/bitposition.h
@@ -12,46 +12,32 @@
 //
 // Notes:
 //    'value' must have exactly one bit set.
-//    The algorithm is as follows:
-//    - PRIME is a prime bigger than sizeof(unsigned int), which is not of the
-//      form 2^n-1.
-//    - Taking the modulo of 'value' with this will produce a unique hash for all
-//      powers of 2 (which is what "value" is).
-//    - Entries in hashTable[] which are -1 should never be used. There
-//      should be PRIME-8*sizeof(value) entries which are -1 .
 //
 inline
 unsigned            BitPosition(unsigned value)
 {
     _ASSERTE((value != 0) && ((value & (value-1)) == 0));
-#if defined(HOST_ARM) && defined(__llvm__)
-    // use intrinsic functions for arm32
-    // this is applied for LLVM only but it may work for some compilers
-    DWORD index = __builtin_clz(__builtin_arm_rbit(value));
-#elif !defined(HOST_AMD64)
-    const unsigned PRIME = 37;
-
-    static const char hashTable[PRIME] =
-    {
-        -1,  0,  1, 26,  2, 23, 27, -1,  3, 16,
-        24, 30, 28, 11, -1, 13,  4,  7, 17, -1,
-        25, 22, 31, 15, 29, 10, 12,  6, -1, 21,
-        14,  9,  5, 20,  8, 19, 18
-    };
-
-    _ASSERTE(PRIME >= 8*sizeof(value));
-    _ASSERTE(sizeof(hashTable) == PRIME);
-
-
-    unsigned hash   = value % PRIME;
-    unsigned index  = hashTable[hash];
-    _ASSERTE(index != (unsigned char)-1);
-#else
-    // not enabled for x86 because BSF is extremely slow on Atom
-    // (15 clock cycles vs 1-3 on any other Intel CPU post-P4)
     DWORD index;
     BitScanForward(&index, value);
-#endif
+    return index;
+}
+
+
+//------------------------------------------------------------------------
+// BitPosition: Return the position of the single bit that is set in 'value'.
+//
+// Return Value:
+//    The position (0 is LSB) of bit that is set in 'value'
+//
+// Notes:
+//    'value' must have exactly one bit set.
+//
+inline
+unsigned            BitPosition(unsigned __int64 value)
+{
+    _ASSERTE((value != 0) && ((value & (value-1)) == 0));
+    DWORD index;
+    BitScanForward64(&index, value);
     return index;
 }
 

--- a/src/coreclr/inc/bitposition.h
+++ b/src/coreclr/inc/bitposition.h
@@ -12,6 +12,7 @@
 //
 // Notes:
 //    'value' must have exactly one bit set.
+//    It performs the "TrailingZeroCount" operation using intrinsics.
 //
 inline
 unsigned            BitPosition(unsigned value)
@@ -23,7 +24,7 @@ unsigned            BitPosition(unsigned value)
 }
 
 
-#ifdef TARGET_64BIT
+#ifdef HOST_64BIT
 //------------------------------------------------------------------------
 // BitPosition: Return the position of the single bit that is set in 'value'.
 //
@@ -32,6 +33,7 @@ unsigned            BitPosition(unsigned value)
 //
 // Notes:
 //    'value' must have exactly one bit set.
+//    It performs the "TrailingZeroCount" operation using intrinsics.
 //
 inline
 unsigned            BitPosition(unsigned __int64 value)
@@ -41,6 +43,6 @@ unsigned            BitPosition(unsigned __int64 value)
     BitScanForward64(&index, value);
     return index;
 }
-#endif // TARGET_64BIT
+#endif // HOST_64BIT
 
 #endif

--- a/src/coreclr/inc/bitposition.h
+++ b/src/coreclr/inc/bitposition.h
@@ -23,6 +23,7 @@ unsigned            BitPosition(unsigned value)
 }
 
 
+#ifdef TARGET_64BIT
 //------------------------------------------------------------------------
 // BitPosition: Return the position of the single bit that is set in 'value'.
 //
@@ -40,5 +41,6 @@ unsigned            BitPosition(unsigned __int64 value)
     BitScanForward64(&index, value);
     return index;
 }
+#endif // TARGET_64BIT
 
 #endif

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -105,7 +105,11 @@ inline T genFindLowestBit(T value)
 inline unsigned int genFindHighestBit(unsigned int mask)
 {
     assert(mask != 0);
+#if defined(_MSC_VER)
     unsigned long index;
+#else
+    unsigned int index;
+#endif
     BitScanReverse(&index, mask);
     return 1L << index;
 }
@@ -113,7 +117,11 @@ inline unsigned int genFindHighestBit(unsigned int mask)
 inline unsigned __int64 genFindHighestBit(unsigned __int64 mask)
 {
     assert(mask != 0);
+#if defined(_MSC_VER)
     unsigned long index;
+#else
+    unsigned int index;
+#endif
     BitScanReverse64(&index, mask);
     return 1LL << index;
 }

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -101,39 +101,12 @@ inline T genFindLowestBit(T value)
 /*****************************************************************************
  *
  *  Return the highest bit that is set (that is, a mask that includes just the highest bit).
- *  TODO-ARM64-Throughput: we should convert these to use the _BitScanReverse() / _BitScanReverse64()
- *  compiler intrinsics, but our CRT header file intrin.h doesn't define these for ARM64 yet.
  */
-
-inline unsigned int genFindHighestBit(unsigned int mask)
-{
-    assert(mask != 0);
-    unsigned int bit = 1U << ((sizeof(unsigned int) * 8) - 1); // start looking at the top
-    while ((bit & mask) == 0)
-    {
-        bit >>= 1;
-    }
-    return bit;
-}
-
-inline unsigned __int64 genFindHighestBit(unsigned __int64 mask)
-{
-    assert(mask != 0);
-    unsigned __int64 bit = 1ULL << ((sizeof(unsigned __int64) * 8) - 1); // start looking at the top
-    while ((bit & mask) == 0)
-    {
-        bit >>= 1;
-    }
-    return bit;
-}
-
-#if 0
-// TODO-ARM64-Cleanup: These should probably be the implementation, when intrin.h is updated for ARM64
 inline
 unsigned int genFindHighestBit(unsigned int mask)
 {
     assert(mask != 0);
-    unsigned int index;
+    unsigned long index;
     _BitScanReverse(&index, mask);
     return 1L << index;
 }
@@ -142,11 +115,10 @@ inline
 unsigned __int64 genFindHighestBit(unsigned __int64 mask)
 {
     assert(mask != 0);
-    unsigned int index;
+    unsigned long index;
     _BitScanReverse64(&index, mask);
     return 1LL << index;
 }
-#endif // 0
 
 /*****************************************************************************
 *
@@ -222,18 +194,7 @@ inline unsigned uhi32(unsigned __int64 value)
 
 inline unsigned genLog2(unsigned __int64 value)
 {
-    unsigned lo32 = ulo32(value);
-    unsigned hi32 = uhi32(value);
-
-    if (lo32 != 0)
-    {
-        assert(hi32 == 0);
-        return genLog2(lo32);
-    }
-    else
-    {
-        return genLog2(hi32) + 32;
-    }
+    return BitPosition(value);
 }
 
 /*****************************************************************************

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -97,11 +97,16 @@ inline T genFindLowestBit(T value)
     return (value & (0 - value));
 }
 
-/*****************************************************************************/
-/*****************************************************************************
- *
- *  Return the highest bit that is set (that is, a mask that includes just the highest bit).
- */
+//------------------------------------------------------------------------
+// genFindHighestBit:  Return the highest bit that is set (that is, a mask that includes just the
+//                     highest bit).
+//
+// Return Value:
+//    The highest position (0 is LSB) of bit that is set in the 'value'.
+//
+// Note:
+//    It performs the "LeadingZeroCount " operation using intrinsics and then mask out everything
+//    but the highest bit.
 inline unsigned int genFindHighestBit(unsigned int mask)
 {
     assert(mask != 0);
@@ -114,6 +119,16 @@ inline unsigned int genFindHighestBit(unsigned int mask)
     return 1L << index;
 }
 
+//------------------------------------------------------------------------
+// genFindHighestBit:  Return the highest bit that is set (that is, a mask that includes just the
+//                     highest bit).
+//
+// Return Value:
+//    The highest position (0 is LSB) of bit that is set in the 'value'.
+//
+// Note:
+//    It performs the "LeadingZeroCount " operation using intrinsics and then mask out everything
+//    but the highest bit.
 inline unsigned __int64 genFindHighestBit(unsigned __int64 mask)
 {
     assert(mask != 0);
@@ -200,9 +215,9 @@ inline unsigned uhi32(unsigned __int64 value)
 
 inline unsigned genLog2(unsigned __int64 value)
 {
-#ifdef TARGET_64BIT
+#ifdef HOST_64BIT
     return BitPosition(value);
-#else // TARGET_32BIT
+#else // HOST_32BIT
     unsigned     lo32 = ulo32(value);
     unsigned     hi32 = uhi32(value);
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -200,7 +200,22 @@ inline unsigned uhi32(unsigned __int64 value)
 
 inline unsigned genLog2(unsigned __int64 value)
 {
+#ifdef TARGET_64BIT
     return BitPosition(value);
+#else // TARGET_32BIT
+    unsigned     lo32 = ulo32(value);
+    unsigned     hi32 = uhi32(value);
+
+    if (lo32 != 0)
+    {
+        assert(hi32 == 0);
+        return genLog2(lo32);
+    }
+    else
+    {
+        return genLog2(hi32) + 32;
+    }
+#endif
 }
 
 /*****************************************************************************

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -102,21 +102,19 @@ inline T genFindLowestBit(T value)
  *
  *  Return the highest bit that is set (that is, a mask that includes just the highest bit).
  */
-inline
-unsigned int genFindHighestBit(unsigned int mask)
+inline unsigned int genFindHighestBit(unsigned int mask)
 {
     assert(mask != 0);
     unsigned long index;
-    _BitScanReverse(&index, mask);
+    BitScanReverse(&index, mask);
     return 1L << index;
 }
 
-inline
-unsigned __int64 genFindHighestBit(unsigned __int64 mask)
+inline unsigned __int64 genFindHighestBit(unsigned __int64 mask)
 {
     assert(mask != 0);
     unsigned long index;
-    _BitScanReverse64(&index, mask);
+    BitScanReverse64(&index, mask);
     return 1LL << index;
 }
 


### PR DESCRIPTION
After recent VC++ upgrade, we saw a bad codegen C++ bug that repros only on release build of windows/arrm64. Explanation is in https://github.com/dotnet/runtime/issues/69222#issuecomment-1125710956. To get around the bug, use intrinsic `BitForward64`. I also simplified the code in `BitPosition` to always use `BitScanForward()`. 

Here is the code that is generated by various compilers/archs for BitScanForward:
vc++:      https://godbolt.org/z/h4e7MqMsE
clang/gcc: https://godbolt.org/z/jWc6YPGd1

Also using `_BitScanReverse()` methods in `genFindHighestBit()` (although they are not used by anyone).

Fixes: https://github.com/dotnet/runtime/issues/69222