### PR TITLE
Fix handling process affinity mask on Windows 11

### DIFF
--- a/src/coreclr/gc/windows/gcenv.windows.cpp
+++ b/src/coreclr/gc/windows/gcenv.windows.cpp
@@ -234,7 +234,6 @@ void InitCPUGroupInfo()
     DWORD_PTR processAffinityMask, systemAffinityMask;
     if (::GetProcessAffinityMask(::GetCurrentProcess(), &processAffinityMask, &systemAffinityMask))
     {
-        processAffinityMask &= systemAffinityMask;
         if (processAffinityMask != 0 && // only one CPU group is involved
             (processAffinityMask & (processAffinityMask - 1)) == 0) // only one bit is set
         {
@@ -503,8 +502,6 @@ bool GCToOSInterface::Initialize()
         uintptr_t pmask, smask;
         if (!!::GetProcessAffinityMask(::GetCurrentProcess(), (PDWORD_PTR)&pmask, (PDWORD_PTR)&smask))
         {
-            pmask &= smask;
-
             for (size_t i = 0; i < 8 * sizeof(uintptr_t); i++)
             {
                 if ((pmask & ((uintptr_t)1 << i)) != 0)

--- a/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
@@ -79,7 +79,6 @@ void InitializeCurrentProcessCpuCount()
         }
         else
         {
-            pmask &= smask;
             count = 0;
 
             while (pmask)

--- a/src/coreclr/utilcode/util.cpp
+++ b/src/coreclr/utilcode/util.cpp
@@ -1064,7 +1064,6 @@ int GetCurrentProcessCpuCount()
             }
             else
             {
-                pmask &= smask;
                 count = 0;
 
                 while (pmask)
@@ -1143,7 +1142,6 @@ DWORD_PTR GetCurrentProcessCpuMask()
     if (!GetProcessAffinityMask(GetCurrentProcess(), &pmask, &smask))
         return 1;
 
-    pmask &= smask;
     return pmask;
 #else
     return 0;

--- a/src/coreclr/vm/gcenv.os.cpp
+++ b/src/coreclr/vm/gcenv.os.cpp
@@ -146,8 +146,6 @@ bool GCToOSInterface::Initialize()
         uintptr_t pmask, smask;
         if (!!::GetProcessAffinityMask(::GetCurrentProcess(), (PDWORD_PTR)&pmask, (PDWORD_PTR)&smask))
         {
-            pmask &= smask;
-
             for (size_t i = 0; i < 8 * sizeof(uintptr_t); i++)
             {
                 if ((pmask & ((uintptr_t)1 << i)) != 0)


### PR DESCRIPTION
Remove `processAffinityMask &= systemAffinityMask;` assignments in the runtime.  They are useless on Windows 7–10 according to `GetProcessAffinityMask`'s [documentation](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getprocessaffinitymask):
> A process affinity mask is a subset of the system affinity mask. A process is only allowed to run on the processors configured into a system. Therefore, **the process affinity mask cannot specify a 1 bit for a processor when the system affinity mask specifies a 0 bit for that processor.**

and may not work as expected on Windows 11.

On Windows 11 and Windows Server 2022, a process is no longer restricted to a single processor group by default.  While each process is assigned a primary processor group at creation, its threads may be scheduled on other processor groups as well.

It may happen that `GetProcessAffinityMask` is called on a thread running on a non-primary processor group _G_.  If the process is not explicitly multi-group aware[^1], the reported `processAffinityMask` value will contain the process affinity mask for its primary processor group, while `systemAffinityMask` will contain the system affinity mask for the non-primary processor group _G_.

[^1]: A process becomes explicitly multi-group aware when it explicitly sets the affinity of one of its threads outside of the process's primary processor group.

For instance, on an 80 core Ampere machine with two uneven processor groups (64+16 cores) the following values may be observed in some runs:
* `processAffinityMask` = 0xffffffffffffffff, `systemAffinityMask` = 0xffff: the process is assigned a primary group with 64 cores, while the thread is running on a non-primary group with 16 cores.
* `processAffinityMask` = 0xffff, `systemAffinityMask` = 0xffffffffffffffff: the process is assigned a primary group with 16 cores, while the thread is running on a non-primary group with 64 cores.

For that reason, clipping `processAffinityMask` with `systemAffinityMask` may lead to suboptimal behavior, e.g., `Environment.ProcessorCount` may report 16 instead of 64.  The fix is to remove the clipping and use just `processAffinityMask`.