### PR TITLE
[QUIC] Fixed work with QUIC_BUFFER

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -351,19 +351,19 @@ namespace System.Net.Quic.Implementations.MsQuic
                     {
                         unsafe
                         {
-                            ReadOnlySpan<QUIC_BUFFER> quicBuffer = new ReadOnlySpan<QUIC_BUFFER>((void*)certificateHandle, sizeof(QUIC_BUFFER));
-                            certificate = new X509Certificate2(new ReadOnlySpan<byte>(quicBuffer[0].Buffer, (int)quicBuffer[0].Length));
-                            certificateBuffer = (IntPtr)quicBuffer[0].Buffer;
-                            certificateLength = (int)quicBuffer[0].Length;
+                            QUIC_BUFFER* certBuffer = (QUIC_BUFFER*)certificateHandle;
+                            certificate = new X509Certificate2(new ReadOnlySpan<byte>(certBuffer->Buffer, (int)certBuffer->Length));
+                            certificateBuffer = (IntPtr)certBuffer->Buffer;
+                            certificateLength = (int)certBuffer->Length;
 
                             IntPtr chainHandle = (IntPtr)connectionEvent.PEER_CERTIFICATE_RECEIVED.Chain;
                             if (chainHandle != IntPtr.Zero)
                             {
-                                quicBuffer = new ReadOnlySpan<QUIC_BUFFER>((void*)chainHandle, sizeof(QUIC_BUFFER));
-                                if (quicBuffer[0].Length != 0 && quicBuffer[0].Buffer != null)
+                                QUIC_BUFFER* chainBuffer = (QUIC_BUFFER*)chainHandle;
+                                if (chainBuffer->Length != 0 && chainBuffer->Buffer != null)
                                 {
                                     additionalCertificates = new X509Certificate2Collection();
-                                    additionalCertificates.Import(new ReadOnlySpan<byte>(quicBuffer[0].Buffer, (int)quicBuffer[0].Length));
+                                    additionalCertificates.Import(new ReadOnlySpan<byte>(chainBuffer->Buffer, (int)chainBuffer->Length));
                                 }
                             }
                         }


### PR DESCRIPTION
The usage of `sizeof(QUIC_BUFFER)` in `ReadOnlySpan` ctor seemed suspicious since the argument signifies number of items in the span. 
According to msquic, it does contain a single QUIC_BUFFER pointer:
https://github.com/microsoft/msquic/blob/ae18e89ec787854d5e86bffa8b745266e3a117c1/src/platform/tls_openssl.c#L223-L224

cc @wfurt 