### PR TITLE
[release/6.0] Add windows runtime packs as a workload

### DIFF
--- a/eng/pipelines/mono/templates/workloads-build.yml
+++ b/eng/pipelines/mono/templates/workloads-build.yml
@@ -65,6 +65,10 @@ jobs:
           IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.MonoTargets.Sdk*.nupkg
           IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.MonoAOTCompiler.Task*.nupkg
           IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.WebAssembly.Sdk*.nupkg
+          IntermediateArtifacts/windows_arm/Shipping/Microsoft.NETCore.App.Runtime.win-arm*.nupkg
+          IntermediateArtifacts/windows_arm64/Shipping/Microsoft.NETCore.App.Runtime.win-arm64*.nupkg
+          IntermediateArtifacts/windows_x64/Shipping/Microsoft.NETCore.App.Runtime.win-x64*.nupkg
+          IntermediateArtifacts/windows_x86/Shipping/Microsoft.NETCore.App.Runtime.win-x86*.nupkg
 
     - task: CopyFiles@2
       displayName: Flatten packages

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -426,6 +426,10 @@ stages:
         - Build_tvOSSimulator_arm64_release_AllSubsets_Mono
         - Build_tvOSSimulator_x64_release_AllSubsets_Mono
         - Build_Windows_x64_release_CrossAOT_Mono
+        - installer__coreclr__windows_x64_Release_
+        - installer__coreclr__windows_x86_Release_
+        - installer__coreclr__windows_arm_Release_
+        - installer__coreclr__windows_arm64_Release_
 
 - ${{ if eq(variables.isOfficialBuild, true) }}:
   - template: /eng/pipelines/official/stages/publish.yml

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in
@@ -118,6 +118,15 @@
       "extends": [ "microsoft-net-runtime-mono-tooling" ],
       "platforms": [ "win-x64", "osx-arm64", "osx-x64" ]
     },
+    "runtimes-windows": {
+      "description": "Windows Runtime Packs",
+      "packs": [
+        "Microsoft.NETCore.App.Runtime.win-x64",
+        "Microsoft.NETCore.App.Runtime.win-x86",
+        "Microsoft.NETCore.App.Runtime.win-arm",
+        "Microsoft.NETCore.App.Runtime.win-arm64"
+      ]
+    },
     "microsoft-net-runtime-mono-tooling": {
       "abstract": true,
       "description": "Shared native build tooling for Mono runtime",
@@ -346,5 +355,21 @@
       "kind": "framework",
       "version": "${PackageVersion}"
     },
+    "Microsoft.NETCore.App.Runtime.win-x64" : {
+      "kind": "framework",
+      "version": "${PackageVersion}"
+    },
+    "Microsoft.NETCore.App.Runtime.win-x86" : {
+      "kind": "framework",
+      "version": "${PackageVersion}"
+    },
+    "Microsoft.NETCore.App.Runtime.win-arm" : {
+      "kind": "framework",
+      "version": "${PackageVersion}"
+    },
+    "Microsoft.NETCore.App.Runtime.win-arm64" : {
+      "kind": "framework",
+      "version": "${PackageVersion}"
+    }
   }
 }

--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -72,6 +72,8 @@
                           Description=".NET runtime components for tvOS execution."/>
       <ComponentResources Include="runtimes-maccatalyst" Title=".NET Mac Catalyst Build Tools"
                           Description=".NET runtime components for Mac Catalyst execution."/>
+      <ComponentResources Include="runtimes-windows" Title=".NET Windows Runtimes"
+                          Description=".NET runtime components for Windows execution."/>
 
       <!-- Visual Studio components must be versioned. Build tasks will fall back to cobbling a version number from
            the manifest information unless it's overridden. -->
@@ -85,6 +87,7 @@
       <ComponentVersions Include="runtimes-ios" Version="$(FileVersion)" />
       <ComponentVersions Include="runtimes-tvos" Version="$(FileVersion)" />
       <ComponentVersions Include="runtimes-maccatalyst" Version="$(FileVersion)" />
+      <ComponentVersions Include="runtimes-windows" Version="$(FileVersion)" />
     </ItemGroup>
 
     <!-- BAR requires having version information in blobs -->


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/68981

## Customer Impact
At certain points in time internally, the sdk will rev its version and insert into VS. It's at this point the sdk version will be ahead of the runtime version as we have not published anything into nuget. In MAUI and WinUI scenarios, this creates a bit of a pickle as the sdk will try to download a new version of the windows runtime pack, but it will not be available.

To get around this limitation, we are introducing a workload that will be inserted into VS where you can optionally install Windows runtime packs.

## Testing
Manual validation the workload artifacts contains the windows workload.

## Risk
Low
