### PR TITLE
Fix ASAN violation under Samsung's netcoredbg

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -155,6 +155,40 @@ template<class T> void DeleteDbiMemory(T *p)
     g_pAllocator->Free((BYTE*) p);
 }
 
+void* AllocDbiMemory(size_t size)
+{
+    void *result;
+    if (g_pAllocator != nullptr)
+    {
+        result = g_pAllocator->Alloc(size);
+    }
+    else
+    {
+        result = new (nothrow) BYTE[size];
+    }
+    if (result == NULL)
+    {
+        ThrowOutOfMemory();
+    }
+    return result;
+}
+
+void DeleteDbiMemory(void* p)
+{
+    if (p == NULL)
+    {
+        return;
+    }
+    if (g_pAllocator != nullptr)
+    {
+        g_pAllocator->Free((BYTE*)p);
+    }
+    else
+    {
+        ::delete (BYTE*)p;
+    }
+}
+
 // Delete memory and invoke dtor for memory allocated with 'operator (forDbi) new[]'
 // There's an inherent risk here - where each element's destructor will get called within
 // the context of the DAC. If the destructor tries to use the CRT allocator logic expecting
@@ -868,7 +902,7 @@ void DacDbiInterfaceImpl::GetNativeVarData(MethodDesc *    pMethodDesc,
         return;
     }
 
-    NewHolder<ICorDebugInfo::NativeVarInfo> nativeVars(NULL);
+    NewArrayHolder<ICorDebugInfo::NativeVarInfo> nativeVars(NULL);
 
     DebugInfoRequest request;
     request.InitFromStartingAddr(pMethodDesc, CORDB_ADDRESS_TO_TADDR(startAddr));

--- a/src/coreclr/inc/ex.h
+++ b/src/coreclr/inc/ex.h
@@ -186,6 +186,10 @@ class Exception
  public:
     Exception() {LIMITED_METHOD_DAC_CONTRACT; m_innerException = NULL;}
     virtual ~Exception() {LIMITED_METHOD_DAC_CONTRACT; if (m_innerException != NULL) Exception::Delete(m_innerException); }
+#ifdef DACCESS_COMPILE
+    void * operator new(size_t size);
+    void operator delete(void* ptr);
+#endif
     virtual BOOL IsDomainBound() {return m_innerException!=NULL && m_innerException->IsDomainBound();} ;
     virtual HRESULT GetHR() = 0;
     virtual void GetMessage(SString &s);

--- a/src/coreclr/utilcode/ex.cpp
+++ b/src/coreclr/utilcode/ex.cpp
@@ -63,6 +63,23 @@ Exception * Exception::GetOOMException()
     return GetOOMException();
 }
 
+#ifdef DACCESS_COMPILE
+
+extern void* AllocDbiMemory(size_t size);
+extern void DeleteDbiMemory(void* p);
+
+void * Exception::operator new(size_t size)
+{
+    return AllocDbiMemory(size);
+}
+
+void Exception::operator delete(void* ptr)
+{
+    DeleteDbiMemory(ptr);
+}
+
+#endif
+
 //------------------------------------------------------------------------------
 void Exception::Delete(Exception* pvMemory)
 {
@@ -79,7 +96,12 @@ void Exception::Delete(Exception* pvMemory)
         return;
     }
 
+#ifdef DACCESS_COMPILE
+    pvMemory->~Exception();
+    DeleteDbiMemory(pvMemory);
+#else
     ::delete((Exception *) pvMemory);
+#endif
 }
 
 void Exception::GetMessage(SString &result)

--- a/src/coreclr/utilcode/ex.cpp
+++ b/src/coreclr/utilcode/ex.cpp
@@ -97,11 +97,11 @@ void Exception::Delete(Exception* pvMemory)
     }
 
 #ifdef DACCESS_COMPILE
-    pvMemory->~Exception();
-    DeleteDbiMemory(pvMemory);
+    delete pvMemory;
 #else
-    ::delete((Exception *) pvMemory);
+    ::delete pvMemory;
 #endif
+
 }
 
 void Exception::GetMessage(SString &result)


### PR DESCRIPTION
Fixes issue https://github.com/dotnet/runtime/issues/62281

The wrong holder was being used in DacDbiInterfaceImpl::GetNativeVarData(); change to NewArrayHolder.

Added new/delete operators to Exception so when it is thrown from the DAC and caught/deleted in DBI, the
correct C++ allocator is used. When the DAC is called by DBI, g_pAllocator points to the DBI allocator.