### PR TITLE
Add CopyString and ValueIsEscaped APIs to Utf8JsonReader

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -415,8 +415,11 @@ namespace System.Text.Json
         public System.SequencePosition Position { get { throw null; } }
         public readonly long TokenStartIndex { get { throw null; } }
         public System.Text.Json.JsonTokenType TokenType { get { throw null; } }
+        public readonly bool ValueIsEscaped { get { throw null; } }
         public readonly System.Buffers.ReadOnlySequence<byte> ValueSequence { get { throw null; } }
         public readonly System.ReadOnlySpan<byte> ValueSpan { get { throw null; } }
+        public readonly int CopyString(Span<byte> utf8Destination) { throw null; }
+        public readonly int CopyString(Span<char> destination) { throw null; }
         public bool GetBoolean() { throw null; }
         public byte GetByte() { throw null; }
         public byte[] GetBytesFromBase64() { throw null; }

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -165,6 +165,9 @@
   <data name="DepthTooLarge" xml:space="preserve">
     <value>CurrentDepth ({0}) is equal to or larger than the maximum allowed depth of {1}. Cannot write the next JSON object or array.</value>
   </data>
+  <data name="DestinationTooShort" xml:space="preserve">
+    <value>Destination is too short.</value>
+  </data>
   <data name="EmptyJsonIsInvalid" xml:space="preserve">
     <value>Writing an empty JSON payload (excluding comments) is invalid.</value>
   </data>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -290,8 +290,7 @@ namespace System.Text.Json
 
             if (row.HasComplexChildren)
             {
-                int backslash = segment.IndexOf(JsonConstants.BackSlash);
-                lastString = JsonReaderHelper.GetUnescapedString(segment, backslash);
+                lastString = JsonReaderHelper.GetUnescapedString(segment);
             }
             else
             {
@@ -409,9 +408,7 @@ namespace System.Text.Json
             // Segment needs to be unescaped
             if (row.HasComplexChildren)
             {
-                int idx = segment.IndexOf(JsonConstants.BackSlash);
-                Debug.Assert(idx != -1);
-                return JsonReaderHelper.TryGetUnescapedBase64Bytes(segment, idx, out value);
+                return JsonReaderHelper.TryGetUnescapedBase64Bytes(segment, out value);
             }
 
             Debug.Assert(segment.IndexOf(JsonConstants.BackSlash) == -1);
@@ -893,13 +890,8 @@ namespace System.Text.Json
                 return text;
             }
 
-            int idx = text.IndexOf(JsonConstants.BackSlash);
-            Debug.Assert(idx >= 0);
-
             byte[] rent = ArrayPool<byte>.Shared.Rent(length);
-            text.Slice(0, idx).CopyTo(rent);
-
-            JsonReaderHelper.Unescape(text, rent, idx, out int written);
+            JsonReaderHelper.Unescape(text, rent, out int written);
             rented = new ArraySegment<byte>(rent, 0, written);
             return rented.AsSpan();
         }
@@ -938,7 +930,6 @@ namespace System.Text.Json
             finally
             {
                 ClearAndReturn(rented);
-
             }
         }
 
@@ -1052,7 +1043,7 @@ namespace System.Text.Json
 
                     database.Append(tokenType, tokenStart + 1, reader.ValueSpan.Length);
 
-                    if (reader._stringHasEscaping)
+                    if (reader.ValueIsEscaped)
                     {
                         database.SetHasComplexChildren(database.Length - DbRow.Size);
                     }
@@ -1077,7 +1068,7 @@ namespace System.Text.Json
 
                         database.Append(tokenType, tokenStart + 1, reader.ValueSpan.Length);
 
-                        if (reader._stringHasEscaping)
+                        if (reader.ValueIsEscaped)
                         {
                             database.SetHasComplexChildren(database.Length - DbRow.Size);
                         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -892,8 +892,7 @@ namespace System.Text.Json
 
             byte[] rent = ArrayPool<byte>.Shared.Rent(length);
             JsonReaderHelper.Unescape(text, rent, out int written);
-            rented = new ArraySegment<byte>(rent, 0, written);
-            return rented.AsSpan();
+            return rent.AsSpan(0, written);
         }
 
         private static void ClearAndReturn(ArraySegment<byte> rented)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -892,7 +892,8 @@ namespace System.Text.Json
 
             byte[] rent = ArrayPool<byte>.Shared.Rent(length);
             JsonReaderHelper.Unescape(text, rent, out int written);
-            return rent.AsSpan(0, written);
+            rented = new ArraySegment<byte>(rent, 0, written);
+            return rented.AsSpan();
         }
 
         private static void ClearAndReturn(ArraySegment<byte> rented)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.Unescaping.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.Unescaping.cs
@@ -439,99 +439,94 @@ namespace System.Text.Json
                     goto DestinationTooShort;
                 }
 
-                int currentByte = source[++idx];
-                if (currentByte == JsonConstants.Quote)
+                switch (source[++idx])
                 {
-                    destination[written++] = JsonConstants.Quote;
-                }
-                else if (currentByte == 'n')
-                {
-                    destination[written++] = JsonConstants.LineFeed;
-                }
-                else if (currentByte == 'r')
-                {
-                    destination[written++] = JsonConstants.CarriageReturn;
-                }
-                else if (currentByte == JsonConstants.BackSlash)
-                {
-                    destination[written++] = JsonConstants.BackSlash;
-                }
-                else if (currentByte == JsonConstants.Slash)
-                {
-                    destination[written++] = JsonConstants.Slash;
-                }
-                else if (currentByte == 't')
-                {
-                    destination[written++] = JsonConstants.Tab;
-                }
-                else if (currentByte == 'b')
-                {
-                    destination[written++] = JsonConstants.BackSpace;
-                }
-                else if (currentByte == 'f')
-                {
-                    destination[written++] = JsonConstants.FormFeed;
-                }
-                else if (currentByte == 'u')
-                {
-                    // The source is known to be valid JSON, and hence if we see a \u, it is guaranteed to have 4 hex digits following it
-                    // Otherwise, the Utf8JsonReader would have already thrown an exception.
-                    Debug.Assert(source.Length >= idx + 5);
-
-                    bool result = Utf8Parser.TryParse(source.Slice(idx + 1, 4), out int scalar, out int bytesConsumed, 'x');
-                    Debug.Assert(result);
-                    Debug.Assert(bytesConsumed == 4);
-                    idx += 4;
-
-                    if (JsonHelpers.IsInRangeInclusive((uint)scalar, JsonConstants.HighSurrogateStartValue, JsonConstants.LowSurrogateEndValue))
-                    {
-                        // The first hex value cannot be a low surrogate.
-                        if (scalar >= JsonConstants.LowSurrogateStartValue)
-                        {
-                            ThrowHelper.ThrowInvalidOperationException_ReadInvalidUTF16(scalar);
-                        }
-
-                        Debug.Assert(JsonHelpers.IsInRangeInclusive((uint)scalar, JsonConstants.HighSurrogateStartValue, JsonConstants.HighSurrogateEndValue));
-
-                        // We must have a low surrogate following a high surrogate.
-                        if (source.Length < idx + 7 || source[idx + 1] != '\\' || source[idx + 2] != 'u')
-                        {
-                            ThrowHelper.ThrowInvalidOperationException_ReadIncompleteUTF16();
-                        }
+                    case JsonConstants.Quote:
+                        destination[written++] = JsonConstants.Quote;
+                        break;
+                    case (byte)'n':
+                        destination[written++] = JsonConstants.LineFeed;
+                        break;
+                    case (byte)'r':
+                        destination[written++] = JsonConstants.CarriageReturn;
+                        break;
+                    case JsonConstants.BackSlash:
+                        destination[written++] = JsonConstants.BackSlash;
+                        break;
+                    case JsonConstants.Slash:
+                        destination[written++] = JsonConstants.Slash;
+                        break;
+                    case (byte)'t':
+                        destination[written++] = JsonConstants.Tab;
+                        break;
+                    case (byte)'b':
+                        destination[written++] = JsonConstants.BackSpace;
+                        break;
+                    case (byte)'f':
+                        destination[written++] = JsonConstants.FormFeed;
+                        break;
+                    default:
+                        Debug.Assert(source[idx] == 'u', "invalid escape sequences must have already been caught by Utf8JsonReader.Read()");
 
                         // The source is known to be valid JSON, and hence if we see a \u, it is guaranteed to have 4 hex digits following it
                         // Otherwise, the Utf8JsonReader would have already thrown an exception.
-                        result = Utf8Parser.TryParse(source.Slice(idx + 3, 4), out int lowSurrogate, out bytesConsumed, 'x');
+                        Debug.Assert(source.Length >= idx + 5);
+
+                        bool result = Utf8Parser.TryParse(source.Slice(idx + 1, 4), out int scalar, out int bytesConsumed, 'x');
                         Debug.Assert(result);
                         Debug.Assert(bytesConsumed == 4);
-                        idx += 6;
+                        idx += 4;
 
-                        // If the first hex value is a high surrogate, the next one must be a low surrogate.
-                        if (!JsonHelpers.IsInRangeInclusive((uint)lowSurrogate, JsonConstants.LowSurrogateStartValue, JsonConstants.LowSurrogateEndValue))
+                        if (JsonHelpers.IsInRangeInclusive((uint)scalar, JsonConstants.HighSurrogateStartValue, JsonConstants.LowSurrogateEndValue))
                         {
-                            ThrowHelper.ThrowInvalidOperationException_ReadInvalidUTF16(lowSurrogate);
+                            // The first hex value cannot be a low surrogate.
+                            if (scalar >= JsonConstants.LowSurrogateStartValue)
+                            {
+                                ThrowHelper.ThrowInvalidOperationException_ReadInvalidUTF16(scalar);
+                            }
+
+                            Debug.Assert(JsonHelpers.IsInRangeInclusive((uint)scalar, JsonConstants.HighSurrogateStartValue, JsonConstants.HighSurrogateEndValue));
+
+                            // We must have a low surrogate following a high surrogate.
+                            if (source.Length < idx + 7 || source[idx + 1] != '\\' || source[idx + 2] != 'u')
+                            {
+                                ThrowHelper.ThrowInvalidOperationException_ReadIncompleteUTF16();
+                            }
+
+                            // The source is known to be valid JSON, and hence if we see a \u, it is guaranteed to have 4 hex digits following it
+                            // Otherwise, the Utf8JsonReader would have already thrown an exception.
+                            result = Utf8Parser.TryParse(source.Slice(idx + 3, 4), out int lowSurrogate, out bytesConsumed, 'x');
+                            Debug.Assert(result);
+                            Debug.Assert(bytesConsumed == 4);
+                            idx += 6;
+
+                            // If the first hex value is a high surrogate, the next one must be a low surrogate.
+                            if (!JsonHelpers.IsInRangeInclusive((uint)lowSurrogate, JsonConstants.LowSurrogateStartValue, JsonConstants.LowSurrogateEndValue))
+                            {
+                                ThrowHelper.ThrowInvalidOperationException_ReadInvalidUTF16(lowSurrogate);
+                            }
+
+                            // To find the unicode scalar:
+                            // (0x400 * (High surrogate - 0xD800)) + Low surrogate - 0xDC00 + 0x10000
+                            scalar = (JsonConstants.BitShiftBy10 * (scalar - JsonConstants.HighSurrogateStartValue))
+                                + (lowSurrogate - JsonConstants.LowSurrogateStartValue)
+                                + JsonConstants.UnicodePlane01StartValue;
                         }
 
-                        // To find the unicode scalar:
-                        // (0x400 * (High surrogate - 0xD800)) + Low surrogate - 0xDC00 + 0x10000
-                        scalar = (JsonConstants.BitShiftBy10 * (scalar - JsonConstants.HighSurrogateStartValue))
-                            + (lowSurrogate - JsonConstants.LowSurrogateStartValue)
-                            + JsonConstants.UnicodePlane01StartValue;
-                    }
-
 #if BUILDING_INBOX_LIBRARY
-                    var rune = new Rune(scalar);
-                    bool success = rune.TryEncodeToUtf8(destination.Slice(written), out int bytesWritten);
+                        var rune = new Rune(scalar);
+                        bool success = rune.TryEncodeToUtf8(destination.Slice(written), out int bytesWritten);
 #else
-                    bool success = TryEncodeToUtf8Bytes((uint)scalar, destination.Slice(written), out int bytesWritten);
+                        bool success = TryEncodeToUtf8Bytes((uint)scalar, destination.Slice(written), out int bytesWritten);
 #endif
-                    if (!success)
-                    {
-                        goto DestinationTooShort;
-                    }
+                        if (!success)
+                        {
+                            goto DestinationTooShort;
+                        }
 
-                    Debug.Assert(bytesWritten <= 4);
-                    written += bytesWritten;
+                        Debug.Assert(bytesWritten <= 4);
+                        written += bytesWritten;
+                        break;
                 }
 
                 if (++idx == source.Length)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.Unescaping.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.Unescaping.cs
@@ -5,12 +5,13 @@ using System.Buffers;
 using System.Buffers.Text;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace System.Text.Json
 {
     internal static partial class JsonReaderHelper
     {
-        public static bool TryGetUnescapedBase64Bytes(ReadOnlySpan<byte> utf8Source, int idx, [NotNullWhen(true)] out byte[]? bytes)
+        public static bool TryGetUnescapedBase64Bytes(ReadOnlySpan<byte> utf8Source, [NotNullWhen(true)] out byte[]? bytes)
         {
             byte[]? unescapedArray = null;
 
@@ -18,7 +19,7 @@ namespace System.Text.Json
                 stackalloc byte[JsonConstants.StackallocByteThreshold] :
                 (unescapedArray = ArrayPool<byte>.Shared.Rent(utf8Source.Length));
 
-            Unescape(utf8Source, utf8Unescaped, idx, out int written);
+            Unescape(utf8Source, utf8Unescaped, out int written);
             Debug.Assert(written > 0);
 
             utf8Unescaped = utf8Unescaped.Slice(0, written);
@@ -38,7 +39,7 @@ namespace System.Text.Json
         public static readonly UTF8Encoding s_utf8Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
         // TODO: Similar to escaping, replace the unescaping logic with publicly shipping APIs from https://github.com/dotnet/runtime/issues/27919
-        public static string GetUnescapedString(ReadOnlySpan<byte> utf8Source, int idx)
+        public static string GetUnescapedString(ReadOnlySpan<byte> utf8Source)
         {
             // The escaped name is always >= than the unescaped, so it is safe to use escaped name for the buffer length.
             int length = utf8Source.Length;
@@ -48,7 +49,7 @@ namespace System.Text.Json
                 stackalloc byte[JsonConstants.StackallocByteThreshold] :
                 (pooledName = ArrayPool<byte>.Shared.Rent(length));
 
-            Unescape(utf8Source, utf8Unescaped, idx, out int written);
+            Unescape(utf8Source, utf8Unescaped, out int written);
             Debug.Assert(written > 0);
 
             utf8Unescaped = utf8Unescaped.Slice(0, written);
@@ -65,7 +66,7 @@ namespace System.Text.Json
             return utf8String;
         }
 
-        public static ReadOnlySpan<byte> GetUnescapedSpan(ReadOnlySpan<byte> utf8Source, int idx)
+        public static ReadOnlySpan<byte> GetUnescapedSpan(ReadOnlySpan<byte> utf8Source)
         {
             // The escaped name is always >= than the unescaped, so it is safe to use escaped name for the buffer length.
             int length = utf8Source.Length;
@@ -75,7 +76,7 @@ namespace System.Text.Json
                 stackalloc byte[JsonConstants.StackallocByteThreshold] :
                 (pooledName = ArrayPool<byte>.Shared.Rent(length));
 
-            Unescape(utf8Source, utf8Unescaped, idx, out int written);
+            Unescape(utf8Source, utf8Unescaped, out int written);
             Debug.Assert(written > 0);
 
             ReadOnlySpan<byte> propertyName = utf8Unescaped.Slice(0, written).ToArray();
@@ -236,6 +237,71 @@ namespace System.Text.Json
             }
         }
 
+        public static int TranscodeHelperWithCleanupOnFailure(ReadOnlySpan<byte> utf8Unescaped, Span<char> destination)
+        {
+            try
+            {
+#if BUILDING_INBOX_LIBRARY
+                return s_utf8Encoding.GetChars(utf8Unescaped, destination);
+#else
+                unsafe
+                {
+                    fixed (byte* srcPtr = utf8Unescaped)
+                    fixed (char* destPtr = destination)
+                    {
+                        return s_utf8Encoding.GetChars(srcPtr, utf8Unescaped.Length, destPtr, destination.Length);
+                    }
+                }
+#endif
+            }
+            catch (DecoderFallbackException dfe)
+            {
+                destination.Clear();
+
+                // We want to be consistent with the exception being thrown
+                // so the user only has to catch a single exception.
+                // Since we already throw InvalidOperationException for mismatch token type,
+                // and while unescaping, using that exception for failure to decode invalid UTF-8 bytes as well.
+                // Therefore, wrapping the DecoderFallbackException around an InvalidOperationException.
+                throw ThrowHelper.GetInvalidOperationException_ReadInvalidUTF8(dfe);
+            }
+            catch (ArgumentException)
+            {
+                // Destination buffer was too small; clear it up since the encoder might have not.
+                destination.Clear();
+                throw;
+            }
+        }
+
+        public static void ValidateUtf8WithCleanupOnFailure(Span<byte> utf8Buffer)
+        {
+            try
+            {
+#if BUILDING_INBOX_LIBRARY
+                s_utf8Encoding.GetCharCount(utf8Buffer);
+#else
+                unsafe
+                {
+                    fixed (byte* srcPtr = utf8Buffer)
+                    {
+                        s_utf8Encoding.GetCharCount(srcPtr, utf8Buffer.Length);
+                    }
+                }
+#endif
+            }
+            catch (DecoderFallbackException ex)
+            {
+                utf8Buffer.Clear();
+
+                // We want to be consistent with the exception being thrown
+                // so the user only has to catch a single exception.
+                // Since we already throw InvalidOperationException for mismatch token type,
+                // and while unescaping, using that exception for failure to decode invalid UTF-8 bytes as well.
+                // Therefore, wrapping the DecoderFallbackException around an InvalidOperationException.
+                throw ThrowHelper.GetInvalidOperationException_ReadInvalidUTF8(ex);
+            }
+        }
+
         internal static int GetUtf8ByteCount(ReadOnlySpan<char> text)
         {
             try
@@ -320,118 +386,223 @@ namespace System.Text.Json
 #endif
         }
 
+        internal static void Unescape(ReadOnlySpan<byte> source, Span<byte> destination, out int written)
+        {
+            Debug.Assert(destination.Length >= source.Length);
+
+            int idx = source.IndexOf(JsonConstants.BackSlash);
+            Debug.Assert(idx >= 0);
+
+            bool result = TryUnescape(source, destination, idx, out written, clearBufferOnFailure: false);
+            Debug.Assert(result);
+        }
+
         internal static void Unescape(ReadOnlySpan<byte> source, Span<byte> destination, int idx, out int written)
         {
             Debug.Assert(idx >= 0 && idx < source.Length);
             Debug.Assert(source[idx] == JsonConstants.BackSlash);
             Debug.Assert(destination.Length >= source.Length);
 
-            source.Slice(0, idx).CopyTo(destination);
+            bool result = TryUnescape(source, destination, idx, out written, clearBufferOnFailure: false);
+            Debug.Assert(result);
+        }
+
+        /// <summary>
+        /// Used when writing to buffers not guaranteed to fit the unescaped result.
+        /// </summary>
+        internal static bool TryUnescape(ReadOnlySpan<byte> source, Span<byte> destination, out int written, bool clearBufferOnFailure)
+        {
+            int idx = source.IndexOf(JsonConstants.BackSlash);
+            Debug.Assert(idx >= 0);
+
+            return TryUnescape(source, destination, idx, out written, clearBufferOnFailure);
+        }
+
+        /// <summary>
+        /// Used when writing to buffers not guaranteed to fit the unescaped result.
+        /// </summary>
+        private static bool TryUnescape(ReadOnlySpan<byte> source, Span<byte> destination, int idx, out int written, bool clearBufferOnFailure)
+        {
+            Debug.Assert(idx >= 0 && idx < source.Length);
+            Debug.Assert(source[idx] == JsonConstants.BackSlash);
+
+            if (!source.Slice(0, idx).TryCopyTo(destination))
+            {
+                written = 0;
+                goto DestinationTooShort;
+            }
+
             written = idx;
 
-            for (; idx < source.Length; idx++)
+            while (true)
             {
-                byte currentByte = source[idx];
-                if (currentByte == JsonConstants.BackSlash)
+                Debug.Assert(source[idx] == JsonConstants.BackSlash);
+
+                if (written == destination.Length)
                 {
-                    idx++;
-                    currentByte = source[idx];
+                    goto DestinationTooShort;
+                }
 
-                    if (currentByte == JsonConstants.Quote)
-                    {
-                        destination[written++] = JsonConstants.Quote;
-                    }
-                    else if (currentByte == 'n')
-                    {
-                        destination[written++] = JsonConstants.LineFeed;
-                    }
-                    else if (currentByte == 'r')
-                    {
-                        destination[written++] = JsonConstants.CarriageReturn;
-                    }
-                    else if (currentByte == JsonConstants.BackSlash)
-                    {
-                        destination[written++] = JsonConstants.BackSlash;
-                    }
-                    else if (currentByte == JsonConstants.Slash)
-                    {
-                        destination[written++] = JsonConstants.Slash;
-                    }
-                    else if (currentByte == 't')
-                    {
-                        destination[written++] = JsonConstants.Tab;
-                    }
-                    else if (currentByte == 'b')
-                    {
-                        destination[written++] = JsonConstants.BackSpace;
-                    }
-                    else if (currentByte == 'f')
-                    {
-                        destination[written++] = JsonConstants.FormFeed;
-                    }
-                    else if (currentByte == 'u')
-                    {
-                        // The source is known to be valid JSON, and hence if we see a \u, it is guaranteed to have 4 hex digits following it
-                        // Otherwise, the Utf8JsonReader would have already thrown an exception.
-                        Debug.Assert(source.Length >= idx + 5);
+                int currentByte = source[++idx];
+                if (currentByte == JsonConstants.Quote)
+                {
+                    destination[written++] = JsonConstants.Quote;
+                }
+                else if (currentByte == 'n')
+                {
+                    destination[written++] = JsonConstants.LineFeed;
+                }
+                else if (currentByte == 'r')
+                {
+                    destination[written++] = JsonConstants.CarriageReturn;
+                }
+                else if (currentByte == JsonConstants.BackSlash)
+                {
+                    destination[written++] = JsonConstants.BackSlash;
+                }
+                else if (currentByte == JsonConstants.Slash)
+                {
+                    destination[written++] = JsonConstants.Slash;
+                }
+                else if (currentByte == 't')
+                {
+                    destination[written++] = JsonConstants.Tab;
+                }
+                else if (currentByte == 'b')
+                {
+                    destination[written++] = JsonConstants.BackSpace;
+                }
+                else if (currentByte == 'f')
+                {
+                    destination[written++] = JsonConstants.FormFeed;
+                }
+                else if (currentByte == 'u')
+                {
+                    // The source is known to be valid JSON, and hence if we see a \u, it is guaranteed to have 4 hex digits following it
+                    // Otherwise, the Utf8JsonReader would have already thrown an exception.
+                    Debug.Assert(source.Length >= idx + 5);
 
-                        bool result = Utf8Parser.TryParse(source.Slice(idx + 1, 4), out int scalar, out int bytesConsumed, 'x');
-                        Debug.Assert(result);
-                        Debug.Assert(bytesConsumed == 4);
-                        idx += bytesConsumed;     // The loop iteration will increment idx past the last hex digit
+                    bool result = Utf8Parser.TryParse(source.Slice(idx + 1, 4), out int scalar, out int bytesConsumed, 'x');
+                    Debug.Assert(result);
+                    Debug.Assert(bytesConsumed == 4);
+                    idx += 4;
 
-                        if (JsonHelpers.IsInRangeInclusive((uint)scalar, JsonConstants.HighSurrogateStartValue, JsonConstants.LowSurrogateEndValue))
+                    if (JsonHelpers.IsInRangeInclusive((uint)scalar, JsonConstants.HighSurrogateStartValue, JsonConstants.LowSurrogateEndValue))
+                    {
+                        // The first hex value cannot be a low surrogate.
+                        if (scalar >= JsonConstants.LowSurrogateStartValue)
                         {
-                            // The first hex value cannot be a low surrogate.
-                            if (scalar >= JsonConstants.LowSurrogateStartValue)
-                            {
-                                ThrowHelper.ThrowInvalidOperationException_ReadInvalidUTF16(scalar);
-                            }
-
-                            Debug.Assert(JsonHelpers.IsInRangeInclusive((uint)scalar, JsonConstants.HighSurrogateStartValue, JsonConstants.HighSurrogateEndValue));
-
-                            idx += 3;   // Skip the last hex digit and the next \u
-
-                            // We must have a low surrogate following a high surrogate.
-                            if (source.Length < idx + 4 || source[idx - 2] != '\\' || source[idx - 1] != 'u')
-                            {
-                                ThrowHelper.ThrowInvalidOperationException_ReadInvalidUTF16();
-                            }
-
-                            // The source is known to be valid JSON, and hence if we see a \u, it is guaranteed to have 4 hex digits following it
-                            // Otherwise, the Utf8JsonReader would have already thrown an exception.
-                            result = Utf8Parser.TryParse(source.Slice(idx, 4), out int lowSurrogate, out bytesConsumed, 'x');
-                            Debug.Assert(result);
-                            Debug.Assert(bytesConsumed == 4);
-
-                            // If the first hex value is a high surrogate, the next one must be a low surrogate.
-                            if (!JsonHelpers.IsInRangeInclusive((uint)lowSurrogate, JsonConstants.LowSurrogateStartValue, JsonConstants.LowSurrogateEndValue))
-                            {
-                                ThrowHelper.ThrowInvalidOperationException_ReadInvalidUTF16(lowSurrogate);
-                            }
-
-                            idx += bytesConsumed - 1;  // The loop iteration will increment idx past the last hex digit
-
-                            // To find the unicode scalar:
-                            // (0x400 * (High surrogate - 0xD800)) + Low surrogate - 0xDC00 + 0x10000
-                            scalar = (JsonConstants.BitShiftBy10 * (scalar - JsonConstants.HighSurrogateStartValue))
-                                + (lowSurrogate - JsonConstants.LowSurrogateStartValue)
-                                + JsonConstants.UnicodePlane01StartValue;
+                            HandleBufferClearing(clearBufferOnFailure, destination, written);
+                            ThrowHelper.ThrowInvalidOperationException_ReadInvalidUTF16(scalar);
                         }
 
+                        Debug.Assert(JsonHelpers.IsInRangeInclusive((uint)scalar, JsonConstants.HighSurrogateStartValue, JsonConstants.HighSurrogateEndValue));
+
+                        // We must have a low surrogate following a high surrogate.
+                        if (source.Length < idx + 7 || source[idx + 1] != '\\' || source[idx + 2] != 'u')
+                        {
+                            HandleBufferClearing(clearBufferOnFailure, destination, written);
+                            ThrowHelper.ThrowInvalidOperationException_ReadIncompleteUTF16();
+                        }
+
+                        // The source is known to be valid JSON, and hence if we see a \u, it is guaranteed to have 4 hex digits following it
+                        // Otherwise, the Utf8JsonReader would have already thrown an exception.
+                        result = Utf8Parser.TryParse(source.Slice(idx + 3, 4), out int lowSurrogate, out bytesConsumed, 'x');
+                        Debug.Assert(result);
+                        Debug.Assert(bytesConsumed == 4);
+                        idx += 6;
+
+                        // If the first hex value is a high surrogate, the next one must be a low surrogate.
+                        if (!JsonHelpers.IsInRangeInclusive((uint)lowSurrogate, JsonConstants.LowSurrogateStartValue, JsonConstants.LowSurrogateEndValue))
+                        {
+                            HandleBufferClearing(clearBufferOnFailure, destination, written);
+                            ThrowHelper.ThrowInvalidOperationException_ReadInvalidUTF16(lowSurrogate);
+                        }
+
+                        // To find the unicode scalar:
+                        // (0x400 * (High surrogate - 0xD800)) + Low surrogate - 0xDC00 + 0x10000
+                        scalar = (JsonConstants.BitShiftBy10 * (scalar - JsonConstants.HighSurrogateStartValue))
+                            + (lowSurrogate - JsonConstants.LowSurrogateStartValue)
+                            + JsonConstants.UnicodePlane01StartValue;
+                    }
+
 #if BUILDING_INBOX_LIBRARY
-                        var rune = new Rune(scalar);
-                        int bytesWritten = rune.EncodeToUtf8(destination.Slice(written));
+                    var rune = new Rune(scalar);
+                    bool success = rune.TryEncodeToUtf8(destination.Slice(written), out int bytesWritten);
 #else
-                        EncodeToUtf8Bytes((uint)scalar, destination.Slice(written), out int bytesWritten);
+                    bool success = TryEncodeToUtf8Bytes((uint)scalar, destination.Slice(written), out int bytesWritten);
 #endif
-                        Debug.Assert(bytesWritten <= 4);
-                        written += bytesWritten;
+                    if (!success)
+                    {
+                        goto DestinationTooShort;
+                    }
+
+                    Debug.Assert(bytesWritten <= 4);
+                    written += bytesWritten;
+                }
+
+                if (++idx == source.Length)
+                {
+                    goto Success;
+                }
+
+                if (source[idx] != JsonConstants.BackSlash)
+                {
+                    ReadOnlySpan<byte> remaining = source.Slice(idx);
+                    int nextUnescapedSegmentLength = remaining.IndexOf(JsonConstants.BackSlash);
+                    if (nextUnescapedSegmentLength < 0)
+                    {
+                        nextUnescapedSegmentLength = remaining.Length;
+                    }
+
+                    if ((uint)(written + nextUnescapedSegmentLength) >= (uint)destination.Length)
+                    {
+                        goto DestinationTooShort;
+                    }
+
+                    Debug.Assert(nextUnescapedSegmentLength > 0);
+                    switch (nextUnescapedSegmentLength)
+                    {
+                        case 1:
+                            destination[written++] = source[idx++];
+                            break;
+                        case 2:
+                            destination[written++] = source[idx++];
+                            destination[written++] = source[idx++];
+                            break;
+                        case 3:
+                            destination[written++] = source[idx++];
+                            destination[written++] = source[idx++];
+                            destination[written++] = source[idx++];
+                            break;
+                        default:
+                            remaining.Slice(0, nextUnescapedSegmentLength).CopyTo(destination.Slice(written));
+                            written += nextUnescapedSegmentLength;
+                            idx += nextUnescapedSegmentLength;
+                            break;
+                    }
+
+                    Debug.Assert(idx == source.Length || source[idx] == JsonConstants.BackSlash);
+
+                    if (idx == source.Length)
+                    {
+                        goto Success;
                     }
                 }
-                else
+            }
+
+        Success:
+            return true;
+
+        DestinationTooShort:
+            HandleBufferClearing(clearBufferOnFailure, destination, written);
+            return false;
+
+            static void HandleBufferClearing(bool clearBufferOnFailure, Span<byte> destination, int written)
+            {
+                if (clearBufferOnFailure)
                 {
-                    destination[written++] = currentByte;
+                    destination.Slice(0, written).Clear();
                 }
             }
         }
@@ -441,20 +612,31 @@ namespace System.Text.Json
         /// Copies the UTF-8 code unit representation of this scalar to an output buffer.
         /// The buffer must be large enough to hold the required number of <see cref="byte"/>s.
         /// </summary>
-        private static void EncodeToUtf8Bytes(uint scalar, Span<byte> utf8Destination, out int bytesWritten)
+        private static bool TryEncodeToUtf8Bytes(uint scalar, Span<byte> utf8Destination, out int bytesWritten)
         {
             Debug.Assert(JsonHelpers.IsValidUnicodeScalar(scalar));
-            Debug.Assert(utf8Destination.Length >= 4);
 
             if (scalar < 0x80U)
             {
                 // Single UTF-8 code unit
+                if ((uint)utf8Destination.Length < 1u)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
                 utf8Destination[0] = (byte)scalar;
                 bytesWritten = 1;
             }
             else if (scalar < 0x800U)
             {
                 // Two UTF-8 code units
+                if ((uint)utf8Destination.Length < 2u)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
                 utf8Destination[0] = (byte)(0xC0U | (scalar >> 6));
                 utf8Destination[1] = (byte)(0x80U | (scalar & 0x3FU));
                 bytesWritten = 2;
@@ -462,6 +644,12 @@ namespace System.Text.Json
             else if (scalar < 0x10000U)
             {
                 // Three UTF-8 code units
+                if ((uint)utf8Destination.Length < 3u)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
                 utf8Destination[0] = (byte)(0xE0U | (scalar >> 12));
                 utf8Destination[1] = (byte)(0x80U | ((scalar >> 6) & 0x3FU));
                 utf8Destination[2] = (byte)(0x80U | (scalar & 0x3FU));
@@ -470,12 +658,20 @@ namespace System.Text.Json
             else
             {
                 // Four UTF-8 code units
+                if ((uint)utf8Destination.Length < 4u)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
                 utf8Destination[0] = (byte)(0xF0U | (scalar >> 18));
                 utf8Destination[1] = (byte)(0x80U | ((scalar >> 12) & 0x3FU));
                 utf8Destination[2] = (byte)(0x80U | ((scalar >> 6) & 0x3FU));
                 utf8Destination[3] = (byte)(0x80U | (scalar & 0x3FU));
                 bytesWritten = 4;
             }
+
+            return true;
         }
 #endif
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.Unescaping.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.Unescaping.cs
@@ -244,6 +244,10 @@ namespace System.Text.Json
 #if BUILDING_INBOX_LIBRARY
                 return s_utf8Encoding.GetChars(utf8Unescaped, destination);
 #else
+                if (utf8Unescaped.IsEmpty)
+                {
+                    return 0;
+                }
                 unsafe
                 {
                     fixed (byte* srcPtr = utf8Unescaped)
@@ -278,6 +282,10 @@ namespace System.Text.Json
 #if BUILDING_INBOX_LIBRARY
                 s_utf8Encoding.GetCharCount(utf8Buffer);
 #else
+                if (utf8Buffer.IsEmpty)
+                {
+                    return;
+                }
                 unsafe
                 {
                     fixed (byte* srcPtr = utf8Buffer)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs
@@ -248,13 +248,10 @@ namespace System.Text.Json
 
         public static bool TryGetEscapedDateTime(ReadOnlySpan<byte> source, out DateTime value)
         {
-            int backslash = source.IndexOf(JsonConstants.BackSlash);
-            Debug.Assert(backslash != -1);
-
             Debug.Assert(source.Length <= JsonConstants.MaximumEscapedDateTimeOffsetParseLength);
             Span<byte> sourceUnescaped = stackalloc byte[JsonConstants.MaximumEscapedDateTimeOffsetParseLength];
 
-            Unescape(source, sourceUnescaped, backslash, out int written);
+            Unescape(source, sourceUnescaped, out int written);
             Debug.Assert(written > 0);
 
             sourceUnescaped = sourceUnescaped.Slice(0, written);
@@ -273,13 +270,10 @@ namespace System.Text.Json
 
         public static bool TryGetEscapedDateTimeOffset(ReadOnlySpan<byte> source, out DateTimeOffset value)
         {
-            int backslash = source.IndexOf(JsonConstants.BackSlash);
-            Debug.Assert(backslash != -1);
-
             Debug.Assert(source.Length <= JsonConstants.MaximumEscapedDateTimeOffsetParseLength);
             Span<byte> sourceUnescaped = stackalloc byte[JsonConstants.MaximumEscapedDateTimeOffsetParseLength];
 
-            Unescape(source, sourceUnescaped, backslash, out int written);
+            Unescape(source, sourceUnescaped, out int written);
             Debug.Assert(written > 0);
 
             sourceUnescaped = sourceUnescaped.Slice(0, written);
@@ -300,12 +294,8 @@ namespace System.Text.Json
         {
             Debug.Assert(source.Length <= JsonConstants.MaximumEscapedGuidLength);
 
-            int idx = source.IndexOf(JsonConstants.BackSlash);
-            Debug.Assert(idx != -1);
-
             Span<byte> utf8Unescaped = stackalloc byte[JsonConstants.MaximumEscapedGuidLength];
-
-            Unescape(source, utf8Unescaped, idx, out int written);
+            Unescape(source, utf8Unescaped, out int written);
             Debug.Assert(written > 0);
 
             utf8Unescaped = utf8Unescaped.Slice(0, written);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderState.cs
@@ -17,7 +17,7 @@ namespace System.Text.Json
         internal long _bytePositionInLine;
         internal bool _inObject;
         internal bool _isNotPrimitive;
-        internal bool _stringHasEscaping;
+        internal bool _valueIsEscaped;
         internal bool _trailingCommaBeforeComment;
         internal JsonTokenType _tokenType;
         internal JsonTokenType _previousTokenType;
@@ -42,7 +42,7 @@ namespace System.Text.Json
             _bytePositionInLine = default;
             _inObject = default;
             _isNotPrimitive = default;
-            _stringHasEscaping = default;
+            _valueIsEscaped = default;
             _trailingCommaBeforeComment = default;
             _tokenType = default;
             _previousTokenType = default;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -32,7 +32,7 @@ namespace System.Text.Json
             _bytePositionInLine = state._bytePositionInLine;
             _inObject = state._inObject;
             _isNotPrimitive = state._isNotPrimitive;
-            _stringHasEscaping = state._stringHasEscaping;
+            ValueIsEscaped = state._valueIsEscaped;
             _trailingCommaBeforeComment = state._trailingCommaBeforeComment;
             _tokenType = state._tokenType;
             _previousTokenType = state._previousTokenType;
@@ -121,6 +121,7 @@ namespace System.Text.Json
         {
             bool retVal = false;
             HasValueSequence = false;
+            ValueIsEscaped = false;
             ValueSpan = default;
             ValueSequence = default;
 
@@ -766,7 +767,7 @@ namespace System.Text.Json
                     _bytePositionInLine += idx + 2; // Add 2 for the start and end quotes.
                     ValueSpan = localBuffer.Slice(0, idx);
                     HasValueSequence = false;
-                    _stringHasEscaping = false;
+                    ValueIsEscaped = false;
                     _tokenType = JsonTokenType.String;
                     _consumed += idx + 2;
                     return true;
@@ -822,13 +823,13 @@ namespace System.Text.Json
                         _bytePositionInLine += leftOver + idx + 1;  // Add 1 for the end quote of the string.
                         _totalConsumed += leftOver;
                         _consumed = idx + 1;    // Add 1 for the end quote of the string.
-                        _stringHasEscaping = false;
+                        ValueIsEscaped = false;
                         break;
                     }
                     else
                     {
                         _bytePositionInLine += leftOver + idx;
-                        _stringHasEscaping = true;
+                        ValueIsEscaped = true;
 
                         bool nextCharEscaped = false;
                         while (true)
@@ -1096,7 +1097,7 @@ namespace System.Text.Json
                 ValueSpan = data.Slice(0, idx);
             }
 
-            _stringHasEscaping = true;
+            ValueIsEscaped = true;
             _tokenType = JsonTokenType.String;
             return true;
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -105,7 +105,7 @@ namespace System.Text.Json
         /// <seealso cref="TokenType" />
         /// It will also throw when the JSON string contains invalid UTF-8 bytes, or invalid UTF-16 surrogates.
         /// </exception>
-        /// <exception cref="ArgumentException">Thrown if the destination buffer is too small to hold the unescaped value.</exception>
+        /// <exception cref="ArgumentException">The destination buffer is too small to hold the unescaped value.</exception>
         public readonly int CopyString(Span<char> destination)
         {
             if (_tokenType is not (JsonTokenType.String or JsonTokenType.PropertyName))

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -59,7 +59,7 @@ namespace System.Text.Json
         /// <seealso cref="TokenType" />
         /// It will also throw when the JSON string contains invalid UTF-8 bytes, or invalid UTF-16 surrogates.
         /// </exception>
-        /// <exception cref="ArgumentException">Thrown if the destination buffer is too small to hold the unescaped value.</exception>
+        /// <exception cref="ArgumentException">The destination buffer is too small to hold the unescaped value.</exception>
         public readonly int CopyString(Span<byte> utf8Destination)
         {
             if (_tokenType is not (JsonTokenType.String or JsonTokenType.PropertyName))

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -52,7 +52,13 @@ namespace System.Text.Json
         /// </summary>
         /// <param name="utf8Destination">A buffer to write the unescaped UTF-8 bytes into.</param>
         /// <returns>The number of bytes written to <paramref name="utf8Destination"/>.</returns>
-        /// <remarks>Unlike <see cref="GetString"/>, this method does not support <see cref="JsonTokenType.Null"/>.</remarks>
+        /// <remarks>
+        /// Unlike <see cref="GetString"/>, this method does not support <see cref="JsonTokenType.Null"/>.
+        ///
+        /// This method will throw <see cref="ArgumentException"/> if the destination buffer is too small to hold the unescaped value.
+        /// An appropriately sized buffer can be determined by consulting the length of either <see cref="ValueSpan"/> or <see cref="ValueSequence"/>,
+        /// since the unescaped result is always less than or equal to the length of the encoded strings.
+        /// </remarks>
         /// <exception cref="InvalidOperationException">
         /// Thrown if trying to get the value of the JSON token that is not a string
         /// (i.e. other than <see cref="JsonTokenType.String"/> or <see cref="JsonTokenType.PropertyName"/>.
@@ -102,7 +108,13 @@ namespace System.Text.Json
         /// </summary>
         /// <param name="destination">A buffer to write the transcoded UTF-16 characters into.</param>
         /// <returns>The number of characters written to <paramref name="destination"/>.</returns>
-        /// <remarks>Unlike <see cref="GetString"/>, this method does not support <see cref="JsonTokenType.Null"/>.</remarks>
+        /// <remarks>
+        /// Unlike <see cref="GetString"/>, this method does not support <see cref="JsonTokenType.Null"/>.
+        ///
+        /// This method will throw <see cref="ArgumentException"/> if the destination buffer is too small to hold the unescaped value.
+        /// An appropriately sized buffer can be determined by consulting the length of either <see cref="ValueSpan"/> or <see cref="ValueSequence"/>,
+        /// since the unescaped result is always less than or equal to the length of the encoded strings.
+        /// </remarks>
         /// <exception cref="InvalidOperationException">
         /// Thrown if trying to get the value of the JSON token that is not a string
         /// (i.e. other than <see cref="JsonTokenType.String"/> or <see cref="JsonTokenType.PropertyName"/>.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -1229,25 +1229,22 @@ namespace System.Text.Json
         {
             ReadOnlySpan<byte> span = stackalloc byte[0];
 
-            int maximumLength = ValueIsEscaped ? JsonConstants.MaximumEscapedDateTimeOffsetParseLength : JsonConstants.MaximumDateTimeOffsetParseLength;
-
             if (HasValueSequence)
             {
                 long sequenceLength = ValueSequence.Length;
-                if (!JsonHelpers.IsInRangeInclusive(sequenceLength, JsonConstants.MinimumDateTimeParseLength, maximumLength))
+                if (!JsonHelpers.IsInRangeInclusive(sequenceLength, JsonConstants.MinimumDateTimeParseLength, JsonConstants.MaximumEscapedDateTimeOffsetParseLength))
                 {
                     value = default;
                     return false;
                 }
 
-                Debug.Assert(sequenceLength <= JsonConstants.MaximumEscapedDateTimeOffsetParseLength);
-                Span<byte> stackSpan = stackalloc byte[ValueIsEscaped ? JsonConstants.MaximumEscapedDateTimeOffsetParseLength : JsonConstants.MaximumDateTimeOffsetParseLength];
+                Span<byte> stackSpan = stackalloc byte[JsonConstants.MaximumEscapedDateTimeOffsetParseLength];
                 ValueSequence.CopyTo(stackSpan);
                 span = stackSpan.Slice(0, (int)sequenceLength);
             }
             else
             {
-                if (!JsonHelpers.IsInRangeInclusive(ValueSpan.Length, JsonConstants.MinimumDateTimeParseLength, maximumLength))
+                if (!JsonHelpers.IsInRangeInclusive(ValueSpan.Length, JsonConstants.MinimumDateTimeParseLength, JsonConstants.MaximumEscapedDateTimeOffsetParseLength))
                 {
                     value = default;
                     return false;
@@ -1297,25 +1294,22 @@ namespace System.Text.Json
         {
             ReadOnlySpan<byte> span = stackalloc byte[0];
 
-            int maximumLength = ValueIsEscaped ? JsonConstants.MaximumEscapedDateTimeOffsetParseLength : JsonConstants.MaximumDateTimeOffsetParseLength;
-
             if (HasValueSequence)
             {
                 long sequenceLength = ValueSequence.Length;
-                if (!JsonHelpers.IsInRangeInclusive(sequenceLength, JsonConstants.MinimumDateTimeParseLength, maximumLength))
+                if (!JsonHelpers.IsInRangeInclusive(sequenceLength, JsonConstants.MinimumDateTimeParseLength, JsonConstants.MaximumEscapedDateTimeOffsetParseLength))
                 {
                     value = default;
                     return false;
                 }
 
-                Debug.Assert(sequenceLength <= JsonConstants.MaximumEscapedDateTimeOffsetParseLength);
-                Span<byte> stackSpan = stackalloc byte[ValueIsEscaped ? JsonConstants.MaximumEscapedDateTimeOffsetParseLength : JsonConstants.MaximumDateTimeOffsetParseLength];
+                Span<byte> stackSpan = stackalloc byte[JsonConstants.MaximumEscapedDateTimeOffsetParseLength];
                 ValueSequence.CopyTo(stackSpan);
                 span = stackSpan.Slice(0, (int)sequenceLength);
             }
             else
             {
-                if (!JsonHelpers.IsInRangeInclusive(ValueSpan.Length, JsonConstants.MinimumDateTimeParseLength, maximumLength))
+                if (!JsonHelpers.IsInRangeInclusive(ValueSpan.Length, JsonConstants.MinimumDateTimeParseLength, JsonConstants.MaximumEscapedDateTimeOffsetParseLength))
                 {
                     value = default;
                     return false;
@@ -1366,25 +1360,22 @@ namespace System.Text.Json
         {
             ReadOnlySpan<byte> span = stackalloc byte[0];
 
-            int maximumLength = ValueIsEscaped ? JsonConstants.MaximumEscapedGuidLength : JsonConstants.MaximumFormatGuidLength;
-
             if (HasValueSequence)
             {
                 long sequenceLength = ValueSequence.Length;
-                if (sequenceLength > maximumLength)
+                if (sequenceLength > JsonConstants.MaximumEscapedGuidLength)
                 {
                     value = default;
                     return false;
                 }
 
-                Debug.Assert(sequenceLength <= JsonConstants.MaximumEscapedGuidLength);
-                Span<byte> stackSpan = stackalloc byte[ValueIsEscaped ? JsonConstants.MaximumEscapedGuidLength : JsonConstants.MaximumFormatGuidLength];
+                Span<byte> stackSpan = stackalloc byte[JsonConstants.MaximumEscapedGuidLength];
                 ValueSequence.CopyTo(stackSpan);
                 span = stackSpan.Slice(0, (int)sequenceLength);
             }
             else
             {
-                if (ValueSpan.Length > maximumLength)
+                if (ValueSpan.Length > JsonConstants.MaximumEscapedGuidLength)
                 {
                     value = default;
                     return false;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -40,7 +40,6 @@ namespace System.Text.Json
 
         private long _totalConsumed;
         private bool _isLastSegment;
-        internal bool _stringHasEscaping;
         private readonly bool _isMultiSegment;
         private bool _trailingCommaBeforeComment;
 
@@ -53,6 +52,8 @@ namespace System.Text.Json
         internal ReadOnlySequence<byte> OriginalSequence => _sequence;
 
         internal ReadOnlySpan<byte> OriginalSpan => _sequence.IsEmpty ? _buffer : default;
+
+        internal readonly int ValueLength => HasValueSequence ? checked((int)ValueSequence.Length) : ValueSpan.Length;
 
         /// <summary>
         /// Gets the value of the last processed token as a ReadOnlySpan&lt;byte&gt; slice
@@ -131,6 +132,12 @@ namespace System.Text.Json
         public bool HasValueSequence { get; private set; }
 
         /// <summary>
+        /// Lets the caller know whether the current <see cref="ValueSpan" /> or <see cref="ValueSequence"/> properties
+        /// contain escape sequences per RFC 8259 section 7, and therefore require unescaping before being consumed.
+        /// </summary>
+        public bool ValueIsEscaped { get; private set; }
+
+        /// <summary>
         /// Returns the mode of this instance of the <see cref="Utf8JsonReader"/>.
         /// True when the reader was constructed with the input span containing the entire data to process.
         /// False when the reader was constructed knowing that the input span may contain partial data with more data to follow.
@@ -182,7 +189,7 @@ namespace System.Text.Json
             _bytePositionInLine = _bytePositionInLine,
             _inObject = _inObject,
             _isNotPrimitive = _isNotPrimitive,
-            _stringHasEscaping = _stringHasEscaping,
+            _valueIsEscaped = ValueIsEscaped,
             _trailingCommaBeforeComment = _trailingCommaBeforeComment,
             _tokenType = _tokenType,
             _previousTokenType = _previousTokenType,
@@ -213,7 +220,7 @@ namespace System.Text.Json
             _bytePositionInLine = state._bytePositionInLine;
             _inObject = state._inObject;
             _isNotPrimitive = state._isNotPrimitive;
-            _stringHasEscaping = state._stringHasEscaping;
+            ValueIsEscaped = state._valueIsEscaped;
             _trailingCommaBeforeComment = state._trailingCommaBeforeComment;
             _tokenType = state._tokenType;
             _previousTokenType = state._previousTokenType;
@@ -468,7 +475,7 @@ namespace System.Text.Json
                 return CompareToSequence(otherUtf8Text);
             }
 
-            if (_stringHasEscaping)
+            if (ValueIsEscaped)
             {
                 return UnescapeAndCompare(otherUtf8Text);
             }
@@ -558,7 +565,7 @@ namespace System.Text.Json
         {
             Debug.Assert(HasValueSequence);
 
-            if (_stringHasEscaping)
+            if (ValueIsEscaped)
             {
                 return UnescapeSequenceAndCompare(other);
             }
@@ -699,7 +706,7 @@ namespace System.Text.Json
             //      - For non-ASCII UTF-16 characters outside of the BMP, transcoding = 2x, (surrogate pairs - 2 characters transcode to 4 UTF-8 bytes)
 
             if (sourceLength < charTextLength
-                || sourceLength / (_stringHasEscaping ? JsonConstants.MaxExpansionFactorWhileEscaping : JsonConstants.MaxExpansionFactorWhileTranscoding) > charTextLength)
+                || sourceLength / (ValueIsEscaped ? JsonConstants.MaxExpansionFactorWhileEscaping : JsonConstants.MaxExpansionFactorWhileTranscoding) > charTextLength)
             {
                 return true;
             }
@@ -712,7 +719,7 @@ namespace System.Text.Json
             long sourceLength = ValueSequence.Length;
 
             if (sourceLength < charTextLength
-                || sourceLength / (_stringHasEscaping ? JsonConstants.MaxExpansionFactorWhileEscaping : JsonConstants.MaxExpansionFactorWhileTranscoding) > charTextLength)
+                || sourceLength / (ValueIsEscaped ? JsonConstants.MaxExpansionFactorWhileEscaping : JsonConstants.MaxExpansionFactorWhileTranscoding) > charTextLength)
             {
                 return true;
             }
@@ -799,6 +806,7 @@ namespace System.Text.Json
         {
             bool retVal = false;
             ValueSpan = default;
+            ValueIsEscaped = false;
 
             if (!HasMoreData())
             {
@@ -1283,7 +1291,7 @@ namespace System.Text.Json
                 {
                     _bytePositionInLine += idx + 2; // Add 2 for the start and end quotes.
                     ValueSpan = localBuffer.Slice(0, idx);
-                    _stringHasEscaping = false;
+                    ValueIsEscaped = false;
                     _tokenType = JsonTokenType.String;
                     _consumed += idx + 2;
                     return true;
@@ -1382,7 +1390,7 @@ namespace System.Text.Json
         Done:
             _bytePositionInLine++;  // Add 1 for the end quote
             ValueSpan = data.Slice(0, idx);
-            _stringHasEscaping = true;
+            ValueIsEscaped = true;
             _tokenType = JsonTokenType.String;
             _consumed += idx + 2;
             return true;
@@ -2551,11 +2559,9 @@ namespace System.Text.Json
         private ReadOnlySpan<byte> GetUnescapedSpan()
         {
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            if (_stringHasEscaping)
+            if (ValueIsEscaped)
             {
-                int idx = span.IndexOf(JsonConstants.BackSlash);
-                Debug.Assert(idx != -1);
-                span = JsonReaderHelper.GetUnescapedSpan(span, idx);
+                span = JsonReaderHelper.GetUnescapedSpan(span);
             }
 
             return span;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
@@ -25,48 +25,16 @@ namespace System.Text.Json.Serialization.Converters
             }
 
 #if BUILDING_INBOX_LIBRARY
-            bool isEscaped = reader._stringHasEscaping;
-
-            int maxLength = isEscaped ? MaximumEscapedVersionLength : MaximumVersionLength;
-            ReadOnlySpan<byte> source = stackalloc byte[0];
-            if (reader.HasValueSequence)
+            if (!JsonHelpers.IsInRangeInclusive(reader.ValueLength, MinimumVersionLength, MaximumEscapedVersionLength))
             {
-                if (!JsonHelpers.IsInRangeInclusive(reader.ValueSequence.Length, MinimumVersionLength, maxLength))
-                {
-                    ThrowHelper.ThrowFormatException(DataType.Version);
-                }
-
-                Span<byte> stackSpan = stackalloc byte[isEscaped ? MaximumEscapedVersionLength : MaximumVersionLength];
-                reader.ValueSequence.CopyTo(stackSpan);
-                source = stackSpan.Slice(0, (int)reader.ValueSequence.Length);
-            }
-            else
-            {
-                source = reader.ValueSpan;
-
-                if (!JsonHelpers.IsInRangeInclusive(source.Length, MinimumVersionLength, maxLength))
-                {
-                    ThrowHelper.ThrowFormatException(DataType.Version);
-                }
+                ThrowHelper.ThrowFormatException(DataType.TimeSpan);
             }
 
-            if (isEscaped)
-            {
-                int backslash = source.IndexOf(JsonConstants.BackSlash);
-                Debug.Assert(backslash != -1);
+            Span<char> charBuffer = stackalloc char[MaximumEscapedVersionLength];
+            int bytesWritten = reader.CopyString(charBuffer);
+            ReadOnlySpan<char> source = charBuffer.Slice(0, bytesWritten);
 
-                Span<byte> sourceUnescaped = stackalloc byte[MaximumEscapedVersionLength];
-
-                JsonReaderHelper.Unescape(source, sourceUnescaped, backslash, out int written);
-                Debug.Assert(written > 0);
-
-                source = sourceUnescaped.Slice(0, written);
-                Debug.Assert(!source.IsEmpty);
-            }
-
-            byte firstChar = source[0];
-            byte lastChar = source[source.Length - 1];
-            if (!JsonHelpers.IsDigit(firstChar) || !JsonHelpers.IsDigit(lastChar))
+            if (!char.IsDigit(source[0]) || !char.IsDigit(source[^1]))
             {
                 // Since leading and trailing whitespaces are forbidden throughout System.Text.Json converters
                 // we need to make sure that our input doesn't have them,
@@ -75,9 +43,7 @@ namespace System.Text.Json.Serialization.Converters
                 ThrowHelper.ThrowFormatException(DataType.Version);
             }
 
-            Span<char> charBuffer = stackalloc char[MaximumVersionLength];
-            int writtenChars = JsonReaderHelper.s_utf8Encoding.GetChars(source, charBuffer);
-            if (Version.TryParse(charBuffer.Slice(0, writtenChars), out Version? result))
+            if (Version.TryParse(source, out Version? result))
             {
                 return result;
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -78,11 +78,9 @@ namespace System.Text.Json
             ReadOnlySpan<byte> unescapedPropertyName;
             ReadOnlySpan<byte> propertyName = reader.GetSpan();
 
-            if (reader._stringHasEscaping)
+            if (reader.ValueIsEscaped)
             {
-                int idx = propertyName.IndexOf(JsonConstants.BackSlash);
-                Debug.Assert(idx != -1);
-                unescapedPropertyName = JsonReaderHelper.GetUnescapedSpan(propertyName, idx);
+                unescapedPropertyName = JsonReaderHelper.GetUnescapedSpan(propertyName);
             }
             else
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -52,6 +52,12 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        public static void ThrowArgumentException_DestinationTooShort()
+        {
+            throw GetArgumentException(SR.DestinationTooShort);
+        }
+
+        [DoesNotReturn]
         public static void ThrowArgumentException_PropertyNameTooLarge(int tokenLength)
         {
             throw GetArgumentException(SR.Format(SR.PropertyNameTooLarge, tokenLength));
@@ -480,7 +486,7 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowInvalidOperationException_ReadInvalidUTF16()
+        public static void ThrowInvalidOperationException_ReadIncompleteUTF16()
         {
             throw GetInvalidOperationException(SR.CannotReadIncompleteUTF16);
         }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonTestHelper.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonTestHelper.cs
@@ -140,6 +140,20 @@ namespace System.Text.Json
             return ReaderLoop(data.Length, out length, ref reader);
         }
 
+        public delegate void Utf8JsonReaderAction(ref Utf8JsonReader reader);
+
+        public static void AssertWithSingleAndMultiSegmentReader(string json, Utf8JsonReaderAction action, JsonReaderOptions options = default)
+        {
+            byte[] utf8 = Encoding.UTF8.GetBytes(json);
+
+            var singleSegmentReader = new Utf8JsonReader(utf8, options);
+            action(ref singleSegmentReader);
+
+            ReadOnlySequence<byte> sequence = GetSequence(utf8, segmentSize: 1);
+            var multiSegmentReader = new Utf8JsonReader(sequence, options);
+            action(ref multiSegmentReader);
+        }
+
         public static ReadOnlySequence<byte> CreateSegments(byte[] data)
         {
             ReadOnlyMemory<byte> dataMemory = data;
@@ -743,16 +757,16 @@ namespace System.Text.Json
             Assert.NotEqual(expectedValue.NormalizeToJsonNetFormat(skipSpecialRules), value.NormalizeToJsonNetFormat(skipSpecialRules));
         }
 
-        public delegate void AssertThrowsActionUtf8JsonReader(Utf8JsonReader json);
+        public delegate void AssertThrowsActionUtf8JsonReader(ref Utf8JsonReader json);
 
         // Cannot use standard Assert.Throws() when testing Utf8JsonReader - ref structs and closures don't get along.
-        public static void AssertThrows<E>(Utf8JsonReader json, AssertThrowsActionUtf8JsonReader action) where E : Exception
+        public static TException AssertThrows<TException>(ref Utf8JsonReader json, AssertThrowsActionUtf8JsonReader action) where TException : Exception
         {
             Exception ex;
 
             try
             {
-                action(json);
+                action(ref json);
                 ex = null;
             }
             catch (Exception e)
@@ -760,45 +774,12 @@ namespace System.Text.Json
                 ex = e;
             }
 
-            if (ex == null)
+            if (ex is TException matchingEx)
             {
-                throw new ThrowsException(typeof(E));
+                return matchingEx;
             }
 
-            if (!(ex is E))
-            {
-                throw new ThrowsException(typeof(E), ex);
-            }
-        }
-
-        public delegate void AssertThrowsActionUtf8JsonWriter(ref Utf8JsonWriter writer);
-
-        public static void AssertThrows<E>(
-            ref Utf8JsonWriter writer,
-            AssertThrowsActionUtf8JsonWriter action)
-            where E : Exception
-        {
-            Exception ex;
-
-            try
-            {
-                action(ref writer);
-                ex = null;
-            }
-            catch (Exception e)
-            {
-                ex = e;
-            }
-
-            if (ex == null)
-            {
-                throw new ThrowsException(typeof(E));
-            }
-
-            if (ex.GetType() != typeof(E))
-            {
-                throw new ThrowsException(typeof(E), ex);
-            }
+            throw ex is null ? new ThrowsException(typeof(TException)) : new ThrowsException(typeof(TException), ex);
         }
 
 #if NETCOREAPP

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Null.ReadTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Null.ReadTests.cs
@@ -176,7 +176,7 @@ namespace System.Text.Json.Serialization.Tests
 
             Utf8JsonReader reader = new Utf8JsonReader(nullStringAsBytes);
 
-            JsonTestHelper.AssertThrows<JsonException>(reader, (reader) => JsonSerializer.Deserialize<SimpleStruct>(ref reader));
+            JsonTestHelper.AssertThrows<JsonException>(ref reader, (ref Utf8JsonReader reader) => JsonSerializer.Deserialize<SimpleStruct>(ref reader));
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleStruct>(nullStringAsBytes));
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleStruct>(nullString));
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -25,6 +25,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(JsonTokenType.None, json.TokenType);
             Assert.NotEqual(default, json.Position);
             Assert.False(json.HasValueSequence);
+            Assert.False(json.ValueIsEscaped);
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
 
@@ -57,6 +58,7 @@ namespace System.Text.Json.Tests
                 Assert.Equal(JsonTokenType.None, json.TokenType);
                 Assert.NotEqual(default, json.Position);
                 Assert.False(json.HasValueSequence);
+                Assert.False(json.ValueIsEscaped);
                 Assert.True(json.ValueSpan.SequenceEqual(default));
                 Assert.True(json.ValueSequence.IsEmpty);
 
@@ -403,6 +405,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(JsonTokenType.None, json.TokenType);
             Assert.NotEqual(default, json.Position);
             Assert.False(json.HasValueSequence);
+            Assert.False(json.ValueIsEscaped);
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
 
@@ -427,6 +430,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(JsonTokenType.None, json.TokenType);
             Assert.NotEqual(default, json.Position);
             Assert.False(json.HasValueSequence);
+            Assert.False(json.ValueIsEscaped);
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
 
@@ -691,6 +695,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(0, json.CurrentDepth);
             Assert.Equal(0, json.BytesConsumed);
             Assert.False(json.HasValueSequence);
+            Assert.False(json.ValueIsEscaped);
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
 
@@ -718,6 +723,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(0, json.CurrentDepth);
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
             Assert.False(json.HasValueSequence);
+            Assert.False(json.ValueIsEscaped);
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
 
@@ -729,6 +735,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(0, json.CurrentDepth);
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
             Assert.False(json.HasValueSequence);
+            Assert.False(json.ValueIsEscaped);
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
 
@@ -1685,7 +1692,7 @@ namespace System.Text.Json.Tests
                 Assert.Contains(reader.TokenType, new[] { JsonTokenType.EndArray, JsonTokenType.EndObject });
             }
 
-            JsonTestHelper.AssertThrows<JsonException>(reader, (jsonReader) =>
+            JsonTestHelper.AssertThrows<JsonException>(ref reader, (ref Utf8JsonReader jsonReader) =>
             {
                 jsonReader.Read();
                 if (commentHandling == JsonCommentHandling.Allow && jsonReader.TokenType == JsonTokenType.Comment)
@@ -1796,7 +1803,7 @@ namespace System.Text.Json.Tests
 
             if (expectThrow)
             {
-                JsonTestHelper.AssertThrows<JsonException>(reader, (jsonReader) =>
+                JsonTestHelper.AssertThrows<JsonException>(ref reader, (ref Utf8JsonReader jsonReader) =>
                 {
                     while (jsonReader.Read())
                         ;
@@ -1894,7 +1901,7 @@ namespace System.Text.Json.Tests
 
         private static void ValidateThrows(ref Utf8JsonReader reader)
         {
-            JsonTestHelper.AssertThrows<JsonException>(reader, (jsonReader) =>
+            JsonTestHelper.AssertThrows<JsonException>(ref reader, (ref Utf8JsonReader jsonReader) =>
             {
                 while (jsonReader.Read())
                     ;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.TryGet.Date.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.TryGet.Date.cs
@@ -221,7 +221,7 @@ namespace System.Text.Json.Tests
                 Assert.False(json.TryGetDateTime(out DateTime actual), "json.TryGetDateTime(out DateTime actual)");
                 Assert.Equal(DateTime.MinValue, actual);
 
-                JsonTestHelper.AssertThrows<FormatException>(json, (jsonReader) => jsonReader.GetDateTime());
+                JsonTestHelper.AssertThrows<FormatException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetDateTime());
             }
 
             Test(testString, isFinalBlock: true);
@@ -246,7 +246,7 @@ namespace System.Text.Json.Tests
                 Assert.False(json.TryGetDateTimeOffset(out DateTimeOffset actual), "json.TryGetDateTimeOffset(out DateTimeOffset actual)");
                 Assert.Equal(DateTimeOffset.MinValue, actual);
 
-                JsonTestHelper.AssertThrows<FormatException>(json, (jsonReader) => jsonReader.GetDateTimeOffset());
+                JsonTestHelper.AssertThrows<FormatException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetDateTimeOffset());
             }
 
             Test(testString, isFinalBlock: true);
@@ -264,11 +264,11 @@ namespace System.Text.Json.Tests
 
             Assert.False(json.TryGetDateTime(out var dateTime));
             Assert.Equal(default, dateTime);
-            JsonTestHelper.AssertThrows<FormatException>(json, (json) => json.GetDateTime());
+            JsonTestHelper.AssertThrows<FormatException>(ref json, (ref Utf8JsonReader json) => json.GetDateTime());
 
             Assert.False(json.TryGetDateTimeOffset(out var dateTimeOffset));
             Assert.Equal(default, dateTimeOffset);
-            JsonTestHelper.AssertThrows<FormatException>(json, (json) => json.GetDateTimeOffset());
+            JsonTestHelper.AssertThrows<FormatException>(ref json, (ref Utf8JsonReader json) => json.GetDateTimeOffset());
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.TryGet.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.TryGet.cs
@@ -5,6 +5,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using Xunit;
@@ -736,7 +737,7 @@ namespace System.Text.Json.Tests
                     }
                     else
                     {
-                        JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.GetString());
+                        JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetString());
                     }
 
                     try
@@ -787,9 +788,9 @@ namespace System.Text.Json.Tests
                     catch (InvalidOperationException)
                     { }
 
-                    JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.GetGuid());
+                    JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetGuid());
 
-                    JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.TryGetGuid(out _));
+                    JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.TryGetGuid(out _));
                 }
 
                 if (json.TokenType != JsonTokenType.Comment)
@@ -1092,12 +1093,16 @@ namespace System.Text.Json.Tests
 
                 Assert.True(json.Read());
                 Assert.Equal(JsonTokenType.String, json.TokenType);
-                try
-                {
-                    string val = json.GetString();
-                    Assert.True(false, "Expected InvalidOperationException when trying to get string value for invalid UTF-16 JSON text.");
-                }
-                catch (InvalidOperationException) { }
+
+                JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader json) => json.GetString());
+
+                var byteBuffer = new byte[6 * jsonString.Length];
+                JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader json) => json.CopyString(byteBuffer));
+                Assert.All(byteBuffer, static b => Assert.Equal(0, b));
+
+                var charBuffer = new char[6 * jsonString.Length];
+                JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader json) => json.CopyString(charBuffer));
+                Assert.All(charBuffer, static c => Assert.Equal(0, c));
             }
         }
 
@@ -1123,17 +1128,138 @@ namespace System.Text.Json.Tests
                 {
                     if (json.TokenType == JsonTokenType.String)
                     {
-                        try
-                        {
-                            string val = json.GetString();
-                            Assert.True(false, "Expected InvalidOperationException when trying to get string value for invalid UTF-8 JSON text.");
-                        }
-                        catch (InvalidOperationException ex)
-                        {
-                            Assert.Equal(typeof(DecoderFallbackException), ex.InnerException.GetType());
-                        }
+                        int length = json.HasValueSequence ? (int)json.ValueSequence.Length : json.ValueSpan.Length;
+
+                        InvalidOperationException ex = JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader json) => json.GetString());
+                        Assert.IsType<DecoderFallbackException>(ex.InnerException);
+
+                        var byteBuffer = new byte[length];
+                        ex = JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader json) => json.CopyString(byteBuffer));
+                        Assert.IsType<DecoderFallbackException>(ex.InnerException);
+                        Assert.All(byteBuffer, static b => Assert.Equal(0, b));
+
+                        var charBuffer = new char[length];
+                        ex = JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader json) => json.CopyString(charBuffer));
+                        Assert.IsType<DecoderFallbackException>(ex.InnerException);
+                        Assert.All(charBuffer, static c => Assert.Equal(0, c));
                     }
                 }
+            }
+        }
+
+        [Theory]
+        [InlineData("this is a string without escaping", "this is a string without escaping")]
+        [InlineData(@"this is\t a string with escaping\n", "this is\t a string with escaping\n")]
+        [InlineData(@"\n\r\""\\\/\t\b\f\u0061", "\n\r\"\\/\t\b\fa")]
+        public static void CopyString_Utf8_SuccessPath(string jsonString, string expectedOutput)
+        {
+            string json = $"\"{jsonString}\"";
+            byte[] expectedOutputUtf8 = Encoding.UTF8.GetBytes(expectedOutput);
+            JsonTestHelper.AssertWithSingleAndMultiSegmentReader(json, Test);
+
+            void Test(ref Utf8JsonReader reader)
+            {
+                Assert.True(reader.Read());
+                Span<byte> destination = new byte[128];
+                int bytesWritten = reader.CopyString(destination);
+                Assert.Equal(expectedOutputUtf8.Length, bytesWritten);
+                Assert.True(expectedOutputUtf8.AsSpan().SequenceEqual(destination.Slice(0, bytesWritten)));
+            }
+        }
+
+        [Theory]
+        [InlineData("this is a string without escaping", "this is a string without escaping")]
+        [InlineData(@"this is\t a string with escaping\n", "this is\t a string with escaping\n")]
+        [InlineData(@"\n\r\""\\\/\t\b\f\u0061", "\n\r\"\\/\t\b\fa")]
+        public static void CopyString_Utf16_SuccessPath(string jsonString, string expectedOutput)
+        {
+            string json = $"\"{jsonString}\"";
+            JsonTestHelper.AssertWithSingleAndMultiSegmentReader(json, Test);
+
+            void Test(ref Utf8JsonReader reader)
+            {
+                Assert.True(reader.Read());
+                Span<char> destination = new char[128];
+                int charsWritten = reader.CopyString(destination);
+                Assert.Equal(expectedOutput.Length, charsWritten);
+                Assert.True(expectedOutput.AsSpan().SequenceEqual(destination.Slice(0, charsWritten)));
+            }
+        }
+
+        [Theory]
+        [InlineData("null")]
+        [InlineData("false")]
+        [InlineData("true")]
+        [InlineData("42")]
+        [InlineData("[]")]
+        [InlineData("{}")]
+        [InlineData("/* comment */ null", JsonCommentHandling.Allow)]
+        public static void CopyString_InvalidToken_ThrowsInvalidOperationException(string json, JsonCommentHandling commentHandling = default)
+        {
+            var options = new JsonReaderOptions { CommentHandling = commentHandling };
+            JsonTestHelper.AssertWithSingleAndMultiSegmentReader(json, Test, options);
+
+            static void Test(ref Utf8JsonReader reader)
+            {
+                do
+                {
+                    JsonTestHelper.AssertThrows<InvalidOperationException>(ref reader, (ref Utf8JsonReader reader) => reader.CopyString(new byte[128]));
+                    JsonTestHelper.AssertThrows<InvalidOperationException>(ref reader, (ref Utf8JsonReader reader) => reader.CopyString(new char[128]));
+                }
+                while (reader.Read());
+
+                JsonTestHelper.AssertThrows<InvalidOperationException>(ref reader, (ref Utf8JsonReader reader) => reader.CopyString(new byte[128]));
+                JsonTestHelper.AssertThrows<InvalidOperationException>(ref reader, (ref Utf8JsonReader reader) => reader.CopyString(new char[128]));
+            }
+        }
+
+        [Theory]
+        [InlineData("this is a string without escaping", "this is a string without escaping")]
+        [InlineData(@"this is\t a string with escaping\n", "this is\t a string with escaping\n")]
+        [InlineData(@"\n\r\""\\\/\t\b\f\u0061", "\n\r\"\\/\t\b\fa")]
+        public static void CopyString_Utf8_DestinationTooShort_ThrowsArgumentException(string jsonString, string expectedOutput)
+        {
+            int expectedUtf8Size = Encoding.UTF8.GetByteCount(expectedOutput);
+            string json = $"\"{jsonString}\"";
+            JsonTestHelper.AssertWithSingleAndMultiSegmentReader(json, Test);
+
+            void Test(ref Utf8JsonReader reader)
+            {
+                Assert.True(reader.Read());
+
+                byte[] buffer = new byte[expectedUtf8Size];
+                for (int i = 0; i < expectedUtf8Size; i++)
+                {
+                    JsonTestHelper.AssertThrows<ArgumentException>(ref reader, (ref Utf8JsonReader reader) => reader.CopyString(buffer.AsSpan().Slice(0, i)));
+                    Assert.All(buffer, static b => Assert.Equal(0, b));
+                }
+
+                Assert.Equal(expectedUtf8Size, reader.CopyString(buffer));
+            }
+        }
+
+        [Theory]
+        [InlineData("this is a string without escaping", "this is a string without escaping")]
+        [InlineData(@"this is\t a string with escaping\n", "this is\t a string with escaping\n")]
+        [InlineData(@"\n\r\""\\\/\t\b\f\u0061", "\n\r\"\\/\t\b\fa")]
+        public static void CopyString_Utf16_DestinationTooShort_ThrowsArgumentException(string jsonString, string expectedOutput)
+        {
+            int expectedSize = expectedOutput.Length;
+            string json = $"\"{jsonString}\"";
+            JsonTestHelper.AssertWithSingleAndMultiSegmentReader(json, Test);
+
+            void Test(ref Utf8JsonReader reader)
+            {
+                Assert.True(reader.Read());
+
+                char[] buffer = new char[expectedSize];
+                for (int i = 0; i < expectedSize; i++)
+                {
+                    JsonTestHelper.AssertThrows<ArgumentException>(ref reader, (ref Utf8JsonReader reader) => reader.CopyString(buffer.AsSpan().Slice(0, i)));
+                    Assert.All(buffer, static c => Assert.Equal(0, c));
+                }
+
+                Assert.Equal(expectedSize, reader.CopyString(buffer));
             }
         }
 
@@ -1371,7 +1497,7 @@ namespace System.Text.Json.Tests
             Assert.False(json.TryGetGuid(out Guid actual));
             Assert.Equal(default, actual);
 
-            JsonTestHelper.AssertThrows<FormatException>(json, (jsonReader) => jsonReader.GetGuid());
+            JsonTestHelper.AssertThrows<FormatException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetGuid());
         }
 
         [Theory]
@@ -1392,7 +1518,7 @@ namespace System.Text.Json.Tests
                 Assert.False(json.TryGetGuid(out Guid actual), "json.TryGetGuid(out Guid actual)");
                 Assert.Equal(Guid.Empty, actual);
 
-                JsonTestHelper.AssertThrows<FormatException>(json, (jsonReader) => jsonReader.GetGuid());
+                JsonTestHelper.AssertThrows<FormatException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetGuid());
             }
 
             Test(testString, isFinalBlock: true);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.TryGet.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.TryGet.cs
@@ -1095,14 +1095,8 @@ namespace System.Text.Json.Tests
                 Assert.Equal(JsonTokenType.String, json.TokenType);
 
                 JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader json) => json.GetString());
-
-                var byteBuffer = new byte[6 * jsonString.Length];
-                JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader json) => json.CopyString(byteBuffer));
-                Assert.All(byteBuffer, static b => Assert.Equal(0, b));
-
-                var charBuffer = new char[6 * jsonString.Length];
-                JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader json) => json.CopyString(charBuffer));
-                Assert.All(charBuffer, static c => Assert.Equal(0, c));
+                JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader json) => json.CopyString(new byte[6 * jsonString.Length]));
+                JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader json) => json.CopyString(new char[6 * jsonString.Length]));
             }
         }
 
@@ -1133,15 +1127,11 @@ namespace System.Text.Json.Tests
                         InvalidOperationException ex = JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader json) => json.GetString());
                         Assert.IsType<DecoderFallbackException>(ex.InnerException);
 
-                        var byteBuffer = new byte[length];
-                        ex = JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader json) => json.CopyString(byteBuffer));
+                        ex = JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader json) => json.CopyString(new byte[length]));
                         Assert.IsType<DecoderFallbackException>(ex.InnerException);
-                        Assert.All(byteBuffer, static b => Assert.Equal(0, b));
 
-                        var charBuffer = new char[length];
-                        ex = JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader json) => json.CopyString(charBuffer));
+                        ex = JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader json) => json.CopyString(new char[length]));
                         Assert.IsType<DecoderFallbackException>(ex.InnerException);
-                        Assert.All(charBuffer, static c => Assert.Equal(0, c));
                     }
                 }
             }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.TryGet.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.TryGet.cs
@@ -1138,6 +1138,8 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
+        [InlineData("", "")]
+        [InlineData("1", "1")]
         [InlineData("this is a string without escaping", "this is a string without escaping")]
         [InlineData(@"this is\t a string with escaping\n", "this is\t a string with escaping\n")]
         [InlineData(@"\n\r\""\\\/\t\b\f\u0061", "\n\r\"\\/\t\b\fa")]
@@ -1158,6 +1160,8 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
+        [InlineData("", "")]
+        [InlineData("1", "1")]
         [InlineData("this is a string without escaping", "this is a string without escaping")]
         [InlineData(@"this is\t a string with escaping\n", "this is\t a string with escaping\n")]
         [InlineData(@"\n\r\""\\\/\t\b\f\u0061", "\n\r\"\\/\t\b\fa")]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -26,6 +27,7 @@ namespace System.Text.Json.Tests
             Assert.False(json.IsFinalBlock);
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
+            Assert.False(json.ValueIsEscaped);
 
             Assert.Equal(0, json.CurrentState.Options.MaxDepth);
             Assert.False(json.CurrentState.Options.AllowTrailingCommas);
@@ -34,10 +36,10 @@ namespace System.Text.Json.Tests
             Assert.False(json.Read());
 
             json = default;
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.ValueTextEquals(""));
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.ValueTextEquals("".AsSpan()));
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.ValueTextEquals(default(ReadOnlySpan<char>)));
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.ValueTextEquals(default(ReadOnlySpan<byte>)));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.ValueTextEquals(""));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.ValueTextEquals("".AsSpan()));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.ValueTextEquals(default(ReadOnlySpan<char>)));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.ValueTextEquals(default(ReadOnlySpan<byte>)));
 
             TestGetMethodsOnDefault();
         }
@@ -46,65 +48,67 @@ namespace System.Text.Json.Tests
         {
             Utf8JsonReader json = default;
 
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.TryGetByte(out _));
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.GetByte());
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.TryGetByte(out _));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetByte());
 
             json = default;
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.GetComment());
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetComment());
 
             json = default;
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.TryGetDateTime(out _));
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.GetDateTime());
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.TryGetDateTime(out _));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetDateTime());
 
             json = default;
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.TryGetDateTimeOffset(out _));
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.GetDateTimeOffset());
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.TryGetDateTimeOffset(out _));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetDateTimeOffset());
 
             json = default;
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.TryGetDecimal(out _));
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.GetDecimal());
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.TryGetDecimal(out _));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetDecimal());
 
             json = default;
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.TryGetDouble(out _));
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.GetDouble());
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.TryGetDouble(out _));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetDouble());
 
             json = default;
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.TryGetInt16(out _));
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.GetInt16());
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.TryGetInt16(out _));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetInt16());
 
             json = default;
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.TryGetInt32(out _));
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.GetInt32());
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.TryGetInt32(out _));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetInt32());
 
             json = default;
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.TryGetInt64(out _));
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.GetInt64());
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.TryGetInt64(out _));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetInt64());
 
             json = default;
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.TryGetSByte(out _));
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.GetSByte());
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.TryGetSByte(out _));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetSByte());
 
             json = default;
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.TryGetSingle(out _));
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.GetSingle());
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.TryGetSingle(out _));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetSingle());
 
             json = default;
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.TryGetUInt16(out _));
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.GetUInt16());
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.TryGetUInt16(out _));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetUInt16());
 
             json = default;
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.TryGetUInt32(out _));
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.GetUInt32());
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.TryGetUInt32(out _));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetUInt32());
 
             json = default;
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.TryGetUInt64(out _));
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.GetUInt64());
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.TryGetUInt64(out _));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetUInt64());
 
             json = default;
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.GetString());
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetString());
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.CopyString(new byte[16]));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.CopyString(new char[16]));
 
             json = default;
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.GetBoolean());
+            JsonTestHelper.AssertThrows<InvalidOperationException>(ref json, (ref Utf8JsonReader jsonReader) => jsonReader.GetBoolean());
         }
 
         [Fact]
@@ -118,6 +122,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(JsonTokenType.None, json.TokenType);
             Assert.Equal(default, json.Position);
             Assert.False(json.HasValueSequence);
+            Assert.False(json.ValueIsEscaped);
             Assert.True(json.IsFinalBlock);
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
@@ -141,6 +146,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(JsonTokenType.None, json.TokenType);
             Assert.Equal(default, json.Position);
             Assert.False(json.HasValueSequence);
+            Assert.False(json.ValueIsEscaped);
             Assert.True(json.IsFinalBlock);
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
@@ -165,6 +171,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(JsonTokenType.None, json.TokenType);
             Assert.Equal(default, json.Position);
             Assert.False(json.HasValueSequence);
+            Assert.False(json.ValueIsEscaped);
             Assert.False(json.IsFinalBlock);
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
@@ -182,6 +189,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(JsonTokenType.Number, json.TokenType);
             Assert.Equal(default, json.Position);
             Assert.False(json.HasValueSequence);
+            Assert.False(json.ValueIsEscaped);
             Assert.True(json.ValueSpan.SequenceEqual(new byte[] { (byte)'1' }));
             Assert.True(json.ValueSequence.IsEmpty);
 
@@ -199,6 +207,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(JsonTokenType.Number, json.TokenType);
             Assert.Equal(default, json.Position);
             Assert.False(json.HasValueSequence);
+            Assert.False(json.ValueIsEscaped);
             Assert.True(json.IsFinalBlock);
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
@@ -276,7 +285,7 @@ namespace System.Text.Json.Tests
                 return;
             }
 
-            // Remove all formatting/indendation
+            // Remove all formatting/indentation
             if (compactData)
             {
                 jsonString = JsonTestHelper.GetCompactString(jsonString);
@@ -571,6 +580,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(0, json.CurrentDepth);
             Assert.Equal(0, json.BytesConsumed);
             Assert.False(json.HasValueSequence);
+            Assert.False(json.ValueIsEscaped);
             Assert.True(json.IsFinalBlock);
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
@@ -583,6 +593,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(0, json.CurrentDepth);
             Assert.Equal(0, json.BytesConsumed);
             Assert.False(json.HasValueSequence);
+            Assert.False(json.ValueIsEscaped);
             Assert.True(json.IsFinalBlock);
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
@@ -612,6 +623,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(0, json.CurrentDepth);
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
             Assert.False(json.HasValueSequence);
+            Assert.False(json.ValueIsEscaped);
             Assert.True(json.IsFinalBlock);
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
@@ -624,6 +636,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(0, json.CurrentDepth);
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
             Assert.False(json.HasValueSequence);
+            Assert.False(json.ValueIsEscaped);
             Assert.True(json.IsFinalBlock);
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
@@ -636,6 +649,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(0, json.CurrentDepth);
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
             Assert.False(json.HasValueSequence);
+            Assert.False(json.ValueIsEscaped);
             Assert.True(json.IsFinalBlock);
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
@@ -962,6 +976,7 @@ namespace System.Text.Json.Tests
             int prevDepth = json.CurrentDepth;
             long prevConsumed = json.BytesConsumed;
             Assert.False(json.HasValueSequence);
+            Assert.False(json.ValueIsEscaped);
             Assert.True(json.ValueSequence.IsEmpty);
             ReadOnlySpan<byte> prevValue = json.ValueSpan;
 
@@ -980,6 +995,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(prevDepth, json.CurrentDepth);
             Assert.Equal(prevConsumed, json.BytesConsumed);
             Assert.False(json.HasValueSequence);
+            Assert.False(json.ValueIsEscaped);
             Assert.True(json.ValueSequence.IsEmpty);
             Assert.True(json.ValueSpan.SequenceEqual(prevValue));
         }
@@ -3317,7 +3333,7 @@ namespace System.Text.Json.Tests
                 Assert.Contains(reader.TokenType, new[] { JsonTokenType.EndArray, JsonTokenType.EndObject });
             }
 
-            JsonTestHelper.AssertThrows<JsonException>(reader, (jsonReader) =>
+            JsonTestHelper.AssertThrows<JsonException>(ref reader, (ref Utf8JsonReader jsonReader) =>
             {
                 jsonReader.Read();
                 if (commentHandling == JsonCommentHandling.Allow && jsonReader.TokenType == JsonTokenType.Comment)
@@ -3424,7 +3440,7 @@ namespace System.Text.Json.Tests
 
             if (expectThrow)
             {
-                JsonTestHelper.AssertThrows<JsonException>(reader, (jsonReader) =>
+                JsonTestHelper.AssertThrows<JsonException>(ref reader, (ref Utf8JsonReader jsonReader) =>
                 {
                     while (jsonReader.Read())
                         ;
@@ -3763,6 +3779,134 @@ namespace System.Text.Json.Tests
                 var json = new Utf8JsonReader(utf8BomAndValue, isFinalBlock: isFinalBlock, state: default);
                 json.Read();
             });
+        }
+
+        [Theory]
+        [InlineData("null")]
+        [InlineData("false")]
+        [InlineData("true")]
+        [InlineData("42")]
+        [InlineData("\"stringWithoutEscaping\"")]
+        [InlineData("{}")]
+        [InlineData("[]")]
+        [InlineData("/* comment */ null", JsonCommentHandling.Allow)]
+        public static void ValueIsEscaped_IsFalseOnTokensWithoutEscaping(string json, JsonCommentHandling commentHandling = default)
+        {
+            var options = new JsonReaderOptions { CommentHandling = commentHandling };
+            JsonTestHelper.AssertWithSingleAndMultiSegmentReader(json, Test, options);
+
+            static void Test(ref Utf8JsonReader reader)
+            {
+                while (reader.Read())
+                {
+                    Assert.False(reader.ValueIsEscaped);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(@"\""")]
+        [InlineData(@"\n")]
+        [InlineData(@"\r")]
+        [InlineData(@"\\")]
+        [InlineData(@"\/")]
+        [InlineData(@"\t")]
+        [InlineData(@"\b")]
+        [InlineData(@"\f")]
+        [InlineData(@"\u6F22\u5B57")]
+        public static void ValueIsEscaped_IsTrueOnEscapedStrings(string jsonString)
+        {
+            string json = $@"""{jsonString}""";
+            JsonTestHelper.AssertWithSingleAndMultiSegmentReader(json, Test);
+
+            static void Test(ref Utf8JsonReader reader)
+            {
+                Assert.True(reader.Read());
+                Assert.Equal(JsonTokenType.String, reader.TokenType);
+                Assert.True(reader.ValueIsEscaped);
+            }
+        }
+
+        [Theory]
+        [InlineData(@"\""")]
+        [InlineData(@"\n")]
+        [InlineData(@"\r")]
+        [InlineData(@"\\")]
+        [InlineData(@"\/")]
+        [InlineData(@"\t")]
+        [InlineData(@"\b")]
+        [InlineData(@"\f")]
+        [InlineData(@"\u6F22\u5B57")]
+        public static void ValueIsEscaped_IsTrueOnEscapedPropertyNames(string jsonString)
+        {
+            string json = $@"{{ ""{jsonString}"" : false }}";
+            JsonTestHelper.AssertWithSingleAndMultiSegmentReader(json, Test);
+
+            static void Test(ref Utf8JsonReader reader)
+            {
+                Assert.True(reader.Read());
+                Assert.True(reader.Read());
+                Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+                Assert.True(reader.ValueIsEscaped);
+            }
+        }
+
+        [Theory]
+        [InlineData("null")]
+        [InlineData("false")]
+        [InlineData("true")]
+        [InlineData("42")]
+        [InlineData("\"stringWithoutEscaping\"")]
+        [InlineData("{}")]
+        [InlineData("[]")]
+        [InlineData("/* comment */ null", JsonCommentHandling.Allow)]
+        public static void ValueIsEscaped_AfterEscapedStrings_IsFalseOnNonEscapedTokens(string jsonValue, JsonCommentHandling commentHandling = default)
+        {
+            string json = $@"[""hello\n"", {jsonValue}]";
+            var options = new JsonReaderOptions { CommentHandling = commentHandling };
+            JsonTestHelper.AssertWithSingleAndMultiSegmentReader(json, Test, options);
+
+            static void Test(ref Utf8JsonReader reader)
+            {
+                Assert.True(reader.Read());
+                Assert.True(reader.Read());
+                Assert.Equal(JsonTokenType.String, reader.TokenType);
+                Assert.True(reader.ValueIsEscaped);
+
+                while (reader.Read())
+                {
+                    Assert.False(reader.ValueIsEscaped);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("null")]
+        [InlineData("false")]
+        [InlineData("true")]
+        [InlineData("42")]
+        [InlineData("\"stringWithoutEscaping\"")]
+        [InlineData("{}")]
+        [InlineData("[]")]
+        [InlineData("/* comment */ null", JsonCommentHandling.Allow)]
+        public static void ValueIsEscaped_AfterEscapedPropertyNames_IsFalseOnNonEscapedTokens(string jsonValue, JsonCommentHandling commentHandling = default)
+        {
+            string json = $@"{{ ""hello\n"" : {jsonValue} }}";
+            var options = new JsonReaderOptions { CommentHandling = commentHandling };
+            JsonTestHelper.AssertWithSingleAndMultiSegmentReader(json, Test, options);
+
+            static void Test(ref Utf8JsonReader reader)
+            {
+                Assert.True(reader.Read());
+                Assert.True(reader.Read());
+                Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+                Assert.True(reader.ValueIsEscaped);
+
+                while (reader.Read())
+                {
+                    Assert.False(reader.ValueIsEscaped);
+                }
+            }
         }
 
         public static IEnumerable<object[]> TestCases

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.cs
@@ -3824,6 +3824,7 @@ namespace System.Text.Json.Tests
                 Assert.True(reader.Read());
                 Assert.Equal(JsonTokenType.String, reader.TokenType);
                 Assert.True(reader.ValueIsEscaped);
+                Assert.Contains((byte)'\\', reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan.ToArray());
             }
         }
 
@@ -3848,6 +3849,7 @@ namespace System.Text.Json.Tests
                 Assert.True(reader.Read());
                 Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
                 Assert.True(reader.ValueIsEscaped);
+                Assert.Contains((byte)'\\', reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan.ToArray());
             }
         }
 


### PR DESCRIPTION
This PR

* Implements the `Utf8JsonReader.ValueIsEscaped` property. Fix #45167.
* Implements the `UtfJsonReader.CopyString` methods. Fix #54410.
* Rewires internal converter implementations to use the new APIs, where applicable.
* Reworks the `Unescape` implementation to better take advantage of the `Span.IndexOf` and `CopyTo` methods, resulting in improved performance for certain scenaria because of vectorization.

The changes improve performance in a few applications, most notably when reading escaped strings or when deserializing converters that would until now allocate strings.

### String-based enum deserialization without escaping

|                   Method | Branch |     Mean |   Error |   StdDev |   Median |      Min |      Max | Ratio | MannWhitney(5%) | RatioSD |  Gen 0 | Allocated | Alloc Ratio |
|------------------------- |------- |---------:|--------:|---------:|---------:|---------:|---------:|------:|---------------- |--------:|-------:|----------:|------------:|
| DeserializeFromUtf8Bytes |   main | 200.1 ns | 9.58 ns | 11.03 ns | 193.7 ns | 190.5 ns | 221.4 ns |  1.00 |            Base |    0.00 | 0.0128 |     136 B |        1.00 |
| DeserializeFromUtf8Bytes |     PR | 172.9 ns | 1.14 ns |  0.95 ns | 172.9 ns | 171.6 ns | 175.2 ns |  0.86 |          Faster |    0.05 |      - |         - |        0.00 |

### Utf8JsonReader.GetString() call on escaped string

|    Method | Branch |      Mean |     Error |    StdDev |    Median |       Min |       Max | Ratio | MannWhitney(5%) |  Gen 0 | Allocated | Alloc Ratio |
|---------- |------- |----------:|----------:|----------:|----------:|----------:|----------:|------:|---------------- |-------:|----------:|------------:|
| GetString |   main | 10.643 us | 0.1048 us | 0.0929 us | 10.627 us | 10.527 us | 10.848 us |  1.00 |            Base | 1.1797 |  11.72 KB |        1.00 |
| GetString |     PR |  7.678 us | 0.0615 us | 0.0546 us |  7.658 us |  7.615 us |  7.765 us |  0.72 |          Faster | 1.1651 |  11.72 KB |        1.00 |

cc @davidfowl @bartonjs @steveharter @stephentoub 