### PR TITLE
Add typed and untyped CreateObject to JsonTypeInfo

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -1155,7 +1155,7 @@ namespace System.Text.Json.Serialization.Metadata
         public System.Action<object, T?>? Setter { get { throw null; } init { } }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    public abstract partial class JsonTypeInfo
+    public partial class JsonTypeInfo
     {
         internal JsonTypeInfo() { }
     }

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -1155,7 +1155,7 @@ namespace System.Text.Json.Serialization.Metadata
         public System.Action<object, T?>? Setter { get { throw null; } init { } }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    public partial class JsonTypeInfo
+    public abstract partial class JsonTypeInfo
     {
         internal JsonTypeInfo() { }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ICollectionOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ICollectionOfTConverter.cs
@@ -38,10 +38,10 @@ namespace System.Text.Json.Serialization.Converters
         internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
         {
             // Deserialize as List<T> for interface types that support it.
-            if (jsonTypeInfo.CreateObject is null && TypeToConvert.IsAssignableFrom(typeof(List<TElement>)))
+            if (jsonTypeInfo.UntypedCreateObject is null && TypeToConvert.IsAssignableFrom(typeof(List<TElement>)))
             {
                 Debug.Assert(TypeToConvert.IsInterface);
-                jsonTypeInfo.CreateObject = () => new List<TElement>();
+                jsonTypeInfo.UntypedCreateObject = () => new List<TElement>();
             }
         }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryConverter.cs
@@ -98,10 +98,10 @@ namespace System.Text.Json.Serialization.Converters
         internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
         {
             // Deserialize as Dictionary<TKey,TValue> for interface types that support it.
-            if (jsonTypeInfo.CreateObject is null && TypeToConvert.IsAssignableFrom(typeof(Dictionary<string, object?>)))
+            if (jsonTypeInfo.UntypedCreateObject is null && TypeToConvert.IsAssignableFrom(typeof(Dictionary<string, object?>)))
             {
                 Debug.Assert(TypeToConvert.IsInterface);
-                jsonTypeInfo.CreateObject = () => new Dictionary<string, object?>();
+                jsonTypeInfo.UntypedCreateObject = () => new Dictionary<string, object?>();
             }
         }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryOfTKeyTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryOfTKeyTValueConverter.cs
@@ -40,10 +40,10 @@ namespace System.Text.Json.Serialization.Converters
         internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
         {
             // Deserialize as Dictionary<TKey,TValue> for interface types that support it.
-            if (jsonTypeInfo.CreateObject is null && TypeToConvert.IsAssignableFrom(typeof(Dictionary<TKey, TValue>)))
+            if (jsonTypeInfo.UntypedCreateObject is null && TypeToConvert.IsAssignableFrom(typeof(Dictionary<TKey, TValue>)))
             {
                 Debug.Assert(TypeToConvert.IsInterface);
-                jsonTypeInfo.CreateObject = () => new Dictionary<TKey, TValue>();
+                jsonTypeInfo.UntypedCreateObject = () => new Dictionary<TKey, TValue>();
             }
         }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListConverter.cs
@@ -77,10 +77,10 @@ namespace System.Text.Json.Serialization.Converters
         internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
         {
             // Deserialize as List<object?> for interface types that support it.
-            if (jsonTypeInfo.CreateObject is null && TypeToConvert.IsAssignableFrom(typeof(List<object?>)))
+            if (jsonTypeInfo.UntypedCreateObject is null && TypeToConvert.IsAssignableFrom(typeof(List<object?>)))
             {
                 Debug.Assert(TypeToConvert.IsInterface);
-                jsonTypeInfo.CreateObject = () => new List<object?>();
+                jsonTypeInfo.UntypedCreateObject = () => new List<object?>();
             }
         }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListOfTConverter.cs
@@ -38,10 +38,10 @@ namespace System.Text.Json.Serialization.Converters
         internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
         {
             // Deserialize as List<T> for interface types that support it.
-            if (jsonTypeInfo.CreateObject is null && TypeToConvert.IsAssignableFrom(typeof(List<TElement>)))
+            if (jsonTypeInfo.UntypedCreateObject is null && TypeToConvert.IsAssignableFrom(typeof(List<TElement>)))
             {
                 Debug.Assert(TypeToConvert.IsInterface);
-                jsonTypeInfo.CreateObject = () => new List<TElement>();
+                jsonTypeInfo.UntypedCreateObject = () => new List<TElement>();
             }
         }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ISetOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ISetOfTConverter.cs
@@ -35,10 +35,10 @@ namespace System.Text.Json.Serialization.Converters
         internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
         {
             // Deserialize as HashSet<TElement> for interface types that support it.
-            if (jsonTypeInfo.CreateObject is null && TypeToConvert.IsAssignableFrom(typeof(HashSet<TElement>)))
+            if (jsonTypeInfo.UntypedCreateObject is null && TypeToConvert.IsAssignableFrom(typeof(HashSet<TElement>)))
             {
                 Debug.Assert(TypeToConvert.IsInterface);
-                jsonTypeInfo.CreateObject = () => new HashSet<TElement>();
+                jsonTypeInfo.UntypedCreateObject = () => new HashSet<TElement>();
             }
         }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
@@ -26,7 +26,7 @@ namespace System.Text.Json.Serialization
         {
             JsonTypeInfo typeInfo = state.Current.JsonTypeInfo;
 
-            if (typeInfo.CreateObject is null)
+            if (typeInfo.UntypedCreateObject is null)
             {
                 // The contract model was not able to produce a default constructor for two possible reasons:
                 // 1. Either the declared collection type is abstract and cannot be instantiated.
@@ -41,7 +41,7 @@ namespace System.Text.Json.Serialization
                 }
             }
 
-            state.Current.ReturnValue = typeInfo.CreateObject()!;
+            state.Current.ReturnValue = typeInfo.UntypedCreateObject();
             Debug.Assert(state.Current.ReturnValue is TCollection);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
@@ -41,7 +41,7 @@ namespace System.Text.Json.Serialization
         {
             JsonTypeInfo typeInfo = state.Current.JsonTypeInfo;
 
-            if (typeInfo.CreateObject is null)
+            if (typeInfo.UntypedCreateObject is null)
             {
                 // The contract model was not able to produce a default constructor for two possible reasons:
                 // 1. Either the declared collection type is abstract and cannot be instantiated.
@@ -56,7 +56,7 @@ namespace System.Text.Json.Serialization
                 }
             }
 
-            state.Current.ReturnValue = typeInfo.CreateObject()!;
+            state.Current.ReturnValue = typeInfo.UntypedCreateObject()!;
             Debug.Assert(state.Current.ReturnValue is TDictionary);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ListOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ListOfTConverter.cs
@@ -17,12 +17,12 @@ namespace System.Text.Json.Serialization.Converters
 
         protected override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
         {
-            if (state.Current.JsonTypeInfo.CreateObject == null)
+            if (state.Current.JsonTypeInfo.UntypedCreateObject == null)
             {
                 ThrowHelper.ThrowNotSupportedException_SerializationNotSupported(state.Current.JsonTypeInfo.Type);
             }
 
-            state.Current.ReturnValue = state.Current.JsonTypeInfo.CreateObject();
+            state.Current.ReturnValue = state.Current.JsonTypeInfo.UntypedCreateObject();
         }
 
         protected override bool OnWriteResume(Utf8JsonWriter writer, TCollection value, JsonSerializerOptions options, ref WriteStack state)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/QueueOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/QueueOfTConverter.cs
@@ -16,12 +16,12 @@ namespace System.Text.Json.Serialization.Converters
 
         protected override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
         {
-            if (state.Current.JsonTypeInfo.CreateObject == null)
+            if (state.Current.JsonTypeInfo.UntypedCreateObject == null)
             {
                 ThrowHelper.ThrowNotSupportedException_SerializationNotSupported(state.Current.JsonTypeInfo.Type);
             }
 
-            state.Current.ReturnValue = state.Current.JsonTypeInfo.CreateObject();
+            state.Current.ReturnValue = state.Current.JsonTypeInfo.UntypedCreateObject();
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOfTConverter.cs
@@ -17,12 +17,12 @@ namespace System.Text.Json.Serialization.Converters
 
         protected override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
         {
-            if (state.Current.JsonTypeInfo.CreateObject == null)
+            if (state.Current.JsonTypeInfo.UntypedCreateObject == null)
             {
                 ThrowHelper.ThrowNotSupportedException_SerializationNotSupported(state.Current.JsonTypeInfo.Type);
             }
 
-            state.Current.ReturnValue = state.Current.JsonTypeInfo.CreateObject();
+            state.Current.ReturnValue = state.Current.JsonTypeInfo.UntypedCreateObject();
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOrQueueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOrQueueConverter.cs
@@ -21,7 +21,7 @@ namespace System.Text.Json.Serialization.Converters
         protected sealed override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
         {
             JsonTypeInfo typeInfo = state.Current.JsonTypeInfo;
-            JsonTypeInfo.ConstructorDelegate? constructorDelegate = typeInfo.CreateObject;
+            Func<object>? constructorDelegate = typeInfo.UntypedCreateObject;
 
             if (constructorDelegate == null)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -31,12 +31,12 @@ namespace System.Text.Json.Serialization.Converters
                     ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(TypeToConvert);
                 }
 
-                if (jsonTypeInfo.CreateObject == null)
+                if (jsonTypeInfo.UntypedCreateObject == null)
                 {
                     ThrowHelper.ThrowNotSupportedException_DeserializeNoConstructor(jsonTypeInfo.Type, ref reader, ref state);
                 }
 
-                obj = jsonTypeInfo.CreateObject!()!;
+                obj = jsonTypeInfo.UntypedCreateObject()!;
 
                 if (obj is IJsonOnDeserializing onDeserializing)
                 {
@@ -127,12 +127,12 @@ namespace System.Text.Json.Serialization.Converters
                         return true;
                     }
 
-                    if (jsonTypeInfo.CreateObject == null)
+                    if (jsonTypeInfo.UntypedCreateObject == null)
                     {
                         ThrowHelper.ThrowNotSupportedException_DeserializeNoConstructor(jsonTypeInfo.Type, ref reader, ref state);
                     }
 
-                    obj = jsonTypeInfo.CreateObject!()!;
+                    obj = jsonTypeInfo.UntypedCreateObject()!;
 
                     if (state.Current.MetadataPropertyNames.HasFlag(MetadataPropertyName.Id))
                     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -123,7 +123,7 @@ namespace System.Text.Json
                     genericArgs[1].UnderlyingSystemType == typeof(JsonElement) ||
                     genericArgs[1].UnderlyingSystemType == typeof(Nodes.JsonNode));
 #endif
-                if (jsonPropertyInfo.JsonTypeInfo.CreateObject == null)
+                if (jsonPropertyInfo.JsonTypeInfo.UntypedCreateObject == null)
                 {
                     // Avoid a reference to the JsonNode type for trimming
                     if (jsonPropertyInfo.PropertyType.FullName == JsonTypeInfo.JsonObjectTypeName)
@@ -137,7 +137,7 @@ namespace System.Text.Json
                 }
                 else
                 {
-                    extensionData = jsonPropertyInfo.JsonTypeInfo.CreateObject();
+                    extensionData = jsonPropertyInfo.JsonTypeInfo.UntypedCreateObject();
                 }
 
                 jsonPropertyInfo.SetExtensionDictionaryAsObject(obj, extensionData);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -17,7 +17,7 @@ namespace System.Text.Json.Serialization.Metadata
     /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public abstract partial class JsonTypeInfo
+    public partial class JsonTypeInfo
     {
         internal const string JsonObjectTypeName = "System.Text.Json.Nodes.JsonObject";
 
@@ -34,7 +34,18 @@ namespace System.Text.Json.Serialization.Metadata
 
         // Untyped CreateObject is non-virtual public API so we pretend it's virtual by using this indirection
         // We need it to be abstract so that we can keep typed value in sync
-        internal abstract Func<object>? UntypedCreateObjectAbstract { get; set; }
+        internal virtual Func<object>? UntypedCreateObjectAbstract
+        {
+            get
+            {
+                Debug.Fail("This should be overriden");
+                return null;
+            }
+            set
+            {
+                Debug.Fail("This should be overriden");
+            }
+        }
 
         // Actual value of UntypedCreateObject, for perf it's non-virtual
         internal Func<object>? UntypedCreateObject { get; set; }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -17,15 +17,27 @@ namespace System.Text.Json.Serialization.Metadata
     /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public partial class JsonTypeInfo
+    public abstract partial class JsonTypeInfo
     {
         internal const string JsonObjectTypeName = "System.Text.Json.Nodes.JsonObject";
 
-        internal delegate object? ConstructorDelegate();
-
         internal delegate T ParameterizedConstructorDelegate<T, TArg0, TArg1, TArg2, TArg3>(TArg0 arg0, TArg1 arg1, TArg2 arg2, TArg3 arg3);
 
-        internal ConstructorDelegate? CreateObject { get; set; }
+        /// <summary>
+        /// Object constructor. If set to null type is not deserializable.
+        /// </summary>
+        internal Func<object>? CreateObject
+        {
+            get => UntypedCreateObjectAbstract;
+            set => UntypedCreateObjectAbstract = value;
+        }
+
+        // Untyped CreateObject is non-virtual public API so we pretend it's virtual by using this indirection
+        // We need it to be abstract so that we can keep typed value in sync
+        internal abstract Func<object>? UntypedCreateObjectAbstract { get; set; }
+
+        // Actual value of UntypedCreateObject, for perf it's non-virtual
+        internal Func<object>? UntypedCreateObject { get; set; }
 
         internal object? CreateObjectWithArgs { get; set; }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
@@ -15,6 +15,32 @@ namespace System.Text.Json.Serialization.Metadata
     {
         private Action<Utf8JsonWriter, T>? _serialize;
 
+        private Func<T>? _typedCreateObject;
+
+        /// <summary>
+        /// Function for creating object before properties are set. If set to null type is not deserializable.
+        /// </summary>
+        internal new Func<T>? CreateObject
+        {
+            get => _typedCreateObject ??= UntypedCreateObject == null ? null : () => (T)UntypedCreateObject();
+            set
+            {
+                _typedCreateObject = value;
+                UntypedCreateObject = value == null ? null : () => value()!;
+            }
+        }
+
+        internal override Func<object>? UntypedCreateObjectAbstract
+        {
+            get => UntypedCreateObject;
+            set
+            {
+                UntypedCreateObject = value;
+                // We invalidate the cached typed value
+                _typedCreateObject = null;
+            }
+        }
+
         internal JsonTypeInfo(JsonConverter converter, JsonSerializerOptions options)
             : base(typeof(T), converter, options)
         { }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/MemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/MemberAccessor.cs
@@ -9,7 +9,7 @@ namespace System.Text.Json.Serialization.Metadata
 {
     internal abstract class MemberAccessor
     {
-        public abstract JsonTypeInfo.ConstructorDelegate? CreateConstructor(
+        public abstract Func<object>? CreateConstructor(
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type classType);
 
         public abstract Func<object[], T>? CreateParameterizedConstructor<T>(ConstructorInfo constructor);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.cs
@@ -23,7 +23,7 @@ namespace System.Text.Json.Serialization.Metadata
                     Justification = "Parent method annotation does not flow to lambda method, cf. https://github.com/dotnet/roslyn/issues/46646")]
                 static (_) => s_sourceAccessor.CreateAddMethodDelegate<TCollection>());
 
-        public override JsonTypeInfo.ConstructorDelegate? CreateConstructor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type classType)
+        public override Func<object>? CreateConstructor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type classType)
             => s_cache.GetOrAdd((nameof(CreateConstructor), classType, null),
                 [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2077:UnrecognizedReflectionPattern",
                     Justification = "Cannot apply DynamicallyAccessedMembersAttribute to tuple properties.")]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitMemberAccessor.cs
@@ -13,7 +13,7 @@ namespace System.Text.Json.Serialization.Metadata
     [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
     internal sealed class ReflectionEmitMemberAccessor : MemberAccessor
     {
-        public override JsonTypeInfo.ConstructorDelegate? CreateConstructor(
+        public override Func<object>? CreateConstructor(
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
         {
             Debug.Assert(type != null);
@@ -59,7 +59,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             generator.Emit(OpCodes.Ret);
 
-            return (JsonTypeInfo.ConstructorDelegate)dynamicMethod.CreateDelegate(typeof(JsonTypeInfo.ConstructorDelegate));
+            return (Func<object>)dynamicMethod.CreateDelegate(typeof(Func<object>));
         }
 
         public override Func<object[], T>? CreateParameterizedConstructor<T>(ConstructorInfo constructor) =>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
@@ -40,7 +40,7 @@ namespace System.Text.Json.Serialization.Metadata
                 AddPropertiesAndParametersUsingReflection();
             }
 
-            CreateObject = Options.MemberAccessorStrategy.CreateConstructor(typeof(T));
+            UntypedCreateObject = Options.MemberAccessorStrategy.CreateConstructor(typeof(T));
         }
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionMemberAccessor.cs
@@ -22,7 +22,7 @@ namespace System.Text.Json.Serialization.Metadata
                 => Activator.CreateInstance(_type, nonPublic: false);
         }
 
-        public override JsonTypeInfo.ConstructorDelegate? CreateConstructor(
+        public override Func<object>? CreateConstructor(
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
         {
             Debug.Assert(type != null);
@@ -38,7 +38,7 @@ namespace System.Text.Json.Serialization.Metadata
                 return null;
             }
 
-            return new ConstructorContext(type).CreateInstance;
+            return new ConstructorContext(type).CreateInstance!;
         }
 
         public override Func<object[], T>? CreateParameterizedConstructor<T>(ConstructorInfo constructor)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
@@ -34,7 +34,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
             else
             {
-                SetCreateObjectFunc(objectInfo.ObjectCreator);
+                CreateObject = objectInfo.ObjectCreator;
             }
 
 
@@ -65,7 +65,7 @@ namespace System.Text.Json.Serialization.Metadata
             SerializeHandler = collectionInfo.SerializeHandler;
             CreateObjectWithArgs = createObjectWithArgs;
             AddMethodDelegate = addFunc;
-            SetCreateObjectFunc(collectionInfo.ObjectCreator);
+            CreateObject = collectionInfo.ObjectCreator;
         }
 
         private static JsonConverter GetConverter(JsonObjectInfoValues<T> objectInfo)
@@ -180,14 +180,6 @@ namespace System.Text.Json.Serialization.Metadata
             }
 
             PropertyCache = propertyCache;
-        }
-
-        private void SetCreateObjectFunc(Func<T>? createObjectFunc)
-        {
-            if (createObjectFunc != null)
-            {
-                CreateObject = () => createObjectFunc();
-            }
         }
     }
 }


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/runtime/issues/63686

This makes tiny change to public API (making JsonTypeInfo abstract) which matches approved APIs.

Currently our source of truth is untyped version. I didn't see any easy way to change that for now since it's mostly used in places where JsonTypeInfo is not directly typed - I'll create issue before merging to make sure the potential improvement is on our radar. Since this requires a bit more perf investigation I'll leave that improvement for after the contract resolution is merged.