### PR TITLE
Add some assertions to Stream.Read in System.Text.Encoding.CodePages

### DIFF
--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/BaseCodePageEncoding.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/BaseCodePageEncoding.cs
@@ -100,9 +100,12 @@ namespace System.Text
             internal short unused1;             // Add an unused WORD so that CodePages is aligned with DWORD boundary.
         }
         private const int CODEPAGE_DATA_FILE_HEADER_SIZE = 44;
-        internal static unsafe void ReadCodePageDataFileHeader(Stream stream, byte[] codePageDataFileHeader)
+        private static unsafe void ReadCodePageDataFileHeader(Stream stream, byte[] codePageDataFileHeader)
         {
-            stream.Read(codePageDataFileHeader, 0, codePageDataFileHeader.Length);
+            Debug.Assert(stream is UnmanagedMemoryStream, "UnmanagedMemoryStream will read a full buffer on one call to Read.");
+            int bytesRead = stream.Read(codePageDataFileHeader, 0, codePageDataFileHeader.Length);
+            Debug.Assert(bytesRead == codePageDataFileHeader.Length);
+
             if (!BitConverter.IsLittleEndian)
             {
                 fixed (byte* pBytes = &codePageDataFileHeader[0])
@@ -135,9 +138,12 @@ namespace System.Text
             [FieldOffset(0x24)]
             internal int Offset;            // DWORD
         }
-        internal static unsafe void ReadCodePageIndex(Stream stream, byte[] codePageIndex)
+        private static unsafe void ReadCodePageIndex(Stream stream, byte[] codePageIndex)
         {
-            stream.Read(codePageIndex, 0, codePageIndex.Length);
+            Debug.Assert(stream is UnmanagedMemoryStream, "UnmanagedMemoryStream will read a full buffer on one call to Read.");
+            int bytesRead = stream.Read(codePageIndex, 0, codePageIndex.Length);
+            Debug.Assert(bytesRead == codePageIndex.Length);
+
             if (!BitConverter.IsLittleEndian)
             {
                 fixed (byte* pBytes = &codePageIndex[0])
@@ -146,7 +152,7 @@ namespace System.Text
                     char *pCodePageName = &p->CodePageName;
                     for (int i = 0; i < 16; i++)
                     {
-                            pCodePageName[i] = (char)BinaryPrimitives.ReverseEndianness((ushort)pCodePageName[i]);
+                        pCodePageName[i] = (char)BinaryPrimitives.ReverseEndianness((ushort)pCodePageName[i]);
                     }
                     p->CodePage = BinaryPrimitives.ReverseEndianness(p->CodePage);
                     p->ByteCount = BinaryPrimitives.ReverseEndianness(p->ByteCount);
@@ -178,9 +184,12 @@ namespace System.Text
             internal ushort ByteReplace;    // WORD     // default replacement bytes
         }
         private const int CODEPAGE_HEADER_SIZE = 48;
-        internal static unsafe void ReadCodePageHeader(Stream stream, byte[] codePageHeader)
+        private static unsafe void ReadCodePageHeader(Stream stream, byte[] codePageHeader)
         {
-            stream.Read(codePageHeader, 0, codePageHeader!.Length);
+            Debug.Assert(stream is UnmanagedMemoryStream, "UnmanagedMemoryStream will read a full buffer on one call to Read.");
+            int bytesRead = stream.Read(codePageHeader, 0, codePageHeader!.Length);
+            Debug.Assert(bytesRead == codePageHeader.Length);
+
             if (!BitConverter.IsLittleEndian)
             {
                 fixed (byte* pBytes = &codePageHeader[0])

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/BaseCodePageEncoding.netcoreapp.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/BaseCodePageEncoding.netcoreapp.cs
@@ -1,18 +1,22 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO;
 using System.Buffers.Binary;
-using System.Runtime.Serialization;
+using System.Diagnostics;
+using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
 
 namespace System.Text
 {
     internal abstract partial class BaseCodePageEncoding : EncodingNLS, ISerializable
     {
-        internal static unsafe void ReadCodePageIndex(Stream stream, Span<byte> codePageIndex)
+        private static unsafe void ReadCodePageIndex(Stream stream, Span<byte> codePageIndex)
         {
-            stream.Read(codePageIndex);
+            Debug.Assert(stream is UnmanagedMemoryStream, "UnmanagedMemoryStream will read a full buffer on one call to Read.");
+            int bytesRead = stream.Read(codePageIndex);
+            Debug.Assert(bytesRead == codePageIndex.Length);
+
             if (!BitConverter.IsLittleEndian)
             {
                 fixed (byte* pBytes = &codePageIndex[0])
@@ -21,7 +25,7 @@ namespace System.Text
                     char *pCodePageName = &p->CodePageName;
                     for (int i = 0; i < 16; i++)
                     {
-                            pCodePageName[i] = (char)BinaryPrimitives.ReverseEndianness((ushort)pCodePageName[i]);
+                        pCodePageName[i] = (char)BinaryPrimitives.ReverseEndianness((ushort)pCodePageName[i]);
                     }
                     p->CodePage = BinaryPrimitives.ReverseEndianness(p->CodePage);
                     p->ByteCount = BinaryPrimitives.ReverseEndianness(p->ByteCount);

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/DBCSCodePageEncoding.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/DBCSCodePageEncoding.cs
@@ -135,7 +135,8 @@ namespace System.Text
                 lock (s_streamLock)
                 {
                     s_codePagesEncodingDataStream.Seek(m_firstDataWordOffset, SeekOrigin.Begin);
-                    s_codePagesEncodingDataStream.Read(buffer, 0, m_dataSize);
+                    int bytesRead = s_codePagesEncodingDataStream.Read(buffer, 0, m_dataSize);
+                    Debug.Assert(bytesRead == m_dataSize);
                 }
 
                 fixed (byte* pBuffer = buffer)
@@ -257,7 +258,8 @@ namespace System.Text
                     lock (s_streamLock)
                     {
                         s_codePagesEncodingDataStream.Seek(m_firstDataWordOffset, SeekOrigin.Begin);
-                        s_codePagesEncodingDataStream.Read(buffer, 0, m_dataSize);
+                        int bytesRead = s_codePagesEncodingDataStream.Read(buffer, 0, m_dataSize);
+                        Debug.Assert(bytesRead == m_dataSize);
                     }
 
                     fixed (byte* pBuffer = buffer)

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/DBCSCodePageEncoding.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/DBCSCodePageEncoding.cs
@@ -136,7 +136,7 @@ namespace System.Text
                 {
                     s_codePagesEncodingDataStream.Seek(m_firstDataWordOffset, SeekOrigin.Begin);
                     int bytesRead = s_codePagesEncodingDataStream.Read(buffer, 0, m_dataSize);
-                    Debug.Assert(bytesRead == m_dataSize);
+                    Debug.Assert(bytesRead == m_dataSize, "s_codePagesEncodingDataStream.Read should have read a full buffer.");
                 }
 
                 fixed (byte* pBuffer = buffer)
@@ -259,7 +259,7 @@ namespace System.Text
                     {
                         s_codePagesEncodingDataStream.Seek(m_firstDataWordOffset, SeekOrigin.Begin);
                         int bytesRead = s_codePagesEncodingDataStream.Read(buffer, 0, m_dataSize);
-                        Debug.Assert(bytesRead == m_dataSize);
+                        Debug.Assert(bytesRead == m_dataSize, "s_codePagesEncodingDataStream.Read should have read a full buffer.");
                     }
 
                     fixed (byte* pBuffer = buffer)

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/SBCSCodePageEncoding.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/SBCSCodePageEncoding.cs
@@ -99,7 +99,8 @@ namespace System.Text
                 lock (s_streamLock)
                 {
                     s_codePagesEncodingDataStream.Seek(m_firstDataWordOffset, SeekOrigin.Begin);
-                    s_codePagesEncodingDataStream.Read(buffer, 0, buffer.Length);
+                    int bytesRead = s_codePagesEncodingDataStream.Read(buffer, 0, buffer.Length);
+                    Debug.Assert(bytesRead == buffer.Length);
                 }
 
                 fixed (byte* pBuffer = &buffer[0])
@@ -162,7 +163,8 @@ namespace System.Text
                     lock (s_streamLock)
                     {
                         s_codePagesEncodingDataStream.Seek(m_firstDataWordOffset + 512, SeekOrigin.Begin);
-                        s_codePagesEncodingDataStream.Read(buffer, 0, buffer.Length);
+                        int bytesRead = s_codePagesEncodingDataStream.Read(buffer, 0, buffer.Length);
+                        Debug.Assert(bytesRead == buffer.Length);
                     }
 
                     fixed (byte* pBuffer = buffer)

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/SBCSCodePageEncoding.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/SBCSCodePageEncoding.cs
@@ -100,7 +100,7 @@ namespace System.Text
                 {
                     s_codePagesEncodingDataStream.Seek(m_firstDataWordOffset, SeekOrigin.Begin);
                     int bytesRead = s_codePagesEncodingDataStream.Read(buffer, 0, buffer.Length);
-                    Debug.Assert(bytesRead == buffer.Length);
+                    Debug.Assert(bytesRead == buffer.Length, "s_codePagesEncodingDataStream.Read should have read a full buffer.");
                 }
 
                 fixed (byte* pBuffer = &buffer[0])
@@ -164,7 +164,7 @@ namespace System.Text
                     {
                         s_codePagesEncodingDataStream.Seek(m_firstDataWordOffset + 512, SeekOrigin.Begin);
                         int bytesRead = s_codePagesEncodingDataStream.Read(buffer, 0, buffer.Length);
-                        Debug.Assert(bytesRead == buffer.Length);
+                        Debug.Assert(bytesRead == buffer.Length, "s_codePagesEncodingDataStream.Read should have read a full buffer.");
                     }
 
                     fixed (byte* pBuffer = buffer)


### PR DESCRIPTION
BaseCodePageEncoding is relying on Stream.Read to read a full buffer of data in a single read. This is safe to assume because the only stream ever used is an UnmanagedMemoryStream, which will just copy the data to the buffer.

Adding some asserts to the code to make this assumption explicit.