### PR TITLE
[wasm] Give is_nullish() a type guard type

### DIFF
--- a/src/mono/wasm/runtime/strings.ts
+++ b/src/mono/wasm/runtime/strings.ts
@@ -125,7 +125,7 @@ export function mono_intern_string(string: string): string {
     const result = interned_string_table.get(ptr);
     if (is_nullish(result))
         throw new Error("internal error: interned_string_table did not contain string after js_string_to_mono_string_interned");
-    return result!;
+    return result;
 }
 
 function _store_string_in_intern_table(string: string, root: WasmRoot<MonoString>, internIt: boolean): void {

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -269,7 +269,6 @@ export const enum MarshalError {
 
 // Evaluates whether a value is nullish (same definition used as the ?? operator,
 //  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator)
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function is_nullish (value: any): boolean {
+export function is_nullish<T> (value: T | null | undefined): value is null | undefined {
     return (value === undefined) || (value === null);
 }


### PR DESCRIPTION
allow callers to refine the type of the argument to just `T` on the false
brach

```typescript
let obj: number | null | undefined = ...
if (is_nullish (obj))
   return;
// otherwise obj is known to TS to be 'number'.
```