### PR TITLE
Reuse the throw away buffer in ZipHelper

### DIFF
--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
@@ -163,14 +163,18 @@ namespace System.IO.Compression
         {
             long numBytesLeft = position - stream.Position;
             Debug.Assert(numBytesLeft >= 0);
-            while (numBytesLeft != 0)
+            if (numBytesLeft > 0)
             {
                 const int throwAwayBufferSize = 64;
-                int numBytesToSkip = (numBytesLeft > throwAwayBufferSize) ? throwAwayBufferSize : (int)numBytesLeft;
-                int numBytesActuallySkipped = stream.Read(new byte[throwAwayBufferSize], 0, numBytesToSkip);
-                if (numBytesActuallySkipped == 0)
-                    throw new IOException(SR.UnexpectedEndOfStream);
-                numBytesLeft -= numBytesActuallySkipped;
+                byte[] throwAwayBuffer = new byte[throwAwayBufferSize];
+                do
+                {
+                    int numBytesToSkip = (numBytesLeft > throwAwayBufferSize) ? throwAwayBufferSize : (int)numBytesLeft;
+                    int numBytesActuallySkipped = stream.Read(throwAwayBuffer, 0, numBytesToSkip);
+                    if (numBytesActuallySkipped == 0)
+                        throw new IOException(SR.UnexpectedEndOfStream);
+                    numBytesLeft -= numBytesActuallySkipped;
+                } while (numBytesLeft > 0);
             }
         }
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
@@ -165,12 +165,11 @@ namespace System.IO.Compression
             Debug.Assert(numBytesLeft >= 0);
             if (numBytesLeft > 0)
             {
-                const int throwAwayBufferSize = 64;
-                byte[] throwAwayBuffer = new byte[throwAwayBufferSize];
+                byte[] buffer = new byte[64];
                 do
                 {
-                    int numBytesToSkip = (numBytesLeft > throwAwayBufferSize) ? throwAwayBufferSize : (int)numBytesLeft;
-                    int numBytesActuallySkipped = stream.Read(throwAwayBuffer, 0, numBytesToSkip);
+                    int numBytesToSkip = (int)Math.Min(numBytesLeft, buffer.Length);
+                    int numBytesActuallySkipped = stream.Read(buffer, 0, numBytesToSkip);
                     if (numBytesActuallySkipped == 0)
                         throw new IOException(SR.UnexpectedEndOfStream);
                     numBytesLeft -= numBytesActuallySkipped;


### PR DESCRIPTION
ZipHelper.AdvanceToPosition was allocating a new temporary buffer every time through the loop while reading from the stream. Changing the code to reuse the same buffer through the loop.

### Benchmark

<details><summary>Code</summary>
<p>

```C#
using BenchmarkDotNet.Attributes;
using System.IO.Compression;

namespace Benchmark;

[MemoryDiagnoser]
public class ZipArchiveBenchmark
{
    [Benchmark]
    public ZipArchiveEntry ReadZipContainingExtraFields()
    {
        ZipArchive archive = new(new MemoryStream(s_Zip64Data));
        return archive.GetEntry("file.txt");
    }

    private static readonly byte[] s_Zip64Data =
    {
        // ===== Local file header signature 0x04034b50
        0x50, 0x4b, 0x03, 0x04,
        // version to extract 4.5
        0x2d, 0x00,
        // general purpose flags
        0x00, 0x08,   // 0000_1000 'for enhanced deflating'
        // Deflate
        0x08, 0x00,
        // Last mod file time
        0x17, 0x9b,
        // Last mod date
        0x6d, 0x52,
        // CRC32
        0x0c, 0x7e, 0x7f, 0xd8,
        // compressed size
        0xff, 0xff, 0xff, 0xff,
        // UNcompressed size
        0xff, 0xff, 0xff, 0xff,
        // file name length
        0x08, 0x00,
        // extra field length
        0x38, 0x00,
        // filename
        0x66, 0x69, 0x6c, 0x65, 0x2e, 0x74, 0x78, 0x74,
        // -----Zip64 extra field tag
        0x01, 0x00,
        // size of extra field block
        0x10, 0x00,
                // 8 byte Zip64 UNcompressed size, index 42
                0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                // 8 byte Zip64 compressed size, index 50
                0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
        // ----- NTFS extra field tag
        0x0a, 0x00,
        // size of extra field block
        0x20, 0x00,
                // reserved
                0x00, 0x00, 0x00, 0x00,
                // tag #1
                0x01, 0x00,
                // size of tag #1
                0x18, 0x00,
                        // Mtime, CTime, Atime
                        0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                        0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                        0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
        // -------------
        // Data!
        0x2b, 0x49, 0x2d, 0x2e, 0x01, 0x00,
        // -------- Central directory signature 0x02014b50
        0x50, 0x4b, 0x01, 0x02,
        // version made by 4.5
        0x2d, 0x00,
        // version to extract 4.5
        0x2d, 0x00,
        // general purpose flags
        0x00, 0x08,
        // Deflate
        0x08, 0x00,
        // Last mod file time
        0x17, 0x9b,
        // Last mod date
        0x6d, 0x52,
        // CRC32
        0x0c, 0x7e, 0x7f, 0xd8,
        // 4 byte compressed size, index 120 (-1 indicates refer to Zip64 extra field)
        0xff, 0xff, 0xff, 0xff,
        // 4 byte UNcompressed size, index 124 (-1 indicates refer to Zip64 extra field)
        0xff, 0xff, 0xff, 0xff,
        // file name length
        0x08, 0x00,
        // extra field length
        0x08, 0x04,
        // file comment length
        0x00, 0x00,
        // disk number start (-1 indicates refer to Zip64 extra field)
        0x00, 0x00,
        // internal file attributes
        0x00, 0x00,
        // external file attributes
        0x00, 0x00, 0x00, 0x00,
        // relative offset of local header (-1 indicates refer to Zip64 extra field)
        0x00, 0x00, 0x00, 0x00,
        // file name
        0x66, 0x69, 0x6c, 0x65, 0x2e, 0x74, 0x78, 0x74,
        // extra field, content similar to before
        0x01, 0x00,
        0x1c, 0x00,
                0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                0x00, 0x00, 0x00, 0x00,
        0x0a, 0x00,
        0x20, 0x00,
                0x00, 0x00, 0x00, 0x00,
                0x01, 0x00, 0x18, 0x00,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
        // A MADE-UP EXTRA FIELD THAT NEEDS TO BE SKIPPED
        0x07, 0x00,
        0xC0, 0x03,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0x00, 0x00, 0x00, 0x00 ,0x25, 0x18, 0xd7, 0x01,
                0x01, 0x00, 0x18, 0x00, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
                0xa8, 0xb1, 0xf6, 0x61, 0x25, 0x18, 0xd7, 0x01,
        // == 'end of zip64 central directory record' signature 0x06064b50
        0x50, 0x4b, 0x06, 0x06,
        // size
        0x2c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                // version made by, version needed
                0x2d, 0x00, 0x2d, 0x00,
                // disk number, disk number with CD
                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                // total number of CD records
                0x01, 0x00, 0x00, 0x00,
                // size of CD
                0x00, 0x00, 0x00, 0x00,
                // offset of start of CD wrt starting disk
                0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                // zip64 extensible data sector
                0x7a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
        // == 'zip64 end of CD locator' signature 0x07064b50
        0x50, 0x4b, 0x06, 0x07,
        // number of disk with zip64 CD
        0x00, 0x00, 0x00, 0x00,
        // relative offset of zip64 ECD
        0xa2, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
        // total number of disks
        0x01, 0x00, 0x00, 0x00,
        // == 'end of CD' signature 0x06054b50
        0x50, 0x4b, 0x05, 0x06,
        // disk number, disk number with CD (-1 indicates refer to Zip64 extra field)
        0x00, 0x00,
        0x00, 0x00,
        // total number of entries in CD on this disk, and overall  (-1 indicates refer to Zip64 extra fields)
        0xff, 0xff,
        0xff, 0xff,
        // size of CD (-1 indicates refer to Zip64 extra field)
        0x7a, 0x00, 0x00, 0x00,
        // offset of start of CD wrt start disk (-1 indicates refer to Zip64 extra field)
        0x64, 0x00, 0x00, 0x00,
        // comment length
        0x00, 0x00
    };
}
```

</p>
</details>


### Results

```
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1706 (21H1/May2021Update)
Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK=6.0.300
  [Host]     : .NET 6.0.5 (6.0.522.21309), X64 RyuJIT
  Job-KPZXDU : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT
  Job-FWBHEB : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT
```

|                       Method |        Job |         Toolchain |       Mean |    Error |   StdDev | Ratio |  Gen 0 |  Gen 1 | Allocated |
|----------------------------- |----------- |------------------ |-----------:|---------:|---------:|------:|-------:|-------:|----------:|
| ReadZipContainingExtraFields | Job-KPZXDU | \main\corerun.exe | 1,082.0 ns | 16.70 ns | 15.62 ns |  1.00 | 0.4692 | 0.0038 |      3 KB |
| ReadZipContainingExtraFields | Job-FWBHEB |   \pr\corerun.exe |   968.6 ns |  3.66 ns |  3.06 ns |  0.90 | 0.2575 | 0.0019 |      2 KB |