### PR TITLE
ArrayPool cleans returned array if it contains references

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
@@ -122,7 +122,7 @@ namespace System.Buffers
             return buffer;
         }
 
-        public override void Return(T[] array, bool clearArray = false)
+        public override async void Return(T[] array, bool clearArray = false)
         {
             if (array is null)
             {
@@ -145,7 +145,7 @@ namespace System.Buffers
                 haveBucket = true;
 
                 // Clear the array if the user requested it.
-                if (clearArray)
+                if (clearArray || RuntimeHelpers.IsReferenceOrContainsReferences<T>())
                 {
                     Array.Clear(array);
                 }


### PR DESCRIPTION
Fixes Issue <!-- Issue Number -->

main PR <!-- Link to PR if any that fixed this in the main branch. -->

# Description

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

# Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

# Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

# Testing

<!-- What kind of testing has been done with the fix. -->

# Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

# Package authoring signed off?


IMPORTANT: If this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
