### PR TITLE
Move constants to the right when canonicalizing commutative operations in VN

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1378,12 +1378,6 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                     offset += vnStore->CoercedConstantValue<ssize_t>(funcAttr.m_args[1]);
                     vn = funcAttr.m_args[0];
                 }
-                else if (vnStore->IsVNConstant(funcAttr.m_args[0]) &&
-                         varTypeIsIntegral(vnStore->TypeOfVN(funcAttr.m_args[0])))
-                {
-                    offset += vnStore->CoercedConstantValue<ssize_t>(funcAttr.m_args[0]);
-                    vn = funcAttr.m_args[1];
-                }
                 else
                 {
                     break;
@@ -4407,11 +4401,6 @@ AssertionIndex Compiler::optAssertionIsNonNullInternal(GenTree*         op,
             if (vnStore->IsVNConstant(funcAttr.m_args[1]) && varTypeIsIntegral(vnStore->TypeOfVN(funcAttr.m_args[1])))
             {
                 vnBase = funcAttr.m_args[0];
-            }
-            else if (vnStore->IsVNConstant(funcAttr.m_args[0]) &&
-                     varTypeIsIntegral(vnStore->TypeOfVN(funcAttr.m_args[0])))
-            {
-                vnBase = funcAttr.m_args[1];
             }
             else
             {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -3871,7 +3871,8 @@ ValueNum ValueNumStore::EvalUsingMathIdentity(var_types typ, VNFunc func, ValueN
     auto identityForAddition = [=]() -> ValueNum {
         if (!varTypeIsFloating(typ))
         {
-            if (IsVNConstant(arg1VN) && (arg1VN == VNZeroForType(TypeOfVN(arg1VN))))
+            ValueNum ZeroVN = VNZeroForType(typ);
+            if (arg1VN == ZeroVN)
             {
                 return arg0VN;
             }
@@ -3886,13 +3887,14 @@ ValueNum ValueNumStore::EvalUsingMathIdentity(var_types typ, VNFunc func, ValueN
     auto identityForSubtraction = [=]() -> ValueNum {
         if (!varTypeIsFloating(typ))
         {
-            if (IsVNConstant(arg1VN) && (arg1VN == VNZeroForType(TypeOfVN(arg1VN))))
+            ValueNum ZeroVN = VNZeroForType(typ);
+            if (arg1VN == ZeroVN)
             {
                 return arg0VN;
             }
             else if (arg0VN == arg1VN)
             {
-                return VNZeroForType(typ);
+                return ZeroVN;
             }
         }
 

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -3871,8 +3871,7 @@ ValueNum ValueNumStore::EvalUsingMathIdentity(var_types typ, VNFunc func, ValueN
     auto identityForAddition = [=]() -> ValueNum {
         if (!varTypeIsFloating(typ))
         {
-            ValueNum ZeroVN = VNZeroForType(typ);
-            if (arg1VN == ZeroVN)
+            if (IsVNConstant(arg1VN) && (arg1VN == VNZeroForType(TypeOfVN(arg1VN))))
             {
                 return arg0VN;
             }
@@ -3887,14 +3886,13 @@ ValueNum ValueNumStore::EvalUsingMathIdentity(var_types typ, VNFunc func, ValueN
     auto identityForSubtraction = [=]() -> ValueNum {
         if (!varTypeIsFloating(typ))
         {
-            ValueNum ZeroVN = VNZeroForType(typ);
-            if (arg1VN == ZeroVN)
+            if (IsVNConstant(arg1VN) && (arg1VN == VNZeroForType(TypeOfVN(arg1VN))))
             {
                 return arg0VN;
             }
             else if (arg0VN == arg1VN)
             {
-                return ZeroVN;
+                return VNZeroForType(typ);
             }
         }
 

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -746,7 +746,7 @@ public:
     BasicBlock::loopNumber LoopOfVN(ValueNum vn);
 
     // Returns true iff the VN represents a (non-handle) constant.
-    bool IsVNConstant(ValueNum vn);
+    bool IsVNConstant(ValueNum vn) const;
 
     bool IsVNVectorZero(ValueNum vn);
 


### PR DESCRIPTION
Estimating throughput impact...

Edit: impact estimated to be too large for the benefits provided.