### PR TITLE
File system type fix

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.UnixFileSystemTypes.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.UnixFileSystemTypes.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
@@ -152,6 +154,7 @@ internal static partial class Interop
         {
             long fstatfsResult = GetFileSystemType(fd);
             fileSystemType = (UnixFileSystemTypes)fstatfsResult;
+            Debug.Assert(Enum.IsDefined(fileSystemType) || fstatfsResult == -1, $"GetFileSystemType returned {fstatfsResult}");
             return fstatfsResult != -1;
         }
     }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.UnixFileSystemTypes.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.UnixFileSystemTypes.cs
@@ -155,7 +155,7 @@ internal static partial class Interop
         {
             uint fstatfsResult = GetFileSystemType(fd);
             fileSystemType = (UnixFileSystemTypes)fstatfsResult;
-            Debug.Assert(Enum.IsDefined(fileSystemType) || fstatfsResult == 0, $"GetFileSystemType returned {fstatfsResult}");
+            Debug.Assert(Enum.IsDefined(fileSystemType) || fstatfsResult == 0 || OperatingSystem.IsOSXLike(), $"GetFileSystemType returned {fstatfsResult}");
             return fstatfsResult != 0;
         }
     }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.UnixFileSystemTypes.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.UnixFileSystemTypes.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
         /// where this enum must be a subset of the GetDriveType list, with the enum
         /// values here exactly matching a string there.
         /// </remarks>
-        internal enum UnixFileSystemTypes : long
+        internal enum UnixFileSystemTypes : uint
         {
             adfs = 0xADF5,
             affs = 0xADFF,
@@ -148,14 +148,14 @@ internal static partial class Interop
         }
 
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetFileSystemType")]
-        private static partial long GetFileSystemType(SafeFileHandle fd);
+        private static partial uint GetFileSystemType(SafeFileHandle fd);
 
         internal static bool TryGetFileSystemType(SafeFileHandle fd, out UnixFileSystemTypes fileSystemType)
         {
-            long fstatfsResult = GetFileSystemType(fd);
+            uint fstatfsResult = GetFileSystemType(fd);
             fileSystemType = (UnixFileSystemTypes)fstatfsResult;
-            Debug.Assert(Enum.IsDefined(fileSystemType) || fstatfsResult == -1, $"GetFileSystemType returned {fstatfsResult}");
-            return fstatfsResult != -1;
+            Debug.Assert(Enum.IsDefined(fileSystemType) || fstatfsResult == 0, $"GetFileSystemType returned {fstatfsResult}");
+            return fstatfsResult != 0;
         }
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.UnixFileSystemTypes.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.UnixFileSystemTypes.cs
@@ -155,7 +155,7 @@ internal static partial class Interop
         {
             uint fstatfsResult = GetFileSystemType(fd);
             fileSystemType = (UnixFileSystemTypes)fstatfsResult;
-            Debug.Assert(Enum.IsDefined(fileSystemType) || fstatfsResult == 0 || OperatingSystem.IsOSXLike(), $"GetFileSystemType returned {fstatfsResult}");
+            Debug.Assert(Enum.IsDefined(fileSystemType) || fstatfsResult == 0 || !OperatingSystem.IsLinux(), $"GetFileSystemType returned {fstatfsResult}");
             return fstatfsResult != 0;
         }
     }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.UnixFileSystemTypes.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.UnixFileSystemTypes.cs
@@ -24,6 +24,7 @@ internal static partial class Interop
             affs = 0xADFF,
             afs = 0x5346414F,
             anoninode = 0x09041934,
+            apfs = 0x1A,
             aufs = 0x61756673,
             autofs = 0x0187,
             autofs4 = 0x6D4A556D,

--- a/src/native/libs/System.Native/pal_io.c
+++ b/src/native/libs/System.Native/pal_io.c
@@ -1485,7 +1485,6 @@ uint32_t SystemNative_GetFileSystemType(intptr_t fd)
     // On Linux, f_type is signed. This causes some filesystem types to be represented as
     // negative numbers on 32-bit platforms. We cast to uint32_t to make them positive.
     uint32_t result = (uint32_t)statfsArgs.f_type;
-    assert(result == statfsArgs.f_type);
     return result;
 #elif !HAVE_NON_LEGACY_STATFS
     int statfsRes;

--- a/src/native/libs/System.Native/pal_io.c
+++ b/src/native/libs/System.Native/pal_io.c
@@ -1493,6 +1493,7 @@ uint32_t SystemNative_GetFileSystemType(intptr_t fd)
     else if (strcmp(statfsArgs.f_basetype, "affs") == 0) result = 0xADFF;
     else if (strcmp(statfsArgs.f_basetype, "afs") == 0) result = 0x5346414F;
     else if (strcmp(statfsArgs.f_basetype, "anoninode") == 0) result = 0x09041934;
+    else if (strcmp(statfsArgs.f_basetype, "apfs") == 0) result = 0x1A;
     else if (strcmp(statfsArgs.f_basetype, "aufs") == 0) result = 0x61756673;
     else if (strcmp(statfsArgs.f_basetype, "autofs") == 0) result = 0x0187;
     else if (strcmp(statfsArgs.f_basetype, "autofs4") == 0) result = 0x6D4A556D;

--- a/src/native/libs/System.Native/pal_io.c
+++ b/src/native/libs/System.Native/pal_io.c
@@ -1480,7 +1480,7 @@ int64_t SystemNative_GetFileSystemType(intptr_t fd)
     // for our needs (get file system type) statfs is always enough and there is no need to use statfs64
     // which got deprecated in macOS 10.6, in favor of statfs
     while ((statfsRes = fstatfs(ToFileDescriptor(fd), &statfsArgs)) == -1 && errno == EINTR) ;
-    return statfsRes == -1 ? (int64_t)-1 : (int64_t)statfsArgs.f_type;
+    return statfsRes == -1 ? (int64_t)-1 : (int64_t)((uint64_t)statfsArgs.f_type ^ 0xFFFFFFFF00000000); // disregard the upper bytes #61175
 #elif !HAVE_NON_LEGACY_STATFS
     int statfsRes;
     struct statvfs statfsArgs;

--- a/src/native/libs/System.Native/pal_io.h
+++ b/src/native/libs/System.Native/pal_io.h
@@ -739,9 +739,9 @@ PALEXPORT char* SystemNative_RealPath(const char* path);
 PALEXPORT int32_t SystemNative_GetPeerID(intptr_t socket, uid_t* euid);
 
 /**
-* Returns file system type on success, or -1 on error.
+* Returns file system type on success, or 0 on error.
 */
-PALEXPORT int64_t SystemNative_GetFileSystemType(intptr_t fd);
+PALEXPORT uint32_t SystemNative_GetFileSystemType(intptr_t fd);
 
 /**
 * Attempts to lock/unlock the region of the file "fd" specified by the offset and length. lockType


### PR DESCRIPTION
fixes #61175

context: https://github.com/dotnet/runtime/issues/61175#issuecomment-1129873031

the fix is relatively safe as the maximum know value that we support:

https://github.com/dotnet/runtime/blob/4822e3c3aa77eb82b2fb33c9321f923cf11ddde6/src/libraries/Common/src/Interop/Unix/System.Native/Interop.UnixFileSystemTypes.cs#L38

can be represented using 32 bit value