### PR TITLE
Cleanup some X509 PAL allocations

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.DATA_BLOB.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.DATA_BLOB.cs
@@ -31,6 +31,8 @@ internal static partial class Interop
                 Marshal.Copy(pbData, array, 0, (int)cbData);
                 return array;
             }
+
+            internal unsafe ReadOnlySpan<byte> DangerousAsSpan() => new ReadOnlySpan<byte>((void*)pbData, (int)cbData);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/FindPal.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/FindPal.Windows.cs
@@ -93,11 +93,13 @@ namespace System.Security.Cryptography.X509Certificates
                 (hexValue, decimalValue),
                 static (state, pCertContext) =>
                 {
-                    byte[] actual = pCertContext.CertContext->pCertInfo->SerialNumber.ToByteArray();
-                    GC.KeepAlive(pCertContext);
+                    ReadOnlySpan<byte> actual = pCertContext.CertContext->pCertInfo->SerialNumber.DangerousAsSpan();
 
                     // Convert to BigInteger as the comparison must not fail due to spurious leading zeros
-                    BigInteger actualAsBigInteger = PositiveBigIntegerFromByteArray(actual);
+                    BigInteger actualAsBigInteger = new BigInteger(actual, isUnsigned: true);
+
+                    // Keep the CERT_CONTEXT alive until the data has been read in to the BigInteger.
+                    GC.KeepAlive(pCertContext);
 
                     return state.hexValue.Equals(actualAsBigInteger) || state.decimalValue.Equals(actualAsBigInteger);
                 });

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/FindPal.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/FindPal.cs
@@ -89,11 +89,10 @@ namespace System.Security.Cryptography.X509Certificates
                             // it compares against both interpretations and treats a match
                             // of either as a successful find.
 
-                            // string is big-endian, BigInteger constructor requires little-endian.
+                            // string is big-endian
                             byte[] hexBytes = decimalOrHexString.LaxDecodeHexString();
-                            Array.Reverse(hexBytes);
 
-                            BigInteger hexValue = PositiveBigIntegerFromByteArray(hexBytes);
+                            BigInteger hexValue = new BigInteger(hexBytes, isUnsigned: true, isBigEndian: true);
                             BigInteger decimalValue = LaxParseDecimalBigInteger(decimalOrHexString);
                             findPal.FindBySerialNumber(hexValue, decimalValue);
                             break;
@@ -239,30 +238,6 @@ namespace System.Security.Cryptography.X509Certificates
                 if (keyValue[i] != '.' || keyValue[i + 1] == '.') // disallow double dots
                     throw new ArgumentException(SR.Argument_InvalidOidValue);
             }
-        }
-
-        internal static BigInteger PositiveBigIntegerFromByteArray(byte[] bytes)
-        {
-            // To prevent the big integer from misinterpreted as a negative number,
-            // add a "leading 0" to the byte array if it would considered negative.
-            //
-            // Since BigInteger(bytes[]) requires a little-endian byte array,
-            // the "leading 0" actually goes at the end of the array.
-
-            // An empty array is 0 (non-negative), so no over-allocation is required.
-            //
-            // If the last indexed value doesn't have the sign bit set (0x00-0x7F) then
-            // the number would be positive anyways, so no over-allocation is required.
-            if (bytes.Length == 0 || bytes[bytes.Length - 1] < 0x80)
-            {
-                return new BigInteger(bytes);
-            }
-
-            // Since the sign bit is set, put a new 0x00 on the end to move that bit from
-            // the sign bit to a data bit.
-            byte[] newBytes = new byte[bytes.Length + 1];
-            Buffer.BlockCopy(bytes, 0, newBytes, 0, bytes.Length);
-            return new BigInteger(newBytes);
         }
 
         private static BigInteger LaxParseDecimalBigInteger(string decimalString)


### PR DESCRIPTION
Since this Find PAL was implemented, `BigInteger` gained capabilities for dealing with unsigned and endianness, so use that and get rid of the allocating helper.

This also remove some other small allocations where possible.