### PR TITLE
Clean up code for CPU_Group_Info structs

### DIFF
--- a/src/coreclr/gc/windows/gcenv.windows.cpp
+++ b/src/coreclr/gc/windows/gcenv.windows.cpp
@@ -53,13 +53,11 @@ public:
 
 struct CPU_Group_Info
 {
-    WORD    nr_active;  // at most 64
-    WORD    reserved[1];
-    WORD    begin;
-    WORD    end;
     DWORD_PTR   active_mask;
-    DWORD   groupWeight;
-    DWORD   activeThreadWeight;
+    WORD        nr_active;  // at most 64
+    WORD        begin;
+    DWORD       groupWeight;
+    DWORD       activeThreadWeight;
 };
 
 static bool g_fEnableGCCPUGroups;
@@ -154,8 +152,8 @@ bool InitCPUGroupInfoArray()
     DWORD dwNumElements = 0;
     DWORD dwWeight = 1;
 
-    if (GetLogicalProcessorInformationEx(RelationGroup, pSLPIEx, &cbSLPIEx) &&
-                      GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+    if (GetLogicalProcessorInformationEx(RelationGroup, pSLPIEx, &cbSLPIEx) ||
+        GetLastError() != ERROR_INSUFFICIENT_BUFFER)
         return false;
 
     assert(cbSLPIEx);
@@ -195,6 +193,7 @@ bool InitCPUGroupInfoArray()
     {
         g_CPUGroupInfoArray[i].nr_active   = (WORD)pRecord->Group.GroupInfo[i].ActiveProcessorCount;
         g_CPUGroupInfoArray[i].active_mask = pRecord->Group.GroupInfo[i].ActiveProcessorMask;
+        g_CPUGroupInfoArray[i].begin       = g_nProcessors;
         g_nProcessors += g_CPUGroupInfoArray[i].nr_active;
         dwWeight = LCM(dwWeight, (DWORD)g_CPUGroupInfoArray[i].nr_active);
     }
@@ -216,26 +215,6 @@ bool InitCPUGroupInfoArray()
 #endif
 }
 
-bool InitCPUGroupInfoRange()
-{
-#if (defined(TARGET_AMD64) || defined(TARGET_ARM64))
-    WORD begin   = 0;
-    WORD nr_proc = 0;
-
-    for (WORD i = 0; i < g_nGroups; i++)
-    {
-        nr_proc += g_CPUGroupInfoArray[i].nr_active;
-        g_CPUGroupInfoArray[i].begin = begin;
-        g_CPUGroupInfoArray[i].end   = nr_proc - 1;
-        begin = nr_proc;
-    }
-
-    return true;
-#else
-    return false;
-#endif
-}
-
 void InitCPUGroupInfo()
 {
     g_fEnableGCCPUGroups = false;
@@ -245,9 +224,6 @@ void InitCPUGroupInfo()
         return;
 
     if (!InitCPUGroupInfoArray())
-        return;
-
-    if (!InitCPUGroupInfoRange())
         return;
 
     // only enable CPU groups if more than one group exists

--- a/src/coreclr/gc/windows/gcenv.windows.cpp
+++ b/src/coreclr/gc/windows/gcenv.windows.cpp
@@ -62,7 +62,7 @@ struct CPU_Group_Info
 
 static bool g_fEnableGCCPUGroups;
 static bool g_fHadSingleProcessorAtStartup;
-static DWORD  g_nGroups;
+static DWORD g_nGroups;
 static DWORD g_nProcessors;
 static CPU_Group_Info *g_CPUGroupInfoArray;
 
@@ -193,7 +193,7 @@ bool InitCPUGroupInfoArray()
     {
         g_CPUGroupInfoArray[i].nr_active   = (WORD)pRecord->Group.GroupInfo[i].ActiveProcessorCount;
         g_CPUGroupInfoArray[i].active_mask = pRecord->Group.GroupInfo[i].ActiveProcessorMask;
-        g_CPUGroupInfoArray[i].begin       = g_nProcessors;
+        g_CPUGroupInfoArray[i].begin       = (WORD)g_nProcessors;
         g_nProcessors += g_CPUGroupInfoArray[i].nr_active;
         dwWeight = LCM(dwWeight, (DWORD)g_CPUGroupInfoArray[i].nr_active);
     }

--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -972,13 +972,11 @@ public: 	// functions
 
 struct CPU_Group_Info
 {
-    WORD	nr_active;	// at most 64
-    WORD	reserved[1];
-    WORD	begin;
-    WORD	end;
-    DWORD_PTR	active_mask;
-    DWORD	groupWeight;
-    DWORD	activeThreadWeight;
+    DWORD_PTR   active_mask;
+    WORD        nr_active;  // at most 64
+    WORD        begin;
+    DWORD       groupWeight;
+    DWORD       activeThreadWeight;
 };
 
 class CPUGroupInfo
@@ -994,7 +992,6 @@ private:
     static CPU_Group_Info *m_CPUGroupInfoArray;
 
     static BOOL InitCPUGroupInfoArray();
-    static BOOL InitCPUGroupInfoRange();
     static void InitCPUGroupInfo();
     static BOOL IsInitialized();
 


### PR DESCRIPTION
Split the cleanup part off PR 68639.  This has been already reviewed.

* Remove the unused `end` field from `CPU_Group_Info` structures. Should we need it, it may be trivially calculated as `begin + nr_active - 1`.
* Get rid of the `InitCPUGroupInfoRange` function.
* Fix conditions near the `GetLogicalProcessorInformationEx` calls.