### PR TITLE
[wasm][wbt] Test that `dotnet.js` could be run from any current directory

### DIFF
--- a/eng/testing/scenarios/BuildWasmAppsJobsList.txt
+++ b/eng/testing/scenarios/BuildWasmAppsJobsList.txt
@@ -6,6 +6,7 @@ Wasm.Build.Tests.BlazorWasmBuildPublishTests
 Wasm.Build.Tests.BlazorWasmTests
 Wasm.Build.Tests.BuildPublishTests
 Wasm.Build.Tests.CleanTests
+Wasm.Build.Tests.ConfigSrcTests
 Wasm.Build.Tests.InvariantGlobalizationTests
 Wasm.Build.Tests.LocalEMSDKTests
 Wasm.Build.Tests.MainWithArgsTests
@@ -17,4 +18,5 @@ Wasm.Build.Tests.SatelliteAssembliesTests
 Wasm.Build.Tests.WasmBuildAppTest
 Wasm.Build.Tests.WasmNativeDefaultsTests
 Wasm.Build.Tests.WorkloadTests
+Wasm.Build.Tests.WasmRunOutOfAppBundleTests
 Wasm.Build.Tests.WasmTemplateTests

--- a/src/mono/wasm/test-main.js
+++ b/src/mono/wasm/test-main.js
@@ -362,7 +362,7 @@ Promise.all([argsPromise, loadDotnetPromise]).then(async ([_, createDotnetRuntim
     return createDotnetRuntime(({ MONO, INTERNAL, BINDING, IMPORTS, EXPORTS, Module }) => ({
         disableDotnet6Compatibility: true,
         config: null,
-        configSrc: runArgs.configSrc,
+        configSrc: runArgs.configSrc || "./mono-config.json",
         onConfigLoaded: (config) => {
             if (!Module.config) {
                 const err = new Error("Could not find ./mono-config.json. Cancelling run");

--- a/src/mono/wasm/test-main.js
+++ b/src/mono/wasm/test-main.js
@@ -166,6 +166,7 @@ function initRunArgs() {
     runArgs.enableGC = runArgs.enableGC === undefined ? true : runArgs.enableGC;
     runArgs.diagnosticTracing = runArgs.diagnosticTracing === undefined ? false : runArgs.diagnosticTracing;
     runArgs.debugging = runArgs.debugging === undefined ? false : runArgs.debugging;
+    runArgs.configSrc = runArgs.configSrc === undefined ? './mono-config.json' : runArgs.configSrc;
     // default'ing to true for tests, unless debugging
     runArgs.forwardConsole = runArgs.forwardConsole === undefined ? !runArgs.debugging : runArgs.forwardConsole;
 }
@@ -217,6 +218,12 @@ function processQueryArguments(incomingArguments) {
             } else {
                 console.warn("--fetch-random-delay only works on browser")
             }
+        } else if (currentArg.startsWith("--config-src=")) {
+            const arg = currentArg.substring("--config-src=".length);
+            runArgs.configSrc = arg;
+        } else if (currentArg == ("--deep-work-dir")) {
+            // PR: https://github.com/dotnet/runtime/pull/69441
+            // NOP
         } else {
             break;
         }
@@ -355,7 +362,7 @@ Promise.all([argsPromise, loadDotnetPromise]).then(async ([_, createDotnetRuntim
     return createDotnetRuntime(({ MONO, INTERNAL, BINDING, IMPORTS, EXPORTS, Module }) => ({
         disableDotnet6Compatibility: true,
         config: null,
-        configSrc: "./mono-config.json",
+        configSrc: runArgs.configSrc,
         onConfigLoaded: (config) => {
             if (!Module.config) {
                 const err = new Error("Could not find ./mono-config.json. Cancelling run");

--- a/src/mono/wasm/test-main.js
+++ b/src/mono/wasm/test-main.js
@@ -221,9 +221,6 @@ function processQueryArguments(incomingArguments) {
         } else if (currentArg.startsWith("--config-src=")) {
             const arg = currentArg.substring("--config-src=".length);
             runArgs.configSrc = arg;
-        } else if (currentArg == ("--deep-work-dir")) {
-            // PR: https://github.com/dotnet/runtime/pull/69441
-            // NOP
         } else {
             break;
         }

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
@@ -134,7 +134,8 @@ namespace Wasm.Build.Tests
                                            string? args = null,
                                            Dictionary<string, string>? envVars = null,
                                            string targetFramework = DefaultTargetFramework,
-                                           string? extraXHarnessMonoArgs = null)
+                                           string? extraXHarnessMonoArgs = null,
+                                           string jsRelativePath = "test-main.js")
         {
             buildDir ??= _projectDir;
             envVars ??= new();
@@ -151,22 +152,14 @@ namespace Wasm.Build.Tests
                     envVars[kvp.Key] = kvp.Value;
             }
 
-            bool runDeepWorkDir = false;
-            if (extraXHarnessMonoArgs?.Contains("--deep-work-dir") ?? false)
-            {
-                runDeepWorkDir = true;
-            }
-
             string bundleDir = Path.Combine(GetBinDir(baseDir: buildDir, config: buildArgs.Config, targetFramework: targetFramework), "AppBundle");
 
             // Use wasm-console.log to get the xharness output for non-browser cases
-            (string testCommand, string extraXHarnessArgs, bool useWasmConsoleOutput) = (host, runDeepWorkDir) switch
+            (string testCommand, string extraXHarnessArgs, bool useWasmConsoleOutput) = host switch
             {
-                (RunHost.V8, false)     => ("wasm test", "--js-file=test-main.js --engine=V8 -v trace", true),
-                (RunHost.V8, true)      => ("wasm test", "--js-file=AppBundle/test-main.js --engine=V8 -v trace", true),
-                (RunHost.NodeJS, false) => ("wasm test", "--js-file=test-main.js --engine=NodeJS -v trace", true),
-                (RunHost.NodeJS, true)  => ("wasm test", "--js-file=AppBundle/test-main.js --engine=NodeJS -v trace", true),
-                _                       => ("wasm test-browser", $"-v trace -b {host} --web-server-use-cop", false)
+                RunHost.V8     => ("wasm test", $"--js-file={jsRelativePath} --engine=V8 -v trace", true),
+                RunHost.NodeJS => ("wasm test", $"--js-file={jsRelativePath} --engine=NodeJS -v trace", true),
+                _              => ("wasm test-browser", $"-v trace -b {host} --web-server-use-cop", false)
             };
 
             string testLogPath = Path.Combine(_logPath, host.ToString());

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
@@ -130,6 +130,7 @@ namespace Wasm.Build.Tests
                                            string id,
                                            Action<string>? test=null,
                                            string? buildDir = null,
+                                           string? bundleDir = null,
                                            int expectedExitCode = 0,
                                            string? args = null,
                                            Dictionary<string, string>? envVars = null,
@@ -152,7 +153,7 @@ namespace Wasm.Build.Tests
                     envVars[kvp.Key] = kvp.Value;
             }
 
-            string bundleDir = Path.Combine(GetBinDir(baseDir: buildDir, config: buildArgs.Config, targetFramework: targetFramework), "AppBundle");
+            bundleDir ??= Path.Combine(GetBinDir(baseDir: buildDir, config: buildArgs.Config, targetFramework: targetFramework), "AppBundle");
 
             // Use wasm-console.log to get the xharness output for non-browser cases
             (string testCommand, string extraXHarnessArgs, bool useWasmConsoleOutput) = host switch

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/ConfigSrcTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/ConfigSrcTests.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+#nullable enable
+
+namespace Wasm.Build.Tests
+{
+    public class ConfigSrcTests : BuildTestBase
+    {
+        public ConfigSrcTests(ITestOutputHelper output, SharedBuildPerTestClassFixture buildContext) : base(output, buildContext)
+        {}
+
+        // NOTE: port number determinizes dynamically, so could not generate absolute URI
+        [Theory]
+        [BuildAndRun(aot: false, host: RunHost.V8)]
+        [BuildAndRun(aot: true, host: RunHost.V8)]
+        [BuildAndRun(aot: false, host: RunHost.NodeJS)]
+        [BuildAndRun(aot: true, host: RunHost.NodeJS)]
+        public void ConfigSrcAbsolutePath(BuildArgs buildArgs, RunHost host, string id)
+        {
+            buildArgs = buildArgs with { ProjectName = $"configsrcabsolute_{buildArgs.Config}_{buildArgs.AOT}" };
+            buildArgs = ExpandBuildArgs(buildArgs);
+
+            BuildProject(buildArgs,
+                            id: id,
+                            new BuildProjectOptions(
+                                InitProject: () => File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), s_mainReturns42),
+                                DotnetWasmFromRuntimePack: !(buildArgs.AOT || buildArgs.Config == "Release")));
+
+            string binDir = GetBinDir(baseDir: _projectDir!, config: buildArgs.Config);
+            string bundleDir = Path.Combine(binDir, "AppBundle");
+            string configSrc = Path.GetFullPath(Path.Combine(bundleDir, "mono-config.json"));
+
+            RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id, extraXHarnessMonoArgs: $"--config-src={configSrc}");
+        }
+    }
+}

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/ConfigSrcTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/ConfigSrcTests.cs
@@ -7,32 +7,31 @@ using Xunit.Abstractions;
 
 #nullable enable
 
-namespace Wasm.Build.Tests
+namespace Wasm.Build.Tests;
+
+public class ConfigSrcTests : BuildTestBase
 {
-    public class ConfigSrcTests : BuildTestBase
+    public ConfigSrcTests(ITestOutputHelper output, SharedBuildPerTestClassFixture buildContext) : base(output, buildContext)
+    {}
+
+    // NOTE: port number determinizes dynamically, so could not generate absolute URI
+    [Theory]
+    [BuildAndRun(host: RunHost.V8 | RunHost.NodeJS)]
+    public void ConfigSrcAbsolutePath(BuildArgs buildArgs, RunHost host, string id)
     {
-        public ConfigSrcTests(ITestOutputHelper output, SharedBuildPerTestClassFixture buildContext) : base(output, buildContext)
-        {}
+        buildArgs = buildArgs with { ProjectName = $"configsrcabsolute_{buildArgs.Config}_{buildArgs.AOT}" };
+        buildArgs = ExpandBuildArgs(buildArgs);
 
-        // NOTE: port number determinizes dynamically, so could not generate absolute URI
-        [Theory]
-        [BuildAndRun(host: RunHost.V8 | RunHost.NodeJS)]
-        public void ConfigSrcAbsolutePath(BuildArgs buildArgs, RunHost host, string id)
-        {
-            buildArgs = buildArgs with { ProjectName = $"configsrcabsolute_{buildArgs.Config}_{buildArgs.AOT}" };
-            buildArgs = ExpandBuildArgs(buildArgs);
+        BuildProject(buildArgs,
+                        id: id,
+                        new BuildProjectOptions(
+                            InitProject: () => File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), s_mainReturns42),
+                            DotnetWasmFromRuntimePack: !(buildArgs.AOT || buildArgs.Config == "Release")));
 
-            BuildProject(buildArgs,
-                            id: id,
-                            new BuildProjectOptions(
-                                InitProject: () => File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), s_mainReturns42),
-                                DotnetWasmFromRuntimePack: !(buildArgs.AOT || buildArgs.Config == "Release")));
+        string binDir = GetBinDir(baseDir: _projectDir!, config: buildArgs.Config);
+        string bundleDir = Path.Combine(binDir, "AppBundle");
+        string configSrc = Path.GetFullPath(Path.Combine(bundleDir, "mono-config.json"));
 
-            string binDir = GetBinDir(baseDir: _projectDir!, config: buildArgs.Config);
-            string bundleDir = Path.Combine(binDir, "AppBundle");
-            string configSrc = Path.GetFullPath(Path.Combine(bundleDir, "mono-config.json"));
-
-            RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id, extraXHarnessMonoArgs: $"--config-src={configSrc}");
-        }
+        RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id, extraXHarnessMonoArgs: $"--config-src={configSrc}");
     }
 }

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/ConfigSrcTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/ConfigSrcTests.cs
@@ -16,10 +16,7 @@ namespace Wasm.Build.Tests
 
         // NOTE: port number determinizes dynamically, so could not generate absolute URI
         [Theory]
-        [BuildAndRun(aot: false, host: RunHost.V8)]
-        [BuildAndRun(aot: true, host: RunHost.V8)]
-        [BuildAndRun(aot: false, host: RunHost.NodeJS)]
-        [BuildAndRun(aot: true, host: RunHost.NodeJS)]
+        [BuildAndRun(host: RunHost.V8 | RunHost.NodeJS)]
         public void ConfigSrcAbsolutePath(BuildArgs buildArgs, RunHost host, string id)
         {
             buildArgs = buildArgs with { ProjectName = $"configsrcabsolute_{buildArgs.Config}_{buildArgs.AOT}" };

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/WasmRunOutOfAppBundleTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/WasmRunOutOfAppBundleTests.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+#nullable enable
+
+namespace Wasm.Build.Tests
+{
+    public class WasmRunOutOfAppBundleTests : BuildTestBase
+    {
+        public WasmRunOutOfAppBundleTests(ITestOutputHelper output, SharedBuildPerTestClassFixture buildContext) : base(output, buildContext)
+        {}
+
+        [Theory]
+        [BuildAndRun(aot: false, host: RunHost.V8)]
+        [BuildAndRun(aot: true, host: RunHost.V8)]
+        [BuildAndRun(aot: false, host: RunHost.Chrome)]
+        [BuildAndRun(aot: true, host: RunHost.Chrome)]
+        [BuildAndRun(aot: false, host: RunHost.NodeJS)]
+        [BuildAndRun(aot: true, host: RunHost.NodeJS)]
+        public void RunOutOfAppBundle(BuildArgs buildArgs, RunHost host, string id)
+        {
+            buildArgs = buildArgs with { ProjectName = $"outofappbundle_{buildArgs.Config}_{buildArgs.AOT}" };
+            buildArgs = ExpandBuildArgs(buildArgs);
+
+            BuildProject(buildArgs,
+                            id: id,
+                            new BuildProjectOptions(
+                                InitProject: () => File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), s_mainReturns42),
+                                DotnetWasmFromRuntimePack: !(buildArgs.AOT || buildArgs.Config == "Release"),
+                                UseCache: false));
+
+            string binDir = GetBinDir(baseDir: _projectDir!, config: buildArgs.Config);
+            string baseBundleDir = Path.Combine(binDir, "AppBundle");
+            string tmpBundleDir = Path.Combine(binDir, "AppBundleTmp");
+            string deepBundleDir = Path.Combine(baseBundleDir, "AppBundle");
+
+            Directory.Move(baseBundleDir, tmpBundleDir);
+            Directory.CreateDirectory(baseBundleDir);
+
+            // Create $binDir/AppBundle/AppBundle
+            Directory.Move(tmpBundleDir, deepBundleDir);
+
+            if (host == RunHost.Chrome)
+            {
+                string indexHtmlPath = Path.Combine(baseBundleDir, "index.html");
+                if (!File.Exists(indexHtmlPath))
+                {
+                    var html = @"<html><body><script type=""module"" src=""AppBundle/test-main.js""></script></body></html>";
+                    File.WriteAllText(indexHtmlPath, html);
+                }
+            }
+
+            RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id, extraXHarnessMonoArgs: "--deep-work-dir");
+        }
+    }
+}

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/WasmRunOutOfAppBundleTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/WasmRunOutOfAppBundleTests.cs
@@ -29,38 +29,28 @@ public class WasmRunOutOfAppBundleTests : BuildTestBase
 
         string binDir = GetBinDir(baseDir: _projectDir!, config: buildArgs.Config);
         string appBundleDir = Path.Combine(binDir, "AppBundle");
-        string tmpBundleDirName = "AppBundleTmp";
-        string tmpBundleDir = Path.Combine(binDir, tmpBundleDirName);
+        string outerDir = Path.GetFullPath(Path.Combine(appBundleDir, ".."));
 
-        string tmpDir = Path.Combine(Path.GetTempPath(), $"{id}-{buildArgs.ProjectName}");
-
-        if (host == RunHost.Chrome)
+        if (host is RunHost.Chrome)
         {
-            Directory.Move(appBundleDir, tmpBundleDir);
-            Directory.CreateDirectory(appBundleDir);
-            // Create $binDir/AppBundle/AppBundle
-            Directory.Move(tmpBundleDir, Path.Combine(appBundleDir, "AppBundle"));
-
             string indexHtmlPath = Path.Combine(appBundleDir, "index.html");
+            // Delete the original one, so we don't use that by accident
+            if (File.Exists(indexHtmlPath))
+                File.Delete(indexHtmlPath);
+
+            indexHtmlPath = Path.Combine(outerDir, "index.html");
             if (!File.Exists(indexHtmlPath))
             {
                 var html = @"<html><body><script type=""module"" src=""./AppBundle/test-main.js""></script></body></html>";
                 File.WriteAllText(indexHtmlPath, html);
             }
-        } else {
-            Utils.DirectoryCopy(appBundleDir, tmpDir);
         }
 
-        RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id, jsRelativePath: Path.Combine(tmpDir, "test-main.js"));
-
-        // Restore AppBundle Dir
-        if (host == RunHost.Chrome)
-        {
-            Directory.Move(Path.Combine(appBundleDir, "AppBundle"), tmpBundleDir);
-            Directory.Delete(appBundleDir, true);
-            Directory.Move(tmpBundleDir, appBundleDir);
-        } else {
-            Directory.Delete(tmpDir, true);
-        }
+        RunAndTestWasmApp(buildArgs,
+                            expectedExitCode: 42,
+                            host: host,
+                            id: id,
+                            bundleDir: outerDir,
+                            jsRelativePath: "./AppBundle/test-main.js");
     }
 }

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/WasmRunOutOfAppBundleTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/WasmRunOutOfAppBundleTests.cs
@@ -7,77 +7,76 @@ using Xunit.Abstractions;
 
 #nullable enable
 
-namespace Wasm.Build.Tests
+namespace Wasm.Build.Tests;
+
+public class WasmRunOutOfAppBundleTests : BuildTestBase
 {
-    public class WasmRunOutOfAppBundleTests : BuildTestBase
+    public WasmRunOutOfAppBundleTests(ITestOutputHelper output, SharedBuildPerTestClassFixture buildContext) : base(output, buildContext)
+    {}
+
+    [Theory]
+    [BuildAndRun]
+    public void RunOutOfAppBundle(BuildArgs buildArgs, RunHost host, string id)
     {
-        public WasmRunOutOfAppBundleTests(ITestOutputHelper output, SharedBuildPerTestClassFixture buildContext) : base(output, buildContext)
-        {}
+        buildArgs = buildArgs with { ProjectName = $"outofappbundle_{buildArgs.Config}_{buildArgs.AOT}" };
+        buildArgs = ExpandBuildArgs(buildArgs);
 
-        [Theory]
-        [BuildAndRun]
-        public void RunOutOfAppBundle(BuildArgs buildArgs, RunHost host, string id)
+        BuildProject(buildArgs,
+                        id: id,
+                        new BuildProjectOptions(
+                            InitProject: () => File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), s_mainReturns42),
+                            DotnetWasmFromRuntimePack: !(buildArgs.AOT || buildArgs.Config == "Release")));
+
+        string binDir = GetBinDir(baseDir: _projectDir!, config: buildArgs.Config);
+        string appBundleDir = Path.Combine(binDir, "AppBundle");
+        string tmpBundleDirName = "AppBundleTmp";
+        string tmpBundleDir = Path.Combine(binDir, tmpBundleDirName);
+
+        if (host == RunHost.Chrome)
         {
-            buildArgs = buildArgs with { ProjectName = $"outofappbundle_{buildArgs.Config}_{buildArgs.AOT}" };
-            buildArgs = ExpandBuildArgs(buildArgs);
+            Directory.Move(appBundleDir, tmpBundleDir);
+            Directory.CreateDirectory(appBundleDir);
+            // Create $binDir/AppBundle/AppBundle
+            Directory.Move(tmpBundleDir, Path.Combine(appBundleDir, "AppBundle"));
 
-            BuildProject(buildArgs,
-                            id: id,
-                            new BuildProjectOptions(
-                                InitProject: () => File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), s_mainReturns42),
-                                DotnetWasmFromRuntimePack: !(buildArgs.AOT || buildArgs.Config == "Release")));
-
-            string binDir = GetBinDir(baseDir: _projectDir!, config: buildArgs.Config);
-            string appBundleDir = Path.Combine(binDir, "AppBundle");
-            string tmpBundleDirName = "AppBundleTmp";
-            string tmpBundleDir = Path.Combine(binDir, tmpBundleDirName);
-
-            if (host == RunHost.Chrome)
+            string indexHtmlPath = Path.Combine(appBundleDir, "index.html");
+            if (!File.Exists(indexHtmlPath))
             {
-                Directory.Move(appBundleDir, tmpBundleDir);
-                Directory.CreateDirectory(appBundleDir);
-                // Create $binDir/AppBundle/AppBundle
-                Directory.Move(tmpBundleDir, Path.Combine(appBundleDir, "AppBundle"));
-
-                string indexHtmlPath = Path.Combine(appBundleDir, "index.html");
-                if (!File.Exists(indexHtmlPath))
-                {
-                    var html = @"<html><body><script type=""module"" src=""./AppBundle/test-main.js""></script></body></html>";
-                    File.WriteAllText(indexHtmlPath, html);
-                }
-            } else {
-                CopyAllFiles(appBundleDir, tmpBundleDir);
+                var html = @"<html><body><script type=""module"" src=""./AppBundle/test-main.js""></script></body></html>";
+                File.WriteAllText(indexHtmlPath, html);
             }
-
-            RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id, jsRelativePath: $"../{tmpBundleDirName}/test-main.js");
-
-            // Restore AppBundle Dir
-            if (host == RunHost.Chrome)
-            {
-                Directory.Move(Path.Combine(appBundleDir, "AppBundle"), tmpBundleDir);
-                Directory.Delete(appBundleDir, true);
-                Directory.Move(tmpBundleDir, appBundleDir);
-            } else {
-                Directory.Delete(tmpBundleDir, true);
-            }
+        } else {
+            CopyAllFiles(appBundleDir, tmpBundleDir);
         }
 
-        private void CopyAllFiles(string srcDir, string destDir)
+        RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id, jsRelativePath: $"../{tmpBundleDirName}/test-main.js");
+
+        // Restore AppBundle Dir
+        if (host == RunHost.Chrome)
         {
-            if (!Directory.Exists(destDir))
-            {
-                Directory.CreateDirectory(destDir);
-            }
+            Directory.Move(Path.Combine(appBundleDir, "AppBundle"), tmpBundleDir);
+            Directory.Delete(appBundleDir, true);
+            Directory.Move(tmpBundleDir, appBundleDir);
+        } else {
+            Directory.Delete(tmpBundleDir, true);
+        }
+    }
 
-            foreach (var file in Directory.GetFiles(srcDir))
-            {
-                File.Copy(file, Path.Combine(destDir, Path.GetFileName(file)), true);
-            }
+    private void CopyAllFiles(string srcDir, string destDir)
+    {
+        if (!Directory.Exists(destDir))
+        {
+            Directory.CreateDirectory(destDir);
+        }
 
-            foreach (var directory in Directory.GetDirectories(srcDir))
-            {
-                CopyAllFiles(directory, Path.Combine(destDir, Path.GetFileName(directory)));
-            }
+        foreach (var file in Directory.GetFiles(srcDir))
+        {
+            File.Copy(file, Path.Combine(destDir, Path.GetFileName(file)), true);
+        }
+
+        foreach (var directory in Directory.GetDirectories(srcDir))
+        {
+            CopyAllFiles(directory, Path.Combine(destDir, Path.GetFileName(directory)));
         }
     }
 }

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/WasmRunOutOfAppBundleTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/WasmRunOutOfAppBundleTests.cs
@@ -48,7 +48,7 @@ public class WasmRunOutOfAppBundleTests : BuildTestBase
                 File.WriteAllText(indexHtmlPath, html);
             }
         } else {
-            CopyAllFiles(appBundleDir, tmpDir);
+            Utils.DirectoryCopy(appBundleDir, tmpDir);
         }
 
         RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id, jsRelativePath: Path.Combine(tmpDir, "test-main.js"));
@@ -61,24 +61,6 @@ public class WasmRunOutOfAppBundleTests : BuildTestBase
             Directory.Move(tmpBundleDir, appBundleDir);
         } else {
             Directory.Delete(tmpDir, true);
-        }
-    }
-
-    private void CopyAllFiles(string srcDir, string destDir)
-    {
-        if (!Directory.Exists(destDir))
-        {
-            Directory.CreateDirectory(destDir);
-        }
-
-        foreach (var file in Directory.GetFiles(srcDir))
-        {
-            File.Copy(file, Path.Combine(destDir, Path.GetFileName(file)), true);
-        }
-
-        foreach (var directory in Directory.GetDirectories(srcDir))
-        {
-            CopyAllFiles(directory, Path.Combine(destDir, Path.GetFileName(directory)));
         }
     }
 }

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/WasmRunOutOfAppBundleTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/WasmRunOutOfAppBundleTests.cs
@@ -32,6 +32,8 @@ public class WasmRunOutOfAppBundleTests : BuildTestBase
         string tmpBundleDirName = "AppBundleTmp";
         string tmpBundleDir = Path.Combine(binDir, tmpBundleDirName);
 
+        string tmpDir = Path.Combine(Path.GetTempPath(), $"{id}-{buildArgs.ProjectName}");
+
         if (host == RunHost.Chrome)
         {
             Directory.Move(appBundleDir, tmpBundleDir);
@@ -46,10 +48,10 @@ public class WasmRunOutOfAppBundleTests : BuildTestBase
                 File.WriteAllText(indexHtmlPath, html);
             }
         } else {
-            CopyAllFiles(appBundleDir, tmpBundleDir);
+            CopyAllFiles(appBundleDir, tmpDir);
         }
 
-        RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id, jsRelativePath: $"../{tmpBundleDirName}/test-main.js");
+        RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id, jsRelativePath: Path.Combine(tmpDir, "test-main.js"));
 
         // Restore AppBundle Dir
         if (host == RunHost.Chrome)
@@ -58,7 +60,7 @@ public class WasmRunOutOfAppBundleTests : BuildTestBase
             Directory.Delete(appBundleDir, true);
             Directory.Move(tmpBundleDir, appBundleDir);
         } else {
-            Directory.Delete(tmpBundleDir, true);
+            Directory.Delete(tmpDir, true);
         }
     }
 


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/72275 we fixed `locateFile` to deal with relative file path or URL. We could also handle absolute path/URL. This PR is adding tests to prove it works.