### PR TITLE
Fix some scaling issues with the global queue in the thread pool

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -387,6 +387,11 @@ namespace System.Threading
             }
         }
 
+        private const int ProcessorsPerAssignableWorkItemQueue = 16;
+        private static readonly int AssignableWorkItemQueueCount =
+            Environment.ProcessorCount <= 32 ? 0 :
+                (Environment.ProcessorCount + (ProcessorsPerAssignableWorkItemQueue - 1)) / ProcessorsPerAssignableWorkItemQueue;
+
         private bool _loggingEnabled;
         private bool _dispatchNormalPriorityWorkFirst;
         private int _mayHaveHighPriorityWorkItems;
@@ -394,6 +399,16 @@ namespace System.Threading
         // SOS's ThreadPool command depends on the following names
         internal readonly ConcurrentQueue<object> workItems = new ConcurrentQueue<object>();
         internal readonly ConcurrentQueue<object> highPriorityWorkItems = new ConcurrentQueue<object>();
+
+        // SOS's ThreadPool command depends on the following name. The global queue doesn't scale well beyond a point of
+        // concurrency. Some additional queues may be added and assigned to a limited number of worker threads if necessary to
+        // help with limiting the concurrency level.
+        internal readonly ConcurrentQueue<object>[] assignableWorkItemQueues =
+            new ConcurrentQueue<object>[AssignableWorkItemQueueCount];
+
+        private readonly LowLevelLock _queueAssignmentLock = new();
+        private readonly int[] _assignedWorkItemQueueThreadCounts =
+            AssignableWorkItemQueueCount > 0 ? new int[AssignableWorkItemQueueCount] : Array.Empty<int>();
 
         [StructLayout(LayoutKind.Sequential)]
         private struct CacheLineSeparated
@@ -409,7 +424,124 @@ namespace System.Threading
 
         public ThreadPoolWorkQueue()
         {
+            for (int i = 0; i < AssignableWorkItemQueueCount; i++)
+            {
+                assignableWorkItemQueues[i] = new ConcurrentQueue<object>();
+            }
+
             RefreshLoggingEnabled();
+        }
+
+        private void AssignWorkItemQueue(ThreadPoolWorkQueueThreadLocals tl)
+        {
+            Debug.Assert(AssignableWorkItemQueueCount > 0);
+
+            _queueAssignmentLock.Acquire();
+
+            // Determine the first queue that has not yet been assigned to the limit of worker threads
+            int queueIndex = -1;
+            int minCount = int.MaxValue;
+            int minCountQueueIndex = 0;
+            for (int i = 0; i < AssignableWorkItemQueueCount; i++)
+            {
+                int count = _assignedWorkItemQueueThreadCounts[i];
+                Debug.Assert(count >= 0);
+                if (count < ProcessorsPerAssignableWorkItemQueue)
+                {
+                    queueIndex = i;
+                    _assignedWorkItemQueueThreadCounts[queueIndex] = count + 1;
+                    break;
+                }
+
+                if (count < minCount)
+                {
+                    minCount = count;
+                    minCountQueueIndex = i;
+                }
+            }
+
+            if (queueIndex < 0)
+            {
+                // All queues have been fully assigned. Choose the queue that has been assigned to the least number of worker
+                // threads.
+                queueIndex = minCountQueueIndex;
+                _assignedWorkItemQueueThreadCounts[queueIndex]++;
+            }
+
+            _queueAssignmentLock.Release();
+
+            tl.queueIndex = queueIndex;
+            tl.assignedGlobalWorkItemQueue = assignableWorkItemQueues[queueIndex];
+        }
+
+        private void TryReassignWorkItemQueue(ThreadPoolWorkQueueThreadLocals tl)
+        {
+            Debug.Assert(AssignableWorkItemQueueCount > 0);
+
+            int queueIndex = tl.queueIndex;
+            if (queueIndex == 0)
+            {
+                return;
+            }
+
+            if (!_queueAssignmentLock.TryAcquire())
+            {
+                return;
+            }
+
+            // If the currently assigned queue is assigned to other worker threads, try to reassign an earlier queue to this
+            // worker thread if the earlier queue is not assigned to the limit of worker threads
+            Debug.Assert(_assignedWorkItemQueueThreadCounts[queueIndex] >= 0);
+            if (_assignedWorkItemQueueThreadCounts[queueIndex] > 1)
+            {
+                for (int i = 0; i < queueIndex; i++)
+                {
+                    if (_assignedWorkItemQueueThreadCounts[i] < ProcessorsPerAssignableWorkItemQueue)
+                    {
+                        _assignedWorkItemQueueThreadCounts[queueIndex]--;
+                        queueIndex = i;
+                        _assignedWorkItemQueueThreadCounts[queueIndex]++;
+                        break;
+                    }
+                }
+            }
+
+            _queueAssignmentLock.Release();
+
+            tl.queueIndex = queueIndex;
+            tl.assignedGlobalWorkItemQueue = assignableWorkItemQueues[queueIndex];
+        }
+
+        private void UnassignWorkItemQueue(ThreadPoolWorkQueueThreadLocals tl)
+        {
+            Debug.Assert(AssignableWorkItemQueueCount > 0);
+
+            int queueIndex = tl.queueIndex;
+
+            _queueAssignmentLock.Acquire();
+            int newCount = --_assignedWorkItemQueueThreadCounts[queueIndex];
+            _queueAssignmentLock.Release();
+
+            Debug.Assert(newCount >= 0);
+            if (newCount > 0)
+            {
+                return;
+            }
+
+            // This queue is not assigned to any other worker threads. Move its work items to the global queue to prevent them
+            // from being starved for a long duration.
+            bool movedWorkItem = false;
+            ConcurrentQueue<object> queue = tl.assignedGlobalWorkItemQueue;
+            while (_assignedWorkItemQueueThreadCounts[queueIndex] <= 0 && queue.TryDequeue(out object? workItem))
+            {
+                workItems.Enqueue(workItem);
+                movedWorkItem = true;
+            }
+
+            if (movedWorkItem)
+            {
+                EnsureThreadRequested();
+            }
         }
 
         public ThreadPoolWorkQueueThreadLocals GetOrCreateThreadLocals() =>
@@ -479,7 +611,11 @@ namespace System.Threading
             }
             else
             {
-                workItems.Enqueue(callback);
+                ConcurrentQueue<object> queue =
+                    AssignableWorkItemQueueCount > 0 && (tl = ThreadPoolWorkQueueThreadLocals.threadLocals) != null
+                        ? tl.assignedGlobalWorkItemQueue
+                        : workItems;
+                queue.Enqueue(callback);
             }
 
             EnsureThreadRequested();
@@ -533,22 +669,42 @@ namespace System.Threading
                 return workItem;
             }
 
-            // Check for global work items
+            // Check for work items from the assigned global queue
+            if (AssignableWorkItemQueueCount > 0 && tl.assignedGlobalWorkItemQueue.TryDequeue(out workItem))
+            {
+                return workItem;
+            }
+
+            // Check for work items from the global queue
             if (workItems.TryDequeue(out workItem))
             {
                 return workItem;
             }
 
+            // Check for work items in other assignable global queues
+            uint randomValue = tl.random.NextUInt32();
+            if (AssignableWorkItemQueueCount > 0)
+            {
+                int queueIndex = tl.queueIndex;
+                for (int c = AssignableWorkItemQueueCount, maxIndex = c - 1, i = (int)(randomValue % (uint)c);
+                    c > 0;
+                    i = i < maxIndex ? i + 1 : 0, c--)
+                {
+                    if (i != queueIndex && assignableWorkItemQueues[i].TryDequeue(out workItem))
+                    {
+                        return workItem;
+                    }
+                }
+            }
+
             // Try to steal from other threads' local work items
             WorkStealingQueue localWsq = tl.workStealingQueue;
             WorkStealingQueue[] queues = WorkStealingQueueList.Queues;
-            int c = queues.Length;
-            Debug.Assert(c > 0, "There must at least be a queue for this thread.");
-            int maxIndex = c - 1;
-            uint i = tl.random.NextUInt32() % (uint)c;
-            while (c > 0)
+            Debug.Assert(queues.Length > 0, "There must at least be a queue for this thread.");
+            for (int c = queues.Length, maxIndex = c - 1, i = (int)(randomValue % (uint)c);
+                c > 0;
+                i = i < maxIndex ? i + 1 : 0, c--)
             {
-                i = (i < maxIndex) ? i + 1 : 0;
                 WorkStealingQueue otherQueue = queues[i];
                 if (otherQueue != localWsq && otherQueue.CanSteal)
                 {
@@ -558,7 +714,6 @@ namespace System.Threading
                         return workItem;
                     }
                 }
-                c--;
             }
 
             return null;
@@ -594,7 +749,19 @@ namespace System.Threading
             }
         }
 
-        public long GlobalCount => (long)highPriorityWorkItems.Count + workItems.Count;
+        public long GlobalCount
+        {
+            get
+            {
+                long count = (long)highPriorityWorkItems.Count + workItems.Count;
+                for (int i = 0; i < AssignableWorkItemQueueCount; i++)
+                {
+                    count += assignableWorkItemQueues[i].Count;
+                }
+
+                return count;
+            }
+        }
 
         // Time in ms for which ThreadPoolWorkQueue.Dispatch keeps executing normal work items before either returning from
         // Dispatch (if YieldFromDispatchLoop is true), or performing periodic activities
@@ -612,6 +779,11 @@ namespace System.Threading
             ThreadPoolWorkQueue workQueue = ThreadPool.s_workQueue;
             ThreadPoolWorkQueueThreadLocals tl = workQueue.GetOrCreateThreadLocals();
 
+            if (AssignableWorkItemQueueCount > 0)
+            {
+                workQueue.AssignWorkItemQueue(tl);
+            }
+
             // Before dequeuing the first work item, acknowledge that the thread request has been satisfied
             workQueue.MarkThreadRequestSatisfied();
 
@@ -625,7 +797,12 @@ namespace System.Threading
                 if (dispatchNormalPriorityWorkFirst && !tl.workStealingQueue.CanSteal)
                 {
                     workQueue._dispatchNormalPriorityWorkFirst = !dispatchNormalPriorityWorkFirst;
-                    workQueue.workItems.TryDequeue(out workItem);
+                    ConcurrentQueue<object> queue =
+                        AssignableWorkItemQueueCount > 0 ? tl.assignedGlobalWorkItemQueue : workQueue.workItems;
+                    if (!queue.TryDequeue(out workItem) && AssignableWorkItemQueueCount > 0)
+                    {
+                        workQueue.workItems.TryDequeue(out workItem);
+                    }
                 }
 
                 if (workItem == null)
@@ -635,6 +812,11 @@ namespace System.Threading
 
                     if (workItem == null)
                     {
+                        if (AssignableWorkItemQueueCount > 0)
+                        {
+                            workQueue.UnassignWorkItemQueue(tl);
+                        }
+
                         //
                         // No work.
                         // If we missed a steal, though, there may be more work in the queue.
@@ -689,6 +871,11 @@ namespace System.Threading
 
                     if (workItem == null)
                     {
+                        if (AssignableWorkItemQueueCount > 0)
+                        {
+                            workQueue.UnassignWorkItemQueue(tl);
+                        }
+
                         //
                         // No work.
                         // If we missed a steal, though, there may be more work in the queue.
@@ -753,6 +940,10 @@ namespace System.Threading
                     // processing work items.
                     tl.TransferLocalWork();
                     tl.isProcessingHighPriorityWorkItems = false;
+                    if (AssignableWorkItemQueueCount > 0)
+                    {
+                        workQueue.UnassignWorkItemQueue(tl);
+                    }
                     return false;
                 }
 
@@ -769,7 +960,18 @@ namespace System.Threading
                     // The runtime-specific thread pool implementation requires the Dispatch loop to return to the VM
                     // periodically to let it perform its own work
                     tl.isProcessingHighPriorityWorkItems = false;
+                    if (AssignableWorkItemQueueCount > 0)
+                    {
+                        workQueue.UnassignWorkItemQueue(tl);
+                    }
                     return true;
+                }
+
+                if (AssignableWorkItemQueueCount > 0)
+                {
+                    // Due to hill climbing, over time arbitrary worker threads may stop working and eventually unbalance the
+                    // queue assignments. Periodically try to reassign a queue to keep the assigned queues busy.
+                    workQueue.TryReassignWorkItemQueue(tl);
                 }
 
                 // This method will continue to dispatch work items. Refresh the start tick count for the next dispatch
@@ -823,6 +1025,8 @@ namespace System.Threading
         public static ThreadPoolWorkQueueThreadLocals? threadLocals;
 
         public bool isProcessingHighPriorityWorkItems;
+        public int queueIndex;
+        public ConcurrentQueue<object> assignedGlobalWorkItemQueue;
         public readonly ThreadPoolWorkQueue workQueue;
         public readonly ThreadPoolWorkQueue.WorkStealingQueue workStealingQueue;
         public readonly Thread currentThread;
@@ -831,6 +1035,7 @@ namespace System.Threading
 
         public ThreadPoolWorkQueueThreadLocals(ThreadPoolWorkQueue tpq)
         {
+            assignedGlobalWorkItemQueue = tpq.workItems;
             workQueue = tpq;
             workStealingQueue = new ThreadPoolWorkQueue.WorkStealingQueue();
             ThreadPoolWorkQueue.WorkStealingQueueList.Add(workStealingQueue);
@@ -1404,6 +1609,15 @@ namespace System.Threading
             foreach (object workItem in s_workQueue.highPriorityWorkItems)
             {
                 yield return workItem;
+            }
+
+            // Enumerate assignable global queues
+            foreach (ConcurrentQueue<object> queue in s_workQueue.assignableWorkItemQueues)
+            {
+                foreach (object workItem in queue)
+                {
+                    yield return workItem;
+                }
             }
 
             // Enumerate global queue


### PR DESCRIPTION
- The global concurrent queue is not scaling well in some situations on machines with a large number of processors. A lot of contention is seen in dequeuing work on some benchmarks.
- I initially tried switching to queuing work from thread pool threads more independently with more efficient work stealing, but it looks like that may need more investigation/experimentation. This is a simpler change that seems to work reasonably well for now.
- Beyond 32 procs, added additional concurrent queues, one per 16 procs. When a worker thread begins dispatching work, it assigns one of those additional queues to itself, trying to limit assignments to 16 worker threads per queue.
- Work items queued by a worker thread queues to the assigned queue. The worker thread dequeues from the assigned queue first, and later tries to dequeue from other queues. Work items queued by non-thread-pool threads continue to go into the global queue.
- When a worker thread stops dispatching work items, it unassigns itself from the queue, and may transfer work items from it if it was the last thread assigned to the queue.
- In the observed cases, work items are distributed to the different queues and contention is reduced due to a limited number of threads operating on each queue

Fixes https://github.com/dotnet/runtime/issues/67845