### PR TITLE
make sure socket is intialized before connecting TCPClient

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
@@ -99,6 +99,10 @@ namespace System.Net.Sockets
             {
                 _clientSocket = value;
                 _family = _clientSocket?.AddressFamily ?? AddressFamily.Unknown;
+                if (_clientSocket == null)
+                {
+                    InitializeClientSocket();
+                }
             }
         }
 
@@ -127,12 +131,7 @@ namespace System.Net.Sockets
                 throw new ArgumentOutOfRangeException(nameof(port));
             }
 
-            if (Client == null)
-            {
-                InitializeClientSocket();
-            }
-
-            Client!.Connect(hostname, port);
+            Client.Connect(hostname, port);
             _family = Client.AddressFamily;
             _active = true;
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
@@ -127,7 +127,12 @@ namespace System.Net.Sockets
                 throw new ArgumentOutOfRangeException(nameof(port));
             }
 
-            Client.Connect(hostname, port);
+            if (Client == null)
+            {
+                InitializeClientSocket();
+            }
+
+            Client!.Connect(hostname, port);
             _family = Client.AddressFamily;
             _active = true;
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -271,18 +271,6 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [OuterLoop]
-        [Fact]
-        public void ExclusiveAddressUse_NullClient()
-        {
-            using (TcpClient client = new TcpClient())
-            {
-                client.Client = null;
-
-                Assert.False(client.ExclusiveAddressUse);
-            }
-        }
-
         [Fact]
         public void Roundtrip_ExclusiveAddressUse_GetEqualsSet_True()
         {


### PR DESCRIPTION
fixes #69493 
Socket can be explicitly set to `null` after created in constructor.

 