### PR TITLE
Support ref fields in `System.Reflection.Metadata.Ecma335.BlobEncoder`.

### DIFF
--- a/src/libraries/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
+++ b/src/libraries/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
@@ -2499,6 +2499,7 @@ namespace System.Reflection.Metadata.Ecma335
         public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
         public void CustomAttributeSignature(System.Action<System.Reflection.Metadata.Ecma335.FixedArgumentsEncoder> fixedArguments, System.Action<System.Reflection.Metadata.Ecma335.CustomAttributeNamedArgumentsEncoder> namedArguments) { }
         public void CustomAttributeSignature(out System.Reflection.Metadata.Ecma335.FixedArgumentsEncoder fixedArguments, out System.Reflection.Metadata.Ecma335.CustomAttributeNamedArgumentsEncoder namedArguments) { throw null; }
+        public System.Reflection.Metadata.Ecma335.FieldTypeEncoder Field() { throw null; }
         public System.Reflection.Metadata.Ecma335.SignatureTypeEncoder FieldSignature() { throw null; }
         public System.Reflection.Metadata.Ecma335.LocalVariablesEncoder LocalVariableSignature(int variableCount) { throw null; }
         public System.Reflection.Metadata.Ecma335.MethodSignatureEncoder MethodSignature(System.Reflection.Metadata.SignatureCallingConvention convention = System.Reflection.Metadata.SignatureCallingConvention.Default, int genericParameterCount = 0, bool isInstanceMethod = false) { throw null; }
@@ -2619,6 +2620,16 @@ namespace System.Reflection.Metadata.Ecma335
     public static partial class ExportedTypeExtensions
     {
         public static int GetTypeDefinitionId(this System.Reflection.Metadata.ExportedType exportedType) { throw null; }
+    }
+    public readonly partial struct FieldTypeEncoder
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public FieldTypeEncoder(System.Reflection.Metadata.BlobBuilder builder) { throw null;  }
+        public System.Reflection.Metadata.BlobBuilder Builder { get { throw null; } }
+        public System.Reflection.Metadata.Ecma335.CustomModifiersEncoder CustomModifiers() { throw null; }
+        public System.Reflection.Metadata.Ecma335.SignatureTypeEncoder Type(bool isByRef = false) { throw null; }
+        public void TypedReference() { throw null; }
     }
     public readonly partial struct FixedArgumentsEncoder
     {

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/BlobEncoders.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/BlobEncoders.cs
@@ -23,13 +23,25 @@ namespace System.Reflection.Metadata.Ecma335
         }
 
         /// <summary>
+        /// Encodes Field Signature blob, with additional support for
+        /// encoding ref fields, custom modifiers and typed references.
+        /// </summary>
+        /// <returns>Encoder of the field type.</returns>
+        public FieldTypeEncoder Field()
+        {
+            Builder.WriteByte((byte)SignatureKind.Field);
+            return new FieldTypeEncoder(Builder);
+        }
+
+        /// <summary>
         /// Encodes Field Signature blob.
         /// </summary>
         /// <returns>Encoder of the field type.</returns>
+        /// <remarks>To encode byref fields, custom modifiers or typed
+        /// references use <see cref="Field"/> instead.</remarks>
         public SignatureTypeEncoder FieldSignature()
         {
-            Builder.WriteByte((byte)SignatureKind.Field);
-            return new SignatureTypeEncoder(Builder);
+            return Field().Type(isByRef: false);
         }
 
         /// <summary>
@@ -400,6 +412,36 @@ namespace System.Reflection.Metadata.Ecma335
         public SignatureTypeEncoder AddArgument()
         {
             return new SignatureTypeEncoder(Builder);
+        }
+    }
+
+    public readonly struct FieldTypeEncoder
+    {
+        public BlobBuilder Builder { get; }
+
+        public FieldTypeEncoder(BlobBuilder builder)
+        {
+            Builder = builder;
+        }
+
+        public CustomModifiersEncoder CustomModifiers()
+        {
+            return new CustomModifiersEncoder(Builder);
+        }
+
+        public SignatureTypeEncoder Type(bool isByRef = false)
+        {
+            if (isByRef)
+            {
+                Builder.WriteByte((byte)SignatureTypeCode.ByReference);
+            }
+
+            return new SignatureTypeEncoder(Builder);
+        }
+
+        public void TypedReference()
+        {
+            Builder.WriteByte((byte)SignatureTypeCode.TypedReference);
         }
     }
 

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/Ecma335/Encoding/BlobEncodersTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/Ecma335/Encoding/BlobEncodersTests.cs
@@ -28,6 +28,21 @@ namespace System.Reflection.Metadata.Ecma335.Tests
         }
 
         [Fact]
+        public void BlobEncoder_Field()
+        {
+            var b = new BlobBuilder();
+            var e = new BlobEncoder();
+            Assert.Same(b, e.Builder);
+
+            var f = e.Field();
+            f.CustomModifiers()
+                .AddModifier(MetadataTokens.TypeDefinitionHandle(1), isOptional: true)
+                .AddModifier(MetadataTokens.TypeDefinitionHandle(2), isOptional: false);
+            f.Type(isByRef: true).Object();
+            AssertEx.Equal(new byte[] { 0x06, 0x20, 0x04, 0x1F, 0x08, 0x10, 0x1C }, b.ToArray());
+        }
+
+        [Fact]
         public void BlobEncoder_MethodSpecificationSignature()
         {
             var b = new BlobBuilder();

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/Ecma335/Encoding/BlobEncodersTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/Ecma335/Encoding/BlobEncodersTests.cs
@@ -31,7 +31,7 @@ namespace System.Reflection.Metadata.Ecma335.Tests
         public void BlobEncoder_Field()
         {
             var b = new BlobBuilder();
-            var e = new BlobEncoder();
+            var e = new BlobEncoder(b);
             Assert.Same(b, e.Builder);
 
             var f = e.Field();
@@ -40,6 +40,14 @@ namespace System.Reflection.Metadata.Ecma335.Tests
                 .AddModifier(MetadataTokens.TypeDefinitionHandle(2), isOptional: false);
             f.Type(isByRef: true).Object();
             AssertEx.Equal(new byte[] { 0x06, 0x20, 0x04, 0x1F, 0x08, 0x10, 0x1C }, b.ToArray());
+
+            b.Clear();
+            f = e.Field();
+            f.CustomModifiers()
+                .AddModifier(MetadataTokens.TypeDefinitionHandle(1), isOptional: true)
+                .AddModifier(MetadataTokens.TypeDefinitionHandle(2), isOptional: false);
+            f.Type().Int32();
+            AssertEx.Equal(new byte[] { 0x06, 0x20, 0x04, 0x1F, 0x08, 0x08 }, b.ToArray());
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #68309.
A test case was added.