### PR TITLE
Use span instead of array on PublicKey

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
@@ -300,8 +300,8 @@ namespace System.Security.Cryptography.X509Certificates
                 }
 
                 oid = new Oid(spki.Algorithm.Algorithm, null);
-                parameters = new AsnEncodedData(spki.Algorithm.Parameters?.ToArray() ?? Array.Empty<byte>());
-                keyValue = new AsnEncodedData(spki.SubjectPublicKey.ToArray());
+                parameters = new AsnEncodedData(spki.Algorithm.Parameters.GetValueOrDefault().Span);
+                keyValue = new AsnEncodedData(spki.SubjectPublicKey.Span);
                 return read;
             }
         }


### PR DESCRIPTION
Another place I previously missed in the "we have span overloads for these things now".