### PR TITLE
Minor cleanup and reduce allocations in Apple X.509 certificate PAL

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateData.ManagedDecode.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateData.ManagedDecode.cs
@@ -87,7 +87,7 @@ namespace System.Security.Cryptography.X509Certificates
             certificate.TbsCertificate.SubjectPublicKeyInfo.Encode(writer);
             SubjectPublicKeyInfo = writer.Encode();
 
-            Extensions = new List<X509Extension>();
+            Extensions = new List<X509Extension>((certificate.TbsCertificate.Extensions?.Length).GetValueOrDefault());
             if (certificate.TbsCertificate.Extensions != null)
             {
                 foreach (X509ExtensionAsn rawExtension in certificate.TbsCertificate.Extensions)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateData.ManagedDecode.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateData.ManagedDecode.cs
@@ -78,8 +78,8 @@ namespace System.Security.Cryptography.X509Certificates
             RawData = rawData;
             certificate = CertificateAsn.Decode(rawData, AsnEncodingRules.DER);
             certificate.TbsCertificate.ValidateVersion();
-            Issuer = new X500DistinguishedName(certificate.TbsCertificate.Issuer.ToArray());
-            Subject = new X500DistinguishedName(certificate.TbsCertificate.Subject.ToArray());
+            Issuer = new X500DistinguishedName(certificate.TbsCertificate.Issuer.Span);
+            Subject = new X500DistinguishedName(certificate.TbsCertificate.Subject.Span);
             IssuerName = Issuer.Name;
             SubjectName = Subject.Name;
 
@@ -94,7 +94,7 @@ namespace System.Security.Cryptography.X509Certificates
                 {
                     X509Extension extension = new X509Extension(
                         rawExtension.ExtnId,
-                        rawExtension.ExtnValue.ToArray(),
+                        rawExtension.ExtnValue.Span,
                         rawExtension.Critical);
 
                     Extensions.Add(extension);
@@ -104,9 +104,8 @@ namespace System.Security.Cryptography.X509Certificates
         }
         catch (Exception e)
         {
-            throw new CryptographicException(
-                $"Error in reading certificate:{Environment.NewLine}{PemPrintCert(rawData)}",
-                e);
+            string pem = new string(PemEncoding.Write(PemLabels.X509Certificate, rawData));
+            throw new CryptographicException($"Error in reading certificate:{Environment.NewLine}{pem}", e);
         }
 #endif
         }
@@ -379,25 +378,5 @@ namespace System.Security.Cryptography.X509Certificates
                 }
             }
         }
-
-#if DEBUG
-        private static string PemPrintCert(byte[] rawData)
-        {
-            const string PemHeader = "-----BEGIN CERTIFICATE-----";
-            const string PemFooter = "-----END CERTIFICATE-----";
-
-            StringBuilder builder = new StringBuilder(PemHeader.Length + PemFooter.Length + rawData.Length * 2);
-            builder.Append(PemHeader);
-            builder.AppendLine();
-
-            builder.Append(Convert.ToBase64String(rawData, Base64FormattingOptions.InsertLineBreaks));
-            builder.AppendLine();
-
-            builder.Append(PemFooter);
-            builder.AppendLine();
-
-            return builder.ToString();
-        }
-#endif
     }
 }


### PR DESCRIPTION
Some cleanup in the Apple X.509 PAL

* Remove allocations when decoding since we have span-accepting `X509Extension` and `X500DistinguishedName`.
* Set the initial capacity of a `List<T>` since we know how big it is going to be.
* Clean up some debugging code to use `PemEncoding`.

This knocks off about a kilobyte of allocations when decoding a typical X.509 certificate (depending on the number of extensions, but given the ever-growing size of SCTs, it's noticeable).