### PR TITLE
[wasm] Fix debug proxy when used with blazor

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugHost/DebugProxyHost.cs
+++ b/src/mono/wasm/debugger/BrowserDebugHost/DebugProxyHost.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
@@ -17,16 +19,18 @@ namespace Microsoft.WebAssembly.Diagnostics;
 
 public static class DebugProxyHost
 {
-    public static Task RunDebugProxyAsync(ProxyOptions options, string[] args, ILoggerFactory loggerFactory, CancellationToken token)
+    public static async Task RunDebugProxyAsync(ProxyOptions options, string[] args, ILoggerFactory loggerFactory, CancellationToken token)
     {
-        return Task.WhenAny(
-            RunFirefoxServerLoopAsync(options, args, loggerFactory, token),
+        List<Task> tasks = new(capacity: 2)
+        {
             RunDevToolsProxyAsync(options, args, loggerFactory, token)
-        )
-        .ContinueWith(t => Console.WriteLine($"Debug proxy server failed with {t.Exception}"),
-                            token,
-                            TaskContinuationOptions.OnlyOnFaulted,
-                            TaskScheduler.Default);
+        };
+        if (!options.RunningForBlazor)
+            tasks.Add(RunFirefoxServerLoopAsync(options, args, loggerFactory, token));
+
+        Task completedTask = await Task.WhenAny(tasks);
+        if (completedTask.IsFaulted)
+            ExceptionDispatchInfo.Capture(completedTask.Exception!).Throw();
     }
 
     public static Task RunFirefoxServerLoopAsync(ProxyOptions options, string[] args, ILoggerFactory loggerFactory, CancellationToken token)
@@ -59,7 +63,9 @@ public static class DebugProxyHost
             .UseUrls(proxyUrl)
             .Build();
 
-        token.Register(async () => { Console.WriteLine($"-- token got cancelled, stopping host"); await host.StopAsync(); });
+        if (token.CanBeCanceled)
+            token.Register(async () => await host.StopAsync());
+
         await host.RunAsync(token);
     }
 }

--- a/src/mono/wasm/debugger/BrowserDebugHost/Program.cs
+++ b/src/mono/wasm/debugger/BrowserDebugHost/Program.cs
@@ -20,6 +20,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             IConfigurationRoot config = new ConfigurationBuilder().AddCommandLine(args).Build();
             ProxyOptions options = new();
             config.Bind(options);
+            options.RunningForBlazor = true;
 
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
             {
@@ -37,18 +38,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                                 outputTemplate: "{Timestamp:o} [{Level:u3}] {SourceContext}: {Message}{NewLine}{Exception}");
             });
 
-            CancellationTokenSource cts = new();
-            _ = Task.Run(() => DebugProxyHost.RunDebugProxyAsync(options, args, loggerFactory, cts.Token))
-                                .ConfigureAwait(false);
-
-            TaskCompletionSource tcs = new();
-            Console.CancelKeyPress += (_, _) =>
-            {
-                tcs.SetResult();
-                cts.Cancel();
-            };
-
-            await tcs.Task;
+            await DebugProxyHost.RunDebugProxyAsync(options, args, loggerFactory, CancellationToken.None);
         }
     }
 }

--- a/src/mono/wasm/debugger/BrowserDebugHost/ProxyOptions.cs
+++ b/src/mono/wasm/debugger/BrowserDebugHost/ProxyOptions.cs
@@ -28,4 +28,5 @@ public class ProxyOptions
     }
     public string? LogPath { get; set; }
     public bool AutoSetBreakpointOnEntryPoint { get; set; }
+    public bool RunningForBlazor { get; set; }
 }

--- a/src/mono/wasm/debugger/BrowserDebugHost/Startup.cs
+++ b/src/mono/wasm/debugger/BrowserDebugHost/Startup.cs
@@ -58,7 +58,8 @@ namespace Microsoft.WebAssembly.Diagnostics
                                     .Select(uri => uri.ToString())
                                     .FirstOrDefault();
 
-                Console.WriteLine($"{Environment.NewLine}Debug proxy for chrome now listening on {ipAddress}. And expecting chrome at {options.DevToolsUrl}");
+                if (!options.RunningForBlazor)
+                    Console.WriteLine($"Debug proxy for chrome now listening on {ipAddress}. And expecting chrome at {options.DevToolsUrl}");
             });
 
             app.UseDeveloperExceptionPage()

--- a/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FireforDebuggerProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FireforDebuggerProxy.cs
@@ -28,8 +28,8 @@ public class FirefoxDebuggerProxy : DebuggerProxyBase
         {
             s_tcpListener = new TcpListener(IPAddress.Parse("127.0.0.1"), proxyPort);
             s_tcpListener.Start();
-            Console.WriteLine($"{Environment.NewLine}Debug proxy for firefox now listening on tcp://{s_tcpListener.LocalEndpoint}." +
-                                (browserPort >= 0 ? $"And expecting firefox at port {browserPort}" : string.Empty));
+            Console.WriteLine($"Debug proxy for firefox now listening on tcp://{s_tcpListener.LocalEndpoint}." +
+                                (browserPort >= 0 ? $" And expecting firefox at port {browserPort} ." : string.Empty));
         }
     }
 


### PR DESCRIPTION
Due to recent debug proxy changes, when trying to debug a blazor app, it
fails with:
```
fail: Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware[1]
      An unhandled exception has occurred while executing the request.
      System.InvalidOperationException: No output has been recevied from the application.
         at Microsoft.AspNetCore.Builder.DebugProxyLauncher.LaunchAndGetUrl(IServiceProvider serviceProvider, String devToolsHost)
         at Microsoft.AspNetCore.Builder.WebAssemblyNetDebugProxyAppBuilderExtensions.<>c.<<UseWebAssemblyDebugging>b__0_1>d.MoveNext()
      --- End of stack trace from previous location ---
         at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.InvokeCore(HttpContext context, PathString matchedPath, PathString remainingPath)
         at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware.Invoke(HttpContext context)
```

This is because it's looking for specific lines in output.
- `Now listening on: ..`
- `Application started. Press Ctrl+C ..`

And also, it fails if it gets an empty line.

This commits fixes the output to match what blazor expects. And
essentially, disables firefox debug proxy when the host is directly
used, which is only by blazor right now.

This will change in the future though, and blazor side can be patched to
work better.