### PR TITLE
Allocate less with X500DistinguishedName

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameEncodingTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameEncodingTests.cs
@@ -126,6 +126,17 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             ProcessTestCase(testCase, dn);
         }
 
+        [Theory]
+        [InlineData("OID.STREET=abbeyroad")] // A real friendly name.
+        [InlineData("OID.AGHHHH=internet")] // Not a real friendly name.
+        [InlineData("OID.=internet")] // Blank OID.
+        [InlineData("OID.99.99=sun")] // Invalid OID, bad arc.
+        [InlineData("OID.99.a=sun")] // Invalid OID, not numeric.
+        public static void ParseWithInvalidObjectIdentifiers(string distinguishedName)
+        {
+            Assert.Throws<CryptographicException>(() => new X500DistinguishedName(distinguishedName));
+        }
+
         private static void ProcessTestCase(SimpleEncoderTestCase testCase, X500DistinguishedName dn)
         {
             // The simple encoding test is "does it output the expected text?", then

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameEncodingTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameEncodingTests.cs
@@ -134,7 +134,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("OID.99.a=sun")] // Invalid OID, not numeric.
         public static void ParseWithInvalidObjectIdentifiers(string distinguishedName)
         {
-            Assert.Throws<CryptographicException>(() => new X500DistinguishedName(distinguishedName));
+            Assert.ThrowsAny<CryptographicException>(() => new X500DistinguishedName(distinguishedName));
         }
 
         private static void ProcessTestCase(SimpleEncoderTestCase testCase, X500DistinguishedName dn)

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -255,6 +255,8 @@
              Link="Common\System\Security\Cryptography\RSAKeyFormatHelper.Encrypted.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\RsaPaddingProcessor.cs"
              Link="Common\System\Security\Cryptography\RsaPaddingProcessor.cs" />
+    <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"
+             Link="Common\System\Text\ValueStringBuilder.cs" />
     <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs"
              Link="Common\System\Threading\Tasks\TaskToApm.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafePasswordHandle.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500NameEncoder.ManagedDecode.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500NameEncoder.ManagedDecode.cs
@@ -33,7 +33,7 @@ namespace System.Security.Cryptography.X509Certificates
                     rdnReaders.Add(x500NameSequenceReader.ReadSetOf(skipSortOrderValidation: true));
                 }
 
-                // We need to allocate a StringBuilder to hold the data as we're building it, and there's the usual
+                // We need to use a ValueStringBuilder to hold the data as we're building it, and there's the usual
                 // arbitrary process of choosing a number that's "big enough" to minimize reallocations without wasting
                 // too much space in the average case.
                 //
@@ -57,7 +57,7 @@ namespace System.Security.Cryptography.X509Certificates
                 // Throw in some "maybe-I-need-to-quote-this" quotes, and a couple of extra/extra-long O/OU values
                 // and round that up to the next programmer number, and you get that 512 should avoid reallocations
                 // in all but the most dire of cases.
-                StringBuilder decodedName = new StringBuilder(512);
+                ValueStringBuilder decodedName = new ValueStringBuilder(stackalloc char[512]);
                 int entryCount = rdnReaders.Count;
                 bool printSpacing = false;
 
@@ -107,7 +107,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                         if (printOid)
                         {
-                            AppendOid(decodedName, oid);
+                            AppendOid(ref decodedName, oid);
                         }
 
                         bool quote = quoteIfNeeded && NeedsQuoting(attributeValue);
@@ -135,7 +135,9 @@ namespace System.Security.Cryptography.X509Certificates
                     decodedName.Append(dnSeparator);
                 }
 
-                return decodedName.ToString();
+                string name = decodedName.ToString();
+                decodedName.Dispose();
+                return name;
             }
             catch (AsnContentException e)
             {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500NameEncoder.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500NameEncoder.cs
@@ -163,7 +163,7 @@ namespace System.Security.Cryptography.X509Certificates
             return (c == ' ' || (c >= 0x09 && c <= 0x0D));
         }
 
-        private static void AppendOid(StringBuilder decodedName, string oidValue)
+        private static void AppendOid(ref ValueStringBuilder decodedName, string oidValue)
         {
             Oid oid = new Oid(oidValue);
 


### PR DESCRIPTION
This cleans up some allocations with X500DistinguishedName.

* Use `ValueStringBuilder` since it seems well suited for this task and distinguished names will usually fit in a stack buffer.
* `ParseOid` has a breaking change. Previously, the managed decoder would permit a friendly name where an OID was expected, such as `OID.STREET=downingstreet`. This does not work with Windows, and it should not have worked on Linux / macOS.
* `ParseOid` avoids allocating an `Oid` object when parsing `OID.`-prefixed RDNs.
* `ParseRdn` will now write to a destination instead of building a list. We know that the result will be at most the size of the original input, so we can allocate a buffer in one go and write to it. Since we are writing to a buffer now, a sufficiently small destination will be stack allocated.
* Add tests for some invalid OID scenarios to codify their behavior.

Benchmark:

To summarize, writing to a string approximately halved the allocations where the `ValueStringBuilder` is used, and some improvements throughout.

|   Method |        Job | Toolchain |                                        DN |    Flags |        Mean |    Error |   StdDev | Ratio |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|--------- |----------- |---------- |-------------------------------------------|--------- |------------:|---------:|---------:|------:|-------:|-------:|------:|----------:|
|  ParseDN | Job-XUBWZR |    branch |  CN="Adjacent Escaped""""Quotes", OU=home |     None | 18,289.7 ns | 27.20 ns | 25.44 ns |  1.00 | 0.8545 |      - |     - |   5,472 B |
|  ParseDN | Job-XFDWAU |      main |  CN="Adjacent Escaped""""Quotes", OU=home |     None | 18,298.4 ns | 59.09 ns | 52.39 ns |  1.00 | 0.9155 |      - |     - |   5,752 B |
|          |            |           |                                           |          |             |          |          |       |        |        |       |           |
| DecodeDN | Job-XUBWZR |    branch |  CN="Adjacent Escaped""""Quotes", OU=home |     None |    722.7 ns |  1.38 ns |  1.08 ns |  0.97 | 0.1612 |      - |     - |   1,016 B |
| DecodeDN | Job-XFDWAU |      main |  CN="Adjacent Escaped""""Quotes", OU=home |     None |    747.7 ns |  1.02 ns |  0.96 ns |  1.00 | 0.3366 | 0.0010 |     - |   2,112 B |
|          |            |           |                                           |          |             |          |          |       |        |        |       |           |
|  ParseDN | Job-XUBWZR |    branch |  CN="Adjacent Escaped""""Quotes", OU=home | Reversed | 18,241.1 ns | 38.97 ns | 34.55 ns |  1.00 | 0.8545 |      - |     - |   5,472 B |
|  ParseDN | Job-XFDWAU |      main |  CN="Adjacent Escaped""""Quotes", OU=home | Reversed | 18,269.6 ns | 52.11 ns | 48.74 ns |  1.00 | 0.9155 |      - |     - |   5,752 B |
|          |            |           |                                           |          |             |          |          |       |        |        |       |           |
| DecodeDN | Job-XUBWZR |    branch |  CN="Adjacent Escaped""""Quotes", OU=home | Reversed |    713.5 ns |  0.67 ns |  0.63 ns |  0.95 | 0.1612 |      - |     - |   1,016 B |
| DecodeDN | Job-XFDWAU |      main |  CN="Adjacent Escaped""""Quotes", OU=home | Reversed |    748.0 ns |  1.45 ns |  1.21 ns |  1.00 | 0.3366 | 0.0010 |     - |   2,112 B |
|          |            |           |                                           |          |             |          |          |       |        |        |       |           |
|  ParseDN | Job-XUBWZR |    branch |                                    CN=CAT |     None |    807.6 ns |  0.90 ns |  0.80 ns |  1.01 | 0.4826 | 0.0019 |     - |   3,032 B |
|  ParseDN | Job-XFDWAU |      main |                                    CN=CAT |     None |    797.2 ns |  1.47 ns |  1.37 ns |  1.00 | 0.4826 | 0.0019 |     - |   3,032 B |
|          |            |           |                                           |          |             |          |          |       |        |        |       |           |
| DecodeDN | Job-XUBWZR |    branch |                                    CN=CAT |     None |    355.5 ns |  0.29 ns |  0.25 ns |  0.91 | 0.0839 |      - |     - |     528 B |
| DecodeDN | Job-XFDWAU |      main |                                    CN=CAT |     None |    388.6 ns |  0.55 ns |  0.48 ns |  1.00 | 0.2584 | 0.0005 |     - |   1,624 B |
|          |            |           |                                           |          |             |          |          |       |        |        |       |           |
|  ParseDN | Job-XUBWZR |    branch |                                    CN=CAT | Reversed |    794.7 ns |  1.22 ns |  1.08 ns |  1.00 | 0.4826 | 0.0010 |     - |   3,032 B |
|  ParseDN | Job-XFDWAU |      main |                                    CN=CAT | Reversed |    794.9 ns |  1.19 ns |  1.06 ns |  1.00 | 0.4826 | 0.0019 |     - |   3,032 B |
|          |            |           |                                           |          |             |          |          |       |        |        |       |           |
| DecodeDN | Job-XUBWZR |    branch |                                    CN=CAT | Reversed |    356.7 ns |  0.48 ns |  0.42 ns |  0.92 | 0.0839 |      - |     - |     528 B |
| DecodeDN | Job-XFDWAU |      main |                                    CN=CAT | Reversed |    388.5 ns |  0.39 ns |  0.34 ns |  1.00 | 0.2584 | 0.0005 |     - |   1,624 B |
|          |            |           |                                           |          |             |          |          |       |        |        |       |           |
|  ParseDN | Job-XUBWZR |    branch | [large truncated]                         |     None |  9,731.7 ns | 10.26 ns |  8.57 ns |  0.97 | 2.8229 | 0.0458 |     - |  17,720 B |
|  ParseDN | Job-XFDWAU |      main | [large truncated]                         |     None | 10,062.5 ns |  6.84 ns |  5.34 ns |  1.00 | 2.8839 | 0.0458 |     - |  18,120 B |
|          |            |           |                                           |          |             |          |          |       |        |        |       |           |
| DecodeDN | Job-XUBWZR |    branch | [large truncated]                         |     None |  4,775.6 ns |  4.35 ns |  4.07 ns |  1.00 | 0.9003 | 0.0076 |     - |   5,672 B |
| DecodeDN | Job-XFDWAU |      main | [large truncated]                         |     None |  4,783.2 ns |  9.09 ns |  8.50 ns |  1.00 | 1.2512 | 0.0153 |     - |   7,864 B |
|          |            |           |                                           |          |             |          |          |       |        |        |       |           |
|  ParseDN | Job-XUBWZR |    branch | [large truncated]                         | Reversed |  9,709.9 ns | 20.31 ns | 19.00 ns |  0.96 | 2.8229 | 0.0458 |     - |  17,720 B |
|  ParseDN | Job-XFDWAU |      main | [large truncated]                         | Reversed | 10,141.9 ns | 14.12 ns | 12.52 ns |  1.00 | 2.8839 | 0.0458 |     - |  18,120 B |
|          |            |           |                                           |          |             |          |          |       |        |        |       |           |
| DecodeDN | Job-XUBWZR |    branch | [large truncated]                         | Reversed |  4,731.7 ns |  8.64 ns |  8.08 ns |  0.99 | 0.9003 | 0.0076 |     - |   5,672 B |
| DecodeDN | Job-XFDWAU |      main | [large truncated]                         | Reversed |  4,781.4 ns |  5.69 ns |  4.76 ns |  1.00 | 1.2512 | 0.0229 |     - |   7,864 B |
|          |            |           |                                           |          |             |          |          |       |        |        |       |           |
|  ParseDN | Job-XUBWZR |    branch |    OID.1.2.3.4=hello, OID.1.2.3.5=goodbye |     None |  1,430.9 ns |  2.58 ns |  2.29 ns |  0.90 | 0.7038 | 0.0019 |     - |   4,424 B |
|  ParseDN | Job-XFDWAU |      main |    OID.1.2.3.4=hello, OID.1.2.3.5=goodbye |     None |  1,584.0 ns |  1.46 ns |  1.29 ns |  1.00 | 0.7305 | 0.0019 |     - |   4,584 B |
|          |            |           |                                           |          |             |          |          |       |        |        |       |           |
| DecodeDN | Job-XUBWZR |    branch |    OID.1.2.3.4=hello, OID.1.2.3.5=goodbye |     None |    704.2 ns |  0.55 ns |  0.49 ns |  0.93 | 0.1440 |      - |     - |     904 B |
| DecodeDN | Job-XFDWAU |      main |    OID.1.2.3.4=hello, OID.1.2.3.5=goodbye |     None |    760.5 ns |  1.42 ns |  1.26 ns |  1.00 | 0.3185 | 0.0010 |     - |   2,000 B |
|          |            |           |                                           |          |             |          |          |       |        |        |       |           |
|  ParseDN | Job-XUBWZR |    branch |    OID.1.2.3.4=hello, OID.1.2.3.5=goodbye | Reversed |  1,430.0 ns |  2.27 ns |  2.01 ns |  0.91 | 0.7038 | 0.0019 |     - |   4,424 B |
|  ParseDN | Job-XFDWAU |      main |    OID.1.2.3.4=hello, OID.1.2.3.5=goodbye | Reversed |  1,571.7 ns |  1.89 ns |  1.68 ns |  1.00 | 0.7305 | 0.0019 |     - |   4,584 B |
|          |            |           |                                           |          |             |          |          |       |        |        |       |           |
| DecodeDN | Job-XUBWZR |    branch |    OID.1.2.3.4=hello, OID.1.2.3.5=goodbye | Reversed |    709.7 ns |  0.97 ns |  0.91 ns |  0.94 | 0.1440 |      - |     - |     904 B |
| DecodeDN | Job-XFDWAU |      main |    OID.1.2.3.4=hello, OID.1.2.3.5=goodbye | Reversed |    751.6 ns |  0.89 ns |  0.79 ns |  1.00 | 0.3185 | 0.0010 |     - |   2,000 B |