### PR TITLE
Allow ZipArchive to create duplicate entries

### DIFF
--- a/src/libraries/System.IO.Compression/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Compression/src/Resources/Strings.resx
@@ -302,9 +302,6 @@
   <data name="Zip64EOCDNotWhereExpected" xml:space="preserve">
     <value>Zip 64 End of Central Directory Record not where indicated.</value>
   </data>
-  <data name="EntryNameAlreadyExists" xml:space="preserve">
-    <value>An entry named '{0}' already exists in the archive.</value>
-  </data>
   <data name="PlatformNotSupported_Compression" xml:space="preserve">
     <value>System.IO.Compression is not supported on this platform.</value>
   </data>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -433,12 +433,7 @@ namespace System.IO.Compression
         private void AddEntry(ZipArchiveEntry entry)
         {
             _entries.Add(entry);
-
-            string entryName = entry.FullName;
-            if (!_entriesDictionary.ContainsKey(entryName))
-            {
-                _entriesDictionary.Add(entryName, entry);
-            }
+            _entriesDictionary.TryAdd(entry.FullName, entry);
         }
 
         [Conditional("DEBUG")]

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -400,11 +400,6 @@ namespace System.IO.Compression
             if (_mode == ZipArchiveMode.Read)
                 throw new NotSupportedException(SR.CreateInReadMode);
 
-            if (_entriesDictionary.ContainsKey(entryName))
-            {
-                throw new InvalidOperationException(string.Format(SR.EntryNameAlreadyExists, entryName));
-            }
-
             ThrowIfDisposed();
 
 
@@ -438,7 +433,12 @@ namespace System.IO.Compression
         private void AddEntry(ZipArchiveEntry entry)
         {
             _entries.Add(entry);
-            _entriesDictionary.TryAdd(entry.FullName, entry);
+
+            string entryName = entry.FullName;
+            if (!_entriesDictionary.ContainsKey(entryName))
+            {
+                _entriesDictionary.Add(entryName, entry);
+            }
         }
 
         [Conditional("DEBUG")]

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -191,23 +191,6 @@ namespace System.IO.Compression.Tests
             AssertUnicodeFileNameAndComment(ms, isUnicodeFlagExpected);
         }
 
-        [Fact]
-        public static void CreateNormal_With2SameEntries_ThrowException()
-        {
-            using var memoryStream = new MemoryStream();
-            // We need an non-seekable stream so the data descriptor bit is turned on when saving
-            var wrappedStream = new WrappedStream(memoryStream);
-
-            // Creation will go through the path that sets the data descriptor bit when the stream is unseekable
-            using (var archive = new ZipArchive(wrappedStream, ZipArchiveMode.Create))
-            {
-                string entryName = "duplicate.txt";
-                CreateEntry(archive, entryName, "xxx");
-                AssertExtensions.ThrowsContains<InvalidOperationException>(() => CreateEntry(archive, entryName, "yyy"),
-                    entryName);
-            }
-        }
-
         private static string ReadStringFromSpan(Span<byte> input)
         {
             return Text.Encoding.UTF8.GetString(input.ToArray());

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -191,6 +191,23 @@ namespace System.IO.Compression.Tests
             AssertUnicodeFileNameAndComment(ms, isUnicodeFlagExpected);
         }
 
+        [Fact]
+        public void Create_VerifyDuplicateEntriesAreAllowed()
+        {
+            using var ms = new MemoryStream();
+            using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                string entryName = "foo";
+                AddEntry(archive, entryName, contents: "xxx", DateTimeOffset.Now);
+                AddEntry(archive, entryName, contents: "yyy", DateTimeOffset.Now);
+            }
+
+            using (var archive = new ZipArchive(ms, ZipArchiveMode.Update))
+            {
+                Assert.Equal(2, archive.Entries.Count);
+            }
+        }
+
         private static string ReadStringFromSpan(Span<byte> input)
         {
             return Text.Encoding.UTF8.GetString(input.ToArray());

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -93,38 +93,20 @@ namespace System.IO.Compression.Tests
             baseline = baseline.Clone();
             using (ZipArchive archive = new ZipArchive(baseline, mode))
             {
-                if (mode == ZipArchiveMode.Create)
-                {
-                    AddEntry(archive, "data1.txt", data1, lastWrite);
+                AddEntry(archive, "data1.txt", data1, lastWrite);
 
-                    ZipArchiveEntry e = archive.CreateEntry("empty.txt");
-                    e.LastWriteTime = lastWrite;
-                    using (Stream s = e.Open()) { }
-                }
-                else
-                {
-                    Assert.Throws<InvalidOperationException>(() => AddEntry(archive, "data1.txt", data1, lastWrite));
-
-                    Assert.Throws<InvalidOperationException>(() => archive.CreateEntry("empty.txt"));
-                }
+                ZipArchiveEntry e = archive.CreateEntry("empty.txt");
+                e.LastWriteTime = lastWrite;
+                using (Stream s = e.Open()) { }
             }
 
             test = test.Clone();
             using (ZipArchive archive = new ZipArchive(test, mode))
             {
-                if (mode == ZipArchiveMode.Create)
-                {
-                    AddEntry(archive, "data1.txt", data1, lastWrite);
+                AddEntry(archive, "data1.txt", data1, lastWrite);
 
-                    ZipArchiveEntry e = archive.CreateEntry("empty.txt");
-                    e.LastWriteTime = lastWrite;
-                }
-                else
-                {
-                    Assert.Throws<InvalidOperationException>(() => AddEntry(archive, "data1.txt", data1, lastWrite));
-
-                    Assert.Throws<InvalidOperationException>(() => archive.CreateEntry("empty.txt"));
-                }
+                ZipArchiveEntry e = archive.CreateEntry("empty.txt");
+                e.LastWriteTime = lastWrite;
             }
             //compare
             Assert.True(ArraysEqual(baseline.ToArray(), test.ToArray()), "Arrays didn't match after update");

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -338,5 +338,18 @@ namespace System.IO.Compression.Tests
                 Assert.Equal(0, compressionMethod); // stored => 0, deflate => 8
             }
         }
+
+        [Fact]
+        public void Update_VerifyDuplicateEntriesAreAllowed()
+        {
+            using var ms = new MemoryStream();
+            using var archive = new ZipArchive(ms, ZipArchiveMode.Update);
+
+            string entryName = "foo";
+            AddEntry(archive, entryName, contents: "xxx", DateTimeOffset.Now);
+            AddEntry(archive, entryName, contents: "yyy", DateTimeOffset.Now);
+
+            Assert.Equal(2, archive.Entries.Count);
+        }
     }
 }


### PR DESCRIPTION
Reverts https://github.com/dotnet/runtime/pull/60973
Fixes https://github.com/dotnet/runtime/issues/68734

See https://github.com/dotnet/runtime/issues/68734#issuecomment-1129595384 for context.