### PR TITLE
Move dead code removal in lower after last updategraph

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4977,9 +4977,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     fgDebugCheckLinks(compStressCompile(STRESS_REMORPH_TREES, 50));
 #endif
 
-    // Remove dead blocks
-    DoPhase(this, PHASE_REMOVE_DEAD_BLOCKS, &Compiler::fgRemoveDeadBlocks);
-
     // Dominator and reachability sets are no longer valid.
     fgDomsComputed = false;
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4965,7 +4965,7 @@ protected:
 
     void fgComputeReachability(); // Perform flow graph node reachability analysis.
 
-    void fgRemoveDeadBlocks(); // Identify and remove dead blocks.
+    bool fgRemoveDeadBlocks(); // Identify and remove dead blocks.
 
     BasicBlock* fgIntersectDom(BasicBlock* a, BasicBlock* b); // Intersect two immediate dominator sets.
 

--- a/src/coreclr/jit/compphases.h
+++ b/src/coreclr/jit/compphases.h
@@ -84,7 +84,6 @@ CompPhaseNameMacro(PHASE_OPTIMIZE_BRANCHES,      "Redundant branch opts",       
 CompPhaseNameMacro(PHASE_ASSERTION_PROP_MAIN,    "Assertion prop",                 "AST-PROP", false, -1, false)
 CompPhaseNameMacro(PHASE_OPT_UPDATE_FLOW_GRAPH,  "Update flow graph opt pass",     "UPD-FG-O", false, -1, false)
 CompPhaseNameMacro(PHASE_COMPUTE_EDGE_WEIGHTS2,  "Compute edge weights (2, false)","EDG-WGT2", false, -1, false)
-CompPhaseNameMacro(PHASE_REMOVE_DEAD_BLOCKS,     "Remove dead blocks",             "DEAD-BLK", false, -1, false)
 CompPhaseNameMacro(PHASE_INSERT_GC_POLLS,        "Insert GC Polls",                "GC-POLLS", false, -1, true)
 CompPhaseNameMacro(PHASE_DETERMINE_FIRST_COLD_BLOCK, "Determine first cold block", "COLD-BLK", false, -1, true)
 CompPhaseNameMacro(PHASE_RATIONALIZE,            "Rationalize IR",                 "RAT",      false, -1, false)

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -649,8 +649,10 @@ void Compiler::fgComputeReachability()
 //         be removed. For Arm32, do not remove BBJ_ALWAYS block of
 //         BBJ_CALLFINALLY/BBJ_ALWAYS pair.
 //
-void Compiler::fgRemoveDeadBlocks()
+bool Compiler::fgRemoveDeadBlocks()
 {
+    JITDUMP("\n*************** In fgRemoveDeadBlocks()");
+
     jitstd::list<BasicBlock*> worklist(jitstd::allocator<void>(getAllocator(CMK_Reachability)));
     worklist.push_back(fgFirstBB);
 
@@ -730,6 +732,7 @@ void Compiler::fgRemoveDeadBlocks()
     fgVerifyHandlerTab();
     fgDebugCheckBBlist(false);
 #endif // DEBUG
+    return changed;
 }
 
 //-------------------------------------------------------------

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6393,6 +6393,8 @@ PhaseStatus Lowering::DoPhase()
     {
         comp->optLoopsMarked = false;
         bool modified        = comp->fgUpdateFlowGraph();
+        modified |= comp->fgRemoveDeadBlocks();
+
         if (modified)
         {
             JITDUMP("had to run another liveness pass:\n");

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6401,6 +6401,11 @@ PhaseStatus Lowering::DoPhase()
             comp->fgLocalVarLiveness();
         }
     }
+    else
+    {
+        // If we are not optimizing, remove the dead blocks regardless.
+        comp->fgRemoveDeadBlocks();
+    }
 
     // Recompute local var ref counts again after liveness to reflect
     // impact of any dead code removal. Note this may leave us with


### PR DESCRIPTION
We perform "dead code removal" pass just before "gc poll insertion", but we should do it just after the last `updateFlowGraph()` happens which is inside lower. This PR moves the phase into lower eliminating some other dead blocks that were left behind because of which LSRA adds resolution moves in them.

![image](https://user-images.githubusercontent.com/12488060/168751784-48c3d8ea-ad96-46a2-a71b-3b1c5582d238.png)

See https://github.com/dotnet/runtime/pull/69041#issuecomment-1126587870 and https://github.com/dotnet/runtime/pull/69041#issuecomment-1128481537 for details.