### PR TITLE
Fix data race on incoming MsQuicStream abort

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -1114,7 +1114,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                     shouldShutdownWriteComplete = true;
                 }
 
-                state.SendState = SendState.Aborted;
+                state.SendErrorCode = (long)streamEvent.PEER_RECEIVE_ABORTED.ErrorCode;
                 // make sure the SendErrorCode above is commited to memory before we assign the state. This
                 // ensures that the code is read correctly in SetupWriteStartState when checking without lock
                 Volatile.Write(ref Unsafe.As<SendState, int>(ref state.SendState), (int)SendState.Aborted);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -330,7 +330,8 @@ namespace System.Net.Quic.Implementations.MsQuic
             {
                 throw new InvalidOperationException(SR.net_quic_writing_notallowed);
             }
-            if (_state.SendState == SendState.Aborted)
+            // Use Volatile.Read to ensure we read the actual SendErrorCode set by the racing callback thread.
+            if ((SendState)Volatile.Read(ref Unsafe.As<SendState, int>(ref _state.SendState)) == SendState.Aborted)
             {
                 if (_state.SendErrorCode != -1)
                 {
@@ -1114,7 +1115,9 @@ namespace System.Net.Quic.Implementations.MsQuic
                 }
 
                 state.SendState = SendState.Aborted;
-                state.SendErrorCode = (long)streamEvent.PEER_RECEIVE_ABORTED.ErrorCode;
+                // make sure the SendErrorCode above is commited to memory before we assign the state. This
+                // ensures that the code is read correctly in SetupWriteStartState when checking without lock
+                Volatile.Write(ref Unsafe.As<SendState, int>(ref state.SendState), (int)SendState.Aborted);
             }
 
             if (shouldSendComplete)


### PR DESCRIPTION
This PR fixes a data race which we occasionally hit when running Http.Funcional.Tests in a tight loop. 

The data race this PR fixes occurs like this:
- MsQuicThread indicates that our write side was aborted by the peer (in `HandleEventPeerRecvAborted`). And sets `_state.SendState = SendState.Aborted`
- Application thread attempts to send data on the stream and in `SetupWriteStartState`, we check the `_state.SendState == SendState.Aborted`. This is done outside the lock to avoid locking when stream is in a terminal state.
- Application thread continues and reads `_state.SendErrorCode` which hasn't been set yet by the MsQuic thread -> we throw `QuicOperationAbortedException` instead of `QuicStreamAbortedException` with appropriate error code.

<details><summary>Example test failure due to the race</summary>

```
Failed System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_Http3_MsQuic.RequestSentResponseDisposed_ThrowsOnServer [43 ms]
  Error Message:
   System.AggregateException : One or more errors occurred. (Sending has already been aborted on the stream) (Sending has already been aborted on the stream)
---- System.Net.Quic.QuicOperationAbortedException : Sending has already been aborted on the stream
---- System.Net.Quic.QuicOperationAbortedException : Sending has already been aborted on the stream
  Stack Trace:
     at System.Threading.Tasks.TaskTimeoutExtensions.WhenAllOrAnyFailed(Task[] tasks) in /home/rzikm/dotnet-runtime/src/libraries/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs:line 88
   at System.Threading.Tasks.TaskTimeoutExtensions.WhenAllOrAnyFailed(Task[] tasks, Int32 millisecondsTimeout) in /home/rzikm/dotnet-runtime/src/libraries/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs:line 55
   at System.Net.Http.Functional.Tests.HttpClientHandlerTest_Http3.RequestSentResponseDisposed_ThrowsOnServer() in /home/rzikm/dotnet-runtime/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs:line 367
--- End of stack trace from previous location ---
----- Inner Stack Trace #1 (System.Net.Quic.QuicOperationAbortedException) -----
   at System.Net.Quic.Implementations.MsQuic.MsQuicStream.SetupWriteStartState(Boolean emptyBuffer, CancellationToken cancellationToken) in /home/rzikm/dotnet-runtime/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs:line 342
   at System.Net.Quic.Implementations.MsQuic.MsQuicStream.WriteAsync(ReadOnlyMemory`1 buffer, Boolean endStream, CancellationToken cancellationToken) in /home/rzikm/dotnet-runtime/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs:line 307
   at System.Net.Test.Common.Http3LoopbackStream.SendFrameHeaderAsync(Int64 frameType, Int32 payloadLength) in /home/rzikm/dotnet-runtime/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs:line 162
   at System.Net.Test.Common.Http3LoopbackStream.SendFrameAsync(Int64 frameType, ReadOnlyMemory`1 framePayload) in /home/rzikm/dotnet-runtime/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs:line 167
   at System.Net.Test.Common.Http3LoopbackStream.SendDataFrameAsync(ReadOnlyMemory`1 data) in /home/rzikm/dotnet-runtime/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs:line 140
   at System.Net.Test.Common.Http3LoopbackStream.SendResponseBodyAsync(Byte[] content, Boolean isFinal) in /home/rzikm/dotnet-runtime/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs:line 283
   at System.Net.Http.Functional.Tests.HttpClientHandlerTest_Http3.<>c__DisplayClass8_0.<<RequestSentResponseDisposed_ThrowsOnServer>b__0>d.MoveNext() in /home/rzikm/dotnet-runtime/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs:line 332
--- End of stack trace from previous location ---
   at System.Threading.Tasks.TaskTimeoutExtensions.GetRealException(Task task) in /home/rzikm/dotnet-runtime/src/libraries/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs:line 120
----- Inner Stack Trace #2 (System.Net.Quic.QuicOperationAbortedException) -----
   at System.Net.Quic.Implementations.MsQuic.MsQuicStream.SetupWriteStartState(Boolean emptyBuffer, CancellationToken cancellationToken) in /home/rzikm/dotnet-runtime/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs:line 342
   at System.Net.Quic.Implementations.MsQuic.MsQuicStream.WriteAsync(ReadOnlyMemory`1 buffer, Boolean endStream, CancellationToken cancellationToken) in /home/rzikm/dotnet-runtime/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs:line 307
   at System.Net.Test.Common.Http3LoopbackStream.SendFrameHeaderAsync(Int64 frameType, Int32 payloadLength) in /home/rzikm/dotnet-runtime/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs:line 162
   at System.Net.Test.Common.Http3LoopbackStream.SendFrameAsync(Int64 frameType, ReadOnlyMemory`1 framePayload) in /home/rzikm/dotnet-runtime/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs:line 167
   at System.Net.Test.Common.Http3LoopbackStream.SendDataFrameAsync(ReadOnlyMemory`1 data) in /home/rzikm/dotnet-runtime/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs:line 140
   at System.Net.Test.Common.Http3LoopbackStream.SendResponseBodyAsync(Byte[] content, Boolean isFinal) in /home/rzikm/dotnet-runtime/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs:line 283
   at System.Net.Http.Functional.Tests.HttpClientHandlerTest_Http3.<>c__DisplayClass8_0.<<RequestSentResponseDisposed_ThrowsOnServer>b__0>d.MoveNext() in /home/rzikm/dotnet-runtime/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs:line 332
--- End of stack trace from previous location ---
   at System.Threading.Tasks.TaskTimeoutExtensions.GetRealException(Task task) in /home/rzikm/dotnet-runtime/src/libraries/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs:line 120
```
</details>