### PR TITLE
Allow convert from pointer to pointer

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -746,7 +746,7 @@ namespace System.Linq.Expressions
         {
             ExpressionUtils.RequiresCanRead(expression, nameof(expression));
             ArgumentNullException.ThrowIfNull(type);
-            TypeUtils.ValidateType(type, nameof(type));
+            TypeUtils.ValidateType(type, nameof(type), allowPointer: expression.Type.IsPointer && type.IsPointer);
             if (method == null)
             {
                 if (expression.Type.HasIdentityPrimitiveOrNullableConversionTo(type) ||

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -746,7 +746,7 @@ namespace System.Linq.Expressions
         {
             ExpressionUtils.RequiresCanRead(expression, nameof(expression));
             ArgumentNullException.ThrowIfNull(type);
-            TypeUtils.ValidateType(type, nameof(type), allowPointer: expression.Type.IsPointer && type.IsPointer);
+            TypeUtils.ValidateType(type, nameof(type), false, expression.Type.IsPointer && type.IsPointer);
             if (method == null)
             {
                 if (expression.Type.HasIdentityPrimitiveOrNullableConversionTo(type) ||


### PR DESCRIPTION
The below case is valid:
```C#
var fchar = 'f';
var fp = Pointer.Box(&fchar, typeof(char*));
char* x = (char*)Pointer.Unbox(fp);
```