### PR TITLE
Use span to pass type modifiers in RuntimeTypeHandle.GetTypeHelper

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -40,7 +40,7 @@ namespace System
         internal static extern bool IsInstanceOfType(RuntimeType type, [NotNullWhen(true)] object? o);
 
         [RequiresUnreferencedCode("MakeGenericType cannot be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.")]
-        internal static Type GetTypeHelper(Type typeStart, Type[]? genericArgs, IntPtr pModifiers, int cModifiers)
+        internal static Type GetTypeHelper(Type typeStart, Type[]? genericArgs, ReadOnlySpan<int> modifiers)
         {
             Type type = typeStart;
 
@@ -49,20 +49,16 @@ namespace System
                 type = type.MakeGenericType(genericArgs);
             }
 
-            if (cModifiers > 0)
+            for (int i = 0; i < modifiers.Length; i++)
             {
-                int* arModifiers = (int*)pModifiers.ToPointer();
-                for (int i = 0; i < cModifiers; i++)
-                {
-                    if ((CorElementType)Marshal.ReadInt32((IntPtr)arModifiers, i * sizeof(int)) == CorElementType.ELEMENT_TYPE_PTR)
-                        type = type.MakePointerType();
-                    else if ((CorElementType)Marshal.ReadInt32((IntPtr)arModifiers, i * sizeof(int)) == CorElementType.ELEMENT_TYPE_BYREF)
-                        type = type.MakeByRefType();
-                    else if ((CorElementType)Marshal.ReadInt32((IntPtr)arModifiers, i * sizeof(int)) == CorElementType.ELEMENT_TYPE_SZARRAY)
-                        type = type.MakeArrayType();
-                    else
-                        type = type.MakeArrayType(Marshal.ReadInt32((IntPtr)arModifiers, ++i * sizeof(int)));
-                }
+                if ((CorElementType)modifiers[i] == CorElementType.ELEMENT_TYPE_PTR)
+                    type = type.MakePointerType();
+                else if ((CorElementType)modifiers[i] == CorElementType.ELEMENT_TYPE_BYREF)
+                    type = type.MakeByRefType();
+                else if ((CorElementType)modifiers[i] == CorElementType.ELEMENT_TYPE_SZARRAY)
+                    type = type.MakeArrayType();
+                else
+                    type = type.MakeArrayType(modifiers[++i]);
             }
 
             return type;

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -51,7 +51,13 @@ namespace System
 
             for (int i = 0; i < modifiers.Length; i++)
             {
-                switch ((CorElementType)modifiers[i])
+                type = (CorElementType)modifiers[i] switch
+                {
+                    CorElementType.ELEMENT_TYPE_PTR => type.MakePointerType(),
+                    CorElementType.ELEMENT_TYPE_BYREF => type.MakeByRefType(),
+                    CorElementType.ELEMENT_TYPE_SZARRAY => type.MakeArrayType(),
+                    _ => type.MakeArrayType(modifiers[++i])
+                };
                 {
                     case CorElementType.ELEMENT_TYPE_PTR:
                         type = type.MakePointerType();

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -58,20 +58,6 @@ namespace System
                     CorElementType.ELEMENT_TYPE_SZARRAY => type.MakeArrayType(),
                     _ => type.MakeArrayType(modifiers[++i])
                 };
-                {
-                    case CorElementType.ELEMENT_TYPE_PTR:
-                        type = type.MakePointerType();
-                        break;
-                    case CorElementType.ELEMENT_TYPE_BYREF:
-                        type = type.MakeByRefType();
-                        break;
-                    case CorElementType.ELEMENT_TYPE_SZARRAY:
-                        type = type.MakeArrayType();
-                        break;
-                    default:
-                        type = type.MakeArrayType(modifiers[++i]);
-                        break;
-                }
             }
 
             return type;

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -40,6 +40,10 @@ namespace System
         internal static extern bool IsInstanceOfType(RuntimeType type, [NotNullWhen(true)] object? o);
 
         [RequiresUnreferencedCode("MakeGenericType cannot be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.")]
+        internal static Type GetTypeHelper(Type typeStart, Type[]? genericArgs, IntPtr pModifiers, int cModifiers) // called by VM
+            => GetTypeHelper(typeStart, genericArgs, new ReadOnlySpan<int>((void*)pModifiers, cModifiers));
+
+        [RequiresUnreferencedCode("MakeGenericType cannot be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.")]
         internal static Type GetTypeHelper(Type typeStart, Type[]? genericArgs, ReadOnlySpan<int> modifiers)
         {
             Type type = typeStart;

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -51,14 +51,21 @@ namespace System
 
             for (int i = 0; i < modifiers.Length; i++)
             {
-                if ((CorElementType)modifiers[i] == CorElementType.ELEMENT_TYPE_PTR)
-                    type = type.MakePointerType();
-                else if ((CorElementType)modifiers[i] == CorElementType.ELEMENT_TYPE_BYREF)
-                    type = type.MakeByRefType();
-                else if ((CorElementType)modifiers[i] == CorElementType.ELEMENT_TYPE_SZARRAY)
-                    type = type.MakeArrayType();
-                else
-                    type = type.MakeArrayType(modifiers[++i]);
+                switch ((CorElementType)modifiers[i])
+                {
+                    case CorElementType.ELEMENT_TYPE_PTR:
+                        type = type.MakePointerType();
+                        break;
+                    case CorElementType.ELEMENT_TYPE_BYREF:
+                        type = type.MakeByRefType();
+                        break;
+                    case CorElementType.ELEMENT_TYPE_SZARRAY:
+                        type = type.MakeArrayType();
+                        break;
+                    default:
+                        type = type.MakeArrayType(modifiers[++i]);
+                        break;
+                }
             }
 
             return type;

--- a/src/coreclr/System.Private.CoreLib/src/System/TypeNameParser.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/TypeNameParser.cs
@@ -174,12 +174,7 @@ namespace System
             }
 
             int[]? modifiers = GetModifiers();
-
-            fixed (int* ptr = modifiers)
-            {
-                IntPtr intPtr = new IntPtr(ptr);
-                return RuntimeTypeHandle.GetTypeHelper(baseType, types!, intPtr, modifiers == null ? 0 : modifiers.Length);
-            }
+            return RuntimeTypeHandle.GetTypeHelper(baseType, types!, modifiers);
         }
 
         private static Assembly? ResolveAssembly(string asmName, Func<AssemblyName, Assembly?>? assemblyResolver, bool throwOnError, ref StackCrawlMark stackMark)


### PR DESCRIPTION
It's the last remaining usage of `Marshal.ReadIntX` in CoreLib.
Should also prevents an array overrun if the native parser returns malformed modifiers.