### PR TITLE
Handle multiple incoming connection at the beginning of Http3LoopbackConnection use

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
@@ -64,6 +64,11 @@ namespace System.Net.Test.Common
                 stream.Dispose();
             }
 
+            foreach (QuicStream stream in _delayedStreams)
+            {
+                stream.Dispose();
+            }
+
             // We don't dispose the connection currently, because this causes races when the server connection is closed before
             // the client has received and handled all response data.
             // See discussion in https://github.com/dotnet/runtime/pull/57223#discussion_r687447832

--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
@@ -35,6 +35,9 @@ namespace System.Net.Test.Common
 
         private readonly QuicConnection _connection;
 
+        // Queue for holding streams we accepted before we managed to accept the control stream
+        private readonly Queue<QuicStream> _delayedStreams = new Queue<QuicStream>();
+
         // This is specifically request streams, not control streams
         private readonly Dictionary<int, Http3LoopbackStream> _openStreams = new Dictionary<int, Http3LoopbackStream>();
 
@@ -50,6 +53,8 @@ namespace System.Net.Test.Common
         {
             _connection = connection;
         }
+
+        public long MaxHeaderListSize { get; private set; } = -1;
 
         public override void Dispose()
         {
@@ -107,100 +112,74 @@ namespace System.Net.Test.Common
             throw new NotImplementedException();
         }
 
-        public async Task<Http3LoopbackStream> AcceptStreamAsync()
+        private Task EnsureControlStreamAcceptedAsync()
         {
-            QuicStream quicStream = await _connection.AcceptStreamAsync().ConfigureAwait(false);
-            var stream = new Http3LoopbackStream(quicStream);
-
-            if (quicStream.CanWrite)
+            if (_inboundControlStream != null)
             {
-                _openStreams.Add(checked((int)quicStream.StreamId), stream);
-                _currentStream = stream;
-                _currentStreamId = quicStream.StreamId;
+                return Task.CompletedTask;
             }
 
-            return stream;
-        }
-
-        private async Task HandleControlStreamAsync(Http3LoopbackStream controlStream)
-        {
-            if (_inboundControlStream is not null)
+            return EnsureControlStreamAcceptedInternalAsync();
+            async Task EnsureControlStreamAcceptedInternalAsync()
             {
-                throw new Exception("Received second control stream from client???");
+                Http3LoopbackStream controlStream;
+
+                while (true)
+                {
+                    QuicStream quicStream = await _connection.AcceptStreamAsync().ConfigureAwait(false);
+
+                    if (!quicStream.CanWrite)
+                    {
+                        // control stream accepted
+                        controlStream = new Http3LoopbackStream(quicStream);
+                        break;
+                    }
+
+                    // control streams are unidirectional, so this must be a request stream
+                    // keep it for later and wait for another stream
+                    _delayedStreams.Enqueue(quicStream);
+                }
+
+                long? streamType = await controlStream.ReadIntegerAsync();
+                Assert.Equal(Http3LoopbackStream.ControlStream, streamType);
+
+                List<(long settingId, long settingValue)> settings = await controlStream.ReadSettingsAsync();
+                (long settingId, long settingValue) = Assert.Single(settings);
+
+                Assert.Equal(Http3LoopbackStream.MaxHeaderListSize, settingId);
+                MaxHeaderListSize = settingValue;
+
+                _inboundControlStream = controlStream;
             }
-
-            Assert.False(controlStream.CanWrite);
-
-            long? streamType = await controlStream.ReadIntegerAsync();
-            Assert.Equal(Http3LoopbackStream.ControlStream, streamType);
-
-            List<(long settingId, long settingValue)> settings = await controlStream.ReadSettingsAsync();
-            (long settingId, long settingValue) = Assert.Single(settings);
-
-            Assert.Equal(Http3LoopbackStream.MaxHeaderListSize, settingId);
-
-            _inboundControlStream = controlStream;
         }
 
         // This will automatically handle the control stream, including validating its contents
         public async Task<Http3LoopbackStream> AcceptRequestStreamAsync()
         {
-            Http3LoopbackStream requestStream = null;
+            await EnsureControlStreamAcceptedAsync().ConfigureAwait(false);
 
-            while (true)
+            if (!_delayedStreams.TryDequeue(out QuicStream quicStream))
             {
-                var stream = await AcceptStreamAsync().ConfigureAwait(false);
-
-                // Accepted request stream.
-                if (stream.CanWrite)
-                {
-                    // Only one expected.
-                    Assert.True(requestStream is null, "Expected single request stream, got a second");
-
-                    // Control stream is set --> return the request stream.
-                    if (_inboundControlStream is not null)
-                    {
-                        return stream;
-                    }
-
-                    // Control stream not set --> need to accept another stream.
-                    requestStream = stream;
-                    continue;
-                }
-
-                // Must be the control stream.
-                await HandleControlStreamAsync(stream);
-
-                // We've already accepted request stream --> return it.
-                if (requestStream is not null)
-                {
-                    return requestStream;
-                }
+                quicStream = await _connection.AcceptStreamAsync().ConfigureAwait(false);
             }
+
+            var stream = new Http3LoopbackStream(quicStream);
+
+            Assert.True(quicStream.CanWrite, "Expected writeable stream.");
+
+            _openStreams.Add(checked((int)quicStream.StreamId), stream);
+            _currentStream = stream;
+            _currentStreamId = quicStream.StreamId;
+
+            return stream;
         }
 
         public async Task<(Http3LoopbackStream clientControlStream, Http3LoopbackStream requestStream)> AcceptControlAndRequestStreamAsync()
         {
-            Http3LoopbackStream streamA = null, streamB = null;
+            Http3LoopbackStream requestStream = await AcceptRequestStreamAsync();
+            Http3LoopbackStream controlStream = _inboundControlStream;
 
-            try
-            {
-                streamA = await AcceptStreamAsync();
-                streamB = await AcceptStreamAsync();
-
-                return (streamA.CanWrite, streamB.CanWrite) switch
-                {
-                    (false, true) => (streamA, streamB),
-                    (true, false) => (streamB, streamA),
-                    _ => throw new Exception("Expected one unidirectional and one bidirectional stream; received something else.")
-                };
-            }
-            catch
-            {
-                streamA?.Dispose();
-                streamB?.Dispose();
-                throw;
-            }
+            return (controlStream, requestStream);
         }
 
         public async Task EstablishControlStreamAsync()

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -45,15 +45,7 @@ namespace System.Net.Http.Functional.Tests
                 using (requestStream)
                 {
                     Assert.False(settingsStream.CanWrite, "Expected unidirectional control stream.");
-
-                    long? streamType = await settingsStream.ReadIntegerAsync();
-                    Assert.Equal(Http3LoopbackStream.ControlStream, streamType);
-
-                    List<(long settingId, long settingValue)> settings = await settingsStream.ReadSettingsAsync();
-                    (long settingId, long settingValue) = Assert.Single(settings);
-
-                    Assert.Equal(Http3LoopbackStream.MaxHeaderListSize, settingId);
-                    Assert.Equal(headerSizeLimit * 1024L, settingValue);
+                    Assert.Equal(headerSizeLimit * 1024L, connection.MaxHeaderListSize);
 
                     await requestStream.ReadRequestDataAsync();
                     await requestStream.SendResponseAsync();


### PR DESCRIPTION
Fixes #69387.

This PR makes sure the `Http3LoopbackConnection` used in tests does not choke on multiple simultaneous requests from a client, when two or more request streams are accepted before the control stream.

The Http functional tests were run in a tight loop and the original test failure was not observed.