### PR TITLE
Ensure the shared framework build uses the generated runtime.json

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -267,6 +267,7 @@
     <Owners>microsoft,dotnetframework</Owners>
     <IncludeSymbols>true</IncludeSymbols>
     <RuntimeIdGraphDefinitionFile>$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'Microsoft.NETCore.Platforms', 'src', 'runtime.json'))</RuntimeIdGraphDefinitionFile>
+    <LiveRuntimeIdGraphDefinitionFile>$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', 'Microsoft.NETCore.Platforms', '$(Configuration)', 'runtime.json'))</LiveRuntimeIdGraphDefinitionFile>
     <LicenseFile>$(MSBuildThisFileDirectory)LICENSE.TXT</LicenseFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -221,6 +221,6 @@
             ResolveLibrariesRuntimeFilesFromLocalBuild" />
 
   <PropertyGroup>
-    <BundledRuntimeIdentifierGraphFile>$(RuntimeIdGraphDefinitionFile)</BundledRuntimeIdentifierGraphFile>
+    <BundledRuntimeIdentifierGraphFile>$(LiveRuntimeIdGraphDefinitionFile)</BundledRuntimeIdentifierGraphFile>
   </PropertyGroup>
 </Project>

--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -43,8 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Condition="'$(AdditionalRuntimeIdentifiers)' == ''" Include="runtime.json" PackagePath="/" />
-    <Content Condition="'$(AdditionalRuntimeIdentifiers)' != ''" Include="$(IntermediateOutputPath)runtime.json" PackagePath="/" />
+    <Content Include="$(LiveRuntimeIdGraphDefinitionFile)" PackagePath="/" />
     <Content Include="$(PlaceholderFile)" PackagePath="lib/netstandard1.0" />
   </ItemGroup>
 
@@ -58,13 +57,17 @@
   
   <UsingTask TaskName="GenerateRuntimeGraph" AssemblyFile="$(_generateRuntimeGraphTask)"/>
 
-  <Target Name="GenerateRuntimeJson" Condition="'$(AdditionalRuntimeIdentifiers)' != ''">
+  <Target Name="GenerateRuntimeJson">
     <MakeDir Directories="$(IntermediateOutputPath)" />
-    <GenerateRuntimeGraph RuntimeGroups="@(RuntimeGroupWithQualifiers)"
+    <GenerateRuntimeGraph Condition="'$(AdditionalRuntimeIdentifiers)' != ''"
+                          RuntimeGroups="@(RuntimeGroupWithQualifiers)"
                           AdditionalRuntimeIdentifiers="$(AdditionalRuntimeIdentifiers)"
                           AdditionalRuntimeIdentifierParent="$(AdditionalRuntimeIdentifierParent)"
-                          RuntimeJson="$(IntermediateOutputPath)runtime.json"
+                          RuntimeJson="$(LiveRuntimeIdGraphDefinitionFile)"
                           UpdateRuntimeFiles="True" />
+    <Copy Condition="'$(AdditionalRuntimeIdentifiers)' == ''"
+          SourceFiles="runtime.json"
+          DestinationFiles="$(LiveRuntimeIdGraphDefinitionFile)" />
   </Target>
 
   <Target Name="UpdateRuntimeJson">

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -93,7 +93,7 @@
           Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' or '$(BuildTargetFramework)' == ''">
     <!-- Shared framework deps file generation. Produces a test shared-framework deps file. -->
     <GenerateTestSharedFrameworkDepsFile SharedFrameworkDirectory="$(NetCoreAppCurrentTestHostSharedFrameworkPath)"
-                                         RuntimeGraphFiles="$(RuntimeIdGraphDefinitionFile)"
+                                         RuntimeGraphFiles="$(LiveRuntimeIdGraphDefinitionFile)"
                                          TargetRuntimeIdentifier="$(PackageRID)" />
   </Target>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/53550