### PR TITLE
Use Rfc3279DerSequence to get the signature in the right format

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ECDsaX509SignatureGenerator.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ECDsaX509SignatureGenerator.cs
@@ -51,8 +51,7 @@ namespace System.Security.Cryptography.X509Certificates
 
         public override byte[] SignData(byte[] data, HashAlgorithmName hashAlgorithm)
         {
-            byte[] ieeeFormat = _key.SignData(data, hashAlgorithm);
-            return AsymmetricAlgorithmHelpers.ConvertIeee1363ToDer(ieeeFormat);
+            return _key.SignData(data, hashAlgorithm, DSASignatureFormat.Rfc3279DerSequence);
         }
 
         protected override PublicKey BuildPublicKey()


### PR DESCRIPTION
Just ask for the format to be right in the first place. For OpenSSL platforms which natively produce DER, the result was "Get it in DER. Okay now convert it to IEEE, okay now convert it back to DER".