### PR TITLE
UOH alloc fix for hardlimit

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -17879,6 +17879,9 @@ try_again:
 gc_heap* gc_heap::balance_heaps_uoh_hard_limit_retry (alloc_context* acontext, size_t alloc_size, int generation_num)
 {
     assert (heap_hard_limit);
+#ifdef USE_REGIONS
+    return balance_heaps_uoh (acontext, alloc_size, generation_num);
+#else //USE_REGIONS
     const int home_heap = heap_select::select_heap(acontext);
     dprintf (3, ("[h%d] balance_heaps_loh_hard_limit_retry alloc_size: %d", home_heap, alloc_size));
     int start, end;
@@ -17914,6 +17917,7 @@ try_again:
     }
 
     return max_hp;
+#endif //USE_REGIONS
 }
 #endif //MULTIPLE_HEAPS
 


### PR DESCRIPTION
Hit this when I was doing some stress testing. I noticed that when I’m running stress with hardlimit and Server GC I get OOM from one of the tests -

`corerun ..\..\GC\Stress\Framework\ReliabilityFramework\ReliabilityFramework.dll ..\..\GC\Stress\Framework\ReliabilityFramework\testmix_gc_ci.config`

I narrowed it down to just have stress running the test that got OOM - 

```
C:\runtime-mvc\artifacts\tests\coreclr\windows.x64.Release\Tests\Core_Root>type ..\..\GC\Stress\Framework\ReliabilityFramework\testmix_gc_ci.config
<?xml version="1.0" encoding="utf-8"?>
<Test xmlns:xsd=http://www.w3.org/2001/XMLSchema xmlns:xsi=http://www.w3.org/2001/XMLSchema-instance
            id="NightlyRun"
            maximumTestRuns="-1"
            maximumExecutionTime="01:00:00"
            defaultTestLoader="processLoader"
            minimumCPU="0"
            minimumMem="0"
            maximumTests="0"
            percentPassIsPass="100"
            installDetours="false"
           minimumTests="0"
            minMaxTestUseCPUCount="true"
            suppressConsoleOutputFromTests="false">

   <Assembly id="LeakGenThrd.dll"
            successCode="100"
            filename="LeakGenThrd.dll"
            arguments=""
            concurrentCopies="1"
    />
</Test>
```

I can repro this with concurrent GC disabled but needs to have server GC and hardlimit -

complus_gcConcurrent=0
complus_GCHeapCount=2
complus_GCHeapHardLimit=300000000
complus_gcServer=1

The problematic sequence is this –

1) Thread asks to allocate a large object, notices a GC is happening in `try_allocate_more_space`, returns `a_state_retry_allocate`.
2) `allocate_more_space` then calls `balance_heaps_uoh_hard_limit_retry`, which returns null for `alloc_heap` because none of the starting region for any heap has enough for the requested size

So the culprit is `balance_heaps_uoh_hard_limit_retry` is still doing the special thing it was done for segments which is not applicable to regions, ie, it needs to be changed the same way `get_balance_heaps_uoh_effective_budget` was. I verified this fixed the stress problem.