### PR TITLE
Permit SET OF to be incorrectly sorted in GetNameInfo

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
@@ -392,6 +392,23 @@ Wry5FNNo
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        public static void GetNameInfo_IncorrectSetOfSorting(bool forIssuer)
+        {
+            using ECDsa key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+            CertificateRequest req = new CertificateRequest(
+                new X500DistinguishedName(Convert.FromHexString("301C311A300B060355040B13047A7A7A7A300B060355040B130461616161")),
+                key,
+                HashAlgorithmName.SHA256);
+
+            using X509Certificate2 cert = req.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now);
+            string name = cert.GetNameInfo(X509NameType.SimpleName, forIssuer);
+            Assert.Equal("aaaa", name);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public static void GetNameInfo_HandlesUtf8Encoding(bool issuer)
         {
             using (X509Certificate2 c = new X509Certificate2(TestData.CertificateWithUtf8))

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateData.ManagedDecode.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateData.ManagedDecode.cs
@@ -347,7 +347,8 @@ namespace System.Security.Cryptography.X509Certificates
 
                 while (sequenceReader.HasData)
                 {
-                    rdnReaders.Push(sequenceReader.ReadSetOf());
+                    // To match Windows' behavior, permit multi-value RDN SETs to not be DER sorted.
+                    rdnReaders.Push(sequenceReader.ReadSetOf(skipSortOrderValidation: true));
                 }
             }
             catch (AsnContentException e)


### PR DESCRIPTION
`GetNameInfo` for `SimpleName` did not permit not-DER-sorted SET OF. Since we've seen certificates with subjects / issuers in the wild with this, I suggest we permit it here since [we have permitted it elsewhere](https://github.com/dotnet/runtime/pull/32604).