### PR TITLE
[wasm-mt] Add coop GC transitions to various EMSCRIPTEN_KEEPALIVE functions; define to noop if no threads

### DIFF
--- a/src/mono/mono/component/mini-wasm-debugger.c
+++ b/src/mono/mono/component/mini-wasm-debugger.c
@@ -14,6 +14,7 @@
 #include "debugger-protocol.h"
 #include "debugger-agent.h"
 #include <mono/metadata/components.h>
+#include <mono/utils/mono-threads-api.h>
 
 //XXX This is dirty, extend ee.h to support extracting info from MonoInterpFrameHandle
 #include <mono/mini/interp/interp-internals.h>
@@ -343,6 +344,7 @@ write_value_to_buffer (MdbgProtBuffer *buf, MonoTypeEnum type, const char* varia
 EMSCRIPTEN_KEEPALIVE void
 mono_wasm_set_is_debugger_attached (gboolean is_attached)
 {
+	MONO_ENTER_GC_UNSAFE;
 	mono_set_is_debugger_attached (is_attached);
 	if (is_attached && has_pending_lazy_loaded_assemblies)
 	{
@@ -354,12 +356,15 @@ mono_wasm_set_is_debugger_attached (gboolean is_attached)
 		g_ptr_array_free (assemblies, TRUE);
 		has_pending_lazy_loaded_assemblies = FALSE;
 	}
+	MONO_EXIT_GC_UNSAFE;
 }
 
 EMSCRIPTEN_KEEPALIVE void
 mono_wasm_change_debugger_log_level (int new_log_level)
 {
+	MONO_ENTER_GC_UNSAFE;
 	mono_change_log_level (new_log_level);
+	MONO_EXIT_GC_UNSAFE;
 }
 
 extern void mono_wasm_add_dbg_command_received(mono_bool res_ok, int id, void* buffer, int buffer_len);
@@ -367,28 +372,38 @@ extern void mono_wasm_add_dbg_command_received(mono_bool res_ok, int id, void* b
 EMSCRIPTEN_KEEPALIVE gboolean
 mono_wasm_send_dbg_command_with_parms (int id, MdbgProtCommandSet command_set, int command, guint8* data, unsigned int size, int valtype, char* newvalue)
 {
+	gboolean result = FALSE;
+	MONO_ENTER_GC_UNSAFE;
 	if (!debugger_enabled) {
 		mono_wasm_add_dbg_command_received (0, id, 0, 0);
-		return TRUE;
+		result = TRUE;
+		goto done;
 	}
 	MdbgProtBuffer bufWithParms;
 	buffer_init (&bufWithParms, 128);
 	m_dbgprot_buffer_add_data (&bufWithParms, data, size);
 	if (!write_value_to_buffer(&bufWithParms, valtype, newvalue)) {
 		mono_wasm_add_dbg_command_received(0, id, 0, 0);
-		return TRUE;
+		result = TRUE;
+		goto done;
 	}
 	mono_wasm_send_dbg_command(id, command_set, command, bufWithParms.buf, m_dbgprot_buffer_len(&bufWithParms));
 	buffer_free (&bufWithParms);
-	return TRUE;
+	result = TRUE;
+done:
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 EMSCRIPTEN_KEEPALIVE gboolean
 mono_wasm_send_dbg_command (int id, MdbgProtCommandSet command_set, int command, guint8* data, unsigned int size)
 {
+	gboolean result = FALSE;
+	MONO_ENTER_GC_UNSAFE;
 	if (!debugger_enabled) {
 		mono_wasm_add_dbg_command_received(0, id, 0, 0);
-		return TRUE;
+		result = TRUE;
+		goto done;
 	}
 	ss_calculate_framecount (NULL, NULL, TRUE, NULL, NULL);
 	MdbgProtBuffer buf;
@@ -409,7 +424,10 @@ mono_wasm_send_dbg_command (int id, MdbgProtCommandSet command_set, int command,
 	mono_wasm_add_dbg_command_received (error == MDBGPROT_ERR_NONE, id, buf.buf, buf.p-buf.buf);
 
 	buffer_free (&buf);
-	return TRUE;
+	result = TRUE;
+done:
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 static gboolean

--- a/src/mono/mono/mini/debugger-agent-external.c
+++ b/src/mono/mono/mini/debugger-agent-external.c
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 //
 
+#include <config.h>
 #include <glib.h>
 #include <mono/metadata/components.h>
 #include "debugger-agent-external.h"

--- a/src/mono/mono/mini/mini-wasm.c
+++ b/src/mono/mono/mini/mini-wasm.c
@@ -548,6 +548,7 @@ mono_thread_state_init_from_handle (MonoThreadUnwindState *tctx, MonoThreadInfo 
 EMSCRIPTEN_KEEPALIVE void
 mono_set_timeout_exec (void)
 {
+	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
 
 	static MonoMethod *method = NULL;
@@ -576,6 +577,7 @@ mono_set_timeout_exec (void)
 		g_printerr ("timeout callback threw a %s\n", type_name);
 		g_free (type_name);
 	}
+	MONO_EXIT_GC_UNSAFE;
 }
 
 #endif

--- a/src/mono/mono/utils/mono-threads-api.h
+++ b/src/mono/mono/utils/mono-threads-api.h
@@ -106,6 +106,7 @@ This will put the current thread in GC Unsafe mode.
 For further explanation of what can and can't be done in GC unsafe mode:
 http://www.mono-project.com/docs/advanced/runtime/docs/coop-suspend/#gc-unsafe-mode
 */
+#ifndef DISABLE_THREADS
 #define MONO_ENTER_GC_UNSAFE	\
 	do {	\
 		MONO_STACKDATA (__gc_unsafe_dummy); \
@@ -136,6 +137,24 @@ http://www.mono-project.com/docs/advanced/runtime/docs/coop-suspend/#gc-unsafe-m
 #define MONO_ENTER_GC_SAFE_UNBALANCED	\
 		MONO_STACKDATA (__gc_safe_unbalanced_dummy); \
 		mono_threads_enter_gc_safe_region_unbalanced_internal (&__gc_safe_unbalanced_dummy)
+
+#else /* DISABLE_THREADS */
+
+#define MONO_ENTER_GC_UNSAFE	do {
+
+#define MONO_EXIT_GC_UNSAFE	(void)0; } while (0)
+
+#define MONO_ENTER_GC_UNSAFE_UNBALANCED	do {
+
+#define MONO_EXIT_GC_UNSAFE_UNBALANCED	(void)0; } while (0)
+
+#define MONO_ENTER_GC_SAFE	do {
+
+#define MONO_EXIT_GC_SAFE	(void)0; } while (0)
+
+#define MONO_ENTER_GC_SAFE_UNBALANCED	/* empty */
+
+#endif /* DISABLE_THREADS */
 
 void
 mono_threads_enter_no_safepoints_region (const char *func);

--- a/src/mono/mono/utils/mono-threads-coop.h
+++ b/src/mono/mono/utils/mono-threads-coop.h
@@ -129,12 +129,17 @@ MONO_PROFILER_API
 gpointer
 mono_threads_enter_gc_safe_region_with_info (THREAD_INFO_TYPE *info, MonoStackData *stackdata);
 
+#ifndef DISABLE_THREADS
 #define MONO_ENTER_GC_SAFE_WITH_INFO(info)	\
 	do {	\
 		MONO_STACKDATA (__gc_safe_dummy); \
 		gpointer __gc_safe_cookie = mono_threads_enter_gc_safe_region_with_info ((info), &__gc_safe_dummy)
 
 #define MONO_EXIT_GC_SAFE_WITH_INFO	MONO_EXIT_GC_SAFE
+#else
+#define MONO_ENTER_GC_SAFE_WITH_INFO(info)	do { (void)info;
+#define MONO_EXIT_GC_SAFE_WITH_INFO	MONO_EXIT_GC_SAFE
+#endif
 
 MONO_PROFILER_API
 gpointer

--- a/src/mono/mono/utils/mono-threads-wasm.c
+++ b/src/mono/mono/utils/mono-threads-wasm.c
@@ -8,6 +8,7 @@
 
 #include <mono/utils/mono-threads.h>
 #include <mono/utils/mono-mmap.h>
+#include <mono/utils/mono-threads-api.h>
 #include <mono/utils/mono-threads-debug.h>
 
 #include <glib.h>
@@ -28,6 +29,7 @@ EMSCRIPTEN_KEEPALIVE
 static int
 wasm_get_stack_base (void)
 {
+	// wasm-mt: add MONO_ENTER_GC_UNSAFE / MONO_EXIT_GC_UNSAFE if this function becomes more complex
 	return emscripten_stack_get_end ();
 }
 
@@ -35,6 +37,7 @@ EMSCRIPTEN_KEEPALIVE
 static int
 wasm_get_stack_size (void)
 {
+	// wasm-mt: add MONO_ENTER_GC_UNSAFE / MONO_EXIT_GC_UNSAFE if this function becomes more complex
 	return (guint8*)emscripten_stack_get_base () - (guint8*)emscripten_stack_get_end ();
 }
 
@@ -355,6 +358,7 @@ G_EXTERN_C
 EMSCRIPTEN_KEEPALIVE void
 mono_background_exec (void)
 {
+	MONO_ENTER_GC_UNSAFE;
 #ifndef DISABLE_THREADS
 	g_assert (mono_threads_wasm_is_browser_thread ());
 #endif
@@ -366,6 +370,7 @@ mono_background_exec (void)
 		cb ();
 	}
 	g_slist_free (j);
+	MONO_EXIT_GC_UNSAFE;
 }
 
 gboolean

--- a/src/mono/wasm/runtime/gc-common.h
+++ b/src/mono/wasm/runtime/gc-common.h
@@ -20,6 +20,8 @@ mono_threads_exit_gc_safe_region (gpointer cookie, gpointer *stackdata);
 
 MONO_API void
 mono_threads_assert_gc_safe_region (void);
+
+#ifndef DISABLE_THREADS
 #define MONO_ENTER_GC_UNSAFE	\
 	do {	\
 		gpointer __dummy;	\
@@ -37,6 +39,18 @@ mono_threads_assert_gc_safe_region (void);
 #define MONO_EXIT_GC_SAFE	\
 		mono_threads_exit_gc_safe_region (__gc_safe_cookie, &__dummy);	\
 	} while (0)
+
+#else /* DISABLE_THREADS */
+
+#define MONO_ENTER_GC_UNSAFE	do {
+
+#define MONO_EXIT_GC_UNSAFE	(void)0; } while (0)
+
+#define MONO_ENTER_GC_SAFE	do {
+
+#define MONO_EXIT_GC_SAFE	(void)0; } while (0)
+
+#endif /* DISABLE_THREADS */
 
 static void
 store_volatile (PPVOLATILE(MonoObject) destination, PVOLATILE(MonoObject) source) {


### PR DESCRIPTION
Any runtime function that is called from JS must perform a transition to GC unsafe mode on the multi-threaded runtime.

With threading disabled, these macros will expand to nothing.