### PR TITLE
Add new public APIs for safely manipulating managed pointers

### DIFF
--- a/src/mono/wasm/runtime/dotnet-legacy.d.ts
+++ b/src/mono/wasm/runtime/dotnet-legacy.d.ts
@@ -302,6 +302,10 @@ declare type MONOType = {
      * @deprecated Please use getHeapF64
      */
     getF64: (offset: MemOffset) => number;
+    mono_wasm_memcpy_from_managed_object(destination: VoidPtr, destination_offset: number, destination_size_bytes: number, source_object: MonoObjectRef, source_offset: number, count_bytes: number): void;
+    mono_wasm_get_object_field_i32(source_object: MonoObjectRef, source_offset: number): number;
+    mono_wasm_get_object_field_f64(source_object: MonoObjectRef, source_offset: number): number;
+    mono_wasm_copy_managed_pointer_from_field(destination: MonoObjectRef, source_object: MonoObjectRef, field_offset: number): void;
 };
 
 export { BINDINGType, MONOType, MonoArray, MonoObject, MonoString };

--- a/src/mono/wasm/runtime/es6/dotnet.es6.lib.js
+++ b/src/mono/wasm/runtime/es6/dotnet.es6.lib.js
@@ -71,6 +71,7 @@ const linked_functions = [
 
     // driver.c
     "mono_wasm_invoke_js_blazor",
+    "mono_wasm_invoke_js_blazor_ref",
     "mono_wasm_trace_logger",
     "mono_wasm_event_pipe_early_startup_callback",
 

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -22,7 +22,6 @@ const __initializeImportsAndExports: any = initializeImportsAndExports; // don't
 const __setEmscriptenEntrypoint: any = setEmscriptenEntrypoint; // don't want to export the type
 let __linker_exports: any = null;
 
-
 // this is executed early during load of emscripten runtime
 // it exports methods to global objects MONO, BINDING and Module in backward compatible way
 // At runtime this will be referred to as 'createDotnetRuntime'

--- a/src/mono/wasm/runtime/gc-common.h
+++ b/src/mono/wasm/runtime/gc-common.h
@@ -53,12 +53,12 @@ mono_threads_assert_gc_safe_region (void);
 #endif /* DISABLE_THREADS */
 
 static void
-store_volatile (PPVOLATILE(MonoObject) destination, PVOLATILE(MonoObject) source) {
+store_volatile (PPVOLATILE(MonoObject) destination, PVOLATILE(const MonoObject) source) {
 	mono_gc_wbarrier_generic_store_atomic((void*)destination, (MonoObject*)source);
 }
 
 static void
-copy_volatile (PPVOLATILE(MonoObject) destination, PPVOLATILE(MonoObject) source) {
+copy_volatile (PPVOLATILE(MonoObject) destination, PPVOLATILE(const MonoObject) source) {
 	mono_gc_wbarrier_generic_store_atomic((void*)destination, (MonoObject*)(*source));
 }
 

--- a/src/mono/wasm/runtime/net6-legacy/export-types.ts
+++ b/src/mono/wasm/runtime/net6-legacy/export-types.ts
@@ -250,6 +250,13 @@ export type MONOType = {
      * @deprecated Please use getHeapF64
      */
     getF64: (offset: MemOffset) => number;
+    mono_wasm_memcpy_from_managed_object (
+        destination: VoidPtr, destination_offset: number, destination_size_bytes: number,
+        source_object: MonoObjectRef, source_offset: number, count_bytes: number
+    ): void;
+    mono_wasm_get_object_field_i32 (source_object: MonoObjectRef, source_offset: number): number;
+    mono_wasm_get_object_field_f64 (source_object: MonoObjectRef, source_offset: number): number;
+    mono_wasm_copy_managed_pointer_from_field (destination: MonoObjectRef, source_object: MonoObjectRef, field_offset: number): void;
 };
 
 export { MonoArray, MonoObject, MonoString };

--- a/src/mono/wasm/runtime/net6-legacy/exports-legacy.ts
+++ b/src/mono/wasm/runtime/net6-legacy/exports-legacy.ts
@@ -39,6 +39,11 @@ export function export_mono_api(): MONOType {
         mono_wasm_add_assembly: <any>null,
         mono_wasm_load_runtime,
 
+        mono_wasm_memcpy_from_managed_object: cwraps.mono_wasm_memcpy_from_managed_object,
+        mono_wasm_get_object_field_i32: cwraps.mono_wasm_get_object_field_i32,
+        mono_wasm_get_object_field_f64: cwraps.mono_wasm_get_object_field_f64,
+        mono_wasm_copy_managed_pointer_from_field: cwraps.mono_wasm_copy_managed_pointer_from_field,
+
         config: <MonoConfig | MonoConfigError>runtimeHelpers.config,
         loaded_files: <string[]>[],
 

--- a/src/mono/wasm/runtime/types/emscripten.ts
+++ b/src/mono/wasm/runtime/types/emscripten.ts
@@ -12,6 +12,9 @@ export declare interface NativePointer {
 export declare interface VoidPtr extends NativePointer {
     __brand: "VoidPtr"
 }
+export declare interface VoidPtrPtr extends NativePointer {
+    __brand: "VoidPtrPtr"
+}
 export declare interface CharPtr extends NativePointer {
     __brand: "CharPtr"
 }

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -82,7 +82,6 @@
   </Target>
 
   <Target Name="GenerateEmccPropsAndRspFiles">
-
     <!-- Generate emcc-props.json -->
 
     <RunWithEmSdkEnv Command="$(EmccCmd) --version"
@@ -128,7 +127,7 @@
       <_EmccLinkFlags Include="-s ALLOW_MEMORY_GROWTH=1" />
       <_EmccLinkFlags Include="-s NO_EXIT_RUNTIME=1" />
       <_EmccLinkFlags Include="-s FORCE_FILESYSTEM=1" />
-      <_EmccLinkFlags Include="-s EXPORTED_RUNTIME_METHODS=&quot;['FS','print','ccall','cwrap','setValue','getValue','UTF8ToString','UTF8ArrayToString','FS_createPath','FS_createDataFile','removeRunDependency','addRunDependency', 'FS_readFile']&quot;"  />
+      <_EmccLinkFlags Include="-s EXPORTED_RUNTIME_METHODS=&quot;['FS','print','ccall','cwrap','setValue','getValue','UTF8ToString','UTF8ArrayToString','FS_createPath','FS_createDataFile','removeRunDependency','addRunDependency','stackSave','stackRestore','stackAlloc','FS_readFile']&quot;"  />
       <_EmccLinkFlags Include="-s EXPORTED_FUNCTIONS=$(_DefaultExportedFunctions)" Condition="'$(_DefaultExportedFunctions)' != ''" />
       <_EmccLinkFlags Include="--source-map-base http://example.com" />
       <_EmccLinkFlags Include="-s STRICT_JS=1" />


### PR DESCRIPTION
I still need to adjust this PR so that it won't break blazor when we land it, but I've been experimenting with an updated version of blazor that works great on top of it.

* Update WasmRootBuffer so it can point into implicitly-rooted stack memory
* Add mono_wasm_with_hazard_buffer API you can use to request a root buffer that automatically pins (not just roots) all of the pointers inside of it, allowing you to manipulate them freely
* Add mono_wasm_with_pinned_object API that temporarily pins the contents of a root and then passes you the raw pointer
* Expose stackSave/Restore/Alloc emscripten APIs as part of Module
* Fix GetCallSignatureRef not properly marshaling its return value
* Add new API that converts an arbitrary managed array into a JS TypedArray view of a given type (or copy of the data)
* Introduce new safe variant of blazor's invoke API
* Add experimental APIs for safely manipulating fields of managed objects