### PR TITLE
Add Generic Enum.TryFormat()

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -1086,6 +1086,25 @@ namespace System
 
             throw new FormatException(SR.Format_InvalidEnumFormatSpecification);
         }
+
+        public static bool TryFormat<TEnum>(TEnum value, Span<char> destination, out int charsWritten) where TEnum : struct, Enum
+        {
+            if (!destination.IsEmpty)
+            {
+                string? enumName = InternalFormat((RuntimeType)typeof(TEnum), ToUInt64(value));
+
+                if (enumName != null
+                    && destination.Length >= enumName.Length)
+                {
+                    enumName.CopyTo(destination);
+                    charsWritten = enumName.Length;
+                    return true;
+                }
+            }
+
+            charsWritten = 0;
+            return false;
+        }
         #endregion
 
         #region Private Methods

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2275,6 +2275,7 @@ namespace System
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("EnumFormat")] string? format) { throw null; }
         [System.ObsoleteAttribute("The provider argument is not used. Use ToString(String) instead.")]
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("EnumFormat")] string? format, System.IFormatProvider? provider) { throw null; }
+        public static bool TryFormat<TEnum>(TEnum value, System.Span<char> destination, out int charsWritten) where TEnum : struct { throw null; }
         public static bool TryParse(System.Type enumType, System.ReadOnlySpan<char> value, bool ignoreCase, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out object? result) { throw null; }
         public static bool TryParse(System.Type enumType, System.ReadOnlySpan<char> value, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out object? result) { throw null; }
         public static bool TryParse(System.Type enumType, string? value, bool ignoreCase, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out object? result) { throw null; }


### PR DESCRIPTION
Partial implementation of #57881 

Please view comment (not in PR details here) below regarding partial implementation.

## Performance Benchmarks:

### The benchmark:
```C#
[Benchmark]
public Span<char> TryFormat()
{
    Span<char> destination = new char[5];
    Enum.TryFormat(Colors.Green, destination, out _);
    return destination;
}
```

### 1. Current Implementation:

```C#
public static bool TryFormat<TEnum>(TEnum value, Span<char> destination, out int charsWritten) where TEnum : struct, Enum
{
    if (!destination.IsEmpty)
    {
        string? enumName = InternalFormat((RuntimeType)typeof(TEnum), ToUInt64(value));

        if (enumName != null
            && destination.Length >= enumName.Length)
        {
            enumName.CopyTo(destination);
            charsWritten = enumName.Length;
            return true;
        }
    }

    charsWritten = 0;
    return false;
}
```

|    Method |     Mean |    Error |   StdDev |   Median |      Min |      Max |  Gen 0 | Allocated |
|---------- |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
| TryFormat | 15.36 ns | 0.168 ns | 0.157 ns | 15.40 ns | 14.95 ns | 15.53 ns | 0.0031 |      40 B |

### Other slower implementations for benchmark comparisons:

### 2. `ToString()` Implementation (slower)

```C#
public static bool TryFormat<TEnum>(TEnum value, Span<char> destination, out int charsWritten) where TEnum : struct, Enum
{
    if (!destination.IsEmpty)
    {
        string? enumName = value.ToString();

        if (enumName != null
            && destination.Length >= enumName.Length)
        {
            enumName.CopyTo(destination);
            charsWritten = enumName.Length;
            return true;
        }
    }

    charsWritten = 0;
    return false;
}
```

|                 Method |     Mean |    Error |   StdDev |   Median |      Min |      Max |  Gen 0 | Allocated |
|----------------------- |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
| TryFormat_WithToString | 17.70 ns | 0.332 ns | 0.310 ns | 17.77 ns | 17.00 ns | 18.26 ns | 0.0050 |      64 B |

### 3. `typeof(TEnum).GetEnumName(value)` Implementation (slower)

```C#
public static bool TryFormat<TEnum>(TEnum value, Span<char> destination, out int charsWritten) where TEnum : struct, Enum
{
    if (!destination.IsEmpty)
    {
        string? enumName = typeof(TEnum).GetEnumName(value);

        if (enumName != null
            && destination.Length >= enumName.Length)
        {
            enumName.CopyTo(destination);
            charsWritten = enumName.Length;
            return true;
        }
    }

    charsWritten = 0;
    return false;
}
```

|                    Method |     Mean |    Error |   StdDev |   Median |      Min |      Max |  Gen 0 | Allocated |
|-------------------------- |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
| TryFormat_WithGetEnumName | 31.78 ns | 0.885 ns | 1.019 ns | 31.66 ns | 30.19 ns | 34.38 ns | 0.0050 |      64 B |

### 4. Current Implementation with unsafe and pointers (slower):

As per the Guid.TryFormat() implementation: https://github.com/madelson/runtime/blob/2d4f2d0c8f60d5f49e39f3ddbe1824648ee2b306/src/libraries/System.Private.CoreLib/src/System/Guid.cs#L1147

I'm quite sure why this is even slower than `string.copy()`

```C#
public static bool TryFormat<TEnum>(TEnum value, Span<char> destination, out int charsWritten) where TEnum : struct, Enum
{
    if (!destination.IsEmpty)
    {
        string? enumName = InternalFormat((RuntimeType)typeof(TEnum), ToUInt64(value));

        if (enumName != null
            && destination.Length >= enumName.Length)
        {
            unsafe
            {
                fixed (char* p1 = enumName)
                {
                    fixed (char* charP = &MemoryMarshal.GetReference(destination))
                    {
                        char* p2 = charP;
                        for (int i = 0; i < enumName.Length; i++)
                        {
                            *p2++ = p1[i];
                        }
                    }
                }
            }

            charsWritten = enumName.Length;
            return true;
        }
    }

    charsWritten = 0;
    return false;
}
```


|                          Method |     Mean |    Error |   StdDev |   Median |      Min |      Max |  Gen 0 | Allocated |
|-------------------------------- |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
| TryFormat_WithUnsafeAndPointers | 18.75 ns | 0.201 ns | 0.188 ns | 18.78 ns | 18.44 ns | 19.05 ns | 0.0031 |      40 B |

### 5. Current Implementation with index assignment of span (slower):

As per the DateTime.TryFormat() implementation: https://github.com/madelson/runtime/blob/2d4f2d0c8f60d5f49e39f3ddbe1824648ee2b306/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormat.cs#L1437

```C#
public static bool TryFormat<TEnum>(TEnum value, Span<char> destination, out int charsWritten) where TEnum : struct, Enum
{
    if (!destination.IsEmpty)
    {
        string? enumName = InternalFormat((RuntimeType)typeof(TEnum), ToUInt64(value));

        if (enumName != null
            && destination.Length >= enumName.Length)
        {
            for (int i = 0; i < enumName.Length; i++)
            {
                destination[i] = enumName[i];
            }

            charsWritten = enumName.Length;
            return true;
        }
    }

    charsWritten = 0;
    return false;
}
```

|                        Method |     Mean |    Error |   StdDev |   Median |      Min |      Max |  Gen 0 | Allocated |
|------------------------------ |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
| TryFormat_WithIndexAssignment | 18.96 ns | 0.724 ns | 0.805 ns | 18.81 ns | 17.84 ns | 20.82 ns | 0.0031 |      40 B |
