### PR TITLE
Optimize ManifestResourceStream.Read(Span<byte>)

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -36,12 +36,18 @@ namespace System.Reflection
 
         private sealed class ManifestResourceStream : UnmanagedMemoryStream
         {
+            // ensures the RuntimeAssembly is kept alive for as long as the stream lives
             private RuntimeAssembly _manifestAssembly;
 
             internal unsafe ManifestResourceStream(RuntimeAssembly manifestAssembly, byte* pointer, long length, long capacity, FileAccess access) : base(pointer, length, capacity, access)
             {
                 _manifestAssembly = manifestAssembly;
             }
+
+            // override Read(Span<byte>) because the base UnmanagedMemoryStream doesn't optimize it for derived types
+            public override int Read(Span<byte> buffer) => ReadCore(buffer);
+
+            // NOTE: no reason to override Write(Span<byte>), since a ManifestResourceStream is read-only.
         }
 
         internal object SyncRoot


### PR DESCRIPTION
ManifestResourceStream is derived from UnmanagedMemoryStream. UnmanagedMemoryStream optimizes Read(Span<byte>), but only if the instance is concretely an UnmanagedMemoryStream. This is to protect in case the derived Stream overriddes Read(byte[], int, int) prior to the Read(Span<byte>) overload being introduced.

Optimize ManifestResourceStream by overriding Read(Span<byte>) and call ReadCore, so the Stream.Read(Span<byte>) logic of using a pooled byte[] buffer isn't used.

### Benchmark

```C#
[MemoryDiagnoser]
public class ManifestResourceStreamBenchmark
{
    private Stream _stream;

    [GlobalSetup]
    public void Setup()
    {
        _stream = typeof(object).Assembly.GetManifestResourceStream("System.Private.CoreLib.Strings.resources");
    }

    [Benchmark]
    public void ReadAll()
    {
        Span<byte> buffer = stackalloc byte[1024];
        while (_stream.Read(buffer) != 0)
        {
        }
    }
}
```

### Results

```
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1706 (21H1/May2021Update)
Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK=6.0.300
  [Host]     : .NET 6.0.5 (6.0.522.21309), X64 RyuJIT
  Job-AASUSC : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT
  Job-LHCSRL : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT
```

|  Method |        Job |         Toolchain |     Mean |    Error |   StdDev | Ratio | Allocated |
|-------- |----------- |------------------ |---------:|---------:|---------:|------:|----------:|
| ReadAll | Job-AASUSC | \main\corerun.exe | 66.06 ns | 0.408 ns | 0.362 ns |  1.00 |         - |
| ReadAll | Job-LHCSRL |   \pr\corerun.exe | 42.82 ns | 0.093 ns | 0.078 ns |  0.65 |         - |