### PR TITLE
Move MsQuicStream._streamId into MsQuicStream.State

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -32,8 +32,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             // It must be kept alive until we receive SHUTDOWN_COMPLETE event
             public GCHandle StateGCHandle;
 
-            // Backing for StreamId
-            public long _streamId = -1;
+            public long StreamId = -1;
 
             public MsQuicStream? Stream; // roots the stream in the pinned state to prevent GC during an async read I/O.
             public MsQuicConnection.State ConnectionState = null!; // set in ctor.
@@ -113,7 +112,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             // Inbound streams are already started
             _state.StartCompletionSource.SetResult();
             _state.Handle = streamHandle;
-            _state._streamId = GetStreamId(streamHandle);
+            _state.StreamId = GetStreamId(streamHandle);
 
             _canRead = true;
             _canWrite = !flags.HasFlag(QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL);
@@ -144,7 +143,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                 NetEventSource.Info(
                     _state,
                     $"{_state.Handle} Inbound {(flags.HasFlag(QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL) ? "uni" : "bi")}directional stream created " +
-                        $"in connection {_state.ConnectionState.Handle} with StreamId {_state._streamId}.");
+                        $"in connection {_state.ConnectionState.Handle} with StreamId {_state.StreamId}.");
             }
         }
 
@@ -258,8 +257,8 @@ namespace System.Net.Quic.Implementations.MsQuic
             get
             {
                 ThrowIfDisposed();
-                Debug.Assert(_state._streamId != -1);
-                return _state._streamId;
+                Debug.Assert(_state.StreamId != -1);
+                return _state.StreamId;
             }
         }
 
@@ -1143,8 +1142,8 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             if (StatusSucceeded(status))
             {
-                state._streamId = (long)streamEvent.START_COMPLETE.ID;
-                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(state, $"{state.Handle} StreamId = {state._streamId}");
+                state.StreamId = (long)streamEvent.START_COMPLETE.ID;
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(state, $"{state.Handle} StreamId = {state.StreamId}");
 
                 if (streamEvent.START_COMPLETE.PeerAccepted != 0)
                 {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -23,9 +23,6 @@ namespace System.Net.Quic.Implementations.MsQuic
         private readonly bool _canRead;
         private readonly bool _canWrite;
 
-        // Backing for StreamId
-        private long _streamId = -1;
-
         private int _disposed;
 
         private sealed class State
@@ -34,6 +31,9 @@ namespace System.Net.Quic.Implementations.MsQuic
             // Roots the state in GC and it won't get collected while this exist.
             // It must be kept alive until we receive SHUTDOWN_COMPLETE event
             public GCHandle StateGCHandle;
+
+            // Backing for StreamId
+            public long _streamId = -1;
 
             public MsQuicStream? Stream; // roots the stream in the pinned state to prevent GC during an async read I/O.
             public MsQuicConnection.State ConnectionState = null!; // set in ctor.
@@ -113,7 +113,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             // Inbound streams are already started
             _state.StartCompletionSource.SetResult();
             _state.Handle = streamHandle;
-            _streamId = GetStreamId(); // needs _state.Handle to be set
+            _state._streamId = GetStreamId(streamHandle);
 
             _canRead = true;
             _canWrite = !flags.HasFlag(QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL);
@@ -144,7 +144,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                 NetEventSource.Info(
                     _state,
                     $"{_state.Handle} Inbound {(flags.HasFlag(QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL) ? "uni" : "bi")}directional stream created " +
-                        $"in connection {_state.ConnectionState.Handle}.");
+                        $"in connection {_state.ConnectionState.Handle} with StreamId {_state._streamId}.");
             }
         }
 
@@ -258,8 +258,8 @@ namespace System.Net.Quic.Implementations.MsQuic
             get
             {
                 ThrowIfDisposed();
-                Debug.Assert(_streamId != -1);
-                return _streamId;
+                Debug.Assert(_state._streamId != -1);
+                return _state._streamId;
             }
         }
 
@@ -1134,7 +1134,6 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         private static int HandleEventStartComplete(State state, ref QUIC_STREAM_EVENT streamEvent)
         {
-            Debug.Assert(state.Stream != null);
             int status = streamEvent.START_COMPLETE.Status;
 
             // The way we expose Open(Uni|Bi)directionalStreamAsync operations is that the stream
@@ -1144,7 +1143,8 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             if (StatusSucceeded(status))
             {
-                state.Stream._streamId = (long)streamEvent.START_COMPLETE.ID;
+                state._streamId = (long)streamEvent.START_COMPLETE.ID;
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(state, $"{state.Handle} StreamId = {state._streamId}");
 
                 if (streamEvent.START_COMPLETE.PeerAccepted != 0)
                 {
@@ -1584,9 +1584,9 @@ namespace System.Net.Quic.Implementations.MsQuic
         }
 
         // This can fail if the stream isn't started.
-        private long GetStreamId()
+        private static long GetStreamId(SafeMsQuicStreamHandle handle)
         {
-            return (long)MsQuicParameterHelpers.GetULongParam(MsQuicApi.Api, _state.Handle, QUIC_PARAM_STREAM_ID);
+            return (long)MsQuicParameterHelpers.GetULongParam(MsQuicApi.Api, handle, QUIC_PARAM_STREAM_ID);
         }
 
         private void ThrowIfDisposed()
@@ -1709,7 +1709,6 @@ namespace System.Net.Quic.Implementations.MsQuic
             int status;
             unsafe
             {
-                _state.Stream = this;
                 status = MsQuicApi.Api.ApiTable->StreamStart(
                     _state.Handle.QuicHandle,
                     QUIC_STREAM_START_FLAGS.SHUTDOWN_ON_FAIL | QUIC_STREAM_START_FLAGS.INDICATE_PEER_ACCEPT);
@@ -1723,7 +1722,6 @@ namespace System.Net.Quic.Implementations.MsQuic
             }
 
             await _state.StartCompletionSource.Task.ConfigureAwait(false);
-            _state.Stream = null;
         }
 
         // Read state transitions:


### PR DESCRIPTION
Follow up from https://github.com/dotnet/runtime/pull/69301#discussion_r872616046, we should avoid mutual references between `MsQuicStream` and `MsQuicStream.State` since it may cause issues with finalization.