### PR TITLE
Fix executable memory reservation when range is not requested

### DIFF
--- a/src/coreclr/minipal/Unix/doublemapping.cpp
+++ b/src/coreclr/minipal/Unix/doublemapping.cpp
@@ -118,34 +118,42 @@ void* VMToOSInterface::ReserveDoubleMappedMemory(void *mapperHandle, size_t offs
 {
     int fd = (int)(size_t)mapperHandle;
 
-    if (rangeStart != NULL || rangeEnd != NULL)
+    bool isUnlimitedRange = (rangeStart == NULL) && (rangeEnd == NULL);
+
+    if (isUnlimitedRange)
     {
-        void* result = PAL_VirtualReserveFromExecutableMemoryAllocatorWithinRange(rangeStart, rangeEnd, size);
+        rangeEnd = (void*)SIZE_MAX;
+    }
+
+    void* result = PAL_VirtualReserveFromExecutableMemoryAllocatorWithinRange(rangeStart, rangeEnd, size);
 #ifndef TARGET_OSX
-        if (result != NULL)
+    if (result != NULL)
+    {
+        // Map the shared memory over the range reserved from the executable memory allocator.
+        result = mmap(result, size, PROT_NONE, MAP_SHARED | MAP_FIXED, fd, offset);
+        if (result == MAP_FAILED)
         {
-            // Map the shared memory over the range reserved from the executable memory allocator.
-            result = mmap(result, size, PROT_NONE, MAP_SHARED | MAP_FIXED, fd, offset);
-            if (result == MAP_FAILED)
-            {
-                assert(false);
-                result = NULL;
-            }
+            assert(false);
+            result = NULL;
         }
+    }
 #endif // TARGET_OSX
 
+    // For requests with limited range, don't try to fall back to reserving at any address
+    if ((result != NULL) || !isUnlimitedRange)
+    {
         return result;
     }
 
 #ifndef TARGET_OSX
-    void* result = mmap(NULL, size, PROT_NONE, MAP_SHARED, fd, offset);
+    result = mmap(NULL, size, PROT_NONE, MAP_SHARED, fd, offset);
 #else
     int mmapFlags = MAP_ANON | MAP_PRIVATE;
     if (IsMapJitFlagNeeded())
     {
         mmapFlags |= MAP_JIT;
     }
-    void* result = mmap(NULL, size, PROT_NONE, mmapFlags, -1, 0);
+    result = mmap(NULL, size, PROT_NONE, mmapFlags, -1, 0);
 #endif    
     if (result == MAP_FAILED)
     {


### PR DESCRIPTION
The VMToOSInterface::ReserveDoubleMappedMemory on Unix currently
doesn't use the range of memory reserved for executable purposes
in PAL in case there was no specific range of memory requested.
This is incorrect and it leads to steady state performance
degradation when W^X is enabled.

This change fixes it by using the PAL reserved memory even for
requests without specified range. This makes the steady state
performance the same both with and without W^X enabled.
This is very well visible on the Orchards and Fortunes benchmarks
performance where the regression was 17% resp 12% with W^X enabled.