### PR TITLE
Spanify some Windows X.509 PAL and improve formatting.

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertGetCertificateContextProperty.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertGetCertificateContextProperty.cs
@@ -17,6 +17,14 @@ internal static partial class Interop
             byte[]? pvData,
             ref int pcbData);
 
+        [LibraryImport(Libraries.Crypt32, SetLastError = true, EntryPoint = "CertGetCertificateContextProperty")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static unsafe partial bool CertGetCertificateContextPropertyPtr(
+            SafeCertContextHandle pCertContext,
+            CertContextPropId dwPropId,
+            byte* pvData,
+            ref int pcbData);
+
         [LibraryImport(Libraries.Crypt32, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool CertGetCertificateContextProperty(

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptDecodeObjectPointer_IntPtr.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptDecodeObjectPointer_IntPtr.cs
@@ -18,5 +18,16 @@ internal static partial class Interop
             CryptDecodeObjectFlags dwFlags,
             void* pvStructInfo,
             ref int pcbStructInfo);
+
+        [LibraryImport(Libraries.Crypt32, EntryPoint = "CryptDecodeObject",  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static unsafe partial bool CryptDecodeObjectPointer(
+            CertEncodingType dwCertEncodingType,
+            IntPtr lpszStructType,
+            byte* pbEncoded,
+            int cbEncoded,
+            CryptDecodeObjectFlags dwFlags,
+            void* pvStructInfo,
+            ref int pcbStructInfo);
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/FindPal.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/FindPal.Windows.cs
@@ -105,20 +105,9 @@ namespace System.Security.Cryptography.X509Certificates
                 });
         }
 
-        public void FindByTimeValid(DateTime dateTime)
-        {
-            FindByTime(dateTime, 0);
-        }
-
-        public void FindByTimeNotYetValid(DateTime dateTime)
-        {
-            FindByTime(dateTime, -1);
-        }
-
-        public void FindByTimeExpired(DateTime dateTime)
-        {
-            FindByTime(dateTime, 1);
-        }
+        public void FindByTimeValid(DateTime dateTime) => FindByTime(dateTime, 0);
+        public void FindByTimeNotYetValid(DateTime dateTime) => FindByTime(dateTime, -1);
+        public void FindByTimeExpired(DateTime dateTime) => FindByTime(dateTime, 1);
 
         private unsafe void FindByTime(DateTime dateTime, int compareResult)
         {
@@ -128,7 +117,8 @@ namespace System.Security.Cryptography.X509Certificates
                 (fileTime, compareResult),
                 static (state, pCertContext) =>
                 {
-                    int comparison = Interop.Crypt32.CertVerifyTimeValidity(ref state.fileTime,
+                    int comparison = Interop.Crypt32.CertVerifyTimeValidity(
+                        ref state.fileTime,
                         pCertContext.CertContext->pCertInfo);
                     GC.KeepAlive(pCertContext);
                     return comparison == state.compareResult;
@@ -137,6 +127,34 @@ namespace System.Security.Cryptography.X509Certificates
 
         public unsafe void FindByTemplateName(string templateName)
         {
+            static unsafe bool DecodeV1TemplateCallback(void* pvDecoded, int cbDecoded, string templateName)
+            {
+                Debug.Assert(cbDecoded >= sizeof(CERT_NAME_VALUE));
+                CERT_NAME_VALUE* pNameValue = (CERT_NAME_VALUE*)pvDecoded;
+                string? actual = Marshal.PtrToStringUni(pNameValue->Value.pbData);
+                return templateName.Equals(actual, StringComparison.OrdinalIgnoreCase);
+            }
+
+            static unsafe bool DecodeV2TemplateCallback(void* pvDecoded, int cbDecoded, string templateName)
+            {
+                Debug.Assert(cbDecoded >= sizeof(CERT_TEMPLATE_EXT));
+                CERT_TEMPLATE_EXT* pTemplateExt = (CERT_TEMPLATE_EXT*)pvDecoded;
+                string? actual = Marshal.PtrToStringAnsi(pTemplateExt->pszObjId);
+
+                string? expectedOidValue = Interop.Crypt32.FindOidInfo(
+                    Interop.Crypt32.CryptOidInfoKeyType.CRYPT_OID_INFO_NAME_KEY,
+                    templateName,
+                    OidGroup.Template,
+                    fallBackToAllGroups: true).OID;
+
+                if (expectedOidValue is null)
+                {
+                    expectedOidValue = templateName;
+                }
+
+                return expectedOidValue.Equals(actual, StringComparison.OrdinalIgnoreCase);
+            }
+
             FindCore(
                 templateName,
                 static (templateName, pCertContext) =>
@@ -147,50 +165,41 @@ namespace System.Security.Cryptography.X509Certificates
 
                     bool foundMatch = false;
                     Interop.Crypt32.CERT_INFO* pCertInfo = pCertContext.CertContext->pCertInfo;
+                    Interop.Crypt32.CERT_EXTENSION* pV1Template = Interop.Crypt32.CertFindExtension(
+                        Oids.EnrollCertTypeExtension,
+                        pCertInfo->cExtension,
+                        pCertInfo->rgExtension);
+
+                    if (pV1Template != null)
                     {
-                        Interop.Crypt32.CERT_EXTENSION* pV1Template = Interop.Crypt32.CertFindExtension(Oids.EnrollCertTypeExtension,
-                            pCertInfo->cExtension, pCertInfo->rgExtension);
-                        if (pV1Template != null)
+                        ReadOnlySpan<byte> extensionRawData = pV1Template->Value.DangerousAsSpan();
+
+                        if (!extensionRawData.DecodeObjectNoThrow(
+                            CryptDecodeObjectStructType.X509_UNICODE_ANY_STRING,
+                            state: templateName,
+                            DecodeV1TemplateCallback,
+                            out foundMatch))
                         {
-                            byte[] extensionRawData = pV1Template->Value.ToByteArray();
-                            if (!extensionRawData.DecodeObjectNoThrow(
-                                CryptDecodeObjectStructType.X509_UNICODE_ANY_STRING,
-                                delegate (void* pvDecoded, int cbDecoded)
-                                {
-                                    Debug.Assert(cbDecoded >= sizeof(CERT_NAME_VALUE));
-                                    CERT_NAME_VALUE* pNameValue = (CERT_NAME_VALUE*)pvDecoded;
-                                    string? actual = Marshal.PtrToStringUni(pNameValue->Value.pbData);
-                                    if (templateName.Equals(actual, StringComparison.OrdinalIgnoreCase))
-                                        foundMatch = true;
-                                }))
-                            {
-                                return false;
-                            }
+                            return false;
                         }
                     }
 
                     if (!foundMatch)
                     {
-                        Interop.Crypt32.CERT_EXTENSION* pV2Template = Interop.Crypt32.CertFindExtension(Oids.CertificateTemplate,
-                            pCertInfo->cExtension, pCertInfo->rgExtension);
+                        Interop.Crypt32.CERT_EXTENSION* pV2Template = Interop.Crypt32.CertFindExtension(
+                            Oids.CertificateTemplate,
+                            pCertInfo->cExtension,
+                            pCertInfo->rgExtension);
+
                         if (pV2Template != null)
                         {
-                            byte[] extensionRawData = pV2Template->Value.ToByteArray();
+                            ReadOnlySpan<byte> extensionRawData = pV2Template->Value.DangerousAsSpan();
+
                             if (!extensionRawData.DecodeObjectNoThrow(
                                 CryptDecodeObjectStructType.X509_CERTIFICATE_TEMPLATE,
-                                delegate (void* pvDecoded, int cbDecoded)
-                                {
-                                    Debug.Assert(cbDecoded >= sizeof(CERT_TEMPLATE_EXT));
-                                    CERT_TEMPLATE_EXT* pTemplateExt = (CERT_TEMPLATE_EXT*)pvDecoded;
-                                    string? actual = Marshal.PtrToStringAnsi(pTemplateExt->pszObjId);
-                                    string? expectedOidValue =
-                                        Interop.Crypt32.FindOidInfo(Interop.Crypt32.CryptOidInfoKeyType.CRYPT_OID_INFO_NAME_KEY, templateName,
-                                            OidGroup.Template, fallBackToAllGroups: true).OID;
-                                    if (expectedOidValue == null)
-                                        expectedOidValue = templateName;
-                                    if (expectedOidValue.Equals(actual, StringComparison.OrdinalIgnoreCase))
-                                        foundMatch = true;
-                                }))
+                                state: templateName,
+                                DecodeV2TemplateCallback,
+                                out foundMatch))
                             {
                                 return false;
                             }
@@ -211,23 +220,33 @@ namespace System.Security.Cryptography.X509Certificates
                     int numOids;
                     int cbData = 0;
                     if (!Interop.Crypt32.CertGetValidUsages(1, ref pCertContext, out numOids, null, ref cbData))
+                    {
                         return false;
+                    }
 
                     // -1 means the certificate is good for all usages.
                     if (numOids == -1)
+                    {
                         return true;
+                    }
 
                     fixed (byte* pOidsPointer = new byte[cbData])
                     {
                         if (!Interop.Crypt32.CertGetValidUsages(1, ref pCertContext, out numOids, pOidsPointer, ref cbData))
+                        {
                             return false;
+                        }
 
                         IntPtr* pOids = (IntPtr*)pOidsPointer;
+
                         for (int i = 0; i < numOids; i++)
                         {
                             string actual = Marshal.PtrToStringAnsi(pOids[i])!;
+
                             if (oidValue.Equals(actual, StringComparison.OrdinalIgnoreCase))
+                            {
                                 return true;
+                            }
                         }
                         return false;
                     }
@@ -236,36 +255,44 @@ namespace System.Security.Cryptography.X509Certificates
 
         public unsafe void FindByCertificatePolicy(string oidValue)
         {
+            static unsafe bool DecodeObjectCallback(void* pvDecoded, int cbDecoded, string oidValue)
+            {
+                Debug.Assert(cbDecoded >= sizeof(CERT_POLICIES_INFO));
+                CERT_POLICIES_INFO* pCertPoliciesInfo = (CERT_POLICIES_INFO*)pvDecoded;
+
+                for (int i = 0; i < pCertPoliciesInfo->cPolicyInfo; i++)
+                {
+                    CERT_POLICY_INFO* pCertPolicyInfo = &(pCertPoliciesInfo->rgPolicyInfo[i]);
+                    string actual = Marshal.PtrToStringAnsi(pCertPolicyInfo->pszPolicyIdentifier)!;
+
+                    if (oidValue.Equals(actual, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
             FindCore(
                 oidValue,
                 static (oidValue, pCertContext) =>
                 {
                     Interop.Crypt32.CERT_INFO* pCertInfo = pCertContext.CertContext->pCertInfo;
-                    Interop.Crypt32.CERT_EXTENSION* pCertExtension = Interop.Crypt32.CertFindExtension(Oids.CertPolicies,
-                        pCertInfo->cExtension, pCertInfo->rgExtension);
+                    Interop.Crypt32.CERT_EXTENSION* pCertExtension = Interop.Crypt32.CertFindExtension(
+                        Oids.CertPolicies,
+                        pCertInfo->cExtension,
+                        pCertInfo->rgExtension);
+
                     if (pCertExtension == null)
+                    {
                         return false;
+                    }
 
                     bool foundMatch = false;
-                    byte[] extensionRawData = pCertExtension->Value.ToByteArray();
-                    if (!extensionRawData.DecodeObjectNoThrow(
-                        CryptDecodeObjectStructType.X509_CERT_POLICIES,
-                        delegate (void* pvDecoded, int cbDecoded)
-                        {
-                            Debug.Assert(cbDecoded >= sizeof(CERT_POLICIES_INFO));
-                            CERT_POLICIES_INFO* pCertPoliciesInfo = (CERT_POLICIES_INFO*)pvDecoded;
-                            for (int i = 0; i < pCertPoliciesInfo->cPolicyInfo; i++)
-                            {
-                                CERT_POLICY_INFO* pCertPolicyInfo = &(pCertPoliciesInfo->rgPolicyInfo[i]);
-                                string actual = Marshal.PtrToStringAnsi(pCertPolicyInfo->pszPolicyIdentifier)!;
-                                if (oidValue.Equals(actual, StringComparison.OrdinalIgnoreCase))
-                                {
-                                    foundMatch = true;
-                                    break;
-                                }
-                            }
-                        }
-                        ))
+                    ReadOnlySpan<byte> extensionRawData = pCertExtension->Value.DangerousAsSpan();
+
+                    if (!extensionRawData.DecodeObjectNoThrow(CryptDecodeObjectStructType.X509_CERT_POLICIES, oidValue, DecodeObjectCallback, out foundMatch))
                     {
                         return false;
                     }
@@ -296,8 +323,12 @@ namespace System.Security.Cryptography.X509Certificates
                 {
                     Interop.Crypt32.CERT_INFO* pCertInfo = pCertContext.CertContext->pCertInfo;
                     X509KeyUsageFlags actual;
+
                     if (!Interop.crypt32.CertGetIntendedKeyUsage(Interop.Crypt32.CertEncodingType.All, pCertInfo, out actual, sizeof(X509KeyUsageFlags)))
+                    {
                         return true;  // no key usage means it is valid for all key usages.
+                    }
+
                     GC.KeepAlive(pCertContext);
                     return (actual & keyUsage) == keyUsage;
                 });
@@ -311,11 +342,16 @@ namespace System.Security.Cryptography.X509Certificates
                 {
                     int cbData = 0;
                     if (!Interop.Crypt32.CertGetCertificateContextProperty(pCertContext, Interop.Crypt32.CertContextPropId.CERT_KEY_IDENTIFIER_PROP_ID, null, ref cbData))
+                    {
                         return false;
+                    }
 
                     byte[] actual = new byte[cbData];
+
                     if (!Interop.Crypt32.CertGetCertificateContextProperty(pCertContext, Interop.Crypt32.CertContextPropId.CERT_KEY_IDENTIFIER_PROP_ID, actual, ref cbData))
+                    {
                         return false;
+                    }
 
                     return keyIdentifier.ContentsEqual(actual);
                 });
@@ -339,23 +375,33 @@ namespace System.Security.Cryptography.X509Certificates
                 IntPtr.Zero,
                 Interop.Crypt32.CertStoreFlags.CERT_STORE_ENUM_ARCHIVED_FLAG | Interop.Crypt32.CertStoreFlags.CERT_STORE_CREATE_NEW_FLAG,
                 null);
+
             if (findResults.IsInvalid)
+            {
                 throw Marshal.GetHRForLastWin32Error().ToCryptographicException();
+            }
 
             SafeCertContextHandle? pCertContext = null;
+
             while (Interop.crypt32.CertFindCertificateInStore(_storePal.SafeCertStoreHandle, dwFindType, pvFindPara, ref pCertContext))
             {
                 if (filter != null && !filter(state, pCertContext))
+                {
                     continue;
+                }
 
                 if (_validOnly)
                 {
                     if (!VerifyCertificateIgnoringErrors(pCertContext))
+                    {
                         continue;
+                    }
                 }
 
                 if (!Interop.Crypt32.CertAddCertificateLinkToStore(findResults, pCertContext, Interop.Crypt32.CertStoreAddDisposition.CERT_STORE_ADD_ALWAYS, IntPtr.Zero))
+                {
                     throw Marshal.GetLastWin32Error().ToCryptographicException();
+                }
             }
 
             using (StorePal resultsStore = new StorePal(findResults))
@@ -383,14 +429,19 @@ namespace System.Security.Cryptography.X509Certificates
                 disableAia: false);
 
             if (chainPal == null)
+            {
                 return false;
+            }
 
             using (chainPal)
             {
                 Exception? verificationException;
                 bool? verified = chainPal.Verify(X509VerificationFlags.NoFlag, out verificationException);
+
                 if (!verified.GetValueOrDefault())
+                {
                     return false;
+                }
             }
 
             return true;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/WindowsInterop.crypt32.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/WindowsInterop.crypt32.cs
@@ -90,6 +90,14 @@ internal static partial class Interop
             return Interop.Crypt32.CryptDecodeObjectPointer(dwCertEncodingType, (IntPtr)lpszStructType, pbEncoded, cbEncoded, dwFlags, pvStructInfo, ref pcbStructInfo);
         }
 
+        public static unsafe bool CryptDecodeObjectPointer(Interop.Crypt32.CertEncodingType dwCertEncodingType, CryptDecodeObjectStructType lpszStructType, ReadOnlySpan<byte> encoded, Interop.Crypt32.CryptDecodeObjectFlags dwFlags, void* pvStructInfo, ref int pcbStructInfo)
+        {
+            fixed (byte* pEncoded = encoded)
+            {
+                return Interop.Crypt32.CryptDecodeObjectPointer(dwCertEncodingType, (IntPtr)lpszStructType, pEncoded, encoded.Length, dwFlags, pvStructInfo, ref pcbStructInfo);
+            }
+        }
+
         public static unsafe bool CryptEncodeObject(Interop.Crypt32.CertEncodingType dwCertEncodingType, CryptDecodeObjectStructType lpszStructType, void* pvStructInfo, byte[]? pbEncoded, ref int pcbEncoded)
         {
             return Interop.Crypt32.CryptEncodeObject(dwCertEncodingType, (IntPtr)lpszStructType, pvStructInfo, pbEncoded, ref pcbEncoded);


### PR DESCRIPTION
This PR does:

1. Change `DecodeObjectNoThrow` to operate off of `ReadOnlySpan<byte>` instead of `byte[]`. This lets us save a few allocations since the input is usually from a `DATA_BLOB`.
2. Change `DecodeObjectNoThrow` to accept and return `TState` and `TResult`. This means the callback functions can be fully static and not capture state, thus making them easier to extract in to static-local functions.
3. Various cleanup. Bring the formatting up to be more consistent with our style guidelines. Braces where appropriate, new lines between control blocks, etc.